### PR TITLE
Update GCE source_image in the docs

### DIFF
--- a/website/source/docs/builders/googlecompute.markdown
+++ b/website/source/docs/builders/googlecompute.markdown
@@ -59,7 +59,7 @@ files obtained in the previous section.
   "client_secrets_file": "client_secret.json",
   "private_key_file": "XXXXXX-privatekey.p12",
   "project_id": "my-project",
-  "source_image": "debian-7-wheezy-v20140415",
+  "source_image": "debian-7-wheezy-v20140718",
   "zone": "us-central1-a"
 }
 </pre>


### PR DESCRIPTION
I tried copy-pasting the `source_image` from the docs, but the version listed (from 2013) fails with the following error:

`bash: /usr/bin/gcimagebundle: No such file or directory`

Updating to the latest image resolves the issue.
