### PR TITLE
post-processor/vagrant: inject "provider" metadata for atlas artifacts

### DIFF
--- a/post-processor/vagrant/artifact.go
+++ b/post-processor/vagrant/artifact.go
@@ -36,9 +36,29 @@ func (a *Artifact) String() string {
 }
 
 func (a *Artifact) State(name string) interface{} {
-	return nil
+	switch name {
+	case "atlas.artifact.metadata":
+		return a.stateAtlasMetadata()
+	default:
+		return nil
+	}
 }
 
 func (a *Artifact) Destroy() error {
 	return os.Remove(a.Path)
+}
+
+func (a *Artifact) stateAtlasMetadata() map[string]string {
+	return map[string]string{"provider": a.vagrantProvider()}
+}
+
+func (a *Artifact) vagrantProvider() string {
+	switch a.Provider {
+	case "digitalocean":
+		return "digital_ocean"
+	case "vmware":
+		return "vmware_desktop"
+	default:
+		return a.Provider
+	}
 }

--- a/post-processor/vagrant/artifact_test.go
+++ b/post-processor/vagrant/artifact_test.go
@@ -2,6 +2,7 @@ package vagrant
 
 import (
 	"github.com/mitchellh/packer/packer"
+	"reflect"
 	"testing"
 )
 
@@ -17,5 +18,16 @@ func TestArtifact_Id(t *testing.T) {
 	artifact := NewArtifact("vmware", "./")
 	if artifact.Id() != "vmware" {
 		t.Fatalf("should return name as Id")
+	}
+}
+
+func TestArtifact_StateAtlasMetadata(t *testing.T) {
+	artifact := NewArtifact("vmware", "./")
+
+	actual := artifact.State("atlas.artifact.metadata")
+	expected := map[string]string{"provider": "vmware_desktop"}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
 	}
 }


### PR DESCRIPTION
This change eliminates the need to specify "provider" metadata in atlas post-processor config.
