### PR TITLE
provisioner/shell: fix an issue where configured Scripts were overridden

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -101,7 +101,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) {
-	scripts := make([]string, len(p.config.Scripts))
+	scripts := p.config.Scripts
 
 	// If we have an inline script, then turn that into a temporary
 	// shell script and use that.


### PR DESCRIPTION
Shell provisioning scripts specified with both `path` and `scripts` were failing with "unable to open file: " errors.

It seems we were overriding the `config.Scripts` with a new `[]string`, while maintaining the length.

This effectively dropped the configured scripts, while the validator still passed.

This fix worked for me, as it simply appends to the `[]string` created in `Prepare`.

Pretty sure this was introduced somewhere in badad141d3e72e296cefa6d6f1c30dc810501b4a. 
