### PR TITLE
Ability to specify a pre-existing SecurityGroupId for the AmazonEBS Builder

### DIFF
--- a/builder/amazonebs/builder.go
+++ b/builder/amazonebs/builder.go
@@ -29,12 +29,13 @@ type config struct {
 	SecretKey string `mapstructure:"secret_key"`
 
 	// Information for the source instance
-	Region       string
-	SourceAmi    string `mapstructure:"source_ami"`
-	InstanceType string `mapstructure:"instance_type"`
-	SSHUsername  string `mapstructure:"ssh_username"`
-	SSHPort      int    `mapstructure:"ssh_port"`
-	SSHTimeout   time.Duration
+	Region          string
+	SourceAmi       string `mapstructure:"source_ami"`
+	InstanceType    string `mapstructure:"instance_type"`
+	SSHUsername     string `mapstructure:"ssh_username"`
+	SSHPort         int    `mapstructure:"ssh_port"`
+	SSHTimeout      time.Duration
+	SecurityGroupId string `mapstructure:"security_group_id"`
 
 	// Configuration of the resulting AMI
 	AMIName string `mapstructure:"ami_name"`

--- a/builder/amazonebs/step_security_group.go
+++ b/builder/amazonebs/step_security_group.go
@@ -19,6 +19,12 @@ func (s *stepSecurityGroup) Run(state map[string]interface{}) multistep.StepActi
 	ec2conn := state["ec2"].(*ec2.EC2)
 	ui := state["ui"].(packer.Ui)
 
+	if config.SecurityGroupId != "" {
+		log.Printf("Using specified security group: %s", config.SecurityGroupId)
+		state["securityGroupId"] = config.SecurityGroupId
+		return multistep.ActionContinue
+	}
+
 	// Create the group
 	ui.Say("Creating temporary security group for this instance...")
 	groupName := fmt.Sprintf("packer %s", hex.EncodeToString(identifier.NewUUID().Raw()))


### PR DESCRIPTION
Adds `security_group_id` to the builder configuration for the `amazonebs` builder.

This allows you to use an existing Security Group and have the provisioning step communicate with other nodes in EC2 securely (ie. an APT repository).

If specified the builder will continue with the given id, otherwise it'll will proceed
with creating the temporary group and retrieving it's id.

Since `s.groupId` is not set `CleanUp` returns without attempting to delete the group.

> For now, this requires the person specifying the SecurityGroupId to be aware that the group needs SSH access.
> Not sure whether this should just be documented, or whether there should be a verification step to give a nice error message in the failure case.
