### PR TITLE
Re-add "Region" to uploadCmdData struct

### DIFF
--- a/builder/amazon/instance/step_upload_bundle.go
+++ b/builder/amazon/instance/step_upload_bundle.go
@@ -12,6 +12,7 @@ type uploadCmdData struct {
 	BundleDirectory string
 	ManifestPath    string
 	S3Endpoint      string
+	Region          string
 	SecretKey       string
 }
 
@@ -38,6 +39,7 @@ func (s *StepUploadBundle) Run(state multistep.StateBag) multistep.StepAction {
 		BundleDirectory: config.BundleDestination,
 		ManifestPath:    manifestPath,
 		S3Endpoint:      region.S3Endpoint,
+		Region:          region.Name,
 		SecretKey:       config.SecretKey,
 	})
 	if err != nil {


### PR DESCRIPTION
https://github.com/mitchellh/packer/commit/af89b31a4067e2acd1f9c5f370a90218885a29be removed "Region" which prevents the --region parameter being used (dynamically) in "bundle_upload_command".  For example, currently:
`
"bundle_upload_command": "sudo -in ec2-upload-bundle -b {{.BucketName}} -m {{.ManifestPath}} -a {{.AccessKey}} -s {{.SecretKey}} -d {{.BundleDirectory}} --batch --region {{.Region}} --retry"
`
causes:
`
Build 'amazon-instance' errored: Error processing bundle upload command: template: tpl29:1:146: executing "tpl29" at <.Region>: Region is not a field of struct type instance.uploadCmdData
`
