### PR TITLE
ignore disconnects while executing ansible

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -321,6 +321,10 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator) err
 				"PATH after connecting to the machine.",
 				p.config.Command)
 		}
+		if cmd.ExitStatus == packer.CmdDisconnect {
+			ui.Message("Remote end disconnected while executing Ansible. Ignoring.")
+			return nil
+		}
 
 		return fmt.Errorf("Non-zero exit status: %d", cmd.ExitStatus)
 	}


### PR DESCRIPTION
Sometimes ansible will drop the network, so let's expect that

resolves #4623

Will probably want to do the same on all other provisioners that execute remote commands directly. Perhaps when we create the remote command we can define the disconnect behavior instead of checking it everywhere it's used?