### PR TITLE
Adds support for encrypted EBS volumes

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -8,6 +8,7 @@ import (
 type BlockDevice struct {
 	DeleteOnTermination bool   `mapstructure:"delete_on_termination"`
 	DeviceName          string `mapstructure:"device_name"`
+	Encrypted           bool   `mapstructure:"encrypted"`
 	IOPS                int64  `mapstructure:"iops"`
 	NoDevice            bool   `mapstructure:"no_device"`
 	SnapshotId          string `mapstructure:"snapshot_id"`
@@ -34,6 +35,7 @@ func buildBlockDevices(b []BlockDevice) []ec2.BlockDeviceMapping {
 			DeleteOnTermination: blockDevice.DeleteOnTermination,
 			IOPS:                blockDevice.IOPS,
 			NoDevice:            blockDevice.NoDevice,
+			Encrypted:           blockDevice.Encrypted,
 		})
 	}
 	return blockDevices

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -62,7 +62,8 @@ each category, the available configuration keys are alphabetized.
   device mappings to the AMI. The block device mappings allow for keys:
   "device\_name" (string), "virtual\_name" (string), "snapshot\_id" (string),
   "volume\_type" (string), "volume\_size" (integer), "delete\_on\_termination"
-  (boolean), "no\_device" (boolean), and "iops" (integer).
+  (boolean), "encrypted" (boolean), "no\_device" (boolean), and "iops"
+  (integer).
 
 * `ami_description` (string) - The description to set for the resulting
   AMI(s). By default this description is empty.

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -84,7 +84,7 @@ each category, the available configuration keys are alphabetized.
   device mappings to the AMI. The block device mappings allow for keys:
   "device\_name" (string), "virtual\_name" (string), "snapshot\_id" (string),
   "volume\_type" (string), "volume\_size" (integer), "delete\_on\_termination"
-  (boolean), "no\_device" (boolean), and "iops" (integer).
+  (boolean), "encrypted" (boolean), "no\_device" (boolean), and "iops" (integer).
   See [amazon-ebs](/docs/builders/amazon-ebs.html) for an example template.
 
 * `ami_description` (string) - The description to set for the resulting


### PR DESCRIPTION
Exposes encrypted EBS volumes to Packer http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html

Relies on https://github.com/mitchellh/goamz/pull/45, which I now see was merged. 
