### PR TITLE
Add group_vars and host_vars to Ansible provisioner docs

### DIFF
--- a/website/source/docs/provisioners/ansible-local.html.markdown
+++ b/website/source/docs/provisioners/ansible-local.html.markdown
@@ -76,6 +76,14 @@ Optional:
   your local system. These will be uploaded to the remote machine under
   `staging_directory`/playbooks. By default, this is empty.
 
+* `group_vars` (string) - a path to the directory containing ansible
+  group variables on your local system to be copied to the
+  remote machine. By default, this is empty.
+
+* `host_vars` (string) - a path to the directory containing ansible
+  host variables on your local system to be copied to the
+  remote machine. By default, this is empty.
+
 * `role_paths` (array of strings) - An array of paths to role directories on
   your local system. These will be uploaded to the remote machine under
   `staging_directory`/roles. By default, this is empty.


### PR DESCRIPTION
As per GH-975, update docs to reflect what is currently implemented in the provisioner code. Let me know if anything needs adjusting or updating.

Thanks!
