### PR TITLE
Add default nodename for chef-client

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/common/uuid"
 	"github.com/mitchellh/packer/packer"
 )
 
@@ -187,7 +188,11 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
+
 	nodeName := p.config.NodeName
+	if nodeName == "" {
+		nodeName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
+	}
 	remoteValidationKeyPath := ""
 	serverUrl := p.config.ServerUrl
 
@@ -553,9 +558,7 @@ validation_client_name "chef-validator"
 {{if ne .ValidationKeyPath ""}}
 validation_key "{{.ValidationKeyPath}}"
 {{end}}
-{{if ne .NodeName ""}}
 node_name "{{.NodeName}}"
-{{end}}
 {{if ne .ChefEnvironment ""}}
 environment "{{.ChefEnvironment}}"
 {{end}}

--- a/website/source/docs/provisioners/chef-client.html.markdown
+++ b/website/source/docs/provisioners/chef-client.html.markdown
@@ -27,14 +27,14 @@ remote machine and run Chef client.
 }
 </pre>
 
-Note: to properly clean up the Chef node and client, you must have
-`knife` on your path and properly configured.
+Note: to properly clean up the Chef node and client the machine on which
+packer is running must have knife on the path and configured globally,
+i.e, ~/.chef/knife.rb must be present and configured for the target chef server
 
 ## Configuration Reference
 
 The reference of available configuration options is listed below. No
-configuration is actually required, but `node_name` is recommended
-since it will allow the provisioner to clean up the node/client.
+configuration is actually required.
 
 * `chef_environment` (string) - The name of the chef_environment sent to the
   Chef server. By default this is empty and will not use an environment.
@@ -58,8 +58,7 @@ since it will allow the provisioner to clean up the node/client.
   node attributes while running Chef.
 
 * `node_name` (string) - The name of the node to register with the Chef
-  Server. This is optional and by defalt is empty. If you don't set this,
-  Packer can't clean up the node from the Chef Server using knife.
+  Server. This is optional and by default is packer-{{uuid}}.
 
 * `prevent_sudo` (boolean) - By default, the configured commands that are
   executed to install and run Chef are executed with `sudo`. If this is true,
@@ -76,7 +75,6 @@ since it will allow the provisioner to clean up the node/client.
 
 * `skip_clean_node` (boolean) - If true, Packer won't remove the node
   from the Chef server after it is done running. By default, this is false.
-  This will be true by default if `node_name` is not set.
 
 * `skip_install` (boolean) - If true, Chef will not automatically be installed
   on the machine using the Opscode omnibus installers.
@@ -114,9 +112,7 @@ validation_client_name "chef-validator"
 {{if ne .ValidationKeyPath ""}}
 validation_key "{{.ValidationKeyPath}}"
 {{end}}
-{{if ne .NodeName ""}}
 node_name "{{.NodeName}}"
-{{end}}
 ```
 
 This template is a [configuration template](/docs/templates/configuration-templates.html)


### PR DESCRIPTION
Defaulting on nodename which seems more graceful and in-line with other provisioners. Also clarifying knife docs. RFC.

See #1520, #1295, #1100, and probably some others :grinning:  
