### PR TITLE
Handle missing source AMI error

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -41,6 +41,10 @@ func (s *StepRunSourceInstance) Run(state map[string]interface{}) multistep.Step
 		state["error"] = fmt.Errorf("There was a problem with the source AMI: %s", err)
 		return multistep.ActionHalt
 	}
+	if len(imageResp.Images) != 1 {
+		state["error"] = fmt.Errorf("The source AMI '%s' could not be found.", s.SourceAMI)
+		return multistep.ActionHalt
+	}
 
 	if s.ExpectedRootDevice != "" && imageResp.Images[0].RootDeviceType != s.ExpectedRootDevice {
 		state["error"] = fmt.Errorf(


### PR DESCRIPTION
Specifying a non-existent source AMI will result in an empty array of
images in the response which would cause an "index out of range" panic.
This change handles this case more gracefully with an error message.
