### PR TITLE
Amazon Instance Builder Docs Still Reference Deprecated S3Endpoint

### DIFF
--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -309,7 +309,7 @@ sudo -n ec2-upload-bundle \
 	-s {{.SecretKey}} \
 	-d {{.BundleDirectory}} \
 	--batch \
-	--url {{.S3Endpoint}} \
+	--region {{.Region}} \
 	--retry
 ```
 


### PR DESCRIPTION
Per https://github.com/mitchellh/packer/commit/c791216 the `ec2-upload-bundle` command parameters changed from using `--url {{.S3Endpoint}}` to `--region {{.Region}}`

The docs at http://www.packer.io/docs/builders/amazon-instance.html still reference the `S3Endpoint` syntax which results in an error if used in a custom bundle upload command.  

```
    amazon-instance: ec2-bundle-vol complete.
==> amazon-instance: Error processing bundle upload command: template: tpl30:1:194: executing "tpl30" at <.S3Endpoint>: S3Endpoint is not a field of struct type instance.uploadCmdData
```

Would you please update the Amazon instance docs to help future folks avoid this?

The use of custom bundle commands is necessary due to the default sudo `PATH` environment per https://groups.google.com/forum/#!topic/packer-tool/69wHimRb964 and my current lack of will to fix our base AMI to handle this issue more gracefully.
