### PR TITLE
Update HTML characters for the <enter> command in VMware builder documentation

### DIFF
--- a/website/source/docs/builders/vmware.html.markdown
+++ b/website/source/docs/builders/vmware.html.markdown
@@ -180,6 +180,6 @@ an Ubuntu 12.04 installer:
   "fb=false debconf/frontend=noninteractive ",
   "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
   "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
-  "initrd=/install/initrd.gz -- <enter>"
+  "initrd=/install/initrd.gz -- &lt;enter&gt;"
 ]
 </pre>


### PR DESCRIPTION
This commit removes <, > and instead uses &lt;,&gt; to describe the
enter command in the boot command code block in vmware builder
documentation.

Thanks!
