### PR TITLE
fix invalid esx5 path separator in windows

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -64,7 +64,7 @@ func (d *ESX5Driver) Stop(vmxPathLocal string) error {
 }
 
 func (d *ESX5Driver) Register(vmxPathLocal string) error {
-	vmxPath := filepath.Join(d.outputDir, filepath.Base(vmxPathLocal))
+	vmxPath := filepath.ToSlash(filepath.Join(d.outputDir, filepath.Base(vmxPathLocal)))
 	if err := d.upload(vmxPath, vmxPathLocal); err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (d *ESX5Driver) UploadISO(localPath string) (string, error) {
 	}
 
 	finalPath := d.datastorePath(targetFile)
-	if err := d.mkdir(filepath.Dir(finalPath)); err != nil {
+	if err := d.mkdir(filepath.ToSlash(filepath.Dir(finalPath))); err != nil {
 		return "", err
 	}
 
@@ -233,7 +233,7 @@ func (d *ESX5Driver) ListFiles() ([]string, error) {
 			continue
 		}
 
-		files = append(files, filepath.Join(d.outputDir, string(line)))
+		files = append(files, filepath.ToSlash(filepath.Join(d.outputDir, string(line))))
 	}
 
 	return files, nil
@@ -261,7 +261,7 @@ func (d *ESX5Driver) String() string {
 
 func (d *ESX5Driver) datastorePath(path string) string {
 	baseDir := filepath.Base(filepath.Dir(path))
-	return filepath.Join("/vmfs/volumes", d.Datastore, baseDir, filepath.Base(path))
+	return filepath.ToSlash(filepath.Join("/vmfs/volumes", d.Datastore, baseDir, filepath.Base(path)))
 }
 
 func (d *ESX5Driver) connect() error {


### PR DESCRIPTION
Before, ESX5Driver had joining path elements by filepath module. filepath module generates path strings with backslash("\")-joined in Windows. but ESX require path strings with slash("/")-joined. it means that this code generate illegal path string in windows. illegal path string raised "Error creating disk".

this patch fixes path separator from backslash to slash in windows. from this, creating disk would succeed without error.

probably, this pull request addresses the issue #1291 .
