### PR TITLE
Synchronous Deletes for Triton Machines

### DIFF
--- a/builder/triton/step_create_source_machine.go
+++ b/builder/triton/step_create_source_machine.go
@@ -64,5 +64,12 @@ func (s *StepCreateSourceMachine) Cleanup(state multistep.StateBag) {
 			state.Put("error", fmt.Errorf("Problem deleting source machine: %s", err))
 			return
 		}
+
+		ui.Say(fmt.Sprintf("Waiting for source machine to be destroyed (%s)...", machineId))
+		err = driver.WaitForMachineDeletion(machineId, 10*time.Minute)
+		if err != nil {
+			state.Put("error", fmt.Errorf("Problem waiting for source machine to be deleted: %s", err))
+			return
+		}
 	}
 }

--- a/vendor/github.com/joyent/triton-go/machines.go
+++ b/vendor/github.com/joyent/triton-go/machines.go
@@ -102,7 +102,8 @@ func (client *MachinesClient) GetMachine(ctx context.Context, input *GetMachineI
 	}
 	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
 		return nil, &TritonError{
-			Code: "ResourceNotFound",
+			StatusCode: response.StatusCode,
+			Code:       "ResourceNotFound",
 		}
 	}
 	if err != nil {
@@ -134,7 +135,8 @@ func (client *MachinesClient) ListMachines(ctx context.Context, _ *ListMachinesI
 	}
 	if response.StatusCode == http.StatusNotFound {
 		return nil, &TritonError{
-			Code: "ResourceNotFound",
+			StatusCode: response.StatusCode,
+			Code:       "ResourceNotFound",
 		}
 	}
 	if err != nil {
@@ -249,7 +251,7 @@ func (client *MachinesClient) DeleteMachine(ctx context.Context, input *DeleteMa
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
-	if response.StatusCode == http.StatusNotFound {
+	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
 		return nil
 	}
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -520,10 +520,10 @@
 			"revision": "c01cf91b011868172fdcd9f41838e80c9d716264"
 		},
 		{
-			"checksumSHA1": "3yw6Wr66v4WrQyY2hYveEmiFadM=",
+			"checksumSHA1": "cdoXZmgAhucjxu9V0xuAwwOoN0U=",
 			"path": "github.com/joyent/triton-go",
-			"revision": "16cef4c2d78ba1d3bf89af75e93ae2dec6e56634",
-			"revisionTime": "2017-05-04T20:45:05Z"
+			"revision": "97ccd9f6c0c0652cf87997bcb01955e0329cd37e",
+			"revisionTime": "2017-05-09T20:29:43Z"
 		},
 		{
 			"checksumSHA1": "QzUqkCSn/ZHyIK346xb9V6EBw9U=",


### PR DESCRIPTION
Before this PR, it is possible to run Packer in a tight loop against triton and have unexpected failures due to the asynchronous nature of images on Triton.

The attached changes the behavior of delete operations so that they return only when the source machine has been fully removed, not just its metadata.

CC @jen20 