### PR TITLE
Fix make updatedeps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ testrace:
 updatedeps:
 	go get -d -v -p 2 ./...
 	@sh -c "go get -u -v -p 2 ./...; exit 0"
-	@sh -c "cd ../../rackspace/gophercloud && git checkout release/v0.1.1" # because dependency management
 	go get -d -v -p 2 ./...
 
 .PHONY: bin default test updatedeps


### PR DESCRIPTION
Since the fork mitchellh/gophercloud-fork-40444fb is used for
gophercloud the folder rackspace/gophercloud does not exist and the
version fix does not have to happen.

Signed-off-by: BlackEagle ike.devolder@gmail.com
