### PR TITLE
Added support for setting attributes on the AMI

### DIFF
--- a/builder/amazon/common/step_modify_attributes.go
+++ b/builder/amazon/common/step_modify_attributes.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"fmt"
+	"github.com/mitchellh/goamz/ec2"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+)
+
+type StepModifyAttributes struct {
+	Users        []string
+	Groups       []string
+	ProductCodes []string
+	Description  string
+}
+
+func (s *StepModifyAttributes) Run(state map[string]interface{}) multistep.StepAction {
+	ec2conn := state["ec2"].(*ec2.EC2)
+	ui := state["ui"].(packer.Ui)
+	amis := state["amis"].(map[string]string)
+	ami := amis[ec2conn.Region.Name]
+
+	if s.Description != "" {
+		ui.Say(fmt.Sprintf("Setting Description of AMI (%s) to '%s'...", ami, s.Description))
+		_, err := ec2conn.ModifyImageAttribute(ami, &ec2.ModifyImageAttribute{
+			Attribute:   ec2.DescriptionAttribute,
+			Description: s.Description,
+		})
+		if err != nil {
+			err := fmt.Errorf("Error setting Description of AMI (%s): %s", ami, err)
+			state["error"] = err
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	if len(s.Users) > 0 || len(s.Groups) > 0 {
+		ui.Say(fmt.Sprintf("Setting Launch Permissions for AMI (%s)...", ami))
+		_, err := ec2conn.ModifyImageAttribute(ami, &ec2.ModifyImageAttribute{
+			Attribute: ec2.LaunchPermissionAttribute,
+			Operation: ec2.LaunchPermissionAdd,
+			Users:     s.Users,
+			Groups:    s.Groups,
+		})
+		if err != nil {
+			err := fmt.Errorf("Error setting Launch Permissions for AMI (%s): %s", ami, err)
+			state["error"] = err
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	if len(s.ProductCodes) > 0 {
+		ui.Say(fmt.Sprintf("Setting Product Code(s) for AMI (%s)...", ami))
+		_, err := ec2conn.ModifyImageAttribute(ami, &ec2.ModifyImageAttribute{
+			Attribute:    ec2.ProductCodeAttribute,
+			ProductCodes: s.ProductCodes,
+		})
+		if err != nil {
+			err := fmt.Errorf("Error setting Product Code(s) for AMI (%s): %s", ami, err)
+			state["error"] = err
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepModifyAttributes) Cleanup(state map[string]interface{}) {
+	// No cleanup...
+}

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -28,6 +28,11 @@ type config struct {
 	// Configuration of the resulting AMI
 	AMIName string `mapstructure:"ami_name"`
 
+	// AMI attributes
+	AMIDescription string   `mapstructure:"ami_description"`
+	AMIUsers       []string `mapstructure:"ami_users"`
+	AMIGroups      []string `mapstructure:"ami_groups"`
+
 	// Tags for the AMI
 	Tags map[string]string
 }
@@ -112,6 +117,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&stepStopInstance{},
 		&stepCreateAMI{},
 		&awscommon.StepCreateTags{Tags: b.config.Tags},
+		&awscommon.StepModifyAttributes{
+			Description: b.config.AMIDescription,
+			Users:       b.config.AMIUsers,
+			Groups:      b.config.AMIGroups,
+		},
 	}
 
 	// Run!

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -37,6 +37,12 @@ type Config struct {
 	X509CertPath        string `mapstructure:"x509_cert_path"`
 	X509KeyPath         string `mapstructure:"x509_key_path"`
 	X509UploadPath      string `mapstructure:"x509_upload_path"`
+
+	// AMI attributes
+	AMIDescription  string   `mapstructure:"ami_description"`
+	AMIUsers        []string `mapstructure:"ami_users"`
+	AMIGroups       []string `mapstructure:"ami_groups"`
+	AMIProductCodes []string `mapstructure:"ami_product_codes"`
 }
 
 type Builder struct {
@@ -178,6 +184,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepUploadBundle{},
 		&StepRegisterAMI{},
 		&awscommon.StepCreateTags{Tags: b.config.Tags},
+		&awscommon.StepModifyAttributes{
+			Description:  b.config.AMIDescription,
+			Users:        b.config.AMIUsers,
+			Groups:       b.config.AMIGroups,
+			ProductCodes: b.config.AMIProductCodes,
+		},
 	}
 
 	// Run!


### PR DESCRIPTION
Added a new amazon/common step for modifying ami attributes (ModifyImageAttribute). The main purpose is for authorizing an AMI after it's been created.  This change is contingent on this pull request: https://github.com/mitchellh/goamz/pull/6

Example ebs config:

``` json
{
  "type": "amazon-ebs",
  "region": "us-east-1",
  "source_ami": "ami-de0d9eb7",
  "instance_type": "t1.micro",
  "ssh_username": "ubuntu",
  "ami_name": "packer-quick-start {{.CreateTime}}",
  "ami_description": "My Description",
  "ami_users": ["444455556666", "444455556667"]
}
```

Example instance config:

``` json
{
  "type": "amazon-instance",
  "region": "us-east-1",
  "source_ami": "ami-de0d9eb7",
  "instance_type": "t1.micro",
  "ssh_username": "ubuntu",
  "ami_name": "packer-quick-start {{.CreateTime}}",
  "ami_description": "My Description",
  "ami_groups": ["all"],
  "ami_product_codes": ["123456789"]
}
```
