### PR TITLE
Extract Vagrant provider processing logic to a method

### DIFF
--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -64,20 +64,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
-
-	name, ok := builtins[artifact.BuilderId()]
-	if !ok {
-		return nil, false, fmt.Errorf(
-			"Unknown artifact type, can't build box: %s", artifact.BuilderId())
-	}
-
-	provider := providerForName(name)
-	if provider == nil {
-		// This shouldn't happen since we hard code all of these ourselves
-		panic(fmt.Sprintf("bad provider name: %s", name))
-	}
-
+func (p *PostProcessor) PostProcessProvider(name string, provider Provider, ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
 	config := p.configs[""]
 	if specificConfig, ok := p.configs[name]; ok {
 		config = specificConfig
@@ -156,6 +143,23 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 
 	return NewArtifact(name, outputPath), provider.KeepInputArtifact(), nil
+}
+
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+
+	name, ok := builtins[artifact.BuilderId()]
+	if !ok {
+		return nil, false, fmt.Errorf(
+			"Unknown artifact type, can't build box: %s", artifact.BuilderId())
+	}
+
+	provider := providerForName(name)
+	if provider == nil {
+		// This shouldn't happen since we hard code all of these ourselves
+		panic(fmt.Sprintf("bad provider name: %s", name))
+	}
+
+	return p.PostProcessProvider(name, provider, ui, artifact)
 }
 
 func (p *PostProcessor) configureSingle(config *Config, raws ...interface{}) error {


### PR DESCRIPTION
This change extracts the provider processing logic to a separate method which can be invoked from a subtype, providing a custom provider.

External builders (e.g. [packer-cloudstack](https://github.com/klarna/packer-cloudstack)) can enable Vagrant support by subtyping `vagrant.PostProcessor` and invoking the new method:

``` go
type PostProcessor struct {
  vagrant.PostProcessor
}

func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
  if artifact.BuilderId() != "mindjiver.cloudstack" {
    return p.PostProcessor.PostProcess(ui, artifact)
  }

  return p.PostProcessor.PostProcessProvider("cloudstack", new(CloudStackProvider), ui, artifact)
}
```
