### PR TITLE
builder/parallels: Default cdrom0 should be disconnected

### DIFF
--- a/builder/parallels/iso/step_attach_iso.go
+++ b/builder/parallels/iso/step_attach_iso.go
@@ -81,7 +81,7 @@ func (s *stepAttachISO) Cleanup(state multistep.StateBag) {
 	log.Println("Enabling default CD/DVD drive...")
 	command := []string{
 		"set", vmName,
-		"--device-set", "cdrom0", "--enable",
+		"--device-set", "cdrom0", "--enable", "--disconnect",
 	}
 
 	if err := driver.Prlctl(command...); err != nil {


### PR DESCRIPTION
This is a minor change and it doesn't break backward compatibility. 
Actually, before #1502, we had `cdrom0` device disconnected.

But now (since eb37742ab032c9cd1aa24a2669a220ebab416558) `cdrom0` is not marked as disconnected and the next error message is displayed in GUI:
![screenshot_21_10_14_16_28](https://cloud.githubusercontent.com/assets/4846154/4718464/520aedd2-5921-11e4-9fa6-ffdc7b7ca605.png)

So, this pull-request fixes that.
