### PR TITLE
Update example to match parameter.

### DIFF
--- a/website/source/docs/post-processors/compress.html.markdown
+++ b/website/source/docs/post-processors/compress.html.markdown
@@ -24,6 +24,6 @@ An example is shown below, showing only the post-processor configuration:
 <pre class="prettyprint">
 {
   "type": "compress",
-  "path": "foo.tar.gz"
+  "output": "foo.tar.gz"
 }
 </pre>


### PR DESCRIPTION
The example showed "path" instead of "output".
