### PR TITLE
Default to AWS_ env vars for key and secret

### DIFF
--- a/builder/amazonebs/builder.go
+++ b/builder/amazonebs/builder.go
@@ -59,7 +59,15 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 	}
 
 	if b.config.AccessKey == "" {
+		b.config.AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+	}
+
+	if b.config.AccessKey == "" {
 		b.config.AccessKey = os.Getenv("AWS_ACCESS_KEY")
+	}
+
+	if b.config.SecretKey == "" {
+		b.config.SecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
 	}
 
 	if b.config.SecretKey == "" {


### PR DESCRIPTION
This allows the amazonebs builder to use the standard AWS environment variables, if available.
