### PR TITLE
Allow project to be specified for openstack

### DIFF
--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -40,8 +40,11 @@ func (c *AccessConfig) Auth() (gophercloud.AccessProvider, error) {
 	authoptions := gophercloud.AuthOptions{
 		Username:    username,
 		Password:    password,
-		TenantName:  project,
 		AllowReauth: true,
+	}
+
+	if project != "" {
+		authoptions.TenantName = project
 	}
 
 	return gophercloud.Authenticate(provider, authoptions)


### PR DESCRIPTION
For some OpenStack providers, the project must be specified to get a non-empty service catalog.

I think that (according to the spec) the project is actually required, but some implementations don't require it (e.g. Rackspace Cloud)
