### PR TITLE
Warn that ec2-bundle-vol may ignore some important files

### DIFF
--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -151,6 +151,14 @@ the section above for more information on what environmental variables Packer
 will look for.
 </div>
 
+<div class="alert alert-block">
+  <strong>Warning!</strong> Some versions of ec2-bundle-vol silently
+ignore all .pem and .gpg files during the bundling of the AMI, which can
+cause problems on some systems, for example Ubuntu. You may want to
+customize the bundle volume command with `bundle_vol_command` to include
+those files (see the `--no-filter` option of `ec2-bundle-vol`).
+</div>
+
 ## AMI Name Variables
 
 The AMI name specified by the `ami_name` configuration variable is actually


### PR DESCRIPTION
I discovered that the version of ec2-bundle-vol packaged in Ubuntu 13.04 (and, according to online information, previous Ubuntu versions as well) will silently ignore any .gpg and .pem files.

This is done for security purposes, but it is a problem because it drops all files in /etc/ssl and /use/share/keyrings. Consequently, an Ubuntu image created with the default ec2-bundle-vol command will fail to validate signed packages (because the Ubuntu public key has disappeared).

Warn about this issue and suggest the use of the --no-filter option.

Alternatively this could be made the default and users with sensitive files should customize the bundle volume command to exclude them.
