### PR TITLE
Use the same vagrant post-processor for amazon instances than EBS

### DIFF
--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -12,9 +12,10 @@ import (
 )
 
 var builtins = map[string]string{
-	"mitchellh.amazonebs":  "aws",
-	"mitchellh.virtualbox": "virtualbox",
-	"mitchellh.vmware":     "vmware",
+	"mitchellh.amazonebs":       "aws",
+	"mitchellh.amazon.instance": "aws",
+	"mitchellh.virtualbox":      "virtualbox",
+	"mitchellh.vmware":          "vmware",
 }
 
 type Config struct {


### PR DESCRIPTION
 Fixes #502
