### PR TITLE
change --sataportcount to --portcount

### DIFF
--- a/builder/virtualbox/step_create_disk.go
+++ b/builder/virtualbox/step_create_disk.go
@@ -60,7 +60,7 @@ func (s *stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
 			"storagectl", vmName,
 			"--name", controllerName,
 			"--add", "sata",
-			"--sataportcount", "1",
+			"--portcount", "1",
 		}
 		if err := driver.VBoxManage(command...); err != nil {
 			err := fmt.Errorf("Error creating disk controller: %s", err)


### PR DESCRIPTION
After setting my hard drive interface to “sata”, I hit a VBoxManage error during the build process: `Unknown option: --sataportcount`.  Looking at the docs for [VBoxManage storagectl](https://www.virtualbox.org/manual/ch08.html#vboxmanage-storagectl), it appears that this option’s name is actually `--portcount` (as opposed to `--sataportcount`).
