### PR TITLE
increase VMware cleanup timeout to 120 seconds

### DIFF
--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -102,7 +102,7 @@ func (s *StepShutdown) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Message("Waiting for VMware to clean up after itself...")
 	lockRegex := regexp.MustCompile(`(?i)\.lck$`)
-	timer := time.After(15 * time.Second)
+	timer := time.After(120 * time.Second)
 LockWaitLoop:
 	for {
 		files, err := dir.ListFiles()


### PR DESCRIPTION
This is a fix for #1267 to give VMware Workstation more time to cleanup its lock files. I have increased the timeout from 15 seconds to 120 seconds.
