### PR TITLE
builder/amazon: set flag to delete temporary keypair

### DIFF
--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -19,7 +19,8 @@ type StepKeyPair struct {
 	KeyPairName          string
 	PrivateKeyFile       string
 
-	keyName string
+	keyName   string
+	doCleanup bool
 }
 
 func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
@@ -69,6 +70,7 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Set the keyname so we know to delete it later
 	s.keyName = s.TemporaryKeyPairName
+	s.doCleanup = true
 
 	// Set some state data for use in future steps
 	state.Put("keyPair", s.keyName)
@@ -104,10 +106,7 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 }
 
 func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
-	// If no key name is set, then we never created it, so just return
-	// If we used an SSH private key file, do not go about deleting
-	// keypairs
-	if s.PrivateKeyFile != "" || (s.KeyPairName == "" && s.keyName == "") {
+	if !s.doCleanup {
 		return
 	}
 

--- a/builder/amazon/common/step_key_pair.go
+++ b/builder/amazon/common/step_key_pair.go
@@ -19,7 +19,6 @@ type StepKeyPair struct {
 	KeyPairName          string
 	PrivateKeyFile       string
 
-	keyName   string
 	doCleanup bool
 }
 
@@ -68,12 +67,10 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	// Set the keyname so we know to delete it later
-	s.keyName = s.TemporaryKeyPairName
 	s.doCleanup = true
 
 	// Set some state data for use in future steps
-	state.Put("keyPair", s.keyName)
+	state.Put("keyPair", s.TemporaryKeyPairName)
 	state.Put("privateKey", *keyResp.KeyMaterial)
 
 	// If we're in debug mode, output the private key to the working
@@ -115,10 +112,10 @@ func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 
 	// Remove the keypair
 	ui.Say("Deleting temporary keypair...")
-	_, err := ec2conn.DeleteKeyPair(&ec2.DeleteKeyPairInput{KeyName: &s.keyName})
+	_, err := ec2conn.DeleteKeyPair(&ec2.DeleteKeyPairInput{KeyName: &s.TemporaryKeyPairName})
 	if err != nil {
 		ui.Error(fmt.Sprintf(
-			"Error cleaning up keypair. Please delete the key manually: %s", s.keyName))
+			"Error cleaning up keypair. Please delete the key manually: %s", s.TemporaryKeyPairName))
 	}
 
 	// Also remove the physical key if we're debugging.

--- a/builder/openstack/step_key_pair.go
+++ b/builder/openstack/step_key_pair.go
@@ -22,7 +22,8 @@ type StepKeyPair struct {
 	KeyPairName          string
 	PrivateKeyFile       string
 
-	keyName string
+	keyName   string
+	doCleanup bool
 }
 
 func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
@@ -84,6 +85,7 @@ func (s *StepKeyPair) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	ui.Say(fmt.Sprintf("Created temporary keypair: %s", s.TemporaryKeyPairName))
+	s.doCleanup = true
 
 	keypair.PrivateKey = berToDer(keypair.PrivateKey, ui)
 
@@ -167,13 +169,7 @@ func berToDer(ber string, ui packer.Ui) string {
 }
 
 func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
-	// If we used an SSH private key file, do not go about deleting
-	// keypairs
-	if s.PrivateKeyFile != "" || (s.KeyPairName == "" && s.keyName == "") {
-		return
-	}
-	// If no key name is set, then we never created it, so just return
-	if s.TemporaryKeyPairName == "" {
+	if !s.doCleanup {
 		return
 	}
 


### PR DESCRIPTION
fixes #4807

The logic was getting far too complicated to decide if we need to clean up a temporary key pair, so let's just set a flag after we do create one.

Also noticed that openstack replicated the same complicated logic, so I added the flag there, too.

I feel like this is too simple a fix for what appears to be complex logic, so I'd like a second set of eyes on this if possible.

