### PR TITLE
Allow 'tcg' as accelerator in builder-qemu

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -249,9 +249,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 			errs, errors.New("invalid format, only 'qcow2' or 'raw' are allowed"))
 	}
 
-	if !(b.config.Accelerator == "kvm" || b.config.Accelerator == "xen") {
+	if !(b.config.Accelerator == "kvm" || b.config.Accelerator == "xen" || b.config.Accelerator == "tcg") {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("invalid format, only 'kvm' or 'xen' are allowed"))
+			errs, errors.New("invalid format, only 'kvm', 'xen' or 'tcg' are allowed"))
 	}
 
 	if _, ok := netDevice[b.config.NetDevice]; !ok {

--- a/website/source/docs/builders/qemu.html.markdown
+++ b/website/source/docs/builders/qemu.html.markdown
@@ -91,8 +91,8 @@ each category, the available options are alphabetized and described.
 ### Optional:
 
 * `accelerator` (string) - The accelerator type to use when running the VM.
-  This may have a value of either "kvm" or "xen" and you must have that
-  support in on the machine on which you run the builder.
+  This may have a value of either "kvm", "xen" or "tcg" and you must have that
+  support on the machine on which you run the builder. By default "kvm" is used.
 
 * `boot_command` (array of strings) - This is an array of commands to type
   when the virtual machine is first booted. The goal of these commands should


### PR DESCRIPTION
Hi everyone!

I tried to run packer inside a virtual machine (kvm) and run into the "accelerator" parameter which only can be kvm or xen. This pull-request adds 'tcg' as allowed accelerator. The virtual machine will run slower as with kvm or xen as it does not use the virtualization extension but it will run inside a vm (and also on Windows?). 
- Using 'tcg' as accelerator for qemu-system allows packer to run in a
  virtual machine as no kvm or xen support is needed.
- Also document the default behavior if no accelerator is given in the
  documentation.
