### PR TITLE
facter vars may collide with puppet command

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -69,7 +69,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	// Set some defaults
 	if p.config.ExecuteCommand == "" {
-		p.config.ExecuteCommand = "{{.FacterVars}}{{if .Sudo}} sudo -E {{end}}" +
+		p.config.ExecuteCommand = "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
 			"puppet apply --verbose --modulepath='{{.ModulePath}}' " +
 			"{{if .HasHieraConfigPath}}--hiera_config='{{.HieraConfigPath}}' {{end}}" +
 			"--detailed-exitcodes " +


### PR DESCRIPTION
When facter vars are included in the puppet-masterless provisioner _and_ prevent_sudo is set to true, there is no whitespace between the last facter var value and the beginning of the puppet apply command. This pull request simply adds the missing space.
