### PR TITLE
updated step_clone_vmx.go to work with vmx files using sata

### DIFF
--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -37,8 +37,14 @@ func (s *StepCloneVMX) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	diskName, ok := vmxData["scsi0:0.filename"]
-	if !ok {
+	var diskName string
+	_, scsi := vmxData["scsi0:0.filename"]
+	_, sata := vmxData["sata0:0.filename"]
+	if scsi {
+		diskName = vmxData["scsi0:0.filename"]
+	} else if sata {
+		diskName = vmxData["sata0:0.filename"]
+	} else {
 		err := fmt.Errorf("Root disk filename could not be found!")
 		state.Put("error", err)
 		return multistep.ActionHalt


### PR DESCRIPTION
Reference issues 1242, 1595

Problem:  When using the vmware vmx builder, it fails if the vmx is using sata rather than scsi.

I tested with VMware 7.0 Professional.  I used both a vmx with scsi and one with sata, with success. 

Please forgive the code if it is terrible.  This is my first attempt with go and I referenced a few stack exchange sites to get what I needed.
