### PR TITLE
communicator/ssh, builder/digitalocean: fix new SSH API from upstream

### DIFF
--- a/builder/digitalocean/step_create_ssh_key.go
+++ b/builder/digitalocean/step_create_ssh_key.go
@@ -38,7 +38,8 @@ func (s *stepCreateSSHKey) Run(state multistep.StateBag) multistep.StepAction {
 	state.Put("privateKey", string(pem.EncodeToMemory(&priv_blk)))
 
 	// Marshal the public key into SSH compatible format
-	pub := ssh.NewRSAPublicKey(&priv.PublicKey)
+	// TODO properly handle the public key error
+	pub, _ := ssh.NewPublicKey(&priv.PublicKey)
 	pub_sshformat := string(ssh.MarshalAuthorizedKey(pub))
 
 	// The name of the public key on DO

--- a/communicator/ssh/keychain.go
+++ b/communicator/ssh/keychain.go
@@ -60,9 +60,9 @@ func (k *SimpleKeychain) Key(i int) (ssh.PublicKey, error) {
 	}
 	switch key := k.keys[i].(type) {
 	case *rsa.PrivateKey:
-		return ssh.NewRSAPublicKey(&key.PublicKey), nil
+		return ssh.NewPublicKey(&key.PublicKey)
 	case *dsa.PrivateKey:
-		return ssh.NewDSAPublicKey(&key.PublicKey), nil
+		return ssh.NewPublicKey(&key.PublicKey)
 	}
 	panic("unknown key type")
 }


### PR DESCRIPTION
Upstream SSH API remove the key type specific New Public Key functions, in favor of a generic function. This needs further testing, as I don't have a good key based authentication test case, but based on what I see in the upstream code this should resolve the issues.

Error messages resulting from these API changes are showing up in the Travis CI logs.

/cc @kelseyhightower
