### PR TITLE
Parallels: Fixed issue #1667

### DIFF
--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -256,6 +256,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		new(stepHTTPServer),
 		new(stepCreateVM),
 		new(stepCreateDisk),
+		new(stepSetBootOrder),
 		new(stepAttachISO),
 		&parallelscommon.StepAttachParallelsTools{
 			ParallelsToolsMode: b.config.ParallelsToolsMode,

--- a/builder/parallels/iso/step_attach_iso.go
+++ b/builder/parallels/iso/step_attach_iso.go
@@ -26,23 +26,9 @@ func (s *stepAttachISO) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	vmName := state.Get("vmName").(string)
 
-	// Set new boot order
-	ui.Say("Setting the boot order...")
-	command := []string{
-		"set", vmName,
-		"--device-bootorder", fmt.Sprintf("hdd0 cdrom0 net0"),
-	}
-
-	if err := driver.Prlctl(command...); err != nil {
-		err := fmt.Errorf("Error setting the boot order: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
-
 	// Attach the disk to the cdrom0 device. We couldn't use a separated device because it is failed to boot in PD9 [GH-1667]
 	ui.Say("Attaching ISO to the default CD/DVD ROM device...")
-	command = []string{
+	command := []string{
 		"set", vmName,
 		"--device-set", "cdrom0",
 		"--image", isoPath,

--- a/builder/parallels/iso/step_set_boot_order.go
+++ b/builder/parallels/iso/step_set_boot_order.go
@@ -1,0 +1,42 @@
+package iso
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	parallelscommon "github.com/mitchellh/packer/builder/parallels/common"
+	"github.com/mitchellh/packer/packer"
+)
+
+// This step sets the device boot order for the virtual machine.
+//
+// Uses:
+//   driver Driver
+//   ui packer.Ui
+//   vmName string
+//
+// Produces:
+type stepSetBootOrder struct{}
+
+func (s *stepSetBootOrder) Run(state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packer.Ui)
+	vmName := state.Get("vmName").(string)
+
+	// Set new boot order
+	ui.Say("Setting the boot order...")
+	command := []string{
+		"set", vmName,
+		"--device-bootorder", fmt.Sprintf("hdd0 cdrom0 net0"),
+	}
+
+	if err := driver.Prlctl(command...); err != nil {
+		err := fmt.Errorf("Error setting the boot order: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepSetBootOrder) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
1) Fixed issue #1667 by partially reverting the previous changes.

While attaching the bootable ISO to the DVD/CD-ROM device we will attach it exactly to the first one, `cdrom0`. 
It is caused by Parallels Desktop 9 bug - virtual machine is failed to boot from any cdrom device except the first one (regardless of its enabled/disabled state). 

So, on the cleanup stage we will detach the ISO with a little trick, by setting the image path as an empty string.
It is working fine on both of supported versions: Parallels Desktop 9 and 10 as well.

2) Setting the boot order moved to the separated step, `stepSetBootOrder`.  It makes the build process more clear.
P.s. This setting is still required because HDD is added (by `stepCreateDisk`) to the end of boot order.
