### PR TITLE
Documentation: Note for private cloud users building custom images on Triton

### DIFF
--- a/website/source/docs/builders/triton.html.md
+++ b/website/source/docs/builders/triton.html.md
@@ -30,6 +30,13 @@ This reusable image can then be used to launch new machines.
 The builder does *not* manage images. Once it creates an image, it is up to you
 to use it or delete it.
 
+~> **Private installations of Triton must have custom images enabled!** To use
+the Triton builder with a private/on-prem installation of Joyent's Triton
+software, you'll need an operator to manually
+[enable custom images](https://docs.joyent.com/private-cloud/install/image-management)
+after installing Triton. This is not a requirement for Joyent's public cloud
+offering of Triton.
+
 ## Configuration Reference
 
 There are many configuration options available for the builder. They are
@@ -110,7 +117,7 @@ builder.
     added to the source machine used for creating the image. For example if any
     of the provisioners which are run need Internet access you will need to add
     the UUID's of the appropriate networks here. If this is not specified,
-    instances will be placed into the default Triton public and internal 
+    instances will be placed into the default Triton public and internal
     networks.
 - `source_machine_tags` (object of key/value strings) - Tags applied to the VM
     used to create the image.


### PR DESCRIPTION
Albeit a small demographic, it's worth noting an additional step which is required for Packer usage on private cloud installations of Joyent's Triton software. This has been hit by myself as well as a few others in the community (thanks @Smithx10) so I figured it was worth a quick link.

I stole the formatting from OpenStack's documentation which [notes an OpenSSL requirement](https://www.packer.io/docs/builders/openstack.html).

Here's a screenshot for those perusing GitHub Issues...

<img width="885" alt="screen shot 2017-05-21 at 2 37 01 pm" src="https://cloud.githubusercontent.com/assets/140/26286456/fd8c229e-3e33-11e7-8429-849999976c54.png">

/cc @jen20 @misterbisson