### PR TITLE
provisioner/chef-solo: fix .RolesPath and .DataBagsPath in the config template

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -212,7 +212,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 
 	rolesPath := ""
 	if p.config.RolesPath != "" {
-		rolesPath := fmt.Sprintf("%s/roles", p.config.StagingDir)
+		rolesPath = fmt.Sprintf("%s/roles", p.config.StagingDir)
 		if err := p.uploadDirectory(ui, comm, rolesPath, p.config.RolesPath); err != nil {
 			return fmt.Errorf("Error uploading roles: %s", err)
 		}
@@ -220,7 +220,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 
 	dataBagsPath := ""
 	if p.config.DataBagsPath != "" {
-		dataBagsPath := fmt.Sprintf("%s/data_bags", p.config.StagingDir)
+		dataBagsPath = fmt.Sprintf("%s/data_bags", p.config.StagingDir)
 		if err := p.uploadDirectory(ui, comm, dataBagsPath, p.config.DataBagsPath); err != nil {
 			return fmt.Errorf("Error uploading data bags: %s", err)
 		}


### PR DESCRIPTION
Variables `.RolesPath` and `.DataBagsPath` were empty in the template for Chef's `solo.rb`; variables `.HasRolesPath` and `.HasDataBagsPath` were `false` there.
