### PR TITLE
Add support for passphrase-encrypted SSH Keys

### DIFF
--- a/common/ssh/key.go
+++ b/common/ssh/key.go
@@ -38,8 +38,9 @@ func PassphraseFileSigner(path, passphrase string) (ssh.Signer, error) {
 	if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
 		if passphrase == "" {
 			return nil, fmt.Errorf(
-				"Failed to read key '%s': password protected keys require\n"+
-					"ssh_private_key_passphrase to be set.", path)
+				"Failed to read key '%s': password protected keys for bastion\n"+
+					"hosts require ssh_bastion_private_key_passphrase to\n"+
+					"be set.", path)
 		}
 		return parseEncryptedKey(block, path, passphrase)
 	}

--- a/common/ssh/key.go
+++ b/common/ssh/key.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -11,6 +12,11 @@ import (
 
 // FileSigner returns an ssh.Signer for a key file.
 func FileSigner(path string) (ssh.Signer, error) {
+	return PassphraseFileSigner(path, "")
+}
+
+// PassphraseFileSigner returns an ssh.Signer for a key file.
+func PassphraseFileSigner(path, passphrase string) (ssh.Signer, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -30,9 +36,12 @@ func FileSigner(path string) (ssh.Signer, error) {
 			"Failed to read key '%s': no key found", path)
 	}
 	if block.Headers["Proc-Type"] == "4,ENCRYPTED" {
-		return nil, fmt.Errorf(
-			"Failed to read key '%s': password protected keys are\n"+
-				"not supported. Please decrypt the key prior to use.", path)
+		if passphrase == "" {
+			return nil, fmt.Errorf(
+				"Failed to read key '%s': password protected keys require\n"+
+					"ssh_private_key_passphrase to be set.", path)
+		}
+		return parseEncryptedKey(block, path, passphrase)
 	}
 
 	signer, err := ssh.ParsePrivateKey(keyBytes)
@@ -40,5 +49,30 @@ func FileSigner(path string) (ssh.Signer, error) {
 		return nil, fmt.Errorf("Error setting up SSH config: %s", err)
 	}
 
+	return signer, nil
+}
+
+// parseEncryptedKey returns an ssh.Signer from an encrypted key file.
+func parseEncryptedKey(block *pem.Block, path, passphrase string) (ssh.Signer, error) {
+	der, err := x509.DecryptPEMBlock(block, []byte(passphrase))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to decrypt key '%s': %s", path, err)
+	}
+	var key interface{}
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		key, err = x509.ParsePKCS1PrivateKey(der)
+	case "EC PRIVATE KEY":
+		key, err = x509.ParseECPrivateKey(der)
+	default:
+		err = fmt.Errorf("unsupported key type %q", block.Type)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Error decrypting private key: %s", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("Error setting up encrypted SSH config: %s", err)
+	}
 	return signer, nil
 }

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -16,23 +16,24 @@ type Config struct {
 	Type string `mapstructure:"communicator"`
 
 	// SSH
-	SSHHost                 string        `mapstructure:"ssh_host"`
-	SSHPort                 int           `mapstructure:"ssh_port"`
-	SSHUsername             string        `mapstructure:"ssh_username"`
-	SSHPassword             string        `mapstructure:"ssh_password"`
-	SSHPrivateKey           string        `mapstructure:"ssh_private_key_file"`
-	SSHPrivateKeyPassphrase string        `mapstructure:"ssh_private_key_passphrase"`
-	SSHPty                  bool          `mapstructure:"ssh_pty"`
-	SSHTimeout              time.Duration `mapstructure:"ssh_timeout"`
-	SSHAgentAuth            bool          `mapstructure:"ssh_agent_auth"`
-	SSHDisableAgent         bool          `mapstructure:"ssh_disable_agent"`
-	SSHHandshakeAttempts    int           `mapstructure:"ssh_handshake_attempts"`
-	SSHBastionHost          string        `mapstructure:"ssh_bastion_host"`
-	SSHBastionPort          int           `mapstructure:"ssh_bastion_port"`
-	SSHBastionUsername      string        `mapstructure:"ssh_bastion_username"`
-	SSHBastionPassword      string        `mapstructure:"ssh_bastion_password"`
-	SSHBastionPrivateKey    string        `mapstructure:"ssh_bastion_private_key_file"`
-	SSHFileTransferMethod   string        `mapstructure:"ssh_file_transfer_method"`
+	SSHHost                        string        `mapstructure:"ssh_host"`
+	SSHPort                        int           `mapstructure:"ssh_port"`
+	SSHUsername                    string        `mapstructure:"ssh_username"`
+	SSHPassword                    string        `mapstructure:"ssh_password"`
+	SSHPrivateKey                  string        `mapstructure:"ssh_private_key_file"`
+	SSHPrivateKeyPassphrase        string        `mapstructure:"ssh_private_key_passphrase"`
+	SSHPty                         bool          `mapstructure:"ssh_pty"`
+	SSHTimeout                     time.Duration `mapstructure:"ssh_timeout"`
+	SSHAgentAuth                   bool          `mapstructure:"ssh_agent_auth"`
+	SSHDisableAgent                bool          `mapstructure:"ssh_disable_agent"`
+	SSHHandshakeAttempts           int           `mapstructure:"ssh_handshake_attempts"`
+	SSHBastionHost                 string        `mapstructure:"ssh_bastion_host"`
+	SSHBastionPort                 int           `mapstructure:"ssh_bastion_port"`
+	SSHBastionUsername             string        `mapstructure:"ssh_bastion_username"`
+	SSHBastionPassword             string        `mapstructure:"ssh_bastion_password"`
+	SSHBastionPrivateKey           string        `mapstructure:"ssh_bastion_private_key_file"`
+	SSHBastionPrivateKeyPassphrase string        `mapstructure:"ssh_bastion_private_key_passphrase"`
+	SSHFileTransferMethod          string        `mapstructure:"ssh_file_transfer_method"`
 
 	// WinRM
 	WinRMUser               string        `mapstructure:"winrm_username"`

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -16,22 +16,23 @@ type Config struct {
 	Type string `mapstructure:"communicator"`
 
 	// SSH
-	SSHHost               string        `mapstructure:"ssh_host"`
-	SSHPort               int           `mapstructure:"ssh_port"`
-	SSHUsername           string        `mapstructure:"ssh_username"`
-	SSHPassword           string        `mapstructure:"ssh_password"`
-	SSHPrivateKey         string        `mapstructure:"ssh_private_key_file"`
-	SSHPty                bool          `mapstructure:"ssh_pty"`
-	SSHTimeout            time.Duration `mapstructure:"ssh_timeout"`
-	SSHAgentAuth          bool          `mapstructure:"ssh_agent_auth"`
-	SSHDisableAgent       bool          `mapstructure:"ssh_disable_agent"`
-	SSHHandshakeAttempts  int           `mapstructure:"ssh_handshake_attempts"`
-	SSHBastionHost        string        `mapstructure:"ssh_bastion_host"`
-	SSHBastionPort        int           `mapstructure:"ssh_bastion_port"`
-	SSHBastionUsername    string        `mapstructure:"ssh_bastion_username"`
-	SSHBastionPassword    string        `mapstructure:"ssh_bastion_password"`
-	SSHBastionPrivateKey  string        `mapstructure:"ssh_bastion_private_key_file"`
-	SSHFileTransferMethod string        `mapstructure:"ssh_file_transfer_method"`
+	SSHHost                 string        `mapstructure:"ssh_host"`
+	SSHPort                 int           `mapstructure:"ssh_port"`
+	SSHUsername             string        `mapstructure:"ssh_username"`
+	SSHPassword             string        `mapstructure:"ssh_password"`
+	SSHPrivateKey           string        `mapstructure:"ssh_private_key_file"`
+	SSHPrivateKeyPassphrase string        `mapstructure:"ssh_private_key_passphrase"`
+	SSHPty                  bool          `mapstructure:"ssh_pty"`
+	SSHTimeout              time.Duration `mapstructure:"ssh_timeout"`
+	SSHAgentAuth            bool          `mapstructure:"ssh_agent_auth"`
+	SSHDisableAgent         bool          `mapstructure:"ssh_disable_agent"`
+	SSHHandshakeAttempts    int           `mapstructure:"ssh_handshake_attempts"`
+	SSHBastionHost          string        `mapstructure:"ssh_bastion_host"`
+	SSHBastionPort          int           `mapstructure:"ssh_bastion_port"`
+	SSHBastionUsername      string        `mapstructure:"ssh_bastion_username"`
+	SSHBastionPassword      string        `mapstructure:"ssh_bastion_password"`
+	SSHBastionPrivateKey    string        `mapstructure:"ssh_bastion_private_key_file"`
+	SSHFileTransferMethod   string        `mapstructure:"ssh_file_transfer_method"`
 
 	// WinRM
 	WinRMUser               string        `mapstructure:"winrm_username"`
@@ -153,7 +154,7 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 		if _, err := os.Stat(c.SSHPrivateKey); err != nil {
 			errs = append(errs, fmt.Errorf(
 				"ssh_private_key_file is invalid: %s", err))
-		} else if _, err := SSHFileSigner(c.SSHPrivateKey); err != nil {
+		} else if _, err := SSHFileSigner(c.SSHPrivateKey, c.SSHPrivateKeyPassphrase); err != nil {
 			errs = append(errs, fmt.Errorf(
 				"ssh_private_key_file is invalid: %s", err))
 		}

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -205,7 +205,7 @@ func sshBastionConfig(config *Config) (*gossh.ClientConfig, error) {
 	}
 
 	if config.SSHBastionPrivateKey != "" {
-		signer, err := commonssh.FileSigner(config.SSHBastionPrivateKey)
+		signer, err := commonssh.PassphraseFileSigner(config.SSHBastionPrivateKey, config.SSHBastionPrivateKeyPassphrase)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds two new options:

* `ssh_private_key_passphrase`
* `ssh_bastion_private_key_passphrase`

When attempting to open an encrypted key to create a new `ssh.Signer`, the helpers will now use the passphrase to decrypt the block and create a signer.

Basic example:
```
{
  "type": "amazon-ebs",
  "region": "{{ user `region` }}",
  "source_ami": "{{ user `ami` }}",
  "instance_type": "{{ user `instance_type` }}",
  "ssh_private_key_file": "./rsa_key",
  "ssh_private_key_passphrase": "{{ user `ssh_key_passphrase` }}",
  "ssh_username": "ubuntu",
  "ssh_bastion_host": "{{ user `bastion_host_ip` }}",
  "ssh_bastion_username": "{{ user `bastion_username` }}",
  "ssh_bastion_private_key_file": "./bastion_key",
  "ssh_bastion_private_key_passphrase": "{{ user `bastion_key_passphrase` }}"
  "ami_name": "packer {{ timestamp }}"
}
```

Closes #4732 