### PR TITLE
Delay extra args 4462

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-
+* text=auto
+*.go text eol=lf
+*.sh text eol=lf
 common/test-fixtures/root/*	eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ packer-test*.log
 *.iml
 Thumbs.db
 /packer.exe
+.project

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VET?=$(shell ls -d */ | grep -v vendor | grep -v website)
 GITSHA:=$(shell git rev-parse HEAD)
 # Get the current local branch name from git (if we can, this may be blank)
 GITBRANCH:=$(shell git symbolic-ref --short HEAD 2>/dev/null)
-GOFMT_FILES?=$$(find . -not -path "./vendor/*" -name "*.go")
+GOFMT_FILES?=find . -path ./vendor -prune -o -name "*.go"
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 GOPATH=$(shell go env GOPATH)
@@ -58,10 +58,13 @@ dev: deps ## Build and install a development build
 	@cp $(GOPATH)/bin/packer pkg/$(GOOS)_$(GOARCH)
 
 fmt: ## Format Go code
-	@gofmt -w -s $(GOFMT_FILES)
+	@$(GOFMT_FILES) | xargs gofmt -w -s
 
 fmt-check: ## Check go code formatting
-	$(CURDIR)/scripts/gofmtcheck.sh $(GOFMT_FILES)
+	@echo "==> Checking that code complies with gofmt requirements..."
+	@echo "You can use the command: \`make fmt\` to reformat code."
+	@$(GOFMT_FILES) | xargs $(CURDIR)/scripts/gofmtcheck.sh
+	@echo "Check complete."
 
 fmt-docs:
 	@find ./website/source/docs -name "*.md" -exec pandoc --wrap auto --columns 79 --atx-headers -s -f "markdown_github+yaml_metadata_block" -t "markdown_github+yaml_metadata_block" {} -o {} \;

