### PR TITLE
It's possible to create instance-store images from EBS-based images

### DIFF
--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -204,7 +204,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&awscommon.StepRunSourceInstance{
 			Debug:                    b.config.PackerDebug,
-			ExpectedRootDevice:       "instance-store",
 			InstanceType:             b.config.InstanceType,
 			IamInstanceProfile:       b.config.IamInstanceProfile,
 			UserData:                 b.config.UserData,


### PR DESCRIPTION
It's not necessary to use an instance-store image to build an instance-store image, see this example http://sorcery.smugmug.com/2014/01/29/instance-store-hvm-amis-for-amazon-ec2/ so there should be no restriction on the ExpectedRootDevice
