### PR TITLE
Add special keys for backspace, delete and F1-F12

### DIFF
--- a/builder/virtualbox/step_type_boot_command.go
+++ b/builder/virtualbox/step_type_boot_command.go
@@ -91,8 +91,22 @@ func (*stepTypeBootCommand) Cleanup(map[string]interface{}) {}
 
 func scancodes(message string) []string {
 	special := make(map[string][]string)
+	special["<backspace>"] = []string{"ff", "08"}
+	special["<delete>"] = []string{"ff", "ff"}
 	special["<enter>"] = []string{"1c", "9c"}
 	special["<esc>"] = []string{"01", "81"}
+	special["<f1>"] = []string{"ff", "be"}
+	special["<f2>"] = []string{"ff", "bf"}
+	special["<f3>"] = []string{"ff", "c0"}
+	special["<f4>"] = []string{"ff", "c1"}
+	special["<f5>"] = []string{"ff", "c2"}
+	special["<f6>"] = []string{"ff", "c3"}
+	special["<f7>"] = []string{"ff", "c4"}
+	special["<f8>"] = []string{"ff", "c5"}
+	special["<f9>"] = []string{"ff", "c6"}
+	special["<f10>"] = []string{"ff", "c7"}
+	special["<f11>"] = []string{"ff", "c8"}
+	special["<f12>"] = []string{"ff", "c9"}
 	special["<return>"] = []string{"1c", "9c"}
 	special["<tab>"] = []string{"0f", "8f"}
 

--- a/builder/vmware/step_type_boot_command.go
+++ b/builder/vmware/step_type_boot_command.go
@@ -95,8 +95,22 @@ func (*stepTypeBootCommand) Cleanup(map[string]interface{}) {}
 
 func vncSendString(c *vnc.ClientConn, original string) {
 	special := make(map[string]uint32)
+	special["<backspace>"] = 0xFF08
+	special["<delete>"] = 0xFFFF
 	special["<enter>"] = 0xFF0D
 	special["<esc>"] = 0xFF1B
+	special["<f1>"] = 0xFFBE
+	special["<f2>"] = 0xFFBF
+	special["<f3>"] = 0xFFC0
+	special["<f4>"] = 0xFFC1
+	special["<f5>"] = 0xFFC2
+	special["<f6>"] = 0xFFC3
+	special["<f7>"] = 0xFFC4
+	special["<f8>"] = 0xFFC5
+	special["<f9>"] = 0xFFC6
+	special["<f10>"] = 0xFFC7
+	special["<f11>"] = 0xFFC8
+	special["<f12>"] = 0xFFC9
 	special["<return>"] = 0xFF0D
 	special["<tab>"] = 0xFF09
 


### PR DESCRIPTION
I started working on a packer template for OmniOS and needed F2 and backspace to navigate the installer. I added the additional function keys and delete in the interest of completeness. I considered shortening "backspace" to "bs" and "delete" to "del", but opted for verbosity. @mitchellh, if you'd prefer shorter versions, a la "esc", let me know and I'll update the PR.
