### PR TITLE
Expand VMware support to Workstation 9 (Linux).

### DIFF
--- a/builder/vmware/builder.go
+++ b/builder/vmware/builder.go
@@ -359,7 +359,7 @@ func (b *Builder) Cancel() {
 	}
 }
 
-func (b *Builder) newDriver() (Driver, error) {
+func (b *Builder) newFusionDriver() (Driver, error) {
 	fusionAppPath := "/Applications/VMware Fusion.app"
 	driver := &Fusion5Driver{fusionAppPath}
 	if err := driver.Verify(); err != nil {
@@ -367,4 +367,28 @@ func (b *Builder) newDriver() (Driver, error) {
 	}
 
 	return driver, nil
+}
+
+func (b *Builder) newWorkstationLinuxDriver() (Driver, error) {
+	driver := &WS9LnxDriver{}
+	if err := driver.Verify(); err != nil {
+		return nil, err
+	}
+
+	return driver, nil
+}
+
+func (b *Builder) newDriver() (Driver, error) {
+	fusion, fusionErr := b.newFusionDriver()
+	ws, wsErr := b.newWorkstationLinuxDriver()
+
+	if fusionErr == nil {
+		return fusion, nil
+	}
+
+	if wsErr == nil {
+		return ws, nil
+	}
+
+	return nil, fmt.Errorf("Unable to initialise VMware driver:\nFusion 5: %s\nWorkstation 9: %s", fusionErr, wsErr)
 }

--- a/builder/vmware/guest_ip.go
+++ b/builder/vmware/guest_ip.go
@@ -2,7 +2,6 @@ package vmware
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -18,6 +17,9 @@ type GuestIPFinder interface {
 // DHCPLeaseGuestLookup looks up the IP address of a guest using DHCP
 // lease information from the VMware network devices.
 type DHCPLeaseGuestLookup struct {
+	// Driver that is being used (to find leases path)
+	Driver Driver
+
 	// Device that the guest is connected to.
 	Device string
 
@@ -26,7 +28,7 @@ type DHCPLeaseGuestLookup struct {
 }
 
 func (f *DHCPLeaseGuestLookup) GuestIP() (string, error) {
-	fh, err := os.Open(fmt.Sprintf("/var/db/vmware/vmnet-dhcpd-%s.leases", f.Device))
+	fh, err := os.Open(f.Driver.DhcpLeasesPath(f.Device))
 	if err != nil {
 		return "", err
 	}

--- a/builder/vmware/host_ip.go
+++ b/builder/vmware/host_ip.go
@@ -33,7 +33,7 @@ func (f *IfconfigIPFinder) HostIP() (string, error) {
 		return "", err
 	}
 
-	re := regexp.MustCompile(`inet\s*(.+?)\s`)
+	re := regexp.MustCompile(`inet\s*(?:addr:)?(.+?)\s`)
 	matches := re.FindStringSubmatch(stdout.String())
 	if matches == nil {
 		return "", errors.New("IP not found in ifconfig output...")

--- a/builder/vmware/ssh.go
+++ b/builder/vmware/ssh.go
@@ -12,6 +12,7 @@ import (
 
 func sshAddress(state map[string]interface{}) (string, error) {
 	config := state["config"].(*config)
+	driver := state["driver"].(Driver)
 	vmxPath := state["vmx_path"].(string)
 
 	log.Println("Lookup up IP information...")
@@ -37,6 +38,7 @@ func sshAddress(state map[string]interface{}) (string, error) {
 	}
 
 	ipLookup := &DHCPLeaseGuestLookup{
+		Driver:     driver,
 		Device:     "vmnet8",
 		MACAddress: macAddress,
 	}


### PR DESCRIPTION
The VMware builder should automatically pick between Fusion 5 and Workstation
9, based on which one is installed.
