### PR TITLE
templates: filter out C-style comments.

### DIFF
--- a/packer/template.go
+++ b/packer/template.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"sort"
 	"text/template"
 	"time"
@@ -91,7 +92,9 @@ type RawVariable struct {
 // The second parameter, vars, are the values for a set of user variables.
 func ParseTemplate(data []byte, vars map[string]string) (t *Template, err error) {
 	var rawTplInterface interface{}
-	err = jsonutil.Unmarshal(data, &rawTplInterface)
+	re := regexp.MustCompile("(?s)//.*?\n|/\\*.*?\\*/")
+	filteredData := re.ReplaceAll(data, nil)
+	err = jsonutil.Unmarshal(filteredData, &rawTplInterface)
 	if err != nil {
 		return
 	}

--- a/packer/template_test.go
+++ b/packer/template_test.go
@@ -1590,3 +1590,29 @@ func TestTemplateBuild_variablesRequiredNotSet(t *testing.T) {
 		t.Fatal("should error")
 	}
 }
+
+func TestTemplateBuild_commentsIgnored(t *testing.T) {
+	data := `
+	{
+        // we null the foo
+		"variables": {
+			"foo": null
+		},
+		"builders": [
+			{
+				"name": "test1",
+				"type": "test-builder"
+			}
+		]
+	}
+	`
+
+	result, err := ParseTemplate([]byte(data), map[string]string{})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if result.Variables == nil || len(result.Variables) != 1 {
+		t.Fatalf("bad vars: %#v", result.Variables)
+	}
+}


### PR DESCRIPTION
This is a dead simple solution to #283. I grabbed the regex from http://stackoverflow.com/a/12682896/105571

Not set on getting this merged, but it's an example of a minimally invasive way to solve this.

Fixes #283
