### PR TITLE
Move AWS auth decisions to goamz [GH-160]

### DIFF
--- a/builder/amazonebs/builder.go
+++ b/builder/amazonebs/builder.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mitchellh/packer/builder/common"
 	"github.com/mitchellh/packer/packer"
 	"log"
-	"os"
 	"text/template"
 	"time"
 )
@@ -27,6 +26,7 @@ type config struct {
 	// Access information
 	AccessKey string `mapstructure:"access_key"`
 	SecretKey string `mapstructure:"secret_key"`
+	AWSAuth   aws.Auth
 
 	// Information for the source instance
 	Region       string
@@ -58,22 +58,6 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 		}
 	}
 
-	if b.config.AccessKey == "" {
-		b.config.AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
-	}
-
-	if b.config.AccessKey == "" {
-		b.config.AccessKey = os.Getenv("AWS_ACCESS_KEY")
-	}
-
-	if b.config.SecretKey == "" {
-		b.config.SecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
-	}
-
-	if b.config.SecretKey == "" {
-		b.config.SecretKey = os.Getenv("AWS_SECRET_KEY")
-	}
-
 	if b.config.SSHPort == 0 {
 		b.config.SSHPort = 22
 	}
@@ -85,12 +69,9 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 	// Accumulate any errors
 	errs := make([]error, 0)
 
-	if b.config.AccessKey == "" {
-		errs = append(errs, errors.New("An access_key must be specified"))
-	}
-
-	if b.config.SecretKey == "" {
-		errs = append(errs, errors.New("A secret_key must be specified"))
+	b.config.AWSAuth, err = aws.GetAuth(b.config.AccessKey, b.config.SecretKey)
+	if err != nil {
+		errs = append(errs, err)
 	}
 
 	if b.config.SourceAmi == "" {
@@ -139,8 +120,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		panic("region not found")
 	}
 
-	auth := aws.Auth{b.config.AccessKey, b.config.SecretKey}
-	ec2conn := ec2.New(auth, region)
+	ec2conn := ec2.New(b.config.AWSAuth, region)
 
 	// Setup the state bag and initial state for the steps
 	state := make(map[string]interface{})


### PR DESCRIPTION
Currently the passed in AWS auth or AWS environment variables are
interpreted by packer. This change moves that logic into goamz in
order to support both the existing and instance based IAM role
authentication. This requires a corresponding change to goamz.
