### PR TITLE
Fix ansible-local 'command' config key

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -16,7 +16,7 @@ type Config struct {
 	tpl                 *packer.ConfigTemplate
 
 	// The command to run ansible
-	Command string
+	Command string `mapstructure:"command"`
 
 	// Extra options to pass to the ansible command
 	ExtraArguments []string `mapstructure:"extra_arguments"`


### PR DESCRIPTION
This updates the behaviour to match the documentation.

I'm not 100% sure this is the way to fix this; I don't understand golang enough to be sure.
