### PR TITLE
fix error handeling when creating a floppy

### DIFF
--- a/common/step_create_floppy.go
+++ b/common/step_create_floppy.go
@@ -66,7 +66,7 @@ func (s *StepCreateFloppy) Run(state multistep.StateBag) multistep.StepAction {
 		Label:   "packer",
 		OEMName: "packer",
 	}
-	if fat.FormatSuperFloppy(device, formatConfig); err != nil {
+	if err := fat.FormatSuperFloppy(device, formatConfig); err != nil {
 		state.Put("error", fmt.Errorf("Error creating floppy: %s", err))
 		return multistep.ActionHalt
 	}
@@ -90,7 +90,7 @@ func (s *StepCreateFloppy) Run(state multistep.StateBag) multistep.StepAction {
 	// Go over each file and copy it.
 	for _, filename := range s.Files {
 		ui.Message(fmt.Sprintf("Copying: %s", filepath.Base(filename)))
-		if s.addSingleFile(rootDir, filename); err != nil {
+		if err := s.addSingleFile(rootDir, filename); err != nil {
 			state.Put("error", fmt.Errorf("Error adding file to floppy: %s", err))
 			return multistep.ActionHalt
 		}


### PR DESCRIPTION
I noticed that the error checking is broken in two places during floppy creation. Most noticeably when specifying nonexistent files in `floppy_files` packer does not fail and gives the impression it successfully added the missing files to the floppy image.
