### PR TITLE
Use sudo only if prevent_sudo is not set

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -333,8 +333,14 @@ func (p *Provisioner) createJson(ui packer.Ui, comm packer.Communicator) (string
 
 func (p *Provisioner) createDir(ui packer.Ui, comm packer.Communicator, dir string) error {
 	ui.Message(fmt.Sprintf("Creating directory: %s", dir))
+
+	mkdirCmd := fmt.Sprintf("mkdir -p '%s'", dir)
+	if !p.config.PreventSudo {
+		mkdirCmd = "sudo " + mkdirCmd
+	}
+
 	cmd := &packer.RemoteCmd{
-		Command: fmt.Sprintf("sudo mkdir -p '%s'", dir),
+		Command: mkdirCmd,
 	}
 
 	if err := cmd.StartWithUi(comm, ui); err != nil {
@@ -382,8 +388,14 @@ func (p *Provisioner) cleanClient(ui packer.Ui, comm packer.Communicator, node s
 
 func (p *Provisioner) removeDir(ui packer.Ui, comm packer.Communicator, dir string) error {
 	ui.Message(fmt.Sprintf("Removing directory: %s", dir))
+
+	rmCmd := fmt.Sprintf("rm -rf '%s'", dir)
+	if !p.config.PreventSudo {
+		rmCmd = "sudo " + rmCmd
+	}
+
 	cmd := &packer.RemoteCmd{
-		Command: fmt.Sprintf("sudo rm -rf %s", dir),
+		Command: rmCmd,
 	}
 
 	if err := cmd.StartWithUi(comm, ui); err != nil {


### PR DESCRIPTION
Honor the prevent_sudo configuration setting when creating and removing the chef staging directory.  Sudo is not always installed (e.g. docker containers).
