### PR TITLE
comm/ssh: Add support for using SSH Agent auth towards a bastion host.

### DIFF
--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	SSHHandshakeAttempts  int           `mapstructure:"ssh_handshake_attempts"`
 	SSHBastionHost        string        `mapstructure:"ssh_bastion_host"`
 	SSHBastionPort        int           `mapstructure:"ssh_bastion_port"`
+	SSHBastionAgentAuth   bool          `mapstructure:"ssh_bastion_agent_auth"`
 	SSHBastionUsername    string        `mapstructure:"ssh_bastion_username"`
 	SSHBastionPassword    string        `mapstructure:"ssh_bastion_password"`
 	SSHBastionPrivateKey  string        `mapstructure:"ssh_bastion_private_key_file"`
@@ -159,7 +160,7 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 		}
 	}
 
-	if c.SSHBastionHost != "" {
+	if c.SSHBastionHost != "" && !c.SSHBastionAgentAuth {
 		if c.SSHBastionPassword == "" && c.SSHBastionPrivateKey == "" {
 			errs = append(errs, errors.New(
 				"ssh_bastion_password or ssh_bastion_private_key_file must be specified"))

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -230,7 +230,8 @@ func sshBastionConfig(config *Config) (*gossh.ClientConfig, error) {
 	}
 
 	return &gossh.ClientConfig{
-		User: config.SSHBastionUsername,
-		Auth: auth,
+		User:            config.SSHBastionUsername,
+		Auth:            auth,
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
 	}, nil
 }

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -58,6 +58,9 @@ the SSH agent to the remote host.
 
 The SSH communicator has the following options:
 
+- `ssh_bastion_agent_auth` (boolean) - If true, the local SSH agent will
+    be used to authenticate with the bastion host. Defaults to false.
+
 - `ssh_bastion_host` (string) - A bastion host to use for the actual
     SSH connection.
 


### PR DESCRIPTION
Adds `ssh_bastion_agent_auth`

Fixes: #4732