### PR TITLE
Fixed dead links in doc section environment-variables.

### DIFF
--- a/website/source/docs/other/environmental-variables.html.markdown
+++ b/website/source/docs/other/environmental-variables.html.markdown
@@ -11,22 +11,22 @@ Packer uses a variety of environmental variables. A listing and description of e
 
 * `PACKER_CONFIG` - The location of the core configuration file. The format
      of the configuration file is basic JSON.
-     See the [core configuration page](docs/other/core-configuration.html).
+     See the [core configuration page](/docs/other/core-configuration.html).
 
 * `PACKER_LOG` - Setting this to any value will enable the logger.
-     See the [debugging page](docs/other/debugging.html).
+     See the [debugging page](/docs/other/debugging.html).
 
 * `PACKER_LOG_PATH` - The location of the log file. Note: `PACKER_LOG` must
-     be set for any logging to occur. See the [debugging page](docs/other/debugging.html).
+     be set for any logging to occur. See the [debugging page](/docs/other/debugging.html).
 
 * `PACKER_NO_COLOR` - Setting this to any value will disable color in the terminal.
 
 * `PACKER_PLUGIN_MAX_PORT` - The maximum port that Packer uses for
      communication with plugins, since plugin communication happens over
      TCP connections on your local host. The default is 25,000.
-     See the [core configuration page](docs/other/core-configuration.html).
+     See the [core configuration page](/docs/other/core-configuration.html).
 
 * `PACKER_PLUGIN_MIN_PORT` - The minimum port that Packer uses for
      communication with plugins, since plugin communication happens
      over TCP connections on your local host. The default is 10,000.
-     See the [core configuration page](docs/other/core-configuration.html).
+     See the [core configuration page](/docs/other/core-configuration.html).


### PR DESCRIPTION
Due to a missing `/` the links pointed to i.e. `docs/other/docs/other/core-configuration.html` producing a 404 / Page not found.
