### PR TITLE
Add block_device_mappings configuration option for AWS [GH-90]

### DIFF
--- a/builder/amazonebs/builder.go
+++ b/builder/amazonebs/builder.go
@@ -37,7 +37,8 @@ type config struct {
 	SSHTimeout   time.Duration
 
 	// Configuration of the resulting AMI
-	AMIName string `mapstructure:"ami_name"`
+	AMIName             string                   `mapstructure:"ami_name"`
+	BlockDeviceMappings []ec2.BlockDeviceMapping `mapstructure:"block_device_mappings"`
 
 	PackerDebug   bool   `mapstructure:"packer_debug"`
 	RawSSHTimeout string `mapstructure:"ssh_timeout"`

--- a/builder/amazonebs/step_create_ami.go
+++ b/builder/amazonebs/step_create_ami.go
@@ -37,8 +37,9 @@ func (s *stepCreateAMI) Run(state map[string]interface{}) multistep.StepAction {
 	// Create the image
 	ui.Say(fmt.Sprintf("Creating the AMI: %s", amiName))
 	createOpts := &ec2.CreateImage{
-		InstanceId: instance.InstanceId,
-		Name:       amiName,
+		InstanceId:   instance.InstanceId,
+		Name:         amiName,
+		BlockDevices: config.BlockDeviceMappings,
 	}
 
 	createResp, err := ec2conn.CreateImage(createOpts)

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -63,6 +63,9 @@ Required:
 
 Optional:
 
+* `block_device_mappings` (array of block device structures) - The additional
+block device mappings to be included in the AMI.
+
 * `ssh_port` (int) - The port that SSH will be available on. This defaults
   to port 22.
 
@@ -93,6 +96,32 @@ access key from environmental variables. See the configuration reference in
 the section above for more information on what environmental variables Packer
 will look for.
 </div>
+
+Here is an example with additional block device mappings which will map
+/dev/sdb onto ephemeral0 and /dev/sdc onto ephemeral1.
+
+<pre class="prettyprint">
+{
+  "type": "amazon-ebs",
+  "access_key": "YOUR KEY HERE",
+  "secret_key": "YOUR SECRET KEY HERE",
+  "region": "us-east-1",
+  "source_ami": "ami-de0d9eb7",
+  "instance_type": "t1.micro",
+  "ssh_username": "ubuntu",
+  "ami_name": "packer-quick-start {{.CreateTime}}",
+  "block_device_mappings": [
+    {
+      "DeviceName": "/dev/sdb",
+      "VirtualName": "ephemeral0"
+    },
+    {
+      "DeviceName": "/dev/sdc",
+      "VirtualName": "ephemeral1"
+    }
+  ]
+}
+</pre>
 
 ## AMI Name Variables
 


### PR DESCRIPTION
This allows the block device mappings to be specified for the
amazon-ebs builder. Note: this requires an update to mitchell/goamz
to pick up the corresponding block device mapping support.
