### PR TITLE
increase SSH timeouts for Amazon builders

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -47,7 +47,7 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 	}
 
 	if c.RawSSHTimeout == "" {
-		c.RawSSHTimeout = "1m"
+		c.RawSSHTimeout = "5m"
 	}
 
 	if c.TemporaryKeyPairName == "" {


### PR DESCRIPTION
they can take a while to spin up at times
