### PR TITLE
Fix openstack ServerById crash

### DIFF
--- a/builder/openstack/server.go
+++ b/builder/openstack/server.go
@@ -30,7 +30,7 @@ type StateChangeConf struct {
 }
 
 // ServerStateRefreshFunc returns a StateRefreshFunc that is used to watch
-// an openstacn server.
+// an openstack server.
 func ServerStateRefreshFunc(csp gophercloud.CloudServersProvider, s *gophercloud.Server) StateRefreshFunc {
 	return func() (interface{}, string, int, error) {
 		servers, err := csp.ListServers()


### PR DESCRIPTION
Workaround for gophercloud.ServerById crashing, fixes #1257

gophercloud.ServerById is broken in v0.1.0 - it will crash if you feed it a
non-existing server ID (see [rackspace/gophercloud #168(https://github.com/rackspace/gophercloud/issues/168))

Instead, list all servers and iterate over them. If the server id isn't found,
return "DELETED" as a state. Not perfect but it works until next version of
 gophercloud is released.
