### PR TITLE
Update packer.go to cleanup plugin clients on exit. 

### DIFF
--- a/packer.go
+++ b/packer.go
@@ -90,6 +90,7 @@ func main() {
 	env, err := packer.NewEnvironment(envConfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Packer initialization error: \n\n%s\n", err)
+		plugin.CleanupClients()
 		os.Exit(1)
 	}
 
@@ -98,6 +99,7 @@ func main() {
 	exitCode, err := env.Cli(os.Args[1:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error executing CLI: %s\n", err.Error())
+		plugin.CleanupClients()
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Since defer does not fire when exiting the application with os.Exit we need to be sure that we cleanup all of the clients on failures from the CLI and creating a new environment object.
