### PR TITLE
Add support for generating tfvars files for AWS

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -238,6 +238,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the artifact and return it
 	artifact := &awscommon.Artifact{
 		Amis:           state.Get("amis").(map[string]string),
+		NamedAmis:      state.Get("namedamis").(map[string]string),
 		BuilderIdValue: BuilderId,
 		Conn:           ec2conn,
 	}

--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -50,6 +50,10 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	amis[ec2conn.Region.Name] = registerResp.ImageId
 	state.Put("amis", amis)
 
+	namedamis := make(map[string]string)
+	namedamis[config.AMIName] = registerResp.ImageId
+	state.Put("namedamis", namedamis)
+
 	// Wait for the image to become ready
 	stateChange := awscommon.StateChangeConf{
 		Pending:   []string{"pending"},

--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -16,6 +16,9 @@ type Artifact struct {
 	// A map of regions to AMI IDs.
 	Amis map[string]string
 
+	// A map of AMI Names to AMI IDs.
+	NamedAmis map[string]string
+
 	// BuilderId is the unique ID for the builder that created this AMI
 	BuilderIdValue string
 
@@ -57,6 +60,8 @@ func (a *Artifact) State(name string) interface{} {
 	switch name {
 	case "atlas.artifact.metadata":
 		return a.stateAtlasMetadata()
+	case "awsgeneric.artifact.metadata":
+		return a.stateGenericMetadata()
 	default:
 		return nil
 	}
@@ -94,4 +99,13 @@ func (a *Artifact) stateAtlasMetadata() interface{} {
 	}
 
 	return metadata
+}
+
+func (a *Artifact) stateGenericMetadata() interface{} {
+	metadata := make(map[string]string)
+	for name, imageId := range a.NamedAmis {
+		metadata[name] = imageId
+	}
+
+	return metadata;
 }

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -164,6 +164,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the artifact and return it
 	artifact := &awscommon.Artifact{
 		Amis:           state.Get("amis").(map[string]string),
+		NamedAmis:      state.Get("namedamis").(map[string]string),
 		BuilderIdValue: BuilderId,
 		Conn:           ec2conn,
 	}

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -40,6 +40,10 @@ func (s *stepCreateAMI) Run(state multistep.StateBag) multistep.StepAction {
 	amis[ec2conn.Region.Name] = createResp.ImageId
 	state.Put("amis", amis)
 
+	namedamis := make(map[string]string)
+	namedamis[config.AMIName] = createResp.ImageId
+	state.Put("namedamis", namedamis)
+
 	// Wait for the image to become ready
 	stateChange := awscommon.StateChangeConf{
 		Pending:   []string{"pending"},

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -273,6 +273,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the artifact and return it
 	artifact := &awscommon.Artifact{
 		Amis:           state.Get("amis").(map[string]string),
+		NamedAmis:      state.Get("namedamis").(map[string]string),
 		BuilderIdValue: BuilderId,
 		Conn:           ec2conn,
 	}

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -43,6 +43,10 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	amis[ec2conn.Region.Name] = registerResp.ImageId
 	state.Put("amis", amis)
 
+	namedamis := make(map[string]string)
+	namedamis[config.AMIName] = registerResp.ImageId
+	state.Put("namedamis", namedamis)
+
 	// Wait for the image to become ready
 	stateChange := awscommon.StateChangeConf{
 		Pending:   []string{"pending"},

--- a/plugin/post-processor-terraform-export/main.go
+++ b/plugin/post-processor-terraform-export/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/mitchellh/packer/packer/plugin"
+	"github.com/mitchellh/packer/post-processor/terraform-export"
+)
+
+func main() {
+	server, err := plugin.Server()
+	if err != nil {
+		panic(err)
+	}
+	server.RegisterPostProcessor(new(terraformexport.PostProcessor))
+	server.Serve()
+}

--- a/post-processor/terraform-export/artifact.go
+++ b/post-processor/terraform-export/artifact.go
@@ -1,0 +1,44 @@
+package terraformexport
+
+import (
+	"fmt"
+	"os"
+)
+
+const BuilderId = "crunch.post-processor.terraform-export"
+
+type Artifact struct {
+	Variable	string
+	Output		string
+}
+
+func NewArtifact(output, variable string) *Artifact {
+	return &Artifact{
+		Output:     output,
+		Variable: 	variable,
+	}
+}
+
+func (*Artifact) BuilderId() string {
+	return BuilderId
+}
+
+func (a *Artifact) Files() []string {
+	return []string{a.Output}
+}
+
+func (a *Artifact) Id() string {
+	return a.Variable
+}
+
+func (a *Artifact) String() string {
+	return fmt.Sprintf("'%s' saved to: %s", a.Variable, a.Output)
+}
+
+func (a *Artifact) State(name string) interface{} {
+	return nil
+}
+
+func (a *Artifact) Destroy() error {
+	return os.Remove(a.Output)
+}

--- a/post-processor/terraform-export/post-processor.go
+++ b/post-processor/terraform-export/post-processor.go
@@ -1,0 +1,148 @@
+package terraformexport
+
+import (
+	"fmt"
+	"encoding/json"
+	"os"
+	"strings"
+	"io/ioutil"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/builder/amazon/chroot"
+	"github.com/mitchellh/packer/builder/amazon/ebs"
+	"github.com/mitchellh/packer/builder/amazon/instance"
+	"github.com/mitchellh/mapstructure"
+)
+
+const ArtifactStateMetadata = "awsgeneric.artifact.metadata"
+
+type Config struct {
+	common.PackerConfig `mapstructure:",squash"`
+
+	Output string `mapstructure:"output"`
+	Variable string `mapstructure:"variable"`
+	EnablePartialMatch bool `mapstructure:"enable_partial_match"`
+	AmiName string `mapstructure:"ami_name"`
+
+	tpl *packer.ConfigTemplate
+}
+
+type PostProcessor struct {
+	config Config
+}
+
+func (p *PostProcessor) Configure(raws ...interface{}) error {
+	_, err := common.DecodeConfig(&p.config, raws...)
+	if err != nil {
+		return err
+	}
+
+	p.config.tpl, err = packer.NewConfigTemplate()
+	if err != nil {
+		return err
+	}
+	p.config.tpl.UserVars = p.config.PackerUserVars
+
+	// Accumulate any errors
+	errs := new(packer.MultiError)
+
+	templates := map[string]*string{
+		"output" : &p.config.Output,
+		"ami_name" : &p.config.AmiName,
+	}
+
+	for key, ptr := range templates {
+		if *ptr == "" {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("%s must be set", key))
+		}
+
+		*ptr, err = p.config.tpl.Process(*ptr, nil)
+		if err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("Error processing %s: %s", key, err))
+		}
+	}
+
+	if len(errs.Errors) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
+func (p *PostProcessor) metadata(artifact packer.Artifact) map[string]string {
+	var metadata map[string]string
+	metadataRaw := artifact.State(ArtifactStateMetadata)
+	if metadataRaw != nil {
+		if err := mapstructure.Decode(metadataRaw, &metadata); err != nil {
+			panic(err)
+		}
+	}
+
+	return metadata
+}
+
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+	if artifact.BuilderId() != chroot.BuilderId && artifact.BuilderId() != ebs.BuilderId && artifact.BuilderId() != instance.BuilderId {
+		err := fmt.Errorf(
+			"Unknown artifact type: %s\nCan only import from AWS builder artifacts.",
+			artifact.BuilderId())
+		return nil, false, err
+	}
+
+	// Get the named AMIs from the AWS builder
+	awsMetadata := p.metadata(artifact)
+
+	if(awsMetadata == nil) {
+		return nil, false, fmt.Errorf("No AMIs were available to process")
+	}
+
+	config := map[string]string {}
+
+	if _, err := os.Stat(p.config.Output); err == nil {
+		file, e := ioutil.ReadFile(p.config.Output)
+	    if e == nil {
+	        json.Unmarshal(file, &config)
+	    }else {
+	    	ui.Message("Unable to load existing tfvars file '" + p.config.Output + "': " + e.Error())
+	    }
+	}
+
+	for sourceAmiName, amiId := range awsMetadata {
+		var amiName = p.config.AmiName
+
+		if(p.config.EnablePartialMatch) {
+			if(!strings.HasPrefix(sourceAmiName, amiName)) {
+				continue;
+			}
+		}else {
+			if(amiName != sourceAmiName) {
+				continue;
+			}
+		}
+
+		config[p.config.Variable] = amiId
+	}
+
+	jsonString, err := json.Marshal(config)
+
+	if(err != nil) {
+		return nil, false, fmt.Errorf("Error serializing to '%s'", p.config.Output)
+	}
+
+	f, err := os.Create(p.config.Output)
+    if err != nil {
+        panic(err)
+    }
+
+    defer f.Close()
+
+    _, err = f.Write(jsonString)
+	if err != nil {
+        panic(err)
+    }
+    f.Sync()
+
+	return NewArtifact(p.config.Output, p.config.Variable), true, nil
+}

--- a/post-processor/terraform-export/post-processor_test.go
+++ b/post-processor/terraform-export/post-processor_test.go
@@ -1,0 +1,31 @@
+package terraformexport
+
+import (
+	"bytes"
+	"github.com/mitchellh/packer/packer"
+	"testing"
+)
+
+func testConfig() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func testPP(t *testing.T) *PostProcessor {
+	var p PostProcessor
+	if err := p.Configure(testConfig()); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return &p
+}
+
+func testUi() *packer.BasicUi {
+	return &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	}
+}
+
+func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
+	var _ packer.PostProcessor = new(PostProcessor)
+}


