### PR TITLE
added :Z to volume mount

### DIFF
--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -227,7 +227,7 @@ func (d *DockerDriver) StartContainer(config *ContainerConfig) (string, error) {
 		args = append(args, "--privileged")
 	}
 	for host, guest := range config.Volumes {
-		args = append(args, "-v", fmt.Sprintf("%s:%s", host, guest))
+		args = append(args, "-v", fmt.Sprintf("%s:%s:Z", host, guest))
 	}
 	for _, v := range config.RunCommand {
 		v, err := interpolate.Render(v, &ctx)

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -75,8 +75,8 @@ type PluginCommand struct {
 var Builders = map[string]packer.Builder{
 	"amazon-chroot":       new(amazonchrootbuilder.Builder),
 	"amazon-ebs":          new(amazonebsbuilder.Builder),
-	"amazon-ebsvolume":    new(amazonebsvolumebuilder.Builder),
 	"amazon-ebssurrogate": new(amazonebssurrogatebuilder.Builder),
+	"amazon-ebsvolume":    new(amazonebsvolumebuilder.Builder),
 	"amazon-instance":     new(amazoninstancebuilder.Builder),
 	"azure-arm":           new(azurearmbuilder.Builder),
 	"cloudstack":          new(cloudstackbuilder.Builder),


### PR DESCRIPTION
I hit an issue using the ansible builder with docker when selinux is enable on the docker host.

It appears that selinux prevents the copying of the files from packer-files to the location ansible requests.

I've added :Z to the volume mounts so that docker labels the volumes to allow the container access.

There was a issue here which has been closed as no one could recreate.

https://github.com/hashicorp/packer/issues/1324

Closes #1324