### PR TITLE
Fix incorrect config key for staging directory

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -25,7 +25,7 @@ type Config struct {
 	PreventSudo         bool     `mapstructure:"prevent_sudo"`
 	RunList             []string `mapstructure:"run_list"`
 	SkipInstall         bool     `mapstructure:"skip_install"`
-	StagingDir          string   `mapstructure:"staging_directory"`
+	StagingDir          string   `mapstructure:"staging_dir"`
 
 	tpl *packer.ConfigTemplate
 }


### PR DESCRIPTION
I assume `staging_dir` was intended based on its use in `Prepare` and in the documentation.
