### PR TITLE
post-processor/checksum: fix crash when invalid checksum is used

### DIFF
--- a/post-processor/checksum/post-processor.go
+++ b/post-processor/checksum/post-processor.go
@@ -31,10 +31,9 @@ type PostProcessor struct {
 }
 
 type outputPathTemplate struct {
-	BuildName   string
-	BuilderType string
-	ArtifactID  string
-	HashType    string
+	BuildName    string
+	BuilderType  string
+	ChecksumType string
 }
 
 func getHash(t string) hash.Hash {
@@ -80,7 +79,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}
 
 	if p.config.OutputPath == "" {
-		p.config.OutputPath = "packer_{{.BuildName}}_{{.BuilderType}}_{{.HashType}}.checksum"
+		p.config.OutputPath = "packer_{{.BuildName}}_{{.BuilderType}}_{{.ChecksumType}}.checksum"
 	}
 
 	if err = interpolate.Validate(p.config.OutputPath, &p.config.ctx); err != nil {
@@ -103,12 +102,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	opTpl := &outputPathTemplate{
 		BuildName:   p.config.PackerBuildName,
 		BuilderType: p.config.PackerBuilderType,
-		ArtifactID:  artifact.Id(),
 	}
 
 	for _, ct := range p.config.ChecksumTypes {
 		h = getHash(ct)
-		opTpl.HashType = ct
+		opTpl.ChecksumType = ct
 		p.config.ctx.Data = &opTpl
 
 		for _, art := range files {

--- a/website/source/docs/post-processors/checksum.html.md
+++ b/website/source/docs/post-processors/checksum.html.md
@@ -44,4 +44,13 @@ Optional parameters:
 
 - `checksum_types` (array of strings) - An array of strings of checksum types
 to compute. Allowed values are md5, sha1, sha224, sha256, sha384, sha512.
-- `output` (string) - Specify filename to store checksums.
+- `output` (string) - Specify filename to store checksums. This defaults to
+    `packer_{{.BuildName}}_{{.BuilderType}}_{{.ChecksumType}}.checksum`. For
+    example, if you had a builder named `database`, you might see the file
+    written as `packer_database_docker_md5.checksum`. The following variables are
+    available to use in the output template:
+
+    * `BuildName`: The name of the builder that produced the artifact.
+    * `BuilderType`: The type of builder used to produce the artifact.
+    * `ChecksumType`: The type of checksums the file contains. This should be
+        used if you have more than one value in `checksum_types`.


### PR DESCRIPTION
closes #4805

I'm not sure the checksum post processor has been working. It doesn't look like the output template was being processed.

This PR does the following:

* add checksum type to the default output file
* validate the checksum types

This PR breaks BC in that it changes the default checksum output file, however, I don't believe that was working to begin with. Here's how it works on master

```
cat 4805.json
{
    "builders": [
        {
            "export_path": "image.tar",
            "image": "ubuntu:xenial",
            "type": "docker",
            "name": "foob"
        }
    ],
    "post-processors": [
        [
            {
                "checksum_types": ["md5", "sha256"],
                "type": "checksum"
            }
        ]
    ]
}

~/dev/packertest ᐅ packer build 4805.json
foob output will be in this color.

==> foob: Creating a temporary directory for sharing data...
==> foob: Pulling Docker image: ubuntu:xenial
    foob: xenial: Pulling from library/ubuntu
    foob: Digest: sha256:c2bbf50d276508d73dd865cda7b4ee9b5243f2648647d21e3a471dd3cc4209a0
    foob: Status: Image is up to date for ubuntu:xenial
==> foob: Starting docker container...
    foob: Run command: docker run -v /Users/mwhooker/.packer.d/tmp/packer-docker175563564:/packer-files -d -i -t ubuntu:xenial /bin/bash
    foob: Container ID: 8eca7521f109ff3fec414ef976d8f50227b41b2e07dfa33cae68895bb28eb871
==> foob: Exporting the container
==> foob: Killing the container: 8eca7521f109ff3fec414ef976d8f50227b41b2e07dfa33cae68895bb28eb871
==> foob: Running post-processor: checksum
Build 'foob' finished.

==> Builds finished. The artifacts of successful builds are:
--> foob: Exported Docker file: image.tar
--> foob: Created artifact from files: image.tar, packer_{{.BuildName}}_{{.BuilderType}}.checksum
```