### PR TITLE
Fix EC2 IAM documentation.  Possibly fixes #577

### DIFF
--- a/website/source/docs/builders/amazon.html.markdown
+++ b/website/source/docs/builders/amazon.html.markdown
@@ -46,19 +46,25 @@ The following policy document provides the minimal set permissions necessary for
         "ec2:AttachVolume",
         "ec2:CreateVolume",
         "ec2:DeleteVolume",
+        "ec2:CreateKeypair",
+        "ec2:DeleteKeypair",
+        "ec2:CreateSecurityGroup",
+        "ec2:DeleteSecurityGroup",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateImage",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:StopInstances",
         "ec2:DescribeVolumes",
         "ec2:DetachVolume",
-
         "ec2:DescribeInstances",
-
         "ec2:CreateSnapshot",
         "ec2:DeleteSnapshot",
         "ec2:DescribeSnapshots",
-
         "ec2:DescribeImages",
         "ec2:RegisterImage",
-
-        "ec2:CreateTags"
+        "ec2:CreateTags",
+        "ec2:ModifyImageAttribute"
       ],
       "Resource" : "*"
   }]


### PR DESCRIPTION
When using the amazon-ebs builder with an IAM user or role additional permissions are required.
