### PR TITLE
Fix URL and Relative Windows file path support #235/#239

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-  "runtime"
+	"runtime"
 	"sort"
 	"strings"
 )
@@ -74,11 +74,11 @@ func DownloadableURL(original string) (string, error) {
 	}
 
 	if url.Scheme == "file" {
-    // For Windows absolute file paths, remove leading /
-    // prior to processing
-    if runtime.GOOS == "windows" && url.Path[0] == '/' {
-      url.Path = url.Path[1:len(url.Path)]
-    }
+		// For Windows absolute file paths, remove leading /
+		// prior to processing
+		if runtime.GOOS == "windows" && url.Path[0] == '/' {
+			url.Path = url.Path[1:len(url.Path)]
+		}
 
 		if _, err := os.Stat(url.Path); err != nil {
 			return "", err

--- a/common/download.go
+++ b/common/download.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-  "runtime"
+	"runtime"
 )
 
 // DownloadConfig is the configuration given to instantiate a new
@@ -107,13 +107,13 @@ func (d *DownloadClient) Get() (string, error) {
 	// Files when we don't copy the file are special cased.
 	var finalPath string
 	if url.Scheme == "file" && !d.config.CopyFile {
-    // Remove forward slash on absolute Windows file URLs
-    // Before processing
+		// Remove forward slash on absolute Windows file URLs
+		// Before processing
 		if runtime.GOOS == "windows" && url.Path[0] == '/' {
-      finalPath = url.Path[1:len(url.Path)]
-    } else {
-      finalPath = url.Path
-    }
+			finalPath = url.Path[1:len(url.Path)]
+		} else {
+			finalPath = url.Path
+		}
 	} else {
 		finalPath = d.config.TargetPath
 


### PR DESCRIPTION
Address all of #235 and the portion of #239 dealing with URLs including a properly formed `file://` schema. 

Based on the nature of this behavior, I'm not sure if any clear way to add tests to verify this behavior to make the verification more robust. There is currently a failing test in `common/config_test.go` when comparing the file URL generated against a custom built URL string because of the mismatch of the Windows file path separators.

/cc @rasa
