### PR TITLE
Force LANG=C before appending rest of environment

### DIFF
--- a/builder/amazon/chroot/communicator.go
+++ b/builder/amazon/chroot/communicator.go
@@ -89,8 +89,8 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 
 	var stderr bytes.Buffer
 	cmd := ShellCommand(cpCmd)
-	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Env = append(cmd.Env, "LANG=C")
+	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Stderr = &stderr
 	err = cmd.Run()
 	if err == nil {

--- a/builder/parallels/iso/host_ip_ifconfig.go
+++ b/builder/parallels/iso/host_ip_ifconfig.go
@@ -34,11 +34,10 @@ func (f *IfconfigIPFinder) HostIP() (string, error) {
 		stdout := new(bytes.Buffer)
 
 		cmd := exec.Command(ifconfigPath, device)
-		cmd.Env = append(cmd.Env, os.Environ()...)
-
 		// Force LANG=C so that the output is what we expect it to be
 		// despite the locale.
 		cmd.Env = append(cmd.Env, "LANG=C")
+		cmd.Env = append(cmd.Env, os.Environ()...)
 
 		cmd.Stdout = stdout
 		cmd.Stderr = new(bytes.Buffer)

--- a/builder/vmware/iso/host_ip_ifconfig.go
+++ b/builder/vmware/iso/host_ip_ifconfig.go
@@ -33,11 +33,10 @@ func (f *IfconfigIPFinder) HostIP() (string, error) {
 	stdout := new(bytes.Buffer)
 
 	cmd := exec.Command(ifconfigPath, f.Device)
-	cmd.Env = append(cmd.Env, os.Environ()...)
-
 	// Force LANG=C so that the output is what we expect it to be
 	// despite the locale.
 	cmd.Env = append(cmd.Env, "LANG=C")
+	cmd.Env = append(cmd.Env, os.Environ()...)
 
 	cmd.Stdout = stdout
 	cmd.Stderr = new(bytes.Buffer)


### PR DESCRIPTION
It seems that go `Command` only overrides an environment variable with the first value seen in the `Env` array, so if `os.Environ()` already has `LANG` set, the other appended value is ignored. This causes problems as not being able to correctly parse the ifconfig output to retrieve the host IP.

This pull request reorders how Env is built, fixing this problem.
