### PR TITLE
Fix a trailing comma in an example template

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -148,7 +148,7 @@ Here is a basic example. It is completely valid except for the access keys:
   "source_ami": "ami-de0d9eb7",
   "instance_type": "t1.micro",
   "ssh_username": "ubuntu",
-  "ami_name": "packer-quick-start {{timestamp}}",
+  "ami_name": "packer-quick-start {{timestamp}}"
 }
 </pre>
 


### PR DESCRIPTION
The trailing makes the template invalid. Error:
`Failed to parse template: Error in line 10, char 0: invalid character '}' looking for beginning of object key string
}`
