### PR TITLE
builder/amazon: add clean_ami_name template function

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -53,6 +53,7 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 		return err
 	}
 	b.config.tpl.UserVars = b.config.PackerUserVars
+	awscommon.AddAMITemplateFuncs(b.config.tpl)
 
 	// Defaults
 	if b.config.ChrootMounts == nil {

--- a/builder/amazon/common/ami_template.go
+++ b/builder/amazon/common/ami_template.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/mitchellh/packer/packer"
+	"text/template"
+)
+
+func isalphanumeric(b byte) bool {
+	if '0' <= b && b <= '9' {
+		return true
+	}
+	if 'a' <= b && b <= 'z' {
+		return true
+	}
+	if 'A' <= b && b <= 'Z' {
+		return true
+	}
+	return false
+}
+
+// Clean up AMI name by replacing invalid characters with "-"
+func cleanAMIName(s string) string {
+	allowed := []byte{'(', ')', ',', '/', '-', '_'}
+	b := []byte(s)
+	newb := make([]byte, len(b))
+	for i, c := range b {
+		if isalphanumeric(c) || bytes.IndexByte(allowed, c) != -1 {
+			newb[i] = c
+		} else {
+			newb[i] = '-'
+		}
+	}
+	return string(newb[:])
+}
+
+func templateCleanAMIName(args ...interface{}) string {
+	s, ok := "", false
+	if len(args) == 1 {
+		s, ok = args[0].(string)
+	}
+	if !ok {
+		s = fmt.Sprint(args...)
+	}
+	s = cleanAMIName(s)
+	return s
+}
+
+func AddAMITemplateFuncs(t *packer.ConfigTemplate) {
+	t.AddFuncs(template.FuncMap{
+		"clean_ami_name": templateCleanAMIName,
+	})
+}

--- a/builder/amazon/common/ami_template_test.go
+++ b/builder/amazon/common/ami_template_test.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestAMITemplatePrepare_clean(t *testing.T) {
+	origName := "AMZamz09(),/-_:&^$%"
+	expected := "AMZamz09(),/-_-----"
+
+	name := templateCleanAMIName(origName)
+
+	if name != expected {
+		t.Fatalf("template names do not match: expected %s got %s\n", expected, name)
+	}
+}

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -44,6 +44,7 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 		return err
 	}
 	b.config.tpl.UserVars = b.config.PackerUserVars
+	awscommon.AddAMITemplateFuncs(b.config.tpl)
 
 	// Accumulate any errors
 	errs := common.CheckUnusedConfig(md)

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -56,6 +56,7 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 		return err
 	}
 	b.config.tpl.UserVars = b.config.PackerUserVars
+	awscommon.AddAMITemplateFuncs(b.config.tpl)
 
 	if b.config.BundleDestination == "" {
 		b.config.BundleDestination = "/tmp"

--- a/packer/config_template.go
+++ b/packer/config_template.go
@@ -63,6 +63,11 @@ func (t *ConfigTemplate) Validate(s string) error {
 	return err
 }
 
+// Add additional functions to the template
+func (t *ConfigTemplate) AddFuncs(funcs template.FuncMap) {
+	t.root.Funcs(funcs)
+}
+
 func (t *ConfigTemplate) nextTemplateName() string {
 	name := fmt.Sprintf("tpl%d", t.i)
 	t.i++


### PR DESCRIPTION
Add a clean_ami_name template function which will translate illegal
characters in an AMI name to '-'. Example usage would be:
    "ami_name": "Ubuntu 12.04 {{isotime | clean_ami_name}}"
