### PR TITLE
add disk size to google compute

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -18,6 +18,7 @@ type Config struct {
 
 	BucketName        string            `mapstructure:"bucket_name"`
 	ClientSecretsFile string            `mapstructure:"client_secrets_file"`
+	DiskSizeGb        int64             `mapstructure:"disk_size"`
 	ImageName         string            `mapstructure:"image_name"`
 	ImageDescription  string            `mapstructure:"image_description"`
 	InstanceName      string            `mapstructure:"instance_name"`
@@ -62,6 +63,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	// Set defaults.
 	if c.Network == "" {
 		c.Network = "default"
+	}
+
+	if c.DiskSizeGb == 0 {
+		c.DiskSizeGb = 10
 	}
 
 	if c.ImageDescription == "" {

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -25,6 +25,7 @@ type Driver interface {
 
 type InstanceConfig struct {
 	Description string
+	DiskSizeGb  int64
 	Image       string
 	MachineType string
 	Metadata    map[string]string

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -177,6 +177,7 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 				AutoDelete: true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					SourceImage: image.SelfLink,
+					DiskSizeGb:  c.DiskSizeGb,
 				},
 			},
 		},

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -31,8 +31,8 @@ func (s *StepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Creating image...")
 	cmd := new(packer.RemoteCmd)
-	cmd.Command = fmt.Sprintf("%s%s --output_file_name %s",
-		sudoPrefix, imageBundleCmd, imageFilename)
+	cmd.Command = fmt.Sprintf("%s%s --output_file_name %s --fssize %d",
+		sudoPrefix, imageBundleCmd, imageFilename, config.DiskSizeGb*1024*1024*1024)
 	err := cmd.StartWithUi(comm, ui)
 	if err == nil && cmd.ExitStatus != 0 {
 		err = fmt.Errorf(

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -28,6 +28,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 
 	errCh, err := driver.RunInstance(&InstanceConfig{
 		Description: "New instance created by Packer",
+		DiskSizeGb:  config.DiskSizeGb,
 		Image:       config.SourceImage,
 		MachineType: config.MachineType,
 		Metadata: map[string]string{

--- a/website/source/docs/builders/googlecompute.markdown
+++ b/website/source/docs/builders/googlecompute.markdown
@@ -91,6 +91,9 @@ each category, the available options are alphabetized and described.
 
 ### Optional:
 
+* `disk_size` (integer) - The size of the disk in GB.
+  This defaults to 10, which is 10GB.
+
 * `image_name` (string) - The unique name of the resulting image.
   Defaults to `packer-{{timestamp}}`.
 


### PR DESCRIPTION
This will avoid 'not enough disk space' errors on creating the image.
