### PR TITLE
provisioner/powershell: Delete Task registered in Guest OS from elevated script

### DIFF
--- a/provisioner/powershell/elevated.go
+++ b/provisioner/powershell/elevated.go
@@ -84,5 +84,6 @@ $result = $t.LastTaskResult
 if (Test-Path $log) {
     Remove-Item $log -Force -ErrorAction SilentlyContinue | Out-Null
 }
+$f.DeleteTask("\$name",0)
 [System.Runtime.Interopservices.Marshal]::ReleaseComObject($s) | Out-Null
 exit $result`))


### PR DESCRIPTION
Added `$f.DeleteTask("\$name",0)` to the Elevated Template in provisioner/powershell/elevated.go. This gets rid of the task right after execution, so that the Task Scheduler isn't full of old tasks.

Tested on Windows 10, Windows Server 2016 and 2012 R2 that tasks were deleted after completion.