### PR TITLE
Minor URL typo

### DIFF
--- a/website/source/docs/provisioners/shell.html.markdown
+++ b/website/source/docs/provisioners/shell.html.markdown
@@ -59,7 +59,7 @@ Optional parameters:
   `environment_vars`, if configured.
 
 * `inline_shebang` (string) - The
-  [shebang](http://en.wikipedia.org/wiki/Shebang_(Unix)) value to use when
+  [shebang](http://en.wikipedia.org/wiki/Shebang_%28Unix%29) value to use when
   running commands specified by `inline`. By default, this is `/bin/sh`.
   If you're not using `inline`, then this configuration has no effect.
 


### PR DESCRIPTION
URLs with special characters should escape them.
