### PR TITLE
qemu format img is invalid

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -217,7 +217,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if !(b.config.Format == "qcow2" || b.config.Format == "raw") {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("invalid format, only 'qcow2' or 'img' are allowed"))
+			errs, errors.New("invalid format, only 'qcow2' or 'raw' are allowed"))
 	}
 
 	if !(b.config.Accelerator == "kvm" || b.config.Accelerator == "xen") {

--- a/website/source/docs/builders/qemu.html.markdown
+++ b/website/source/docs/builders/qemu.html.markdown
@@ -115,7 +115,7 @@ Optional:
   commands or kickstart type scripts must have proper adjustments for
   resulting device names. The Qemu builder uses "virtio" by default.
 
-* `format` (string) - Either "qcow2" or "img", this specifies the output
+* `format` (string) - Either "qcow2" or "raw", this specifies the output
   format of the virtual machine image. This defaults to "qcow2".
 
 * `headless` (bool) - Packer defaults to building virtual machines by


### PR DESCRIPTION
The tool qemu-img doesn't seem to have a format type 'img'.  The logic is correct, this PR just fixes the error messages and web docs.
