### PR TITLE
Fix detecting guest additions URL

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -49,11 +49,12 @@ func (d *VBox42Driver) Iso() (string, error) {
 		return "", err
 	}
 
-	DefaultGuestAdditionsRe := regexp.MustCompile("Default Guest Additions ISO:(.*)")
+	DefaultGuestAdditionsRe := regexp.MustCompile("Default Guest Additions ISO:(.+)")
 
 	for _, line := range strings.Split(stdout.String(), "\n") {
 		// Need to trim off CR character when running in windows
-		line = strings.TrimRight(line, "\r")
+		// Trimming whitespaces at this point helps to filter out empty value
+		line = strings.TrimRight(line, " \r")
 
 		matches := DefaultGuestAdditionsRe.FindStringSubmatch(line)
 		if matches == nil {
@@ -66,7 +67,7 @@ func (d *VBox42Driver) Iso() (string, error) {
 		return isoname, nil
 	}
 
-	return "", fmt.Errorf("Cannot find \"Default Guest Additions ISO\" in vboxmanage output")
+	return "", fmt.Errorf("Cannot find \"Default Guest Additions ISO\" in vboxmanage output (or it is empty)")
 }
 
 func (d *VBox42Driver) Import(name string, path string, flags []string) error {


### PR DESCRIPTION
When `Default Guest Additions ISO` system property exists with empty value, packer treats that empty value as a URL. The issue has been spotted on Arch with Virtualbox 4.3.16.

Here is the output of `vboxmanage list systemproperties` packer built from master choked with:

```
API version:                     4_3
Minimum guest RAM size:          4 Megabytes
Maximum guest RAM size:          2097152 Megabytes
Minimum video RAM size:          1 Megabytes
Maximum video RAM size:          256 Megabytes
Maximum guest monitor count:     64
Minimum guest CPU count:         1
Maximum guest CPU count:         32
Virtual disk limit (info):       2199022206976 Bytes
Maximum Serial Port count:       2
Maximum Parallel Port count:     2
Maximum Boot Position:           4
Maximum PIIX3 Network Adapter count:   8
Maximum ICH9 Network Adapter count:   36
Maximum PIIX3 IDE Controllers:   1
Maximum ICH9 IDE Controllers:    1
Maximum IDE Port count:          2
Maximum Devices per IDE Port:    2
Maximum PIIX3 SATA Controllers:  1
Maximum ICH9 SATA Controllers:   8
Maximum SATA Port count:         30
Maximum Devices per SATA Port:   1
Maximum PIIX3 SCSI Controllers:  1
Maximum ICH9 SCSI Controllers:   8
Maximum SCSI Port count:         16
Maximum Devices per SCSI Port:   1
Maximum SAS PIIX3 Controllers:   1
Maximum SAS ICH9 Controllers:    8
Maximum SAS Port count:          8
Maximum Devices per SAS Port:    1
Maximum PIIX3 Floppy Controllers:1
Maximum ICH9 Floppy Controllers: 1
Maximum Floppy Port count:       1
Maximum Devices per Floppy Port: 2
Default machine folder:          /home/alex/VirtualBox VMs
Exclusive HW virtualization use: on
Default hard disk format:        VDI
VRDE auth library:               VBoxAuth
Webservice auth. library:        VBoxAuth
Remote desktop ExtPack:          Oracle VM VirtualBox Extension Pack
Log history count:               3
Default frontend:                
Autostart database path:         
Default Guest Additions ISO:     
```
