### PR TITLE
Remove output directory in a step when "-force" flag step [GH-178]

### DIFF
--- a/builder/virtualbox/builder.go
+++ b/builder/virtualbox/builder.go
@@ -220,10 +220,7 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 	}
 
 	if _, err := os.Stat(b.config.OutputDir); err == nil {
-		if b.config.PackerForce {
-			log.Printf("Build forced, removing existing output directory: %s", string(b.config.OutputDir))
-			os.RemoveAll(b.config.OutputDir)
-		} else {
+		if !b.config.PackerForce {
 			errs = append(errs, errors.New("Output directory already exists. It must not exist."))
 		}
 	}

--- a/builder/virtualbox/step_prepare_output_dir.go
+++ b/builder/virtualbox/step_prepare_output_dir.go
@@ -10,6 +10,12 @@ type stepPrepareOutputDir struct{}
 
 func (stepPrepareOutputDir) Run(state map[string]interface{}) multistep.StepAction {
 	config := state["config"].(*config)
+	ui := state["ui"].(packer.Ui)
+
+	if _, err := os.Stat(config.OutputDir); err == nil && config.PackerForce {
+		ui.Say("Deleting previous output directory...")
+		os.RemoveAll(config.OutputDir)
+	}
 
 	if err := os.MkdirAll(config.OutputDir, 0755); err != nil {
 		state["error"] = err

--- a/builder/vmware/builder.go
+++ b/builder/vmware/builder.go
@@ -176,10 +176,7 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 	}
 
 	if _, err := os.Stat(b.config.OutputDir); err == nil {
-		if b.config.PackerForce {
-			log.Printf("Build forced, removing existing output directory: %s", string(b.config.OutputDir))
-			os.RemoveAll(b.config.OutputDir)
-		} else {
+		if !b.config.PackerForce {
 			errs = append(errs, errors.New("Output directory already exists. It must not exist."))
 		}
 	}

--- a/builder/vmware/step_prepare_output_dir.go
+++ b/builder/vmware/step_prepare_output_dir.go
@@ -10,6 +10,12 @@ type stepPrepareOutputDir struct{}
 
 func (stepPrepareOutputDir) Run(state map[string]interface{}) multistep.StepAction {
 	config := state["config"].(*config)
+	ui := state["ui"].(packer.Ui)
+
+	if _, err := os.Stat(config.OutputDir); err == nil && config.PackerForce {
+		ui.Say("Deleting previous output directory...")
+		os.RemoveAll(config.OutputDir)
+  }
 
 	if err := os.MkdirAll(config.OutputDir, 0755); err != nil {
 		state["error"] = err


### PR DESCRIPTION
As part of the change, also switch user feedback to UI instead of logging, as it makes sense for users to be aware when the directory is deleted during a forced build.
