### PR TITLE
Handle case where block devices start with both sd and xvd

### DIFF
--- a/builder/amazon/chroot/step_attach_volume.go
+++ b/builder/amazon/chroot/step_attach_volume.go
@@ -99,9 +99,8 @@ func (s *StepAttachVolume) Run(state multistep.StateBag) multistep.StepAction {
 }
 
 func statDevice(attachVolume string, state multistep.StateBag) error {
-	statAttempts := 0
 	deviceAltName := strings.Replace(attachVolume, "/sd", "/xvd", 1)
-	for statAttempts < 30 {
+	for statAttempts := 0; statAttempts < 30; statAttempts++ {
 		if _, err := os.Stat(attachVolume); err == nil {
 			state.Put("device", attachVolume)
 			return nil


### PR DESCRIPTION
When using certain AMI's as bases when packing in a chroot, a new volume attached to the instance may not enumerate using the same prefix as other block devices.  For instance, the root device may enumerate as /dev/sda1 , while subsequently attached volumes enumerate as /dev/xvdf, etc.

Formerly, the code made the assumption that only one device file type would be present. This code checks that assumption, and, after attaching the volume, ensures that the expected device is found prior to mounting the device. 