### PR TITLE
OpenStack: Support client certificate

### DIFF
--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 	"os"
 
+	"crypto/x509"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/hashicorp/packer/template/interpolate"
 	"io/ioutil"
-	"crypto/x509"
 )
 
 // AccessConfig is for common configuration related to openstack access

--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -3,14 +3,15 @@ package openstack
 import (
 	"crypto/tls"
 	"fmt"
-	"net/http"
 	"os"
 
 	"crypto/x509"
+	"io/ioutil"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/packer/template/interpolate"
-	"io/ioutil"
 )
 
 // AccessConfig is for common configuration related to openstack access
@@ -126,7 +127,7 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 		tls_config.Certificates = []tls.Certificate{cert}
 	}
 
-	transport := http.DefaultTransport.(*http.Transport)
+	transport := cleanhttp.DefaultTransport()
 	transport.TLSClientConfig = tls_config
 	client.HTTPClient.Transport = transport
 

--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -126,9 +126,9 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 		tls_config.Certificates = []tls.Certificate{cert}
 	}
 
-	var transport http.Transport = *http.DefaultTransport.(*http.Transport)
+	transport := http.DefaultTransport.(*http.Transport)
 	transport.TLSClientConfig = tls_config
-	client.HTTPClient.Transport = &transport
+	client.HTTPClient.Transport = transport
 
 	// Auth
 	err = openstack.Authenticate(client, ao)

--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -125,8 +125,10 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 
 		tls_config.Certificates = []tls.Certificate{cert}
 	}
-	transport := &http.Transport{TLSClientConfig: tls_config}
-	client.HTTPClient.Transport = transport
+
+	var transport http.Transport = *http.DefaultTransport.(*http.Transport)
+	transport.TLSClientConfig = tls_config
+	client.HTTPClient.Transport = &transport
 
 	// Auth
 	err = openstack.Authenticate(client, ao)

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -79,6 +79,9 @@ builder.
 - `config_drive` (boolean) - Whether or not nova should use ConfigDrive for
      cloud-init metadata.
 
+- `cert` (string) - Client certificate file path for SSL client authentication.
+    If omitted the OS_CERT environment variable is used.
+
 - `domain_name` or `domain_id` (string) - The Domain name or ID you are
     authenticating with. OpenStack installations require this if identity v3 is used.
     Packer will use the environment variable `OS_DOMAIN_NAME` or `OS_DOMAIN_ID`, if set.
@@ -101,6 +104,9 @@ builder.
 
 - `insecure` (boolean) - Whether or not the connection to OpenStack can be
     done over an insecure connection. By default this is false.
+
+- `key` (string) - Cleint private key file path for SSL client authentication.
+    If ommited the OS_KEY environment variable is used.
 
 - `metadata` (object of key/value strings) - Glance metadata that will be
     applied to the image.

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -76,6 +76,9 @@ builder.
     server in. If this isn't specified, the default enforced by your OpenStack
     cluster will be used. This may be required for some OpenStack clusters.
 
+- `cacert` (string) - Custom CA certificate file path.
+     If ommited the OS_CACERT environment variable can be used.
+
 - `config_drive` (boolean) - Whether or not nova should use ConfigDrive for
      cloud-init metadata.
 

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -80,7 +80,7 @@ builder.
      cloud-init metadata.
 
 - `cert` (string) - Client certificate file path for SSL client authentication.
-    If omitted the OS_CERT environment variable is used.
+    If omitted the OS_CERT environment variable can be used.
 
 - `domain_name` or `domain_id` (string) - The Domain name or ID you are
     authenticating with. OpenStack installations require this if identity v3 is used.
@@ -105,8 +105,8 @@ builder.
 - `insecure` (boolean) - Whether or not the connection to OpenStack can be
     done over an insecure connection. By default this is false.
 
-- `key` (string) - Cleint private key file path for SSL client authentication.
-    If ommited the OS_KEY environment variable is used.
+- `key` (string) - Client private key file path for SSL client authentication.
+    If ommited the OS_KEY environment variable can be used.
 
 - `metadata` (object of key/value strings) - Glance metadata that will be
     applied to the image.


### PR DESCRIPTION
When AUTH_URL and each endpoints need SSL client authentication, we have to specify cert file and private key file.
So, add optional config, cert and key.