### PR TITLE
make docker-push work with docker-tag artifacts

### DIFF
--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
 	"github.com/mitchellh/packer/post-processor/docker-import"
+  "github.com/mitchellh/packer/post-processor/docker-tag"
 	"strings"
 )
 
@@ -67,9 +68,9 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 }
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
-	if artifact.BuilderId() != dockerimport.BuilderId {
+	if artifact.BuilderId() != dockerimport.BuilderId && artifact.BuilderId() != dockertag.BuilderId {
 		err := fmt.Errorf(
-			"Unknown artifact type: %s\nCan only import from docker-import artifacts.",
+			"Unknown artifact type: %s\nCan only import from docker-import and docker-tag artifacts.",
 			artifact.BuilderId())
 		return nil, false, err
 	}


### PR DESCRIPTION
Ref. the docker builder documentation it should be possible to tag an artifact using
docker-tag and then pass it to docker-push using a set of sequential post-processors
e.g. 

```
  "post-processors": [
    [
      {
          "type": "docker-tag",
          "repository": "askholme/configurator",
          "tag": "newest"
      },
      "docker-push"
    ]
  ]
```

However in this gives below error, since docker-push refuses to deal with docker-tag artifacts.

```
==> docker: Running post-processor: docker-tag
    docker (docker-tag): Tagging image: 2626017c150ee05f6c30d2bde0c421aba19e9c4ffda4b93e1917e9b5a82887f4
    docker (docker-tag): Repository: askholme/nginx_media:latest
==> docker: Running post-processor: docker-push
Build 'docker' errored: 1 error(s) occurred:

* Post-processor failed: Unknown artifact type: packer.post-processor.docker-tag
Can only import from docker-import artifacts.
```

This PR updates docker-push to accept both docker-import and docker-tag artifacts
docker-tag itself checks for docker-import artifacts, so any unwelcome artifacts 
will still raise an error.
