### PR TITLE
Run two builds in parallel with go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ testrace:
 	go test -race $(TEST) $(TESTARGS)
 
 updatedeps:
-	go get -u -v ./...
+	go get -u -v -p 2 ./...
 
 .PHONY: bin default test updatedeps


### PR DESCRIPTION
By default, go get determines parallelism based on the number of
cores available. Those show up as 32 in the Travis CI environment
but a virtual machine is limited both by the amount of cores it
has allocated and the amount of memory available to it. 32 parallel
build processes are likely to exhaust the memory resources, leading
to killed processes.

This change reduces the number of builds running concurrently to 2,
which should reduce the likelihood of memory exhaustion greatly.

The number could probably be dialed up a little bit, but this should
give a good default reflecting the environment's resources.
