### PR TITLE
Force IPv4 addresses from address pools in Openstack. Fixes #1258

### DIFF
--- a/builder/openstack/ssh.go
+++ b/builder/openstack/ssh.go
@@ -26,7 +26,7 @@ func SSHAddress(csp gophercloud.CloudServersProvider, port int) func(multistep.S
 		for pool, addresses := range ip_pools {
 			if pool != "" {
 				for _, address := range addresses {
-					if address.Addr != "" {
+					if address.Addr != "" && address.Version == 4 {
 						return fmt.Sprintf("%s:%d", address.Addr, port), nil
 					}
 				}


### PR DESCRIPTION
Force IPv4 addresses from address pools in Openstack. Fixes #1258 

Rackspace defaults to a public IPv4 and IPv6 address. These are returned in
random order, with the sprintf further on generating an incorrect connection
string if on IPv6. Force IPv4 until support for correct connection strings and
a configuration flag for logging in over IPv6 is added.
