### PR TITLE
Kms key regions

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -264,9 +264,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Name:              b.config.AMIName,
 		},
 		&awscommon.StepAMIRegionCopy{
-			AccessConfig: &b.config.AccessConfig,
-			Regions:      b.config.AMIRegions,
-			Name:         b.config.AMIName,
+			AccessConfig:      &b.config.AccessConfig,
+			Regions:           b.config.AMIRegions,
+			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
+			EncryptBootVolume: b.config.AMIEncryptBootVolume,
+			Name:              b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -66,11 +66,11 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 
 			// Make sure that if we have region_kms_key_ids defined the regions in ami_regions are also in region_kms_key_ids
 			if len(c.AMIRegionKmsKeyIds) > 0 {
-				regions_in_key_map := make([]string, 0, len(c.AMIRegionKmsKeyIds))
+				regionsInKeyMap := make([]string, 0, len(c.AMIRegionKmsKeyIds))
 				for reg := range c.AMIRegionKmsKeyIds {
-					regions_in_key_map = append(regions_in_key_map, reg)
+					regionsInKeyMap = append(regionsInKeyMap, reg)
 				}
-				if regions_match := stringInSlice(region, regions_in_key_map); !regions_match {
+				if regionsMatch := stringInSlice(region, regionsInKeyMap); !regionsMatch {
 					errs = append(errs, fmt.Errorf("Region %s is in ami_regions but not in region_kms_key_ids", region))
 				}
 			}
@@ -82,9 +82,9 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 	// Make sure that if we have region_kms_key_ids defined the regions in region_kms_key_ids are also in ami_regions
 	if len(c.AMIRegionKmsKeyIds) > 0 {
-		for KMS_key_region := range c.AMIRegionKmsKeyIds {
-			if regions_match := stringInSlice(KMS_key_region, c.AMIRegions); !regions_match {
-				errs = append(errs, fmt.Errorf("Region %s is in region_kms_key_ids but not in ami_regions", KMS_key_region))
+		for kmsKeyRegion := range c.AMIRegionKmsKeyIds {
+			if regionsMatch := stringInSlice(kmsKeyRegion, c.AMIRegions); !regionsMatch {
+				errs = append(errs, fmt.Errorf("Region %s is in region_kms_key_ids but not in ami_regions", kmsKeyRegion))
 			}
 		}
 	}
@@ -98,8 +98,8 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 			errs = append(errs, fmt.Errorf("Cannot share snapshot encrypted with default KMS key"))
 		}
 		if len(c.AMIRegionKmsKeyIds) > 0 {
-			for _, KMS_key_region := range c.AMIRegionKmsKeyIds {
-				if len(KMS_key_region) == 0 {
+			for _, kmsKeyRegion := range c.AMIRegionKmsKeyIds {
+				if len(kmsKeyRegion) == 0 {
 					errs = append(errs, fmt.Errorf("Cannot share snapshot encrypted with default KMS key"))
 				}
 			}

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -57,6 +57,46 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	}
 	c.AMISkipRegionValidation = false
 
+	c.AMIRegions = []string{"us-east-1", "us-east-2", "us-west-1"}
+	c.AMIRegionKmsKeyIds = map[string]string{
+		"us-east-1": "123-456-7890",
+		"us-west-1": "789-012-3456",
+		"us-east-2": "456-789-0123",
+	}
+	if err := c.Prepare(nil); err != nil {
+		t.Fatal("shouldn't have error")
+	}
+
+	c.AMIRegions = []string{"us-east-1", "us-west-1"}
+	c.AMIRegionKmsKeyIds = map[string]string{
+		"us-east-1": "123-456-7890",
+		"us-west-1": "789-012-3456",
+		"us-east-2": "456-789-0123",
+	}
+	if err := c.Prepare(nil); err == nil {
+		t.Fatal("should have error b/c theres a region in the key map that isn't in ami_regions")
+	}
+
+	c.AMIRegions = []string{"us-east-1", "us-west-1", "us-east-2"}
+	c.AMIRegionKmsKeyIds = map[string]string{
+		"us-east-1": "123-456-7890",
+		"us-west-1": "789-012-3456",
+	}
+	if err := c.Prepare(nil); err == nil {
+		t.Fatal("should have error b/c theres a region in in ami_regions that isn't in the key map")
+	}
+
+	c.SnapshotUsers = []string{"foo", "bar"}
+	c.AMIKmsKeyId = "123-abc-456"
+	c.AMIEncryptBootVolume = true
+	c.AMIRegions = []string{"us-east-1", "us-west-1"}
+	c.AMIRegionKmsKeyIds = map[string]string{
+		"us-east-1": "123-456-7890",
+		"us-west-1": "",
+	}
+	if err := c.Prepare(nil); err == nil {
+		t.Fatal("should have error b/c theres a region in in ami_regions that isn't in the key map")
+	}
 }
 
 func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -58,7 +58,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	c.AMISkipRegionValidation = false
 
 	c.AMIRegions = []string{"us-east-1", "us-east-2", "us-west-1"}
-	c.AMIRegionKmsKeyIds = map[string]string{
+	c.AMIRegionKMSKeyIDs = map[string]string{
 		"us-east-1": "123-456-7890",
 		"us-west-1": "789-012-3456",
 		"us-east-2": "456-789-0123",
@@ -69,7 +69,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 
 	c.SnapshotUsers = []string{"user-foo", "user-bar"}
 	c.AMIRegions = []string{"us-east-1", "us-east-2", "us-west-1"}
-	c.AMIRegionKmsKeyIds = map[string]string{
+	c.AMIRegionKMSKeyIDs = map[string]string{
 		"us-east-1": "123-456-7890",
 		"us-west-1": "789-012-3456",
 		"us-east-2": "",
@@ -79,7 +79,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	}
 
 	c.AMIRegions = []string{"us-east-1", "us-west-1"}
-	c.AMIRegionKmsKeyIds = map[string]string{
+	c.AMIRegionKMSKeyIDs = map[string]string{
 		"us-east-1": "123-456-7890",
 		"us-west-1": "789-012-3456",
 		"us-east-2": "456-789-0123",
@@ -89,7 +89,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	}
 
 	c.AMIRegions = []string{"us-east-1", "us-west-1", "us-east-2"}
-	c.AMIRegionKmsKeyIds = map[string]string{
+	c.AMIRegionKMSKeyIDs = map[string]string{
 		"us-east-1": "123-456-7890",
 		"us-west-1": "789-012-3456",
 	}
@@ -101,7 +101,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	c.AMIKmsKeyId = "123-abc-456"
 	c.AMIEncryptBootVolume = true
 	c.AMIRegions = []string{"us-east-1", "us-west-1"}
-	c.AMIRegionKmsKeyIds = map[string]string{
+	c.AMIRegionKMSKeyIDs = map[string]string{
 		"us-east-1": "123-456-7890",
 		"us-west-1": "",
 	}

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -67,6 +67,16 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 		t.Fatal("shouldn't have error")
 	}
 
+	c.AMIRegions = []string{"us-east-1", "us-east-2", "us-west-1"}
+	c.AMIRegionKMSKeyIDs = map[string]string{
+		"us-east-1": "123-456-7890",
+		"us-west-1": "789-012-3456",
+		"us-east-2": "",
+	}
+	if err := c.Prepare(nil); err != nil {
+		t.Fatal("should have passed; we are able to use default KMS key if not sharing")
+	}
+
 	c.SnapshotUsers = []string{"user-foo", "user-bar"}
 	c.AMIRegions = []string{"us-east-1", "us-east-2", "us-west-1"}
 	c.AMIRegionKMSKeyIDs = map[string]string{

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -67,6 +67,17 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 		t.Fatal("shouldn't have error")
 	}
 
+	c.SnapshotUsers = []string{"user-foo", "user-bar"}
+	c.AMIRegions = []string{"us-east-1", "us-east-2", "us-west-1"}
+	c.AMIRegionKmsKeyIds = map[string]string{
+		"us-east-1": "123-456-7890",
+		"us-west-1": "789-012-3456",
+		"us-east-2": "",
+	}
+	if err := c.Prepare(nil); err == nil {
+		t.Fatal("should have an error b/c can't use default KMS key if sharing")
+	}
+
 	c.AMIRegions = []string{"us-east-1", "us-west-1"}
 	c.AMIRegionKmsKeyIds = map[string]string{
 		"us-east-1": "123-456-7890",

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -35,7 +35,7 @@ func (s *StepAMIRegionCopy) Run(state multistep.StateBag) multistep.StepAction {
 
 	var lock sync.Mutex
 	var wg sync.WaitGroup
-	var reg_key_id string
+	var regKeyID string
 	errs := new(packer.MultiError)
 	for _, region := range s.Regions {
 		if region == *ec2conn.Config.Region {
@@ -47,14 +47,14 @@ func (s *StepAMIRegionCopy) Run(state multistep.StateBag) multistep.StepAction {
 		wg.Add(1)
 		ui.Message(fmt.Sprintf("Copying to: %s", region))
 
-		reg_key_id = s.RegionKeyIds[region]
+		regKeyID = s.RegionKeyIds[region]
 		if !s.EncryptBootVolume {
-			reg_key_id = ""
+			regKeyID = ""
 		}
 
 		go func(region string) {
 			defer wg.Done()
-			id, snapshotIds, err := amiRegionCopy(state, s.AccessConfig, s.Name, ami, region, *ec2conn.Config.Region, reg_key_id)
+			id, snapshotIds, err := amiRegionCopy(state, s.AccessConfig, s.Name, ami, region, *ec2conn.Config.Region, regKeyID)
 			lock.Lock()
 			defer lock.Unlock()
 			amis[region] = id
@@ -87,9 +87,9 @@ func (s *StepAMIRegionCopy) Cleanup(state multistep.StateBag) {
 // amiRegionCopy does a copy for the given AMI to the target region and
 // returns the resulting ID and snapshot IDs, or error.
 func amiRegionCopy(state multistep.StateBag, config *AccessConfig, name string, imageId string,
-	target string, source string, key_id string) (string, []string, error) {
+	target string, source string, keyID string) (string, []string, error) {
 	snapshotIds := []string{}
-	is_encrypted := false
+	isEncrypted := false
 
 	// Connect to the region where the AMI will be copied to
 	awsConfig, err := config.Config()
@@ -104,15 +104,15 @@ func amiRegionCopy(state multistep.StateBag, config *AccessConfig, name string, 
 	}
 	regionconn := ec2.New(session)
 	// if we've provided a map of key ids to regions, use those keys.
-	if len(key_id) > 0 {
-		is_encrypted = true
+	if len(keyID) > 0 {
+		isEncrypted = true
 	}
 	resp, err := regionconn.CopyImage(&ec2.CopyImageInput{
 		SourceRegion:  &source,
 		SourceImageId: &imageId,
 		Name:          &name,
-		Encrypted:     aws.Bool(is_encrypted),
-		KmsKeyId:      aws.String(key_id),
+		Encrypted:     aws.Bool(isEncrypted),
+		KmsKeyId:      aws.String(keyID),
 	})
 
 	if err != nil {

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -47,9 +47,8 @@ func (s *StepAMIRegionCopy) Run(state multistep.StateBag) multistep.StepAction {
 		wg.Add(1)
 		ui.Message(fmt.Sprintf("Copying to: %s", region))
 
-		regKeyID = s.RegionKeyIds[region]
-		if !s.EncryptBootVolume {
-			regKeyID = ""
+		if s.EncryptBootVolume {
+			regKeyID = s.RegionKeyIds[region]
 		}
 
 		go func(region string) {

--- a/builder/amazon/common/step_encrypted_ami.go
+++ b/builder/amazon/common/step_encrypted_ami.go
@@ -25,7 +25,7 @@ func (s *StepCreateEncryptedAMICopy) Run(state multistep.StateBag) multistep.Ste
 	// Encrypt boot not set, so skip step
 	if !s.EncryptBootVolume {
 		if kmsKeyId != "" {
-			log.Printf("Ignoring KMS Key ID: %s, encrypted_boot=false", kmsKeyId)
+			log.Printf("Ignoring KMS Key ID: %s, encrypted=false", kmsKeyId)
 		}
 		return multistep.ActionContinue
 	}
@@ -36,14 +36,14 @@ func (s *StepCreateEncryptedAMICopy) Run(state multistep.StateBag) multistep.Ste
 	var region, id string
 	if amis != nil {
 		for region, id = range amis {
-			break // Only get the first
+			break // There is only ever one region:ami pair in this map
 		}
 	}
 
 	ui.Say(fmt.Sprintf("Copying AMI: %s(%s)", region, id))
 
 	if kmsKeyId != "" {
-		ui.Say(fmt.Sprintf("Encrypting with KMS Key ID: %s", kmsKeyId))
+		ui.Say(fmt.Sprintf("Encypting with KMS Key ID: %s", kmsKeyId))
 	}
 
 	copyOpts := &ec2.CopyImageInput{

--- a/builder/amazon/common/step_encrypted_ami.go
+++ b/builder/amazon/common/step_encrypted_ami.go
@@ -25,7 +25,7 @@ func (s *StepCreateEncryptedAMICopy) Run(state multistep.StateBag) multistep.Ste
 	// Encrypt boot not set, so skip step
 	if !s.EncryptBootVolume {
 		if kmsKeyId != "" {
-			log.Printf("Ignoring KMS Key ID: %s, encrypted=false", kmsKeyId)
+			log.Printf("Ignoring KMS Key ID: %s, encrypted_boot=false", kmsKeyId)
 		}
 		return multistep.ActionContinue
 	}
@@ -43,7 +43,7 @@ func (s *StepCreateEncryptedAMICopy) Run(state multistep.StateBag) multistep.Ste
 	ui.Say(fmt.Sprintf("Copying AMI: %s(%s)", region, id))
 
 	if kmsKeyId != "" {
-		ui.Say(fmt.Sprintf("Encypting with KMS Key ID: %s", kmsKeyId))
+		ui.Say(fmt.Sprintf("Encrypting with KMS Key ID: %s", kmsKeyId))
 	}
 
 	copyOpts := &ec2.CopyImageInput{

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -200,7 +200,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,
 			Regions:           b.config.AMIRegions,
-			RegionKeyIds:      b.config.AMIRegionKmsKeyIds,
+			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,
 		},

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -198,9 +198,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Name:              b.config.AMIName,
 		},
 		&awscommon.StepAMIRegionCopy{
-			AccessConfig: &b.config.AccessConfig,
-			Regions:      b.config.AMIRegions,
-			Name:         b.config.AMIName,
+			AccessConfig:      &b.config.AccessConfig,
+			Regions:           b.config.AMIRegions,
+			RegionKeyIds:      b.config.AMIRegionKmsKeyIds,
+			EncryptBootVolume: b.config.AMIEncryptBootVolume,
+			Name:              b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -217,9 +217,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Name:              b.config.AMIName,
 		},
 		&awscommon.StepAMIRegionCopy{
-			AccessConfig: &b.config.AccessConfig,
-			Regions:      b.config.AMIRegions,
-			Name:         b.config.AMIName,
+			AccessConfig:      &b.config.AccessConfig,
+			Regions:           b.config.AMIRegions,
+			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
+			EncryptBootVolume: b.config.AMIEncryptBootVolume,
+			Name:              b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -270,9 +270,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&StepRegisterAMI{},
 		&awscommon.StepAMIRegionCopy{
-			AccessConfig: &b.config.AccessConfig,
-			Regions:      b.config.AMIRegions,
-			Name:         b.config.AMIName,
+			AccessConfig:      &b.config.AccessConfig,
+			Regions:           b.config.AMIRegions,
+			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
+			EncryptBootVolume: b.config.AMIEncryptBootVolume,
+			Name:              b.config.AMIName,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -194,6 +194,15 @@ each category, the available configuration keys are alphabetized.
         volumes, io1 for Provisioned IOPS (SSD) volumes, and standard for Magnetic
         volumes
 
+- `region_kms_key_ids` (map of strings) - a map of regions to copy the ami to, 
+   along with the custom kms key id to use for encryption for that region. 
+   Keys must match the regions provided in `ami_regions`. If you just want to 
+   encrypt using a default ID, you can stick with `kms_key_id` and `ami_regions`.
+   If you want a region to be encrypted with that region's default key ID, you can 
+   use an empty string `""` instead of a key id in this map. (e.g. `"us-east-1": ""`)
+   However, you cannot use default key IDs if you are using this in conjunction with 
+   `snapshot_users` -- in that situation you must use custom keys.
+
 - `root_device_name` (string) - The root device name. For example, `xvda`.
 
 - `mount_path` (string) - The path where the volume will be mounted. This is

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -128,10 +128,6 @@ builder.
   Tags and attributes are copied along with the AMI. AMI copying takes time
   depending on the size of the AMI, but will generally take many minutes.
 
-- `region_kms_key_ids` (map of strings) - a map of regions to copy the ami to, 
-  along with the custom kms key id to use for encryption for that region. 
-  Keys must match the regions provided in `ami_regions`
-
 - `ami_users` (array of strings) - A list of account IDs that have access to
   launch the resulting AMI(s). By default no additional users other than the
   user creating the AMI has permissions to launch it.
@@ -198,6 +194,15 @@ builder.
   more block devices before the Packer build starts. These are not necessarily
   preserved when booting from the AMI built with Packer. See
   `ami_block_device_mappings`, above, for details.
+
+- `region_kms_key_ids` (map of strings) - a map of regions to copy the ami to, 
+  along with the custom kms key id to use for encryption for that region. 
+  Keys must match the regions provided in `ami_regions`. If you just want to 
+  encrypt using a default ID, you can stick with `kms_key_id` and `ami_regions`.
+  If you want a region to be encrypted with that region's default key ID, you can 
+  use an empty string `""` instead of a key id in this map. (e.g. `"us-east-1": ""`)
+  However, you cannot use default key IDs if you are using this in conjunction with 
+  `snapshot_users` -- in that situation you must use custom keys.
 
 - `run_tags` (object of key/value strings) - Tags to apply to the instance
   that is *launched* to create the AMI. These tags are *not* applied to the

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -128,6 +128,10 @@ builder.
   Tags and attributes are copied along with the AMI. AMI copying takes time
   depending on the size of the AMI, but will generally take many minutes.
 
+- `region_kms_key_ids` (map of strings) - a map of regions to copy the ami to, 
+  along with the custom kms key id to use for encryption for that region. 
+  Keys must match the regions provided in `ami_regions`
+
 - `ami_users` (array of strings) - A list of account IDs that have access to
   launch the resulting AMI(s). By default no additional users other than the
   user creating the AMI has permissions to launch it.

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -188,6 +188,15 @@ builder.
     preserved when booting from the AMI built with packer. See
     `ami_block_device_mappings`, above, for details.
 
+- `region_kms_key_ids` (map of strings) - a map of regions to copy the ami to, 
+   along with the custom kms key id to use for encryption for that region. 
+   Keys must match the regions provided in `ami_regions`. If you just want to 
+   encrypt using a default ID, you can stick with `kms_key_id` and `ami_regions`.
+   If you want a region to be encrypted with that region's default key ID, you can 
+   use an empty string `""` instead of a key id in this map. (e.g. `"us-east-1": ""`)
+   However, you cannot use default key IDs if you are using this in conjunction with 
+   `snapshot_users` -- in that situation you must use custom keys.
+
 - `run_tags` (object of key/value strings) - Tags to apply to the instance
     that is *launched* to create the AMI. These tags are *not* applied to the
     resulting AMI unless they're duplicated in `tags`. This is a

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -115,6 +115,15 @@ builder.
     profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
     to launch the EC2 instance with.
 
+- `region_kms_key_ids` (map of strings) - a map of regions to copy the ami to, 
+   along with the custom kms key id to use for encryption for that region. 
+   Keys must match the regions provided in `ami_regions`. If you just want to 
+   encrypt using a default ID, you can stick with `kms_key_id` and `ami_regions`.
+   If you want a region to be encrypted with that region's default key ID, you can 
+   use an empty string `""` instead of a key id in this map. (e.g. `"us-east-1": ""`)
+   However, you cannot use default key IDs if you are using this in conjunction with 
+   `snapshot_users` -- in that situation you must use custom keys.    
+
 - `run_tags` (object of key/value strings) - Tags to apply to the instance
     that is *launched* to create the AMI. These tags are *not* applied to the
     resulting AMI unless they're duplicated in `tags`. This is a

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -211,6 +211,15 @@ builder.
     preserved when booting from the AMI built with Packer. See
     `ami_block_device_mappings`, above, for details.
 
+- `region_kms_key_ids` (map of strings) - a map of regions to copy the ami to, 
+   along with the custom kms key id to use for encryption for that region. 
+   Keys must match the regions provided in `ami_regions`. If you just want to 
+   encrypt using a default ID, you can stick with `kms_key_id` and `ami_regions`.
+   If you want a region to be encrypted with that region's default key ID, you can 
+   use an empty string `""` instead of a key id in this map. (e.g. `"us-east-1": ""`)
+   However, you cannot use default key IDs if you are using this in conjunction with 
+   `snapshot_users` -- in that situation you must use custom keys.       
+
 - `run_tags` (object of key/value strings) - Tags to apply to the instance
     that is *launched* to create the AMI. These tags are *not* applied to the
     resulting AMI unless they're duplicated in `tags`. This is a


### PR DESCRIPTION
Add a new map of regions to custom kms key ids so that users can specify how to encrypt amis that they want to share across regions; use this map when copying the files between regions. Add some extra validation of packer config to make sure user knows what they're doing and doesn't get unexpected behavior.

Closes #4249
