### PR TITLE
Fix syntax error

### DIFF
--- a/scripts/devcompile.sh
+++ b/scripts/devcompile.sh
@@ -15,7 +15,7 @@ verify_go () {
         return 0
     fi
     local IFS=.
-    local i ver1="$1" ver2="$2"
+    local i ver1=($1) ver2=($2)
 
     for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
     do


### PR DESCRIPTION
Fix issue where using double quotes instead of round brackets would cause the following error:
./scripts/devcompile.sh: line 30: 10#1.2 > 10#1.2.1: syntax error: invalid arithmetic operator (error token is ".2 > 10#1.2.1")
