### PR TITLE
Add support for -force flag on builds [GH-119]

### DIFF
--- a/builder/virtualbox/builder.go
+++ b/builder/virtualbox/builder.go
@@ -54,6 +54,7 @@ type config struct {
 
 	PackerBuildName string `mapstructure:"packer_build_name"`
 	PackerDebug     bool   `mapstructure:"packer_debug"`
+	PackerForce     bool   `mapstructure:"packer_force"`
 
 	RawBootWait        string `mapstructure:"boot_wait"`
 	RawShutdownTimeout string `mapstructure:"shutdown_timeout"`
@@ -219,7 +220,12 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 	}
 
 	if _, err := os.Stat(b.config.OutputDir); err == nil {
-		errs = append(errs, errors.New("Output directory already exists. It must not exist."))
+		if b.config.PackerForce {
+			log.Printf("Build forced, removing existing output directory: %s", string(b.config.OutputDir))
+				os.RemoveAll(b.config.OutputDir)
+		} else {
+			errs = append(errs, errors.New("Output directory already exists. It must not exist."))
+		}
 	}
 
 	b.config.BootWait, err = time.ParseDuration(b.config.RawBootWait)

--- a/builder/vmware/builder.go
+++ b/builder/vmware/builder.go
@@ -55,6 +55,7 @@ type config struct {
 
 	PackerBuildName string `mapstructure:"packer_build_name"`
 	PackerDebug     bool   `mapstructure:"packer_debug"`
+	PackerForce     bool   `mapstructure:"packer_force"`
 
 	RawBootWait        string `mapstructure:"boot_wait"`
 	RawShutdownTimeout string `mapstructure:"shutdown_timeout"`
@@ -175,7 +176,12 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 	}
 
 	if _, err := os.Stat(b.config.OutputDir); err == nil {
-		errs = append(errs, errors.New("Output directory already exists. It must not exist."))
+		if b.config.PackerForce {
+			log.Printf("Build forced, removing existing output directory: %s", string(b.config.OutputDir))
+				os.RemoveAll(b.config.OutputDir)
+		} else {
+			errs = append(errs, errors.New("Output directory already exists. It must not exist."))
+		}
 	}
 
 	if b.config.SSHUser == "" {

--- a/command/build/command.go
+++ b/command/build/command.go
@@ -21,12 +21,14 @@ func (Command) Help() string {
 
 func (c Command) Run(env packer.Environment, args []string) int {
 	var cfgDebug bool
+	var cfgForce bool
 	var cfgExcept []string
 	var cfgOnly []string
 
 	cmdFlags := flag.NewFlagSet("build", flag.ContinueOnError)
 	cmdFlags.Usage = func() { env.Ui().Say(c.Help()) }
 	cmdFlags.BoolVar(&cfgDebug, "debug", false, "debug mode for builds")
+	cmdFlags.BoolVar(&cfgForce, "force", false, "force a build if artifacts exist")
 	cmdFlags.Var((*stringSliceValue)(&cfgExcept), "except", "build all builds except these")
 	cmdFlags.Var((*stringSliceValue)(&cfgOnly), "only", "only build the given builds by name")
 	if err := cmdFlags.Parse(args); err != nil {
@@ -141,11 +143,13 @@ func (c Command) Run(env packer.Environment, args []string) int {
 	env.Ui().Say("")
 
 	log.Printf("Build debug mode: %v", cfgDebug)
+	log.Printf("Force build: %v", cfgForce)
 
-	// Set the debug mode and prepare all the builds
+	// Set the debug and force mode and prepare all the builds
 	for _, b := range builds {
 		log.Printf("Preparing build: %s", b.Name())
 		b.SetDebug(cfgDebug)
+		b.SetForce(cfgForce)
 		err := b.Prepare()
 		if err != nil {
 			env.Ui().Error(err.Error())

--- a/command/build/help.go
+++ b/command/build/help.go
@@ -9,6 +9,7 @@ Usage: packer build [options] TEMPLATE
 Options:
 
   -debug                     Debug mode enabled for builds
+  -force                     Force a build to continue if artifacts exist, deletes existing artifacts
   -except=foo,bar,baz        Build all builds other than these
   -only=foo,bar,baz          Only build the given builds by name
 `

--- a/packer/build_test.go
+++ b/packer/build_test.go
@@ -42,6 +42,7 @@ func TestBuild_Prepare(t *testing.T) {
 	packerConfig := map[string]interface{}{
 		BuildNameConfigKey: "test",
 		DebugConfigKey:     false,
+		ForceConfigKey:     false,
 	}
 
 	build := testBuild()
@@ -88,6 +89,7 @@ func TestBuild_Prepare_Debug(t *testing.T) {
 	packerConfig := map[string]interface{}{
 		BuildNameConfigKey: "test",
 		DebugConfigKey:     true,
+		ForceConfigKey:     false,
 	}
 
 	build := testBuild()

--- a/packer/rpc/build.go
+++ b/packer/rpc/build.go
@@ -69,6 +69,12 @@ func (b *build) SetDebug(val bool) {
 	}
 }
 
+func (b *build) SetForce(val bool) {
+	if err := b.client.Call("Build.SetForce", val, new(interface{})); err != nil {
+		panic(err)
+	}
+}
+
 func (b *build) Cancel() {
 	if err := b.client.Call("Build.Cancel", new(interface{}), new(interface{})); err != nil {
 		panic(err)
@@ -108,6 +114,11 @@ func (b *BuildServer) Run(args *BuildRunArgs, reply *[]string) error {
 
 func (b *BuildServer) SetDebug(val *bool, reply *interface{}) error {
 	b.build.SetDebug(*val)
+	return nil
+}
+
+func (b *BuildServer) SetForce(val *bool, reply *interface{}) error {
+	b.build.SetForce(*val)
 	return nil
 }
 

--- a/packer/rpc/build_test.go
+++ b/packer/rpc/build_test.go
@@ -17,6 +17,7 @@ type testBuild struct {
 	runCache       packer.Cache
 	runUi          packer.Ui
 	setDebugCalled bool
+	setForceCalled bool
 	cancelCalled   bool
 
 	errRunResult bool
@@ -46,6 +47,10 @@ func (b *testBuild) Run(ui packer.Ui, cache packer.Cache) ([]packer.Artifact, er
 
 func (b *testBuild) SetDebug(bool) {
 	b.setDebugCalled = true
+}
+
+func (b *testBuild) SetForce(bool) {
+	b.setForceCalled = true
 }
 
 func (b *testBuild) Cancel() {
@@ -103,6 +108,10 @@ func TestBuildRPC(t *testing.T) {
 	// Test SetDebug
 	bClient.SetDebug(true)
 	assert.True(b.setDebugCalled, "should be called")
+
+	// Test SetForce
+	bClient.SetForce(true)
+	assert.True(b.setForceCalled, "should be called")
 
 	// Test Cancel
 	bClient.Cancel()

--- a/website/source/docs/command-line/build.html.markdown
+++ b/website/source/docs/command-line/build.html.markdown
@@ -17,6 +17,12 @@ artifacts that are created will be outputted at the end of the build.
   between each step, waiting for keyboard input before continuing. This will allow
   the user to inspect state and so on.
 
+* `-force` - Forces a builder to run when artifacts from a previous build prevent
+  a build from running. The exact behavior of a forced build is left to the builder.
+  In general, a builder supporting the forced build will remove the artifacts from
+  the previous build. This will allow the user to repeat a build without having to
+  manually clean these artifacts beforehand.
+  
 * `-except=foo,bar,baz` - Builds all the builds except those with the given
   comma-separated names. Build names by default are the names of their builders,
   unless a specific `name` attribute is specified within the configuration.


### PR DESCRIPTION
Currently only supports VirtualBox and VMware builders, and will only clean-up the Packer produced build artifact folders. This pull request does not address what happens if a previous build is still running either in a failed or ongoing state.
