### PR TITLE
Install gox during build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ all: deps
 deps:
 	@$(ECHO) "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
 	@go get -d -v ./...
+	@go get github.com/mitchellh/gox
 	@echo $(DEPS) | xargs -n1 go get -d
 
 updatedeps:


### PR DESCRIPTION
Just so that we can just run `make` without installing gox separately. Not sure if this patch is even valid but people could just get all the build dependencies in one go if gox is installed as part of the `make deps`
