### PR TITLE
Optional parameters in vSphere post-processor

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -64,14 +64,11 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	templates := map[string]*string{
 		"cluster":       &p.config.Cluster,
 		"datacenter":    &p.config.Datacenter,
-		"datastore":     &p.config.Datastore,
 		"diskmode":      &p.config.DiskMode,
 		"host":          &p.config.Host,
-		"vm_network":    &p.config.VMNetwork,
 		"password":      &p.config.Password,
 		"resource_pool": &p.config.ResourcePool,
 		"username":      &p.config.Username,
-		"vm_folder":     &p.config.VMFolder,
 		"vm_name":       &p.config.VMName,
 	}
 
@@ -80,7 +77,13 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 			errs = packer.MultiErrorAppend(
 				errs, fmt.Errorf("%s must be set", key))
 		}
+	}
 
+	templates ["datastore"] = &p.config.Datastore
+	templates ["vm_network"] = &p.config.VMNetwork
+	templates ["vm_folder"] = &p.config.VMFolder
+
+	for key, ptr := range templates {
 		*ptr, err = p.config.tpl.Process(*ptr, nil)
 		if err != nil {
 			errs = packer.MultiErrorAppend(

--- a/website/source/docs/post-processors/vsphere.html.markdown
+++ b/website/source/docs/post-processors/vsphere.html.markdown
@@ -23,8 +23,6 @@ Required:
 * `datacenter` (string) - The name of the datacenter within vSphere to
   add the VM to.
 
-* `datastore` (string) - The name of the datastore to store this VM.
-
 * `host` (string) - The vSphere host that will be contacted to perform
   the VM upload.
 
@@ -36,17 +34,19 @@ Required:
 * `username` (string) - The username to use to authenticate to the vSphere
   endpoint.
 
-* `vm_folder` (string) - The folder within the datastore to store the VM.
-
 * `vm_name` (string) - The name of the VM once it is uploaded.
 
-* `vm_network` (string) - The name of the VM network this VM will be
-  added to.
-
 Optional:
+
+* `datastore` (string) - The name of the datastore to store this VM.
 
 * `disk_mode` (string) - Target disk format. See `ovftool` manual for
   available options. By default, "thick" will be used.
 
 * `insecure` (bool) - Whether or not the connection to vSphere can be done
   over an insecure connection. By default this is false.
+
+* `vm_folder` (string) - The folder within the datastore to store the VM.
+
+* `vm_network` (string) - The name of the VM network this VM will be
+  added to.


### PR DESCRIPTION
`datastore`, `vm_folder`, and `vm_network` become optional and can be omitted in templates.
Technically, they are not required by OVFTool.

Mandatory `vm_folder` doesn't allow me to use this post-processor.
In my environment VM folders are not used, and there can be no valid value for this option. I'm not an administrator of our vSphere server, and don't have permissions to create new VM folders. 
So I had to make this change in Packer code, to run OVFTool with an empty value.

`datastore`, and `vm_network` are not showstoppers, but they can be also skipped, just to make templates simplier.
