### PR TITLE
Add details about allowed provisioner values

### DIFF
--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -37,7 +37,8 @@ Required:
 
 * `provider` (string) - The provider used to connect to the OpenStack service.
   If not specified, Packer will attempt to read this from the
-  `SDK_PROVIDER` environment variable.
+  `SDK_PROVIDER` environment variable. Currently the options supported are
+  `rackspace-us` or `rackspace-uk`. 
 
 * `source_image` (string) - The ID or full URL to the base image to use.
   This is the image that will be used to launch a new server and provision it.


### PR DESCRIPTION
Currently gophercloud only accepts `rackspace-us` or `rackspace-uk` as provider values[1] although there is a pull request to allow arbitrary endpoints[2]

[1](https://github.com/rackspace/gophercloud/blob/master/global_context.go#L14)
[2](https://github.com/rackspace/gophercloud/pull/84)
