### PR TITLE
.gitignore the /src directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /local
 /pkg
+/src
 /website/.sass-cache
 /website/build


### PR DESCRIPTION
When building Packer, a `/src` directory is made. It isn't Git ignored. It probably should be.
