### PR TITLE
azure: Add missing instruction for Windows Image user

### DIFF
--- a/website/source/docs/builders/azure-setup.html.md
+++ b/website/source/docs/builders/azure-setup.html.md
@@ -17,6 +17,8 @@ In order to build VMs in Azure Packer needs 6 configuration options to be specif
 
 - `client_secret` - service principal secret / password
 
+- `object_id` - service principal object id (OSType = Windows Only)
+
 - `resource_group_name` - name of the resource group where your VHD(s) will be stored
 
 - `storage_account` - name of the storage account where your VHD(s) will be stored
@@ -191,6 +193,12 @@ $ azure ad app list --json \
 Get `client_secret`
 
 This cannot be retrieved. If you forgot this, you will have to delete and re-create your service principal and the associated permissions.
+
+Get `object_id` (OSTYpe=Windows only)
+
+```shell
+azure ad sp show -n CLIENT_ID
+```
 
 Get `resource_group_name`
 


### PR DESCRIPTION
When we build a Windows based VHD image, we need to specify object_id.
However, object_id is very ambiguous and not mentioned on this document.
I add some explanation and how to get it.

closes #4803

Related source code 

https://github.com/hashicorp/packer/blob/81522dced0b25084a824e79efda02483b12dc7cd/builder/azure/arm/builder.go#L125

https://github.com/hashicorp/packer/blob/81522dced0b25084a824e79efda02483b12dc7cd/builder/azure/arm/template_factory.go#L19



