### PR TITLE
builder/parallels: Create VM without hdd and then add it later

### DIFF
--- a/builder/parallels/iso/step_create_disk.go
+++ b/builder/parallels/iso/step_create_disk.go
@@ -20,7 +20,7 @@ func (s *stepCreateDisk) Run(state multistep.StateBag) multistep.StepAction {
 
 	command := []string{
 		"set", vmName,
-		"--device-set", "hdd0",
+		"--device-add", "hdd",
 		"--size", strconv.FormatUint(uint64(config.DiskSize), 10),
 		"--iface", config.HardDriveInterface,
 	}

--- a/builder/parallels/iso/step_create_vm.go
+++ b/builder/parallels/iso/step_create_vm.go
@@ -29,6 +29,7 @@ func (s *stepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 		"--distribution", config.GuestOSType,
 		"--dst", config.OutputDir,
 		"--vmtype", "vm",
+		"--no-hdd",
 	}
 	commands[1] = []string{"set", name, "--cpus", "1"}
 	commands[2] = []string{"set", name, "--memsize", "512"}


### PR DESCRIPTION
With this changeset `parallels-iso` builder will create the VM without default HDD. Instead, this disk will be created right after, during the _stepCreateDisk_

Otherwise, `--device-set` command option means that existing disk will be resized. It isn't working for OS X guests, because these disks are creating already with HFS partition inside (http://kb.parallels.com/en/113653)
So, this pull-request fixes that.

/cc: @rickard-von-essen 
