### PR TITLE
Help ensure VMX builder properly removes mounted CDs on OS X

### DIFF
--- a/builder/vmware/common/step_shutdown.go
+++ b/builder/vmware/common/step_shutdown.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mitchellh/multistep"
 	"log"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -125,10 +124,10 @@ LockWaitLoop:
 		}
 	}
 
-	if runtime.GOOS != "darwin" && !s.Testing {
+	if !s.Testing {
 		// Windows takes a while to yield control of the files when the
-		// process is exiting. Ubuntu will yield control of the files but
-		// VMWare may overwrite the VMX cleanup steps that run after this,
+		// process is exiting. Ubuntu and OS X will yield control of the files
+		// but VMWare may overwrite the VMX cleanup steps that run after this,
 		// so we wait to ensure VMWare has exited and flushed the VMX.
 
 		// We just sleep here. In the future, it'd be nice to find a better


### PR DESCRIPTION
Pull request #1504 describes a workaround for a potential race condition in which the VMX builder can fail to remove mounted floppies or CDs. This workaround was enabled for all operating systems except darwin. Since this issue can also occur on OS X, also apply the workaround on it.