### PR TITLE
add skip_register_ami option

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -212,19 +212,22 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepPreValidate{
 			DestAmiName:     b.config.AMIName,
 			ForceDeregister: b.config.AMIForceDeregister,
+			SkipRegister:    b.config.AMISkipRegister,
 		},
 		&StepInstanceInfo{},
 	}
 
+	sourceInfoSteps := []multistep.Step{
+		&awscommon.StepSourceAMIInfo{
+			SourceAmi:          b.config.SourceAmi,
+			EnhancedNetworking: b.config.AMIEnhancedNetworking,
+			AmiFilters:         b.config.SourceAmiFilter,
+		},
+		&StepCheckRootDevice{},
+	}
+
 	if !b.config.FromScratch {
-		steps = append(steps,
-			&awscommon.StepSourceAMIInfo{
-				SourceAmi:          b.config.SourceAmi,
-				EnhancedNetworking: b.config.AMIEnhancedNetworking,
-				AmiFilters:         b.config.SourceAmiFilter,
-			},
-			&StepCheckRootDevice{},
-		)
+		steps = append(steps, sourceInfoSteps...)
 	}
 
 	steps = append(steps,
@@ -249,6 +252,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepCopyFiles{},
 		&StepChrootProvision{},
 		&StepEarlyCleanup{},
+	)
+
+	amiCreationSteps := []multistep.Step{
 		&StepSnapshot{},
 		&awscommon.StepDeregisterAMI{
 			ForceDeregister:     b.config.AMIForceDeregister,
@@ -282,7 +288,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SnapshotTags: b.config.SnapshotTags,
 			Ctx:          b.config.ctx,
 		},
-	)
+	}
+
+	if !b.config.AMISkipRegister {
+		steps = append(steps, amiCreationSteps...)
+	}
 
 	// Run!
 	b.runner = common.NewRunner(steps, b.config.PackerConfig, ui)

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -21,6 +21,7 @@ type AMIConfig struct {
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 	AMIForceDeleteSnapshot  bool              `mapstructure:"force_delete_snapshot"`
 	AMIEncryptBootVolume    bool              `mapstructure:"encrypt_boot"`
+	AMISkipRegister         bool              `mapstructure:"skip_register_ami"`
 	AMIKmsKeyId             string            `mapstructure:"kms_key_id"`
 	SnapshotTags            map[string]string `mapstructure:"snapshot_tags"`
 	SnapshotUsers           []string          `mapstructure:"snapshot_users"`
@@ -29,7 +30,7 @@ type AMIConfig struct {
 
 func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 	var errs []error
-	if c.AMIName == "" {
+	if c.AMIName == "" && !c.AMISkipRegister {
 		errs = append(errs, fmt.Errorf("ami_name must be specified"))
 	}
 

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -15,10 +15,17 @@ import (
 type StepPreValidate struct {
 	DestAmiName     string
 	ForceDeregister bool
+	SkipRegister    bool
 }
 
 func (s *StepPreValidate) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
+
+	if s.SkipRegister {
+		ui.Say("Skip Register flag found, skipping prevalidating AMI Name")
+		return multistep.ActionContinue
+	}
+
 	if s.ForceDeregister {
 		ui.Say("Force Deregister flag found, skipping prevalidating AMI Name")
 		return multistep.ActionContinue

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -118,6 +118,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepPreValidate{
 			DestAmiName:     b.config.AMIName,
 			ForceDeregister: b.config.AMIForceDeregister,
+			SkipRegister:    b.config.AMISkipRegister,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:          b.config.SourceAmi,
@@ -179,6 +180,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				b.config.RunConfig.Comm.SSHPassword),
 		},
 		&common.StepProvision{},
+	}
+
+	amiCreationSteps := []multistep.Step{
 		&awscommon.StepStopEBSBackedInstance{
 			SpotPrice:           b.config.SpotPrice,
 			DisableStopInstance: b.config.DisableStopInstance,
@@ -216,6 +220,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SnapshotTags: b.config.SnapshotTags,
 			Ctx:          b.config.ctx,
 		},
+	}
+
+	if !b.config.AMISkipRegister {
+		steps = append(steps, amiCreationSteps...)
 	}
 
 	// Run!

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -204,6 +204,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepPreValidate{
 			DestAmiName:     b.config.AMIName,
 			ForceDeregister: b.config.AMIForceDeregister,
+			SkipRegister:    b.config.AMISkipRegister,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:          b.config.SourceAmi,
@@ -256,6 +257,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				b.config.RunConfig.Comm.SSHPassword),
 		},
 		&common.StepProvision{},
+	}
+
+	amiCreationSteps := []multistep.Step{
 		&StepUploadX509Cert{},
 		&StepBundleVolume{
 			Debug: b.config.PackerDebug,
@@ -288,6 +292,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SnapshotTags: b.config.SnapshotTags,
 			Ctx:          b.config.ctx,
 		},
+	}
+
+	if !b.config.AMISkipRegister {
+		steps = append(steps, amiCreationSteps...)
 	}
 
 	// Run!

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -231,6 +231,12 @@ each category, the available configuration keys are alphabetized.
 - `skip_region_validation` (boolean) - Set to true if you want to skip
     validation of the `ami_regions` configuration option. Default `false`.
 
+- `skip_register_ami` (boolean) - Set to `true` if you want to skip creation of
+  an AMI. This skips snapshot and AMI creation and jumps directly to deleting
+  the volume after provisioning. This may be useful if the chroot provisioning
+  is producing an artifact other than an AMI. The `ami_name` setting can be
+  omitted if this is set. Default `false`.
+
 - `snapshot_tags` (object of key/value strings) - Tags to apply to snapshot.
     They will override AMI tags if already applied to snapshot. This is a
     [template engine](/docs/templates/engine.html)

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -226,6 +226,12 @@ builder.
 - `skip_region_validation` (boolean) - Set to true if you want to skip
   validation of the region configuration option.  Default `false`.
 
+- `skip_register_ami` (boolean) - Set to `true` if you want to skip creation of
+  an AMI. This skips stopping the instance and creation of the AMI and jumps
+  directly to instance termination after provisioning. This may be useful if the
+  instance provisioning is producing an artifact other than an AMI. The
+  `ami_name` option can be omitted if this is set.  Default `false`.
+
 - `snapshot_groups` (array of strings) - A list of groups that have access to
   create volumes from the snapshot(s). By default no groups have permission to create
   volumes form the snapshot(s). `all` will make the snapshot publicly accessible.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -231,6 +231,12 @@ builder.
 - `skip_region_validation` (boolean) - Set to true if you want to skip
     validation of the region configuration option.  Defaults to `false`.
 
+- `skip_register_ami` (boolean) - Set to `true` if you want to skip creation of
+  an AMI. This skips volume bundling and AMI creation and jumps directly to
+  instance termination after provisioning. This may be useful if the instance
+  provisioning is producing an artifact other than an AMI. The `ami_name` option
+  can be omitted if this is set.  Default `false`.
+
 - `snapshot_groups` (array of strings) - A list of groups that have access to
     create volumes from the snapshot(s). By default no groups have permission to create
     volumes form the snapshot(s). `all` will make the snapshot publicly accessible.


### PR DESCRIPTION
This is a cleaner implementation of #3793 which should take into account feedback from @mwhooker.  In summary, this allows the AWS builders to be used for additional purposes when the AMI is not the final product of the build.  When the "skip_register_ami" option is set, this skips all the steps following provisioning and proceeds straight to instance termination.

Note: this PR doesn't yet modify the newer `EBS Surrogate Builder`.  I wasn't clear on how it works or how it differs from using `from_scratch` option I added to the Chroot builder.  I can add a similar bypass to the Surrogate builder if that makes sense.  @jen20 could your clarify?