### PR TITLE
Add support for custom nat interfaces in VMWare when attempting to SSH

### DIFF
--- a/builder/vmware/common/ssh.go
+++ b/builder/vmware/common/ssh.go
@@ -44,9 +44,19 @@ func CommHost(config *SSHConfig) func(multistep.StateBag) (string, error) {
 			}
 		}
 
+		vmnet := "vmnet8"
+		connectionType := ""
+		if connectionType, ok = vmxData["ethernet0.connectiontype"]; ok && connectionType == "custom" {
+			log.Printf("Using connection type: %s", connectionType);
+			if vmnet, ok = vmxData["ethernet0.vnet"]; !ok || vmnet == "" {
+				log.Println("No vmnet found, using vmnet8");
+				vmnet = "vmnet8"
+			}
+		}
+
 		ipLookup := &DHCPLeaseGuestLookup{
 			Driver:     driver,
-			Device:     "vmnet8",
+			Device:     vmnet,
 			MACAddress: macAddress,
 		}
 


### PR DESCRIPTION
When the `connectiontype` vmx value is `custom`, use the `vnet` vmx value from the VM instead of assuming vmnet8 when trying to lookup the VM's IP via the DHCP leases file.

Previously, packer would timeout when trying to connect via SSH due to either not being able to find the VM's IP or using an incorrect IP if a stale lease was found in vmnet8's leases file.

This PR doesn't add 100% support for using a custom vmnet since: 1) packer still uses vmnet8 to find the host IP after connecting to VNC; and 2) bridged vmnets don't have a DHCP leases file.
