### PR TITLE
googlecompute: fix build by updating Go imports.

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"code.google.com/p/google-api-go-client/compute/v1"
-	"github.com/golang/oauth2"
-	"github.com/golang/oauth2/google"
 	"github.com/mitchellh/packer/packer"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
 // driverGCE is a Driver implementation that actually talks to GCE.


### PR DESCRIPTION
The canonical Go path for the OAuth2 library has changed as of
[this commit](https://github.com/golang/oauth2/commit/e750a2fd5a9df201dc09483a023db10cd797ec41)
from `github.com/golang/oauth2` to `golang.org/x/oauth2`.

It was previously announced on the
[golang-nuts@ mailing list](https://groups.google.com/d/msg/golang-nuts/eD8dh3T9yyA/l5Ail-xfMiAJ).

Without this change, builds of the `googlecompute` module in Packer result in
the following error messages:

```
builder/googlecompute/driver_gce.go:39: cannot use google.JWTEndpoint() (type "golang.org/x/oauth2".Option) as type "github.com/golang/oauth2".Option in function argument
builder/googlecompute/driver_gce.go:43: cannot use google.ComputeEngineAccount("") (type "golang.org/x/oauth2".Opti on) as type "github.com/golang/oauth2".Option in function argument
```

Credit for source of information and pointers:
[this Stack Overflow answer](http://stackoverflow.com/a/27227705).
