### PR TITLE
builder/vmware: correctly default export format to ovf

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -212,11 +212,13 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		}
 	}
 
-	if b.config.Format != "" {
-		if !(b.config.Format == "ova" || b.config.Format == "ovf" || b.config.Format == "vmx") {
-			errs = packer.MultiErrorAppend(errs,
-				fmt.Errorf("format must be one of ova, ovf, or vmx"))
-		}
+	if b.config.Format == "" {
+		b.config.Format = "ovf"
+	}
+
+	if !(b.config.Format == "ova" || b.config.Format == "ovf" || b.config.Format == "vmx") {
+		errs = packer.MultiErrorAppend(errs,
+			fmt.Errorf("format must be one of ova, ovf, or vmx"))
 	}
 
 	// Warnings
@@ -256,7 +258,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	exportOutputPath := b.config.OutputDir
 
-	if b.config.RemoteType != "" && b.config.Format != "" {
+	if b.config.RemoteType != "" {
 		b.config.OutputDir = b.config.VMName
 	}
 	dir.SetOutputDir(b.config.OutputDir)

--- a/builder/vmware/iso/step_export.go
+++ b/builder/vmware/iso/step_export.go
@@ -45,8 +45,8 @@ func (s *StepExport) Run(_ context.Context, state multistep.StateBag) multistep.
 		return multistep.ActionContinue
 	}
 
-	if c.RemoteType != "esx5" || s.Format == "" {
-		ui.Say("Skipping export of virtual machine (export is allowed only for ESXi and the format needs to be specified)...")
+	if c.RemoteType != "esx5" {
+		ui.Say("Skipping export of virtual machine (export is allowed only for ESXi)...")
 		return multistep.ActionContinue
 	}
 


### PR DESCRIPTION
Closes #3385

Need some help thinking on this.

* It looks like previously omitting a format will implicitly skip export.
* this change brings us in line with the docs, but may break existing templates (by exporting where it wouldn't before). I think this is fine since the docs haven't changed.
* https://github.com/mitchellh/packer/pull/4378 added a new skip_export option, so the implicit behavior is no longer needed.
* worth writing a fixer to change format = "" to skip_export=true?