### PR TITLE
builder/googlecompute: rename "Gsutil" to "Gcloud" now that we're updating "gcloud" and not "gsutil".

### DIFF
--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -65,7 +65,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SSHWaitTimeout: 5 * time.Minute,
 		},
 		new(common.StepProvision),
-		new(StepUpdateGsutil),
+		new(StepUpdateGcloud),
 		new(StepCreateImage),
 		new(StepUploadImage),
 		new(StepRegisterImage),

--- a/builder/googlecompute/step_update_gcloud.go
+++ b/builder/googlecompute/step_update_gcloud.go
@@ -7,9 +7,9 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-// StepUpdateGsutil represents a Packer build step that updates the gsutil
+// StepUpdateGcloud represents a Packer build step that updates the gsutil
 // utility to the latest version available.
-type StepUpdateGsutil int
+type StepUpdateGcloud int
 
 // Run executes the Packer build step that updates the gsutil utility to the
 // latest version available.
@@ -17,7 +17,7 @@ type StepUpdateGsutil int
 // This step is required to prevent the image creation process from hanging;
 // the image creation process utilizes the gcimagebundle cli tool which will
 // prompt to update gsutil if a newer version is available.
-func (s *StepUpdateGsutil) Run(state multistep.StateBag) multistep.StepAction {
+func (s *StepUpdateGcloud) Run(state multistep.StateBag) multistep.StepAction {
 	comm := state.Get("communicator").(packer.Communicator)
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
@@ -49,4 +49,4 @@ func (s *StepUpdateGsutil) Run(state multistep.StateBag) multistep.StepAction {
 }
 
 // Cleanup.
-func (s *StepUpdateGsutil) Cleanup(state multistep.StateBag) {}
+func (s *StepUpdateGcloud) Cleanup(state multistep.StateBag) {}

--- a/builder/googlecompute/step_update_gcloud_test.go
+++ b/builder/googlecompute/step_update_gcloud_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-func TestStepUpdateGsutil_impl(t *testing.T) {
-	var _ multistep.Step = new(StepUpdateGsutil)
+func TestStepUpdateGcloud_impl(t *testing.T) {
+	var _ multistep.Step = new(StepUpdateGcloud)
 }
 
-func TestStepUpdateGsutil(t *testing.T) {
+func TestStepUpdateGcloud(t *testing.T) {
 	state := testState(t)
-	step := new(StepUpdateGsutil)
+	step := new(StepUpdateGcloud)
 	defer step.Cleanup(state)
 
 	comm := new(packer.MockCommunicator)
@@ -37,9 +37,9 @@ func TestStepUpdateGsutil(t *testing.T) {
 	}
 }
 
-func TestStepUpdateGsutil_badExitStatus(t *testing.T) {
+func TestStepUpdateGcloud_badExitStatus(t *testing.T) {
 	state := testState(t)
-	step := new(StepUpdateGsutil)
+	step := new(StepUpdateGcloud)
 	defer step.Cleanup(state)
 
 	comm := new(packer.MockCommunicator)
@@ -56,9 +56,9 @@ func TestStepUpdateGsutil_badExitStatus(t *testing.T) {
 	}
 }
 
-func TestStepUpdateGsutil_nonRoot(t *testing.T) {
+func TestStepUpdateGcloud_nonRoot(t *testing.T) {
 	state := testState(t)
-	step := new(StepUpdateGsutil)
+	step := new(StepUpdateGcloud)
 	defer step.Cleanup(state)
 
 	comm := new(packer.MockCommunicator)


### PR DESCRIPTION
Also renamed files accordingly.
