### PR TITLE
builder/ebssurrogate: Use correct devices for AMI.

### DIFF
--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -209,7 +209,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&StepRegisterAMI{
 			RootDevice:   b.config.RootDevice,
-			BlockDevices: b.config.BlockDevices.BuildLaunchDevices(),
+			BlockDevices: b.config.BlockDevices.BuildAMIDevices(),
 		},
 		&awscommon.StepCreateEncryptedAMICopy{
 			KeyID:             b.config.AMIKmsKeyId,


### PR DESCRIPTION
replaces #4835