### PR TITLE
Add documentation on installing through Homebrew

### DIFF
--- a/website/source/docs/installation.html.markdown
+++ b/website/source/docs/installation.html.markdown
@@ -50,3 +50,18 @@ environmental variable was not setup properly. Please go back and ensure
 that your PATH variable contains the directory which has Packer installed.
 
 Otherwise, Packer is installed and you're ready to go!
+
+## Alternative Installation Methods
+
+While the binary packages is the only official method of installation, there
+are alternatives available.
+
+### Homebrew
+
+If you're using OS X and [Homebrew](http://brew.sh), you can install Packer by
+adding the `binary` tap:
+
+```
+$ brew tap homebrew/binary
+$ brew install packer
+```

--- a/website/source/intro/getting-started/setup.html.markdown
+++ b/website/source/intro/getting-started/setup.html.markdown
@@ -53,3 +53,18 @@ environment variable was not setup properly. Please go back and ensure
 that your PATH variable contains the directory which has Packer installed.
 
 Otherwise, Packer is installed and you're ready to go!
+
+## Alternative Installation Methods
+
+While the binary packages is the only official method of installation, there
+are alternatives available.
+
+### Homebrew
+
+If you're using OS X and [Homebrew](http://brew.sh), you can install Packer by
+adding the `binary` tap:
+
+```
+$ brew tap homebrew/binary
+$ brew install packer
+```


### PR DESCRIPTION
This adds documentation about installing using Homebrew as suggested in #227.

I'm not 100% sure on the copy, please let me know if you have any suggestions on how to improve it.

This is what it looks like rendered:

![install packer - packer 2013-08-03 16-49-01](https://f.cloud.github.com/assets/24421/906371/46ad9b34-fc97-11e2-9cd0-3470f6197b9c.png)
