### PR TITLE
Update docker metadata fields that can be changed

### DIFF
--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -75,6 +75,7 @@ Example uses of all of the options, assuming one is building an NGINX image from
     "VOLUME /test1 /test2",
     "EXPOSE 80 443",
     "LABEL version=1.0",
+    "ONBUILD RUN date",
     "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
     "MAINTAINER Captain Kirk",
     "ENTRYPOINT /var/www/start.sh"
@@ -100,6 +101,9 @@ Allowed metadata fields that can be changed are:
 - LABEL
 	- String, space separated key=value pairs
 	- EX: `"LABEL version=1.0"`
+- ONBUILD
+	- String
+	- EX: `"ONBUILD RUN date"`
 - MAINTAINER
 	- String, deprecated in Docker version 1.13.0
 	- EX: `"MAINTAINER NAME"`

--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -97,7 +97,7 @@ Allowed metadata fields that can be changed are:
 	- String, space separated ports
 	- EX: `"EXPOSE 80 443"`
 - MAINTAINER
-	- String
+	- String, deprecated in Docker version 1.13.0
 	- EX: `"MAINTAINER NAME"`
 - USER
 	- String

--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -74,6 +74,7 @@ Example uses of all of the options, assuming one is building an NGINX image from
     "ENV HOSTNAME www.example.com",
     "VOLUME /test1 /test2",
     "EXPOSE 80 443",
+    "LABEL version=1.0",
     "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
     "MAINTAINER Captain Kirk",
     "ENTRYPOINT /var/www/start.sh"
@@ -96,6 +97,9 @@ Allowed metadata fields that can be changed are:
 - EXPOSE
 	- String, space separated ports
 	- EX: `"EXPOSE 80 443"`
+- LABEL
+	- String, space separated key=value pairs
+	- EX: `"LABEL version=1.0"`
 - MAINTAINER
 	- String, deprecated in Docker version 1.13.0
 	- EX: `"MAINTAINER NAME"`


### PR DESCRIPTION
- Deprecation notice for `MAINTAINER` field.
- Adds `LABEL` and `ONBUILD` fields.

```
Error response from daemon: maintainer is not a valid change command
```

I've looked up what fields are accepted by `docker commit --change` in the [reference](https://docs.docker.com/engine/reference/commandline/commit/#extended-description) when I got this error.
