### PR TITLE
Builder virtualbox additional disks

### DIFF
--- a/builder/virtualbox/builder.go
+++ b/builder/virtualbox/builder.go
@@ -35,6 +35,7 @@ type config struct {
 
 	BootCommand          []string   `mapstructure:"boot_command"`
 	DiskSize             uint       `mapstructure:"disk_size"`
+	AdditionalDiskSize   []uint     `mapstructure:"additionaldisk_size"`
 	FloppyFiles          []string   `mapstructure:"floppy_files"`
 	Format               string     `mapstructure:"format"`
 	GuestAdditionsMode   string     `mapstructure:"guest_additions_mode"`

--- a/builder/virtualbox/driver.go
+++ b/builder/virtualbox/driver.go
@@ -20,6 +20,12 @@ type Driver interface {
 	// Create a SATA controller.
 	CreateSATAController(vm string, controller string) error
 
+	// Create a IDE controller.
+	CreateIDEController(vm string, controller string) error
+
+	// Create a Disk.
+	CreateDisk(path string, size string, format string) error
+
 	// Checks if the VM with the given name is running.
 	IsRunning(string) (bool, error)
 
@@ -65,6 +71,48 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string) error {
 		portCountArg, "1",
 	}
 
+	return d.VBoxManage(command...)
+}
+
+func (d *VBox42Driver) CreateIDEController(vmName string, name string) error {
+	version, err := d.Version()
+	if err != nil {
+		return err
+	}
+
+	portCountArg := "--port"
+	if strings.HasPrefix(version, "4.3") {
+		portCountArg = "--portcount"
+	}
+
+	command := []string{
+		"storagectl", vmName,
+		"--name", name,
+		"--add", "ide",
+		portCountArg, "2",
+	}
+
+	return d.VBoxManage(command...)
+}
+
+func (d *VBox42Driver) CreateDisk(path string, size string, format string) error {
+	version, err := d.Version()
+	if err != nil {
+		return err
+	}
+
+	variant := "Standard"
+	if strings.HasPrefix(version, "4.3") {
+		variant = "Standard"
+	}
+
+	command := []string{
+         	"createhd",
+         	"--filename", path,
+         	"--size", size,
+         	"--format", format,
+         	"--variant", variant,
+ 	}
 	return d.VBoxManage(command...)
 }
 


### PR DESCRIPTION
This PR implement the option to add additional disks at the moment of the creation.

This have been tested on Windows 8.1 + virtualbox 4.3.4 + vagrant

on the json template file:

...
"hard_drive_interface" : "sata",
"disk_size" : 16000,
"additionaldisk_size" : [32000, 22000, 11000],
...

At execution, this out put is generated:

..
==> virtualbox: Creating virtual machine...
==> virtualbox: Creating hard drive...
==> virtualbox: Creating additional hard drives...
==> virtualbox: Creating forwarded port mapping for SSH (host port 3499)
..

During the execution, the disks are created as expected:

$ ls -alh output-virtualbox/
-rw-r--r-- 1 AlvaroM Administ 2.0M Dec 11 23:06 packer-virtualbox1.vdi
-rw-r--r-- 1 AlvaroM Administ 2.0M Dec 11 23:06 packer-virtualbox2.vdi
-rw-r--r-- 1 AlvaroM Administ 2.0M Dec 11 23:06 packer-virtualbox3.vdi
-rw-r--r-- 1 AlvaroM Administ 2.0M Dec 11 23:06 packer-virtualbox4.vdi
