### PR TITLE
Do not re-add floppy disk files to VMX

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -367,10 +367,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Timeout: b.config.ShutdownTimeout,
 		},
 		&vmwcommon.StepCleanFiles{},
-		&vmwcommon.StepCleanVMX{},
 		&vmwcommon.StepConfigureVMX{
 			CustomData: b.config.VMXDataPost,
 		},
+		&vmwcommon.StepCleanVMX{},
 		&vmwcommon.StepCompactDisk{
 			Skip: b.config.SkipCompaction,
 		},

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -94,10 +94,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Timeout: b.config.ShutdownTimeout,
 		},
 		&vmwcommon.StepCleanFiles{},
-		&vmwcommon.StepCleanVMX{},
 		&vmwcommon.StepConfigureVMX{
 			CustomData: b.config.VMXDataPost,
 		},
+		&vmwcommon.StepCleanVMX{},
 		&vmwcommon.StepCompactDisk{
 			Skip: b.config.SkipCompaction,
 		},


### PR DESCRIPTION
This fixes errors like this in the vsphere post-processor when using floppy files in the builder step:
`Error: File (/var/folders/zl/57c1vmr532z_ryf1scw53_b9ycmxh7/T/packer964492999) could not be found`

The configure VMX step re-adds the floppy files, so we need to configure the VMX and _then_ clean the VMX in that order.

See https://github.com/joefitzgerald/packer-windows/issues/27
