### PR TITLE
[GCE] google compute builder is broken, gsutil update fails in newer images

### DIFF
--- a/builder/googlecompute/step_update_gsutil.go
+++ b/builder/googlecompute/step_update_gsutil.go
@@ -28,18 +28,18 @@ func (s *StepUpdateGsutil) Run(state multistep.StateBag) multistep.StepAction {
 		sudoPrefix = "sudo "
 	}
 
-	gsutilUpdateCmd := "/usr/local/bin/gsutil update -n -f"
+	gsutilUpdateCmd := "/usr/local/bin/gcloud -q components update"
 	cmd := new(packer.RemoteCmd)
 	cmd.Command = fmt.Sprintf("%s%s", sudoPrefix, gsutilUpdateCmd)
 
-	ui.Say("Updating gsutil...")
+	ui.Say("Updating gcloud components...")
 	err := cmd.StartWithUi(comm, ui)
 	if err == nil && cmd.ExitStatus != 0 {
 		err = fmt.Errorf(
-			"gsutil update exited with non-zero exit status: %d", cmd.ExitStatus)
+			"gcloud components update exited with non-zero exit status: %d", cmd.ExitStatus)
 	}
 	if err != nil {
-		err := fmt.Errorf("Error updating gsutil: %s", err)
+		err := fmt.Errorf("Error updating gcloud components: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/googlecompute/step_update_gsutil_test.go
+++ b/builder/googlecompute/step_update_gsutil_test.go
@@ -32,7 +32,7 @@ func TestStepUpdateGsutil(t *testing.T) {
 	if strings.HasPrefix(comm.StartCmd.Command, "sudo") {
 		t.Fatal("should not sudo")
 	}
-	if !strings.Contains(comm.StartCmd.Command, "gsutil update") {
+	if !strings.Contains(comm.StartCmd.Command, "gcloud -q components update") {
 		t.Fatalf("bad command: %#v", comm.StartCmd.Command)
 	}
 }
@@ -79,7 +79,7 @@ func TestStepUpdateGsutil_nonRoot(t *testing.T) {
 	if !strings.HasPrefix(comm.StartCmd.Command, "sudo") {
 		t.Fatal("should sudo")
 	}
-	if !strings.Contains(comm.StartCmd.Command, "gsutil update") {
+	if !strings.Contains(comm.StartCmd.Command, "gcloud -q components update") {
 		t.Fatalf("bad command: %#v", comm.StartCmd.Command)
 	}
 }


### PR DESCRIPTION
gsutil update fails in newer images, use gcloud

```
googlecompute: It looks like you are trying to run "/usr/local/bin/../share/google/google-cloud-sdk/bin/bootstrapping/gsutil.py update".
googlecompute: The "update" command is no longer needed with the Cloud SDK.
googlecompute: To update, run: gcloud components update
```
