### PR TITLE
fixed `packer --version` to show version again

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,6 +166,7 @@ func wrappedMain() int {
 		Commands:   Commands,
 		HelpFunc:   cli.BasicHelpFunc("packer"),
 		HelpWriter: os.Stdout,
+		Version:    Version,
 	}
 
 	exitCode, err := cli.Run()

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -17,20 +17,20 @@ load test_helper
     [[ "$output" == *"Packer v"* ]]
 
     run packer -v
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"Packer v"* ]]
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ ([0-9]+\.[0-9]+) ]]
 
     run packer --version
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"Packer v"* ]]
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ ([0-9]+\.[0-9]+) ]]
 }
 
 @test "cli: packer version show help" {
     run packer version -h
     [ "$status" -eq 0 ]
-    [[ "$output" == *"usage: packer version"* ]]
+    [[ "$output" == *"Packer v"* ]]
 
     run packer version --help
     [ "$status" -eq 0 ]
-    [[ "$output" == *"usage: packer version"* ]]
+    [[ "$output" == *"Packer v"* ]]
 }


### PR DESCRIPTION
As mentioned by @kensykora in #1753 I also first tried a `packer --version` after upgrading to Packer 0.7.5 and only got the usage, but no version number.

I also found the BATS script `test/cli.bats` which checks some packer options. This test script shows errors:

``` bash
$ test/cli.bats 
 ✓ cli: packer should show help
 ✗ cli: packer version
   (in test file test/cli.bats, line 24)
     `[ "$status" -eq 1 ]' failed
   Executing:  packer version
   Packer v0.7.5
   Executing:  packer -v
   usage: packer [--version] [--help] <command> [<args>]
   Available commands are:
       build       build image(s) from template
       fix         fixes templates from old versions of packer
       inspect     see components of a template
       push        push template files to a Packer build service
       validate    check that a template is valid
       version     Prints the Packer version
   Executing:  packer --version
   usage: packer [--version] [--help] <command> [<args>]
   Available commands are:
       build       build image(s) from template
       fix         fixes templates from old versions of packer
       inspect     see components of a template
       push        push template files to a Packer build service
       validate    check that a template is valid
       version     Prints the Packer version
 ✓ cli: packer version show help
```

In the `main.go` I only added the `Version` field and now packer shows at least the version number:

``` bash
$ packer version
Packer v0.7.5

$ packer --version
0.7.5

$ packer -v
0.7.5

$ echo $?
1
```

I have updated the `test/cli.bats` script as well to make the test work.
