### PR TITLE
builder/vmware-iso: Fail on wrong remote_type value

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -162,6 +162,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 			errs = packer.MultiErrorAppend(errs,
 				fmt.Errorf("remote_host must be specified"))
 		}
+		if b.config.RemoteType != "esx5" {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("Only 'esx5' value is accepted for remote_type"))
+		}
 	}
 
 	if b.config.Format != "" {

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -156,7 +156,7 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 	}
 
 	config["remote_host"] = ""
-	config["remote_type"] = "esx5"
+	config["remote_type"] = ""
 	// Bad
 	warns, err = b.Prepare(config)
 	if len(warns) > 0 {
@@ -164,6 +164,18 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("should have error")
+	}
+
+	// Good
+	config["remote_type"] = "esx5"
+	config["remote_host"] = "foobar.example.com"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
 	}
 
 	// Good

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -139,6 +139,46 @@ func TestBuilderPrepare_InvalidFloppies(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare_RemoteType(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	config["format"] = "ovf"
+	config["remote_host"] = "foobar.example.com"
+	// Bad
+	config["remote_type"] = "foobar"
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	config["remote_host"] = ""
+	config["remote_type"] = "esx5"
+	// Bad
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Good
+	config["remote_type"] = "esx5"
+	config["remote_host"] = "foobar.example.com"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
 func TestBuilderPrepare_Format(t *testing.T) {
 	var b Builder
 	config := testConfig()


### PR DESCRIPTION
Since I loose also some times on doing this silly mistake, I had prefered that the build fail directly.
Add only a test that the value of remote_type either empty or is the only one accepted.

I've also added test on this option and the remote_host.

Closes #4214

Have to be modified if someone would work on #4228
