### PR TITLE
Fix Puppet Provisioner crash when HieraConfigPath or ManifestDir is specified in the config file.

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -75,8 +75,8 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	if p.config.ExecuteCommand == "" {
 		p.config.ExecuteCommand = "{{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
 			"puppet apply --verbose --modulepath='{{.ModulePath}}' " +
-			"{{if .HieraConfigPath ne \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}}" +
-			"{{if .ManifestDir ne \"\"}}--manifestdir='{{.ManifestDir}}' {{end}}" +
+			"{{if ne .HieraConfigPath \"\"}}--hiera_config='{{.HieraConfigPath}}' {{end}}" +
+			"{{if ne .ManifestDir \"\"}}--manifestdir='{{.ManifestDir}}' {{end}}" +
 			"--detailed-exitcodes " +
 			"{{.ManifestFile}}"
 	}


### PR DESCRIPTION
Prevents the following error,

```
Build 'amazon-instance' errored: template: tpl11:1:103: executing "tpl11" at <.HieraConfigPath>: HieraConfigPath has arguments but cannot be invoked as function
```
