### PR TITLE
An SSH timeout should be treated as an error

### DIFF
--- a/common/step_connect_ssh.go
+++ b/common/step_connect_ssh.go
@@ -72,7 +72,9 @@ WaitLoop:
 			state.Put("communicator", comm)
 			break WaitLoop
 		case <-timeout:
-			ui.Error("Timeout waiting for SSH.")
+			err := fmt.Errorf("Timeout waiting for SSH.")
+			state.Put("error", err)
+			ui.Error(err.Error())
 			close(cancel)
 			return multistep.ActionHalt
 		case <-time.After(1 * time.Second):


### PR DESCRIPTION
I am automating AMI-baking with Packer, but had a build "succeed" (exit 0) even though it experienced an SSH timeout and did not produce an image.

This follows the same pattern I found elsewhere in the codebase, for displaying an error as well as storing it in `state`.
