### PR TITLE
Adding docs to #645 on the website

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.markdown
+++ b/website/source/docs/builders/amazon-chroot.html.markdown
@@ -83,7 +83,7 @@ Optional:
 
 * `ami_groups` (array of string) - A list of groups that have access
   to launch the resulting AMI(s). By default no groups have permission
-  to launch the AMI.
+  to launch the AMI. `all` will make the AMI publicly accessible.
 
 * `ami_product_codes` (array of string) - A list of product codes to
   associate with the AMI. By default no product codes are associated with

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -69,7 +69,7 @@ Optional:
 
 * `ami_groups` (array of string) - A list of groups that have access
   to launch the resulting AMI(s). By default no groups have permission
-  to launch the AMI.
+  to launch the AMI. `all` will make the AMI publicly accessible.
 
 * `ami_product_codes` (array of string) - A list of product codes to
   associate with the AMI. By default no product codes are associated with

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -92,7 +92,7 @@ Optional:
 
 * `ami_groups` (array of string) - A list of groups that have access
   to launch the resulting AMI(s). By default no groups have permission
-  to launch the AMI.
+  to launch the AMI. `all` will make the AMI publicly accessible.
 
 * `ami_product_codes` (array of string) - A list of product codes to
   associate with the AMI. By default no product codes are associated with


### PR DESCRIPTION
Setting `"ami_groups": ["all"]` will make the AMI publicly accessible.
Correcting website docs for this.
