### PR TITLE
Fix for Parallels builder ID in vagrant post-processor

### DIFF
--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -21,7 +21,7 @@ var builtins = map[string]string{
 	"mitchellh.virtualbox":        "virtualbox",
 	"mitchellh.vmware":            "vmware",
 	"pearkes.digitalocean":        "digitalocean",
-	"rickard-von-essen.parallels": "parallels",
+	"packer.parallels":            "parallels",
 }
 
 type Config struct {


### PR DESCRIPTION
3a68c8a changed builder ID and it caused an error while `parallels-iso` building:

```
==> parallels-iso: Running post-processor: vagrant
Build 'parallels-iso' errored: 1 error(s) occurred:

* Post-processor failed: Unknown artifact type, can't build box: packer.parallels
```

This pull-request contains a fix for this error
