### PR TITLE
Allow customization of SSH Key pair pattern

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -22,6 +22,7 @@ type RunConfig struct {
 	SecurityGroupId    string `mapstructure:"security_group_id"`
 	SubnetId           string `mapstructure:"subnet_id"`
 	VpcId              string `mapstructure:"vpc_id"`
+	SSHKeyPairPattern  string `mapstructure:"ssh_keypair_pattern"`
 
 	// Unexported fields that are calculated from others
 	sshTimeout time.Duration
@@ -43,6 +44,10 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 
 	if c.RawSSHTimeout == "" {
 		c.RawSSHTimeout = "1m"
+	}
+
+	if c.SSHKeyPairPattern == "" {
+		c.SSHKeyPairPattern = "packer %s"
 	}
 
 	// Validation

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -126,3 +126,24 @@ func TestRunConfigPrepare_UserDataFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestRunConfigPrepare_SSHKeyPairPattern(t *testing.T) {
+	c := testConfig()
+	c.SSHKeyPairPattern = ""
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c.SSHKeyPairPattern != "packer %s" {
+		t.Fatalf("invalid value: %s", c.SSHKeyPairPattern)
+	}
+
+	c.SSHKeyPairPattern = "valid-%s"
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c.SSHKeyPairPattern != "valid-%s" {
+		t.Fatalf("invalid value: %s", c.SSHKeyPairPattern)
+	}
+}

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -13,8 +13,9 @@ import (
 )
 
 type StepKeyPair struct {
-	Debug        bool
-	DebugKeyPath string
+	Debug          bool
+	DebugKeyPath   string
+	KeyPairPattern string
 
 	keyName string
 }
@@ -24,7 +25,7 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Creating temporary keypair for this instance...")
-	keyName := fmt.Sprintf("packer %s", hex.EncodeToString(identifier.NewUUID().Raw()))
+	keyName := fmt.Sprintf(s.KeyPairPattern, hex.EncodeToString(identifier.NewUUID().Raw()))
 	log.Printf("temporary keypair name: %s", keyName)
 	keyResp, err := ec2conn.CreateKeyPair(keyName)
 	if err != nil {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -82,8 +82,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepKeyPair{
-			Debug:        b.config.PackerDebug,
-			DebugKeyPath: fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
+			Debug:          b.config.PackerDebug,
+			DebugKeyPath:   fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
+			KeyPairPattern: b.config.SSHKeyPairPattern,
 		},
 		&awscommon.StepSecurityGroup{
 			SecurityGroupId: b.config.SecurityGroupId,


### PR DESCRIPTION
Defined in a template using ssh_keypair_pattern. Defaults to "packer %s"

We need the ability to customize the key pair name.

This is my first time looking at Go code, I'm happy to be educated and have another crack at it! I've added a test and everything passes but that doesn't say a lot.
