### PR TITLE
Attempt to use recursive unmount if available

### DIFF
--- a/builder/amazon/chroot/step_mount_device.go
+++ b/builder/amazon/chroot/step_mount_device.go
@@ -138,7 +138,11 @@ func (s *StepMountDevice) CleanupFunc(state multistep.StateBag) error {
 
 	cmd := ShellCommand(unmountCommand)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("Error unmounting root device: %s", err)
+		unmountRecursiveCommand, err := wrappedCommand(fmt.Sprintf("umount -R %s", s.mountPath))
+		recursiveCmd := ShellCommand(unmountCommand)
+		if err := recursiveCmd.Run(); err != nil {
+			return fmt.Errorf("Error unmounting root device: %s", err)
+		}
 	}
 
 	s.mountPath = ""

--- a/builder/amazon/chroot/step_mount_device.go
+++ b/builder/amazon/chroot/step_mount_device.go
@@ -139,7 +139,7 @@ func (s *StepMountDevice) CleanupFunc(state multistep.StateBag) error {
 	cmd := ShellCommand(unmountCommand)
 	if err := cmd.Run(); err != nil {
 		unmountRecursiveCommand, err := wrappedCommand(fmt.Sprintf("umount -R %s", s.mountPath))
-		recursiveCmd := ShellCommand(unmountCommand)
+		recursiveCmd := ShellCommand(unmountRecursiveCommand)
 		if err := recursiveCmd.Run(); err != nil {
 			return fmt.Errorf("Error unmounting root device: %s", err)
 		}


### PR DESCRIPTION
Some versions of the umount command include a recursive option. This could be useful if services that are installed during the course of the packer run mount some temporary filesystems (cgroup, securityfs) under other mount points automatically. Currently we unmount these manually in the final shell provisioning script, but if a previous provisioning script fails, we don't get to it, which leads to garbage mounts on the shared packer instance. Perhaps ultimately the better option when totally finished is to examine the contents of /proc/mounts.
