### PR TITLE
Was missing sending IAM profile data to instance store builders.

### DIFF
--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -193,6 +193,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepRunSourceInstance{
 			ExpectedRootDevice: "instance-store",
 			InstanceType:       b.config.InstanceType,
+			IamInstanceProfile: b.config.IamInstanceProfile,
 			UserData:           b.config.UserData,
 			UserDataFile:       b.config.UserDataFile,
 			SourceAMI:          b.config.SourceAmi,


### PR DESCRIPTION
Simple bug. We send IAM data in the EBS builder, but forget to set it in the instance-store builder.
