### PR TITLE
post-processor/vagrant: fix bug in ova support caused by wrong file path

### DIFF
--- a/post-processor/vagrant/virtualbox.go
+++ b/post-processor/vagrant/virtualbox.go
@@ -92,7 +92,7 @@ func (p *VBoxBoxPostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifac
 		// directory so we can get the resulting disk and OVF.
 		if extension := filepath.Ext(path); extension == ".ova" {
 			ui.Message(fmt.Sprintf("Unpacking OVA: %s", path))
-			if err := DecompressOva(dir, filepath.Base(path)); err != nil {
+			if err := DecompressOva(dir, path); err != nil {
 				return nil, false, err
 			}
 		} else {


### PR DESCRIPTION
Without this fix, packer fails with the following error: `* Post-processor failed: open <name>.ova: no such file or directory`.
