### PR TITLE
Parallels: Removed unnecessary filling the Vagranfile

### DIFF
--- a/post-processor/vagrant/parallels.go
+++ b/post-processor/vagrant/parallels.go
@@ -54,13 +54,5 @@ func (p *ParallelsProvider) Process(ui packer.Ui, artifact packer.Artifact, dir 
 		}
 	}
 
-	// Create the Vagrantfile from the template
-	vagrantfile = fmt.Sprintf(parallelsVagrantfile)
-
 	return
 }
-
-var parallelsVagrantfile = `
-Vagrant.configure("2") do |config|
-end
-`


### PR DESCRIPTION
We really don't need to put this empty block to Vagrantfile for each box prepared by Vagrant post-processor:

``` ruby
Vagrant.configure("2") do |config|      
end
```
