### PR TITLE
Fix ansible paths when provisioning Linux from Windows

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -153,7 +153,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 
 	ui.Message("Uploading main Playbook file...")
 	src := p.config.PlaybookFile
-	dst := filepath.Join(p.config.StagingDir, filepath.Base(src))
+	dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(src)))
 	if err := p.uploadFile(ui, comm, dst, src); err != nil {
 		return fmt.Errorf("Error uploading main playbook: %s", err)
 	}
@@ -161,7 +161,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	if len(p.config.GroupVars) > 0 {
 		ui.Message("Uploading group_vars directory...")
 		src := p.config.GroupVars
-		dst := filepath.Join(p.config.StagingDir, "group_vars")
+		dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, "group_vars"))
 		if err := p.uploadDir(ui, comm, dst, src); err != nil {
 			return fmt.Errorf("Error uploading group_vars directory: %s", err)
 		}
@@ -170,7 +170,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	if len(p.config.HostVars) > 0 {
 		ui.Message("Uploading host_vars directory...")
 		src := p.config.HostVars
-		dst := filepath.Join(p.config.StagingDir, "host_vars")
+		dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, "host_vars"))
 		if err := p.uploadDir(ui, comm, dst, src); err != nil {
 			return fmt.Errorf("Error uploading host_vars directory: %s", err)
 		}
@@ -179,7 +179,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	if len(p.config.RolePaths) > 0 {
 		ui.Message("Uploading role directories...")
 		for _, src := range p.config.RolePaths {
-			dst := filepath.Join(p.config.StagingDir, "roles", filepath.Base(src))
+			dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, "roles", filepath.Base(src)))
 			if err := p.uploadDir(ui, comm, dst, src); err != nil {
 				return fmt.Errorf("Error uploading roles: %s", err)
 			}
@@ -188,11 +188,12 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 
 	if len(p.config.PlaybookPaths) > 0 {
 		ui.Message("Uploading additional Playbooks...")
-		if err := p.createDir(ui, comm, filepath.Join(p.config.StagingDir, "playbooks")); err != nil {
+		playbookDir := filepath.ToSlash(filepath.Join(p.config.StagingDir, "playbooks"))
+		if err := p.createDir(ui, comm, playbookDir); err != nil {
 			return fmt.Errorf("Error creating playbooks directory: %s", err)
 		}
 		for _, src := range p.config.PlaybookPaths {
-			dst := filepath.Join(p.config.StagingDir, "playbooks", filepath.Base(src))
+			dst := filepath.ToSlash(filepath.Join(playbookDir, filepath.Base(src)))
 			if err := p.uploadDir(ui, comm, dst, src); err != nil {
 				return fmt.Errorf("Error uploading playbooks: %s", err)
 			}
@@ -212,7 +213,7 @@ func (p *Provisioner) Cancel() {
 }
 
 func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator) error {
-	playbook := filepath.Join(p.config.StagingDir, filepath.Base(p.config.PlaybookFile))
+	playbook := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.PlaybookFile)))
 
 	// The inventory must be set to "127.0.0.1,".  The comma is important
 	// as its the only way to override the ansible inventory when dealing


### PR DESCRIPTION
When using Ansible-local to provision a Linux VM from Windows it is crashing with an error like the following:

```
virtualbox-iso: Provisioning with Ansible...
virtualbox-iso: Creating Ansible staging directory...
virtualbox-iso: Creating directory: /tmp/packer-provisioner-ansible-local
virtualbox-iso: Uploading main Playbook file...
virtualbox-iso: Uploading additional Playbooks...
virtualbox-iso: Creating directory: \tmp\packer-provisioner-ansible-local\playbooks
virtualbox-iso: Creating directory: \tmp\packer-provisioner-ansible-local\playbooks\tasks
virtualbox-iso: Executing Ansible: ansible-playbook \tmp\packer-provisioner-ansible-local\dev_config.yml --extra-vars task_path=playbooks/tasks -c local -i "127.0.0.1,"
virtualbox-iso: ERROR: the playbook: tmppacker-provisioner-ansible-localdev_config.yml could not be found
virtualbox-iso: Unregistering and deleting virtual machine...
virtualbox-iso: Deleting output directory...
Build 'virtualbox-iso' errored: Error executing Ansible: Non-zero exit status: 1
```

This is happening because the path to the files is being generated on the host Windows machine and executed on the Linux VM so it doesn't recognize the path separator. This patch converts all the paths to using '/' for the separator.

I'm not very familiar with Go but I believe using a slash for the separator will work for either case on the VM operating system. I'm basing this on the comment here:

https://github.com/mitchellh/packer/blob/master/communicator/ssh/communicator.go#L168

I don't have a big variety of environments to test on but this change worked for the above mentioned case for me.

It looks like there is a similar issue for the chef-solo provisioner in #394
