### PR TITLE
Log error messages from goamz.

### DIFF
--- a/builder/amazon/common/instance.go
+++ b/builder/amazon/common/instance.go
@@ -36,6 +36,7 @@ func InstanceStateRefreshFunc(conn *ec2.EC2, i *ec2.Instance) StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.Instances([]string{i.InstanceId}, ec2.NewFilter())
 		if err != nil {
+			log.Printf("Error on InstanceStateRefresh: %s", err)
 			return nil, "", err
 		}
 


### PR DESCRIPTION
Helps debug issues with the EC2 api. For example, RequestLimitReached exceptions. Right now this sets the error message to nil, then returns. This will log before doing so.
