### PR TITLE
Better Windows support in puppet. guess guest os type

### DIFF
--- a/common/step_provision.go
+++ b/common/step_provision.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"github.com/mitchellh/multistep"
-	"github.com/mitchellh/packer/packer"
 	"log"
 	"time"
+
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
 )
 
 // StepProvision runs the provisioners.

--- a/communicator/ssh/communicator_test.go
+++ b/communicator/ssh/communicator_test.go
@@ -120,7 +120,7 @@ func newMockBrokenServer(t *testing.T) string {
 
 func TestCommIsCommunicator(t *testing.T) {
 	var raw interface{}
-	raw = &comm{}
+	raw = &Communicator{}
 	if _, ok := raw.(packer.Communicator); !ok {
 		t.Fatalf("comm must be a communicator")
 	}

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -119,42 +119,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		return err
 	}
 
-	if p.config.GuestOSType == "" {
-		p.config.GuestOSType = provisioner.DefaultOSType
-	}
-	p.config.GuestOSType = strings.ToLower(p.config.GuestOSType)
-
-	var ok bool
-	p.guestOSTypeConfig, ok = guestOSTypeConfigs[p.config.GuestOSType]
-	if !ok {
-		return fmt.Errorf("Invalid guest_os_type: \"%s\"", p.config.GuestOSType)
-	}
-
-	p.guestCommands, err = provisioner.NewGuestCommands(p.config.GuestOSType, !p.config.PreventSudo)
-	if err != nil {
-		return fmt.Errorf("Invalid guest_os_type: \"%s\"", p.config.GuestOSType)
-	}
-
-	if p.config.ExecuteCommand == "" {
-		p.config.ExecuteCommand = p.guestOSTypeConfig.executeCommand
-	}
-
-	if p.config.InstallCommand == "" {
-		p.config.InstallCommand = p.guestOSTypeConfig.installCommand
-	}
-
-	if p.config.RunList == nil {
-		p.config.RunList = make([]string, 0)
-	}
-
-	if p.config.StagingDir == "" {
-		p.config.StagingDir = p.guestOSTypeConfig.stagingDir
-	}
-
-	if p.config.KnifeCommand == "" {
-		p.config.KnifeCommand = p.guestOSTypeConfig.knifeCommand
-	}
-
 	var errs *packer.MultiError
 	if p.config.ConfigTemplate != "" {
 		fi, err := os.Stat(p.config.ConfigTemplate)
@@ -312,6 +276,51 @@ func (p *Provisioner) Cancel() {
 	// Just hard quit. It isn't a big deal if what we're doing keeps
 	// running on the other side.
 	os.Exit(0)
+}
+
+func (p *Provisioner) prepareGuestOs(comm packer.Communicator) error {
+	if p.config.GuestOSType == "" {
+		osType, err := provisioner.GuestOSTypeFromComm(comm)
+		if err != nil {
+			return err
+		}
+		p.config.GuestOSType = osType
+	}
+	p.config.GuestOSType = strings.ToLower(p.config.GuestOSType)
+
+	var ok bool
+	p.guestOSTypeConfig, ok = guestOSTypeConfigs[p.config.GuestOSType]
+	if !ok {
+		return fmt.Errorf("Invalid guest_os_type: \"%s\"", p.config.GuestOSType)
+	}
+
+	var err error
+	p.guestCommands, err = provisioner.NewGuestCommands(p.config.GuestOSType, !p.config.PreventSudo)
+	if err != nil {
+		return fmt.Errorf("Invalid guest_os_type: \"%s\"", p.config.GuestOSType)
+	}
+
+	if p.config.ExecuteCommand == "" {
+		p.config.ExecuteCommand = p.guestOSTypeConfig.executeCommand
+	}
+
+	if p.config.InstallCommand == "" {
+		p.config.InstallCommand = p.guestOSTypeConfig.installCommand
+	}
+
+	if p.config.RunList == nil {
+		p.config.RunList = make([]string, 0)
+	}
+
+	if p.config.StagingDir == "" {
+		p.config.StagingDir = p.guestOSTypeConfig.stagingDir
+	}
+
+	if p.config.KnifeCommand == "" {
+		p.config.KnifeCommand = p.guestOSTypeConfig.knifeCommand
+	}
+	return nil
+
 }
 
 func (p *Provisioner) uploadDirectory(ui packer.Ui, comm packer.Communicator, dst string, src string) error {

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -184,7 +184,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	err := p.prepareGuestOS(comm)
 	if err != nil {
-		return fmt.Errorf("Error discovering guest OS.")
+		return fmt.Errorf("Error discovering guest OS: %s", err)
 	}
 
 	ui.Say("Provisioning with Chef-client...")

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -182,7 +182,12 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
+	err := p.prepareGuestOS(comm)
+	if err != nil {
+		return fmt.Errorf("Error discovering guest OS.")
+	}
 
+	ui.Say("Provisioning with Chef-client...")
 	nodeName := p.config.NodeName
 	if nodeName == "" {
 		nodeName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
@@ -278,7 +283,7 @@ func (p *Provisioner) Cancel() {
 	os.Exit(0)
 }
 
-func (p *Provisioner) prepareGuestOs(comm packer.Communicator) error {
+func (p *Provisioner) prepareGuestOS(comm packer.Communicator) error {
 	if p.config.GuestOSType == "" {
 		osType, err := provisioner.GuestOSTypeFromComm(comm)
 		if err != nil {

--- a/provisioner/chef-client/provisioner_test.go
+++ b/provisioner/chef-client/provisioner_test.go
@@ -12,7 +12,8 @@ import (
 
 func testConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"server_url": "foo",
+		"server_url":    "foo",
+		"guest_os_type": "unix",
 	}
 }
 
@@ -199,6 +200,10 @@ func TestProvisioner_createDir(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
+		if err := p.prepareGuestOS(comm); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
 		if err := p.createDir(ui, comm, "/tmp/foo"); err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -227,6 +232,10 @@ func TestProvisioner_removeDir(t *testing.T) {
 
 		err := p.Prepare(config)
 		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if err := p.prepareGuestOS(comm); err != nil {
 			t.Fatalf("err: %s", err)
 		}
 

--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -196,7 +196,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	err := p.prepareGuestOS(comm)
 	if err != nil {
-		return fmt.Errorf("Error discovering guest OS.")
+		return fmt.Errorf("Error discovering guest OS: %s", err)
 	}
 
 	ui.Say("Provisioning with chef-solo")

--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -194,6 +194,11 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
+	err := p.prepareGuestOS(comm)
+	if err != nil {
+		return fmt.Errorf("Error discovering guest OS.")
+	}
+
 	ui.Say("Provisioning with chef-solo")
 
 	if !p.config.SkipInstall {
@@ -271,7 +276,7 @@ func (p *Provisioner) Cancel() {
 	os.Exit(0)
 }
 
-func (p *Provisioner) prepareGuestOs(comm packer.Communicator) error {
+func (p *Provisioner) prepareGuestOS(comm packer.Communicator) error {
 	if p.config.GuestOSType == "" {
 		osType, err := provisioner.GuestOSTypeFromComm(comm)
 		if err != nil {

--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -3,6 +3,10 @@ package provisioner
 import (
 	"fmt"
 	"strings"
+
+	"github.com/mitchellh/packer/communicator/ssh"
+	"github.com/mitchellh/packer/communicator/winrm"
+	"github.com/mitchellh/packer/packer"
 )
 
 const UnixOSType = "unix"
@@ -26,6 +30,17 @@ var guestOSTypeCommands = map[string]guestOSTypeCommand{
 		mkdir:     "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s\"",
 		removeDir: "powershell.exe -Command \"rm %s -recurse -force\"",
 	},
+}
+
+func GuestOSTypeFromComm(comm packer.Communicator) (string, error) {
+	switch comm.(type) {
+	case *winrm.Communicator:
+		return WindowsOSType, nil
+	case *ssh.Communicator:
+		return UnixOSType, nil
+	default:
+		return "", fmt.Errorf("Unable to guess guest os type from connection type. Please specify `guest_os_type` in the provisioner.")
+	}
 }
 
 type GuestCommands struct {

--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -191,10 +191,10 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	err := p.prepareGuestOS(comm)
 	if err != nil {
-		return fmt.Errorf("Error discovering guest OS.")
+		return fmt.Errorf("Error discovering guest OS: %s", err)
 	}
 
-	ui.Say("Provisioning with Puppet...")
+	ui.Say("Provisioning with pupper-masterless...")
 	ui.Message("Creating Puppet staging directory...")
 	if err := p.createDir(ui, comm, p.config.StagingDir); err != nil {
 		return fmt.Errorf("Error creating staging directory: %s", err)

--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -63,8 +63,8 @@ type Config struct {
 	// If true, packer will ignore all exit-codes from a puppet run
 	IgnoreExitCodes bool `mapstructure:"ignore_exit_codes"`
 
-	GuestOSType    string `mapstructure:"guest_os_type"`
-	ConfigTemplate string `mapstructure:"config_template"`
+	// The Guest OS Type (unix or windows)
+	GuestOSType string `mapstructure:"guest_os_type"`
 }
 
 type guestOSTypeConfig struct {
@@ -73,7 +73,7 @@ type guestOSTypeConfig struct {
 }
 
 var guestOSTypeConfigs = map[string]guestOSTypeConfig{
-	provisioner.UnixOSType: guestOSTypeConfig{
+	provisioner.UnixOSType: {
 		stagingDir: "/tmp/packer-puppet-masterless",
 		executeCommand: "cd {{.WorkingDir}} && " +
 			"{{.FacterVars}} {{if .Sudo}} sudo -E {{end}}" +
@@ -84,7 +84,7 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 			"{{if ne .ExtraArguments \"\"}}{{.ExtraArguments}} {{end}}" +
 			"{{.ManifestFile}}",
 	},
-	provisioner.WindowsOSType: guestOSTypeConfig{
+	provisioner.WindowsOSType: {
 		stagingDir: "C:/Windows/Temp/packer-puppet-masterless",
 		executeCommand: "cd {{.WorkingDir}} && " +
 			"{{.FacterVars}} && " +
@@ -212,17 +212,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if p.config.ExecuteCommand == "" {
 		p.config.ExecuteCommand = p.guestOSTypeConfig.executeCommand
-	}
-
-	if p.config.ConfigTemplate != "" {
-		fi, err := os.Stat(p.config.ConfigTemplate)
-		if err != nil {
-			errs = packer.MultiErrorAppend(
-				errs, fmt.Errorf("Bad config template path: %s", err))
-		} else if fi.IsDir() {
-			errs = packer.MultiErrorAppend(
-				errs, fmt.Errorf("Config template path must be a file: %s", err))
-		}
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -189,7 +189,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
-	err := p.prepareGuestOs(comm)
+	err := p.prepareGuestOS(comm)
 	if err != nil {
 		return fmt.Errorf("Error discovering guest OS.")
 	}
@@ -298,7 +298,7 @@ func (p *Provisioner) Cancel() {
 	os.Exit(0)
 }
 
-func (p *Provisioner) prepareGuestOs(comm packer.Communicator) error {
+func (p *Provisioner) prepareGuestOS(comm packer.Communicator) error {
 	if p.config.GuestOSType == "" {
 		osType, err := provisioner.GuestOSTypeFromComm(comm)
 		if err != nil {

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -17,6 +17,7 @@ func testConfig() map[string]interface{} {
 
 	return map[string]interface{}{
 		"manifest_file": tf.Name(),
+		"guest_os_type": "unix",
 	}
 }
 
@@ -246,11 +247,16 @@ func TestProvisionerPrepare_extraArguments(t *testing.T) {
 
 func TestProvisionerPrepare_stagingDir(t *testing.T) {
 	config := testConfig()
+	comm := &packer.MockCommunicator{}
 
 	delete(config, "staging_directory")
 	p := new(Provisioner)
 	err := p.Prepare(config)
 	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := p.prepareGuestOS(comm); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -266,6 +272,9 @@ func TestProvisionerPrepare_stagingDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	if err := p.prepareGuestOS(comm); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
 	if p.config.StagingDir != "/tmp/override" {
 		t.Fatalf("err: Overridden staging_directory is not set correctly in the Puppet provisioner!")
@@ -274,11 +283,16 @@ func TestProvisionerPrepare_stagingDir(t *testing.T) {
 
 func TestProvisionerPrepare_workingDir(t *testing.T) {
 	config := testConfig()
+	comm := &packer.MockCommunicator{}
 
 	delete(config, "working_directory")
 	p := new(Provisioner)
 	err := p.Prepare(config)
 	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := p.prepareGuestOS(comm); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -297,6 +311,10 @@ func TestProvisionerPrepare_workingDir(t *testing.T) {
 	p = new(Provisioner)
 	err = p.Prepare(config)
 	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := p.prepareGuestOS(comm); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -160,7 +160,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
-	err := p.prepareGuestOs(comm)
+	err := p.prepareGuestOS(comm)
 	if err != nil {
 		return fmt.Errorf("Error discovering guest OS.")
 	}
@@ -239,7 +239,7 @@ func (p *Provisioner) Cancel() {
 	os.Exit(0)
 }
 
-func (p *Provisioner) prepareGuestOs(comm packer.Communicator) error {
+func (p *Provisioner) prepareGuestOS(comm packer.Communicator) error {
 	if p.config.GuestOSType == "" {
 		osType, err := provisioner.GuestOSTypeFromComm(comm)
 		if err != nil {

--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -162,10 +162,10 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	err := p.prepareGuestOS(comm)
 	if err != nil {
-		return fmt.Errorf("Error discovering guest OS.")
+		return fmt.Errorf("Error discovering guest OS: %s", err)
 	}
 
-	ui.Say("Provisioning with Puppet...")
+	ui.Say("Provisioning with puppet-server...")
 	ui.Message("Creating Puppet staging directory...")
 	if err := p.createDir(ui, comm, p.config.StagingDir); err != nil {
 		return fmt.Errorf("Error creating staging directory: %s", err)

--- a/provisioner/puppet-server/provisioner_test.go
+++ b/provisioner/puppet-server/provisioner_test.go
@@ -15,6 +15,7 @@ func testConfig() map[string]interface{} {
 
 	return map[string]interface{}{
 		"puppet_server": tf.Name(),
+		"guest_os_type": "unix",
 	}
 }
 
@@ -182,11 +183,16 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 
 func TestProvisionerPrepare_stagingDir(t *testing.T) {
 	config := testConfig()
+	comm := &packer.MockCommunicator{}
 
 	delete(config, "staging_dir")
 	p := new(Provisioner)
 	err := p.Prepare(config)
 	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := p.prepareGuestOS(comm); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -200,6 +206,9 @@ func TestProvisionerPrepare_stagingDir(t *testing.T) {
 	p = new(Provisioner)
 	err = p.Prepare(config)
 	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := p.prepareGuestOS(comm); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/website/source/docs/provisioners/chef-client.html.md
+++ b/website/source/docs/provisioners/chef-client.html.md
@@ -61,7 +61,8 @@ configuration is actually required.
 
 -   `guest_os_type` (string) - The target guest OS type, either "unix" or
     "windows". Setting this to "windows" will cause the provisioner to use
-     Windows friendly paths and commands. By default, this is "unix".
+     Windows friendly paths and commands. By default, this is guessed from the
+     communicator type: winrm for Windows, ssh for Unix.
 
 -   `install_command` (string) - The command used to install Chef. This has
     various [configuration template

--- a/website/source/docs/provisioners/chef-solo.html.md
+++ b/website/source/docs/provisioners/chef-solo.html.md
@@ -70,7 +70,8 @@ configuration is actually required, but at least `run_list` is recommended.
 
 -   `guest_os_type` (string) - The target guest OS type, either "unix" or
     "windows". Setting this to "windows" will cause the provisioner to use
-     Windows friendly paths and commands. By default, this is "unix".
+     Windows friendly paths and commands. By default, this is guessed from the
+     communicator type: winrm for Windows, ssh for Unix.
 
 -   `install_command` (string) - The command used to install Chef. This has
     various [configuration template

--- a/website/source/docs/provisioners/puppet-masterless.html.md
+++ b/website/source/docs/provisioners/puppet-masterless.html.md
@@ -61,7 +61,8 @@ Optional parameters:
 
 -   `guest_os_type` (string) - The target guest OS type, either "unix" or
     "windows". Setting this to "windows" will cause the provisioner to use
-     Windows friendly paths and commands. By default, this is "unix".
+     Windows friendly paths and commands. By default, this is guessed from the
+     communicator type: winrm for Windows, ssh for Unix.
 
 -   `extra_arguments` (array of strings) - This is an array of additional options to
     pass to the puppet command when executing puppet. This allows for

--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -68,12 +68,13 @@ listed below:
 -   `puppet_server` (string) - Hostname of the Puppet server. By default
     "puppet" will be used.
 
--   `staging_dir` (string) - This is the directory where all the
-    configuration of Puppet by Packer will be placed. By default this
-    is /tmp/packer-puppet-server. This directory doesn't need to exist but
-    must have proper permissions so that the SSH user that Packer uses is able
-    to create directories and write into this folder. If the permissions are not
-    correct, use a shell provisioner prior to this to configure it properly.
+-   `staging_dir` (string) - This is the directory where all the configuration
+    of Puppet by Packer will be placed. By default this is "/tmp/packer-puppet-server"
+    when guest_os_type unix and "C:/Windows/Temp/packer-puppet-server" when windows.
+    This directory doesn't need to exist but must have proper permissions so that
+    the SSH user that Packer uses is able to create directories and write into this
+    folder. If the permissions are not correct, use a shell provisioner prior to this
+    to configure it properly.
 
 -   `puppet_bin_dir` (string) - The path to the directory that contains the puppet
     binary for running `puppet agent`. Usually, this would be found via the `$PATH`
@@ -83,18 +84,11 @@ listed below:
 -   `execute_command` (string) - This is optional. The command used to execute Puppet. This has
     various [configuration template
     variables](/docs/templates/configuration-templates.html) available. See
-    below for more information. By default, Packer uses the following command:
+    below for more information.
 
-```
-{{.FacterVars}} {{if .Sudo}} sudo -E {{end}} \
-  {{if ne .PuppetBinDir \"\"}}{{.PuppetBinDir}}/{{end}}puppet agent --onetime --no-daemonize \
-  {{if ne .PuppetServer \"\"}}--server='{{.PuppetServer}}' {{end}} \
-  {{if ne .Options \"\"}}{{.Options}} {{end}} \
-  {{if ne .PuppetNode \"\"}}--certname={{.PuppetNode}} {{end}} \
-  {{if ne .ClientCertPath \"\"}}--certdir='{{.ClientCertPath}}' {{end}} \
-  {{if ne .ClientPrivateKeyPath \"\"}}--privatekeydir='{{.ClientPrivateKeyPath}}' \
-  {{end}} --detailed-exitcodes
-```
+-   `guest_os_type` (string) - The target guest OS type, either "unix" or
+    "windows". Setting this to "windows" will cause the provisioner to use
+     Windows friendly paths and commands. By default, this is "unix".
 
 ## Default Facts
 

--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -88,7 +88,8 @@ listed below:
 
 -   `guest_os_type` (string) - The target guest OS type, either "unix" or
     "windows". Setting this to "windows" will cause the provisioner to use
-     Windows friendly paths and commands. By default, this is "unix".
+     Windows friendly paths and commands. By default, this is guessed from the
+     communicator type: winrm for Windows, ssh for Unix.
 
 ## Default Facts
 


### PR DESCRIPTION
This builds upon #4391, but also adds the ability to auto-discover the guest os type from the communicator type. This way, most puppet/chef users will not have to change their templates

Replaces #4391

Closes #4384
Closes #2566