### PR TITLE
Match default ec2-bundle-vol documented on the website to the one that's used by the code.

### DIFF
--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -238,7 +238,7 @@ sudo -n ec2-bundle-vol \
 	-u {{.AccountId}} \
 	-c {{.CertPath}} \
 	-r {{.Architecture}} \
-	-e {{.PrivatePath}} \
+	-e {{.PrivatePath}}/* \
 	-d {{.Destination}} \
 	-p {{.Prefix}} \
 	--batch


### PR DESCRIPTION
Issue #248 contained a PR which changes the way bundle_vol_command is used by default. This change to the defaults was not reflected on the website, so I encountered the same issue when making changes to the bundle_vol_command in my config.
