### PR TITLE
googlecompute-export: use application default credential 

### DIFF
--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -2,7 +2,6 @@ package googlecomputeexport
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/mitchellh/multistep"
@@ -83,13 +82,12 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		exporterConfig.CalcTimeout()
 
 		// Set up credentials and GCE driver.
-		b, err := ioutil.ReadFile(accountKeyFilePath)
-		if err != nil {
-			err = fmt.Errorf("Error fetching account credentials: %s", err)
-			return nil, p.config.KeepOriginalImage, err
+		if accountKeyFilePath != "" {
+			err := googlecompute.ProcessAccountFile(&exporterConfig.Account, accountKeyFilePath)
+			if err != nil {
+				return nil, p.config.KeepOriginalImage, err
+			}
 		}
-		accountKeyContents := string(b)
-		googlecompute.ProcessAccountFile(&exporterConfig.Account, accountKeyContents)
 		driver, err := googlecompute.NewDriverGCE(ui, projectId, &exporterConfig.Account)
 		if err != nil {
 			return nil, p.config.KeepOriginalImage, err


### PR DESCRIPTION
Current googlecompute-export uses `account_file` field in googlecompute builder's config,
so `account_file` field cannot be omitted.

With this change, googlecompute-export use application default credential (if `account_file` field is omitted)
as same as googlecompute builder.