### PR TITLE
provisioner/ansible: upload playbooks correctly

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -137,7 +137,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		}
 		for _, src := range p.config.PlaybookPaths {
 			dst := filepath.Join(p.config.StagingDir, "playbooks", filepath.Base(src))
-			if err := p.uploadFile(ui, comm, dst, src); err != nil {
+			if err := p.uploadDir(ui, comm, dst, src); err != nil {
 				return fmt.Errorf("Error uploading playbooks: %s", err)
 			}
 		}


### PR DESCRIPTION
in #475, @kelseyhightower introduced the `ansible-local` Provisioner, which originally accepted a `playbook_paths` option, an array of paths to files to be copied over to the target.

in bf7530ca28,  @whoisjake updated `Prepare` in this Provisioner to validate that each path in `playbook_paths` corresponded to a directory, instead of a file, but did not update the original `Provision` implementation, which still calls `uploadFile` on each path. 

the end result appears to be that a user is unable to supply custom playbooks, because the call to `validateDirConfig` in `Prepare` ensures that only a directory can be supplied, while call to `uploadFile` in `Provision` ensures that directory never uploads correctly.

this updates `Provision` to call `uploadDir` instead, which creates the directories on the target, and uploads their contents, which i believe was the intention.
