### PR TITLE
updatedeps target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ NO_COLOR=\033[0m
 OK_COLOR=\033[32;01m
 ERROR_COLOR=\033[31;01m
 WARN_COLOR=\033[33;01m
+DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 
 all: deps
 	@mkdir -p bin/
@@ -11,7 +12,11 @@ all: deps
 deps:
 	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
 	@go get -d -v ./...
-	@go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | xargs -n1 go get -d
+	@echo $(DEPS) | xargs -n1 go get -d
+
+updatedeps:
+	@echo "$(OK_COLOR)==> Updating all dependencies$(NO_COLOR)"
+	@echo $(DEPS) | xargs -n1 go get -d -u
 
 clean:
 	@rm -rf bin/ local/ pkg/ src/ website/.sass-cache website/build


### PR DESCRIPTION
I'm running packer from HEAD, and every time I pull I get dependency-related errors, ie

```
==> Installing dependencies
==> Building
--> Installing dependencies to speed up builds...
# github.com/mitchellh/packer/builder/amazon/common
builder/amazon/common/block_device.go:36: unknown ec2.BlockDeviceMapping field 'NoDevice' in struct literal
make: *** [all] Error 2
```

I don't think updating deps should be default, but this will provide a lot of utility.
