### PR TITLE
Check also for updated deps (so I can successfully make after a git pull)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: deps
 
 deps:
 	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
-	@go get -d -v ./...
+	@go get -d -v -u ./...
 	@go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | xargs -n1 go get -d
 
 clean:


### PR DESCRIPTION
I was getting build errors and this patch, to update dependencies (go get -u) if they exist, fixed it :)

```
$ make
==> Installing dependencies
==> Building
--> Installing dependencies to speed up builds...
# github.com/mitchellh/packer/builder/amazon/common
builder/amazon/common/step_ami_region_copy.go:32: regionconn.CopyImage undefined (type *ec2.EC2 has no field or method CopyImage)
builder/amazon/common/step_ami_region_copy.go:32: undefined: ec2.CopyImage
make: *** [all] Error 2
```
