### PR TITLE
Fixes for running on windows

### DIFF
--- a/builder/virtualbox/driver.go
+++ b/builder/virtualbox/driver.go
@@ -50,6 +50,9 @@ func (d *VBox42Driver) IsRunning(name string) (bool, error) {
 	}
 
 	for _, line := range strings.Split(stdout.String(), "\n") {
+		// Need to trim off CR character when running in windows
+		line = strings.TrimRight(line, "\r");
+
 		if line == `VMState="running"` {
 			return true, nil
 		}

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -130,6 +130,11 @@ func (c *comm) Upload(path string, input io.Reader) error {
 	target_dir := filepath.Dir(path)
 	target_file := filepath.Base(path)
 
+	// On windows, filepath.Dir uses backslash seperators (ie. "\tmp").
+	// This does not work when the target host is unix.  Switch to forward slash
+	// which works for unix and windows
+	target_dir = filepath.ToSlash(target_dir)
+
 	// Start the sink mode on the other side
 	// TODO(mitchellh): There are probably issues with shell escaping the path
 	log.Println("Starting remote scp process in sink mode")


### PR DESCRIPTION
When running VBoxManage in windows, the output of each line ends with a carriage return and line feed (not just a line feed).  This causes the parsing of the output in virtualbox/driver.go to malfunction and think that the VM is not running when it is, in fact, still running...which leads to more failures.

Also, in communicator/ssh/communicator.go, path/filepath is used to parse directory / filename from a path string.  When running with Windows GO, this returns backslash separators in the directory name.  For example, filepath.Dir("/tmp/script.sh") returns "\tmp".  When uploading to a unix target host, this does not work.  I fixed this by converting separator characters in the directory to forward slash via a call to filepath.ToSlash().
