### PR TITLE
Support more user variables in the OpenStack builder

### DIFF
--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -81,10 +81,14 @@ func (c *AccessConfig) Prepare(t *packer.ConfigTemplate) []error {
 	}
 
 	templates := map[string]*string{
-		"username": &c.Username,
-		"password": &c.Password,
-		"apiKey":   &c.ApiKey,
-		"provider": &c.Provider,
+		"username":  &c.Username,
+		"password":  &c.Password,
+		"api_key":   &c.ApiKey,
+		"provider":  &c.Provider,
+		"project":   &c.Project,
+		"tenant_id": &c.TenantId,
+		"region":    &c.RawRegion,
+		"proxy_url": &c.ProxyUrl,
 	}
 
 	errs := make([]error, 0)


### PR DESCRIPTION
The user variables documentations says:

```
This function can be used in any value within the template
```

But it appears that support must be explicitly added for each key in the builder.
