### PR TITLE
Add .editorconfig to specify preferred style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# All files
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Golang
+[*.go]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
http://editorconfig.org/

Added this, because packer Golang files use tabs for indentation and my editor (Vim) is set to use spaces by default and I keep forgetting to change it to use tabs and then I have to reformat before I submit my changes.
