### PR TITLE
Specify InsecureIgnoreHostKey for HostKeyCallback

### DIFF
--- a/builder/hyperv/common/ssh.go
+++ b/builder/hyperv/common/ssh.go
@@ -42,8 +42,9 @@ func SSHConfigFunc(config *SSHConfig) func(multistep.StateBag) (*gossh.ClientCon
 		}
 
 		return &gossh.ClientConfig{
-			User: config.Comm.SSHUsername,
-			Auth: auth,
+			User:            config.Comm.SSHUsername,
+			Auth:            auth,
+			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 		}, nil
 	}
 }

--- a/builder/null/ssh.go
+++ b/builder/null/ssh.go
@@ -50,6 +50,7 @@ func SSHConfig(username string, password string, privateKeyFile string) func(mul
 					gossh.KeyboardInteractive(
 						ssh.PasswordKeyboardInteractive(password)),
 				},
+				HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 			}, nil
 		}
 	}

--- a/builder/oneandone/ssh.go
+++ b/builder/oneandone/ssh.go
@@ -41,7 +41,8 @@ func sshConfig(state multistep.StateBag) (*gossh.ClientConfig, error) {
 		auth = append(auth, gossh.PublicKeys(signer))
 	}
 	return &gossh.ClientConfig{
-		User: config.Comm.SSHUsername,
-		Auth: auth,
+		User:            config.Comm.SSHUsername,
+		Auth:            auth,
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 	}, nil
 }

--- a/builder/profitbricks/ssh.go
+++ b/builder/profitbricks/ssh.go
@@ -41,7 +41,8 @@ func sshConfig(state multistep.StateBag) (*gossh.ClientConfig, error) {
 		auth = append(auth, gossh.PublicKeys(signer))
 	}
 	return &gossh.ClientConfig{
-		User: config.Comm.SSHUsername,
-		Auth: auth,
+		User:            config.Comm.SSHUsername,
+		Auth:            auth,
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 	}, nil
 }

--- a/builder/qemu/ssh.go
+++ b/builder/qemu/ssh.go
@@ -35,7 +35,8 @@ func sshConfig(state multistep.StateBag) (*gossh.ClientConfig, error) {
 	}
 
 	return &gossh.ClientConfig{
-		User: config.Comm.SSHUsername,
-		Auth: auth,
+		User:            config.Comm.SSHUsername,
+		Auth:            auth,
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 	}, nil
 }

--- a/builder/virtualbox/common/ssh.go
+++ b/builder/virtualbox/common/ssh.go
@@ -36,8 +36,9 @@ func SSHConfigFunc(config SSHConfig) func(multistep.StateBag) (*gossh.ClientConf
 		}
 
 		return &gossh.ClientConfig{
-			User: config.Comm.SSHUsername,
-			Auth: auth,
+			User:            config.Comm.SSHUsername,
+			Auth:            auth,
+			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 		}, nil
 	}
 }

--- a/builder/vmware/common/ssh.go
+++ b/builder/vmware/common/ssh.go
@@ -84,8 +84,9 @@ func SSHConfigFunc(config *SSHConfig) func(multistep.StateBag) (*gossh.ClientCon
 		}
 
 		return &gossh.ClientConfig{
-			User: config.Comm.SSHUsername,
-			Auth: auth,
+			User:            config.Comm.SSHUsername,
+			Auth:            auth,
+			HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 		}, nil
 	}
 }


### PR DESCRIPTION
[A recent breaking change upstream in Golang's crypto
library](https://github.com/golang/crypto/commit/e4e2799dd7aab89f583e1d898300d96367750991)
has broken SSH connectivity for a few builders:

```
==> qemu: Waiting for SSH to become available...
2017/05/20 16:23:58 ui: ==> qemu: Waiting for SSH to become available...
2017/05/20 16:23:58 packer: 2017/05/20 16:23:58 [INFO] Attempting SSH connection...
2017/05/20 16:23:58 packer: 2017/05/20 16:23:58 reconnecting to TCP connection for SSH
2017/05/20 16:23:58 packer: 2017/05/20 16:23:58 handshaking with SSH
2017/05/20 16:23:58 packer: 2017/05/20 16:23:58 handshake error: ssh: must specify HostKeyCallback
2017/05/20 16:23:58 packer: 2017/05/20 16:23:58 [DEBUG] SSH handshake err: ssh: must specify HostKeyCallback
2017/05/20 16:24:05 packer: 2017/05/20 16:24:05 [INFO] Attempting SSH connection...
2017/05/20 16:24:05 packer: 2017/05/20 16:24:05 reconnecting to TCP connection for SSH
2017/05/20 16:24:05 packer: 2017/05/20 16:24:05 handshaking with SSH
2017/05/20 16:24:05 packer: 2017/05/20 16:24:05 handshake error: ssh: must specify HostKeyCallback
2017/05/20 16:24:05 packer: 2017/05/20 16:24:05 [DEBUG] SSH handshake err: ssh: must specify HostKeyCallback
```

Specifying HostKeyCallback as insecure should make things work again
and would make sense for packer's use case.