### PR TITLE
Add version selection for chef-solo provisioner

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -28,7 +28,7 @@ type guestOSTypeConfig struct {
 var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	provisioner.UnixOSType: {
 		executeCommand: "{{if .Sudo}}sudo {{end}}chef-solo --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "curl -L https://omnitruck.chef.io/install.sh | {{if .Sudo}}sudo {{end}}bash",
+		installCommand: "curl -L https://omnitruck.chef.io/install.sh | {{if .Sudo}}sudo {{end}}bash -s --{{if .Version}} -v {{.Version}}{{end}}",
 		stagingDir:     "/tmp/packer-chef-solo",
 	},
 	provisioner.WindowsOSType: {
@@ -57,6 +57,7 @@ type Config struct {
 	SkipInstall                bool     `mapstructure:"skip_install"`
 	StagingDir                 string   `mapstructure:"staging_directory"`
 	GuestOSType                string   `mapstructure:"guest_os_type"`
+	Version                    string   `mapstructure:"version"`
 
 	ctx interpolate.Context
 }
@@ -91,7 +92,8 @@ type ExecuteTemplate struct {
 }
 
 type InstallChefTemplate struct {
-	Sudo bool
+	Sudo    bool
+	Version string
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
@@ -229,7 +231,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	ui.Say("Provisioning with chef-solo")
 
 	if !p.config.SkipInstall {
-		if err := p.installChef(ui, comm); err != nil {
+		if err := p.installChef(ui, comm, p.config.Version); err != nil {
 			return fmt.Errorf("Error installing Chef: %s", err)
 		}
 	}
@@ -462,11 +464,12 @@ func (p *Provisioner) executeChef(ui packer.Ui, comm packer.Communicator, config
 	return nil
 }
 
-func (p *Provisioner) installChef(ui packer.Ui, comm packer.Communicator) error {
+func (p *Provisioner) installChef(ui packer.Ui, comm packer.Communicator, version string) error {
 	ui.Message("Installing Chef...")
 
 	p.config.ctx.Data = &InstallChefTemplate{
-		Sudo: !p.config.PreventSudo,
+		Sudo:    !p.config.PreventSudo,
+		Version: version,
 	}
 	command, err := interpolate.Render(p.config.InstallCommand, &p.config.ctx)
 	if err != nil {

--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -33,7 +33,7 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	},
 	provisioner.WindowsOSType: {
 		executeCommand: "c:/opscode/chef/bin/chef-solo.bat --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install\"",
+		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; Install-Project{{if .Version}} -v {{.Version}}{{end}}\"",
 		stagingDir:     "C:/Windows/Temp/packer-chef-solo",
 	},
 }

--- a/website/source/docs/provisioners/chef-solo.html.md
+++ b/website/source/docs/provisioners/chef-solo.html.md
@@ -178,7 +178,7 @@ readability) to install Chef. This command can be customized if you want to
 install Chef in another way.
 
 ```text
-curl -L https://www.chef.io/chef/install.sh | \
+curl -L https://omnitruck.chef.io/install.sh | \
   {{if .Sudo}}sudo{{end}} bash -s --{{if .Version}} -v {{.Version}}{{end}}
 ```
 
@@ -186,7 +186,7 @@ When guest_os_type is set to "windows", Packer uses the following command to
 install the latest version of Chef:
 
 ```text
-powershell.exe -Command "(New-Object System.Net.WebClient).DownloadFile('http://chef.io/chef/install.msi', 'C:\\Windows\\Temp\\chef.msi');Start-Process 'msiexec' -ArgumentList '/qb /i C:\\Windows\\Temp\\chef.msi' -NoNewWindow -Wait"
+powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install\"
 ```
 
 This command can be customized using the `install_command` configuration.

--- a/website/source/docs/provisioners/chef-solo.html.md
+++ b/website/source/docs/provisioners/chef-solo.html.md
@@ -110,6 +110,8 @@ configuration is actually required, but at least `run_list` is recommended.
     able to create directories and write into this folder. If the permissions
     are not correct, use a shell provisioner prior to this to configure it
     properly.
+- `version` (string) - The version of Chef to be installed. By default this is
+    empty which will install the latest version of Chef.
 
 ## Chef Configuration
 
@@ -177,7 +179,7 @@ install Chef in another way.
 
 ```text
 curl -L https://www.chef.io/chef/install.sh | \
-  {{if .Sudo}}sudo{{end}} bash
+  {{if .Sudo}}sudo{{end}} bash -s --{{if .Version}} -v {{.Version}}{{end}}
 ```
 
 When guest_os_type is set to "windows", Packer uses the following command to


### PR DESCRIPTION
Prevents issues such as #1751 when chef changes major versions

Allow setting version when installing chef-solo.

TODO:
- [x] Doc changes
- [x] Windows support? (No Windows machine to test from)
