### PR TITLE
Fix the value for the QEMU size parameter in the documentation

### DIFF
--- a/website/source/docs/builders/qemu.html.markdown
+++ b/website/source/docs/builders/qemu.html.markdown
@@ -184,7 +184,7 @@ each category, the available options are alphabetized and described.
 <pre class="prettyprint">
   . . .
   "qemuargs": [
-    [ "-m", "1024m" ],
+    [ "-m", "1024M" ],
     [ "--no-acpi", "" ],
     [
        "-netdev",
@@ -200,7 +200,7 @@ each category, the available options are alphabetized and described.
   would produce the following (not including other defaults supplied by the builder and not otherwise conflicting with the qemuargs):
 
 <pre class="prettyprint">
-    qemu-system-x86 -m 1024m --no-acpi -netdev user,id=mynet0,hostfwd=hostip:hostport-guestip:guestport -device virtio-net,netdev=mynet0"
+    qemu-system-x86 -m 1024M --no-acpi -netdev user,id=mynet0,hostfwd=hostip:hostport-guestip:guestport -device virtio-net,netdev=mynet0"
 </pre>
 
 * `qemu_binary` (string) - The name of the Qemu binary to look for.  This


### PR DESCRIPTION
Instead of 1024m it shoud be 1024M. Using 1024m as value does not work:

---snip---
2014/10/27 10:21:41 packer-builder-qemu: 2014/10/27 10:21:41 Executing
/usr/bin/qemu-system-x86_64: []string{"-m", "1024m", "-redir",
"tcp:3213::22", "-device", "virtio-net,netdev=user.0", "-cdrom",
"/home/berendt/B1-Systems/openstack-appliance/packer_cache/436c246ce08d768bbacce00e39c11ecd09071565542788d08b3120de0228c9eb.iso",
"-machine", "type=pc-1.0,accel=kvm", "-vnc", "0.0.0.0:47", "-netdev",
"user,id=user.0", "-name", "openstack", "-drive",
"file=openstack/openstack.qcow2,if=virtio", "-boot", "once=d"}
2014/10/27 10:21:41 packer-builder-qemu: 2014/10/27 10:21:41 Started
Qemu. Pid: 2618
2014/10/27 10:21:41 packer-builder-qemu: 2014/10/27 10:21:41 Qemu
stderr: qemu-system-x86_64: -m 1024m: Parameter 'size' expects a size
==> qemu: Error launching VM: Qemu failed to start. Please run with logs
to get more info.
---snap---
