### PR TITLE
Resolves #1256, add warning mesasge to VMware ESXi driver

### DIFF
--- a/builder/vmware/common/step_upload_tools.go
+++ b/builder/vmware/common/step_upload_tools.go
@@ -23,7 +23,7 @@ func (c *StepUploadTools) Run(state multistep.StateBag) multistep.StepAction {
 
 	if c.RemoteType == "esx5" {
 		if err := driver.ToolsInstall(); err != nil {
-			state.Put("error", fmt.Errorf("Couldn't mount VMware tools ISO."))
+			state.Put("error", fmt.Errorf("Couldn't mount VMware tools ISO. Please check the 'guest_os_type' in your template.json."))
 		}
 		return multistep.ActionContinue
 	}


### PR DESCRIPTION
Resolves #1256

I added the warning message, `Please check the 'guest_os_type' in your template.json.`.
If there is no `guest_os_type` in template.json, Packer use `other` for `guest_os_type` by default.
But correct `guest_os_type` is required by `vim-cmd tools.install` command.
