### PR TITLE
fixed vmware-vmx step order

### DIFF
--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -62,15 +62,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&common.StepCreateFloppy{
 			Files: b.config.FloppyFiles,
 		},
-		&vmwcommon.StepHTTPServer{
-			HTTPDir:     b.config.HTTPDir,
-			HTTPPortMin: b.config.HTTPPortMin,
-			HTTPPortMax: b.config.HTTPPortMax,
-		},
-		&vmwcommon.StepConfigureVNC{
-			VNCPortMin: b.config.VNCPortMin,
-			VNCPortMax: b.config.VNCPortMax,
-		},
 		&StepCloneVMX{
 			OutputDir: b.config.OutputDir,
 			Path:      b.config.SourcePath,
@@ -80,6 +71,15 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			CustomData: b.config.VMXData,
 		},
 		&vmwcommon.StepSuppressMessages{},
+		&vmwcommon.StepHTTPServer{
+			HTTPDir:     b.config.HTTPDir,
+			HTTPPortMin: b.config.HTTPPortMin,
+			HTTPPortMax: b.config.HTTPPortMax,
+		},
+		&vmwcommon.StepConfigureVNC{
+			VNCPortMin: b.config.VNCPortMin,
+			VNCPortMax: b.config.VNCPortMax,
+		},
 		&vmwcommon.StepRun{
 			BootWait:           b.config.BootWait,
 			DurationBeforeStop: 5 * time.Second,


### PR DESCRIPTION
The VMX needs to be cloned first, or StepConfigureVNC will fail on line 58.  I was hung up on checking out yamux, but this ended up being something simple I had figured out in my fixed fork from shortly after pr/1169.  Either way, cheers!

solves at least:
https://gist.github.com/anonymous/d850e34b063501620b61 and https://github.com/mitchellh/packer/issues/1492
