### PR TITLE
Validate that instance exists and is EBS based before trying to launch it

### DIFF
--- a/builder/amazonebs/step_run_source_instance.go
+++ b/builder/amazonebs/step_run_source_instance.go
@@ -28,6 +28,22 @@ func (s *stepRunSourceInstance) Run(state map[string]interface{}) multistep.Step
 		SecurityGroups: []ec2.SecurityGroup{ec2.SecurityGroup{Id: securityGroupId}},
 	}
 
+    ui.Say("Validating Source AMI...")
+    imageResp, err := ec2conn.Images([]string{config.SourceAmi}, ec2.NewFilter())
+    if err != nil {
+    	err := fmt.Errorf("There was a problem with the provided source AMI: %s", err)
+    	state["error"] = err
+    	ui.Error(err.Error())
+        return multistep.ActionHalt
+    }
+
+    if imageResp.Images[0].RootDeviceType != "ebs" {
+    	err := fmt.Errorf("The provided source AMI is instance-store based. The amazon-ebs bundler can only work with EBS based AMIs.")
+        state["error"] = err
+        ui.Error(err.Error())
+    	return multistep.ActionHalt
+    }
+
 	ui.Say("Launching a source AWS instance...")
 	runResp, err := ec2conn.RunInstances(runOpts)
 	if err != nil {


### PR DESCRIPTION
_For Open Issue:_ https://github.com/mitchellh/packer/issues/169
### Approach:

In the run source instance step make a call to ec2conn.Images using the source_ami id and no filters. Bails and throws errors on error response.  If an Image is returned confirm that its root_device_type is ebs, if not bails and throw errors.
### Source AMI IDs for testing:

**Ubuntu 10.04 LTS Instance-Store**

```
"source_ami": "ami-da0cf8b3"
```

**Ubuntu 10.04 LTS EBS**

```
"source_ami": "ami-4a0df923"
```

Link to base AMI the above IDs came from: https://aws.amazon.com/amis/ubuntu-10-04-lts-lucid-lynx-server-64-bit
