### PR TITLE
Fix amazon instance type on build an image page

### DIFF
--- a/website/source/intro/getting-started/build-image.html.markdown
+++ b/website/source/intro/getting-started/build-image.html.markdown
@@ -16,7 +16,7 @@ with Redis pre-installed. This is just an example. Packer can create images
 for [many platforms](/intro/platforms.html) with anything pre-installed.
 
 If you don't have an AWS account, [create one now](http://aws.amazon.com/free/).
-For the example, we'll use a "t1.micro" instance to build our image, which
+For the example, we'll use a "t2.micro" instance to build our image, which
 qualifies under the AWS [free-tier](http://aws.amazon.com/free/), meaning
 it will be free. If you already have an AWS account, you may be charged some
 amount of money, but it shouldn't be more than a few cents.


### PR DESCRIPTION
This page referred to using a "t1.micro" instance but the template actually uses a "t2.micro".
