### PR TITLE
builder/vmware: added vmx_data_post option

### DIFF
--- a/builder/vmware/common/vmx_config.go
+++ b/builder/vmware/common/vmx_config.go
@@ -8,6 +8,7 @@ import (
 
 type VMXConfig struct {
 	VMXData map[string]string `mapstructure:"vmx_data"`
+	VMXDataPost map[string]string `mapstructure:"vmx_data_post"`
 }
 
 func (c *VMXConfig) Prepare(t *packer.ConfigTemplate) []error {
@@ -18,20 +19,41 @@ func (c *VMXConfig) Prepare(t *packer.ConfigTemplate) []error {
 		k, err = t.Process(k, nil)
 		if err != nil {
 			errs = append(errs,
-				fmt.Errorf("Error processing VMX data key %s: %s", k, err))
+				fmt.Errorf("Error processing vmx_data key %s: %s", k, err))
 			continue
 		}
 
 		v, err = t.Process(v, nil)
 		if err != nil {
 			errs = append(errs,
-				fmt.Errorf("Error processing VMX data value '%s': %s", v, err))
+				fmt.Errorf("Error processing vmx_data value '%s': %s", v, err))
 			continue
 		}
 
 		newVMXData[k] = v
 	}
 	c.VMXData = newVMXData
+
+	newVMXDataPost := make(map[string]string)
+	for k, v := range c.VMXDataPost {
+		var err error
+		k, err = t.Process(k, nil)
+		if err != nil {
+			errs = append(errs,
+				fmt.Errorf("Error processing vmx_post_data key %s: %s", k, err))
+			continue
+		}
+
+		v, err = t.Process(v, nil)
+		if err != nil {
+			errs = append(errs,
+				fmt.Errorf("Error processing vmx_post_data value '%s': %s", v, err))
+			continue
+		}
+
+		newVMXData[k] = v
+	}
+	c.VMXDataPost = newVMXDataPost
 
 	return errs
 }

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -371,6 +371,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&vmwcommon.StepCleanFiles{},
 		&vmwcommon.StepCleanVMX{},
+		&vmwcommon.StepConfigureVMX{
+			CustomData: b.config.VMXDataPost,
+		},
 		&vmwcommon.StepCompactDisk{
 			Skip: b.config.SkipCompaction,
 		},

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -85,6 +85,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&vmwcommon.StepCleanFiles{},
 		&vmwcommon.StepCleanVMX{},
+		&vmwcommon.StepConfigureVMX{
+			CustomData: b.config.VMXDataPost,
+		},
 		&vmwcommon.StepCompactDisk{
 			Skip: b.config.SkipCompaction,
 		},

--- a/website/source/docs/builders/vmware-iso.html.markdown
+++ b/website/source/docs/builders/vmware-iso.html.markdown
@@ -227,6 +227,10 @@ each category, the available options are alphabetized and described.
   to enter into the virtual machine VMX file. This is for advanced users
   who want to set properties such as memory, CPU, etc.
 
+* `vmx_data_post` (object of key/value strings) - Identical to `vmx_data`,
+  except that it is run after the virtual machine is shutdown, and before the
+  virtual machine is exported.
+
 * `vmx_template_path` (string) - Path to a
   [configuration template](/docs/templates/configuration-templates.html) that
   defines the contents of the virtual machine VMX file for VMware. This is

--- a/website/source/docs/builders/vmware-vmx.html.markdown
+++ b/website/source/docs/builders/vmware-vmx.html.markdown
@@ -120,3 +120,7 @@ each category, the available options are alphabetized and described.
 * `vmx_data` (object of key/value strings) - Arbitrary key/values
   to enter into the virtual machine VMX file. This is for advanced users
   who want to set properties such as memory, CPU, etc.
+
+* `vmx_data_post` (object of key/value strings) - Identical to `vmx_data`,
+  except that it is run after the virtual machine is shutdown, and before the
+  virtual machine is exported.


### PR DESCRIPTION
I'm not too keen on the name `vmx_data_post`, but it mimics the `vboxmanage_post` name.

Fixes #1149
