### PR TITLE
Add more special scancodes

### DIFF
--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -16,9 +16,9 @@ import (
 const KeyLeftShift uint32 = 0xFFE1
 
 type bootCommandTemplateData struct {
-	HTTPIP   string
+	HTTPIP	 string
 	HTTPPort uint
-	Name     string
+	Name	 string
 }
 
 // This step "types" the boot command into the VM over VNC.
@@ -112,16 +112,16 @@ func vncSendString(c *vnc.ClientConn, original string) {
 	special["<f12>"] = 0xFFC9
 	special["<return>"] = 0xFF0D
 	special["<tab>"] = 0xFF09
-        special["<up>"] = 0xFF52
-        special["<down>"] = 0xFF54
-        special["<left>"] = 0xFF51
-        special["<right>"] = 0xFF53
-        special["<spacebar>"] = 0x020
-        special["<insert>"] = 0xFF63
-        special["<home>"] = 0xFF50
-        special["<end>"] = 0xFF57
-        special["<pageUp>"] = 0xFF55
-        special["<pageDown>"] = 0xFF56
+	special["<up>"] = 0xFF52
+	special["<down>"] = 0xFF54
+	special["<left>"] = 0xFF51
+	special["<right>"] = 0xFF53
+	special["<spacebar>"] = 0x020
+	special["<insert>"] = 0xFF63
+	special["<home>"] = 0xFF50
+	special["<end>"] = 0xFF57
+	special["<pageUp>"] = 0xFF55
+	special["<pageDown>"] = 0xFF56
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
 

--- a/builder/virtualbox/iso/step_type_boot_command.go
+++ b/builder/virtualbox/iso/step_type_boot_command.go
@@ -15,9 +15,9 @@ import (
 const KeyLeftShift uint32 = 0xFFE1
 
 type bootCommandTemplateData struct {
-	HTTPIP   string
+	HTTPIP	 string
 	HTTPPort uint
-	Name     string
+	Name	 string
 }
 
 // This step "types" the boot command into the VM over VNC.
@@ -118,16 +118,16 @@ func scancodes(message string) []string {
 	special["<f10>"] = []string{"44", "c4"}
 	special["<return>"] = []string{"1c", "9c"}
 	special["<tab>"] = []string{"0f", "8f"}
-        special["<up>"] = []string{"48", "c8"}
-        special["<down>"] = []string{"50", "d0"}
-        special["<left>"] = []string{"4b", "cb"}
-        special["<right>"] = []string{"4d", "cd"}
-        special["<spacebar>"] = []string{"39", "b9"}
-        special["<insert>"] = []string{"52", "d2"}
-        special["<home>"] = []string{"47", "c7"}
-        special["<end>"] = []string{"4f", "cf"}
-        special["<pageUp>"] = []string{"49", "c9"}
-        special["<pageDown>"] = []string{"51", "d1"}
+	special["<up>"] = []string{"48", "c8"}
+	special["<down>"] = []string{"50", "d0"}
+	special["<left>"] = []string{"4b", "cb"}
+	special["<right>"] = []string{"4d", "cd"}
+	special["<spacebar>"] = []string{"39", "b9"}
+	special["<insert>"] = []string{"52", "d2"}
+	special["<home>"] = []string{"47", "c7"}
+	special["<end>"] = []string{"4f", "cf"}
+	special["<pageUp>"] = []string{"49", "c9"}
+	special["<pageDown>"] = []string{"51", "d1"}
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
 

--- a/builder/vmware/iso/step_type_boot_command.go
+++ b/builder/vmware/iso/step_type_boot_command.go
@@ -18,9 +18,9 @@ import (
 const KeyLeftShift uint32 = 0xFFE1
 
 type bootCommandTemplateData struct {
-	HTTPIP   string
+	HTTPIP	 string
 	HTTPPort uint
-	Name     string
+	Name	 string
 }
 
 // This step "types" the boot command into the VM over VNC.
@@ -136,16 +136,16 @@ func vncSendString(c *vnc.ClientConn, original string) {
 	special["<f12>"] = 0xFFC9
 	special["<return>"] = 0xFF0D
 	special["<tab>"] = 0xFF09
-        special["<up>"] = 0xFF52
-        special["<down>"] = 0xFF54
-        special["<left>"] = 0xFF51
-        special["<right>"] = 0xFF53
-        special["<spacebar>"] = 0x020
-        special["<insert>"] = 0xFF63
-        special["<home>"] = 0xFF50
-        special["<end>"] = 0xFF57
-        special["<pageUp>"] = 0xFF55
-        special["<pageDown>"] = 0xFF56
+	special["<up>"] = 0xFF52
+	special["<down>"] = 0xFF54
+	special["<left>"] = 0xFF51
+	special["<right>"] = 0xFF53
+	special["<spacebar>"] = 0x020
+	special["<insert>"] = 0xFF63
+	special["<home>"] = 0xFF50
+	special["<end>"] = 0xFF57
+	special["<pageUp>"] = 0xFF55
+	special["<pageDown>"] = 0xFF56
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
 


### PR DESCRIPTION
While working on Solaris automated installation, @ccope found that Packer was missing some scancodes needed to walk-through/get-out of the GUI to a command line shell. The `virtualbox` types were ported from the old veewee code whereas the `qemu` and `vmware` came from the newly added comment.

There are certainly more keys which could be added, but this was all that we needed for now.
