### PR TITLE
website: Vagrant Cloud post-processor updates

### DIFF
--- a/website/source/docs/post-processors/atlas.html.md
+++ b/website/source/docs/post-processors/atlas.html.md
@@ -14,7 +14,7 @@ Type: `atlas`
 
 The Atlas post-processor uploads artifacts from your packer builds to Atlas for
 hosting. Artifacts hosted in Atlas are automatically made available for use
-with Vagrant and Terraform, and Atlas provides additional features for managing
+with Terraform, and Atlas provides additional features for managing
 versions and releases. [Learn more about packer in
 Atlas.](https://atlas.hashicorp.com/help/packer/features)
 
@@ -58,8 +58,7 @@ The configuration allows you to specify and access the artifact in Atlas.
     `cloudstack.image`, `digitalocean.image`, `docker.image`,
     `googlecompute.image`, `hyperv.image`, `oneandone.image`,
     `openstack.image`, `parallels.image`, `profitbricks.image`, `qemu.image`,
-    `triton.image`, `virtualbox.image`, `vmware.image`, `custom.image`, and
-    `vagrant.box`.
+    `triton.image`, `virtualbox.image`, `vmware.image`, and `custom.image`.
 
 ### Optional:
 
@@ -74,9 +73,7 @@ you can also use `token` configuration option.
     you're using Atlas Enterprise in your own network. Defaults to
     `https://atlas.hashicorp.com/api/v1`.
 
-- `metadata` (map) - Send metadata about the artifact. If the artifact type
-    is `vagrant.box`, you must specify a `provider` metadata about what
-    provider to use.
+- `metadata` (map) - Send metadata about the artifact.
 
     - `description` (string) - Inside the metadata blob you can add a information
         about the uploaded artifact to Atlas. This will be reflected in the box

--- a/website/source/docs/post-processors/atlas.html.md
+++ b/website/source/docs/post-processors/atlas.html.md
@@ -22,6 +22,8 @@ You can also use the push command to [run packer builds in
 Atlas](/docs/commands/push.html). The push command and Atlas post-processor
 can be used together or independently.
 
+~> If you'd like to publish a Vagrant box to [Vagrant Cloud](https://vagrantcloud.com), you must use the [`vagrant-cloud`](/docs/post-processors/vagrant-cloud.html) post-processor.
+
 ## Workflow
 
 To take full advantage of Packer and Atlas, it's important to understand the

--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -11,10 +11,6 @@ description: |-
 
 # Vagrant Cloud Post-Processor
 
-~> Vagrant Cloud has been superseded by Atlas. Please use the [Atlas
-post-processor](/docs/post-processors/atlas.html) instead. Learn more about
-[Atlas](https://atlas.hashicorp.com/).
-
 Type: `vagrant-cloud`
 
 The Packer Vagrant Cloud post-processor receives a Vagrant box from the


### PR DESCRIPTION
Vagrant Cloud will be extracted from Terraform Enterprise (atlas) on June 27th. These documentation updates reflect those upcoming changes.

More information is available here: https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html