### PR TITLE
Fix issue 4693 - Derive vpc_id from subnet_id

### DIFF
--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -89,15 +89,21 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	}
 	ec2conn := ec2.New(session)
 
-	// If the subnet is specified but not the AZ, try to determine the AZ automatically
-	if b.config.SubnetId != "" && b.config.AvailabilityZone == "" {
-		log.Printf("[INFO] Finding AZ for the given subnet '%s'", b.config.SubnetId)
+	// If the subnet is specified but not the VpcId or AZ, try to determine them automatically
+	if b.config.SubnetId != "" && (b.config.AvailabilityZone == "" || b.config.VpcId == "") {
+		log.Printf("[INFO] Finding AZ and VpcId for the given subnet '%s'", b.config.SubnetId)
 		resp, err := ec2conn.DescribeSubnets(&ec2.DescribeSubnetsInput{SubnetIds: []*string{&b.config.SubnetId}})
 		if err != nil {
 			return nil, err
 		}
-		b.config.AvailabilityZone = *resp.Subnets[0].AvailabilityZone
-		log.Printf("[INFO] AZ found: '%s'", b.config.AvailabilityZone)
+		if b.config.AvailabilityZone == "" {
+			b.config.AvailabilityZone = *resp.Subnets[0].AvailabilityZone
+			log.Printf("[INFO] AvailabilityZone found: '%s'", b.config.AvailabilityZone)
+		}
+		if b.config.VpcId == "" {
+			b.config.VpcId = *resp.Subnets[0].VpcId
+			log.Printf("[INFO] VpcId found: '%s'", b.config.VpcId)
+		}
 	}
 
 	// Setup the state bag and initial state for the steps

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -106,15 +106,21 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	ec2conn := ec2.New(awsSession)
 
-	// If the subnet is specified but not the AZ, try to determine the AZ automatically
-	if b.config.SubnetId != "" && b.config.AvailabilityZone == "" {
-		log.Printf("[INFO] Finding AZ for the given subnet '%s'", b.config.SubnetId)
+	// If the subnet is specified but not the VpcId or AZ, try to determine them automatically
+	if b.config.SubnetId != "" && (b.config.AvailabilityZone == "" || b.config.VpcId == "") {
+		log.Printf("[INFO] Finding AZ and VpcId for the given subnet '%s'", b.config.SubnetId)
 		resp, err := ec2conn.DescribeSubnets(&ec2.DescribeSubnetsInput{SubnetIds: []*string{&b.config.SubnetId}})
 		if err != nil {
 			return nil, err
 		}
-		b.config.AvailabilityZone = *resp.Subnets[0].AvailabilityZone
-		log.Printf("[INFO] AZ found: '%s'", b.config.AvailabilityZone)
+		if b.config.AvailabilityZone == "" {
+			b.config.AvailabilityZone = *resp.Subnets[0].AvailabilityZone
+			log.Printf("[INFO] AvailabilityZone found: '%s'", b.config.AvailabilityZone)
+		}
+		if b.config.VpcId == "" {
+			b.config.VpcId = *resp.Subnets[0].VpcId
+			log.Printf("[INFO] VpcId found: '%s'", b.config.VpcId)
+		}
 	}
 
 	// Setup the state bag and initial state for the steps

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -175,15 +175,21 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	}
 	ec2conn := ec2.New(session)
 
-	// If the subnet is specified but not the AZ, try to determine the AZ automatically
-	if b.config.SubnetId != "" && b.config.AvailabilityZone == "" {
-		log.Printf("[INFO] Finding AZ for the given subnet '%s'", b.config.SubnetId)
+	// If the subnet is specified but not the VpcId or AZ, try to determine them automatically
+	if b.config.SubnetId != "" && (b.config.AvailabilityZone == "" || b.config.VpcId == "") {
+		log.Printf("[INFO] Finding AZ and VpcId for the given subnet '%s'", b.config.SubnetId)
 		resp, err := ec2conn.DescribeSubnets(&ec2.DescribeSubnetsInput{SubnetIds: []*string{&b.config.SubnetId}})
 		if err != nil {
 			return nil, err
 		}
-		b.config.AvailabilityZone = *resp.Subnets[0].AvailabilityZone
-		log.Printf("[INFO] AZ found: '%s'", b.config.AvailabilityZone)
+		if b.config.AvailabilityZone == "" {
+			b.config.AvailabilityZone = *resp.Subnets[0].AvailabilityZone
+			log.Printf("[INFO] AvailabilityZone found: '%s'", b.config.AvailabilityZone)
+		}
+		if b.config.VpcId == "" {
+			b.config.VpcId = *resp.Subnets[0].VpcId
+			log.Printf("[INFO] VpcId found: '%s'", b.config.VpcId)
+		}
 	}
 
 	// Setup the state bag and initial state for the steps

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -328,7 +328,8 @@ builder.
 
 - `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
   in order to create a temporary security group within the VPC. Requires `subnet_id`
-  to be set.
+  to be set. If this field is left blank, Packer will try to get the VPC ID from the
+  `subnet_id`.
 
 - `windows_password_timeout` (string) - The timeout for waiting for a Windows
   password for Windows instances. Defaults to 20 minutes. Example value: `10m`

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -319,8 +319,9 @@ builder.
     data when launching the instance.
 
 - `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
-    in order to create a temporary security group within the VPC. Requires `subnet_id`
-    to be set.
+  in order to create a temporary security group within the VPC. Requires `subnet_id`
+  to be set. If this field is left blank, Packer will try to get the VPC ID from the
+  `subnet_id`.
 
 - `windows_password_timeout` (string) - The timeout for waiting for a Windows
     password for Windows instances. Defaults to 20 minutes. Example value: `10m`

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -219,8 +219,9 @@ builder.
     data when launching the instance.
 
 - `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
-    in order to create a temporary security group within the VPC. Requires `subnet_id`
-    to be set.
+  in order to create a temporary security group within the VPC. Requires `subnet_id`
+  to be set. If this field is left blank, Packer will try to get the VPC ID from the
+  `subnet_id`.
 
 - `windows_password_timeout` (string) - The timeout for waiting for a Windows
     password for Windows instances. Defaults to 20 minutes. Example value: `10m`

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -323,7 +323,9 @@ builder.
     data when launching the instance.
 
 - `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
-    in order to create a temporary security group within the VPC.
+  in order to create a temporary security group within the VPC. Requires `subnet_id`
+  to be set. If this field is left blank, Packer will try to get the VPC ID from the
+  `subnet_id`.
 
 - `x509_upload_path` (string) - The path on the remote machine where the X509
     certificate will be uploaded. This path must already exist and be writable.


### PR DESCRIPTION
In AWS we can derive the `VpcId` and AZ from the `SubnetId`, so now we do. In the config you can now only specify the `SubnetId`.

This closes #4693.