### PR TITLE
Changed type of version.number / vagrant-cloud post-processor

### DIFF
--- a/post-processor/vagrant-cloud/step_create_provider.go
+++ b/post-processor/vagrant-cloud/step_create_provider.go
@@ -25,7 +25,7 @@ func (s *stepCreateProvider) Run(state multistep.StateBag) multistep.StepAction 
 	providerName := state.Get("providerName").(string)
 	downloadUrl := state.Get("boxDownloadUrl").(string)
 
-	path := fmt.Sprintf("box/%s/version/%v/providers", box.Tag, version.Number)
+	path := fmt.Sprintf("box/%s/version/%v/providers", box.Tag, version.Version)
 
 	provider := &Provider{Name: providerName}
 
@@ -86,7 +86,7 @@ func (s *stepCreateProvider) Cleanup(state multistep.StateBag) {
 	ui.Say("Cleaning up provider")
 	ui.Message(fmt.Sprintf("Deleting provider: %s", s.name))
 
-	path := fmt.Sprintf("box/%s/version/%v/provider/%s", box.Tag, version.Number, s.name)
+	path := fmt.Sprintf("box/%s/version/%v/provider/%s", box.Tag, version.Version, s.name)
 
 	// No need for resp from the cleanup DELETE
 	_, err := client.Delete(path)

--- a/post-processor/vagrant-cloud/step_prepare_upload.go
+++ b/post-processor/vagrant-cloud/step_prepare_upload.go
@@ -22,7 +22,7 @@ func (s *stepPrepareUpload) Run(state multistep.StateBag) multistep.StepAction {
 	provider := state.Get("provider").(*Provider)
 	artifactFilePath := state.Get("artifactFilePath").(string)
 
-	path := fmt.Sprintf("box/%s/version/%v/provider/%s/upload", box.Tag, version.Number, provider.Name)
+	path := fmt.Sprintf("box/%s/version/%v/provider/%s/upload", box.Tag, version.Version, provider.Name)
 	upload := &Upload{}
 
 	ui.Say(fmt.Sprintf("Preparing upload of box: %s", artifactFilePath))

--- a/post-processor/vagrant-cloud/step_release_version.go
+++ b/post-processor/vagrant-cloud/step_release_version.go
@@ -24,7 +24,7 @@ func (s *stepReleaseVersion) Run(state multistep.StateBag) multistep.StepAction 
 		return multistep.ActionContinue
 	}
 
-	path := fmt.Sprintf("box/%s/version/%v/release", box.Tag, version.Number)
+	path := fmt.Sprintf("box/%s/version/%v/release", box.Tag, version.Version)
 
 	resp, err := client.Put(path)
 

--- a/post-processor/vagrant-cloud/step_verify_upload.go
+++ b/post-processor/vagrant-cloud/step_verify_upload.go
@@ -19,7 +19,7 @@ func (s *stepVerifyUpload) Run(state multistep.StateBag) multistep.StepAction {
 	upload := state.Get("upload").(*Upload)
 	provider := state.Get("provider").(*Provider)
 
-	path := fmt.Sprintf("box/%s/version/%v/provider/%s", box.Tag, version.Number, provider.Name)
+	path := fmt.Sprintf("box/%s/version/%v/provider/%s", box.Tag, version.Version, provider.Name)
 
 	providerCheck := &Provider{}
 


### PR DESCRIPTION
A few weeks ago ... the version.number changed from an integer to a
semver based string.

I guess version.number and version.version are equals now. So
version.version can be used.

This commit should fix #1735
