### PR TITLE
builder/parallels: Don't delete sound, since it doesn't always exist.

### DIFF
--- a/builder/parallels/iso/step_create_vm.go
+++ b/builder/parallels/iso/step_create_vm.go
@@ -25,7 +25,7 @@ func (s *stepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 	name := config.VMName
 	path := filepath.Join(".", config.OutputDir)
 
-	commands := make([][]string, 9)
+	commands := make([][]string, 8)
 	commands[0] = []string{
 		"create", name,
 		"--ostype", config.GuestOSType,
@@ -39,8 +39,7 @@ func (s *stepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 	commands[4] = []string{"set", name, "--on-shutdown", "close"}
 	commands[5] = []string{"set", name, "--on-window-close", "keep-running"}
 	commands[6] = []string{"set", name, "--auto-share-camera", "off"}
-	commands[7] = []string{"set", name, "--device-del", "sound0"}
-	commands[8] = []string{"set", name, "--smart-guard", "off"}
+	commands[7] = []string{"set", name, "--smart-guard", "off"}
 
 	ui.Say("Creating virtual machine...")
 	for _, command := range commands {


### PR DESCRIPTION
The sound device is only created for some _Guest OS_ types. Packer will fail trying to delete it.
