### PR TITLE
Updating check for version when on devel.

### DIFF
--- a/scripts/devcompile.sh
+++ b/scripts/devcompile.sh
@@ -14,6 +14,10 @@ verify_go () {
         return 0
     fi
 
+    if [[ "$2" == "devel" ]]; then
+        return 0
+    fi
+
     local IFS=.
     local i ver1=($1) ver2=($2)
 


### PR DESCRIPTION
# Problem

When on a development version of Go, `go version devel +7e00313f3b3a Tue Aug 19 08:50:35 2014 -0700 darwin/amd64` for example, you get an error about not having at least Go 1.2:

```
$ make
==> Installing dependencies
==> Building
==> Verifying Go
./scripts/devcompile.sh: line 32: 10#1 > 10#devel: value too great for base (error token is "10#devel")
==> Required Go version 1.2 not installed. Found devel instead
make: *** [all] Error 1
```
# Proposed solution

It seems reasonable to assume that if you're on a `devel` version, then you're up to date, or at least know what you're doing.

In this case, if your version of Go is `devel`, just bail out of the version check and continue on.
