### PR TITLE
esx5, get host IP by creating & inspecting connection, allows hypervisor...

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -126,27 +126,14 @@ func (d *ESX5Driver) Verify() error {
 }
 
 func (d *ESX5Driver) HostIP() (string, error) {
-	ip := net.ParseIP(d.Host)
-	interfaces, err := net.Interfaces()
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", d.Host, d.Port))
+	defer conn.Close()
 	if err != nil {
 		return "", err
 	}
 
-	for _, dev := range interfaces {
-		addrs, err := dev.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, addr := range addrs {
-			if ipnet, ok := addr.(*net.IPNet); ok {
-				if ipnet.Contains(ip) {
-					return ipnet.IP.String(), nil
-				}
-			}
-		}
-	}
-
-	return "", errors.New("Unable to determine Host IP")
+	host, _, err := net.SplitHostPort(conn.LocalAddr().String())
+	return host, err
 }
 
 func (d *ESX5Driver) VNCAddress(portMin, portMax uint) (string, uint) {

--- a/builder/vmware/iso/driver_esx5_test.go
+++ b/builder/vmware/iso/driver_esx5_test.go
@@ -1,7 +1,9 @@
 package iso
 
 import (
+	"fmt"
 	vmwcommon "github.com/mitchellh/packer/builder/vmware/common"
+	"net"
 	"testing"
 )
 
@@ -15,4 +17,19 @@ func TestESX5Driver_implOutputDir(t *testing.T) {
 
 func TestESX5Driver_implRemoteDriver(t *testing.T) {
 	var _ RemoteDriver = new(ESX5Driver)
+}
+
+func TestESX5Driver_HostIP(t *testing.T) {
+        expected_host := "127.0.0.1"
+
+        //create mock SSH server
+	listen, _ := net.Listen("tcp", fmt.Sprintf("%s:0", expected_host))
+	port := listen.Addr().(*net.TCPAddr).Port
+	defer listen.Close()
+
+	driver := ESX5Driver{Host: "localhost", Port: uint(port)}
+
+	if host, _ := driver.HostIP(); host != expected_host {
+		t.Error(fmt.Sprintf("Expected string, %s but got %s", expected_host, host))
+	}
 }


### PR DESCRIPTION
Previously the hypervisor had to be on the same network as the host machine running packer. This fix allows the hypervisor packer runs against to be on a different network.

Incidentally this fix also allows you to specify the remote hypervisor address using a hostname in the template, previously it had to be a IP address or this method would return nil.
