### PR TITLE
Make null builder actually have the ability to do nothing

### DIFF
--- a/builder/null/builder.go
+++ b/builder/null/builder.go
@@ -27,18 +27,25 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 }
 
 func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
-	steps := []multistep.Step{
-		&communicator.StepConnect{
-			Config: &b.config.CommConfig,
-			Host:   CommHost(b.config.CommConfig.Host()),
-			SSHConfig: SSHConfig(
-				b.config.CommConfig.SSHAgentAuth,
-				b.config.CommConfig.SSHUsername,
-				b.config.CommConfig.SSHPassword,
-				b.config.CommConfig.SSHPrivateKey),
-		},
-		&common.StepProvision{},
+	steps := []multistep.Step{}
+
+	if b.config.CommConfig.Type != "none" {
+		steps = append(steps,
+			&communicator.StepConnect{
+				Config: &b.config.CommConfig,
+				Host:   CommHost(b.config.CommConfig.Host()),
+				SSHConfig: SSHConfig(
+					b.config.CommConfig.SSHAgentAuth,
+					b.config.CommConfig.SSHUsername,
+					b.config.CommConfig.SSHPassword,
+					b.config.CommConfig.SSHPrivateKey),
+			},
+		)
 	}
+
+	steps = append(steps,
+		new(common.StepProvision),
+	)
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)

--- a/builder/null/config.go
+++ b/builder/null/config.go
@@ -31,26 +31,30 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	if es := c.CommConfig.Prepare(nil); len(es) > 0 {
 		errs = packer.MultiErrorAppend(errs, es...)
 	}
-	if c.CommConfig.Host() == "" {
-		errs = packer.MultiErrorAppend(errs,
-			fmt.Errorf("a Host must be specified, please reference your communicator documentation"))
-	}
 
-	if c.CommConfig.User() == "" {
-		errs = packer.MultiErrorAppend(errs,
-			fmt.Errorf("a Username must be specified, please reference your communicator documentation"))
-	}
+	if c.CommConfig.Type != "none" {
+		if c.CommConfig.Host() == "" {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("a Host must be specified, please reference your communicator documentation"))
+		}
 
-	if !c.CommConfig.SSHAgentAuth && c.CommConfig.Password() == "" && c.CommConfig.SSHPrivateKey == "" {
-		errs = packer.MultiErrorAppend(errs,
-			fmt.Errorf("one authentication method must be specified, please reference your communicator documentation"))
-	}
+		if c.CommConfig.User() == "" {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("a Username must be specified, please reference your communicator documentation"))
+		}
 
-	if (c.CommConfig.SSHAgentAuth &&
-		(c.CommConfig.SSHPassword != "" || c.CommConfig.SSHPrivateKey != "")) ||
-		(c.CommConfig.SSHPassword != "" && c.CommConfig.SSHPrivateKey != "") {
-		errs = packer.MultiErrorAppend(errs,
-			fmt.Errorf("only one of ssh_agent_auth, ssh_password, and ssh_private_key_file must be specified"))
+		if !c.CommConfig.SSHAgentAuth && c.CommConfig.Password() == "" && c.CommConfig.SSHPrivateKey == "" {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("one authentication method must be specified, please reference your communicator documentation"))
+		}
+
+		if (c.CommConfig.SSHAgentAuth &&
+			(c.CommConfig.SSHPassword != "" || c.CommConfig.SSHPrivateKey != "")) ||
+			(c.CommConfig.SSHPassword != "" && c.CommConfig.SSHPrivateKey != "") {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("only one of ssh_agent_auth, ssh_password, and ssh_private_key_file must be specified"))
+
+		}
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {


### PR DESCRIPTION
'null' builder currently still requires an ssh connection, this let's
the null builder actually noop by suporting `"communicator": "none"`