### PR TITLE
Addition export options for Virtualbox

### DIFF
--- a/builder/virtualbox/common/export_config.go
+++ b/builder/virtualbox/common/export_config.go
@@ -8,6 +8,13 @@ import (
 
 type ExportConfig struct {
 	Format string `mapstruture:"format"`
+	Product string `mapstruture:"product"`
+	ProductUrl string `mapstructure:"product-url"`
+	Vendor string `mapstruture:"vendor"`
+	VendorUrl string `mapstruture:"vendor-url"`
+	Version string `mapstruture:"version"`
+	EULA string `mapstruture:"eula"`
+	EULAFile string `mapstruture:"eula-file-path"`
 }
 
 func (c *ExportConfig) Prepare(t *packer.ConfigTemplate) []error {


### PR DESCRIPTION
Added the missing VirtualBox options for Exporting a VM. These options are really handy when building VM's for virtualbox automatically. I'm not 100% what other file I need to modify to make these to map to the proper commands for VBoxManage Export as these are the following options

--product
--producturl
--vendor
--venderurl
--version
--eula
--eulafile
