### PR TITLE
Properly return error when invalid instance state is found

### DIFF
--- a/builder/openstack/server.go
+++ b/builder/openstack/server.go
@@ -75,8 +75,7 @@ func WaitForState(conf *StateChangeConf) (i interface{}, err error) {
 		}
 
 		if !found {
-			fmt.Errorf("unexpected state '%s', wanted target '%s'", currentState, conf.Target)
-			return
+			return nil, fmt.Errorf("unexpected state '%s', wanted target '%s'", currentState, conf.Target)
 		}
 
 		log.Printf("Waiting for state to become: %s currently %s (%d%%)", conf.Target, currentState, currentProgress)


### PR DESCRIPTION
The OpenStack builder detects when an instance reaches an invalid state and prepares an error message. However the error message is never returned to the calling function. As such, Packer will continue building and try to ssh to an instance that is in ERROR state.
