### PR TITLE
builder/amazon-ebs: Skip modification of the "enhanced networking"

### DIFF
--- a/builder/amazon/ebs/step_modify_instance.go
+++ b/builder/amazon/ebs/step_modify_instance.go
@@ -3,6 +3,7 @@ package ebs
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"


### PR DESCRIPTION
Skip modification of the _"enhanced networking"_ attribute for Amazon EBS-backed instances when it is already enabled. For instances based on relatively recent Amazon Linux HVM AMIs, this capability is already enabled by default. Furthermore, attempting to modify this attribute on a spot instance fails, as they are not stopped at this stage of the builder pipeline.
