### PR TITLE
Appending wildcard to src causes problems

### DIFF
--- a/builder/amazon/chroot/communicator.go
+++ b/builder/amazon/chroot/communicator.go
@@ -82,7 +82,7 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 	// TODO: remove any file copied if it appears in `exclude`
 	chrootDest := filepath.Join(c.Chroot, dst)
 	log.Printf("Uploading directory '%s' to '%s'", src, chrootDest)
-	cpCmd, err := c.CmdWrapper(fmt.Sprintf("cp -R %s* %s", src, chrootDest))
+	cpCmd, err := c.CmdWrapper(fmt.Sprintf("cp -R '%s' %s", src, chrootDest))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It appears that the desired effect was to support
    src = "dir" -> dest/dir
    src = "dir/" -> dest

but cp -R already handles this, provided the trailing slash does not
get consumed by the shell. Adding single quotes prevents that.

The wildcard causes problems when multiple files match the
shell glob, e.g.

UploadDir("/tmp", "./salt*", [])

where my working dir contains
- salt
- salt-foo

will error.
