### PR TITLE
Fix reference of typo corrected on 43bb20d

### DIFF
--- a/website/source/docs/templates/provisioners.html.markdown
+++ b/website/source/docs/templates/provisioners.html.markdown
@@ -39,7 +39,7 @@ the `type` key. This key specifies the name of the provisioner to use.
 Additional keys within the object are used to configure the provisioner,
 with the exception of a handful of special keys, covered later.
 
-As an example, the "shell" provisioner requires at least the `path` key,
+As an example, the "shell" provisioner requires at least the `script` key,
 which specifies a path to a shell script to execute within the machines
 being created.
 


### PR DESCRIPTION
The typo on the code snippet was corrected, but not the reference in the docs.