--- a/builder/vmware/common/step_compact_disk.go
+++ b/builder/vmware/common/step_compact_disk.go
@@ -28,7 +28,7 @@ type StepCompactDisk struct {
 func (s StepCompactDisk) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
-	diskPaths := state.Get("disk_full_paths").([]string)
+	diskFullPaths := state.Get("disk_full_paths").([]string)
 
 	if s.Skip {
 		log.Println("Skipping disk compaction step...")
@@ -36,22 +36,22 @@ func (s StepCompactDisk) Run(_ context.Context, state multistep.StateBag) multis
 	}
 
 	ui.Say("Compacting all attached virtual disks...")
-	for i, diskPath := range diskPaths {
+	for i, diskFullPath := range diskFullPaths {
 		ui.Message(fmt.Sprintf("Compacting virtual disk %d", i+1))
 		// Get the file size of the virtual disk prior to compaction
-		fi, err := os.Stat(diskPath)
+		fi, err := os.Stat(diskFullPath)
 		if err != nil {
 			state.Put("error", fmt.Errorf("Error getting virtual disk file info pre compaction: %s", err))
 			return multistep.ActionHalt
 		}
 		diskFileSizeStart := fi.Size()
 		// Defragment and compact the disk
-		if err := driver.CompactDisk(diskPath); err != nil {
+		if err := driver.CompactDisk(diskFullPath); err != nil {
 			state.Put("error", fmt.Errorf("Error compacting disk: %s", err))
 			return multistep.ActionHalt
 		}
 		// Get the file size of the virtual disk post compaction
-		fi, err = os.Stat(diskPath)
+		fi, err = os.Stat(diskFullPath)
 		if err != nil {
 			state.Put("error", fmt.Errorf("Error getting virtual disk file info post compaction: %s", err))
 			return multistep.ActionHalt

--- a/builder/vmware/common/step_compact_disk_test.go
+++ b/builder/vmware/common/step_compact_disk_test.go
@@ -23,8 +23,8 @@ func TestStepCompactDisk(t *testing.T) {
 		t.Fatalf("Error creating fake vmdk file: %s", err)
 	}
 
-	diskPath := diskFile.Name()
-	defer os.Remove(diskPath)
+	diskFullPath := diskFile.Name()
+	defer os.Remove(diskFullPath)
 
 	content := []byte("I am the fake vmdk's contents")
 	if _, err := diskFile.Write(content); err != nil {
@@ -35,7 +35,7 @@ func TestStepCompactDisk(t *testing.T) {
 	}
 
 	// Set up required state
-	state.Put("disk_full_paths", []string{diskPath})
+	state.Put("disk_full_paths", []string{diskFullPath})
 
 	driver := state.Get("driver").(*DriverMock)
 
@@ -51,7 +51,7 @@ func TestStepCompactDisk(t *testing.T) {
 	if !driver.CompactDiskCalled {
 		t.Fatal("should've called")
 	}
-	if driver.CompactDiskPath != diskPath {
+	if driver.CompactDiskPath != diskFullPath {
 		t.Fatal("should call with right path")
 	}
 }
@@ -61,8 +61,8 @@ func TestStepCompactDisk_skip(t *testing.T) {
 	step := new(StepCompactDisk)
 	step.Skip = true
 
-	diskPaths := []string{"foo"}
-	state.Put("disk_full_paths", diskPaths)
+	diskFullPaths := []string{"foo"}
+	state.Put("disk_full_paths", diskFullPaths)
 
 	driver := state.Get("driver").(*DriverMock)
 

--- a/builder/vmware/iso/step_create_disk.go
+++ b/builder/vmware/iso/step_create_disk.go
@@ -31,26 +31,26 @@ func (stepCreateDisk) Run(_ context.Context, state multistep.StateBag) multistep
 
 	// Users can configure disks at several locations in the template so
 	// first collate all the disk requirements
-	var diskPaths, diskSizes []string
+	var diskFullPaths, diskSizes []string
 	// The 'main' or 'default' disk
-	diskPaths = append(diskPaths, filepath.Join(config.OutputDir, config.DiskName+".vmdk"))
+	diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, config.DiskName+".vmdk"))
 	diskSizes = append(diskSizes, fmt.Sprintf("%dM", uint64(config.DiskSize)))
 	// Additional disks
 	if len(config.AdditionalDiskSize) > 0 {
 		for i, diskSize := range config.AdditionalDiskSize {
 			path := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d.vmdk", config.DiskName, i+1))
-			diskPaths = append(diskPaths, path)
+			diskFullPaths = append(diskFullPaths, path)
 			size := fmt.Sprintf("%dM", uint64(diskSize))
 			diskSizes = append(diskSizes, size)
 		}
 	}
 
 	// Create all required disks
-	for i, diskPath := range diskPaths {
-		log.Printf("[INFO] Creating disk with Path: %s and Size: %s", diskPath, diskSizes[i])
+	for i, diskFullPath := range diskFullPaths {
+		log.Printf("[INFO] Creating disk with Path: %s and Size: %s", diskFullPath, diskSizes[i])
 		// Additional disks currently use the same adapter type and disk
 		// type as specified for the main disk
-		if err := driver.CreateDisk(diskPath, diskSizes[i], config.DiskAdapterType, config.DiskTypeId); err != nil {
+		if err := driver.CreateDisk(diskFullPath, diskSizes[i], config.DiskAdapterType, config.DiskTypeId); err != nil {
 			err := fmt.Errorf("Error creating disk: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
@@ -59,7 +59,7 @@ func (stepCreateDisk) Run(_ context.Context, state multistep.StateBag) multistep
 	}
 
 	// Stash the disk paths so we can retrieve later e.g. when compacting
-	state.Put("disk_full_paths", diskPaths)
+	state.Put("disk_full_paths", diskFullPaths)
 	return multistep.ActionContinue
 }
 

--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -115,13 +115,13 @@ func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	// Write out the relative, host filesystem paths to the disks
-	var diskPaths []string
+	var diskFullPaths []string
 	for _, diskFilename := range diskFilenames {
 		log.Printf("Found attached disk with filename: %s", diskFilename)
-		diskPaths = append(diskPaths, filepath.Join(s.OutputDir, diskFilename))
+		diskFullPaths = append(diskFullPaths, filepath.Join(s.OutputDir, diskFilename))
 	}
 
-	if len(diskPaths) == 0 {
+	if len(diskFullPaths) == 0 {
 		state.Put("error", fmt.Errorf("Could not enumerate disk info from the vmx file"))
 		return multistep.ActionHalt
 	}
@@ -139,7 +139,7 @@ func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multiste
 
 	// Stash all required information in our state bag
 	state.Put("vmx_path", vmxPath)
-	state.Put("disk_full_paths", diskPaths)
+	state.Put("disk_full_paths", diskFullPaths)
 	state.Put("vmnetwork", networkType)
 
 	return multistep.ActionContinue

--- a/builder/vmware/vmx/step_clone_vmx_test.go
+++ b/builder/vmware/vmx/step_clone_vmx_test.go
@@ -43,9 +43,9 @@ func TestStepCloneVMX(t *testing.T) {
 
 	// Set up expected mock disk file paths
 	diskFilenames := []string{scsiFilename, sataFilename, ideFilename, nvmeFilename}
-	var diskPaths []string
+	var diskFullPaths []string
 	for _, diskFilename := range diskFilenames {
-		diskPaths = append(diskPaths, filepath.Join(td, diskFilename))
+		diskFullPaths = append(diskFullPaths, filepath.Join(td, diskFilename))
 	}
 
 	// Create the source
@@ -91,8 +91,8 @@ func TestStepCloneVMX(t *testing.T) {
 	if stateDiskPaths, ok := state.GetOk("disk_full_paths"); !ok {
 		t.Fatal("should set disk_full_paths")
 	} else {
-		assert.ElementsMatchf(t, stateDiskPaths.([]string), diskPaths,
-			"%s\nshould contain the same elements as:\n%s", stateDiskPaths.([]string), diskPaths)
+		assert.ElementsMatchf(t, stateDiskPaths.([]string), diskFullPaths,
+			"%s\nshould contain the same elements as:\n%s", stateDiskPaths.([]string), diskFullPaths)
 	}
 
 	// Test we got the network type

--- a/packer/config_file_unix.go
+++ b/packer/config_file_unix.go
@@ -18,7 +18,7 @@ func configFile() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(dir, ".packerconfig"), nil
+	return filepath.Join(dir, "packer.config"), nil
 }
 
 func configDir() (string, error) {

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -80,7 +80,7 @@ func TestGuestOSConfig_full_unix(t *testing.T) {
 		PuppetBinDir:    p.config.PuppetBinDir,
 		Sudo:            !p.config.PreventSudo,
 		WorkingDir:      p.config.WorkingDir,
-		ExtraArguments:  strings.Join(p.config.ExtraArguments, " "),
+		Options:         strings.Join(p.config.Options, " "),
 	}
 	command, err := interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 	if err != nil {
@@ -143,7 +143,7 @@ func TestGuestOSConfig_full_windows(t *testing.T) {
 		PuppetBinDir:    p.config.PuppetBinDir,
 		Sudo:            !p.config.PreventSudo,
 		WorkingDir:      p.config.WorkingDir,
-		ExtraArguments:  strings.Join(p.config.ExtraArguments, " "),
+		Options:         strings.Join(p.config.Options, " "),
 	}
 	command, err := interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 	if err != nil {
@@ -345,11 +345,11 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 	}
 }
 
-func TestProvisionerPrepare_extraArguments(t *testing.T) {
+func TestProvisionerPrepare_options(t *testing.T) {
 	config := testConfig()
 
 	// Test with missing parameter
-	delete(config, "extra_arguments")
+	delete(config, "options")
 	p := new(Provisioner)
 	err := p.Prepare(config)
 	if err != nil {
@@ -357,7 +357,7 @@ func TestProvisionerPrepare_extraArguments(t *testing.T) {
 	}
 
 	// Test with malformed value
-	config["extra_arguments"] = "{{}}"
+	config["options"] = "{{}}"
 	p = new(Provisioner)
 	err = p.Prepare(config)
 	if err == nil {
@@ -365,7 +365,7 @@ func TestProvisionerPrepare_extraArguments(t *testing.T) {
 	}
 
 	// Test with valid values
-	config["extra_arguments"] = []string{
+	config["options"] = []string{
 		"arg",
 	}
 
@@ -437,18 +437,18 @@ func TestProvisionerPrepare_workingDir(t *testing.T) {
 	}
 }
 
-func TestProvisionerProvision_extraArguments(t *testing.T) {
+func TestProvisionerProvision_options(t *testing.T) {
 	config := testConfig()
 	ui := &packer.MachineReadableUi{
 		Writer: ioutil.Discard,
 	}
 	comm := new(packer.MockCommunicator)
 
-	extraArguments := []string{
+	options := []string{
 		"--some-arg=yup",
 		"--some-other-arg",
 	}
-	config["extra_arguments"] = extraArguments
+	config["options"] = options
 
 	// Test with valid values
 	p := new(Provisioner)
@@ -462,14 +462,14 @@ func TestProvisionerProvision_extraArguments(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	expectedArgs := strings.Join(extraArguments, " ")
+	expectedArgs := strings.Join(options, " ")
 
 	if !strings.Contains(comm.StartCmd.Command, expectedArgs) {
 		t.Fatalf("Command %q doesn't contain the expected arguments %q", comm.StartCmd.Command, expectedArgs)
 	}
 
 	// Test with missing parameter
-	delete(config, "extra_arguments")
+	delete(config, "options")
 
 	p = new(Provisioner)
 	err = p.Prepare(config)
@@ -482,7 +482,7 @@ func TestProvisionerProvision_extraArguments(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Check the expected `extra_arguments` position for an empty value
+	// Check the expected `options` position for an empty value
 	splitCommand := strings.Split(comm.StartCmd.Command, " ")
 	if "" == splitCommand[len(splitCommand)-2] {
 		t.Fatalf("Command %q contains an extra-space which may cause arg parsing issues", comm.StartCmd.Command)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-#
+
 # This script builds the application from source for multiple platforms.
+# Determine the arch/os combos we're building for
+ALL_XC_ARCH="386 amd64 arm arm64 ppc64le"
+ALL_XC_OS="linux darwin windows freebsd openbsd solaris"
+
 set -e
 
 # Get the parent directory of where this script is.
@@ -11,54 +15,88 @@ DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 # Change into that directory
 cd $DIR
 
-# Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64 arm arm64 ppc64le"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd solaris}
-
 # Delete the old dir
 echo "==> Removing old directory..."
 rm -f bin/*
 rm -rf pkg/*
 mkdir -p bin/
 
+# helpers for Cygwin-hosted builds
+: ${OSTYPE:=`uname`}
+
+case $OSTYPE in
+    MINGW*|MSYS*|cygwin|CYGWIN*)
+        # cygwin only translates ';' to ':' on select environment variables
+        PATHSEP=';'
+        ;;
+    *)	PATHSEP=':'
+esac
+
+function convert_path() {
+    local flag
+    [ "${1:0:1}" = '-' ] && { flag="$1"; shift; }
+
+    [ -n "$1" ] || return 0
+    case ${OSTYPE:-`uname`} in
+        cygwin|CYGWIN*)
+            cygpath $flag -- "$1"
+            ;;
+        *)  echo "$1"
+    esac
+}
+
+# XXX works in MINGW?
+which go &>/dev/null || PATH+=":`convert_path "${GOROOT:?}"`/bin"
+
+OLDIFS="$IFS"
+
+# make sure GOPATH is consistent - Windows binaries can't handle Cygwin-style paths
+IFS="$PATHSEP"
+for d in ${GOPATH:-$(go env GOPATH)}; do
+    _GOPATH+="${_GOPATH:+$PATHSEP}$(convert_path --windows "$d")"
+done
+GOPATH="$_GOPATH"
+
+# locate 'gox' and traverse GOPATH if needed
+which "${GOX:=gox}" &>/dev/null || {
+    for d in $GOPATH; do
+        GOX="$(convert_path --unix "$d")/bin/gox"
+        [ -x "$GOX" ] && break || unset GOX
+    done
+}
+IFS="$OLDIFS"
+
 # Build!
 echo "==> Building..."
+
+# If in dev mode, only build for ourself
+if [ -n "${PACKER_DEV+x}" ]; then
+    XC_OS=$(go env GOOS)
+    XC_ARCH=$(go env GOARCH)
+fi
+
 set +e
-gox \
-    -os="${XC_OS}" \
-    -arch="${XC_ARCH}" \
+${GOX:?command not found} \
+    -os="${XC_OS:-$ALL_XC_OS}" \
+    -arch="${XC_ARCH:-$ALL_XC_ARCH}" \
     -osarch="!darwin/arm !darwin/arm64" \
     -ldflags "${GOLDFLAGS}" \
     -output "pkg/{{.OS}}_{{.Arch}}/packer" \
     .
-set -e
 
-# Move all the compiled things to the $GOPATH/bin
-GOPATH=${GOPATH:-$(go env GOPATH)}
-case $(uname) in
-    CYGWIN*)
-        GOPATH="$(cygpath $GOPATH)"
-        ;;
-esac
-OLDIFS=$IFS
-IFS=:
-case $(uname) in
-    MINGW*)
-        IFS=";"
-        ;;
-    MSYS*)
-        IFS=";"
-        ;;
-esac
+set -e
+# trim GOPATH to first element
+IFS="$PATHSEP"
 MAIN_GOPATH=($GOPATH)
+MAIN_GOPATH="$(convert_path --unix "$MAIN_GOPATH")"
 IFS=$OLDIFS
 
 # Copy our OS/Arch to the bin/ directory
 echo "==> Copying binaries for this platform..."
 DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
 for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    cp ${F} ${MAIN_GOPATH}/bin/
+    cp -v ${F} bin/
+    cp -v ${F} ${MAIN_GOPATH}/bin/
 done
 
 # Done!

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
 
-# Check gofmt
-echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(gofmt -s -l ${@})
-if [[ -n ${gofmt_files} ]]; then
-    echo 'gofmt needs running on the following files:'
-    echo "${gofmt_files}"
-    echo "You can use the command: \`make fmt\` to reformat code."
-    exit 1
-fi
-echo "Check passed."
+for f in $@; do
+  [ -n "`dos2unix 2>/dev/null < $f | gofmt -s -d`" ] && echo $f
+done
 
+# always return success or else 'make' will abort
 exit 0

--- a/vendor/github.com/mitchellh/cli/cli.go
+++ b/vendor/github.com/mitchellh/cli/cli.go
@@ -249,14 +249,14 @@ func (c *CLI) Run() (int, error) {
 			"Invalid flags before the subcommand. If these flags are for\n" +
 				"the subcommand, please put them after the subcommand.\n\n"))
 		c.commandHelp(command)
-		return 1, nil
+		return 2, nil
 	}
 
 	code := command.Run(c.SubcommandArgs())
 	if code == RunResultHelp {
 		// Requesting help
 		c.commandHelp(command)
-		return 1, nil
+		return 0, nil
 	}
 
 	return code, nil

--- a/website/source/docs/other/debugging.html.md
+++ b/website/source/docs/other/debugging.html.md
@@ -130,4 +130,4 @@ Failed to initialize build 'docker': error initializing builder 'docker': plugin
 ```
 
 you should try setting your temp directory to something shorter. This can be
-done through the `TMPDIR` environment variable.
+done through the `PACKER_TMP_DIR` environment variable.

--- a/website/source/docs/other/environment-variables.html.md
+++ b/website/source/docs/other/environment-variables.html.md
@@ -41,8 +41,10 @@ each can be found below:
     new versions of Packer. If you want to disable this for security or privacy
     reasons, you can set this environment variable to `1`.
 
--   `TMPDIR` (Unix) / `TMP` (Windows) - The location of the directory used for temporary files (defaults
-    to `/tmp` on Linux/Unix and `%USERPROFILE%\AppData\Local\Temp` on Windows
-    Vista and above). It might be necessary to customize it when working
-    with large files since `/tmp` is a memory-backed filesystem in some Linux
-    distributions in which case `/var/tmp` might be preferred.
+-   `PACKER_TMP_DIR` - The directory used for temporary files during marshalling.
+    If unset, appends 'packer' to environment variables TEMP, TMP, or LOCALAPPDATA 
+    (Windows) before falling back to the value of `configDir()/tmp` which resolves
+    to `$HOME/.packer.d/` (Unix) or `%APPDATA%\packer.d` (Windows).
+    This is not to be confused with the provisionee's temporary directory which
+    is often defined as '/tmp' or '%SYSTEMROOT%\Temp' (Windows) suffixed by the
+    name of the module.


### PR DESCRIPTION
Fixes pre-mature interpolation of "extra_arguments" and adds "extra_arguments" to puppet-server provisioner. Here is an example from my template:

>  "extra_arguments"   : [
                "{{if ne \"{{user `environment`}}\" \"\"}}--environment={{user `environment`}}{{end}}",
                "{{if user `noop`}}--noop{{end}}",
                "{{if ne \".ModulePath\" \"\"}}--modulepath='{{.ModulePath}}:$basemodulepath'{{end}}"

Closes #4462 

{ed.) I've never programmed in GoLang and a more elegant solution may be possible that de-references p.config.ctx.Data instead of using an intermediate variable.