### PR TITLE
Switch to hashicorp/go-msgpack

### DIFF
--- a/packer/rpc/client.go
+++ b/packer/rpc/client.go
@@ -2,7 +2,7 @@ package rpc
 
 import (
 	"github.com/mitchellh/packer/packer"
-	"github.com/ugorji/go/codec"
+	"github.com/hashicorp/go-msgpack/codec"
 	"io"
 	"log"
 	"net/rpc"

--- a/packer/rpc/server.go
+++ b/packer/rpc/server.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"fmt"
 	"github.com/mitchellh/packer/packer"
-	"github.com/ugorji/go/codec"
+	"github.com/hashicorp/go-msgpack/codec"
 	"io"
 	"log"
 	"net/rpc"


### PR DESCRIPTION
This avoids some serious problems with more recent versions of the msgpack library where unexpected value conversions happen on non-struct `nil` types.
