### PR TITLE
builder/amazon: configurable virtualization type

### DIFF
--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -10,6 +10,7 @@ import (
 type AMIConfig struct {
 	AMIName         string            `mapstructure:"ami_name"`
 	AMIDescription  string            `mapstructure:"ami_description"`
+	AMIVirtType     string            `mapstructure:"ami_virtualization_type"`
 	AMIUsers        []string          `mapstructure:"ami_users"`
 	AMIGroups       []string          `mapstructure:"ami_groups"`
 	AMIProductCodes []string          `mapstructure:"ami_product_codes"`
@@ -27,8 +28,9 @@ func (c *AMIConfig) Prepare(t *packer.ConfigTemplate) []error {
 	}
 
 	templates := map[string]*string{
-		"ami_name":        &c.AMIName,
-		"ami_description": &c.AMIDescription,
+		"ami_name":                &c.AMIName,
+		"ami_description":         &c.AMIDescription,
+		"ami_virtualization_type": &c.AMIVirtType,
 	}
 
 	errs := make([]error, 0)

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -21,6 +21,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 		ImageLocation: manifestPath,
 		Name:          config.AMIName,
 		BlockDevices:  config.BlockDevices.BuildAMIDevices(),
+		VirtType:      config.AMIVirtType,
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)

--- a/website/source/docs/builders/amazon-chroot.html.markdown
+++ b/website/source/docs/builders/amazon-chroot.html.markdown
@@ -78,6 +78,10 @@ Required:
 
 Optional:
 
+* `ami_virtualization_type` (string) - The type of virtualization for the AMI
+  you are building. This option is required to register HVM images. Can be
+  "paravirtual" (default) or "hvm".
+
 * `ami_description` (string) - The description to set for the resulting
   AMI(s). By default this description is empty.
 
@@ -115,7 +119,7 @@ Optional:
   defaults to "{{.Command}}". This may be useful to set if you want to set
   environmental variables or perhaps run it with `sudo` or so on. This is a
   configuration template where the `.Command` variable is replaced with the
-  command to be run..
+  command to be run.
 
 * `mount_path` (string) - The path where the volume will be mounted. This is
   where the chroot environment will be. This defaults to

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -64,6 +64,10 @@ Optional:
   "volume\_type" (string), "volume\_size" (int), "delete\_on\_termination"
   (bool), "no\_device" (bool), and "iops" (int).
 
+* `ami_virtualization_type` (string) - The type of virtualization for the AMI
+  you are building. This option is required to register HVM images. Can be
+  "paravirtual" (default) or "hvm".
+
 * `ami_description` (string) - The description to set for the resulting
   AMI(s). By default this description is empty.
 

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -87,6 +87,10 @@ Optional:
   (bool), "no\_device" (bool), and "iops" (int).
   See [amazon-ebs](/docs/builders/amazon-ebs.html) for an example template.
 
+* `ami_virtualization_type` (string) - The type of virtualization for the AMI
+  you are building. This option is required to register HVM images. Can be
+  "paravirtual" (default) or "hvm".
+
 * `ami_description` (string) - The description to set for the resulting
   AMI(s). By default this description is empty.
 


### PR DESCRIPTION
This enables building HVM AMIs.

The option is already supported by goamz, I've just exposed the corresponding configuration.

I wasn't sure how to name the property, maybe `virtualization_type` would be better than `ami_virtualization_type`, but I left it as is for consistency.

See [ec2-register](http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-RegisterImage.html).
