### PR TITLE
website: generate toc data for linking into headers

### DIFF
--- a/website/config.rb
+++ b/website/config.rb
@@ -45,7 +45,9 @@ set :images_dir, 'images'
 
 # Use the RedCarpet Markdown engine
 set :markdown_engine, :redcarpet
-set :markdown, :fenced_code_blocks => true
+set :markdown,
+    :fenced_code_blocks => true,
+    :with_toc_data => true
 
 # Build-specific configuration
 configure :build do


### PR DESCRIPTION
This adds ids to headers, so you can deep link, which will help when linking people into the documentation.

A note: redcarpet just added an awesome feature that makes the
anchor links human readable. i.e `shell-provisioner` instead of `toc_0`, as it will be as of this pull. See the redcarpet [changelog](https://github.com/vmg/redcarpet/blob/master/CHANGELOG.md#changelog). It's not yet released, but when it is we should upgrade to that, ya!
