### PR TITLE
ec2:ModifyImageAttribute already included in the sample policy

### DIFF
--- a/website/source/docs/builders/amazon.html.markdown
+++ b/website/source/docs/builders/amazon.html.markdown
@@ -70,6 +70,3 @@ The following policy document provides the minimal set permissions necessary for
   }]
 }
 </pre>
-
-Depending on what setting you use the following Actions might have to be allowed as well:
-* `ec2:ModifyImageAttribute` when using `ami_description`


### PR DESCRIPTION
ec2:ModifyImageAttribute is already included in the sample policy JSON (line 67 in the source file), so the comment about optionally adding it only adds confusion.
