### PR TITLE
Seed random VirtualBox http port

### DIFF
--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
 	"log"
+	"math/rand"
 	"strings"
 	"time"
 )

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"time"
 
 	"github.com/mitchellh/multistep"


### PR DESCRIPTION
Working on Windows I always struggle building Linux base boxes for VirtualBox with HTTP kickstart files etc.
I found out that the HTTP port used by packer is always port 8081, but the guest will hang trying to download the kickstart/preseed file.
I have checked firewall rules etc, but then found out that this port 8081 is used by McAfee virus scanner.

So one workaround is to use

``` json
    "http_port_min": 8100,
```

in the packer template json file. But I wondered why packer uses always the same port and why packer does not try another port because this port is already listening by McAfee's FrameworkService.exe. The last question would be why a virus scanner uses a not so unusual http port?

I have tried the same code as used in packer to listen on that port and this indeed seems to work, no error from the `net.Listen()` function. It seems that McAfee uses a shared port which is possible on Windows.

Therefore I added the `rand.Seed()` call from the vmware builder to have the virtualbox builder do the same random number generation. With this all standard packer templates out there should work the most time even for Windows users that have McAfee preinstalled (eg. company laptops).
