### PR TITLE
Allow to upload files created on-the-fly

### DIFF
--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -26,6 +26,9 @@ type Config struct {
 	// Direction
 	Direction string
 
+	// False if the sources have to exist.
+	Generated bool
+
 	ctx interpolate.Context
 }
 
@@ -61,7 +64,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if p.config.Direction == "upload" {
 		for _, src := range p.config.Sources {
-			if _, err := os.Stat(src); err != nil {
+			if _, err := os.Stat(src); p.config.Generated == false && err != nil {
 				errs = packer.MultiErrorAppend(errs,
 					fmt.Errorf("Bad source '%s': %s", src, err))
 			}

--- a/provisioner/file/provisioner_test.go
+++ b/provisioner/file/provisioner_test.go
@@ -45,6 +45,12 @@ func TestProvisionerPrepare_InvalidSource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("should require existing file")
 	}
+
+	config["generated"] = false
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatalf("should required existing file")
+	}
 }
 
 func TestProvisionerPrepare_ValidSource(t *testing.T) {
@@ -58,10 +64,27 @@ func TestProvisionerPrepare_ValidSource(t *testing.T) {
 
 	config := testConfig()
 	config["source"] = tf.Name()
-
 	err = p.Prepare(config)
 	if err != nil {
 		t.Fatalf("should allow valid file: %s", err)
+	}
+
+	config["generated"] = false
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("should allow valid file: %s", err)
+	}
+}
+
+func TestProvisionerPrepare_GeneratedSource(t *testing.T) {
+	var p Provisioner
+
+	config := testConfig()
+	config["source"] = "/this/should/not/exist"
+	config["generated"] = true
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("should allow non-existing file: %s", err)
 	}
 }
 

--- a/website/source/docs/provisioners/file.html.md
+++ b/website/source/docs/provisioners/file.html.md
@@ -46,6 +46,9 @@ The available configuration options are listed below. All elements are required.
     "upload." If it is set to "download" then the file "source" in the machine
     will be downloaded locally to "destination"
 
+-   `generated` (boolean) - If true, check the file existence only before uploading.
+    This allows to upload files created on-the-fly. This defaults to false.
+
 ## Directory Uploads
 
 The file provisioner is also able to upload a complete directory to the remote


### PR DESCRIPTION
Add the key "generated" to the file provisioner that allows to upload files created on-the-fly.

Example:

```
{
    "builders": [{
        "type": "docker",
        "image": "ubuntu",
        "commit": true
    }],
    "provisioners": [{
        "type": "shell-local",
        "command": "touch on-the-fly.txt"
    },{
        "type": "file",
        "generated": true,
        "source": "on-the-fly.txt",
        "destination": "/tmp"
    }]
}
```

Closes #2479

I used "generated" as the option name like suggested in #2479. 
