### PR TITLE
Use consistent escaping for ovftool uri creds

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -130,7 +130,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		fmt.Sprintf("%s", vmx),
 		fmt.Sprintf("vi://%s:%s@%s/%s/host/%s/Resources/%s/",
 			url.QueryEscape(p.config.Username),
-			p.config.Password,
+			url.QueryEscape(p.config.Password),
 			p.config.Host,
 			p.config.Datacenter,
 			p.config.Cluster,


### PR DESCRIPTION
I got thrown for a loop since the username is uri-escaped but the password was not.

I got thrown for another couple of loops due to the multiple levels of interpretation involved:
- JSON syntax requires backslashes to be slash-escaped. Some vCenter deployments use windows domain-style usernames DOMAIN\user
- the [OVFTOOL docs](https://www.vmware.com/support/developer/ovf/ovf301/ovftool-301-userguide.pdf) specify that "you must escape special characters" when part of the user name or password
- different shell rules in windows cmd.exe, powershell, linux

I'd say escape both or neither. Sublime was nice enough to warn me that \[:alpha:] isn't valid JSON, but not everyone will be using a validating editor.
