### PR TITLE
[Openstack] added support for gophercloud's PopulateApi

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -60,13 +60,15 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if err != nil {
 		return nil, err
 	}
-	api := &gophercloud.ApiCriteria{
-		Name:      "cloudServersOpenStack",
-		Region:    b.config.AccessConfig.Region(),
-		VersionId: "2",
-		UrlChoice: gophercloud.PublicURL,
+	//fetches the api requisites from gophercloud for the appropriate
+	//openstack variant
+	api, err := gophercloud.PopulateApi(b.config.RunConfig.OpenstackProvider)
+	if err != nil {
+		return nil, err
 	}
-	csp, err := gophercloud.ServersApi(auth, *api)
+	api.Region = b.config.AccessConfig.Region()
+
+	csp, err := gophercloud.ServersApi(auth, api)
 	if err != nil {
 		log.Printf("Region: %s", b.config.AccessConfig.Region())
 		return nil, err

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -10,11 +10,12 @@ import (
 // RunConfig contains configuration for running an instance from a source
 // image and details on how to access that launched image.
 type RunConfig struct {
-	SourceImage   string `mapstructure:"source_image"`
-	Flavor        string `mapstructure:"flavor"`
-	RawSSHTimeout string `mapstructure:"ssh_timeout"`
-	SSHUsername   string `mapstructure:"ssh_username"`
-	SSHPort       int    `mapstructure:"ssh_port"`
+	SourceImage       string `mapstructure:"source_image"`
+	Flavor            string `mapstructure:"flavor"`
+	RawSSHTimeout     string `mapstructure:"ssh_timeout"`
+	SSHUsername       string `mapstructure:"ssh_username"`
+	SSHPort           int    `mapstructure:"ssh_port"`
+	OpenstackProvider string `mapstructure:"openstack_provider"`
 
 	// Unexported fields that are calculated from others
 	sshTimeout time.Duration


### PR DESCRIPTION
Currently different OpenStack api implementations require different hardcoded fields in the Gophercloud ApiCriteria struct, which limits Packer's ability to work with these varying Openstack implementations (currently it is hardcoded to only work with Rackspace).

This commit simplifies the packer OpenStack plug-in by allowing a user to specify their chosen OpenStack implementation via a string in the template, and gophercloud takes care of the rest (https://github.com/rackspace/gophercloud/commit/12bc4df91910b2fbae02df4a542e56137594a95e).
