### PR TITLE
Fix import paths in "make test" dependency fetching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ format:
 
 test:
 	@echo "$(OK_COLOR)==> Testing Packer...$(NO_COLOR)"
-	@go list -f '{{range .TestImports}}{{.}}\
-		{{end}}' ./... | xargs -n1 go get -d
+	@go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | xargs -n1 go get -d
 	go test ./...
 
 .PHONY: all format test


### PR DESCRIPTION
When running `make test` on my machine, I got many unrecognized import
path errors (shown below), and the path showed a trailing "\n". Changing the `go list`
format to remove the newline fixed these.

```
==> Testing Packer...
package cgl.tideland.biz/asserts
: unrecognized import path "cgl.tideland.biz/asserts\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package os
: unrecognized import path "os\n"
package testing
: unrecognized import path "testing\n"
package crypto/md5
: unrecognized import path "crypto/md5\n"
package encoding/hex
: unrecognized import path "encoding/hex\n"
package io/ioutil
: unrecognized import path "io/ioutil\n"
package os
: unrecognized import path "os\n"
package testing
: unrecognized import path "testing\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package strconv
: unrecognized import path "strconv\n"
package testing
: unrecognized import path "testing\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package io/ioutil
: unrecognized import path "io/ioutil\n"
package os
: unrecognized import path "os\n"
package reflect
: unrecognized import path "reflect\n"
package testing
: unrecognized import path "testing\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package io/ioutil
: unrecognized import path "io/ioutil\n"
package os
: unrecognized import path "os\n"
package testing
: unrecognized import path "testing\n"
package time
: unrecognized import path "time\n"
package bytes
: unrecognized import path "bytes\n"
package cgl.tideland.biz/asserts
: unrecognized import path "cgl.tideland.biz/asserts\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package testing
: unrecognized import path "testing\n"
package bytes
: unrecognized import path "bytes\n"
package code.google.com/p/go.crypto/ssh
: invalid code.google.com/ import path "code.google.com/p/go.crypto/ssh\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package net
: unrecognized import path "net\n"
package testing
: unrecognized import path "testing\n"
package bytes
: unrecognized import path "bytes\n"
package cgl.tideland.biz/asserts
: unrecognized import path "cgl.tideland.biz/asserts\n"
package errors
: unrecognized import path "errors\n"
package fmt
: unrecognized import path "fmt\n"
package io/ioutil
: unrecognized import path "io/ioutil\n"
package log
: unrecognized import path "log\n"
package os
: unrecognized import path "os\n"
package reflect
: unrecognized import path "reflect\n"
package sort
: unrecognized import path "sort\n"
package strings
: unrecognized import path "strings\n"
package testing
: unrecognized import path "testing\n"
package time
: unrecognized import path "time\n"
package fmt
: unrecognized import path "fmt\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package os
: unrecognized import path "os\n"
package os/exec
: unrecognized import path "os/exec\n"
package testing
: unrecognized import path "testing\n"
package time
: unrecognized import path "time\n"
package bufio
: unrecognized import path "bufio\n"
package cgl.tideland.biz/asserts
: unrecognized import path "cgl.tideland.biz/asserts\n"
package errors
: unrecognized import path "errors\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package io
: unrecognized import path "io\n"
package net
: unrecognized import path "net\n"
package net/rpc
: unrecognized import path "net/rpc\n"
package reflect
: unrecognized import path "reflect\n"
package strings
: unrecognized import path "strings\n"
package testing
: unrecognized import path "testing\n"
package time
: unrecognized import path "time\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package testing
: unrecognized import path "testing\n"
package github.com/mitchellh/packer/packer
: invalid github.com/ import path "github.com/mitchellh/packer/packer\n"
package io/ioutil
: unrecognized import path "io/ioutil\n"
package os
: unrecognized import path "os\n"
package testing
: unrecognized import path "testing\n"
make: *** [test] Error 123
```
