### PR TITLE
Grains

### DIFF
--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -119,6 +119,29 @@ func TestProvisionerPrepare_MinionConfig_RemotePillarRoots(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_GrainsFile(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	config["grains_file"] = "/i/dont/exist/i/think"
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	tf, err := ioutil.TempFile("", "grains")
+	if err != nil {
+		t.Fatalf("error tempfile: %s", err)
+	}
+	defer os.Remove(tf.Name())
+
+	config["grains_file"] = tf.Name()
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestProvisionerPrepare_LocalStateTree(t *testing.T) {
 	var p Provisioner
 	config := testConfig()

--- a/website/source/docs/provisioners/salt-masterless.html.md
+++ b/website/source/docs/provisioners/salt-masterless.html.md
@@ -66,8 +66,8 @@ Optional:
     uploaded to the `/etc/salt` on the remote. This option overrides the
     `remote_state_tree` or `remote_pillar_roots` options.
 
-- `grains_file` (string) - The path to your local [grains file]
-    (https://docs.saltstack.com/en/latest/topics/grains). This will be
+- `grains_file` (string) - The path to your local [grains file](
+    https://docs.saltstack.com/en/latest/topics/grains). This will be
     uploaded to `/etc/salt/grains` on the remote.
 
 - `skip_bootstrap` (boolean) - By default the salt provisioner runs [salt

--- a/website/source/docs/provisioners/salt-masterless.html.md
+++ b/website/source/docs/provisioners/salt-masterless.html.md
@@ -66,6 +66,10 @@ Optional:
     uploaded to the `/etc/salt` on the remote. This option overrides the
     `remote_state_tree` or `remote_pillar_roots` options.
 
+- `grains_file` (string) - The path to your local [grains file]
+    (https://docs.saltstack.com/en/latest/topics/grains). This will be
+    uploaded to `/etc/salt/grains` on the remote.
+
 - `skip_bootstrap` (boolean) - By default the salt provisioner runs [salt
     bootstrap](https://github.com/saltstack/salt-bootstrap) to install salt. Set
     this to true to skip this step.


### PR DESCRIPTION
Added a new salt-masterless provisioner config item 'grains_file' to copy a file to /etc/salt/grains. Code is basically copy of the minion_config item that copies to file to /etc/salt/minion (but without the complication of remotes etc).

Test for grains_file copied from minion_config as well. 

Created this PR because the saltstack I'm working with requires grains and packer salt-masterless provisioner was breaking because grains weren't defined. Works fine with this PR.