### PR TITLE
Allow OpenStack builder to skip certificate verification

### DIFF
--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -66,6 +66,9 @@ each category, the available configuration keys are alphabetized.
   to allocate a floating IP. `use_floating_ip` must also be set to true
   for this to have an affect.
 
+* `insecure` (boolean) - Whether or not the connection to OpenStack can be done
+  over an insecure connection. By default this is false.
+
 * `openstack_provider` (string)
 <!---
 @todo document me


### PR DESCRIPTION
I work with private OpenStack clouds that use self-signed certificates. This commit allows Packer to optionally skip certificate verification.

I am not really happy with how I had to duplicate the code for the insecure + proxy case. Is there a better way to do this in Go?
