### PR TITLE
contributing: clarify how to submit debug output with a new issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,12 @@ it raises the chances we can quickly merge or address your contributions.
 * Make sure you test against the latest released version. It is possible
   we already fixed the bug you're experiencing.
 
+* Run the command with debug ouput with the environment variable
+  `PACKER_LOG`. For example: `PACKER_LOG=1 packer build template.json`. Take
+  the *entire* output and create a [gist](https://gist.github.com) for linking
+  to in your issue. Packer should strip sensitive keys from the output,
+  but take a look through just in case.
+
 * Provide a reproducible test case. If a contributor can't reproduce an
   issue, then it dramatically lowers the chances it'll get fixed. And in
   some cases, the issue will eventually be closed.


### PR DESCRIPTION
Realized the contributing guidelines don't ask for debug output when reporting an issue. This adds a note about that.
