### PR TITLE
Fixes missing entropy in the uuid package.

### DIFF
--- a/common/uuid/uuid.go
+++ b/common/uuid/uuid.go
@@ -1,32 +1,24 @@
 package uuid
 
 import (
-	"fmt"
 	"crypto/rand"
-	"encoding/binary"
+	"fmt"
 	"time"
 )
-
-func uint32rand() (value uint32) {
-	err := binary.Read(rand.Reader, binary.LittleEndian, &value)
-	if err != nil {
-		panic(err)
-	}
-	return
-}
 
 // Generates a time ordered UUID. Top 32 bits are a timestamp,
 // bottom 96 are random.
 func TimeOrderedUUID() string {
 	unix := uint32(time.Now().UTC().Unix())
-	rand1 := uint32rand()
-	rand2 := uint32rand()
-	rand3 := uint32rand()
+
+	b := make([]byte, 12)
+	n, err := rand.Read(b)
+	if n != len(b) {
+		err = fmt.Errorf("Not enough entropy available")
+	}
+	if err != nil {
+		panic(err)
+	}
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%04x%08x",
-		unix,
-		uint16(rand1>>16),
-		uint16(rand1&0xffff),
-		uint16(rand2>>16),
-		uint16(rand2&0xffff),
-		rand3)
+		unix, b[0:2], b[2:4], b[4:6], b[6:8], b[8:])
 }


### PR DESCRIPTION
math/crypto is seeded with 1 and thus will create predictable UUIDs. Because
amazon-instance and amazon-ebs in the same second when building both targets
the timestamp in front doesn't help either. See #552
