### PR TITLE
packer cache now stored by default in HOME/.packer_cache

### DIFF
--- a/packer.go
+++ b/packer.go
@@ -95,11 +95,16 @@ func wrappedMain() int {
 
 	log.Printf("Packer config: %+v", config)
 
+	cacheDir := os.Getenv("PACKER_CACHE_DIR")
 	// Checks for packer cache environment variable,
 	// defaults to putting the cache in the HOME directory
-	cacheDir := os.Getenv("PACKER_CACHE_DIR")
+	// Places the cache in %TEMP% on windows
 	if cacheDir == "" {
-		cacheDir = os.Getenv("HOME") + "./packer_cache"
+		if runtime.GOOS == "windows" {
+			cacheDir = filepath.Join(os.Getenv("TEMP"),"packer_cache")
+		} else {
+			cacheDir = filepath.Join(os.Getenv("HOME"),".packer_cache")
+		}
 	}
 
 	cacheDir, err = filepath.Abs(cacheDir)


### PR DESCRIPTION
Right now Packer creates a folder called "packer_cache" in whatever working directory you're in when you launch Packer. It would probably make more sense to have a default folder in the $HOME directory, so @VulpesArtificem and I have worked out a fix for that.
#367
#436
