### PR TITLE
builder/googlecompute: configure instance name

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mitchellh/packer/common/uuid"
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
 )
@@ -19,6 +20,7 @@ type Config struct {
 	ClientSecretsFile string            `mapstructure:"client_secrets_file"`
 	ImageName         string            `mapstructure:"image_name"`
 	ImageDescription  string            `mapstructure:"image_description"`
+	InstanceName      string            `mapstructure:"instance_name"`
 	MachineType       string            `mapstructure:"machine_type"`
 	Metadata          map[string]string `mapstructure:"metadata"`
 	Network           string            `mapstructure:"network"`
@@ -68,6 +70,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	if c.ImageName == "" {
 		c.ImageName = "packer-{{timestamp}}"
+	}
+
+	if c.InstanceName == "" {
+		c.InstanceName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
 	}
 
 	if c.MachineType == "" {

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/mitchellh/multistep"
-	"github.com/mitchellh/packer/common/uuid"
 	"github.com/mitchellh/packer/packer"
 )
 
@@ -25,7 +24,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Creating instance...")
-	name := fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
+	name := config.InstanceName
 
 	errCh, err := driver.RunInstance(&InstanceConfig{
 		Description: "New instance created by Packer",


### PR DESCRIPTION
Retain the current default of an instance name generated by UUID, but allow
users to choose a specific one. Useful for provisioning with Puppet when a
node name is used to select the right manifest.

This is possibly something useful on all builders, but I started here to see if it was a change you were interested in first.

Let me know if you think this needs additional tests. I also wasn't sure if you wanted to PR to include an entry for CHANGELOG or if you prefer to handle that - happy to adjust.
