### PR TITLE
Set Communicator using ssh_host for connection default when exists in builder config

### DIFF
--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -115,12 +115,19 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 		}
 		first = false
 
-		// First we request the TCP connection information
-		host, err := s.Host(state)
-		if err != nil {
-			log.Printf("[DEBUG] Error getting SSH address: %s", err)
-			continue
+		// if ssh_host exists in config, use it default
+		host := s.Config.SSHHost
+		var err error
+		log.Printf("[DEBUG] Current SSH Host in Config is: %s", host)
+		if s.Config.SSHHost == "" {
+			// First we request the TCP connection information
+			host, err = s.Host(state)
+			if err != nil {
+				log.Printf("[DEBUG] Error getting SSH address: %s", err)
+				continue
+			}
 		}
+
 		port := s.Config.SSHPort
 		if s.SSHPort != nil {
 			port, err = s.SSHPort(state)


### PR DESCRIPTION
when the ssh_host exists in config, the communicator should use the ssh_host default without fetching host ip using Host function.
While there is still some issue on **getting Host** from vmware or others builder, such as #2530 _vmware builder only tries to use the first network interface (eth0) for SSH connections_
