### PR TITLE
Fix plugin loading from CWD

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,14 +72,14 @@ func (c *config) Discover() error {
 	}
 
 	// Look in the cwd.
-  cwd,err := filepath.Abs(".")
-  if err != nil {
-    log.Printf("[ERR] Error getting path for working directory")
-  } else {
-	  if err := c.discover(cwd); err != nil {
-		  return err
-	  }
-  }
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		log.Printf("[ERR] Error getting path for working directory")
+	} else {
+		if err := c.discover(cwd); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently packer can detect plugins in current working directory, but will fail when actually trying to load those plugins. 

This is because the discover mechanism will register a CWD plugin as just it's filename e.g. "packer-builder-foobar". However the plugin loader expect an executable path like "./packer-builder-foo".

This fixes it by passing the absolute path to CWD insto discover instead of ".", which again will lead it to store plugins with an absolute (and executable) path.
