### PR TITLE
Create temporary copy of symlink before uploading, fixes #1765

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -336,7 +336,7 @@ func scpUploadFile(dst string, src io.Reader, w io.Writer, r *bufio.Reader, fi *
 	var mode os.FileMode
 	var size int64
 
-	if fi != nil {
+	if fi != nil && (*fi).Mode().IsRegular() {
 		mode = (*fi).Mode().Perm()
 		size = (*fi).Size()
 	} else {


### PR DESCRIPTION
Have run `go fmt` and `make test`, no problems.

Not sure how I'm supposed to link this to #1765 , hopefully just mentioning it in the description/title does it. Please see that issue for further details.

Thanks!
