### PR TITLE
Colorize Ansible output, and don't buffer output.

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -69,7 +69,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	// Defaults
 	if p.config.Command == "" {
-		p.config.Command = "ansible-playbook"
+		p.config.Command = "ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ansible-playbook"
 	}
 
 	if p.config.StagingDir == "" {


### PR DESCRIPTION
Setting environment variables for the ansible-playbook invocation.

ANSIBLE_FORCE_COLOR will ensure output is colorized.  PYTHONUNBUFFERED will stream output as Ansible runs, vs getting a big dump of output at the end.
