### PR TITLE
Add machine_type option for qemu builder.

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -67,6 +67,7 @@ type config struct {
 	ISOChecksum     string     `mapstructure:"iso_checksum"`
 	ISOChecksumType string     `mapstructure:"iso_checksum_type"`
 	ISOUrls         []string   `mapstructure:"iso_urls"`
+	MachineType     string     `mapstructure:"machine_type"`
 	NetDevice       string     `mapstructure:"net_device"`
 	OutputDir       string     `mapstructure:"output_directory"`
 	QemuArgs        [][]string `mapstructure:"qemuargs"`
@@ -125,6 +126,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if b.config.HTTPPortMax == 0 {
 		b.config.HTTPPortMax = 9000
+	}
+
+	if b.config.MachineType == "" {
+		b.config.MachineType = "pc-1.0"
 	}
 
 	if b.config.OutputDir == "" {
@@ -205,6 +210,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		"shutdown_timeout":  &b.config.RawShutdownTimeout,
 		"ssh_wait_timeout":  &b.config.RawSSHWaitTimeout,
 		"accelerator":       &b.config.Accelerator,
+		"machine_type":      &b.config.MachineType,
 		"net_device":        &b.config.NetDevice,
 		"disk_interface":    &b.config.DiskInterface,
 	}

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -76,7 +76,7 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 
 	defaultArgs := make(map[string]string)
 	defaultArgs["-name"] = vmName
-	defaultArgs["-machine"] = fmt.Sprintf("type=pc-1.0,accel=%s", config.Accelerator)
+	defaultArgs["-machine"] = fmt.Sprintf("type=%s,accel=%s", config.MachineType, config.Accelerator)
 	defaultArgs["-display"] = guiArgument
 	defaultArgs["-netdev"] = "user,id=user.0"
 	defaultArgs["-device"] = fmt.Sprintf("%s,netdev=user.0", config.NetDevice)


### PR DESCRIPTION
On CentOS7, ``pc-1.0'' qemu-kvm machine type are not supported.

Supported machines are:
none                 empty machine
pc                   RHEL 7.0.0 PC (i440FX + PIIX, 1996) (alias of pc-i440fx-rhel7.0.0)
pc-i440fx-rhel7.0.0  RHEL 7.0.0 PC (i440FX + PIIX, 1996) (default)
rhel6.5.0            RHEL 6.5.0 PC
rhel6.4.0            RHEL 6.4.0 PC
rhel6.3.0            RHEL 6.3.0 PC
rhel6.2.0            RHEL 6.2.0 PC
rhel6.1.0            RHEL 6.1.0 PC
rhel6.0.0            RHEL 6.0.0 PC
q35                  RHEL-7.0.0 PC (Q35 + ICH9, 2009) (alias of pc-q35-rhel7.0.0)
pc-q35-rhel7.0.0     RHEL-7.0.0 PC (Q35 + ICH9, 2009)
