### PR TITLE
figure out VirtualBox version on FreeBSD

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -195,12 +195,12 @@ func (d *VBox42Driver) Version() (string, error) {
 		return "", fmt.Errorf("VirtualBox is not properly setup: %s", versionOutput)
 	}
 
-	versionRe := regexp.MustCompile("^[.0-9]+(?:_RC[0-9]+)?")
-	matches := versionRe.FindAllString(versionOutput, 1)
-	if matches == nil {
+	versionRe := regexp.MustCompile("^([.0-9]+)(?:_(?:RC|OSEr)[0-9]+)?")
+	matches := versionRe.FindAllStringSubmatch(versionOutput, 1)
+	if matches == nil || len(matches[0]) != 2 {
 		return "", fmt.Errorf("No version found: %s", versionOutput)
 	}
 
-	log.Printf("VirtualBox version: %s", matches[0])
-	return matches[0], nil
+	log.Printf("VirtualBox version: %s", matches[0][1])
+	return matches[0][1], nil
 }


### PR DESCRIPTION
On my FreeBSD box `VBoxManage --version` reports "4.3.16_OSEr95972" and the
`virtualbox-ovf` builder doesn't parse this correctly, i.e. it does not ignore
the part after the underscore. I had to change the regular expression you
use a bit.
