### PR TITLE
skip adding floppy again in vmx_data_post step

### DIFF
--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -18,6 +18,7 @@ import (
 //   vmx_path string
 type StepConfigureVMX struct {
 	CustomData map[string]string
+	SkipFloppy  bool
 }
 
 func (s *StepConfigureVMX) Run(state multistep.StateBag) multistep.StepAction {
@@ -56,12 +57,15 @@ func (s *StepConfigureVMX) Run(state multistep.StateBag) multistep.StepAction {
 		vmxData[k] = v
 	}
 
-	// Set a floppy disk if we have one
-	if floppyPathRaw, ok := state.GetOk("floppy_path"); ok {
-		log.Println("Floppy path present, setting in VMX")
-		vmxData["floppy0.present"] = "TRUE"
-		vmxData["floppy0.filetype"] = "file"
-		vmxData["floppy0.filename"] = floppyPathRaw.(string)
+	// Set a floppy disk, but only if we should
+	if ! s.SkipFloppy {
+		// Set a floppy disk if we have one
+		if floppyPathRaw, ok := state.GetOk("floppy_path"); ok {
+			log.Println("Floppy path present, setting in VMX")
+			vmxData["floppy0.present"] = "TRUE"
+			vmxData["floppy0.filetype"] = "file"
+			vmxData["floppy0.filename"] = floppyPathRaw.(string)
+		}
 	}
 
 	if err := WriteVMX(vmxPath, vmxData); err != nil {

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -370,6 +370,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&vmwcommon.StepCleanVMX{},
 		&vmwcommon.StepConfigureVMX{
 			CustomData: b.config.VMXDataPost,
+			SkipFloppy:  true,
 		},
 		&vmwcommon.StepCompactDisk{
 			Skip: b.config.SkipCompaction,

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -97,6 +97,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&vmwcommon.StepCleanVMX{},
 		&vmwcommon.StepConfigureVMX{
 			CustomData: b.config.VMXDataPost,
+			SkipFloppy:  true,
 		},
 		&vmwcommon.StepCompactDisk{
 			Skip: b.config.SkipCompaction,


### PR DESCRIPTION
With the new `vmx_data_post` of #1149 / #1152 I have the problem that the floppy is not unmounted properly. 
Watching the progress with PACKER_LOG showed me more details:

```
2014/06/08 23:03:14 ui:     vmware-iso: Unmounting floppy from VMX...
2014/06/08 23:03:14 /Users/stefan/go/bin/packer-builder-vmware-iso: 2014/06/08 23:03:14 Deleting key: floppy0.filename
2014/06/08 23:03:14 /Users/stefan/go/bin/packer-builder-vmware-iso: 2014/06/08 23:03:14 Deleting key: floppy0.filetype
2014/06/08 23:03:14 /Users/stefan/go/bin/packer-builder-vmware-iso: 2014/06/08 23:03:14 Deleting key: floppy0.clientdevice
2014/06/08 23:03:14 /Users/stefan/go/bin/packer-builder-vmware-iso: 2014/06/08 23:03:14 Deleting key: floppy0.present
    vmware-iso: Detaching ISO from CD-ROM device...
2014/06/08 23:03:14 ui:     vmware-iso: Detaching ISO from CD-ROM device...
2014/06/08 23:03:14 /Users/stefan/go/bin/packer-builder-vmware-iso: 2014/06/08 23:03:14 Writing VMX to: output-vmware-iso/ubuntu1204.vmx
2014/06/08 23:03:14 /Users/stefan/go/bin/packer-builder-vmware-iso: 2014/06/08 23:03:14 Floppy path present, setting in VMX
2014/06/08 23:03:14 /Users/stefan/go/bin/packer-builder-vmware-iso: 2014/06/08 23:03:14 Writing VMX to: output-vmware-iso/ubuntu1204.vmx
```

First the floppy is unmounted, but afterwards added again to the vmx file.

My PR skips this floppy mount in the StepConfigureVMX for the VMXDataPost config.
The final vmx file has no floppy mounted, but the additional vmx_data_post config entries.
