### PR TITLE
Increase default SSH timeout for OpenStack from 1m -> 5m

### DIFF
--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -39,7 +39,7 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 	}
 
 	if c.RawSSHTimeout == "" {
-		c.RawSSHTimeout = "1m"
+		c.RawSSHTimeout = "5m"
 	}
 
 	// Validation


### PR DESCRIPTION
Many cloud providers have a minimum charge of 1 hour, and if there are DNS problems we can hit the 1 minute timeout easily.

Waiting five minutes gives more of a margin of error.
