### PR TITLE
fix passing bootstrap_args to bootstrap script (issue #1235)

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -114,7 +114,14 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	ui.Say("Provisioning with Salt...")
 	if !p.config.SkipBootstrap {
 		cmd := &packer.RemoteCmd{
-			Command: fmt.Sprintf("wget -O - https://bootstrap.saltstack.com | sudo sh -s %s", p.config.BootstrapArgs),
+			Command: fmt.Sprintf("curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh"),
+		}
+		ui.Message(fmt.Sprintf("Downloading saltstack bootstrap to /tmp/install_salt.sh"))
+		if err = cmd.StartWithUi(comm, ui); err != nil {
+			return fmt.Errorf("Unable to download Salt: %d", err)
+		}
+		cmd = &packer.RemoteCmd{
+			Command: fmt.Sprintf("sudo sh /tmp/install_salt.sh %s", p.config.BootstrapArgs),
 		}
 		ui.Message(fmt.Sprintf("Installing Salt with command %s", cmd))
 		if err = cmd.StartWithUi(comm, ui); err != nil {


### PR DESCRIPTION
As-is, bootstrap_args are passed to `sh` instead of the saltstack bootstrap script. This commit splits the shell command to download and run the command separately as well as properly passing in bootstrap_args to install_salt.sh instead of sh. 

Before:

```
==> amazon-ebs: Provisioning with Salt...
    amazon-ebs: Installing Salt with command &{wget -O - https://bootstrap.saltstack.com | sudo sh -s -X -N <nil> <nil> <nil> %!s(bool=false) %!s(int=0) %!s(chan struct {}=<nil>) {%!s(int32=0) %!s(uint32=0)}}
    amazon-ebs: --2014-12-22 17:03:36--  https://bootstrap.saltstack.com/
    amazon-ebs: sh: -X: invalid option
    amazon-ebs: Usage:  sh [GNU long option] [option] ...
    amazon-ebs: sh [GNU long option] [option] script-file ...
    amazon-ebs: GNU long options:
    amazon-ebs: --debug
    amazon-ebs: --debugger
    amazon-ebs: --dump-po-strings
    amazon-ebs: --dump-strings
    amazon-ebs: --help
    amazon-ebs: --init-file
    amazon-ebs: --login
    amazon-ebs: --noediting
    amazon-ebs: --noprofile
    amazon-ebs: --norc
    amazon-ebs: --posix
    amazon-ebs: --protected
    amazon-ebs: --rcfile
    amazon-ebs: --rpm-requires
    amazon-ebs: --restricted
    amazon-ebs: --verbose
    amazon-ebs: --version
    amazon-ebs: Shell options:
    amazon-ebs: -irsD or -c command or -O shopt_option      (invocation only)
    amazon-ebs: -abefhkmnptuvxBCHP or -o option
    amazon-ebs: Resolving bootstrap.saltstack.com (bootstrap.saltstack.com)... 162.242.141.13
    amazon-ebs: Connecting to bootstrap.saltstack.com (bootstrap.saltstack.com)|162.242.141.13|:443... connected.
    amazon-ebs: HTTP request sent, awaiting response... 303 See Other
    amazon-ebs: Location: https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh [following]
    amazon-ebs: --2014-12-22 17:03:36--  https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
    amazon-ebs: Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 23.235.47.133
    amazon-ebs: Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|23.235.47.133|:443... connected.
    amazon-ebs: HTTP request sent, awaiting response... 200 OK
    amazon-ebs: Length: 188506 (184K) [text/plain]
    amazon-ebs:
    amazon-ebs: Saving to: ‘STDOUT’
    amazon-ebs:
-             0%       0  --.-KB/s   in 0s--.-KB/s             
    amazon-ebs:
    amazon-ebs:
    amazon-ebs: Cannot write to ‘-’ (Success).
```

After:

```
==> amazon-ebs: Provisioning with Salt...
    amazon-ebs: Downloading saltstack bootstrap to /tmp/install_salt.sh
    amazon-ebs: % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    amazon-ebs: Dload  Upload   Total   Spent    Left  Speed
    amazon-ebs: 100   212  100   212    0     0    393      0 --:--:-- --:--:-- --:--:--   393
    amazon-ebs: 100  184k  100  184k    0     0   140k      0  0:00:01  0:00:01 --:--:--  140k
    amazon-ebs: Installing Salt with command &{sudo sh /tmp/install_salt.sh -X <nil> <nil> <nil> %!s(bool=false) %!s(int=0) %!s(chan struct {}=<nil>) {%!s(int32=0) %!s(uint32=0)}}
    amazon-ebs:  *  INFO: sh /tmp/install_salt.sh -- Version 2014.12.11
    amazon-ebs:
    amazon-ebs:  *  INFO: System Information:
    amazon-ebs:  *  INFO:   CPU:          GenuineIntel
    amazon-ebs:  *  INFO:   CPU Arch:     x86_64
    amazon-ebs:  *  INFO:   OS Name:      Linux
    amazon-ebs:  *  INFO:   OS Version:   3.14.19-17.43.amzn1.x86_64
    amazon-ebs:  *  INFO:   Distribution: Amazon Linux AMI 2014.09
    amazon-ebs:
    amazon-ebs:  *  INFO: Installing minion
    amazon-ebs:  *  INFO: Daemons will not be started
    amazon-ebs:  *  INFO: Found function install_amazon_linux_ami_deps
    amazon-ebs:  *  INFO: Found function install_amazon_linux_ami_stable
    amazon-ebs:  *  INFO: Found function install_amazon_linux_ami_stable_post
    amazon-ebs:  *  INFO: Found function install_amazon_linux_ami_restart_daemons
    amazon-ebs:  *  INFO: Found function daemons_running
    amazon-ebs:  *  INFO: Running install_amazon_linux_ami_deps()
```

This fixes #1235.
