### PR TITLE
triton: Update triton builder for latest upstream

### DIFF
--- a/builder/triton/driver_triton.go
+++ b/builder/triton/driver_triton.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -26,7 +27,7 @@ func NewDriverTriton(ui packer.Ui, config Config) (Driver, error) {
 }
 
 func (d *driverTriton) CreateImageFromMachine(machineId string, config Config) (string, error) {
-	image, err := d.client.Images().CreateImageFromMachine(&triton.CreateImageFromMachineInput{
+	image, err := d.client.Images().CreateImageFromMachine(context.Background(), &triton.CreateImageFromMachineInput{
 		MachineID:   machineId,
 		Name:        config.ImageName,
 		Version:     config.ImageVersion,
@@ -64,7 +65,7 @@ func (d *driverTriton) CreateMachine(config Config) (string, error) {
 		input.Networks = config.MachineNetworks
 	}
 
-	machine, err := d.client.Machines().CreateMachine(input)
+	machine, err := d.client.Machines().CreateMachine(context.Background(), input)
 	if err != nil {
 		return "", err
 	}
@@ -73,19 +74,19 @@ func (d *driverTriton) CreateMachine(config Config) (string, error) {
 }
 
 func (d *driverTriton) DeleteImage(imageId string) error {
-	return d.client.Images().DeleteImage(&triton.DeleteImageInput{
+	return d.client.Images().DeleteImage(context.Background(), &triton.DeleteImageInput{
 		ImageID: imageId,
 	})
 }
 
 func (d *driverTriton) DeleteMachine(machineId string) error {
-	return d.client.Machines().DeleteMachine(&triton.DeleteMachineInput{
+	return d.client.Machines().DeleteMachine(context.Background(), &triton.DeleteMachineInput{
 		ID: machineId,
 	})
 }
 
 func (d *driverTriton) GetMachineIP(machineId string) (string, error) {
-	machine, err := d.client.Machines().GetMachine(&triton.GetMachineInput{
+	machine, err := d.client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 		ID: machineId,
 	})
 	if err != nil {
@@ -96,7 +97,7 @@ func (d *driverTriton) GetMachineIP(machineId string) (string, error) {
 }
 
 func (d *driverTriton) StopMachine(machineId string) error {
-	return d.client.Machines().StopMachine(&triton.StopMachineInput{
+	return d.client.Machines().StopMachine(context.Background(), &triton.StopMachineInput{
 		MachineID: machineId,
 	})
 }
@@ -109,7 +110,7 @@ func (d *driverTriton) StopMachine(machineId string) error {
 func (d *driverTriton) WaitForMachineState(machineId string, state string, timeout time.Duration) error {
 	return waitFor(
 		func() (bool, error) {
-			machine, err := d.client.Machines().GetMachine(&triton.GetMachineInput{
+			machine, err := d.client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 				ID: machineId,
 			})
 			if machine == nil {
@@ -128,7 +129,7 @@ func (d *driverTriton) WaitForMachineState(machineId string, state string, timeo
 func (d *driverTriton) WaitForMachineDeletion(machineId string, timeout time.Duration) error {
 	return waitFor(
 		func() (bool, error) {
-			machine, err := d.client.Machines().GetMachine(&triton.GetMachineInput{
+			machine, err := d.client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 				ID: machineId,
 			})
 			if err != nil && triton.IsResourceNotFound(err) {
@@ -149,7 +150,7 @@ func (d *driverTriton) WaitForMachineDeletion(machineId string, timeout time.Dur
 func (d *driverTriton) WaitForImageCreation(imageId string, timeout time.Duration) error {
 	return waitFor(
 		func() (bool, error) {
-			image, err := d.client.Images().GetImage(&triton.GetImageInput{
+			image, err := d.client.Images().GetImage(context.Background(), &triton.GetImageInput{
 				ImageID: imageId,
 			})
 			if image == nil {

--- a/vendor/github.com/joyent/triton-go/accounts.go
+++ b/vendor/github.com/joyent/triton-go/accounts.go
@@ -1,11 +1,11 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
-
-	"fmt"
 
 	"github.com/hashicorp/errwrap"
 )
@@ -40,9 +40,9 @@ type Account struct {
 
 type GetAccountInput struct{}
 
-func (client *AccountsClient) GetAccount(input *GetAccountInput) (*Account, error) {
+func (client *AccountsClient) GetAccount(ctx context.Context, input *GetAccountInput) (*Account, error) {
 	path := fmt.Sprintf("/%s", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -75,8 +75,9 @@ type UpdateAccountInput struct {
 
 // UpdateAccount updates your account details with the given parameters.
 // TODO(jen20) Work out a safe way to test this
-func (client *AccountsClient) UpdateAccount(input *UpdateAccountInput) (*Account, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s", client.accountName), input)
+func (client *AccountsClient) UpdateAccount(ctx context.Context, input *UpdateAccountInput) (*Account, error) {
+	path := fmt.Sprintf("/%s", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/client.go
+++ b/vendor/github.com/joyent/triton-go/client.go
@@ -2,24 +2,25 @@ package triton
 
 import (
 	"bytes"
+	"context"
+	"crypto/tls"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/joyent/triton-go/authentication"
 )
 
+const nilContext = "nil context"
+
 // Client represents a connection to the Triton API.
 type Client struct {
-	client      *retryablehttp.Client
+	client      *http.Client
 	authorizer  []authentication.Signer
 	apiURL      url.URL
 	accountName string
@@ -31,55 +32,61 @@ type Client struct {
 // At least one signer must be provided - example signers include
 // authentication.PrivateKeySigner and authentication.SSHAgentSigner.
 func NewClient(endpoint string, accountName string, signers ...authentication.Signer) (*Client, error) {
-	defaultRetryWaitMin := 1 * time.Second
-	defaultRetryWaitMax := 5 * time.Minute
-	defaultRetryMax := 32
-
 	apiURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, errwrap.Wrapf("invalid endpoint: {{err}}", err)
 	}
 
 	if accountName == "" {
-		return nil, fmt.Errorf("account name can not be empty")
+		return nil, errors.New("account name can not be empty")
 	}
 
 	httpClient := &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).Dial,
-			TLSHandshakeTimeout: 10 * time.Second,
-			DisableKeepAlives:   true,
-			MaxIdleConnsPerHost: -1,
-		},
+		Transport:     httpTransport(false),
 		CheckRedirect: doNotFollowRedirects,
 	}
 
-	retryableClient := &retryablehttp.Client{
-		HTTPClient:   httpClient,
-		Logger:       log.New(os.Stderr, "", log.LstdFlags),
-		RetryWaitMin: defaultRetryWaitMin,
-		RetryWaitMax: defaultRetryWaitMax,
-		RetryMax:     defaultRetryMax,
-		CheckRetry:   retryablehttp.DefaultRetryPolicy,
-	}
-
 	return &Client{
-		client:      retryableClient,
+		client:      httpClient,
 		authorizer:  signers,
 		apiURL:      *apiURL,
 		accountName: accountName,
 	}, nil
 }
 
+// InsecureSkipTLSVerify turns off TLS verification for the client connection. This
+// allows connection to an endpoint with a certificate which was signed by a non-
+// trusted CA, such as self-signed certificates. This can be useful when connecting
+// to temporary Triton installations such as Triton Cloud-On-A-Laptop.
+func (c *Client) InsecureSkipTLSVerify() {
+	if c.client == nil {
+		return
+	}
+
+	c.client.Transport = httpTransport(true)
+}
+
+func httpTransport(insecureSkipTLSVerify bool) *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		DisableKeepAlives:   true,
+		MaxIdleConnsPerHost: -1,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: insecureSkipTLSVerify,
+		},
+	}
+}
+
 func doNotFollowRedirects(*http.Request, []*http.Request) error {
 	return http.ErrUseLastResponse
 }
 
-func (c *Client) executeRequestURIParams(method, path string, body interface{}, query *url.Values) (io.ReadCloser, error) {
+func (c *Client) executeRequestURIParams(ctx context.Context, method, path string, body interface{}, query *url.Values) (io.ReadCloser, error) {
 	var requestBody io.ReadSeeker
 	if body != nil {
 		marshaled, err := json.MarshalIndent(body, "", "    ")
@@ -95,7 +102,7 @@ func (c *Client) executeRequestURIParams(method, path string, body interface{}, 
 		endpoint.RawQuery = query.Encode()
 	}
 
-	req, err := retryablehttp.NewRequest(method, endpoint.String(), requestBody)
+	req, err := http.NewRequest(method, endpoint.String(), requestBody)
 	if err != nil {
 		return nil, errwrap.Wrapf("Error constructing HTTP request: {{err}}", err)
 	}
@@ -116,7 +123,7 @@ func (c *Client) executeRequestURIParams(method, path string, body interface{}, 
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errwrap.Wrapf("Error executing HTTP request: {{err}}", err)
 	}
@@ -129,23 +136,23 @@ func (c *Client) executeRequestURIParams(method, path string, body interface{}, 
 }
 
 func (c *Client) decodeError(statusCode int, body io.Reader) error {
-	tritonError := &TritonError{
+	err := &TritonError{
 		StatusCode: statusCode,
 	}
 
 	errorDecoder := json.NewDecoder(body)
-	if err := errorDecoder.Decode(tritonError); err != nil {
+	if err := errorDecoder.Decode(err); err != nil {
 		return errwrap.Wrapf("Error decoding error response: {{err}}", err)
 	}
 
-	return tritonError
+	return err
 }
 
-func (c *Client) executeRequest(method, path string, body interface{}) (io.ReadCloser, error) {
-	return c.executeRequestURIParams(method, path, body, nil)
+func (c *Client) executeRequest(ctx context.Context, method, path string, body interface{}) (io.ReadCloser, error) {
+	return c.executeRequestURIParams(ctx, method, path, body, nil)
 }
 
-func (c *Client) executeRequestRaw(method, path string, body interface{}) (*http.Response, error) {
+func (c *Client) executeRequestRaw(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
 	var requestBody io.ReadSeeker
 	if body != nil {
 		marshaled, err := json.MarshalIndent(body, "", "    ")
@@ -158,7 +165,7 @@ func (c *Client) executeRequestRaw(method, path string, body interface{}) (*http
 	endpoint := c.apiURL
 	endpoint.Path = path
 
-	req, err := retryablehttp.NewRequest(method, endpoint.String(), requestBody)
+	req, err := http.NewRequest(method, endpoint.String(), requestBody)
 	if err != nil {
 		return nil, errwrap.Wrapf("Error constructing HTTP request: {{err}}", err)
 	}
@@ -179,7 +186,7 @@ func (c *Client) executeRequestRaw(method, path string, body interface{}) (*http
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errwrap.Wrapf("Error executing HTTP request: {{err}}", err)
 	}

--- a/vendor/github.com/joyent/triton-go/config.go
+++ b/vendor/github.com/joyent/triton-go/config.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,8 +28,9 @@ type Config struct {
 type GetConfigInput struct{}
 
 // GetConfig outputs configuration for your account.
-func (client *ConfigClient) GetConfig(input *GetConfigInput) (*Config, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/config", client.accountName), nil)
+func (client *ConfigClient) GetConfig(ctx context.Context, input *GetConfigInput) (*Config, error) {
+	path := fmt.Sprintf("/%s/config", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -51,9 +53,9 @@ type UpdateConfigInput struct {
 }
 
 // UpdateConfig updates configuration values for your account.
-// TODO(jen20) Work out a safe way to test this (after networks c implemented)
-func (client *ConfigClient) UpdateConfig(input *UpdateConfigInput) (*Config, error) {
-	respReader, err := client.executeRequest(http.MethodPut, fmt.Sprintf("/%s/config", client.accountName), input)
+func (client *ConfigClient) UpdateConfig(ctx context.Context, input *UpdateConfigInput) (*Config, error) {
+	path := fmt.Sprintf("/%s/config", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPut, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/datacenters.go
+++ b/vendor/github.com/joyent/triton-go/datacenters.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -27,9 +28,9 @@ type DataCenter struct {
 
 type ListDataCentersInput struct{}
 
-func (client *DataCentersClient) ListDataCenters(*ListDataCentersInput) ([]*DataCenter, error) {
+func (client *DataCentersClient) ListDataCenters(ctx context.Context, _ *ListDataCentersInput) ([]*DataCenter, error) {
 	path := fmt.Sprintf("/%s/datacenters", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -68,9 +69,9 @@ type GetDataCenterInput struct {
 	Name string
 }
 
-func (client *DataCentersClient) GetDataCenter(input *GetDataCenterInput) (*DataCenter, error) {
+func (client *DataCentersClient) GetDataCenter(ctx context.Context, input *GetDataCenterInput) (*DataCenter, error) {
 	path := fmt.Sprintf("/%s/datacenters/%s", client.accountName, input.Name)
-	resp, err := client.executeRequestRaw(http.MethodGet, path, nil)
+	resp, err := client.executeRequestRaw(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, errwrap.Wrapf("Error executing GetDatacenter request: {{err}}", err)
 	}

--- a/vendor/github.com/joyent/triton-go/fabrics.go
+++ b/vendor/github.com/joyent/triton-go/fabrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -26,9 +27,9 @@ type FabricVLAN struct {
 
 type ListFabricVLANsInput struct{}
 
-func (client *FabricsClient) ListFabricVLANs(*ListFabricVLANsInput) ([]*FabricVLAN, error) {
+func (client *FabricsClient) ListFabricVLANs(ctx context.Context, _ *ListFabricVLANsInput) ([]*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -51,9 +52,9 @@ type CreateFabricVLANInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FabricsClient) CreateFabricVLAN(input *CreateFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) CreateFabricVLAN(ctx context.Context, input *CreateFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans", client.accountName)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -76,9 +77,9 @@ type UpdateFabricVLANInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FabricsClient) UpdateFabricVLAN(input *UpdateFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) UpdateFabricVLAN(ctx context.Context, input *UpdateFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPut, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPut, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -99,9 +100,9 @@ type GetFabricVLANInput struct {
 	ID int `json:"-"`
 }
 
-func (client *FabricsClient) GetFabricVLAN(input *GetFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) GetFabricVLAN(ctx context.Context, input *GetFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -122,9 +123,9 @@ type DeleteFabricVLANInput struct {
 	ID int `json:"-"`
 }
 
-func (client *FabricsClient) DeleteFabricVLAN(input *DeleteFabricVLANInput) error {
+func (client *FabricsClient) DeleteFabricVLAN(ctx context.Context, input *DeleteFabricVLANInput) error {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -139,9 +140,9 @@ type ListFabricNetworksInput struct {
 	FabricVLANID int `json:"-"`
 }
 
-func (client *FabricsClient) ListFabricNetworks(input *ListFabricNetworksInput) ([]*Network, error) {
+func (client *FabricsClient) ListFabricNetworks(ctx context.Context, input *ListFabricNetworksInput) ([]*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks", client.accountName, input.FabricVLANID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -171,9 +172,9 @@ type CreateFabricNetworkInput struct {
 	InternetNAT      bool              `json:"internet_nat"`
 }
 
-func (client *FabricsClient) CreateFabricNetwork(input *CreateFabricNetworkInput) (*Network, error) {
+func (client *FabricsClient) CreateFabricNetwork(ctx context.Context, input *CreateFabricNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks", client.accountName, input.FabricVLANID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -195,9 +196,9 @@ type GetFabricNetworkInput struct {
 	NetworkID    string `json:"-"`
 }
 
-func (client *FabricsClient) GetFabricNetwork(input *GetFabricNetworkInput) (*Network, error) {
+func (client *FabricsClient) GetFabricNetwork(ctx context.Context, input *GetFabricNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks/%s", client.accountName, input.FabricVLANID, input.NetworkID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -219,9 +220,9 @@ type DeleteFabricNetworkInput struct {
 	NetworkID    string `json:"-"`
 }
 
-func (client *FabricsClient) DeleteFabricNetwork(input *DeleteFabricNetworkInput) error {
+func (client *FabricsClient) DeleteFabricNetwork(ctx context.Context, input *DeleteFabricNetworkInput) error {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks/%s", client.accountName, input.FabricVLANID, input.NetworkID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/firewall.go
+++ b/vendor/github.com/joyent/triton-go/firewall.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,9 +39,9 @@ type FirewallRule struct {
 
 type ListFirewallRulesInput struct{}
 
-func (client *FirewallClient) ListFirewallRules(*ListFirewallRulesInput) ([]*FirewallRule, error) {
+func (client *FirewallClient) ListFirewallRules(ctx context.Context, _ *ListFirewallRulesInput) ([]*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/fwrules", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -61,9 +62,9 @@ type GetFirewallRuleInput struct {
 	ID string
 }
 
-func (client *FirewallClient) GetFirewallRule(input *GetFirewallRuleInput) (*FirewallRule, error) {
+func (client *FirewallClient) GetFirewallRule(ctx context.Context, input *GetFirewallRuleInput) (*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -86,8 +87,9 @@ type CreateFirewallRuleInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FirewallClient) CreateFirewallRule(input *CreateFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules", client.accountName), input)
+func (client *FirewallClient) CreateFirewallRule(ctx context.Context, input *CreateFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -111,8 +113,9 @@ type UpdateFirewallRuleInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FirewallClient) UpdateFirewallRule(input *UpdateFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID), input)
+func (client *FirewallClient) UpdateFirewallRule(ctx context.Context, input *UpdateFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -133,8 +136,9 @@ type EnableFirewallRuleInput struct {
 	ID string `json:"-"`
 }
 
-func (client *FirewallClient) EnableFirewallRule(input *EnableFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s/enable", client.accountName, input.ID), input)
+func (client *FirewallClient) EnableFirewallRule(ctx context.Context, input *EnableFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s/enable", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -155,8 +159,9 @@ type DisableFirewallRuleInput struct {
 	ID string `json:"-"`
 }
 
-func (client *FirewallClient) DisableFirewallRule(input *DisableFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s/disable", client.accountName, input.ID), input)
+func (client *FirewallClient) DisableFirewallRule(ctx context.Context, input *DisableFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s/disable", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -177,9 +182,9 @@ type DeleteFirewallRuleInput struct {
 	ID string
 }
 
-func (client *FirewallClient) DeleteFirewallRule(input *DeleteFirewallRuleInput) error {
+func (client *FirewallClient) DeleteFirewallRule(ctx context.Context, input *DeleteFirewallRuleInput) error {
 	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -194,9 +199,9 @@ type ListMachineFirewallRulesInput struct {
 	MachineID string
 }
 
-func (client *FirewallClient) ListMachineFirewallRules(input *ListMachineFirewallRulesInput) ([]*FirewallRule, error) {
+func (client *FirewallClient) ListMachineFirewallRules(ctx context.Context, input *ListMachineFirewallRulesInput) ([]*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/machines/%s/firewallrules", client.accountName, input.MachineID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/images.go
+++ b/vendor/github.com/joyent/triton-go/images.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,9 +49,9 @@ type Image struct {
 
 type ListImagesInput struct{}
 
-func (client *ImagesClient) ListImages(*ListImagesInput) ([]*Image, error) {
+func (client *ImagesClient) ListImages(ctx context.Context, _ *ListImagesInput) ([]*Image, error) {
 	path := fmt.Sprintf("/%s/images", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -71,9 +72,9 @@ type GetImageInput struct {
 	ImageID string
 }
 
-func (client *ImagesClient) GetImage(input *GetImageInput) (*Image, error) {
+func (client *ImagesClient) GetImage(ctx context.Context, input *GetImageInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -94,9 +95,9 @@ type DeleteImageInput struct {
 	ImageID string
 }
 
-func (client *ImagesClient) DeleteImage(input *DeleteImageInput) error {
+func (client *ImagesClient) DeleteImage(ctx context.Context, input *DeleteImageInput) error {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -118,13 +119,13 @@ type MantaLocation struct {
 	ManifestPath string `json:"manifest_path"`
 }
 
-func (client *ImagesClient) ExportImage(input *ExportImageInput) (*MantaLocation, error) {
+func (client *ImagesClient) ExportImage(ctx context.Context, input *ExportImageInput) (*MantaLocation, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
 	query := &url.Values{}
 	query.Set("action", "export")
 	query.Set("manta_path", input.MantaPath)
 
-	respReader, err := client.executeRequestURIParams(http.MethodGet, path, nil, query)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodGet, path, nil, query)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -152,9 +153,9 @@ type CreateImageFromMachineInput struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 }
 
-func (client *ImagesClient) CreateImageFromMachine(input *CreateImageFromMachineInput) (*Image, error) {
+func (client *ImagesClient) CreateImageFromMachine(ctx context.Context, input *CreateImageFromMachineInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images", client.accountName)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -182,12 +183,12 @@ type UpdateImageInput struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 }
 
-func (client *ImagesClient) UpdateImage(input *UpdateImageInput) (*Image, error) {
+func (client *ImagesClient) UpdateImage(ctx context.Context, input *UpdateImageInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
 	query := &url.Values{}
 	query.Set("action", "update")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, input, query)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, input, query)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/keys.go
+++ b/vendor/github.com/joyent/triton-go/keys.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,9 +35,9 @@ type ListKeysInput struct{}
 
 // ListKeys lists all public keys we have on record for the specified
 // account.
-func (client *KeysClient) ListKeys(*ListKeysInput) ([]*Key, error) {
-	path := fmt.Sprintf("/%s/keys")
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+func (client *KeysClient) ListKeys(ctx context.Context, _ *ListKeysInput) ([]*Key, error) {
+	path := fmt.Sprintf("/%s/keys", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -57,9 +58,9 @@ type GetKeyInput struct {
 	KeyName string
 }
 
-func (client *KeysClient) GetKey(input *GetKeyInput) (*Key, error) {
+func (client *KeysClient) GetKey(ctx context.Context, input *GetKeyInput) (*Key, error) {
 	path := fmt.Sprintf("/%s/keys/%s", client.accountName, input.KeyName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -80,9 +81,9 @@ type DeleteKeyInput struct {
 	KeyName string
 }
 
-func (client *KeysClient) DeleteKey(input *DeleteKeyInput) error {
+func (client *KeysClient) DeleteKey(ctx context.Context, input *DeleteKeyInput) error {
 	path := fmt.Sprintf("/%s/keys/%s", client.accountName, input.KeyName)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -104,8 +105,9 @@ type CreateKeyInput struct {
 }
 
 // CreateKey uploads a new OpenSSH key to Triton for use in HTTP signing and SSH.
-func (client *KeysClient) CreateKey(input *CreateKeyInput) (*Key, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/keys", client.accountName), input)
+func (client *KeysClient) CreateKey(ctx context.Context, input *CreateKeyInput) (*Key, error) {
+	path := fmt.Sprintf("/%s/keys", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/machines.go
+++ b/vendor/github.com/joyent/triton-go/machines.go
@@ -1,13 +1,13 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
-
-	"net/url"
 
 	"github.com/hashicorp/errwrap"
 )
@@ -62,7 +62,7 @@ type Machine struct {
 }
 
 // _Machine is a private facade over Machine that handles the necessary API
-// overrides from vmapi's machine endpoint(s).
+// overrides from VMAPI's machine endpoint(s).
 type _Machine struct {
 	Machine
 	Tags map[string]interface{} `json:"tags"`
@@ -90,13 +90,13 @@ func (gmi *GetMachineInput) Validate() error {
 	return nil
 }
 
-func (client *MachinesClient) GetMachine(input *GetMachineInput) (*Machine, error) {
+func (client *MachinesClient) GetMachine(ctx context.Context, input *GetMachineInput) (*Machine, error) {
 	if err := input.Validate(); err != nil {
 		return nil, errwrap.Wrapf("unable to get machine: {{err}}", err)
 	}
 
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
-	response, err := client.executeRequestRaw(http.MethodGet, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodGet, path, nil)
 	if response != nil {
 		defer response.Body.Close()
 	}
@@ -124,9 +124,11 @@ func (client *MachinesClient) GetMachine(input *GetMachineInput) (*Machine, erro
 	return native, nil
 }
 
-func (client *MachinesClient) GetMachines() ([]*Machine, error) {
+type ListMachinesInput struct{}
+
+func (client *MachinesClient) ListMachines(ctx context.Context, _ *ListMachinesInput) ([]*Machine, error) {
 	path := fmt.Sprintf("/%s/machines", client.accountName)
-	response, err := client.executeRequestRaw(http.MethodGet, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodGet, path, nil)
 	if response != nil {
 		defer response.Body.Close()
 	}
@@ -136,14 +138,14 @@ func (client *MachinesClient) GetMachines() ([]*Machine, error) {
 		}
 	}
 	if err != nil {
-		return nil, errwrap.Wrapf("Error executing GetMachines request: {{err}}",
+		return nil, errwrap.Wrapf("Error executing ListMachines request: {{err}}",
 			client.decodeError(response.StatusCode, response.Body))
 	}
 
 	var results []*_Machine
 	decoder := json.NewDecoder(response.Body)
 	if err = decoder.Decode(&results); err != nil {
-		return nil, errwrap.Wrapf("Error decoding GetMachines response: {{err}}", err)
+		return nil, errwrap.Wrapf("Error decoding ListMachines response: {{err}}", err)
 	}
 
 	machines := make([]*Machine, 0, len(results))
@@ -218,9 +220,9 @@ func (input *CreateMachineInput) toAPI() map[string]interface{} {
 	return result
 }
 
-func (client *MachinesClient) CreateMachine(input *CreateMachineInput) (*Machine, error) {
+func (client *MachinesClient) CreateMachine(ctx context.Context, input *CreateMachineInput) (*Machine, error) {
 	path := fmt.Sprintf("/%s/machines", client.accountName)
-	respReader, err := client.executeRequest(http.MethodPost, path, input.toAPI())
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input.toAPI())
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -241,9 +243,9 @@ type DeleteMachineInput struct {
 	ID string
 }
 
-func (client *MachinesClient) DeleteMachine(input *DeleteMachineInput) error {
+func (client *MachinesClient) DeleteMachine(ctx context.Context, input *DeleteMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
-	response, err := client.executeRequestRaw(http.MethodDelete, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodDelete, path, nil)
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -262,9 +264,9 @@ type DeleteMachineTagsInput struct {
 	ID string
 }
 
-func (client *MachinesClient) DeleteMachineTags(input *DeleteMachineTagsInput) error {
+func (client *MachinesClient) DeleteMachineTags(ctx context.Context, input *DeleteMachineTagsInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	response, err := client.executeRequestRaw(http.MethodDelete, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodDelete, path, nil)
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -284,9 +286,9 @@ type DeleteMachineTagInput struct {
 	Key string
 }
 
-func (client *MachinesClient) DeleteMachineTag(input *DeleteMachineTagInput) error {
+func (client *MachinesClient) DeleteMachineTag(ctx context.Context, input *DeleteMachineTagInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/tags/%s", client.accountName, input.ID, input.Key)
-	response, err := client.executeRequestRaw(http.MethodDelete, path, nil)
+	response, err := client.executeRequestRaw(ctx, http.MethodDelete, path, nil)
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
@@ -306,14 +308,14 @@ type RenameMachineInput struct {
 	Name string
 }
 
-func (client *MachinesClient) RenameMachine(input *RenameMachineInput) error {
+func (client *MachinesClient) RenameMachine(ctx context.Context, input *RenameMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
 
 	params := &url.Values{}
 	params.Set("action", "rename")
 	params.Set("name", input.Name)
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -329,9 +331,9 @@ type ReplaceMachineTagsInput struct {
 	Tags map[string]string
 }
 
-func (client *MachinesClient) ReplaceMachineTags(input *ReplaceMachineTagsInput) error {
+func (client *MachinesClient) ReplaceMachineTags(ctx context.Context, input *ReplaceMachineTagsInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPut, path, input.Tags)
+	respReader, err := client.executeRequest(ctx, http.MethodPut, path, input.Tags)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -347,9 +349,9 @@ type AddMachineTagsInput struct {
 	Tags map[string]string
 }
 
-func (client *MachinesClient) AddMachineTags(input *AddMachineTagsInput) error {
+func (client *MachinesClient) AddMachineTags(ctx context.Context, input *AddMachineTagsInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input.Tags)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input.Tags)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -365,9 +367,9 @@ type GetMachineTagInput struct {
 	Key string
 }
 
-func (client *MachinesClient) GetMachineTag(input *GetMachineTagInput) (string, error) {
+func (client *MachinesClient) GetMachineTag(ctx context.Context, input *GetMachineTagInput) (string, error) {
 	path := fmt.Sprintf("/%s/machines/%s/tags/%s", client.accountName, input.ID, input.Key)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -388,9 +390,9 @@ type ListMachineTagsInput struct {
 	ID string
 }
 
-func (client *MachinesClient) ListMachineTags(input *ListMachineTagsInput) (map[string]string, error) {
+func (client *MachinesClient) ListMachineTags(ctx context.Context, input *ListMachineTagsInput) (map[string]string, error) {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -413,9 +415,9 @@ type UpdateMachineMetadataInput struct {
 	Metadata map[string]string
 }
 
-func (client *MachinesClient) UpdateMachineMetadata(input *UpdateMachineMetadataInput) (map[string]string, error) {
+func (client *MachinesClient) UpdateMachineMetadata(ctx context.Context, input *UpdateMachineMetadataInput) (map[string]string, error) {
 	path := fmt.Sprintf("/%s/machines/%s/tags", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input.Metadata)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input.Metadata)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -437,14 +439,14 @@ type ResizeMachineInput struct {
 	Package string
 }
 
-func (client *MachinesClient) ResizeMachine(input *ResizeMachineInput) error {
+func (client *MachinesClient) ResizeMachine(ctx context.Context, input *ResizeMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
 
 	params := &url.Values{}
 	params.Set("action", "resize")
 	params.Set("package", input.Package)
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -459,13 +461,13 @@ type EnableMachineFirewallInput struct {
 	ID string
 }
 
-func (client *MachinesClient) EnableMachineFirewall(input *EnableMachineFirewallInput) error {
+func (client *MachinesClient) EnableMachineFirewall(ctx context.Context, input *EnableMachineFirewallInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
 
 	params := &url.Values{}
 	params.Set("action", "enable_firewall")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -480,13 +482,13 @@ type DisableMachineFirewallInput struct {
 	ID string
 }
 
-func (client *MachinesClient) DisableMachineFirewall(input *DisableMachineFirewallInput) error {
+func (client *MachinesClient) DisableMachineFirewall(ctx context.Context, input *DisableMachineFirewallInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.ID)
 
 	params := &url.Values{}
 	params.Set("action", "disable_firewall")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -501,9 +503,9 @@ type ListNICsInput struct {
 	MachineID string
 }
 
-func (client *MachinesClient) ListNICs(input *ListNICsInput) ([]*NIC, error) {
+func (client *MachinesClient) ListNICs(ctx context.Context, input *ListNICsInput) ([]*NIC, error) {
 	path := fmt.Sprintf("/%s/machines/%s/nics", client.accountName, input.MachineID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -525,9 +527,9 @@ type AddNICInput struct {
 	Network   string `json:"network"`
 }
 
-func (client *MachinesClient) AddNIC(input *AddNICInput) (*NIC, error) {
+func (client *MachinesClient) AddNIC(ctx context.Context, input *AddNICInput) (*NIC, error) {
 	path := fmt.Sprintf("/%s/machines/%s/nics", client.accountName, input.MachineID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -549,9 +551,9 @@ type RemoveNICInput struct {
 	MAC       string
 }
 
-func (client *MachinesClient) RemoveNIC(input *RemoveNICInput) error {
+func (client *MachinesClient) RemoveNIC(ctx context.Context, input *RemoveNICInput) error {
 	path := fmt.Sprintf("/%s/machines/%s/nics/%s", client.accountName, input.MachineID, input.MAC)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -566,13 +568,13 @@ type StopMachineInput struct {
 	MachineID string
 }
 
-func (client *MachinesClient) StopMachine(input *StopMachineInput) error {
+func (client *MachinesClient) StopMachine(ctx context.Context, input *StopMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.MachineID)
 
 	params := &url.Values{}
 	params.Set("action", "stop")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -587,13 +589,13 @@ type StartMachineInput struct {
 	MachineID string
 }
 
-func (client *MachinesClient) StartMachine(input *StartMachineInput) error {
+func (client *MachinesClient) StartMachine(ctx context.Context, input *StartMachineInput) error {
 	path := fmt.Sprintf("/%s/machines/%s", client.accountName, input.MachineID)
 
 	params := &url.Values{}
 	params.Set("action", "start")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, nil, params)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, nil, params)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/networks.go
+++ b/vendor/github.com/joyent/triton-go/networks.go
@@ -2,9 +2,10 @@ package triton
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
-	"fmt"
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -35,9 +36,9 @@ type Network struct {
 
 type ListNetworksInput struct{}
 
-func (client *NetworksClient) ListNetworks(*ListNetworksInput) ([]*Network, error) {
+func (client *NetworksClient) ListNetworks(ctx context.Context, _ *ListNetworksInput) ([]*Network, error) {
 	path := fmt.Sprintf("/%s/networks", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -58,9 +59,9 @@ type GetNetworkInput struct {
 	ID string
 }
 
-func (client *NetworksClient) GetNetwork(input *GetNetworkInput) (*Network, error) {
+func (client *NetworksClient) GetNetwork(ctx context.Context, input *GetNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/networks/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/packages.go
+++ b/vendor/github.com/joyent/triton-go/packages.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -43,8 +44,9 @@ type ListPackagesInput struct {
 	Group   string `json:"group"`
 }
 
-func (client *PackagesClient) ListPackages(input *ListPackagesInput) ([]*Package, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/packages", client.accountName), input)
+func (client *PackagesClient) ListPackages(ctx context.Context, input *ListPackagesInput) ([]*Package, error) {
+	path := fmt.Sprintf("/%s/packages", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -65,9 +67,9 @@ type GetPackageInput struct {
 	ID string
 }
 
-func (client *PackagesClient) GetPackage(input *GetPackageInput) (*Package, error) {
+func (client *PackagesClient) GetPackage(ctx context.Context, input *GetPackageInput) (*Package, error) {
 	path := fmt.Sprintf("/%s/packages/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/roles.go
+++ b/vendor/github.com/joyent/triton-go/roles.go
@@ -1,10 +1,12 @@
 package triton
 
 import (
-	"fmt"
-	"github.com/hashicorp/errwrap"
-	"net/http"
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/errwrap"
 )
 
 type RolesClient struct {
@@ -27,8 +29,9 @@ type Role struct {
 
 type ListRolesInput struct{}
 
-func (client *RolesClient) ListRoles(*ListRolesInput) ([]*Role, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/roles", client.accountName), nil)
+func (client *RolesClient) ListRoles(ctx context.Context, _ *ListRolesInput) ([]*Role, error) {
+	path := fmt.Sprintf("/%s/roles", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -45,13 +48,13 @@ func (client *RolesClient) ListRoles(*ListRolesInput) ([]*Role, error) {
 	return result, nil
 }
 
-type GetRoleInput struct{
+type GetRoleInput struct {
 	RoleID string
 }
 
-func (client *RolesClient) GetRole(input *GetRoleInput) (*Role, error) {
+func (client *RolesClient) GetRole(ctx context.Context, input *GetRoleInput) (*Role, error) {
 	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -85,8 +88,9 @@ type CreateRoleInput struct {
 	DefaultMembers []string `json:"default_members,omitempty"`
 }
 
-func (client *RolesClient) CreateRole(input *CreateRoleInput) (*Role, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/roles", client.accountName), input)
+func (client *RolesClient) CreateRole(ctx context.Context, input *CreateRoleInput) (*Role, error) {
+	path := fmt.Sprintf("/%s/roles", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -123,8 +127,9 @@ type UpdateRoleInput struct {
 	DefaultMembers []string `json:"default_members,omitempty"`
 }
 
-func (client *RolesClient) UpdateRole(input *UpdateRoleInput) (*Role, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID), input)
+func (client *RolesClient) UpdateRole(ctx context.Context, input *UpdateRoleInput) (*Role, error) {
+	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -145,9 +150,9 @@ type DeleteRoleInput struct {
 	RoleID string
 }
 
-func (client *RolesClient) DeleteRoles(input *DeleteRoleInput) error {
+func (client *RolesClient) DeleteRoles(ctx context.Context, input *DeleteRoleInput) error {
 	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/services.go
+++ b/vendor/github.com/joyent/triton-go/services.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,8 +27,9 @@ type Service struct {
 
 type ListServicesInput struct{}
 
-func (client *ServicesClient) ListServices(*ListServicesInput) ([]*Service, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/services", client.accountName), nil)
+func (client *ServicesClient) ListServices(ctx context.Context, _ *ListServicesInput) ([]*Service, error) {
+	path := fmt.Sprintf("/%s/services", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -520,16 +520,16 @@
 			"revision": "c01cf91b011868172fdcd9f41838e80c9d716264"
 		},
 		{
-			"checksumSHA1": "TFdaSXpgmpa6vJzfjtUoHLrp1AM=",
+			"checksumSHA1": "3yw6Wr66v4WrQyY2hYveEmiFadM=",
 			"path": "github.com/joyent/triton-go",
-			"revision": "db2461b5a5a55ca698b4062d95118c03d4aafb88",
-			"revisionTime": "2017-04-26T18:53:01Z"
+			"revision": "16cef4c2d78ba1d3bf89af75e93ae2dec6e56634",
+			"revisionTime": "2017-05-04T20:45:05Z"
 		},
 		{
 			"checksumSHA1": "QzUqkCSn/ZHyIK346xb9V6EBw9U=",
 			"path": "github.com/joyent/triton-go/authentication",
-			"revision": "db2461b5a5a55ca698b4062d95118c03d4aafb88",
-			"revisionTime": "2017-04-26T18:53:01Z"
+			"revision": "16cef4c2d78ba1d3bf89af75e93ae2dec6e56634",
+			"revisionTime": "2017-05-04T20:45:05Z"
 		},
 		{
 			"checksumSHA1": "6nmAJBw2phU9MUmkUnqFvbO5urg=",


### PR DESCRIPTION
This PR updates the triton builder to use the latest `triton-go` library. I've included the vendored lib as well as breaking changes that came along with it. I should also note, the breaking changes include new usage of `context` passed along into the driver client interfaces.

Automated and manual tests all pass for me.

/cc @jen20