### PR TITLE
provisioner/ansible-local: Convert Windows paths with backslashes to …

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -86,7 +86,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.StagingDir == "" {
-		p.config.StagingDir = filepath.Join(DefaultStagingDir, uuid.TimeOrderedUUID())
+		p.config.StagingDir = filepath.ToSlash(filepath.Join(DefaultStagingDir, uuid.TimeOrderedUUID()))
 	}
 
 	// Validation


### PR DESCRIPTION
Fixes #4689.

PR #4472 introduced a bug: if Packer is launched on Windows host, and provisioned VM runs Linux, then staging directory name is generated incorrectly - the path contains backslashes, and Linux cannot handle them.
```
/root/\tmp\packer-provisioner-ansible-local\58d02882-7a65-acd4-fb9c-50a008058b5f
```

Ansible can never be started on Windows host, so it's safe to just convert backslashes to forward slashes.