### PR TITLE
Allow skipping Chef Client staging directory cleanup.

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -63,6 +63,7 @@ type Config struct {
 	ServerUrl                  string   `mapstructure:"server_url"`
 	SkipCleanClient            bool     `mapstructure:"skip_clean_client"`
 	SkipCleanNode              bool     `mapstructure:"skip_clean_node"`
+	SkipCleanStagingDirectory  bool     `mapstructure:"skip_clean_staging_directory"`
 	SkipInstall                bool     `mapstructure:"skip_install"`
 	SslVerifyMode              string   `mapstructure:"ssl_verify_mode"`
 	TrustedCertsDir            string   `mapstructure:"trusted_certs_dir"`
@@ -319,8 +320,10 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		return fmt.Errorf("Error executing Chef: %s", err)
 	}
 
-	if err := p.removeDir(ui, comm, p.config.StagingDir); err != nil {
-		return fmt.Errorf("Error removing %s: %s", p.config.StagingDir, err)
+	if !p.config.SkipCleanStagingDirectory {
+		if err := p.removeDir(ui, comm, p.config.StagingDir); err != nil {
+			return fmt.Errorf("Error removing %s: %s", p.config.StagingDir, err)
+		}
 	}
 
 	return nil

--- a/website/source/docs/provisioners/chef-client.html.md
+++ b/website/source/docs/provisioners/chef-client.html.md
@@ -104,6 +104,9 @@ configuration is actually required.
 -   `skip_clean_node` (boolean) - If true, Packer won't remove the node from the
     Chef server after it is done running. By default, this is false.
 
+-   `skip_clean_staging_directory` (boolean) - If true, Packer won't remove the Chef staging
+    directory from the machine after it is done running. By default, this is false.
+
 -   `skip_install` (boolean) - If true, Chef will not automatically be installed
     on the machine using the Chef omnibus installers.
 


### PR DESCRIPTION
This change allows skipping deletion of the Chef Client staging directory, which leaves files like `client.rb` and `encrypted_data_bag_secret` available for other provisioners to consume.

The specific use case here is for running Chef again after an image boots, without having to reprovision credentials on the box independently of the image creation process, but several others were described in #3151.