### PR TITLE
Removing the check for administrator rights when sending key strokes to Hyper-V

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -806,7 +806,6 @@ func TypeScanCodes(vmName string, scanCodes string) error {
 	var script = `
 param([string]$vmName, [string]$scanCodes)
 	#Requires -Version 3
-	#Requires -RunAsAdministrator
 
 	function Get-VMConsole
 	{


### PR DESCRIPTION
Because Packer has already verified that we are running with at least Hyper-V administrator rights this should be safe. Having the requirement for administrator rights in the script means that you still need to be an administrator (and be elevated to Administrator) if you want to use packer to build Hyper-V images with a configuration that requires you to send keystrokes to the VM, say when building a Linux box.
