### PR TITLE
Sort AMI names in Artifact.String - fixes random test failures

### DIFF
--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mitchellh/goamz/ec2"
 	"github.com/mitchellh/packer/packer"
 	"log"
+	"sort"
 	"strings"
 )
 
@@ -46,6 +47,7 @@ func (a *Artifact) String() string {
 		amiStrings = append(amiStrings, single)
 	}
 
+	sort.Sort(sort.StringSlice(amiStrings))
 	return fmt.Sprintf("AMIs were created:\n\n%s", strings.Join(amiStrings, "\n"))
 }
 


### PR DESCRIPTION
With go tip, the output from Artifact.String will sometimes be output in a
different order than the tests. Sort the AMI strings before outputting.
See https://travis-ci.org/mitchellh/packer/jobs/28748467 for an example of this
failure.
