### PR TITLE
Note that Mercurial (hg) is a dependency for developing on Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ If you wish to work on Packer itself, you'll first need [Go](http://golang.org)
 installed (version 1.1+ is _required_). Make sure you have Go properly installed,
 including setting up your [GOPATH](http://golang.org/doc/code.html#GOPATH).
 
+Additionally, to build Packer, you will need [Mercurial](http://mercurial.selenic.com/) installed.
+
 Next, clone this repository then just type `make`. In a few moments,
 you'll have a working `packer` executable:
 


### PR DESCRIPTION
If you don't have Mercurial, you get:

> go: missing Mercurial command. See http://golang.org/s/gogetcmd
> package code.google.com/p/go.crypto/ssh: exec: "hg": executable file not found in $PATH

when building Packer.
