### PR TITLE
Use DigitalOcean image ID for artifact Id()

### DIFF
--- a/builder/digitalocean/artifact.go
+++ b/builder/digitalocean/artifact.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"fmt"
 	"log"
+	"strconv"
 )
 
 type Artifact struct {
@@ -29,8 +30,7 @@ func (*Artifact) Files() []string {
 }
 
 func (a *Artifact) Id() string {
-	// mimicing the aws builder
-	return fmt.Sprintf("%s:%s", a.regionName, a.snapshotName)
+	return strconv.FormatUint(uint64(a.snapshotId), 10)
 }
 
 func (a *Artifact) String() string {

--- a/builder/digitalocean/artifact_test.go
+++ b/builder/digitalocean/artifact_test.go
@@ -1,8 +1,9 @@
 package digitalocean
 
 import (
-	"github.com/mitchellh/packer/packer"
 	"testing"
+
+	"github.com/mitchellh/packer/packer"
 )
 
 func TestArtifact_Impl(t *testing.T) {
@@ -10,6 +11,15 @@ func TestArtifact_Impl(t *testing.T) {
 	raw = &Artifact{}
 	if _, ok := raw.(packer.Artifact); !ok {
 		t.Fatalf("Artifact should be artifact")
+	}
+}
+
+func TestArtifactId(t *testing.T) {
+	a := &Artifact{"packer-foobar", 42, "San Francisco", nil}
+	expected := "42"
+
+	if a.Id() != expected {
+		t.Fatalf("artifact ID should match: %v", expected)
 	}
 }
 


### PR DESCRIPTION
The DigitalOcean image ID is easier to use than `region/slug` when using Packer as part of a build process, which will probably involve some invocation of the DigitalOcean API.

I'm not sure if there was a good reason for using `region/slug` (based on https://github.com/mitchellh/packer/commit/2cad46aa1fb16ffe1d7bd176050c578004bd10fb, it seems pretty arbitrary).
