### PR TITLE
vSphere upload hangs due to DOMAIN\account format of username

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 	"os/exec"
 	"strings"
+	"net/url"
 )
 
 var builtins = map[string]string{
@@ -128,7 +129,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		fmt.Sprintf("--vmFolder=%s", p.config.VMFolder),
 		fmt.Sprintf("%s", vmx),
 		fmt.Sprintf("vi://%s:%s@%s/%s/host/%s/Resources/%s",
-			p.config.Username,
+			url.QueryEscape(p.config.Username),
 			p.config.Password,
 			p.config.Host,
 			p.config.Datacenter,


### PR DESCRIPTION
VMware vCenter can be integrated with Microsoft Active Directory, so usernames have format `DOMAIN\account`.
At the moment Packer hangs on image uploading, because OVFtool cannot correctly process a back-slash in the username.

This pull request makes URL-encoding for the username value, but leaves all other parameters as they are.
Also it adds a new log line to make OVFtool debugging easier.
