### PR TITLE
accepts user provided private key for windows use case

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -100,7 +100,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&common.StepConnectSSH{
 			SSHAddress:     SSHAddress(csp, b.config.SSHPort),
-			SSHConfig:      SSHConfig(b.config.SSHUsername),
+			SSHConfig:      SSHConfig(b.config.SSHUsername, b.config.PrivateKeyFile),
 			SSHWaitTimeout: b.config.SSHTimeout(),
 		},
 		&common.StepProvision{},

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -21,6 +21,7 @@ type RunConfig struct {
 	FloatingIp        string   `mapstructure:"floating_ip"`
 	SecurityGroups    []string `mapstructure:"security_groups"`
 	Networks          []string `mapstructure:"networks"`
+	PrivateKeyFile    string   `mapstructure:"ssh_private_key"`
 
 	// Unexported fields that are calculated from others
 	sshTimeout time.Duration


### PR DESCRIPTION
I couldn't really come up with a way to use packer generated private/public key pair for windows image. Only way that I could do was to provide a pre-generated private key to packer and expecting a public key to exist on the windows image already. 

I'm not sure if it is a good place to add the functionality though. Let me know if it's ok or not. I'll take another attempt...
