### PR TITLE
packer/plugin: confirm cleanup at first signal received

### DIFF
--- a/signal.go
+++ b/signal.go
@@ -20,6 +20,8 @@ func setupSignalHandlers(env packer.Environment) {
 		<-ch
 		log.Println("First interrupt. Ignoring to allow plugins to clean up.")
 
+		env.Ui().Error("Interrupt signal received. Cleaning up...")
+
 		// Second interrupt. Go down hard.
 		<-ch
 		log.Println("Second interrupt. Exiting now.")


### PR DESCRIPTION
Although I "knew" packer was getting my ctrl-c's, I figured for people less intimately familiar with its behavior that it'd be good to confirm that the signal was received, and that a cleanup is occurring, or will occur. I found in certain steps that the UI feedback from the builder-implemented cleanup would occur after that previous step finished running – this would lead to some time of no UI feedback, even after a ctrl-c was sent.
