### PR TITLE
Use an index loop as range loops over copies, not references

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -60,12 +60,12 @@ func (b *BlockDevices) Prepare(t *packer.ConfigTemplate) []error {
 
 	var errs []error
 	for outer, bds := range lists {
-		for i, bd := range bds {
+		for i := 0; i < len(bds); i++ {
 			templates := map[string]*string{
-				"device_name":  &bd.DeviceName,
-				"snapshot_id":  &bd.SnapshotId,
-				"virtual_name": &bd.VirtualName,
-				"volume_type":  &bd.VolumeType,
+				"device_name":  &bds[i].DeviceName,
+				"snapshot_id":  &bds[i].SnapshotId,
+				"virtual_name": &bds[i].VirtualName,
+				"volume_type":  &bds[i].VolumeType,
 			}
 
 			errs := make([]error, 0)


### PR DESCRIPTION
There have been a few issues opened on this (#1637, #1592, #1090) but the fix didn't work. Looping with range, a copy of each `BlockDevice` is edited so the changes don't end up in the `BlockDevices` struct. Using an indexed loop seems like a quick and easy fix.

Fixes #1637 
