### PR TITLE
builder/digitalocean: default to nyc3

### DIFF
--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -21,8 +21,8 @@ import (
 const DefaultImage = "ubuntu-12-04-x64"
 
 // see https://api.digitalocean.com/regions/?client_id=[client_id]&api_key=[api_key]
-// name="New York", id=1
-const DefaultRegion = "nyc1"
+// name="New York 3", id=8
+const DefaultRegion = "nyc3"
 
 // see https://api.digitalocean.com/sizes/?client_id=[client_id]&api_key=[api_key]
 // name="512MB", id=66 (the smallest droplet size)

--- a/website/source/docs/builders/digitalocean.html.markdown
+++ b/website/source/docs/builders/digitalocean.html.markdown
@@ -66,7 +66,7 @@ each category, the available configuration keys are alphabetized.
 
 * `region` (string) - The name (or slug) of the region to launch the droplet in.
   Consequently, this is the region where the snapshot will be available.
-  This defaults to "nyc1", which is the slug for "New York 1".
+  This defaults to "nyc3", which is the slug for "New York 3".
   See https://developers.digitalocean.com/regions/ for the accepted region names/slugs.
 
 * `region_id` (integer) - The ID of the region to launch the droplet in. Consequently,


### PR DESCRIPTION
Switch to nyc3 as the default. nyc1 won't let you spin up new instances anymore and returns a response like:

```
{"id":"unprocessable_entity","message":"Region is not available"}
```
