### PR TITLE
Allow for referencing $HOME path cookbook dirs

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 )
@@ -151,6 +152,14 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		} else if fi.IsDir() {
 			errs = packer.MultiErrorAppend(
 				errs, fmt.Errorf("Config template path must be a file: %s", err))
+		}
+	}
+
+	usr, _ := user.Current()
+	home_path := usr.HomeDir + "/"
+	for i, path := range p.config.CookbookPaths {
+		if path[:2] == "~/" {
+			p.config.CookbookPaths[i] = strings.Replace(path, "~/", home_path, 1)
 		}
 	}
 


### PR DESCRIPTION
_This is more of a RFC / proof of concept than a ready-to-merge PR._

I'd like to reference my `~/.berkshelf/cookbooks` path in a Packer configuration file. This seemed impossible, so I cracked open [play.golang.org](http://play.golang.org) and some StackOverflow questions and came up with the below solution.

Ideally, this would be extracted into a method and apply to all variables where paths are accepted as input.
