### PR TITLE
doc openstack builder: region req'd only for rackspace

### DIFF
--- a/website/source/docs/builders/openstack.html.markdown
+++ b/website/source/docs/builders/openstack.html.markdown
@@ -41,11 +41,6 @@ each category, the available configuration keys are alphabetized.
   `SDK_PROVIDER`, if set.
   For Rackspace this should be `rackspace-us` or `rackspace-uk`.
 
-* `region` (string) - The name of the region, such as "DFW", in which
-  to launch the server to create the AMI.
-  If not specified, Packer will use the environment variables
-  `SDK_REGION` or `OS_REGION_NAME` (in that order), if set.
-
 * `source_image` (string) - The ID or full URL to the base image to use.
   This is the image that will be used to launch a new server and provision it.
 
@@ -95,6 +90,14 @@ each category, the available configuration keys are alphabetized.
 -->
 * `security_groups` (array of strings) - A list of security groups by name
   to add to this instance.
+
+* `region` (string) - The name of the region, such as "DFW", in which
+  to launch the server to create the AMI.
+  If not specified, Packer will use the environment variables
+  `SDK_REGION` or `OS_REGION_NAME` (in that order), if set.
+  For a `provider` of "rackspace", it is required to specify a region,
+  either using this option or with an environment variable. For other
+  providers, including a private cloud, specifying a region is optional.
 
 * `ssh_port` (integer) - The port that SSH will be available on. Defaults to port
   22.


### PR DESCRIPTION
Modify openstack builder doc to say that specifying a region is only required for public rackspace and is NOT required for a private openstack cloud.

Region was modified to only be required for rackspace in the code by https://github.com/mitchellh/packer/pull/1418

Cc: @sysbot
