### PR TITLE
Add configuration to amazon to allow ssh on Windows

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -75,11 +75,13 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	// Validation
 	errs := c.Comm.Prepare(ctx)
-	if c.SSHKeyPairName != "" {
-		if c.Comm.Type == "winrm" && c.Comm.WinRMPassword == "" && c.Comm.SSHPrivateKey == "" {
+	if c.SSHKeyPairName != "" && c.Comm.SSHPrivateKey == "" {
+		if c.Comm.Type == "winrm" && c.Comm.WinRMPassword == "" {
 			errs = append(errs, errors.New("A private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name."))
-		} else if c.Comm.SSHPrivateKey == "" && !c.Comm.SSHAgentAuth {
+		} else if !c.Comm.SSHAgentAuth {
 			errs = append(errs, errors.New("A private_key_file must be provided or ssh_agent_auth enabled when ssh_keypair_name is specified."))
+		} else if c.Comm.Type == "ssh" && c.Comm.SSHWaitForPassword {
+			errs = append(errs, errors.New("A private_key_file must be provided to retrieve the ssh password when ssh_wait_for_password is enabled and ssh_keypair_name is specified."))
 		}
 	}
 

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -174,9 +174,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				ec2conn,
 				b.config.SSHPrivateIp),
 			SSHConfig: awscommon.SSHConfig(
-				b.config.RunConfig.Comm.SSHAgentAuth,
-				b.config.RunConfig.Comm.SSHUsername,
-				b.config.RunConfig.Comm.SSHPassword),
+				&b.config.RunConfig.Comm),
 		},
 		&common.StepProvision{},
 		&awscommon.StepStopEBSBackedInstance{

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -187,9 +187,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				ec2conn,
 				b.config.SSHPrivateIp),
 			SSHConfig: awscommon.SSHConfig(
-				b.config.RunConfig.Comm.SSHAgentAuth,
-				b.config.RunConfig.Comm.SSHUsername,
-				b.config.RunConfig.Comm.SSHPassword),
+				&b.config.RunConfig.Comm),
 		},
 		&common.StepProvision{},
 		&awscommon.StepStopEBSBackedInstance{

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -162,9 +162,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				ec2conn,
 				b.config.SSHPrivateIp),
 			SSHConfig: awscommon.SSHConfig(
-				b.config.RunConfig.Comm.SSHAgentAuth,
-				b.config.RunConfig.Comm.SSHUsername,
-				b.config.RunConfig.Comm.SSHPassword),
+				&b.config.RunConfig.Comm),
 		},
 		&common.StepProvision{},
 		&awscommon.StepStopEBSBackedInstance{

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -251,9 +251,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				ec2conn,
 				b.config.SSHPrivateIp),
 			SSHConfig: awscommon.SSHConfig(
-				b.config.RunConfig.Comm.SSHAgentAuth,
-				b.config.RunConfig.Comm.SSHUsername,
-				b.config.RunConfig.Comm.SSHPassword),
+				&b.config.RunConfig.Comm),
 		},
 		&common.StepProvision{},
 		&StepUploadX509Cert{},

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	SSHBastionPassword    string        `mapstructure:"ssh_bastion_password"`
 	SSHBastionPrivateKey  string        `mapstructure:"ssh_bastion_private_key_file"`
 	SSHFileTransferMethod string        `mapstructure:"ssh_file_transfer_method"`
+	SSHWaitForPassword    bool          `mapstructure:"ssh_wait_for_password"`
 
 	// WinRM
 	WinRMUser               string        `mapstructure:"winrm_username"`

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -106,6 +106,9 @@ The SSH communicator has the following options:
 - `ssh_username` (string) - The username to connect to SSH with. Required
     if using SSH.
 
+- `ssh_wait_for_password` (boolean) - If true, wait for the generated password
+    to be used to authenticate with SSH. Defaults to false.
+     
 ## WinRM Communicator
 
 The WinRM communicator has the following options.


### PR DESCRIPTION
This PR adds:
- A new optional configuration parameter `ssh_wait_for_password`
 which allows Packer to wait for the generated password and use it to connect via SSH instead of using the private key.


Closes #4958 
