### PR TITLE
Re-factor shell/provisioner command output into StartWithUi

### DIFF
--- a/builder/virtualbox/step_shutdown.go
+++ b/builder/virtualbox/step_shutdown.go
@@ -32,21 +32,21 @@ func (s *stepShutdown) Run(state map[string]interface{}) multistep.StepAction {
 
 	if config.ShutdownCommand != "" {
 		ui.Say("Gracefully halting virtual machine...")
-		log.Printf("Executing shutdown command: %s", config.ShutdownCommand)
+
 		cmd := &packer.RemoteCmd{Command: config.ShutdownCommand}
-		if err := comm.Start(cmd); err != nil {
+
+		log.Printf("Executing shutdown command: %s", cmd.Command)
+		if err := packer.StartWithUi(comm, ui, cmd); err != nil {
 			err := fmt.Errorf("Failed to send shutdown command: %s", err)
 			state["error"] = err
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
 
-		// Wait for the command to run
-		cmd.Wait()
-
 		// Wait for the machine to actually shut down
 		log.Printf("Waiting max %s for shutdown to complete", config.shutdownTimeout)
 		shutdownTimer := time.After(config.shutdownTimeout)
+
 		for {
 			running, _ := driver.IsRunning(vmName)
 			if !running {

--- a/packer/communicator_ui.go
+++ b/packer/communicator_ui.go
@@ -1,0 +1,70 @@
+package packer
+
+import (
+	"fmt"
+	"github.com/mitchellh/iochan"
+	"io"
+	"log"
+	"strings"
+)
+
+func StartWithUi(comm Communicator, ui Ui, r *RemoteCmd) error {
+	if r.Stdout != nil || r.Stderr != nil {
+		log.Printf("not logging remote command: %s", r.Command)
+		return comm.Start(r)
+	}
+
+	// Setup the remote command
+	stdout_r, stdout_w := io.Pipe()
+	stderr_r, stderr_w := io.Pipe()
+
+	r.Stdout = stdout_w
+	r.Stderr = stderr_w
+
+	if err := comm.Start(r); err != nil {
+		return err
+	}
+
+	exitChan := make(chan int, 1)
+	stdoutChan := iochan.DelimReader(stdout_r, '\n')
+	stderrChan := iochan.DelimReader(stderr_r, '\n')
+
+	go func() {
+		defer stdout_w.Close()
+		defer stderr_w.Close()
+
+		r.Wait()
+		exitChan <- r.ExitStatus
+	}()
+
+OutputLoop:
+	for {
+		select {
+		case output := <-stderrChan:
+			ui.Message(strings.TrimSpace(output))
+		case output := <-stdoutChan:
+			ui.Message(strings.TrimSpace(output))
+		case exitStatus := <-exitChan:
+			log.Printf("command exited with status %d", exitStatus)
+
+			if exitStatus != 0 {
+				err := fmt.Errorf("command exited with non-zero exit status: %d", exitStatus)
+				return err
+			}
+
+			break OutputLoop
+		}
+	}
+
+	// Make sure we finish off stdout/stderr because we may have gotten
+	// a message from the exit channel first.
+	for output := range stdoutChan {
+		ui.Message(output)
+	}
+
+	for output := range stderrChan {
+		ui.Message(output)
+	}
+
+	return nil
+}

--- a/packer/communicator_ui_test.go
+++ b/packer/communicator_ui_test.go
@@ -1,0 +1,72 @@
+package packer
+
+import (
+	"cgl.tideland.biz/asserts"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+)
+
+type StubCommunicator struct {
+}
+
+func (c *StubCommunicator) Start(r *RemoteCmd) error {
+	go func() {
+		io.WriteString(r.Stdout, r.Command)
+	}()
+	return nil
+}
+
+func (c *StubCommunicator) Upload(f string, r io.Reader) error {
+	return nil
+}
+
+func (c *StubCommunicator) Download(f string, w io.Writer) error {
+	return nil
+}
+
+type StubUi struct {
+	Messaged bool
+}
+
+func (u *StubUi) Ask(query string) (string, error) {
+	return "", nil
+}
+
+func (u *StubUi) Say(message string) {
+}
+
+func (u *StubUi) Message(message string) {
+	u.Messaged = true
+}
+
+func (u *StubUi) Error(message string) {
+}
+
+func Test_StartWithUi(t *testing.T) {
+	assert := asserts.NewTestingAsserts(t, true)
+
+	cmd := RemoteCmd{Command: "hi"}
+	var comm StubCommunicator
+	var ui StubUi
+
+	result := make(chan bool)
+	go func() {
+		if err := StartWithUi(&comm, &ui, &cmd); err != nil {
+			err := fmt.Errorf("Unexpected error: %s", err)
+			t.Fatal(err)
+		}
+		result <- true
+	}()
+
+	cmd.ExitStatus = 0
+	cmd.Exited = true
+
+	select {
+	case <-result:
+		assert.True(ui.Messaged, "should have written a message")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("never got exit notification")
+	}
+}

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -7,10 +7,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/mitchellh/iochan"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mitchellh/packer/packer"
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -221,59 +219,12 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		t := template.Must(template.New("command").Parse(p.config.ExecuteCommand))
 		t.Execute(&command, &ExecuteCommandTemplate{flattendVars, p.config.RemotePath})
 
-		// Setup the remote command
-		stdout_r, stdout_w := io.Pipe()
-		stderr_r, stderr_w := io.Pipe()
-
-		var cmd packer.RemoteCmd
-		cmd.Command = command.String()
-		cmd.Stdout = stdout_w
-		cmd.Stderr = stderr_w
-
+		cmd := &packer.RemoteCmd{Command: command.String()}
 		log.Printf("Executing command: %s", cmd.Command)
-		err = comm.Start(&cmd)
+
+		err = packer.StartWithUi(comm, ui, cmd)
 		if err != nil {
 			return fmt.Errorf("Failed executing command: %s", err)
-		}
-
-		exitChan := make(chan int, 1)
-		stdoutChan := iochan.DelimReader(stdout_r, '\n')
-		stderrChan := iochan.DelimReader(stderr_r, '\n')
-
-		go func() {
-			defer stdout_w.Close()
-			defer stderr_w.Close()
-
-			cmd.Wait()
-			exitChan <- cmd.ExitStatus
-		}()
-
-	OutputLoop:
-		for {
-			select {
-			case output := <-stderrChan:
-				ui.Message(strings.TrimSpace(output))
-			case output := <-stdoutChan:
-				ui.Message(strings.TrimSpace(output))
-			case exitStatus := <-exitChan:
-				log.Printf("shell provisioner exited with status %d", exitStatus)
-
-				if exitStatus != 0 {
-					return fmt.Errorf("Script exited with non-zero exit status: %d", exitStatus)
-				}
-
-				break OutputLoop
-			}
-		}
-
-		// Make sure we finish off stdout/stderr because we may have gotten
-		// a message from the exit channel first.
-		for output := range stdoutChan {
-			ui.Message(output)
-		}
-
-		for output := range stderrChan {
-			ui.Message(output)
 		}
 	}
 


### PR DESCRIPTION
This is more of a review request to get some feedback.

Currently, there are a few different paths to executing commands on VMs via SSH... there's at least:
1. the shell provisioner does
2. the shutdown step in the VirtualBox provisioner
3. the shutdown steps in the VMware provisioner

1 and 3 log output in different ways, 2 did not at all. I was trying to debug a not-shutting-down shutdown command in VirtualBox so I made the change below to try and capture that.

Questions I had (Go-style aside):
- should the communicator/ui link be part of communicator directly, as a peer to Start? Not sure if you want to link the communicator and ui classes.
- What to name the method? I called it StartWithUi but it also Wait()s so that's not entirely accurate
- Should the VMware shutdown step be changed to act like this? (It currently writes to a byte buffer).

As always, new to Go, so any style comments welcome. Thanks.

---

We may want to capture the output of commands in multiple
places, not just the shell provisioner. In particular, it may
be helpful in debugging shutdown commands.

Extract logic from provisioner to capture SSH output with a pipe
and place it in new StartWithUi command that connects the communicator
to the ui.

Replace the virtualbox shutdown command with an appropriate call.
