### PR TITLE
Add support for download in WinRM communicator

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -1,8 +1,10 @@
 package winrm
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -143,7 +145,20 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 }
 
 func (c *Communicator) Download(src string, dst io.Writer) error {
-	return fmt.Errorf("WinRM doesn't support download.")
+	endpoint := winrm.NewEndpoint(c.endpoint.Host, c.endpoint.Port, c.config.Https, c.config.Insecure, nil, nil, nil, c.config.Timeout)
+	client, err := winrm.NewClient(endpoint, c.config.Username, c.config.Password)
+	if err != nil {
+		return err
+	}
+
+	encodeScript := `$file=[System.IO.File]::ReadAllBytes("%s"); Write-Output $([System.Convert]::ToBase64String($file))`
+
+	base64DecodePipe := &Base64Pipe{w: dst}
+
+	cmd := winrm.Powershell(fmt.Sprintf(encodeScript, src))
+	_, err = client.Run(cmd, base64DecodePipe, ioutil.Discard)
+
+	return err
 }
 
 func (c *Communicator) DownloadDir(src string, dst string, exclude []string) error {
@@ -163,4 +178,34 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 		MaxOperationsPerShell: 15, // lowest common denominator
 		TransportDecorator:    c.config.TransportDecorator,
 	})
+}
+
+type Base64Pipe struct {
+	w io.Writer // underlying writer (file, buffer)
+}
+
+func (d *Base64Pipe) ReadFrom(r io.Reader) (int64, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return 0, err
+	}
+
+	var i int
+	i, err = d.Write(b)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(i), err
+}
+
+func (d *Base64Pipe) Write(p []byte) (int, error) {
+	dst := make([]byte, base64.StdEncoding.DecodedLen(len(p)))
+
+	if _, err := base64.StdEncoding.Decode(dst, p); err != nil {
+		return 0, err
+	}
+
+	return d.w.Write(dst)
 }

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -203,9 +203,10 @@ func (d *Base64Pipe) ReadFrom(r io.Reader) (int64, error) {
 func (d *Base64Pipe) Write(p []byte) (int, error) {
 	dst := make([]byte, base64.StdEncoding.DecodedLen(len(p)))
 
-	if _, err := base64.StdEncoding.Decode(dst, p); err != nil {
+	decodedBytes, err := base64.StdEncoding.Decode(dst, p)
+	if err != nil {
 		return 0, err
 	}
 
-	return d.w.Write(dst)
+	return d.w.Write(dst[0:decodedBytes])
 }

--- a/communicator/winrm/communicator_test.go
+++ b/communicator/winrm/communicator_test.go
@@ -108,7 +108,7 @@ func TestUpload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error downloading file: %s", err)
 	}
-	downloadedPayload := strings.TrimRight(dest.String(), "\x00")
+	downloadedPayload := dest.String()
 
 	if downloadedPayload != PAYLOAD {
 		t.Fatalf("files are not equal: expected [%s] length: %v, got [%s] length %v", PAYLOAD, len(PAYLOAD), downloadedPayload, len(downloadedPayload))

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -576,10 +576,10 @@
 			"revision": "95ba30457eb1121fa27753627c774c7cd4e90083"
 		},
 		{
-			"checksumSHA1": "6uNzRk3ScsTC+olpCXkW4M/L3fg=",
+			"checksumSHA1": "kWWDtHJJp7Hiq0zj0xecRGqMoeU=",
 			"path": "github.com/masterzen/winrm",
-			"revision": "b7e3d2de4979ce5eae5c1c1ef450040c5d675a89",
-			"revisionTime": "2017-01-26T07:02:57Z"
+			"revision": "acf371f6aff113fc0104a61cd72db45a7c27d310",
+			"revisionTime": "2017-03-29T23:04:57Z"
 		},
 		{
 			"checksumSHA1": "KTsgWipT3ennAAtaKxEZairxero=",


### PR DESCRIPTION
This PR will enable `download` direction for WinRM communicator.

```json
{
  "type": "file",
  "source": "C:\\hello.txt",
  "destination": "hello.txt",
  "direction": "download"
}
```
The file could get deleted by packer after it downloads successfully, unless `skip_clean_files` is set. [See PR 4724](https://github.com/mitchellh/packer/pull/4724) 

Check out these examples: `communicator/winrm/communicator_test.go`