### PR TITLE
Added rackspace builder that inherits from the openstack builder

### DIFF
--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -9,11 +9,11 @@ import (
 	"time"
 )
 
-type stepCreateImage struct{}
+type StepCreateImage struct{}
 
-func (s *stepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
+func (s *StepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 	csp := state.Get("csp").(gophercloud.CloudServersProvider)
-	config := state.Get("config").(config)
+	config := state.Get("config").(Config)
 	server := state.Get("server").(*gophercloud.Server)
 	ui := state.Get("ui").(packer.Ui)
 
@@ -46,7 +46,7 @@ func (s *stepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
-func (s *stepCreateImage) Cleanup(multistep.StateBag) {
+func (s *StepCreateImage) Cleanup(multistep.StateBag) {
 	// No cleanup...
 }
 

--- a/builder/rackspace/builder.go
+++ b/builder/rackspace/builder.go
@@ -1,0 +1,105 @@
+
+package rackspace
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/packer"
+	"github.com/rackspace/gophercloud"
+	"github.com/mitchellh/packer/builder/openstack"
+	"log"
+)
+
+// The unique ID for this builder
+const BuilderId = "mitchellh.rackspace"
+
+type Builder struct {
+	builder openstack.Builder
+}
+
+func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
+	// Prepare wraps the openstack prepare function
+	return b.builder.Prepare(raws...)
+}
+
+func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
+	auth, err := b.builder.Config.AccessConfig.Auth()
+	if err != nil {
+		return nil, err
+	}
+	api := &gophercloud.ApiCriteria{ 
+		Name:      "cloudServersOpenStack",
+		Region:    b.builder.Config.AccessConfig.Region(),
+		VersionId: "2",
+		UrlChoice: gophercloud.PublicURL,
+	}
+	csp, err := gophercloud.ServersApi(auth, *api)
+	if err != nil {
+		log.Printf("Region: %s", b.builder.Config.AccessConfig.Region())
+		return nil, err
+	}
+
+	// Setup the state bag and initial state for the steps
+	state := new(multistep.BasicStateBag)
+	state.Put("config", b.builder.Config)
+	state.Put("csp", csp)
+	state.Put("hook", hook)
+	state.Put("ui", ui)
+
+	// Build the steps
+	steps := []multistep.Step{
+		&openstack.StepKeyPair{
+			Debug:        b.builder.Config.PackerDebug,
+			DebugKeyPath: fmt.Sprintf("os_%s.pem", b.builder.Config.PackerBuildName),
+		},
+		&openstack.StepRunSourceServer{
+			Name:        b.builder.Config.ImageName,
+			Flavor:      b.builder.Config.Flavor,
+			SourceImage: b.builder.Config.SourceImage,
+		},
+		&common.StepConnectSSH{
+			SSHAddress:     openstack.SSHAddress(csp, b.builder.Config.SSHPort),
+			SSHConfig:      openstack.SSHConfig(b.builder.Config.SSHUsername),
+			SSHWaitTimeout: b.builder.Config.SSHTimeout(),
+		},
+		&common.StepProvision{},
+		&openstack.StepCreateImage{},
+	}
+
+	// Run!
+	if b.builder.Config.PackerDebug {
+		b.builder.Runner = &multistep.DebugRunner{
+			Steps:   steps,
+			PauseFn: common.MultistepDebugFn(ui),
+		}
+	} else {
+		b.builder.Runner = &multistep.BasicRunner{Steps: steps}
+	}
+
+	b.builder.Runner.Run(state)
+
+	// If there was an error, return that
+	if rawErr, ok := state.GetOk("error"); ok {
+		return nil, rawErr.(error)
+	}
+
+	// If there are no images, then just return
+	if _, ok := state.GetOk("image"); !ok {
+		return nil, nil
+	}
+
+	// Build the artifact and return it
+	artifact := &openstack.Artifact{
+		ImageId:        state.Get("image").(string),
+		BuilderIdValue: BuilderId,
+		Conn:           csp,
+	}
+
+	return artifact, nil
+}
+
+func (b *Builder) Cancel() {
+	// wraps the openstack cancel function 
+	b.builder.Cancel()
+}

--- a/builder/rackspace/builder_test.go
+++ b/builder/rackspace/builder_test.go
@@ -1,0 +1,94 @@
+package rackspace
+
+import (
+	"github.com/mitchellh/packer/packer"
+	"testing"
+)
+
+func testConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"username":     "foo",
+		"password":     "bar",
+		"provider":     "foo",
+		"region":       "DFW",
+		"image_name":   "foo",
+		"source_image": "foo",
+		"flavor":       "foo",
+		"ssh_username": "root",
+	}
+}
+
+func TestBuilder_ImplementsBuilder(t *testing.T) {
+	var raw interface{}
+	raw = &Builder{}
+	if _, ok := raw.(packer.Builder); !ok {
+		t.Fatalf("Builder should be a builder")
+	}
+}
+
+func TestBuilder_Prepare_BadType(t *testing.T) {
+	b := &Builder{}
+	c := map[string]interface{}{
+		"password": []string{},
+	}
+
+	warns, err := b.Prepare(c)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatalf("prepare should fail")
+	}
+}
+
+func TestBuilderPrepare_ImageName(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test good
+	config["image_name"] = "foo"
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	// Test bad
+	config["image_name"] = "foo {{"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test bad
+	delete(config, "image_name")
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}
+
+func TestBuilderPrepare_InvalidKey(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Add a random key
+	config["i_should_not_be_valid"] = true
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}

--- a/plugin/builder-rackspace/main.go
+++ b/plugin/builder-rackspace/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+    "github.com/mitchellh/packer/builder/rackspace"
+    "github.com/mitchellh/packer/packer/plugin"
+)
+
+func main() {
+    server, err := plugin.Server()
+    if err != nil {
+        panic(err)
+    }
+    server.RegisterBuilder(new(rackspace.Builder))
+    server.Serve()
+}

--- a/plugin/builder-rackspace/main_test.go
+++ b/plugin/builder-rackspace/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/scripts/devcompile.sh
+++ b/scripts/devcompile.sh
@@ -56,4 +56,14 @@ export XC_OS=$(go env GOOS)
 ./scripts/compile.sh
 
 # Move all the compiled things to the PATH
+
 cp pkg/${XC_OS}_${XC_ARCH}/* ${GOPATH}/bin
+case $(uname) in
+    CYGWIN*)
+        GOPATH="$(cygpath $GOPATH)"
+        ;;
+esac
+
+IFS=: MAIN_GOPATH=( $GOPATH )
+cp pkg/${XC_OS}_${XC_ARCH}/* ${MAIN_GOPATH}/bin
+


### PR DESCRIPTION
The rackspace builder is essentially the openstack builder but works with rackspace. It wraps the Prepare and Cancel functions in order to implement the Builder interface. The run function is only slightly different and mostly it points to builder/openstack data in order to keep from breaking when openstack changes. 
