### PR TITLE
Update Ansible provisioner to set cwd to staging directory.

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -222,8 +222,8 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator) err
 		extraArgs = " " + strings.Join(p.config.ExtraArguments, " ")
 	}
 
-	command := fmt.Sprintf("%s %s%s -c local -i \"127.0.0.1,\"",
-		p.config.Command, playbook, extraArgs)
+	command := fmt.Sprintf("cd %s && %s %s%s -c local -i \"127.0.0.1,\"",
+		p.config.StagingDir, p.config.Command, playbook, extraArgs)
 	ui.Message(fmt.Sprintf("Executing Ansible: %s", command))
 	cmd := &packer.RemoteCmd{
 		Command: command,


### PR DESCRIPTION
If you want to use a custom ansible.cfg, Ansible will look in the following:
- ANSIBLE_CONFIG (an environment variable)
- ansible.cfg (in the current directory)
- .ansible.cfg (in the home directory)
- /etc/ansible/ansible.cfg

Since the provisioner wasn't running in the staging directory, an uploaded ansible.cfg would not work.
