### PR TITLE
atlas post-processor unknown atlas.UploadartifactOpts field BuildId

### DIFF
--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -157,7 +157,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		Type:     p.config.Type,
 		ID:       artifact.Id(),
 		Metadata: p.metadata(artifact),
-		BuildId:  p.config.buildId,
+		BuildID:  p.config.buildId,
 	}
 
 	if fs := artifact.Files(); len(fs) > 0 {


### PR DESCRIPTION
in https://github.com/hashicorp/atlas-go/blob/master/v1/artifact.go
we can see it is BuildID and not BuildId

Signed-off-by: BlackEagle ike.devolder@gmail.com
