### PR TITLE
Fix build failing to compile driver_gce

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"code.google.com/p/google-api-go-client/compute/v1"
-	"github.com/golang/oauth2"
-	"github.com/golang/oauth2/google"
 	"github.com/mitchellh/packer/packer"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
 // driverGCE is a Driver implementation that actually talks to GCE.


### PR DESCRIPTION
github.com/golang/oauth2 was moved to golang.org/x/oauth2, via golang/oauth2 commit e750a2fd5a9df201dc09483a023db10cd797ec41
