### PR TITLE
Skip gzip compression if compression_level=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* Vagrant post-processor skips gzip compression when compression_level=0
 * builder/amazon/all: Can now specify a list of multiple security group
   IDs to apply. [GH-499]
 * builder/amazon/all: AWS API requests are now retried when a temporary


### PR DESCRIPTION
Even when `compression_level` is set to `0`, it has taken over 12 minutes to compress some boxes. This patch reduces that time to under 20 seconds.
