### PR TITLE
Added IAM Instance Profile support

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -10,15 +10,16 @@ import (
 // RunConfig contains configuration for running an instance from a source
 // AMI and details on how to access that launched image.
 type RunConfig struct {
-	Region          string
-	SourceAmi       string `mapstructure:"source_ami"`
-	InstanceType    string `mapstructure:"instance_type"`
-	RawSSHTimeout   string `mapstructure:"ssh_timeout"`
-	SSHUsername     string `mapstructure:"ssh_username"`
-	SSHPort         int    `mapstructure:"ssh_port"`
-	SecurityGroupId string `mapstructure:"security_group_id"`
-	SubnetId        string `mapstructure:"subnet_id"`
-	VpcId           string `mapstructure:"vpc_id"`
+	Region             string
+	SourceAmi          string `mapstructure:"source_ami"`
+	InstanceType       string `mapstructure:"instance_type"`
+	RawSSHTimeout      string `mapstructure:"ssh_timeout"`
+	SSHUsername        string `mapstructure:"ssh_username"`
+	SSHPort            int    `mapstructure:"ssh_port"`
+	SecurityGroupId    string `mapstructure:"security_group_id"`
+	IamInstanceProfile string `mapstructure:"iam_instance_profile"`
+	SubnetId           string `mapstructure:"subnet_id"`
+	VpcId              string `mapstructure:"vpc_id"`
 
 	// Unexported fields that are calculated from others
 	sshTimeout time.Duration

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -12,6 +12,7 @@ type StepRunSourceInstance struct {
 	ExpectedRootDevice string
 	InstanceType       string
 	SourceAMI          string
+	IamInstanceProfile string
 	SubnetId           string
 
 	instance *ec2.Instance
@@ -24,13 +25,14 @@ func (s *StepRunSourceInstance) Run(state map[string]interface{}) multistep.Step
 	ui := state["ui"].(packer.Ui)
 
 	runOpts := &ec2.RunInstances{
-		KeyName:        keyName,
-		ImageId:        s.SourceAMI,
-		InstanceType:   s.InstanceType,
-		MinCount:       0,
-		MaxCount:       0,
-		SecurityGroups: []ec2.SecurityGroup{ec2.SecurityGroup{Id: securityGroupId}},
-		SubnetId:       s.SubnetId,
+		KeyName:            keyName,
+		ImageId:            s.SourceAMI,
+		InstanceType:       s.InstanceType,
+		MinCount:           0,
+		MaxCount:           0,
+		SecurityGroups:     []ec2.SecurityGroup{ec2.SecurityGroup{Id: securityGroupId}},
+		IamInstanceProfile: s.IamInstanceProfile,
+		SubnetId:           s.SubnetId,
 	}
 
 	ui.Say("Launching a source AWS instance...")

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -98,6 +98,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ExpectedRootDevice: "ebs",
 			InstanceType:       b.config.InstanceType,
 			SourceAMI:          b.config.SourceAmi,
+			IamInstanceProfile: b.config.IamInstanceProfile,
 			SubnetId:           b.config.SubnetId,
 		},
 		&common.StepConnectSSH{


### PR DESCRIPTION
Adds IAM Instance Profile (IIP) support to packer AWS/ebs.  Example config:

{
  "builders": [{
    "type": "amazon-ebs",
    "region": "us-west-1",
    "source_ami": "ami-12345678",
    "iam_instance_profile": "my_iam_role",
    "instance_type": "t1.micro",
    "ssh_username": "ec2-user",
    "ami_name": "packer-test"
  }]
}

Also requires modification to michellh/amz/ec2/ec2.go
