### PR TITLE
pause_before is a valid config setting

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -31,7 +31,7 @@ func CheckUnusedConfig(md *mapstructure.Metadata) *packer.MultiError {
 	if md.Unused != nil && len(md.Unused) > 0 {
 		sort.Strings(md.Unused)
 		for _, unused := range md.Unused {
-			if unused != "type" && !strings.HasPrefix(unused, "packer_") {
+			if unused != "type" && unused != "pause_before" && !strings.HasPrefix(unused, "packer_") {
 				errs = append(
 					errs, fmt.Errorf("Unknown configuration key: %s", unused))
 			}


### PR DESCRIPTION
Without this change the new pause_before setting fails config validation causing Packer to error out.

```
2013/12/27 08:47:18 ui: 
2013/12/27 08:47:18 /Users/sneal/src/packer/bin/packer-command-build: 2013/12/27 08:47:18 Build debug mode: false
2013/12/27 08:47:18 /Users/sneal/src/packer/bin/packer-command-build: 2013/12/27 08:47:18 Force build: false
2013/12/27 08:47:18 /Users/sneal/src/packer/bin/packer-command-build: 2013/12/27 08:47:18 Preparing build: vmware-iso
1 error(s) occurred:

* Unknown configuration key: pause_before
2013/12/27 08:47:18 ui error: 1 error(s) occurred:

* Unknown configuration key: pause_before
```
