### PR TITLE
enable qemu builder to handle reboots in the shell provisioner

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -392,23 +392,13 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		new(stepForwardSSH),
 		new(stepConfigureVNC),
 		&stepRun{
-			BootDrive: "d",
+			BootDrive: "once=d",
 			Message:   "Starting VM, booting from CD-ROM",
 		},
-	}
-
-	if !b.config.RunOnce {
-		steps = append(steps,
-			&stepBootWait{},
-			&stepTypeBootCommand{},
-			&stepWaitForShutdown{
-				Message: "Waiting for initial VM boot to shut down",
-			},
-			&stepRun{
-				BootDrive: "c",
-				Message:   "Starting VM, booting from hard disk",
-			},
-		)
+		&stepBootWait{},
+		&stepTypeBootCommand{},
+		
+		
 	}
 
 	steps = append(steps,


### PR DESCRIPTION
The qemu builder was not able to handle reboots in the provisioning step. I changed the boot drive to perform only the first boot fom cd.
(Now it is not necessary to add "-no-reboot" to the qemuargs.)
