### PR TITLE
builder/v*: Include path to output dir in error

### DIFF
--- a/builder/virtualbox/builder.go
+++ b/builder/virtualbox/builder.go
@@ -242,7 +242,7 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 		if _, err := os.Stat(b.config.OutputDir); err == nil {
 			errs = packer.MultiErrorAppend(
 				errs,
-				errors.New("Output directory already exists. It must not exist."))
+				fmt.Errorf("Output directory '%s' already exists. It must not exist.", b.config.OutputDir))
 		}
 	}
 

--- a/builder/vmware/builder.go
+++ b/builder/vmware/builder.go
@@ -195,7 +195,7 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 		if _, err := os.Stat(b.config.OutputDir); err == nil {
 			errs = packer.MultiErrorAppend(
 				errs,
-				errors.New("Output directory already exists. It must not exist."))
+				fmt.Errorf("Output directory '%s' already exists. It must not exist.", b.config.OutputDir))
 		}
 	}
 


### PR DESCRIPTION
This is a simple change to facilitate debugging (e.g., if you set names on builders).
