### PR TITLE
vmware-vmx clarify VMware Fusion support

### DIFF
--- a/website/source/docs/builders/vmware-vmx.html.markdown
+++ b/website/source/docs/builders/vmware-vmx.html.markdown
@@ -10,13 +10,13 @@ Type: `vmware-vmx`
 This VMware builder is able to create VMware virtual machines from an
 existing VMware virtual machine (a VMX file). It currently
 supports building virtual machines on hosts running
-[VMware Fusion](http://www.vmware.com/products/fusion/overview.html) for OS X,
+[VMware Fusion Professional](http://www.vmware.com/products/fusion-professional/) for OS X,
 [VMware Workstation](http://www.vmware.com/products/workstation/overview.html)
 for Linux and Windows, and
 [VMware Player](http://www.vmware.com/products/player/) on Linux.
 
 The builder builds a virtual machine by cloning the VMX file using
-the clone capabilities introduced in VMware Fusion 6, Workstation 10,
+the clone capabilities introduced in VMware Fusion Professional 6, Workstation 10,
 and Player 6. After cloning the VM, it provisions software within the
 new machine, shuts it down, and compacts the disks. The resulting folder
 contains a new VMware virtual machine.


### PR DESCRIPTION
Cloning is a feature of VMware Fusion Professional.

Using the `vmware-vmx` builder with VMware Fusion (non-pro) will yield `Build 'vmware-vmx' errored: VMware error:` as per https://github.com/mitchellh/packer/issues/1053.
The underlying error is: `Error: One of the parameters was invalid`

This is due to [VMware Fusion not supporting clone](http://stackoverflow.com/a/20914988).

This PR updates the docs references from VMware Fusion to VMware Fusion Professional for `vmware-vmx`.

If you'd like to word this more strongly/obviously I could include something like:

``` html
<div class="alert alert-block alert-warn">
<p><strong>VMware Fusion users.</strong> VMware Fusion Professional is required, the non-professional version does not contain the clone feature.
</div>
```
