### PR TITLE
Partials idea for consolidating docs

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -13,5 +13,5 @@ format:
 	bundle exec htmlbeautifier -t 2 source/*.erb
 	bundle exec htmlbeautifier -t 2 source/layouts/*.erb
 	@pandoc -v > /dev/null || echo "pandoc must be installed in order to format markdown content"
-	pandoc -v > /dev/null && find . -iname "*.html.md" | xargs -I{} bash -c "pandoc -r markdown -w markdown --tab-stop=4 --atx-headers -s --columns=80 {} > {}.new"\; || true
-	pandoc -v > /dev/null && find . -iname "*.html.md" | xargs -I{} bash -c "mv {}.new {}"\; || true
+	pandoc -v > /dev/null && find . -iname "*.html.md*" | xargs -I{} bash -c "pandoc -r markdown -w markdown --tab-stop=4 --atx-headers -s --columns=80 {} > {}.new"\; || true
+	pandoc -v > /dev/null && find . -iname "*.html.md*" | xargs -I{} bash -c "mv {}.new {}"\; || true

--- a/website/source/docs/builders/amazon-chroot.html.md.erb
+++ b/website/source/docs/builders/amazon-chroot.html.md.erb
@@ -6,6 +6,7 @@ description: |
     in the EC2 documentation.
 layout: docs
 page_title: 'Amazon AMI Builder (chroot)'
+builder: amazon-chroot
 ---
 
 # AMI Builder (chroot)
@@ -56,21 +57,7 @@ each category, the available configuration keys are alphabetized.
 
 ### Required:
 
--   `access_key` (string) - The access key used to communicate with AWS. [Learn
-    how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
-
--   `ami_name` (string) - The name of the resulting AMI that will appear when
-    managing AMIs in the AWS console or via APIs. This must be unique. To help
-    make this unique, use a function like `timestamp` (see [configuration
-    templates](/docs/templates/configuration-templates.html) for more info)
-
--   `secret_key` (string) - The secret key used to communicate with AWS. [Learn
-    how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
-
--   `source_ami` (string) - The source AMI whose root volume will be copied and
-    provisioned on the currently running instance. This must be an EBS-backed
-    AMI with a root volume snapshot that you have access to. Note: this is not
-    used when `from_scratch` is set to true.
+<%= partial "partials/builders/amazon-required" %>
 
 ### Optional:
 

--- a/website/source/docs/builders/amazon-chroot.html.md.erb
+++ b/website/source/docs/builders/amazon-chroot.html.md.erb
@@ -122,18 +122,19 @@ each category, the available configuration keys are alphabetized.
     `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
-    AMI if one with the same name already exists. Default false.
+    AMI if one with the same name already exists. Default `false`.
 
 -   `from_scratch` (boolean) - Build a new volume instead of starting from an
-    existing AMI root volume snapshot. Default false. If true, `source_ami` is
+    existing AMI root volume snapshot. Default `false`. If true, `source_ami` is
     no longer used and the following options become required:
     `ami_virtualization_type`, `pre_mount_commands` and `root_volume_size`. The
     below options are also required in this mode only:
 
-    -   `ami_block_device_mappings` (array of block device mappings) An entry
-        matching `root_device_name` should be set. See the
-        [amazon-ebs](/docs/builders/amazon-ebs.html) documentation for more
-        details on this parameter.
+    -   `ami_block_device_mappings` (array of block device mappings) - Add the block
+    device mappings to the AMI. A `device_name` entry matching `root_device_name`
+    should be set. The block device mappings allow for keys:
+
+        <%= partial "partials/builders/ami-block-device-mappings" %>
 
     -   `root_device_name` (string) - The root device name. For example, `xvda`.
 
@@ -170,7 +171,7 @@ each category, the available configuration keys are alphabetized.
     this field must be defined.
 
 -   `skip_region_validation` (boolean) - Set to true if you want to skip
-    validation of the `ami_regions` configuration option. Defaults to false.
+    validation of the `ami_regions` configuration option. Default `false`.
 
 -   `source_ami_filter` (object) - Filters used to populate the `source_ami` field.
     Example:

--- a/website/source/docs/builders/amazon-ebs.html.md.erb
+++ b/website/source/docs/builders/amazon-ebs.html.md.erb
@@ -66,27 +66,8 @@ builder.
 -   `ami_block_device_mappings` (array of block device mappings) - Add the block
     device mappings to the AMI. The block device mappings allow for keys:
 
-    -   `device_name` (string) - The device name exposed to the instance (for
-         example, "/dev/sdh" or "xvdh"). Required when specifying `volume_size`.
-    -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
-        deleted on instance termination
-    -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
-    -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
-        volume supports. See the documentation on
-        [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
-        for more information
-    -   `no_device` (boolean) - Suppresses the specified device included in the
-        block device mapping of the AMI
-    -   `snapshot_id` (string) - The ID of the snapshot
-    -   `virtual_name` (string) - The virtual device name. See the documentation on
-        [Block Device
-        Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
-        for more information
-    -   `volume_size` (integer) - The size of the volume, in GiB. Required if not
-        specifying a `snapshot_id`
-    -   `volume_type` (string) - The volume type. gp2 for General Purpose (SSD)
-        volumes, io1 for Provisioned IOPS (SSD) volumes, and standard for Magnetic
-        volumes
+    <%= partial "partials/builders/ami-block-device-mappings" %>
+
 -   `ami_description` (string) - The description to set for the
     resulting AMI(s). By default this description is empty.
 
@@ -172,8 +153,8 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
--   `skip_region_validation` (boolean) - Set to true if you want to skip 
-    validation of the region configuration option.  Defaults to false.
+-   `skip_region_validation` (boolean) - Set to true if you want to skip
+    validation of the region configuration option.  Default `false`.
 
 -   `source_ami_filter` (object) - Filters used to populate the `source_ami` field.
     Example:
@@ -346,3 +327,4 @@ up all residual volumes that are not designated by the user to remain after
 termination. If you need to preserve those source volumes, you can overwrite the
 termination setting by specifying `delete_on_termination=false` in the
 `launch_block_device_mappings` block for the device.
+

--- a/website/source/docs/builders/amazon-ebs.html.md.erb
+++ b/website/source/docs/builders/amazon-ebs.html.md.erb
@@ -6,6 +6,7 @@ description: |
     the root device section in the EC2 documentation.
 layout: docs
 page_title: 'Amazon AMI Builder (EBS backed)'
+builder: amazon-ebs
 ...
 
 # AMI Builder (EBS backed)
@@ -40,26 +41,7 @@ builder.
 
 ### Required:
 
--   `access_key` (string) - The access key used to communicate with AWS. [Learn
-    how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
-
--   `ami_name` (string) - The name of the resulting AMI that will appear when
-    managing AMIs in the AWS console or via APIs. This must be unique. To help
-    make this unique, use a function like `timestamp` (see [configuration
-    templates](/docs/templates/configuration-templates.html) for more info)
-
--   `instance_type` (string) - The EC2 instance type to use while building the
-    AMI, such as "m1.small".
-
--   `region` (string) - The name of the region, such as "us-east-1", in which to
-    launch the EC2 instance to create the AMI.
-
--   `secret_key` (string) - The secret key used to communicate with AWS. [Learn
-    how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
-
--   `source_ami` (string) - The initial AMI used as a base for the newly
-    created machine. `source_ami_filter` may be used instead to populate this
-    automatically.
+<%= partial "partials/builders/amazon-required" %>
 
 ### Optional:
 

--- a/website/source/docs/builders/amazon-instance.html.md.erb
+++ b/website/source/docs/builders/amazon-instance.html.md.erb
@@ -6,6 +6,7 @@ description: |
     device section in the EC2 documentation.
 layout: docs
 page_title: 'Amazon AMI Builder (instance-store)'
+builder: amazon-instance
 ...
 
 # AMI Builder (instance-store)
@@ -47,41 +48,7 @@ builder.
 
 ### Required:
 
--   `access_key` (string) - The access key used to communicate with AWS. [Learn
-    how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
-
--   `account_id` (string) - Your AWS account ID. This is required for bundling
-    the AMI. This is *not the same* as the access key. You can find your account
-    ID in the security credentials page of your AWS account.
-
--   `ami_name` (string) - The name of the resulting AMI that will appear when
-    managing AMIs in the AWS console or via APIs. This must be unique. To help
-    make this unique, use a function like `timestamp` (see [configuration
-    templates](/docs/templates/configuration-templates.html) for more info)
-
--   `instance_type` (string) - The EC2 instance type to use while building the
-    AMI, such as "m1.small".
-
--   `region` (string) - The name of the region, such as "us-east-1", in which to
-    launch the EC2 instance to create the AMI.
-
--   `s3_bucket` (string) - The name of the S3 bucket to upload the AMI. This
-    bucket will be created if it doesn't exist.
-
--   `secret_key` (string) - The secret key used to communicate with AWS. [Learn
-    how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
-
--   `source_ami` (string) - The initial AMI used as a base for the newly
-    created machine.
-
--   `x509_cert_path` (string) - The local path to a valid X509 certificate for
-    your AWS account. This is used for bundling the AMI. This X509 certificate
-    must be registered with your account from the security credentials page in
-    the AWS console.
-
--   `x509_key_path` (string) - The local path to the private key for the X509
-    certificate specified by `x509_cert_path`. This is used for bundling
-    the AMI.
+<%= partial "partials/builders/amazon-required" %>
 
 ### Optional:
 

--- a/website/source/docs/builders/amazon-instance.html.md.erb
+++ b/website/source/docs/builders/amazon-instance.html.md.erb
@@ -87,27 +87,9 @@ builder.
 
 -   `ami_block_device_mappings` (array of block device mappings) - Add the block
     device mappings to the AMI. The block device mappings allow for keys:
-    -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
-        deleted on instance termination
-    -   `device_name` (string) - The device name exposed to the instance (for
-        example, "/dev/sdh" or "xvdh"). Required when specifying `volume_size`.
-    -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
-    -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
-        volume supports. See the documentation on
-        [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
-        for more information
-    -   `no_device` (boolean) - Suppresses the specified device included in the
-        block device mapping of the AMI
-    -   `snapshot_id` (string) - The ID of the snapshot
-    -   `virtual_name` (string) - The virtual device name. See the documentation on
-        [Block Device
-        Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
-        for more information
-    -   `volume_size` (integer) - The size of the volume, in GiB. Required if not
-        specifying a `snapshot_id`
-    -   `volume_type` (string) - The volume type. gp2 for General Purpose (SSD)
-        volumes, io1 for Provisioned IOPS (SSD) volumes, and standard for Magnetic
-        volumes
+
+    <%= partial "partials/builders/ami-block-device-mappings" %>
+
 -   `ami_description` (string) - The description to set for the
     resulting AMI(s). By default this description is empty.
 
@@ -188,8 +170,8 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
--   `skip_region_validation` (boolean) - Set to true if you want to skip 
-    validation of the region configuration option.  Defaults to false.
+-   `skip_region_validation` (boolean) - Set to true if you want to skip
+    validation of the region configuration option.  Default `false`.
 
 -   `source_ami_filter` (object) - Filters used to populate the `source_ami` field.
     Example:

--- a/website/source/partials/builders/_amazon-required.html.md.erb
+++ b/website/source/partials/builders/_amazon-required.html.md.erb
@@ -1,0 +1,54 @@
+-   `access_key` (string) - The access key used to communicate with AWS. [Learn
+    how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
+
+<% if 'amazon-instance' == current_page.data.builder %>
+-   `account_id` (string) - Your AWS account ID. This is required for bundling
+    the AMI. This is *not the same* as the access key. You can find your account
+    ID in the security credentials page of your AWS account.
+<% end %>
+
+-   `ami_name` (string) - The name of the resulting AMI that will appear when
+    managing AMIs in the AWS console or via APIs. This must be unique. To help
+    make this unique, use a function like `timestamp` (see [configuration
+    templates](/docs/templates/configuration-templates.html) for more info)
+
+<% if ['amazon-instance', 'amazon-ebs'].include? current_page.data.builder %>
+-   `instance_type` (string) - The EC2 instance type to use while building the
+    AMI, such as "m1.small".
+
+-   `region` (string) - The name of the region, such as "us-east-1", in which to
+    launch the EC2 instance to create the AMI.
+<% end %>
+
+<% if 'amazon-instance' == current_page.data.builder %>
+-   `s3_bucket` (string) - The name of the S3 bucket to upload the AMI. This
+    bucket will be created if it doesn't exist.
+<% end %>
+
+-   `secret_key` (string) - The secret key used to communicate with AWS. [Learn
+    how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
+
+<% if 'amazon-instance' == current_page.data.builder %>
+-   `source_ami` (string) - The initial AMI used as a base for the newly
+    created machine.
+<% elsif 'amazon-ebs' == current_page.data.builder %>
+-   `source_ami` (string) - The initial AMI used as a base for the newly
+    created machine. `source_ami_filter` may be used instead to populate this
+    automatically.
+<% elsif 'amazon-chroot' == current_page.data.builder %>
+-   `source_ami` (string) - The source AMI whose root volume will be copied and
+    provisioned on the currently running instance. This must be an EBS-backed
+    AMI with a root volume snapshot that you have access to. Note: this is not
+    used when `from_scratch` is set to true.
+<% end %>
+
+<% if 'amazon-instance' == current_page.data.builder %>
+-   `x509_cert_path` (string) - The local path to a valid X509 certificate for
+    your AWS account. This is used for bundling the AMI. This X509 certificate
+    must be registered with your account from the security credentials page in
+    the AWS console.
+
+-   `x509_key_path` (string) - The local path to the private key for the X509
+    certificate specified by `x509_cert_path`. This is used for bundling
+    the AMI.
+<% end %>

--- a/website/source/partials/builders/_ami-block-device-mappings.html.md
+++ b/website/source/partials/builders/_ami-block-device-mappings.html.md
@@ -1,0 +1,33 @@
+-   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
+    deleted on instance termination. Default `false`. **NOTE**: If this
+    value is not explicitly set to `true` and volumes are not cleaned up by
+    an alternative method, additional volumes will accumulate after
+    every build.
+
+-   `device_name` (string) - The device name exposed to the instance (for
+     example, "/dev/sdh" or "xvdh"). Required when specifying `volume_size`.
+
+-   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
+
+-   `iops` (integer) - The number of I/O operations per second (IOPS) that the
+    volume supports. See the documentation on
+    [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
+    for more information
+
+-   `no_device` (boolean) - Suppresses the specified device included in the
+    block device mapping of the AMI
+
+-   `snapshot_id` (string) - The ID of the snapshot
+
+-   `virtual_name` (string) - The virtual device name. See the documentation on
+    [Block Device
+    Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
+    for more information
+
+-   `volume_size` (integer) - The size of the volume, in GiB. Required if not
+    specifying a `snapshot_id`
+
+-   `volume_type` (string) - The volume type. gp2 for General Purpose (SSD)
+    volumes, io1 for Provisioned IOPS (SSD) volumes, and standard for Magnetic
+    volumes
+


### PR DESCRIPTION
This is just an idea I had while working on #4061. Would it be helpful to pull the docs into partials, so all the fields for a given section of each amazon builder are listed in the same file. I feel like this could help decrease inconsistencies in documentation between the three because there'd only be one file to edit.

If you think it's a decent idea, I'll take this work further and extend it to address the Optional stuff as well. Cheers 
