### PR TITLE
fixing colored output of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 
 all: deps
 	@mkdir -p bin/
-	@echo "$(OK_COLOR)==> Building$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Building$(NO_COLOR)"
 	@bash --norc -i ./scripts/devcompile.sh
 
 deps:
-	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
 	@go get -d -v ./...
 	@echo $(DEPS) | xargs -n1 go get -d
 
 updatedeps:
-	@echo "$(OK_COLOR)==> Updating all dependencies$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Updating all dependencies$(NO_COLOR)"
 	@go get -d -v -u ./...
 	@echo $(DEPS) | xargs -n1 go get -d -u
 
@@ -26,7 +26,7 @@ format:
 	go fmt ./...
 
 test: deps
-	@echo "$(OK_COLOR)==> Testing Packer...$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Testing Packer...$(NO_COLOR)"
 	go test ./...
 
 .PHONY: all clean deps format test updatedeps


### PR DESCRIPTION
The colored output is broken when using Zsh.

\033[32;01m==> Installing dependencies\033[0m
\033[32;01m==> Building\033[0m

After adding the parameter -e to echo I get the expected green lines.
