### PR TITLE
exclude everything in /tmp, but keep /tmp itself when building ami-instance 

### DIFF
--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -83,7 +83,7 @@ func (b *Builder) Prepare(raws ...interface{}) error {
 			"-u {{.AccountId}} " +
 			"-c {{.CertPath}} " +
 			"-r {{.Architecture}} " +
-			"-e {{.PrivatePath}} " +
+			"-e {{.PrivatePath}}/* " +
 			"-d {{.Destination}} " +
 			"-p {{.Prefix}} " +
 			"--batch"


### PR DESCRIPTION
There is IMO a bug with image builder that it removes /tmp, in the
current setup. This patch makes the image bundle ignore everyting in
/tmp, but keeps /tmp on the box.
