### PR TITLE
support for vsphere builder

### DIFF
--- a/plugin/builder-vsphere/main.go
+++ b/plugin/builder-vsphere/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/mitchellh/packer/builder/vsphere"
+	"github.com/mitchellh/packer/packer/plugin"
+)
+
+func main() {
+	plugin.ServeBuilder(new(vsphere.Builder))
+}

--- a/plugin/builder-vsphere/main_test.go
+++ b/plugin/builder-vsphere/main_test.go
@@ -1,0 +1,1 @@
+package main


### PR DESCRIPTION
I'd like to see if there's any interest in a true builder for vSphere. This would differ from the current VMware builder in a number of ways:
1. Rather than the ISO-based approach that the current Virtualbox and VMware builders use, it would behave more like the AWS / DigitalOcean builders, which is to say that it would take an existing machine image (in this case, a VM template), create a new VM, apply any provisioners, and then create a new machine image as the artifact. This would better fit into a CI pipeline for immutable infrastructure, as it does not require anyone's desktop.
2. It would use the [vSphere Web API](http://www.vmware.com/support/developer/vc-sdk). This will likely prove to be the most difficult bit, as the API is SOAP/WSDL based, and the Golang community hasn't shown much interest to date in making anything akin to ruby's savon or handsoap.

Thanks to rbvmomi I am well versed in the API as a whole, but am sorely lacking when it comes to things like decoding XML envelopes. Portions of this have already been discussed in #232, and I know both @jasonberanek and I have been independently circling the wagons on this idea since veewee. I'm very interested in any comments or additional ideas people have regarding this. Packer arrived literally just in time for us to build out our pipeline for AWS, but now we want to be able to implement this immutable infrastructure model to the other 98% of the apps we manage. Our investment in vSphere is fairly entrenched, so proposing something like OpenStack just because it uses REST probably won't fly.
