### PR TITLE
builder/virtualbox,vmware: add logging to http server [GH-906]

### DIFF
--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -280,6 +280,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&common.StepCreateFloppy{
 			Files: b.config.FloppyFiles,
 		},
+		new(stepHTTPFileHandler),
 		new(stepHTTPServer),
 		new(vboxcommon.StepSuppressMessages),
 		new(stepCreateVM),

--- a/builder/virtualbox/iso/step_http_file_handler.go
+++ b/builder/virtualbox/iso/step_http_file_handler.go
@@ -1,0 +1,33 @@
+package iso
+
+import (
+	"github.com/mitchellh/multistep"
+	"log"
+	"net/http"
+)
+
+type stepHTTPFileHandler struct{}
+
+func (s *stepHTTPFileHandler) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*config)
+	fileServer := http.FileServer(http.Dir(config.HTTPDir))
+	fileHander := func(w http.ResponseWriter, r *http.Request) {
+		lw := &loggedResponse{ResponseWriter: w}
+		fileServer.ServeHTTP(lw, r)
+		log.Printf("Received HTTP request: [%s] %s %s %d", r.RemoteAddr, r.Method, r.RequestURI, lw.statusCode)
+	}
+	http.Handle("/", http.HandlerFunc(fileHander))
+	return multistep.ActionContinue
+}
+
+type loggedResponse struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (l *loggedResponse) WriteHeader(statusCode int) {
+	l.statusCode = statusCode
+	l.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (stepHTTPFileHandler) Cleanup(multistep.StateBag) {}

--- a/builder/virtualbox/iso/step_http_server.go
+++ b/builder/virtualbox/iso/step_http_server.go
@@ -57,8 +57,7 @@ func (s *stepHTTPServer) Run(state multistep.StateBag) multistep.StepAction {
 	ui.Say(fmt.Sprintf("Starting HTTP server on port %d", httpPort))
 
 	// Start the HTTP server and run it in the background
-	fileServer := http.FileServer(http.Dir(config.HTTPDir))
-	server := &http.Server{Addr: httpAddr, Handler: fileServer}
+	server := &http.Server{Addr: httpAddr}
 	go server.Serve(s.l)
 
 	// Save the address into the state so it can be accessed in the future

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -344,6 +344,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			CustomData: b.config.VMXData,
 		},
 		&vmwcommon.StepSuppressMessages{},
+		&stepHTTPFileHandler{},
 		&stepHTTPServer{},
 		&stepConfigureVNC{},
 		&StepRegister{},

--- a/builder/vmware/iso/step_http_file_handler.go
+++ b/builder/vmware/iso/step_http_file_handler.go
@@ -1,0 +1,33 @@
+package iso
+
+import (
+	"github.com/mitchellh/multistep"
+	"log"
+	"net/http"
+)
+
+type stepHTTPFileHandler struct{}
+
+func (s *stepHTTPFileHandler) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*config)
+	fileServer := http.FileServer(http.Dir(config.HTTPDir))
+	fileHander := func(w http.ResponseWriter, r *http.Request) {
+		lw := &loggedResponse{ResponseWriter: w}
+		fileServer.ServeHTTP(lw, r)
+		log.Printf("Received HTTP request: [%s] %s %s %d", r.RemoteAddr, r.Method, r.RequestURI, lw.statusCode)
+	}
+	http.Handle("/", http.HandlerFunc(fileHander))
+	return multistep.ActionContinue
+}
+
+type loggedResponse struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (l *loggedResponse) WriteHeader(statusCode int) {
+	l.statusCode = statusCode
+	l.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (stepHTTPFileHandler) Cleanup(multistep.StateBag) {}

--- a/builder/vmware/iso/step_http_server.go
+++ b/builder/vmware/iso/step_http_server.go
@@ -57,8 +57,7 @@ func (s *stepHTTPServer) Run(state multistep.StateBag) multistep.StepAction {
 	ui.Say(fmt.Sprintf("Starting HTTP server on port %d", httpPort))
 
 	// Start the HTTP server and run it in the background
-	fileServer := http.FileServer(http.Dir(config.HTTPDir))
-	server := &http.Server{Addr: httpAddr, Handler: fileServer}
+	server := &http.Server{Addr: httpAddr}
 	go server.Serve(s.l)
 
 	// Save the address into the state so it can be accessed in the future


### PR DESCRIPTION
Fixes #906.

Log format is:

```
Received HTTP request: [192.168.6.228:34412] GET /preseed.cfg 200
```

I don't see an easy way to include the size of the data returned.

If #990 doesn't now merge cleanly, let me know, and I will fix and resubmit.
