### PR TITLE
Fix VMX is overwritten not including vmx_data_post

### DIFF
--- a/builder/vmware/common/vmx.go
+++ b/builder/vmware/common/vmx.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
 
 // ParseVMX parses the keys and values from a VMX file and returns
@@ -66,7 +67,8 @@ func WriteVMX(path string, data map[string]string) (err error) {
 	if _, err = io.Copy(f, &buf); err != nil {
 		return
 	}
-
+	f.Sync()
+        time.Sleep(1000 * time.Millisecond)
 	return
 }
 

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -346,11 +346,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Timeout: b.config.ShutdownTimeout,
 		},
 		&vmwcommon.StepCleanFiles{},
+		&vmwcommon.StepCleanVMX{},
 		&vmwcommon.StepConfigureVMX{
 			CustomData: b.config.VMXDataPost,
 			SkipFloppy: true,
 		},
-		&vmwcommon.StepCleanVMX{},
 		&vmwcommon.StepCompactDisk{
 			Skip: b.config.SkipCompaction,
 		},


### PR DESCRIPTION
I suppose after syncing the file, the sleep is not necessary, but I didn't try it. This is related to this bug
vmx_data_post inconsistently applied or written #1508
