### PR TITLE
Added "inventory_file" and "inventory_path" options for "ansible" provisioner

### DIFF
--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -50,6 +50,11 @@ Optional Parameters:
 - `command` (string) - The command to invoke ansible.
    Defaults to `ansible-playbook`.
 
+- `inventory_file` (string) - The file or directory to use.
+
+- `inventory_path` (string) - The path where to place dynamically generated inventory by packer.
+  Useful when you set `inventory_file` as directory. Defaults to empty string.
+
 - `groups` (array of strings) - The groups into which the Ansible host
   should be placed. When unspecified, the host is not associated with any
   groups.


### PR DESCRIPTION
Now we can control where to place dynamically generated inventory by specifying `inventory_path` option. Internally it tells `io/ioutil` to use this path instead of `os.TempDir` directory. Also, I added option `inventory_file` to be able to use [inventory as a directory](http://docs.ansible.com/ansible/intro_dynamic_inventory.html#using-inventory-directories-and-multiple-inventory-sources).
