### PR TITLE
amazon-instance: Debug the evaluated bundle commands

### DIFF
--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -223,8 +223,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&common.StepProvision{},
 		&StepUploadX509Cert{},
-		&StepBundleVolume{},
-		&StepUploadBundle{},
+		&StepBundleVolume{
+			Debug: b.config.PackerDebug,
+		},
+		&StepUploadBundle{
+			Debug: b.config.PackerDebug,
+		},
 		&StepRegisterAMI{},
 		&awscommon.StepAMIRegionCopy{
 			Regions: b.config.AMIRegions,

--- a/builder/amazon/instance/step_bundle_volume.go
+++ b/builder/amazon/instance/step_bundle_volume.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/goamz/ec2"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
@@ -17,7 +18,9 @@ type bundleCmdData struct {
 	PrivatePath  string
 }
 
-type StepBundleVolume struct{}
+type StepBundleVolume struct {
+	Debug bool
+}
 
 func (s *StepBundleVolume) Run(state multistep.StateBag) multistep.StepAction {
 	comm := state.Get("communicator").(packer.Communicator)
@@ -48,6 +51,11 @@ func (s *StepBundleVolume) Run(state multistep.StateBag) multistep.StepAction {
 	ui.Say("Bundling the volume...")
 	cmd := new(packer.RemoteCmd)
 	cmd.Command = config.BundleVolCommand
+
+	if s.Debug {
+		ui.Say(fmt.Sprintf("Running: %s", config.BundleVolCommand))
+	}
+
 	if err := cmd.StartWithUi(comm, ui); err != nil {
 		state.Put("error", fmt.Errorf("Error bundling volume: %s", err))
 		ui.Error(state.Get("error").(error).Error())

--- a/builder/amazon/instance/step_upload_bundle.go
+++ b/builder/amazon/instance/step_upload_bundle.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
 )
@@ -15,7 +16,9 @@ type uploadCmdData struct {
 	SecretKey       string
 }
 
-type StepUploadBundle struct{}
+type StepUploadBundle struct {
+	Debug bool
+}
 
 func (s *StepUploadBundle) Run(state multistep.StateBag) multistep.StepAction {
 	comm := state.Get("communicator").(packer.Communicator)
@@ -49,6 +52,11 @@ func (s *StepUploadBundle) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Uploading the bundle...")
 	cmd := &packer.RemoteCmd{Command: config.BundleUploadCommand}
+
+	if s.Debug {
+		ui.Say(fmt.Sprintf("Running: %s", config.BundleUploadCommand))
+	}
+
 	if err := cmd.StartWithUi(comm, ui); err != nil {
 		state.Put("error", fmt.Errorf("Error uploading volume: %s", err))
 		ui.Error(state.Get("error").(error).Error())


### PR DESCRIPTION
I'm trying to figure out why the `ec2-bundle-vol` command isn't dropping a manifest in `tmp/image-12345.manifest.xml` and figured this debugging line might be useful for me as well as others. 
