### PR TITLE
Updated Amazon documentation to reflect use of credentials file

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.markdown
+++ b/website/source/docs/builders/amazon-chroot.html.markdown
@@ -54,8 +54,8 @@ each category, the available configuration keys are alphabetized.
 ### Required:
 
 * `access_key` (string) - The access key used to communicate with AWS.
-  If not specified, Packer will use the environment variables
-  `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY` (in that order), if set.
+  If not specified, Packer will use the key from any [credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) file
+  or fall back to environment variables `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY` (in that order), if set.
   If the environmental variables aren't set and Packer is running on
   an EC2 instance, Packer will check the instance metadata for IAM role
   keys.
@@ -66,8 +66,8 @@ each category, the available configuration keys are alphabetized.
   [configuration templates](/docs/templates/configuration-templates.html) for more info)
 
 * `secret_key` (string) - The secret key used to communicate with AWS.
-  If not specified, Packer will use the environment variables
-  `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY` (in that order), if set.
+  If not specified, Packer will use the secret from any [credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) file
+  or fall back to environment variables `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY` (in that order), if set.
   If the environmental variables aren't set and Packer is running on
   an EC2 instance, Packer will check the instance metadata for IAM role
   keys.

--- a/website/source/docs/builders/amazon-ebs.html.markdown
+++ b/website/source/docs/builders/amazon-ebs.html.markdown
@@ -34,8 +34,8 @@ each category, the available configuration keys are alphabetized.
 ### Required:
 
 * `access_key` (string) - The access key used to communicate with AWS.
-  If not specified, Packer will use the environment variables
-  `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY` (in that order), if set.
+  If not specified, Packer will use the key from any [credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) file
+  or fall back to environment variables `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY` (in that order), if set.
 
 * `ami_name` (string) - The name of the resulting AMI that will appear
   when managing AMIs in the AWS console or via APIs. This must be unique.
@@ -49,8 +49,8 @@ each category, the available configuration keys are alphabetized.
   to launch the EC2 instance to create the AMI.
 
 * `secret_key` (string) - The secret key used to communicate with AWS.
-  If not specified, Packer will use the environment variables
-  `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY` (in that order), if set.
+  If not specified, Packer will use the secret from any [credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) file
+  or fall back to environment variables `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY` (in that order), if set.
 
 * `source_ami` (string) - The initial AMI used as a base for the newly
   created machine.

--- a/website/source/docs/builders/amazon-instance.html.markdown
+++ b/website/source/docs/builders/amazon-instance.html.markdown
@@ -39,8 +39,8 @@ each category, the available configuration keys are alphabetized.
 ### Required:
 
 * `access_key` (string) - The access key used to communicate with AWS.
-  If not specified, Packer will use the environment variables
-  `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY` (in that order), if set.
+  If not specified, Packer will use the key from any [credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) file
+  or fall back to environment variables `AWS_ACCESS_KEY_ID` or `AWS_ACCESS_KEY` (in that order), if set.
 
 * `account_id` (string) - Your AWS account ID. This is required for bundling
   the AMI. This is _not the same_ as the access key. You can find your
@@ -61,8 +61,8 @@ each category, the available configuration keys are alphabetized.
   This bucket will be created if it doesn't exist.
 
 * `secret_key` (string) - The secret key used to communicate with AWS.
-  If not specified, Packer will use the environment variables
-  `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY` (in that order), if set.
+  If not specified, Packer will use the secret from any [credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) file
+  or fall back to environment variables `AWS_SECRET_ACCESS_KEY` or `AWS_SECRET_KEY` (in that order), if set.
 
 * `source_ami` (string) - The initial AMI used as a base for the newly
   created machine.

--- a/website/source/docs/builders/amazon.html.markdown
+++ b/website/source/docs/builders/amazon.html.markdown
@@ -33,7 +33,7 @@ much easier to use and Amazon generally recommends EBS-backed images nowadays.
 
 ## Using an IAM Instance Profile
 
-If AWS keys are not specified in the template or through environment variables
+If AWS keys are not specified in the template, a [credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) file or through environment variables
 Packer will use credentials provided by the instance's IAM profile, if it has one.
 
 The following policy document provides the minimal set permissions necessary for Packer to work:


### PR DESCRIPTION
Updated Amazon documentation to reflect the precedence rules putting ~/.aws/credentials files ahead of env vars. The current documentation does not make mention of this file.

See #1612 for more detail on the issue.
