### PR TITLE
Fixes #806 Build fails if GOPATH has multiple paths

### DIFF
--- a/scripts/devcompile.sh
+++ b/scripts/devcompile.sh
@@ -56,4 +56,5 @@ export XC_OS=$(go env GOOS)
 ./scripts/compile.sh
 
 # Move all the compiled things to the PATH
-cp pkg/${XC_OS}_${XC_ARCH}/* ${GOPATH}/bin
+IFS=: MAIN_GOPATH=( $GOPATH )
+cp pkg/${XC_OS}_${XC_ARCH}/* ${MAIN_GOPATH}/bin


### PR DESCRIPTION
Fixes #806 Build fails if GOPATH has multiple paths with a small fix of the build scripts.
