### PR TITLE
Update HTML characters for the <enter> command in Virtualbox builder documentation

### DIFF
--- a/website/source/docs/builders/virtualbox.html.markdown
+++ b/website/source/docs/builders/virtualbox.html.markdown
@@ -191,7 +191,7 @@ an Ubuntu 12.04 installer:
   "fb=false debconf/frontend=noninteractive ",
   "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
   "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
-  "initrd=/install/initrd.gz -- <enter>"
+  "initrd=/install/initrd.gz -- &lt;enter&gt;"
 ]
 </pre>
 


### PR DESCRIPTION
Heya,

This commit removes <, > and instead uses <,> to describe the
enter command in the boot command code block in virtualbox
builder documentation.

Noticed that the doc error was in the Virtualbox doc as well.

Thanks!
