### PR TITLE
Fix: Chef environment doesn't work for chef-solo

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -522,7 +522,7 @@ data_bag_path	"{{.DataBagsPath}}"
 encrypted_data_bag_secret "{{.EncryptedDataBagSecretPath}}"
 {{end}}
 {{if .HasEnvironmentsPath}}
-environments_path "{{.EnvironmentsPath}}"
-chef_environment "{{.ChefEnvironment}}"
+environment_path "{{.EnvironmentsPath}}"
+environment "{{.ChefEnvironment}}"
 {{end}}
 `


### PR DESCRIPTION
This might be true for chef in general, but there is definitely a bug where chef-solo can't pick up the "environments_path" or "chef_environment" variables because of the chef template settings. This pull request changes the default chef template.
