### PR TITLE
[OpenStack] Add flexible IP pool/address handling.

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -92,6 +92,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Flavor:      b.config.Flavor,
 			SourceImage: b.config.SourceImage,
 		},
+		&StepAllocateIp{
+			FloatingIpPool: b.config.FloatingIpPool,
+			FloatingIp:     b.config.FloatingIp,
+		},
 		&common.StepConnectSSH{
 			SSHAddress:     SSHAddress(csp, b.config.SSHPort),
 			SSHConfig:      SSHConfig(b.config.SSHUsername),

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -16,6 +16,9 @@ type RunConfig struct {
 	SSHUsername       string `mapstructure:"ssh_username"`
 	SSHPort           int    `mapstructure:"ssh_port"`
 	OpenstackProvider string `mapstructure:"openstack_provider"`
+	UseFloatingIp     bool   `mapstructure:"use_floating_ip"`
+	FloatingIpPool    string `mapstructure:"floating_ip_pool"`
+	FloatingIp        string `mapstructure:"floating_ip"`
 
 	// Unexported fields that are calculated from others
 	sshTimeout time.Duration
@@ -41,6 +44,10 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 
 	if c.RawSSHTimeout == "" {
 		c.RawSSHTimeout = "5m"
+	}
+
+	if c.UseFloatingIp && c.FloatingIpPool == "" {
+		c.FloatingIpPool = "public"
 	}
 
 	// Validation

--- a/builder/openstack/ssh.go
+++ b/builder/openstack/ssh.go
@@ -13,23 +13,34 @@ import (
 // for determining the SSH address based on the server AccessIPv4 setting..
 func SSHAddress(csp gophercloud.CloudServersProvider, port int) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
-		for j := 0; j < 2; j++ {
-			s := state.Get("server").(*gophercloud.Server)
-			if s.AccessIPv4 != "" {
-				return fmt.Sprintf("%s:%d", s.AccessIPv4, port), nil
-			}
-			if s.AccessIPv6 != "" {
-				return fmt.Sprintf("[%s]:%d", s.AccessIPv6, port), nil
-			}
-			serverState, err := csp.ServerById(s.Id)
+		s := state.Get("server").(*gophercloud.Server)
 
-			if err != nil {
-				return "", err
-			}
-
-			state.Put("server", serverState)
-			time.Sleep(1 * time.Second)
+		if ip := state.Get("access_ip").(gophercloud.FloatingIp); ip.Ip != "" {
+			return fmt.Sprintf("%s:%d", ip.Ip, port), nil
 		}
+
+		ip_pools, err := s.AllAddressPools()
+		if err != nil {
+			return "", errors.New("Error parsing SSH addresses")
+		}
+		for pool, addresses := range ip_pools {
+			if pool != "" {
+				for _, address := range addresses {
+					if address.Addr != "" {
+						return fmt.Sprintf("%s:%d", address.Addr, port), nil
+					}
+				}
+			}
+		}
+
+		serverState, err := csp.ServerById(s.Id)
+
+		if err != nil {
+			return "", err
+		}
+
+		state.Put("server", serverState)
+		time.Sleep(1 * time.Second)
 
 		return "", errors.New("couldn't determine IP address for server")
 	}

--- a/builder/openstack/step_allocate_ip.go
+++ b/builder/openstack/step_allocate_ip.go
@@ -1,0 +1,66 @@
+package openstack
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	"github.com/rackspace/gophercloud"
+)
+
+type StepAllocateIp struct {
+	FloatingIpPool string
+	FloatingIp     string
+}
+
+func (s *StepAllocateIp) Run(state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	csp := state.Get("csp").(gophercloud.CloudServersProvider)
+	server := state.Get("server").(*gophercloud.Server)
+
+	var instanceIp gophercloud.FloatingIp
+	// This is here in case we error out before putting instanceIp into the
+	// statebag below, because it is requested by Cleanup()
+	state.Put("access_ip", instanceIp)
+
+	if s.FloatingIp != "" {
+		instanceIp.Ip = s.FloatingIp
+	} else if s.FloatingIpPool != "" {
+		newIp, err := csp.CreateFloatingIp(s.FloatingIpPool)
+		if err != nil {
+			err := fmt.Errorf("Error creating floating ip from pool '%s'", s.FloatingIpPool)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		instanceIp = newIp
+		ui.Say(fmt.Sprintf("Created temporary floating IP %s...", instanceIp.Ip))
+	}
+
+	if instanceIp.Ip != "" {
+		if err := csp.AssociateFloatingIp(server.Id, instanceIp); err != nil {
+			err := fmt.Errorf("Error associating floating IP %s with instance.", instanceIp.Ip)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		} else {
+			ui.Say(fmt.Sprintf("Added floating IP %s to instance...", instanceIp.Ip))
+		}
+	}
+
+	state.Put("access_ip", instanceIp)
+
+	return multistep.ActionContinue
+}
+
+func (s *StepAllocateIp) Cleanup(state multistep.StateBag) {
+	ui := state.Get("ui").(packer.Ui)
+	csp := state.Get("csp").(gophercloud.CloudServersProvider)
+	instanceIp := state.Get("access_ip").(gophercloud.FloatingIp)
+	if s.FloatingIpPool != "" && instanceIp.Id != 0 {
+		if err := csp.DeleteFloatingIp(instanceIp); err != nil {
+			ui.Error(fmt.Sprintf("Error deleting temporary floating IP %s", instanceIp.Ip))
+			return
+		}
+		ui.Say(fmt.Sprintf("Deleted temporary floating IP %s", instanceIp.Ip))
+	}
+}


### PR DESCRIPTION
This PR fixes #805, and also adds support for specifying floating ips and floating ip pools in the packer template.

In the case that one only has access to OpenStack VMs via floating IPs (i.e., outside the private network), it can be necessary to be able to specify either which IP to use for SSH access to an instance/VM, or which IP pool to create a temporary floating IP from. This PR adds the following optional fields to the openstack builder template:

"use_floating_ip": true    // This creates a temporary floating IP from the default pool "public" and adds it to the instance
"floating_ip_pool": "some_ip_pool"    // Same as above, except the IP is grabbed from "some_ip_pool"
"use_floating_ip": "some_ip_address"    // Adds a pre-existing floating IP to the instance for SSH
