### PR TITLE
Log Packer Version to Debug

### DIFF
--- a/packer.go
+++ b/packer.go
@@ -27,6 +27,8 @@ func main() {
 		runtime.GOMAXPROCS(runtime.NumCPU())
 	}
 
+	log.Printf("Packer Version: %s %s", packer.Version, packer.VersionPrerelease)
+
 	config, err := loadConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading configuration: \n\n%s\n", err)


### PR DESCRIPTION
Figured this would be helpful and remove some debugging / support steps.

Also, I was trying to figure out a way to get the architecture and OS of the binary in there.

One thing I looked at was `runtime.GOOS` and `runtime.GOARCH`, but that didn't seem to give me what I wanted.

Something like this:

`Packer Target OS/Architecture: Darwin x86_64`
