### PR TITLE
builder/vmware: accept IDE drives on root VMX

### DIFF
--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -44,6 +44,9 @@ func (s *StepCloneVMX) Run(state multistep.StateBag) multistep.StepAction {
 	if _, ok := vmxData["sata0:0.filename"]; ok {
 		diskName = vmxData["sata0:0.filename"]
 	}
+	if _, ok := vmxData["ide0:0.filename"]; ok {
+		diskName = vmxData["ide0:0.filename"]
+	}
 	if diskName == "" {
 		err := fmt.Errorf("Root disk filename could not be found!")
 		state.Put("error", err)


### PR DESCRIPTION
IDE being the other, other disk format that some VM appliances are still on for reasons unknown
