### PR TITLE
Fix Ansible-local provisioner configuration check for 'playbook_paths'

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -72,7 +72,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		errs = packer.MultiErrorAppend(errs, err)
 	}
 	for _, path := range p.config.PlaybookPaths {
-		err := validateFileConfig(path, "playbook_paths", false)
+		err := validateDirConfig(path, "playbook_paths")
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs, err)
 		}

--- a/provisioner/ansible-local/provisioner_test.go
+++ b/provisioner/ansible-local/provisioner_test.go
@@ -69,3 +69,55 @@ func TestProvisionerPrepare_PlaybookFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
+
+func TestProvisionerPrepare_Dirs(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	config["playbook_file"] = ""
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	playbook_file, err := ioutil.TempFile("", "playbook")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Remove(playbook_file.Name())
+
+	config["playbook_file"] = playbook_file.Name()
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	config["playbook_paths"] = []string{playbook_file.Name()}
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatal("should error if playbook paths is not a dir")
+	}
+
+	config["playbook_paths"] = []string{os.TempDir()}
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	config["role_paths"] = []string{playbook_file.Name()}
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatal("should error if role paths is not a dir")
+	}
+
+	config["role_paths"] = []string{os.TempDir()}
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}


### PR DESCRIPTION
There's a bug in the ansible-local provisioner. The config section status:
- playbook_paths (array of strings) - An array of paths to playbook files on your local system. These will be uploaded to the remote machine under staging_directory/playbooks. By default, this is empty.

From: http://www.packer.io/docs/provisioners/ansible-local.html

Trying this out locally on:

``` yaml
{
  ...
  "provisioners": [
    {
      "type": "ansible-local",
      "playbook_file": "../ansible/self-contained.yml",
      "playbook_paths": ["../ansible/"],
      "role_paths": ["../ansible/roles/"]
    }
  ],
  ...
}
```

gave me this:

``` bash
$ packer build packer.json 
virtualbox output will be in this color.

1 error(s) occurred:

* playbook_paths: ../ansible must point to a file
```

This commit fixes this
