### PR TITLE
Update SaltStack provision to https

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -108,7 +108,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	ui.Say("Provisioning with Salt...")
 	if !p.config.SkipBootstrap {
 		cmd := &packer.RemoteCmd{
-			Command: fmt.Sprintf("wget -O - http://bootstrap.saltstack.org | sudo sh -s %s", p.config.BootstrapArgs),
+			Command: fmt.Sprintf("wget -O - https://bootstrap.saltstack.com | sudo sh -s %s", p.config.BootstrapArgs),
 		}
 		ui.Message(fmt.Sprintf("Installing Salt with command %s", cmd))
 		if err = cmd.StartWithUi(comm, ui); err != nil {


### PR DESCRIPTION
 #1607 This changes the SaltStack bootstrap URL to use the HTTPS link from the commercial site.  Alternatives are the HTTPS link to the raw file on GitHub, but this, whilst more transparent, might break down the line.