### PR DESCRIPTION
This commit adds a new post processor that allows for tfvars.json files to be exported for a terraform script to pick up. We're currently gluing Packer and Terraform together with a few bash scripts, so this is a handy replacement that might be of use to other people.

The post processor can be configured like this:

``` json
{
"post-processors": [
    {
      "type": "terraform-export",
      "output": "myapp.tfvars.json",
      "variable": "ami_myapp",
      "ami_name": "myapp-prod",
      "enable_partial_match": false
    }
  ]
}
```

`output` is the destination of the tfvars.json file
`variable` is the variable name that represents the AMI ID in Terraform
`ami_name` is the name given to the AMI in the AWS builder
`enable_partial_match` allows for the AMI name to only partially match the one provided by the builder, this can help if you're using timestamps or other dynamic data in your AMI names

The resulting output of running the post processor is:

``` json
{"ami_myapp":"ami-xxxxxxxx"}
```

The post processor automatically merges its data with an existing tfvars.json if one exists at '`output`', so you can chain multiple of these together if you're building more than one AMI and you want to reference all of them in your Terraform scripts.

I'd appreciate any comments or suggestions of ways this can be improved - currently we're piggybacking on a similar mechanism the atlas post processor uses for grabbing AMI data, I'm not sure if this is ideal but it appeared to be the simplest way of achieving the end goal.
