### PR TITLE
support token authentication in openstack

### DIFF
--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -24,6 +24,7 @@ type AccessConfig struct {
 	Insecure         bool   `mapstructure:"insecure"`
 	Region           string `mapstructure:"region"`
 	EndpointType     string `mapstructure:"endpoint_type"`
+	TokenID          string `mapstructure:"token"`
 
 	osClient *gophercloud.ProviderClient
 }
@@ -72,6 +73,7 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 		{&c.TenantName, &ao.TenantName},
 		{&c.DomainID, &ao.DomainID},
 		{&c.DomainName, &ao.DomainName},
+		{&c.TokenID, &ao.TokenID},
 	}
 	for _, s := range overrides {
 		if *s.From != "" {

--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"crypto/tls"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 
@@ -56,7 +57,10 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 
 	// Get as much as possible from the end
-	ao, _ := openstack.AuthOptionsFromEnv()
+	ao, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		log.Printf("[WARN] Error getting openstack auth from environment: %s", err)
+	}
 
 	// Make sure we reauth as needed
 	ao.AllowReauth = true


### PR DESCRIPTION
resolves #4415 

todo:
- [ ] document
- [ ] get other options from env

Also noticed that if you're using a token and not username/password, the gophercloud auth from env function https://github.com/gophercloud/gophercloud/blob/50cdddf51c54e8df178af065055cbc5b3cf442e1/openstack/auth_env.go#L30 will bail out. Naturally, if you're using a token you won't be using a username/pass, so the function won't get any info from env