### PR TITLE
builder/amazon-ebssurrogate: Fix for using ami_block_device_mappings

### DIFF
--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -25,6 +25,8 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Registering the AMI...")
 
+	s.BlockDevices = config.BlockDevices.BuildAMIDevices()
+
 	blockDevicesExcludingRoot := make([]*ec2.BlockDeviceMapping, 0, len(s.BlockDevices)-1)
 	for _, blockDevice := range s.BlockDevices {
 		if *blockDevice.DeviceName == s.RootDevice.SourceDeviceName {


### PR DESCRIPTION
builder/amazon-ebssurrogate is quite useful for me.

But in the current implementation, 
ami_block_device_mappings would be ignored.

This fix is for enabling this.