### PR TITLE
Fix chroot builder to work with chef-solo provisioner

### DIFF
--- a/builder/amazon/chroot/communicator.go
+++ b/builder/amazon/chroot/communicator.go
@@ -79,8 +79,17 @@ func (c *Communicator) Upload(dst string, r io.Reader) error {
 }
 
 func (c *Communicator) UploadDir(dst string, src string, exclude []string) error {
+	// If src ends with a trailing "/", copy from "src/." so that
+	// directory contents (including hidden files) are copied, but the
+	// directory "src" is omitted.  BSD does this automatically when
+	// the source contains a trailing slash, but linux does not.
+	if src[len(src)-1] == '/' {
+		src = src + "."
+	}
+
 	// TODO: remove any file copied if it appears in `exclude`
 	chrootDest := filepath.Join(c.Chroot, dst)
+
 	log.Printf("Uploading directory '%s' to '%s'", src, chrootDest)
 	cpCmd, err := c.CmdWrapper(fmt.Sprintf("cp -R '%s' %s", src, chrootDest))
 	if err != nil {


### PR DESCRIPTION
According to be5adb92b5c4d5d95e5089be94c706b930fea7ba, the `UploadDir` method supports two ways of copying depending on whether a trailing slash is used:

```
src = "dir"  -> dest/dir
src = "dir/" -> dest
```

On BSD-based systems (such as OSX, FreeBSD, etc.) the `cp -R` command handles these two cases automatically.  However, Linux treats "src/" and "src" the same.

To support the trailing slash syntax portably, we can use:

```
src = "dir"   -> dest/dir
src = "dir/." -> dest
```

This works on BSD and Linux.  It is better than using wildcards as it grabs hidden files as well.

This fixes #1196 (chef-solo provisioner doesn't work with chroot builder).
