### PR TITLE
Added missing close-curly-brace to default value of execute_command in Chef Solo docs

### DIFF
--- a/website/source/docs/provisioners/chef-solo.html.markdown
+++ b/website/source/docs/provisioners/chef-solo.html.markdown
@@ -110,7 +110,7 @@ By default, Packer uses the following command (broken across multiple lines
 for readability) to execute Chef:
 
 ```
-{{if .Sudo}sudo {{end}}chef-solo \
+{{if .Sudo}}sudo {{end}}chef-solo \
   --no-color \
   -c {{.ConfigPath}} \
   -j {{.JsonPath}}


### PR DESCRIPTION
This is a minor typo, but may cause brief trouble if a user copy-pastes and edits the default value of execute_command from  without looking too hard. (Guilty.) For example:

```
$ packer -debug build ami_chef.json
amazon-ebs output will be in this color.

1 error(s) occurred:

* Error parsing execute_command: template: template:1: unexpected "}" in operand; missing space?
```
