### PR TITLE
Don't use a real domain in examples.

### DIFF
--- a/website/source/docs/templates/post-processors.html.markdown
+++ b/website/source/docs/templates/post-processors.html.markdown
@@ -81,7 +81,7 @@ compressed then uploaded, but the compressed result is not kept.
   "post-processors": [
     [
       "compress",
-      { "type": "upload", "endpoint": "http://fake.com" }
+      { "type": "upload", "endpoint": "http://example.com" }
     ]
   ]
 }


### PR DESCRIPTION
Use example.com instead.
