### PR TITLE
Use --url flag rather than --location for ec2-upload-bundle

### DIFF
--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -74,7 +74,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 			"-s {{.SecretKey}} " +
 			"-d {{.BundleDirectory}} " +
 			"--batch " +
-			"--location {{.Region}} " +
+			"--url https://s3-{{.Region}}.amazonaws.com " +
 			"--retry"
 	}
 

--- a/builder/amazon/instance/step_upload_bundle.go
+++ b/builder/amazon/instance/step_upload_bundle.go
@@ -32,18 +32,12 @@ func (s *StepUploadBundle) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	// See GH-729 and http://goo.gl/rNZiCs
-	regionName := region.Name
-	if regionName == "us-east-1" {
-		regionName = "US"
-	}
-
 	config.BundleUploadCommand, err = config.tpl.Process(config.BundleUploadCommand, uploadCmdData{
 		AccessKey:       config.AccessKey,
 		BucketName:      config.S3Bucket,
 		BundleDirectory: config.BundleDestination,
 		ManifestPath:    manifestPath,
-		Region:          regionName,
+		Region:          region.Name,
 		SecretKey:       config.SecretKey,
 	})
 	if err != nil {

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -277,7 +277,7 @@ sudo -n ec2-upload-bundle \
 	-s {{.SecretKey}} \
 	-d {{.BundleDirectory}} \
 	--batch \
-	--location {{.Region}} \
+	--url https://s3-{{.Region}}.amazonaws.com \
 	--retry
 ```
 


### PR DESCRIPTION
I encountered a similar issue to [GH729](https://github.com/mitchellh/packer/issues/729) when trying to use eu-west-1 alongside `ec2-upload-bundle`.  After reading through the [AMI Tools docs](http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/CLTRG-ami-upload-bundle.html) it looks like the location should be set to `EU` which would need an extra `if` statement similar to the [GH729](https://github.com/mitchellh/packer/issues/729) fix at [commit 6898626](https://github.com/mitchellh/packer/commit/68986263f41106860fca8e639c5781f79e71c431).

However, the [AMI Tools docs](http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/CLTRG-ami-upload-bundle.html) also states that the `--location` flag is deprecated and to use the `--url` flag and point to the region's endpoint instead ([S3 endpoint docs](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)).  This change brings Packer in line with this recommendation.

I'm not a Go coder so maybe this could have been done nicer/cleaner, however the tests are passing and I'm using this build to successfully bundle up `ec-instance` builds to the correct region now.
