### PR TITLE
Deletes snapshots on AMI artifact destroy

### DIFF
--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -99,7 +99,19 @@ func (a *Artifact) Destroy() error {
 			errors = append(errors, err)
 		}
 
-		// TODO(mitchellh): Delete the snapshots associated with an AMI too
+		// Delete snapshots associated with image
+		image := imageResp.Images[0]
+		for _, device := range image.BlockDeviceMappings {
+			if device.Ebs != nil && device.Ebs.SnapshotId != nil {
+				log.Printf("Deleting snapshot ID (%s) from region (%s)", *device.Ebs.SnapshotId, region)
+				input := &ec2.DeleteSnapshotInput{
+					SnapshotId: aws.String(*device.Ebs.SnapshotId),
+				}
+				if _, err := regionConn.DeleteSnapshot(input); err != nil {
+					errors = append(errors, err)
+				}
+			}
+		}
 	}
 
 	if len(errors) > 0 {


### PR DESCRIPTION
I created this PR at the recommendation of @rickard-von-essen in a
[previous PR](https://github.com/mitchellh/packer/pull/4015#issuecomment-263074360),
but upon further review, I don't really know how to test that it works.

Maybe this is asking too much, but could someone help me figure out what
triggers the `Destroy()` function? This would help me determine whether
this functionality is backwards compatible or not.