### PR TITLE
If no image is generated, just return nil for the Openstack provider

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -112,6 +112,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, rawErr.(error)
 	}
 
+	// If there are no images, then just return
+	if _, ok := state.GetOk("image"); !ok {
+		return nil, nil
+	}
+
 	// Build the artifact and return it
 	artifact := &Artifact{
 		ImageId:        state.Get("image").(string),


### PR DESCRIPTION
This mirrors what is done in other providers e.g. Amazon providers
