### PR TITLE
builder/amazon: Fix S3 endpoint URL for instance-store builds

### DIFF
--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -74,7 +74,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 			"-s {{.SecretKey}} " +
 			"-d {{.BundleDirectory}} " +
 			"--batch " +
-			"--url https://s3-{{.Region}}.amazonaws.com " +
+			"--url {{.S3Endpoint}} " +
 			"--retry"
 	}
 

--- a/builder/amazon/instance/step_upload_bundle.go
+++ b/builder/amazon/instance/step_upload_bundle.go
@@ -11,7 +11,7 @@ type uploadCmdData struct {
 	BucketName      string
 	BundleDirectory string
 	ManifestPath    string
-	Region          string
+	S3Endpoint      string
 	SecretKey       string
 }
 
@@ -37,7 +37,7 @@ func (s *StepUploadBundle) Run(state multistep.StateBag) multistep.StepAction {
 		BucketName:      config.S3Bucket,
 		BundleDirectory: config.BundleDestination,
 		ManifestPath:    manifestPath,
-		Region:          region.Name,
+		S3Endpoint:      region.S3Endpoint,
 		SecretKey:       config.SecretKey,
 	})
 	if err != nil {


### PR DESCRIPTION
The S3 endpoint URLs don't always include the region name. See:

```
http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
```

This mapping is already provided by `goamz` via `region.S3Endpoint`,
so let's use it.
