### PR TITLE
openstack builder api.Type = "compute"

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -67,6 +67,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, err
 	}
 	api.Region = b.config.AccessConfig.Region()
+	api.Name = ""
+	api.Type = "compute"
 
 	csp, err := gophercloud.ServersApi(auth, api)
 	if err != nil {


### PR DESCRIPTION
so that it gets compute (nova) API and not some other incorrect API.
(e.g.: for me it was getting the Volume service API on port 8776 instead of the Compute API on port 8774)

This fixes issue GH-480 for me. @jrperritt from the [gophercloud](https://github.com/rackspace/gophercloud) team suggested this so props to him!!! :clap: 

Without this:

```
$ PATH=bin bin/packer build openstack.json
openstack output will be in this color.

Build 'openstack' errored: Missing endpoint, or insufficient privileges to access endpoint

==> Some builds didn't complete successfully and had errors:
--> openstack: Missing endpoint, or insufficient privileges to access endpoint

==> Builds finished but no artifacts were created.
```

With this:

```
$ PATH=bin bin/packer build openstack.json
openstack output will be in this color.

==> openstack: Creating temporary keypair for this instance...
==> openstack: Waiting for server (3abfb8c9-b714-4b5b-8a87-55f12d90573a) to become ready...
...
```

Here's the template that I'm using (`openstack.json`):

``` json
{
  "builders": [
    {
      "type": "openstack",
      "region": "RegionOne",
      "ssh_username": "cloud",
      "image_name": "ubuntu1404_packer_test_1",
      "source_image": "91d9c168-d1e5-49ca-a775-3bfdbb6c97f1",
      "flavor": "2"
    }
  ]
}
```
