### PR TITLE
Add information about artifact in manifest post-processor

### DIFF
--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -86,8 +86,8 @@ func (*Artifact) Files() []string {
 	return []string{}
 }
 
-func (*Artifact) Id() string {
-	return ""
+func (a *Artifact) Id() string {
+	return a.OSDiskUri
 }
 
 func (a *Artifact) State(name string) interface{} {

--- a/builder/azure/arm/artifact_test.go
+++ b/builder/azure/arm/artifact_test.go
@@ -13,6 +13,37 @@ func getFakeSasUrl(name string) string {
 	return fmt.Sprintf("SAS-%s", name)
 }
 
+func TestArtifactId(t *testing.T) {
+	template := CaptureTemplate{
+		Resources: []CaptureResources{
+			{
+				Properties: CaptureProperties{
+					StorageProfile: CaptureStorageProfile{
+						OSDisk: CaptureDisk{
+							Image: CaptureUri{
+								Uri: "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd",
+							},
+						},
+					},
+				},
+				Location: "southcentralus",
+			},
+		},
+	}
+
+	artifact, err := NewArtifact(&template, getFakeSasUrl)
+	if err != nil {
+		t.Fatalf("err=%s", err)
+	}
+
+	expected := "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd"
+
+	result := artifact.Id()
+	if result != expected {
+		t.Fatalf("bad: %s", result)
+	}
+}
+
 func TestArtifactString(t *testing.T) {
 	template := CaptureTemplate{
 		Resources: []CaptureResources{


### PR DESCRIPTION
After Azure image created new VHD file is available only in packer output as OsDiskUri argument.
There were no any reference to created VHD file in manifest post-processor.
I have added URL to VHD file as id of artifact.

Closes #4350
