### PR TITLE
template: interpolate builder name in ParseTemplate

### DIFF
--- a/packer/template_test.go
+++ b/packer/template_test.go
@@ -825,7 +825,7 @@ func TestTemplateBuild_names(t *testing.T) {
 		t.Fatalf("bad: %#v", b.Name())
 	}
 
-	b, err = template.Build("test2-{{user \"foo\"}}", testComponentFinder())
+	b, err = template.Build("test2-bar", testComponentFinder())
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
i believe this fixes #858, though there may be a more elegant approach. 

the problem, as @jasonberanek noted, was that user variables contained in the Builder names are not resolved in `ParseTemplate`. this revision changes `ParseTemplate` to process the user variables in the `Name` field [before the value of that field is used as a key](https://github.com/strcrzy/packer/blob/81425d6b4d9086c56372415f45015bf78db9e7cb/packer/template.go#L246) to store the Builder in the `Builders` map, which `BuildOptions` uses to match against when enforcing `only` and `except` options.
