### PR TITLE
builder/parallels: Select which interface to connect to.

### DIFF
--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -36,6 +36,7 @@ type config struct {
 	GuestOSType             string   `mapstructure:"guest_os_type"`
 	GuestOSDistribution     string   `mapstructure:"guest_os_distribution"`
 	HardDriveInterface      string   `mapstructure:"hard_drive_interface"`
+	HostInterfaces          []string `mapstructure:"host_interfaces"`
 	HTTPDir                 string   `mapstructure:"http_directory"`
 	HTTPPortMin             uint     `mapstructure:"http_port_min"`
 	HTTPPortMax             uint     `mapstructure:"http_port_max"`
@@ -108,6 +109,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if b.config.HTTPPortMax == 0 {
 		b.config.HTTPPortMax = 9000
+	}
+
+	if len(b.config.HostInterfaces) == 0 {
+		b.config.HostInterfaces = []string{"en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7",
+			"en8", "en9", "ppp0", "ppp1", "ppp2"}
 	}
 
 	if b.config.VMName == "" {

--- a/builder/parallels/iso/step_type_boot_command.go
+++ b/builder/parallels/iso/step_type_boot_command.go
@@ -42,7 +42,7 @@ func (s *stepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction
 	driver := state.Get("driver").(parallelscommon.Driver)
 
 	// Determine the host IP
-	ipFinder := &IfconfigIPFinder{Devices: []string{"en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9", "ppp0", "ppp1", "ppp2"}}
+	ipFinder := &IfconfigIPFinder{Devices: config.HostInterfaces}
 
 	hostIp, err := ipFinder.HostIP()
 	if err != nil {

--- a/website/source/docs/builders/parallels-iso.html.markdown
+++ b/website/source/docs/builders/parallels-iso.html.markdown
@@ -114,6 +114,12 @@ each category, the available options are alphabetized and described.
   hard drives are attached to, defaults to "sata". Valid options are
   "sata", "ide", and "scsi".
 
+* `host_interfaces` (array of strings) - A list of which interfaces on the
+  host should be searched for a IP address. The first IP address found on
+  one of these will be used as `{{ .HTTPIP }}` in the `boot_command`.
+  Defaults to ["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8",
+  "en9", "ppp0", "ppp1", "ppp2"].
+
 * `http_directory` (string) - Path to a directory to serve using an HTTP
   server. The files in this directory will be available over HTTP that will
   be requestable from the virtual machine. This is useful for hosting


### PR DESCRIPTION
The IP address that the guest OS connect to download files from the
`http_dir` is determined by searching for a host interface with an IP
assigned. Now it is possible to use `host_interfaces` to select which
interfaces are searched.
