### PR TITLE
openstack builder error out when gets blank keypair

### DIFF
--- a/builder/openstack/step_key_pair.go
+++ b/builder/openstack/step_key_pair.go
@@ -29,6 +29,10 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 		state.Put("error", fmt.Errorf("Error creating temporary keypair: %s", err))
 		return multistep.ActionHalt
 	}
+	if keyResp.PrivateKey == "" {
+		state.Put("error", fmt.Errorf("The temporary keypair returned was blank"))
+		return multistep.ActionHalt
+	}
 
 	// If we're in debug mode, output the private key to the working
 	// directory.


### PR DESCRIPTION
As I mentioned in https://github.com/mitchellh/packer/pull/1405, somehow gophercloud ends up calling the wrong URL for `os-keypairs` -- it calls the Volume API, which returns a 404, which results in packer getting a blank keypair but packer keeps proceeding and then fails at a later place.

It seems like perhaps the builder should fail immediately when it gets a blank keypair from gophercloud's `CreateKeyPair` function...
