### PR TITLE
Add more debug messages to debug ssh key gen

### DIFF
--- a/builder/openstack/step_key_pair.go
+++ b/builder/openstack/step_key_pair.go
@@ -33,7 +33,9 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	// If we're in debug mode, output the private key to the working
 	// directory.
 	if s.Debug {
-		ui.Message(fmt.Sprintf("Saving key for debug purposes: %s", s.DebugKeyPath))
+		ui.Message(fmt.Sprintf(
+			"Saving key \"%s\" for debug purposes: %s; keyResp.PrivateKey = \"%s\"",
+			keyName, s.DebugKeyPath, keyResp.PrivateKey))
 		f, err := os.Create(s.DebugKeyPath)
 		if err != nil {
 			state.Put("error", fmt.Errorf("Error saving debug key: %s", err))


### PR DESCRIPTION
Add more debug messages to debug ssh key gen with OpenStack builder.

Background: I'm having a problem now where I can't get the OpenStack builder to work with my private Metacloud. One of the things I discovered is that it's failing to generate the private key for some reason. So this seems to be something that a debug message would be useful for.

```
$ PATH=bin bin/packer build -debug openstack.json
Debug mode enabled. Builds will not be parallelized.
openstack output will be in this color.

==> openstack: Creating temporary keypair for this instance...
    openstack: Saving key "packer 53e95eff-84ef-dfe7-4e96-0ef468b95711" for debug purposes: os_openstack.pem; keyResp.PrivateKey = ""
==> openstack: Pausing after run of step 'StepKeyPair'. Press enter to continue.
==> openstack: Error launching source server: Expected HTTP response code [202] when accessing URL(http://...:8776/v1/a5920c8f7bf6441a9e2e96eb7b62d1d5/servers); got 404 instead with the following body:
==> openstack: 404 Not Found
==> openstack:
==> openstack: The resource could not be found.
==> openstack:
==> openstack:
==> openstack: Pausing before cleanup of step 'StepKeyPair'. Press enter to continue.
==> openstack: Deleting temporary keypair...
==> openstack: Error cleaning up keypair. Please delete the key manually: packer 53e95eff-84ef-dfe7-4e96-0ef468b95711
Build 'openstack' errored: Error launching source server: Expected HTTP response code [202] when accessing URL(http://...:8776/v1/a5920c8f7bf6441a9e2e96eb7b62d1d5/servers); got 404 instead with the following body:
404 Not Found

The resource could not be found.



==> Some builds didn't complete successfully and had errors:
--> openstack: Error launching source server: Expected HTTP response code [202] when accessing URL(http://...:8776/v1/a5920c8f7bf6441a9e2e96eb7b62d1d5/servers); got 404 instead with the following body:
404 Not Found

The resource could not be found.



==> Builds finished but no artifacts were created.
```
