### PR TITLE
Clean VMX step should always remove floppy.

### DIFF
--- a/builder/vmware/common/step_clean_vmx_test.go
+++ b/builder/vmware/common/step_clean_vmx_test.go
@@ -88,7 +88,6 @@ func TestStepCleanVMX_isoPath(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	state.Put("iso_path", "foo")
 	state.Put("vmx_path", vmxPath)
 
 	// Test the run
@@ -135,6 +134,7 @@ floppy0.filetype = "file"
 `
 
 const testVMXISOPath = `
+ide0:0.devicetype = "cdrom-image"
 ide0:0.filename = "foo"
 ide0:1.filename = "bar"
 foo = "bar"

--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -137,10 +137,14 @@ LockWaitLoop:
 		}
 	}
 
-	if runtime.GOOS == "windows" && !s.Testing {
+	if runtime.GOOS != "darwin" && !s.Testing {
 		// Windows takes a while to yield control of the files when the
-		// process is exiting. We just sleep here. In the future, it'd be
-		// nice to find a better solution to this.
+		// process is exiting. Ubuntu will yield control of the files but
+		// VMWare may overwrite the VMX cleanup steps that run after this,
+		// so we wait to ensure VMWare has exited and flushed the VMX.
+
+		// We just sleep here. In the future, it'd be nice to find a better
+		// solution to this.
 		time.Sleep(5 * time.Second)
 	}
 


### PR DESCRIPTION
This PR fixes several issues, all related to trying to use the VMX builder and vpshere post processor.
1. GH issue #1508 - VMX file changes not saving to disk
2. VMX builder won't remove mounted floppies or CD-ROMs

When using the VMX builder its possible for the source machine to have a floppy/CD-ROM configured which gets cloned to the new VM Packer spins up. The new VM's Packer config doesn't have a floppy_files/iso_path config entry, the Packer clean VMX step fails to remove the mounted media from the new VM.

This can cause build failures, for example with the vsphere post processor generating errors like:

```
* Post-processor failed: Failed: exit status 1
Error: File (/home/teamcity/tmp/buildTmp/packer941120499) could not be found.
```
