### PR TITLE
Support for Security Groups in Openstack

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -88,9 +88,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DebugKeyPath: fmt.Sprintf("os_%s.pem", b.config.PackerBuildName),
 		},
 		&StepRunSourceServer{
-			Name:        b.config.ImageName,
-			Flavor:      b.config.Flavor,
-			SourceImage: b.config.SourceImage,
+			Name:           b.config.ImageName,
+			Flavor:         b.config.Flavor,
+			SourceImage:    b.config.SourceImage,
+			SecurityGroups: b.config.SecurityGroups,
 		},
 		&StepAllocateIp{
 			FloatingIpPool: b.config.FloatingIpPool,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -10,15 +10,16 @@ import (
 // RunConfig contains configuration for running an instance from a source
 // image and details on how to access that launched image.
 type RunConfig struct {
-	SourceImage       string `mapstructure:"source_image"`
-	Flavor            string `mapstructure:"flavor"`
-	RawSSHTimeout     string `mapstructure:"ssh_timeout"`
-	SSHUsername       string `mapstructure:"ssh_username"`
-	SSHPort           int    `mapstructure:"ssh_port"`
-	OpenstackProvider string `mapstructure:"openstack_provider"`
-	UseFloatingIp     bool   `mapstructure:"use_floating_ip"`
-	FloatingIpPool    string `mapstructure:"floating_ip_pool"`
-	FloatingIp        string `mapstructure:"floating_ip"`
+	SourceImage       string   `mapstructure:"source_image"`
+	Flavor            string   `mapstructure:"flavor"`
+	RawSSHTimeout     string   `mapstructure:"ssh_timeout"`
+	SSHUsername       string   `mapstructure:"ssh_username"`
+	SSHPort           int      `mapstructure:"ssh_port"`
+	OpenstackProvider string   `mapstructure:"openstack_provider"`
+	UseFloatingIp     bool     `mapstructure:"use_floating_ip"`
+	FloatingIpPool    string   `mapstructure:"floating_ip_pool"`
+	FloatingIp        string   `mapstructure:"floating_ip"`
+	SecurityGroups    []string `mapstructure:"security_groups"`
 
 	// Unexported fields that are calculated from others
 	sshTimeout time.Duration
@@ -76,8 +77,7 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 		var err error
 		*ptr, err = t.Process(*ptr, nil)
 		if err != nil {
-			errs = append(
-				errs, fmt.Errorf("Error processing %s: %s", n, err))
+			errs = append(errs, fmt.Errorf("Error processing %s: %s", n, err))
 		}
 	}
 

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -9,9 +9,10 @@ import (
 )
 
 type StepRunSourceServer struct {
-	Flavor      string
-	Name        string
-	SourceImage string
+	Flavor         string
+	Name           string
+	SourceImage    string
+	SecurityGroups []string
 
 	server *gophercloud.Server
 }
@@ -23,11 +24,18 @@ func (s *StepRunSourceServer) Run(state multistep.StateBag) multistep.StepAction
 
 	// XXX - validate image and flavor is available
 
+	securityGroups := make([]map[string]interface{}, len(s.SecurityGroups))
+	for i, groupName := range s.SecurityGroups {
+		securityGroups[i] = make(map[string]interface{})
+		securityGroups[i]["name"] = groupName
+	}
+
 	server := gophercloud.NewServer{
-		Name:        s.Name,
-		ImageRef:    s.SourceImage,
-		FlavorRef:   s.Flavor,
-		KeyPairName: keyName,
+		Name:          s.Name,
+		ImageRef:      s.SourceImage,
+		FlavorRef:     s.Flavor,
+		KeyPairName:   keyName,
+		SecurityGroup: securityGroups,
 	}
 
 	serverResp, err := csp.CreateServer(server)


### PR DESCRIPTION
These changes allow the user to pass a string or a list of strings into the builder template, and then passes that information off to Gophercloud in an acceptable format. This should address issue #800 - but only once a few changes are accepted by Gophercloud upstream - so this branch shouldn't be merged until that's settled, which shouldn't take long.
