### PR TITLE
post-processor/vagrant: fix output errors when sub processor settings undefined [GH-446]

### DIFF
--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -127,7 +127,17 @@ func (p *PostProcessor) subPostProcessor(key string, specific interface{}, extra
 		return nil, nil
 	}
 
-	if err := pp.Configure(extra, specific); err != nil {
+	var err error
+
+	// only spend specific configuration when it exists
+	// otherwise process will fail during post processing
+	if specific != nil {
+		err = pp.Configure(extra, specific)
+	} else {
+		err = pp.Configure(extra)
+	}
+
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Added a check to avoid passing a `nil` configuration element to the sub post-processor. It appears the behavior, whether intended or not, of a mapstructure Decoder is to clear previously processed configuration settings when receiving a `nil` to decode. 

When no sub post-processor settings are made for the Vagrant post-processor, the sub post processors aren't configured until execution time, and provide `nil` as the value for the map of sub post-processor specific settings. This results in `output` configuration value not getting passed to the sub post-processor and the post-processing failing.

Admit this is a work around for the upstream issue/behavior, either making the behavior of a `nil` input explicit in the `common.DecodeConfig` function or within the `mapstructure` library directly would be useful. Since those  changes may create API impacts to other clients, I'm limiting this pull request to just addressing the original issue.
