### PR TITLE
Make port configuration generic.

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,8 +15,8 @@ import (
 // Packer.
 const defaultConfig = `
 {
-	"plugin_min_port": 10000,
-	"plugin_max_port": 25000,
+	"min_port": 10000,
+	"max_port": 25000,
 
 	"builders": {
 		"amazon-ebs": "packer-builder-amazon-ebs",
@@ -54,8 +54,8 @@ const defaultConfig = `
 `
 
 type config struct {
-	PluginMinPort uint
-	PluginMaxPort uint
+	MinPort uint
+	MaxPort uint
 
 	Builders       map[string]string
 	Commands       map[string]string
@@ -166,7 +166,7 @@ func (c *config) pluginClient(path string) *plugin.Client {
 	var config plugin.ClientConfig
 	config.Cmd = exec.Command(path)
 	config.Managed = true
-	config.MinPort = c.PluginMinPort
-	config.MaxPort = c.PluginMaxPort
+	config.MinPort = c.MinPort
+	config.MaxPort = c.MaxPort
 	return plugin.NewClient(&config)
 }

--- a/packer/plugin/client.go
+++ b/packer/plugin/client.go
@@ -219,8 +219,8 @@ func (c *Client) Start() (address string, err error) {
 
 	env := []string{
 		fmt.Sprintf("%s=%s", MagicCookieKey, MagicCookieValue),
-		fmt.Sprintf("PACKER_PLUGIN_MIN_PORT=%d", c.config.MinPort),
-		fmt.Sprintf("PACKER_PLUGIN_MAX_PORT=%d", c.config.MaxPort),
+		fmt.Sprintf("PACKER_MIN_PORT=%d", c.config.MinPort),
+		fmt.Sprintf("PACKER_MAX_PORT=%d", c.config.MaxPort),
 	}
 
 	stdout_r, stdout_w := io.Pipe()

--- a/packer/plugin/plugin_test.go
+++ b/packer/plugin/plugin_test.go
@@ -15,8 +15,8 @@ func helperProcess(s ...string) *exec.Cmd {
 	cs = append(cs, s...)
 	env := []string{
 		"GO_WANT_HELPER_PROCESS=1",
-		"PACKER_PLUGIN_MIN_PORT=10000",
-		"PACKER_PLUGIN_MAX_PORT=25000",
+		"PACKER_MIN_PORT=10000",
+		"PACKER_MAX_PORT=25000",
 	}
 
 	cmd := exec.Command(os.Args[0], cs...)

--- a/packer/rpc/builder.go
+++ b/packer/rpc/builder.go
@@ -61,7 +61,7 @@ func (b *builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	RegisterUi(server, ui)
 
 	// Create a server for the response
-	responseL := netListenerInRange(portRangeMin, portRangeMax)
+	responseL := NetListener()
 	runResponseCh := make(chan *BuilderRunResponse)
 	go func() {
 		defer responseL.Close()

--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -59,24 +59,24 @@ func (c *communicator) Start(cmd *packer.RemoteCmd) (err error) {
 	args.Command = cmd.Command
 
 	if cmd.Stdin != nil {
-		stdinL := netListenerInRange(portRangeMin, portRangeMax)
+		stdinL := NetListener()
 		args.StdinAddress = stdinL.Addr().String()
 		go serveSingleCopy("stdin", stdinL, nil, cmd.Stdin)
 	}
 
 	if cmd.Stdout != nil {
-		stdoutL := netListenerInRange(portRangeMin, portRangeMax)
+		stdoutL := NetListener()
 		args.StdoutAddress = stdoutL.Addr().String()
 		go serveSingleCopy("stdout", stdoutL, cmd.Stdout, nil)
 	}
 
 	if cmd.Stderr != nil {
-		stderrL := netListenerInRange(portRangeMin, portRangeMax)
+		stderrL := NetListener()
 		args.StderrAddress = stderrL.Addr().String()
 		go serveSingleCopy("stderr", stderrL, cmd.Stderr, nil)
 	}
 
-	responseL := netListenerInRange(portRangeMin, portRangeMax)
+	responseL := NetListener()
 	args.ResponseAddress = responseL.Addr().String()
 
 	go func() {
@@ -108,7 +108,7 @@ func (c *communicator) Start(cmd *packer.RemoteCmd) (err error) {
 func (c *communicator) Upload(path string, r io.Reader) (err error) {
 	// We need to create a server that can proxy the reader data
 	// over because we can't simply gob encode an io.Reader
-	readerL := netListenerInRange(portRangeMin, portRangeMax)
+	readerL := NetListener()
 	if readerL == nil {
 		err = errors.New("couldn't allocate listener for upload reader")
 		return
@@ -148,7 +148,7 @@ func (c *communicator) UploadDir(dst string, src string, exclude []string) error
 func (c *communicator) Download(path string, w io.Writer) (err error) {
 	// We need to create a server that can proxy that data downloaded
 	// into the writer because we can't gob encode a writer directly.
-	writerL := netListenerInRange(portRangeMin, portRangeMax)
+	writerL := NetListener()
 	if writerL == nil {
 		err = errors.New("couldn't allocate listener for download writer")
 		return

--- a/packer/rpc/port_test.go
+++ b/packer/rpc/port_test.go
@@ -11,7 +11,7 @@ func addrPort(address net.Addr) string {
 	return parts[len(parts)-1]
 }
 
-func Test_netListenerInRange(t *testing.T) {
+func Test_NetListenerInRange(t *testing.T) {
 	// Open up port 10000 so that we take up a port
 	L1000, err := net.Listen("tcp", "127.0.0.1:11000")
 	defer L1000.Close()
@@ -21,7 +21,7 @@ func Test_netListenerInRange(t *testing.T) {
 
 	if err == nil {
 		// Verify it selects an open port
-		L := netListenerInRange(11000, 11005)
+		L := NetListenerInRange(11000, 11005)
 		if L == nil {
 			t.Fatal("L should not be nil")
 		}
@@ -30,7 +30,7 @@ func Test_netListenerInRange(t *testing.T) {
 		}
 
 		// Returns nil if there are no open ports
-		L = netListenerInRange(11000, 11000)
+		L = NetListenerInRange(11000, 11000)
 		if L != nil {
 			t.Fatalf("bad: %#v", L)
 		}

--- a/packer/rpc/server.go
+++ b/packer/rpc/server.go
@@ -71,7 +71,7 @@ func RegisterUi(s *rpc.Server, ui packer.Ui) {
 }
 
 func serveSingleConn(s *rpc.Server) string {
-	l := netListenerInRange(portRangeMin, portRangeMax)
+	l := NetListener()
 
 	// Accept a single connection in a goroutine and then exit
 	go func() {

--- a/website/source/docs/other/core-configuration.html.markdown
+++ b/website/source/docs/other/core-configuration.html.markdown
@@ -25,11 +25,12 @@ The format of the configuration file is basic JSON.
 Below is the list of all available configuration parameters for the core
 configuration file. None of these are required, since all have sane defaults.
 
-* `plugin_min_port` and `plugin_max_port` (int) - These are the minimum and
-  maximum ports that Packer uses for communication with plugins, since
-  plugin communication happens over TCP connections on your local host.
-  By default these are 10,000 and 25,000, respectively. Be sure to set a fairly
-  wide range here, since Packer can easily use over 25 ports on a single run.
+* `min_port` and `max_port` (int) - These are the minimum and maximum
+  ports that Packer uses for communication, including plugin
+  communication, since plugin communication happens over TCP
+  connections on your local host.  By default these are 10,000 and
+  25,000, respectively. Be sure to set a fairly wide range here, since
+  Packer can easily use over 25 ports on a single run.
 
 * `builders`, `commands`, `post-processors`, and `provisioners` are objects that are used to
   install plugins. The details of how exactly these are set is covered


### PR DESCRIPTION
Renamed plugin_{min,max}_port as {min,max}_port and now using
PACKER_{MIN,MAX}_PORT environement variables to find a port to bind. Got
rid of mutuable globals portRange{Min,Max}. Also refactored plugin.go to
use rpc.NetListener.
