### PR TITLE
Adding support for isotime template variable

### DIFF
--- a/packer/config_template.go
+++ b/packer/config_template.go
@@ -26,6 +26,7 @@ func NewConfigTemplate() (*ConfigTemplate, error) {
 
 	result.root = template.New("configTemplateRoot")
 	result.root.Funcs(template.FuncMap{
+		"isotime":   templateISOTime,
 		"timestamp": templateTimestamp,
 		"user":      result.templateUser,
 	})
@@ -78,4 +79,8 @@ func (t *ConfigTemplate) templateUser(n string) (string, error) {
 
 func templateTimestamp() string {
 	return strconv.FormatInt(time.Now().UTC().Unix(), 10)
+}
+
+func templateISOTime() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }

--- a/packer/config_template_test.go
+++ b/packer/config_template_test.go
@@ -7,6 +7,28 @@ import (
 	"time"
 )
 
+func TestConfigTemplateProcess_isotime(t *testing.T) {
+	tpl, err := NewConfigTemplate()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	result, err := tpl.Process(`{{isotime}}`, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	val, err := time.Parse(time.RFC3339, result)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	currentTime := time.Now().UTC()
+	if currentTime.Sub(val) > 2*time.Second {
+		t.Fatalf("val: %d (current: %d)", val, currentTime)
+	}
+}
+
 func TestConfigTemplateProcess_timestamp(t *testing.T) {
 	tpl, err := NewConfigTemplate()
 	if err != nil {


### PR DESCRIPTION
Uses the RFC 3339 format, much more human readable and friendly for lexical sorting.
