### PR TITLE
builder/docker: include user vars for docker configuration

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -29,6 +29,8 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		return nil, nil, err
 	}
 
+	c.tpl.UserVars = c.PackerUserVars
+
 	// Defaults
 	if len(c.RunCommand) == 0 {
 		c.RunCommand = []string{


### PR DESCRIPTION
Simple, includes user variables so you can use them in the docker builders `export_path` and `image`.
