### PR TITLE
Restore override functionality for provisioners

### DIFF
--- a/packer/template.go
+++ b/packer/template.go
@@ -221,6 +221,11 @@ func ParseTemplate(data []byte) (t *Template, err error) {
 			continue
 		}
 
+		// The provisioners not only don't need or want the override settings
+		// (as they are processed as part of the preparation below), but will
+		// actively reject them as invalid configuration.
+		delete(v, "override")
+
 		raw.rawConfig = v
 	}
 


### PR DESCRIPTION
The recent addition of strict key checking for provisioners has exposed the fact that they don't know about the override object.  Since this is processed entirely in template.go, they don't actually need to even see it, and we can just remove it before it ever gets to them.
