### PR TITLE
add an option custom_endpoint_ec2 for amazon builder, add a condition…

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -17,12 +17,13 @@ import (
 
 // AccessConfig is for common configuration related to AWS access
 type AccessConfig struct {
-	AccessKey      string `mapstructure:"access_key"`
-	SecretKey      string `mapstructure:"secret_key"`
-	RawRegion      string `mapstructure:"region"`
-	SkipValidation bool   `mapstructure:"skip_region_validation"`
-	Token          string `mapstructure:"token"`
-	ProfileName    string `mapstructure:"profile"`
+	AccessKey         string `mapstructure:"access_key"`
+	SecretKey         string `mapstructure:"secret_key"`
+	RawRegion         string `mapstructure:"region"`
+	SkipValidation    bool   `mapstructure:"skip_region_validation"`
+	Token             string `mapstructure:"token"`
+	ProfileName       string `mapstructure:"profile"`
+	CustomEndpointEc2 string `mapstructure:"custom_endpoint_ec2"`
 }
 
 // Config returns a valid aws.Config object for access to AWS services, or
@@ -35,6 +36,11 @@ func (c *AccessConfig) Config() (*aws.Config, error) {
 		return nil, err
 	}
 	config := aws.NewConfig().WithRegion(region).WithMaxRetries(11)
+
+	if c.CustomEndpointEc2 != "" {
+		config.Endpoint = &c.CustomEndpointEc2
+	}
+
 	if c.ProfileName != "" {
 		profile, err := NewFromProfile(c.ProfileName)
 		if err != nil {

--- a/builder/amazon/common/step_security_group.go
+++ b/builder/amazon/common/step_security_group.go
@@ -55,8 +55,12 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 	group := &ec2.CreateSecurityGroupInput{
 		GroupName:   &groupName,
 		Description: aws.String("Temporary group for Packer"),
-		VpcId:       &s.VpcId,
 	}
+
+	if s.VpcId != "" {
+		group.VpcId = &s.VpcId
+	}
+
 	groupResp, err := ec2conn.CreateSecurityGroup(group)
 	if err != nil {
 		ui.Error(err.Error())

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -278,6 +278,9 @@ each category, the available configuration keys are alphabetized.
     `BuildRegion` variable is replaced with name of the region where this
     is built.
 
+- `custom_endpoint_ec2` (string) - this option is useful if you use 
+    another cloud provider that provide a compatible API with aws EC2,
+    specify another endpoint like this "https://ec2.another.endpoint..com"
 
 ## Basic Example
 

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -334,6 +334,10 @@ builder.
 - `windows_password_timeout` (string) - The timeout for waiting for a Windows
   password for Windows instances. Defaults to 20 minutes. Example value: `10m`
 
+- `custom_endpoint_ec2` (string) - this option is useful if you use 
+    another cloud provider that provide a compatible API with aws EC2,
+    specify another endpoint like this "https://ec2.another.endpoint..com"
+
 ## Basic Example
 
 Here is a basic example. You will need to provide access keys, and may need to

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -326,6 +326,10 @@ builder.
 - `windows_password_timeout` (string) - The timeout for waiting for a Windows
     password for Windows instances. Defaults to 20 minutes. Example value: `10m`
 
+- `custom_endpoint_ec2` (string) - this option is useful if you use 
+    another cloud provider that provide a compatible API with aws EC2,
+    specify another endpoint like this "https://ec2.another.endpoint..com"
+
 ## Basic Example
 
 ```json

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -226,6 +226,11 @@ builder.
 - `windows_password_timeout` (string) - The timeout for waiting for a Windows
     password for Windows instances. Defaults to 20 minutes. Example value: `10m`
 
+- `custom_endpoint_ec2` (string) - this option is useful if you use 
+    another cloud provider that provide a compatible API with aws EC2,
+    specify another endpoint like this "https://ec2.another.endpoint..com"
+
+
 ## Basic Example
 
 ```json

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -336,6 +336,10 @@ builder.
 - `windows_password_timeout` (string) - The timeout for waiting for a Windows
     password for Windows instances. Defaults to 20 minutes. Example value: `10m`
 
+- `custom_endpoint_ec2` (string) - this option is useful if you use 
+    another cloud provider that provide a compatible API with aws EC2,
+    specify another endpoint like this "https://ec2.another.endpoint..com"
+
 ## Basic Example
 
 Here is a basic example. It is completely valid except for the access keys:


### PR DESCRIPTION
Hello,

i'm working for cloud provider who provide a API compatible with aws EC2, so i just add an option for the amazon builder to specify a custom endpoint for ec2,

I also add a quick fix for the security group creation as our API doesn't handle a empty string as vpc_id durng security_group creation
so i just add an "if" to not include the parameter vpc_id if the packer option is empty

