### PR TITLE
Docs: Multiple version of VMWare Player available for Linux.

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -28,6 +28,25 @@ scratch, booting it, installing an OS, provisioning software within the OS, then
 shutting it down. The result of the VMware builder is a directory containing all
 the files necessary to run the virtual machine.
 
+### VMware Player on Linux
+
+There are (as of 2016-Apr-18) two versions of VMware Player currently available for download:
+
+* [7.0](https://my.vmware.com/en/web/vmware/free#desktop_end_user_computing/vmware_player/7_0)
+* [12.0](https://my.vmware.com/en/web/vmware/free#desktop_end_user_computing/vmware_workstation_player/12_0)
+
+Unfortunately just installing the VMware player is not quite enough to be able to use
+packer. You will also need the `qemu-img` command which is available in the `qemu-utils`
+package on Debian-like systems and on Fedora-like systems in the `qemu` package.
+
+Additionally you will need to the `vmrun` command, which is part of VMware Virtual
+Infrastructure eXtension [(VIX) SDK](https://developercenter.vmware.com/web/sdk/60/vix).
+
+Finally, if you installed a version of VMware player newer than 7.0, you must edit the
+file `/usr/lib/vmware-vix/vixwrapper-config.txt` and change the version specified in
+the fourth column there to be the output of `vmplayer -v`.
+
+
 ## Basic Example
 
 Here is a basic example. This example is not functional. It will start the OS


### PR DESCRIPTION
Add additional instruciton so that VMware Player can be properly used.

Version 7 and 12.

You might want to use 12 because it support newer operating systems and
has various bug fixed. Irrespective of the version you use, you will
need something to provide 'qemu-img' and 'vmrun'.

For `qemu-img` (used to convert between disk formats), it is available
as part of `qemu-utils` for Debian derivates and as `qemu` for Fedora/EL.

`vmrun` is part of the (deprecated) VIX API, link provided.

If you happen to use the newer VMware player, you will need to edit
some of the VIX API files so that it knows about the version on your
system.

Refs:
- http://askubuntu.com/questions/342552/vmware-vix-vmrun-command-error-unable-to-connect-to-host-version-not-found
- https://jdramer.wordpress.com/2012/11/01/using-vix-and-vmrun-with-vmplayer-5-0-0-on-linux/
- http://www.wentztech.com/radio/Linux/files/vmrun.html
