### PR TITLE
Update packer.go to remove redundant cleanup.

### DIFF
--- a/packer.go
+++ b/packer.go
@@ -101,7 +101,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	plugin.CleanupClients()
 	os.Exit(exitCode)
 }
 


### PR DESCRIPTION
It seems that later a commit was added to use golang #defer for this method (line 79). This seems like the right approach to me.
