### PR TITLE
Add NTLM authentication support for WinRM communicator

### DIFF
--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	WinRMTimeout            time.Duration `mapstructure:"winrm_timeout"`
 	WinRMUseSSL             bool          `mapstructure:"winrm_use_ssl"`
 	WinRMInsecure           bool          `mapstructure:"winrm_insecure"`
+	WinRMUseNTLM            bool          `mapstructure:"winrm_use_ntlm"`
 	WinRMTransportDecorator func() winrm.Transporter
 }
 
@@ -185,6 +186,10 @@ func (c *Config) prepareWinRM(ctx *interpolate.Context) []error {
 
 	if c.WinRMTimeout == 0 {
 		c.WinRMTimeout = 30 * time.Minute
+	}
+
+	if c.WinRMUseNTLM == true {
+		c.WinRMTransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
 	}
 
 	var errs []error

--- a/helper/communicator/config_test.go
+++ b/helper/communicator/config_test.go
@@ -1,9 +1,11 @@
 package communicator
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/packer/template/interpolate"
+	"github.com/masterzen/winrm"
 )
 
 func testConfig() *Config {
@@ -97,6 +99,29 @@ func TestConfig_winrm_port_ssl(t *testing.T) {
 
 	if c.WinRMPort != 5510 {
 		t.Fatalf("WinRMPort doesn't match custom port 5510 when SSL is enabled.")
+	}
+
+}
+
+func TestConfig_winrm_use_ntlm(t *testing.T) {
+	c := &Config{
+		Type:         "winrm",
+		WinRMUser:    "admin",
+		WinRMUseNTLM: true,
+	}
+	if err := c.Prepare(testContext(t)); len(err) > 0 {
+		t.Fatalf("bad: %#v", err)
+	}
+
+	if c.WinRMTransportDecorator == nil {
+		t.Fatalf("WinRMTransportDecorator not set.")
+	}
+
+	expected := &winrm.ClientNTLM{}
+	actual := c.WinRMTransportDecorator()
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("WinRMTransportDecorator isn't ClientNTLM.")
 	}
 
 }

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -128,4 +128,7 @@ The WinRM communicator has the following options.
 - `winrm_insecure` (boolean) - If true, do not check server certificate
     chain and host name
 
-- `winrm_use_ntlm` (boolean) - If true, use NTLM authentication for WinRM
+- `winrm_use_ntlm` (boolean) - If true, NTLM authentication will be used for WinRM, 
+    rather than default (basic authentication), removing the requirement for basic 
+    authentication to be enabled within the target guest. Further reading for remote 
+    connection authentication can be found [here](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx).

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -127,3 +127,5 @@ The WinRM communicator has the following options.
 
 - `winrm_insecure` (boolean) - If true, do not check server certificate
     chain and host name
+
+- `winrm_use_ntlm` (boolean) - If true, use NTLM authentication for WinRM


### PR DESCRIPTION
This pull request adds NTLM authentication support for the WinRM communicator, removing the requirement for enabling basic authentication.

The configuration directive ``winrm_use_ntlm`` has been added, which will set the WinRM transport decorator to the ``ClientNTLM`` implementation if ``true``.