### PR TITLE
add warning about vagrant.box vms being uploaded to atlas

### DIFF
--- a/command/push.go
+++ b/command/push.go
@@ -184,6 +184,9 @@ func (c *PushCommand) Run(args []string) int {
 				"its own product, Vagrant Cloud. This migration is currently planned for June 27th, \n" +
 				"2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see \n" +
 				"https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html\n" +
+				"In the meantime, you should activate your vagrant cloud account and start replacing your \n" +
+				"Atlas post-processor with the vagrant cloud post-processor. See\n" +
+				"https://www.packer.io/docs/post-processors/vagrant-cloud.html for more details." +
 				"-----------------------------------------------------------------------------------\n")
 		}
 

--- a/command/push.go
+++ b/command/push.go
@@ -177,6 +177,15 @@ func (c *PushCommand) Run(args []string) int {
 	uploadOpts.Builds = make(map[string]*uploadBuildInfo)
 	for _, b := range tpl.Builders {
 		info := &uploadBuildInfo{Type: b.Type}
+		// todo: remove post-migration
+		if b.Type == "vagrant" {
+			c.Ui.Message("\n-----------------------------------------------------------------------------------\n" +
+				"Warning: Vagrant-related functionality will be moved from Terraform Enterprise into \n" +
+				"its own product, Vagrant Cloud. This migration is currently planned for June 27th, \n" +
+				"2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see \n" +
+				"https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html\n" +
+				"-----------------------------------------------------------------------------------\n")
+		}
 
 		// Determine if we're artifacting this build
 		for _, pp := range atlasPPs {

--- a/command/push.go
+++ b/command/push.go
@@ -184,8 +184,8 @@ func (c *PushCommand) Run(args []string) int {
 				"its own product, Vagrant Cloud. This migration is currently planned for June 27th, \n" +
 				"2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see \n" +
 				"https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html\n" +
-				"In the meantime, you should activate your vagrant cloud account and start replacing your \n" +
-				"Atlas post-processor with the vagrant cloud post-processor. See\n" +
+				"In the meantime, you should activate your Vagrant Cloud account and replace your \n" +
+				"Atlas post-processor with the Vagrant Cloud post-processor. See\n" +
 				"https://www.packer.io/docs/post-processors/vagrant-cloud.html for more details." +
 				"-----------------------------------------------------------------------------------\n")
 		}

--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -145,9 +145,9 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	// todo: remove/reword after the migration
 	if p.config.Type == "vagrant.box" {
 		ui.Message("\n-----------------------------------------------------------------------------------\n" +
-			"Warning: Vagrant-related functionality will be moved from Terraform Enterprise into " +
-			"its own product, Vagrant Cloud. This migration is currently planned for June 27th, " +
-			"2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see " +
+			"Warning: Vagrant-related functionality will be moved from Terraform Enterprise into \n" +
+			"its own product, Vagrant Cloud. This migration is currently planned for June 27th, \n" +
+			"2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see \n" +
 			"https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html\n" +
 			"-----------------------------------------------------------------------------------\n")
 	}

--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -138,11 +138,19 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 			return errs
 		}
 	}
-
 	return nil
 }
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+	// todo: remove/reword after the migration
+	if p.config.Type == "vagrant.box" {
+		ui.Message("\n-----------------------------------------------------------------------------------\n" +
+			"Warning: Vagrant-related functionality will be moved from Terraform Enterprise into " +
+			"its own product, Vagrant Cloud. This migration is currently planned for June 27th, " +
+			"2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see " +
+			"https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html\n" +
+			"-----------------------------------------------------------------------------------\n")
+	}
 	if _, err := p.client.Artifact(p.config.user, p.config.name); err != nil {
 		if err != atlas.ErrNotFound {
 			return nil, false, fmt.Errorf(

--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -149,8 +149,8 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			"its own product, Vagrant Cloud. This migration is currently planned for June 27th, \n" +
 			"2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see \n" +
 			"https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html\n" +
-			"In the meantime, you should activate your vagrant cloud account and start replacing your \n" +
-			"Atlas post-processor with the vagrant cloud post-processor. See\n" +
+			"In the meantime, you should activate your Vagrant Cloud account and replace your \n" +
+			"Atlas post-processor with the Vagrant Cloud post-processor. See\n" +
 			"https://www.packer.io/docs/post-processors/vagrant-cloud.html for more details." +
 			"-----------------------------------------------------------------------------------\n")
 	}

--- a/post-processor/atlas/post-processor.go
+++ b/post-processor/atlas/post-processor.go
@@ -149,6 +149,9 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			"its own product, Vagrant Cloud. This migration is currently planned for June 27th, \n" +
 			"2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see \n" +
 			"https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html\n" +
+			"In the meantime, you should activate your vagrant cloud account and start replacing your \n" +
+			"Atlas post-processor with the vagrant cloud post-processor. See\n" +
+			"https://www.packer.io/docs/post-processors/vagrant-cloud.html for more details." +
 			"-----------------------------------------------------------------------------------\n")
 	}
 	if _, err := p.client.Artifact(p.config.user, p.config.name); err != nil {


### PR DESCRIPTION
Add copy with a warning and a link to the vagrant cloud migration if a person using packer's Atlas post-processor tries to upload a vagrant.box vm.
example output:

```   
    ubuntu-1604-vbox (atlas): -----------------------------------------------------------------------------------
    ubuntu-1604-vbox (atlas): Warning: Vagrant-related functionality will be moved from Terraform Enterprise into its own product, Vagrant Cloud. This migration is currently planned for June 27th, 2017 at 6PM EDT/3PM PDT/10PM UTC. For more information see https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html
    ubuntu-1604-vbox (atlas): -----------------------------------------------------------------------------------
    ubuntu-1604-vbox (atlas):
    ubuntu-1604-vbox (atlas): Uploading artifact (629945854 bytes)
Build 'ubuntu-1604-vbox' finished.
```

Closes #4920
