### PR TITLE
Propose additional IAM Role Actions

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.markdown
+++ b/website/source/docs/builders/amazon-chroot.html.markdown
@@ -217,3 +217,6 @@ The following policy document provides the minimal set permissions necessary for
   }]
 }
 </pre>
+
+Depending on what setting you use the following Actions might have to be allowed as well:
+* `ec2:ModifyImageAttribute` when using `ami_description`


### PR DESCRIPTION
Depending on what settings you use for the amazon-chroot builder additional actions needs to be allowed in the IAM role for the aws instance.

This patch does not include an exhaustive list of all alternatives, but only the changes I needed to do to get stuff working for me.
