### PR TITLE
Parallels provider: fix typos

### DIFF
--- a/builder/parallels/common/floppy_config.go
+++ b/builder/parallels/common/floppy_config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // FloppyConfig is configuration related to created floppy disks and attaching
-// them to a VirtualBox machine.
+// them to a Parallels virtual machine.
 type FloppyConfig struct {
 	FloppyFiles []string `mapstructure:"floppy_files"`
 }

--- a/builder/parallels/common/step_attach_floppy_test.go
+++ b/builder/parallels/common/step_attach_floppy_test.go
@@ -66,6 +66,6 @@ func TestStepAttachFloppy_noFloppy(t *testing.T) {
 	}
 
 	if len(driver.PrlctlCalls) > 0 {
-		t.Fatal("should not call vboxmanage")
+		t.Fatal("should not call prlctl")
 	}
 }

--- a/builder/parallels/iso/host_ip.go
+++ b/builder/parallels/iso/host_ip.go
@@ -1,7 +1,7 @@
 package iso
 
 // Interface to help find the host IP that is available from within
-// the VMware virtual machines.
+// the Parallels virtual machines.
 type HostIPFinder interface {
 	HostIP() (string, error)
 }


### PR DESCRIPTION
There are few fixes for minor typos, related to the GH-1101.
