### PR TITLE
builder/googlecompute: added support for all standard VM images

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -229,7 +229,7 @@ func (d *driverGCE) WaitForInstance(state, zone, name string) <-chan error {
 }
 
 func (d *driverGCE) getImage(name string) (image *compute.Image, err error) {
-	projects := []string{d.projectId, "centos-cloud", "debian-cloud", "google-containers", "rhel-cloud", "suse-cloud"}
+	projects := []string{d.projectId, "centos-cloud", "coreos-cloud", "debian-cloud", "google-containers", "opensuse-cloud", "rhel-cloud", "suse-cloud", "windows-cloud"}
 	for _, project := range projects {
 		image, err = d.service.Images.Get(project, name).Do()
 		if err == nil && image != nil && image.SelfLink != "" {


### PR DESCRIPTION
Also fixed the error message to be clear that the image was not found in any of
the projects that we attempted to search, rather than keep the error message
from the last project, which may be confusing to users.
