### PR TITLE
use interactive shell to run build script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 all: deps
 	@mkdir -p bin/
 	@echo "$(OK_COLOR)==> Building$(NO_COLOR)"
-	@./scripts/build.sh
+	@bash --norc -i ./scripts/build.sh
 
 deps:
 	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"


### PR DESCRIPTION
the trap in build.sh kills the process group which the make process is a part of. To prevent that, we can run the script in an interactive session which will have a new pgid.

`bash(1)`

> When bash is interactive, in the absence of any traps, it ignores SIGTERM (so that kill 0 does not kill an interactive shell), and SIGINT is caught and handled  (so  that  the wait builtin is interruptible).  In all cases, bash ignores SIGQUIT.  If job control is in effect, bash ignores SIGTTIN, SIGTTOU, and SIGTSTP.
