### PR TITLE
Fixes #1062, ESXi Driver supports PACKER_CACHE_DIR

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -260,10 +260,8 @@ func (d *ESX5Driver) String() string {
 }
 
 func (d *ESX5Driver) datastorePath(path string) string {
-	if filepath.IsAbs(path) {
-		return filepath.Join("/vmfs/volumes", d.Datastore, strings.Replace(path, "/", "", 1))
-	}
-	return filepath.Join("/vmfs/volumes", d.Datastore, path)
+	baseDir := filepath.Base(filepath.Dir(path))
+	return filepath.Join("/vmfs/volumes", d.Datastore, baseDir, filepath.Base(path))
 }
 
 func (d *ESX5Driver) connect() error {


### PR DESCRIPTION
ESXi Driver supports PACKER_CACHE_DIR.

If set PACKER_CACHE_DIR to $HOME/.packer_cache, ESXi Driver set the upload iso directory to "{remote_datastore}/.packer_cache".
And floppy file is uploaded to "{remote_datastore}/tmp/packer######"
