### PR TITLE
Vbox shutdown issue

### DIFF
--- a/builder/virtualbox/step_export.go
+++ b/builder/virtualbox/step_export.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"path/filepath"
 	"log"
+	"path/filepath"
 	"time"
 )
 


### PR DESCRIPTION
Fixes #512  by adding a small pause before starting the export.

The problem I was seeing was that during a packer build for Virtualbox, it would get to the export phase, attempt to delete the forwarding ports and fail with the following error:

```
==> virtualbox: Preparing to export machine...
    virtualbox: Deleting forwarded port mapping for SSH (host port 3499)
==> virtualbox: Error deleting port forwarding rule: VBoxManage error: VBoxManage: error: The machine 'packer-virtualbox' is already locked for a session (or being unlocked)
==> virtualbox: VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component Machine, interface IMachine, callee nsISupports
==> virtualbox: VBoxManage: error: Context: "LockMachine(a->session, LockType_Write)" at line 425 of file VBoxManageModifyVM.cpp
==> virtualbox: Error unregistering ISO: VBoxManage error: VBoxManage: error: Failed to get a console object from the direct session (Unknown Status 0x80BB0002)
==> virtualbox: VBoxManage: error: Details: code VBOX_E_VM_ERROR (0x80bb0003), component Machine, interface IMachine, callee nsISupports
==> virtualbox: VBoxManage: error: Context: "LockMachine(a->session, LockType_Shared)" at line 314 of file VBoxManageStorageController.cpp
==> virtualbox: Unregistering and deleting virtual machine...
==> virtualbox: Deleting output directory...
```

Sometimes however the build would proceed with no timing issues.

Using this as a conversation starter since I am not sure where the real problem lies, but this certainly fixes my problem of intermittent failures to delete the forwarding ports.
