### PR TITLE
Fix a vsphere upload bug so that something is uploaded

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -104,6 +104,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		fmt.Sprintf("--datastore=%s", p.config.Datastore),
 		fmt.Sprintf("--network=%s", p.config.VMNetwork),
 		fmt.Sprintf("--vmFolder=%s", p.config.VMFolder),
+		fmt.Sprintf("%s", vmx),
 		fmt.Sprintf("vi://%s:%s@%s/%s/%s",
 			p.config.Username,
 			p.config.Password,


### PR DESCRIPTION
I think that this slightly modified version of @mheidenr's PR #672 doesn't break any backwards compatibility with the current version, but makes it usable by passing a file to ovftool.

When I used

```
"post-processors": [
    {
      "type": "vsphere",
      "username": "myusername",
      "password": "mypassword",
      "datacenter": "my_datacenter",
      "datastore": "my_datastore",
      "host": "vcenter.example.com",
      "vm_folder": "folder1/folder2",
      "vm_name": "tmpl-ubuntu",
      "path_to_resource_pool": "host/intraNet/IntraServerNet/Resources/Dev%2FTest-Low",
      "vm_network": "intraserver_net",
      "only": ["vmware"]
    }
  ]
```

everything seemed to work after making this one line change.
