### PR TITLE
Added required value for openstack_provider for rackspace example

### DIFF
--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -120,6 +120,7 @@ Ubuntu 12.04 LTS (Precise Pangolin) on Rackspace OpenStack cloud offering.
   "username": "",
   "password": "",
   "provider": "rackspace-us",
+  "openstack_provider":"rackspace",
   "region": "DFW",
   "ssh_username": "root",
   "image_name": "Test image",


### PR DESCRIPTION
If `openstack_provider:rackspace` is omitted in the configuration, the example
won't work at all against Rackspace. Not sure what the actual documentation for
this configuration value should be, but this was a major source of irritation
when I couldn't get the default example working against Rackspace.
