### PR TITLE
Allow Qemu binary name to be configured

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -55,6 +55,7 @@ type config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	Accelerator     string     `mapstructure:"accelerator"`
+	QemuBinary      string     `mapstructure:"qemu_binary"`
 	BootCommand     []string   `mapstructure:"boot_command"`
 	DiskInterface   string     `mapstructure:"disk_interface"`
 	DiskSize        uint       `mapstructure:"disk_size"`
@@ -107,6 +108,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	// Accumulate any errors
 	errs := common.CheckUnusedConfig(md)
+
+	if b.config.QemuBinary == "" {
+		b.config.QemuBinary = "qemu-system-x86_64"
+	}
 
 	if b.config.DiskSize == 0 {
 		b.config.DiskSize = 40000
@@ -370,7 +375,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
 	// Create the driver that we'll use to communicate with Qemu
-	driver, err := b.newDriver()
+	driver, err := b.newDriver(b.config.QemuBinary)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating Qemu driver: %s", err)
 	}
@@ -484,8 +489,8 @@ func (b *Builder) Cancel() {
 	}
 }
 
-func (b *Builder) newDriver() (Driver, error) {
-	qemuPath, err := exec.LookPath("qemu-system-x86_64")
+func (b *Builder) newDriver(qemuBinary string) (Driver, error) {
+	qemuPath, err := exec.LookPath(qemuBinary)
 	if err != nil {
 		return nil, err
 	}

--- a/website/source/docs/builders/qemu.html.markdown
+++ b/website/source/docs/builders/qemu.html.markdown
@@ -192,6 +192,11 @@ Optional:
     qemu-system-x86 -m 1024m --no-acpi -netdev user,id=mynet0,hostfwd=hostip:hostport-guestip:guestport -device virtio-net,netdev=mynet0"
 </pre>
 
+* `qemu_binary` (string) - The name of the Qemu binary to look for.  This
+  defaults to "qemu-system-x86_64", but may need to be changed for some
+  platforms.  For example "qemu-kvm", or "qemu-system-i386" may be a better
+  choice for some systems.
+
 * `output_directory` (string) - This is the path to the directory where the
   resulting virtual machine will be created. This may be relative or absolute.
   If relative, the path is relative to the working directory when `packer`


### PR DESCRIPTION
On some systems the default Qemu binary name of qemu-system-x86_64
isn't appropriate.  So expose the binary name as a configurable item,
allowing the user to set it to something more appropriate if they need
to.
