### PR TITLE
builder/digitalocean: error message key is "message" not "error_message"

### DIFF
--- a/builder/digitalocean/api.go
+++ b/builder/digitalocean/api.go
@@ -227,7 +227,7 @@ func NewRequest(d DigitalOceanClient, path string, params url.Values) (map[strin
 		}
 
 		if status == "ERROR" {
-			status = decodedResponse["error_message"].(string)
+			status = decodedResponse["message"].(string)
 		}
 
 		lastErr = errors.New(fmt.Sprintf("Received error from DigitalOcean (%d): %s",


### PR DESCRIPTION
Don't know if this was a recent API change, but the assertion was causing a panic (`type nil not string`) on bad responses for DO. Changing the API error response to the proper key "message" fixes this.
