### PR TITLE
Enforce go build version dependency

### DIFF
--- a/go_version.go
+++ b/go_version.go
@@ -1,0 +1,3 @@
+// +build !go1.1
+
+"packer requires go version 1.1 or greated to build"


### PR DESCRIPTION
Build will fail if go version is < 1.1
