### PR TITLE
provisioner/shell: fix EOF detection

### DIFF
--- a/provisioner/shell/unix_reader.go
+++ b/provisioner/shell/unix_reader.go
@@ -54,5 +54,8 @@ func (r *UnixReader) Read(p []byte) (n int, err error) {
 // token returned will be "one\n".
 func scanUnixLine(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	advance, token, err = bufio.ScanLines(data, atEOF)
+	if advance == 0 {
+		return
+	}
 	return advance, append(token, "\n"...), err
 }

--- a/provisioner/shell/unix_reader_test.go
+++ b/provisioner/shell/unix_reader_test.go
@@ -18,24 +18,24 @@ func TestUnixReader(t *testing.T) {
 	input := "one\r\ntwo\n\r\nthree\r\n"
 	expected := "one\ntwo\n\nthree\n"
 
-	r := &UnixReader{
-		Reader: bytes.NewReader([]byte(input)),
-	}
-
-	result := new(bytes.Buffer)
-	if _, err := io.Copy(result, r); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	if result.String() != expected {
-		t.Fatalf("bad: %#v", result.String())
-	}
+	unixReaderTest(t, input, expected)
 }
 
 func TestUnixReader_unixOnly(t *testing.T) {
 	input := "\none\n\ntwo\nthree\n\n"
 	expected := "\none\n\ntwo\nthree\n\n"
 
+	unixReaderTest(t, input, expected)
+}
+
+func TestUnixReader_readsLastLine(t *testing.T) {
+	input := "one\ntwo"
+	expected := "one\ntwo\n"
+
+	unixReaderTest(t, input, expected)
+}
+
+func unixReaderTest(t *testing.T, input string, expected string) {
 	r := &UnixReader{
 		Reader: bytes.NewReader([]byte(input)),
 	}


### PR DESCRIPTION
Fixes #507

The scanUnixLine function was erroneously returning empty lines when EOF
was reached.
This commit adds a test for the problem and changes the scanUnixLine
function to elide the trailing \n if no content was read.
