### PR TITLE
builder/parallels: Ignore 'The fdd0 device does not exist'

### DIFF
--- a/builder/parallels/common/step_attach_floppy.go
+++ b/builder/parallels/common/step_attach_floppy.go
@@ -39,11 +39,10 @@ func (s *StepAttachFloppy) Run(state multistep.StateBag) multistep.StepAction {
 		"set", vmName,
 		"--device-del", "fdd0",
 	}
-	if err := driver.Prlctl(del_command...); err != nil {
-		state.Put("error", fmt.Errorf("Error deleting floppy: %s", err))
-	}
-	ui.Say("Attaching floppy disk...")
+	// This will almost certainly fail with 'The fdd0 device does not exist.'
+	driver.Prlctl(del_command...)
 
+	ui.Say("Attaching floppy disk...")
 	// Attaching the floppy disk
 	add_command := []string{
 		"set", vmName,


### PR DESCRIPTION
A current floppy disk probably doesn't exist, so the build shouldn't
fail when we try to delete it.
