### PR TITLE
optionally use existing ssh key for amazon builders

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -19,6 +19,7 @@ type RunConfig struct {
 	SourceAmi                string            `mapstructure:"source_ami"`
 	RawSSHTimeout            string            `mapstructure:"ssh_timeout"`
 	SSHUsername              string            `mapstructure:"ssh_username"`
+	SSHPrivateKeyFile        string            `mapstructure:"ssh_private_key_file"`
 	SSHPort                  int               `mapstructure:"ssh_port"`
 	SecurityGroupId          string            `mapstructure:"security_group_id"`
 	SecurityGroupIds         []string          `mapstructure:"security_group_ids"`
@@ -91,6 +92,7 @@ func (c *RunConfig) Prepare(t *packer.ConfigTemplate) []error {
 		"instance_type":           &c.InstanceType,
 		"ssh_timeout":             &c.RawSSHTimeout,
 		"ssh_username":            &c.SSHUsername,
+		"ssh_private_key_file":    &c.SSHPrivateKeyFile,
 		"source_ami":              &c.SourceAmi,
 		"subnet_id":               &c.SubnetId,
 		"temporary_key_pair_name": &c.TemporaryKeyPairName,

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -83,9 +83,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepKeyPair{
-			Debug:        b.config.PackerDebug,
-			DebugKeyPath: fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
-			KeyPairName:  b.config.TemporaryKeyPairName,
+			Debug:          b.config.PackerDebug,
+			DebugKeyPath:   fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
+			KeyPairName:    b.config.TemporaryKeyPairName,
+			PrivateKeyFile: b.config.SSHPrivateKeyFile,
 		},
 		&awscommon.StepSecurityGroup{
 			SecurityGroupIds: b.config.SecurityGroupIds,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -187,9 +187,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepKeyPair{
-			Debug:        b.config.PackerDebug,
-			DebugKeyPath: fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
-			KeyPairName:  b.config.TemporaryKeyPairName,
+			Debug:          b.config.PackerDebug,
+			DebugKeyPath:   fmt.Sprintf("ec2_%s.pem", b.config.PackerBuildName),
+			KeyPairName:    b.config.TemporaryKeyPairName,
+			PrivateKeyFile: b.config.SSHPrivateKeyFile,
 		},
 		&awscommon.StepSecurityGroup{
 			SecurityGroupIds: b.config.SecurityGroupIds,

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -108,6 +108,9 @@ Optional:
 * `ssh_port` (int) - The port that SSH will be available on. This defaults
   to port 22.
 
+* `ssh_private_key_file` - Use this ssh private key file instead of a generated
+  ssh key pair for connecting to the instance.
+
 * `ssh_timeout` (string) - The time to wait for SSH to become available
   before timing out. The format of this value is a duration such as "5s"
   or "5m". The default SSH timeout is "5m", or five minutes.

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -147,6 +147,9 @@ Optional:
 * `ssh_port` (int) - The port that SSH will be available on. This defaults
   to port 22.
 
+* `ssh_private_key_file` - Use this ssh private key file instead of a generated
+  ssh key pair for connecting to the instance.
+
 * `ssh_timeout` (string) - The time to wait for SSH to become available
   before timing out. The format of this value is a duration such as "5s"
   or "5m". The default SSH timeout is "5m", or five minutes.


### PR DESCRIPTION
Optionally use an existing ssh key with the amazon-ebs and amazon-instance builders. This is especially useful for working with Windows AMIs.
