### PR TITLE
scripts: build.sh exits without being killed by SIGTERM

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -92,3 +92,6 @@ for PLUGIN in $(find ./plugin -mindepth 1 -maxdepth 1 -type d); do
 done
 
 waitAll
+
+# Reset signal trapping to avoid "Terminated: 15" at the end
+trap - SIGINT SIGTERM EXIT


### PR DESCRIPTION
Command `make` finishes with `Terminated: 15` since the build.sh is killed by SIGTERM. I suppose it's because of this tricky trapping `trap "kill 0" SIGINT SIGTERM EXIT`. The solution is to reset the trapping `trap - SIGINT SIGTERM EXIT` at the end. We can do it safely after `waitAll` when there is no child to kill.

I reproduce it on Mac OS X 10.7.5, go 1.1, bash 3.2.48(1).
