### PR TITLE
core: only/except validation after interpolation

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -81,6 +81,10 @@ func NewCore(c *CoreConfig) (*Core, error) {
 		result.builds[v] = b
 	}
 
+	if err := result.postRenderValidate(); err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 
@@ -217,6 +221,10 @@ func (c *Core) Context() *interpolate.Context {
 		TemplatePath:  c.Template.Path,
 		UserVariables: c.variables,
 	}
+}
+
+func (c *Core) postRenderValidate() error {
+	return c.Template.OnlyExceptValidate(c.builds)
 }
 
 // validate does a full validation of the template.


### PR DESCRIPTION
Resolves #2651

Need a few more eyes on this and some input on whether is is something we want to do.

something that needs to be investigated further before this gets merged are the overrides. I didn't update that check to look at the rendered names, so need to decide what to do about that.

TODO
- [ ] fix tests. possibly breaks the `required`ness test for variables
- [ ] comments