### PR TITLE
fix digitalocean v2 api size response

### DIFF
--- a/builder/digitalocean/api.go
+++ b/builder/digitalocean/api.go
@@ -24,7 +24,7 @@ type Size struct {
 	Memory       uint     `json:"memory,omitempty"`        //only in v2 api
 	VCPUS        uint     `json:"vcpus,omitempty"`         //only in v2 api
 	Disk         uint     `json:"disk,omitempty"`          //only in v2 api
-	Transfer     uint     `json:"transfer,omitempty"`      //only in v2 api
+	Transfer     float64  `json:"transfer,omitempty"`      //only in v2 api
 	PriceMonthly float64  `json:"price_monthly,omitempty"` //only in v2 api
 	PriceHourly  float64  `json:"price_hourly,omitempty"`  //only in v2 api
 	Regions      []string `json:"regions,omitempty"`       //only in v2 api


### PR DESCRIPTION
DO documentation have bugs, transfer not in, but float64.

close #1639 

Signed-off-by: Vasiliy Tolstov v.tolstov@selfip.ru
