### PR TITLE
atlas post-processor on 32bit uint32 overflows int

### DIFF
--- a/post-processor/atlas/util.go
+++ b/post-processor/atlas/util.go
@@ -11,13 +11,14 @@ import (
 //
 // This function just uses brute force instead of a more optimized algorithm.
 func longestCommonPrefix(vs []string) string {
+	var length int64
 	// Find the shortest string
 	var shortest string
-	length := math.MaxUint32
+	length = math.MaxUint32
 	for _, v := range vs {
-		if len(v) < length {
+		if int64(len(v)) < length {
 			shortest = v
-			length = len(v)
+			length = int64(len(v))
 		}
 	}
 


### PR DESCRIPTION
post-processor/atlas/util.go:16: constant 4294967295 overflows int

Signed-off-by: BlackEagle ike.devolder@gmail.com
