### PR TITLE
Allow none checksumtype for qemu builder

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -122,6 +122,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	warnings := make([]string, 0)
 
 	b.config.tpl, err = packer.NewConfigTemplate()
 	if err != nil {


### PR DESCRIPTION
Previous commit about disk_image may be used to create vm from another image, but we don't need
to recalculate checksum of already created image. This commit adds 'none' checksum type.

Signed-off-by: Vasiliy Tolstov v.tolstov@selfip.ru
