### PR TITLE
Actual md5sum as Ubuntu Hashesh webpage is out of date.

### DIFF
--- a/website/source/docs/builders/virtualbox.html.markdown
+++ b/website/source/docs/builders/virtualbox.html.markdown
@@ -25,7 +25,7 @@ Ubuntu to self-install. Still, the example serves to show the basic configuratio
   "type": "virtualbox",
   "guest_os_type": "Ubuntu_64",
   "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.3-server-amd64.iso",
-  "iso_checksum": "7d335ca541fc4945b674459cde7bffb9",
+  "iso_checksum": "2cbe868812a871242cdcdd8f2fd6feb9",
   "iso_checksum_type": "md5",
   "ssh_username": "packer",
   "ssh_wait_timeout": "30s",


### PR DESCRIPTION
As mentioned in [PR342](https://github.com/mitchellh/packer/pull/342), the [Ubuntu Hashes](https://help.ubuntu.com/community/UbuntuHashes) page was not updated for the Ubuntu 12.04.3 release. This updates the checksum to the correctly calculated value.
