### PR TITLE
{{user}} is not allowed in variables section

### DIFF
--- a/website/source/docs/templates/user-variables.html.md
+++ b/website/source/docs/templates/user-variables.html.md
@@ -60,8 +60,9 @@ validation will fail.
 
 Using the variables is extremely easy. Variables are used by calling the user
 function in the form of <code>{{user \`variable\`}}</code>. This function can be
-used in *any value* within the template, in builders, provisioners, *anything*.
-The user variable is available globally within the template.
+used in *any value* within the template; in builders, provisioners, *anywhere
+outside the `variables` section*.   The user variable is available globally
+within the rest of the template.
 
 ## Environment Variables
 


### PR DESCRIPTION
Related to https://github.com/hashicorp/packer/issues/1942

Explain that the `{{user ... }}` interpolation is not actually available *everywhere* in the template.
