### PR TITLE
Fixed Rackspace example

### DIFF
--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -120,7 +120,8 @@ Ubuntu 12.04 LTS (Precise Pangolin) on Rackspace OpenStack cloud offering.
 {
   "type": "openstack",
   "username": "",
-  "password": "",
+  "api_key": "",
+  "openstack_provider": "rackspace",
   "provider": "rackspace-us",
   "region": "DFW",
   "ssh_username": "root",


### PR DESCRIPTION
As per https://github.com/mitchellh/packer/issues/1142, it's critical to add openstack_provider: rackspace in order to get anything to work reliably with Rackspace and Packer in 6.0.

Question: should the openstack_provider field now be marked as required?
