### PR TITLE
atlas cloud token warn

### DIFF
--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -53,7 +53,9 @@ on Vagrant Cloud, as well as authentication and version information.
 
 - `access_token` (string) - Your access token for the Vagrant Cloud API. This
     can be generated on your [tokens
-    page](https://vagrantcloud.com/account/tokens).
+    page](https://vagrantcloud.com/account/tokens). If not specified, the
+    environment will be searched. First, `VAGRANT_CLOUD_TOKEN` is checked, and
+    if nothing is found, finally `ATLAS_TOKEN` will be used.
 
 - `box_tag` (string) - The shorthand tag for your box that maps to Vagrant
     Cloud, i.e `hashicorp/precise64` for `vagrantcloud.com/hashicorp/precise64`


### PR DESCRIPTION
get vagrant cloud token from the environment. If we're using `ATLAS_TOKEN`, warn about it.

Should solve point 2 in #4973 