### PR TITLE
Arguments Prefix (--) was missing for (sata)portconfig

### DIFF
--- a/builder/virtualbox/driver.go
+++ b/builder/virtualbox/driver.go
@@ -53,9 +53,9 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string) error {
 		return err
 	}
 
-	portCountArg := "sataportcount"
+	portCountArg := "--sataportcount"
 	if strings.HasPrefix(version, "4.3") {
-		portCountArg = "portcount"
+		portCountArg = "--portcount"
 	}
 
 	command := []string{


### PR DESCRIPTION
Hi,

the prefixes (--) for the (sata)portcount argument in the VirtualBox driver are missing. Current result is:
"==> virtualbox: VBoxManage: error: Invalid parameter 'portcount'"
