### PR TITLE
Only define VAGRANTFILE_API_VERSION if not yet defined

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = "2" if not defined? VAGRANTFILE_API_VERSION
 
 $script = <<SCRIPT
 SRCROOT="/opt/go"

--- a/website/Vagrantfile
+++ b/website/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = "2" if not defined? VAGRANTFILE_API_VERSION
 
 $script = <<SCRIPT
 sudo apt-get -y update


### PR DESCRIPTION
Sometime VAGRANTFILE_API_VERSION is already defined in $HOME/vagrant.d/Vagrantfile.
This will result in the following issue when trying to define VAGRANTFILE_API_VERSION
again in a Vagrantfile of a box.

---snip---
.../Vagrantfile:5: warning: already initialized constant VAGRANTFILE_API_VERSION
$HOME/.vagrant.d/Vagrantfile:1: warning: previous definition of VAGRANTFILE_API_VERSION was here
---snap---
