### PR TITLE
provisioner/puppet-masterless: remove duplicate manifest upload message

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -215,7 +215,6 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	}
 
 	// Upload manifests
-	ui.Message("Uploading manifests...")
 	remoteManifestFile, err := p.uploadManifests(ui, comm)
 	if err != nil {
 		return fmt.Errorf("Error uploading manifests: %s", err)


### PR DESCRIPTION
This also happens on [line 283](https://github.com/mitchellh/packer/blob/master/provisioner/puppet-masterless/provisioner.go#L283).
