### PR TITLE
Accept VirtualBox release candidate version

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -186,9 +186,9 @@ func (d *VBox42Driver) Version() (string, error) {
 		return "", fmt.Errorf("VirtualBox is not properly setup: %s", versionOutput)
 	}
 
-	versionRe := regexp.MustCompile("[^.0-9]")
-	matches := versionRe.Split(versionOutput, 2)
-	if len(matches) == 0 || matches[0] == "" {
+	versionRe := regexp.MustCompile("^[.0-9]+(?:_RC[0-9]+)?")
+	matches := versionRe.FindAllString(versionOutput, 1)
+	if matches == nil {
 		return "", fmt.Errorf("No version found: %s", versionOutput)
 	}
 


### PR DESCRIPTION
With this fix, packer get version for example 4.3.14_RC1 from 4.3.14_RC1r94870.

I also made the minimal fix at 
https://github.com/hnakamur/packer/compare/accept_virtualbox_release_candidate_version_with_minimal_change
but I think this pull requst is easier to understand.

You can try this regexp at
http://play.golang.org/p/9DizYfSy7Y
