### PR TITLE
OpenStack builder: Make region not required

### DIFF
--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -115,6 +115,12 @@ func (c *AccessConfig) Prepare(t *packer.ConfigTemplate) []error {
 		}
 	}
 
+	if strings.HasPrefix(c.Provider, "rackspace") {
+		if c.Region() == "" {
+			errs = append(errs, fmt.Errorf("region must be specified when using rackspace"))
+		}
+	}
+
 	if len(errs) > 0 {
 		return errs
 	}

--- a/builder/openstack/access_config_test.go
+++ b/builder/openstack/access_config_test.go
@@ -8,9 +8,18 @@ func testAccessConfig() *AccessConfig {
 	return &AccessConfig{}
 }
 
-func TestAccessConfigPrepare_NoRegion(t *testing.T) {
+func TestAccessConfigPrepare_NoRegion_Rackspace(t *testing.T) {
 	c := testAccessConfig()
+	c.Provider = "rackspace-us"
 	if err := c.Prepare(nil); err == nil {
+		t.Fatalf("shouldn't have err: %s", err)
+	}
+}
+
+func TestAccessConfigPrepare_NoRegion_PrivateCloud(t *testing.T) {
+	c := testAccessConfig()
+	c.Provider = "http://some-keystone-server:5000/v2.0"
+	if err := c.Prepare(nil); err != nil {
 		t.Fatalf("shouldn't have err: %s", err)
 	}
 }


### PR DESCRIPTION
Perhaps "region" is required when using a public provider like Rackspace? It's not required for my private cloud from Metacloud. I suspect a lot of private clouds have only a single region and thus don't need "region" to be specified.

This makes "region" required for Rackspace but not for other providers.
