### PR TITLE
builder/amazon-ebssurrogate: Fix typo of "type" in Basic Example.

### DIFF
--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -326,7 +326,7 @@ builder.
 
 ```json
 {
-   "type" : "amazon-surrogate",
+   "type" : "amazon-ebssurrogate",
    "secret_key" : "YOUR SECRET KEY HERE",
    "access_key" : "YOUR KEY HERE",
    "region" : "us-east-1",


### PR DESCRIPTION
Fix typo of "type" in Basic Example.