### PR TITLE
Using the vm_name parameter to name OVA/OVF files and their attachments

### DIFF
--- a/builder/virtualbox/step_export.go
+++ b/builder/virtualbox/step_export.go
@@ -50,7 +50,7 @@ func (s *stepExport) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Export the VM to an OVF
-	outputPath := filepath.Join(config.OutputDir, "packer."+config.Format)
+	outputPath := filepath.Join(config.OutputDir, vmName+"."+config.Format)
 
 	command = []string{
 		"export",

--- a/website/source/docs/builders/virtualbox.html.markdown
+++ b/website/source/docs/builders/virtualbox.html.markdown
@@ -191,7 +191,7 @@ Optional:
   By default this is ".vbox_version", which will generally upload it into
   the home directory.
 
-* `vm_name` (string) - This is the name of the VMX file for the new virtual
+* `vm_name` (string) - This is the name of the OVF file for the new virtual
   machine, without the file extension. By default this is "packer-BUILDNAME",
   where "BUILDNAME" is the name of the build.
 


### PR DESCRIPTION
The vm_name parameter is documented for VirtualBox (although it mistakenly refers to VMX files) but it is not actually applied to the filenames of the exported OVA/OVF/VMDK appliance files. This patch applies it to those file names and corrects the documentation.
