### PR TITLE
Virtualbox: clean up port forwarding before exporting OVF.

### DIFF
--- a/builder/virtualbox/step_forward_ssh.go
+++ b/builder/virtualbox/step_forward_ssh.go
@@ -36,7 +36,7 @@ func (s *stepForwardSSH) Run(state map[string]interface{}) multistep.StepAction 
 		}
 	}
 
-	// Attach the disk to the controller
+	// Create a forwarded port mapping to the VM
 	ui.Say(fmt.Sprintf("Creating forwarded port mapping for SSH (host port %d)", sshHostPort))
 	command := []string{
 		"modifyvm", vmName,


### PR DESCRIPTION
Before exporting the VM, remove the 'packerssh' port forwarding rule.

This is helpful for [#117] if the exported ovf is used as input into Packer.

The alternative to this is to remove the rule before it is added in StepForwardSSH, however it seems cleaner not to have these hanging around in the exported VM.
