### PR TITLE
Fix VirtualBox scancodes

### DIFF
--- a/builder/virtualbox/step_type_boot_command.go
+++ b/builder/virtualbox/step_type_boot_command.go
@@ -92,29 +92,34 @@ func (s *stepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 func (*stepTypeBootCommand) Cleanup(multistep.StateBag) {}
 
 func scancodes(message string) []string {
+	// Scancodes reference: http://www.win.tue.nl/~aeb/linux/kbd/scancodes-1.html
+  //
+  // Scancodes represent raw keyboard output and are fed to the VM by the
+  // VBoxManage controlvm keyboardputscancode program.
+  //
+  // Scancodes are recorded here in pairs. The first entry represents
+  // the key press and the second entry represents the key release and is
+  // derived from the first by the addition of 0x81.
 	special := make(map[string][]string)
-	special["<bs>"] = []string{"ff", "08"}
-	special["<del>"] = []string{"ff", "ff"}
+	special["<bs>"] = []string{"0e", "8e"}
+	special["<del>"] = []string{"53", "d3"}
 	special["<enter>"] = []string{"1c", "9c"}
 	special["<esc>"] = []string{"01", "81"}
-	special["<f1>"] = []string{"ff", "be"}
-	special["<f2>"] = []string{"ff", "bf"}
-	special["<f3>"] = []string{"ff", "c0"}
-	special["<f4>"] = []string{"ff", "c1"}
-	special["<f5>"] = []string{"ff", "c2"}
-	special["<f6>"] = []string{"ff", "c3"}
-	special["<f7>"] = []string{"ff", "c4"}
-	special["<f8>"] = []string{"ff", "c5"}
-	special["<f9>"] = []string{"ff", "c6"}
-	special["<f10>"] = []string{"ff", "c7"}
-	special["<f11>"] = []string{"ff", "c8"}
-	special["<f12>"] = []string{"ff", "c9"}
+	special["<f1>"] = []string{"3b", "bb"}
+	special["<f2>"] = []string{"3c", "bc"}
+	special["<f3>"] = []string{"3d", "bd"}
+	special["<f4>"] = []string{"3e", "be"}
+	special["<f5>"] = []string{"3f", "bf"}
+	special["<f6>"] = []string{"40", "c0"}
+	special["<f7>"] = []string{"41", "c1"}
+	special["<f8>"] = []string{"42", "c2"}
+	special["<f9>"] = []string{"43", "c3"}
+	special["<f10>"] = []string{"44", "c4"}
 	special["<return>"] = []string{"1c", "9c"}
 	special["<tab>"] = []string{"0f", "8f"}
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
 
-	// Scancodes reference: http://www.win.tue.nl/~aeb/linux/kbd/scancodes-1.html
 	scancodeIndex := make(map[string]uint)
 	scancodeIndex["1234567890-="] = 0x02
 	scancodeIndex["!@#$%^&*()_+"] = 0x02


### PR DESCRIPTION
Support for the backspace, delete and F1-F12 keys was added in commit 6028a3c.
However, that commit seems to have copied character codes from the vmware
builder into the VirtualBox builder. Character codes are appropriate for VMware
which communicates through a VNC. However, VirtualBox communicates through
simulating raw keyboard input and therefore needs scancodes which are key
press/key release sequences.

This patch converts backspace, delete and F1-F10 to scancodes. F11 and F12 are
not listed in the [scancode reference](http://www.win.tue.nl/~aeb/linux/kbd/scancodes-1.html) so they have been omitted.

I couldn't find a single Veewee template that uses function keys in the boot command, so there shouldn't be much harm from omitting F11 and F12. Plus, without being expressed as scancodes, these keys are currently broken anyway.
