### PR TITLE
Salt masterless provisionner is  missing an option to upload a specific minion.conf

### DIFF
--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -2,6 +2,7 @@ package saltmasterless
 
 import (
 	"github.com/mitchellh/packer/packer"
+	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -43,6 +44,29 @@ func TestProvisionerPrepare_InvalidKey(t *testing.T) {
 	err := p.Prepare(config)
 	if err == nil {
 		t.Fatal("should have error")
+	}
+}
+
+func TestProvisionerPrepare_MinionConfig(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	config["minion_config"] = "/i/dont/exist/i/think"
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	tf, err := ioutil.TempFile("", "minion")
+	if err != nil {
+		t.Fatalf("error tempfile: %s", err)
+	}
+	defer os.Remove(tf.Name())
+
+	config["minion_config"] = tf.Name()
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
 	}
 }
 

--- a/website/source/docs/provisioners/salt.html.markdown
+++ b/website/source/docs/provisioners/salt.html.markdown
@@ -45,3 +45,7 @@ Optional:
 
 * `temp_config_dir` (string) - Where your local state tree will be copied
   before moving to the `/srv/salt` directory. Default is `/tmp/salt`.
+
+* `minion_config` (string) - The path to your local
+  [minion config](http://docs.saltstack.com/topics/configuration.html).
+  This will be uploaded to the `/etc/salt` on the remote.


### PR DESCRIPTION
The minion.conf is the core configuration for salt stack node, for now the default one set by the bootstrap is used.

I thought initially that I could be sorting things out by using the file provisioner but at this stage the bootstrap hasn't been done and after it's too late.

I check the source and it seem straightforward to add. I will look to attach a PR to this issue.

If there is any question about this issues, let me know but I may delay a bit to answer as I'm living on the GMT/London.
