### PR TITLE
FEAT: proof of concept to mound guest on windows.

### DIFF
--- a/builder/virtualbox/builder.go
+++ b/builder/virtualbox/builder.go
@@ -343,39 +343,76 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, fmt.Errorf("Failed creating VirtualBox driver: %s", err)
 	}
 
-	steps := []multistep.Step{
-		new(stepDownloadGuestAdditions),
-		&common.StepDownload{
-			Checksum:     b.config.ISOChecksum,
-			ChecksumType: b.config.ISOChecksumType,
-			Description:  "ISO",
-			ResultKey:    "iso_path",
-			Url:          b.config.ISOUrls,
-		},
-		new(stepPrepareOutputDir),
-		&common.StepCreateFloppy{
-			Files: b.config.FloppyFiles,
-		},
-		new(stepHTTPServer),
-		new(stepSuppressMessages),
-		new(stepCreateVM),
-		new(stepCreateDisk),
-		new(stepAttachISO),
-		new(stepAttachFloppy),
-		new(stepForwardSSH),
-		new(stepVBoxManage),
-		new(stepRun),
-		new(stepTypeBootCommand),
-		&common.StepConnectSSH{
-			SSHAddress:     sshAddress,
-			SSHConfig:      sshConfig,
-			SSHWaitTimeout: b.config.sshWaitTimeout,
-		},
-		new(stepUploadVersion),
-		new(stepUploadGuestAdditions),
-		new(common.StepProvision),
-		new(stepShutdown),
-		new(stepExport),
+	steps := []multistep.Step{}
+
+	if b.config.GuestOSType == "Windows7" {
+		steps = append(steps,
+			new(stepDownloadGuestAdditions),
+			&common.StepDownload{
+				Checksum:     b.config.ISOChecksum,
+				ChecksumType: b.config.ISOChecksumType,
+				Description:  "ISO",
+				ResultKey:    "iso_path",
+				Url:          b.config.ISOUrls,
+			},
+			new(stepPrepareOutputDir),
+			&common.StepCreateFloppy{
+				Files: b.config.FloppyFiles,
+			},
+			new(stepHTTPServer),
+			new(stepSuppressMessages),
+			new(stepCreateVM),
+			new(stepCreateDisk),
+			new(stepAttachISO),
+			new(stepAttachGuestISO),
+			new(stepAttachFloppy),
+			new(stepForwardSSH),
+			new(stepVBoxManage),
+			new(stepRun),
+			new(stepTypeBootCommand),
+			&common.StepConnectSSH{
+				SSHAddress:     sshAddress,
+				SSHConfig:      sshConfig,
+				SSHWaitTimeout: b.config.sshWaitTimeout,
+			},
+			new(stepUploadVersion),
+			new(common.StepProvision),
+			new(stepShutdown),
+			new(stepExport))
+	} else {
+		steps = append(steps,
+			new(stepDownloadGuestAdditions),
+			&common.StepDownload{
+				Checksum:     b.config.ISOChecksum,
+				ChecksumType: b.config.ISOChecksumType,
+				Description:  "ISO",
+				ResultKey:    "iso_path",
+				Url:          b.config.ISOUrls,
+			},
+			new(stepPrepareOutputDir),
+			&common.StepCreateFloppy{
+				Files: b.config.FloppyFiles,
+			},
+			new(stepHTTPServer),
+			new(stepSuppressMessages),
+			new(stepCreateVM),
+			new(stepCreateDisk),
+			new(stepAttachISO),
+			new(stepAttachFloppy),
+			new(stepForwardSSH),
+			new(stepVBoxManage),
+			new(stepRun),
+			new(stepTypeBootCommand),
+			&common.StepConnectSSH{
+				SSHAddress:     sshAddress,
+				SSHConfig:      sshConfig,
+				SSHWaitTimeout: b.config.sshWaitTimeout,
+			},
+			new(stepUploadVersion),
+			new(stepUploadGuestAdditions),
+			new(common.StepProvision),
+			new(stepShutdown),
+			new(stepExport))
 	}
 
 	// Setup the state bag

--- a/builder/virtualbox/step_attach_guest_iso.go
+++ b/builder/virtualbox/step_attach_guest_iso.go
@@ -1,0 +1,66 @@
+package virtualbox
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+)
+
+// This step attaches the ISO to the virtual machine.
+//
+// Uses:
+//
+// Produces:
+type stepAttachGuestISO struct {
+	diskPath string
+}
+
+func (s *stepAttachGuestISO) Run(state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(Driver)
+	guestAdditionsPath := state.Get("guest_additions_path").(string)
+	ui := state.Get("ui").(packer.Ui)
+	vmName := state.Get("vmName").(string)
+
+	// Attach the disk to the controller
+	command := []string{
+		"storageattach", vmName,
+		"--storagectl", "IDE Controller",
+		"--port", "1",
+		"--device", "0",
+		"--type", "dvddrive",
+		"--medium", guestAdditionsPath,
+	}
+	if err := driver.VBoxManage(command...); err != nil {
+		err := fmt.Errorf("Error attaching ISO: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Track the path so that we can unregister it from VirtualBox later
+	s.diskPath = guestAdditionsPath
+
+	return multistep.ActionContinue
+}
+
+func (s *stepAttachGuestISO) Cleanup(state multistep.StateBag) {
+	if s.diskPath == "" {
+		return
+	}
+
+	driver := state.Get("driver").(Driver)
+	ui := state.Get("ui").(packer.Ui)
+	vmName := state.Get("vmName").(string)
+
+	command := []string{
+		"storageattach", vmName,
+		"--storagectl", "IDE Controller",
+		"--port", "1",
+		"--device", "0",
+		"--medium", "none",
+	}
+
+	if err := driver.VBoxManage(command...); err != nil {
+		ui.Error(fmt.Sprintf("Error unregistering ISO: %s", err))
+	}
+}


### PR DESCRIPTION
This is just a proof of concept on mounting vbox additions (as veewee used to do). I think it is easier to deal with on windows.

The code is not ready to be merged, but since I don't know any go, I figure it would be easier for packer developers to do this correctly. That hack allowed me to build a vagrant windows box that I could use in vagrant 1.2.3 (+ vagrant-windows from https://github.com/WinRb/vagrant-windows)
