### PR TITLE
VirtualBox builder: make VCP configurable

### DIFF
--- a/builder/virtualbox/common/step_run.go
+++ b/builder/virtualbox/common/step_run.go
@@ -18,6 +18,8 @@ import (
 type StepRun struct {
 	BootWait time.Duration
 	Headless bool
+        Vcp bool
+        VcpFile string
 
 	vmName string
 }
@@ -26,6 +28,17 @@ func (s *StepRun) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 	vmName := state.Get("vmName").(string)
+
+        if s.Vcp == true {
+                ui.Message("NOTE: Video Capturing enabled.")
+                command := []string{"modifyvm", vmName, "--vcpenabled", "on", "--vcpfile", s.VcpFile}
+                if err := driver.VBoxManage(command...); err != nil {
+                        err := fmt.Errorf("Error enabling Video Capturing: %s", err)
+                        state.Put("error", err)
+                        ui.Error(err.Error())
+                        return multistep.ActionHalt
+                }
+        }
 
 	ui.Say("Starting the virtual machine...")
 	guiArgument := "gui"

--- a/builder/virtualbox/common/vcp_config.go
+++ b/builder/virtualbox/common/vcp_config.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"fmt"
+	"github.com/mitchellh/packer/packer"
+)
+
+type VcpConfig struct {
+	Vcp        bool   `mapstructure:"vcp"`
+	VcpFile    string `mapstructure:"vcpfile"`
+}
+
+func (c *VcpConfig) Prepare(t *packer.ConfigTemplate) []error {
+
+        templates := map[string]*string{
+                "vcpfile": &c.VcpFile,
+        }
+
+	errs := make([]error, 0)
+	for n, ptr := range templates {
+		var err error
+		*ptr, err = t.Process(*ptr, nil)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("Error processing %s: %s", n, err))
+		}
+	}
+
+	return errs
+}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -36,6 +36,7 @@ type config struct {
 	vboxcommon.SSHConfig         `mapstructure:",squash"`
 	vboxcommon.VBoxManageConfig  `mapstructure:",squash"`
 	vboxcommon.VBoxVersionConfig `mapstructure:",squash"`
+        vboxcommon.VcpConfig         `mapstructure:",squash"`
 
 	BootCommand          []string `mapstructure:"boot_command"`
 	DiskSize             uint     `mapstructure:"disk_size"`
@@ -299,6 +300,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&vboxcommon.StepRun{
 			BootWait: b.config.BootWait,
 			Headless: b.config.Headless,
+                        Vcp:      b.config.Vcp,
+                        VcpFile:  b.config.VcpFile,
 		},
 		new(stepTypeBootCommand),
 		&common.StepConnectSSH{


### PR DESCRIPTION
This patch introduces two new attributes for the VirtualBox builder
to control the Video Capturing.

vcp     bool   Enables/Disables the Video Capturing
vcpfile string Location where to store the generated WebM file
