### PR TITLE
ec2-upload-bunlde now uses region, not s3endpoint

### DIFF
--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -309,7 +309,7 @@ sudo -n ec2-upload-bundle \
 	-s {{.SecretKey}} \
 	-d {{.BundleDirectory}} \
 	--batch \
-	--url {{.S3Endpoint}} \
+	-region {{.Region}} \
 	--retry
 ```
 


### PR DESCRIPTION
see commit c79121617cd3c2366481b55e1ddee38ba68deeaf
