### PR TITLE
ansible: add skip_version_check flag

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -52,6 +52,7 @@ type Config struct {
 	SSHHostKeyFile       string   `mapstructure:"ssh_host_key_file"`
 	SSHAuthorizedKeyFile string   `mapstructure:"ssh_authorized_key_file"`
 	SFTPCmd              string   `mapstructure:"sftp_command"`
+	SkipVersionCheck     bool     `mapstructure:"skip_version_check"`
 	UseSFTP              bool     `mapstructure:"use_sftp"`
 	InventoryDirectory   string   `mapstructure:"inventory_directory"`
 	inventoryFile        string
@@ -132,9 +133,11 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		}
 	}
 
-	err = p.getVersion()
-	if err != nil {
-		errs = packer.MultiErrorAppend(errs, err)
+	if !p.config.SkipVersionCheck {
+		err = p.getVersion()
+		if err != nil {
+			errs = packer.MultiErrorAppend(errs, err)
+		}
 	}
 
 	if p.config.User == "" {

--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -51,18 +51,61 @@ Required Parameters:
 
 Optional Parameters:
 
+- `ansible_env_vars` (array of strings) - Environment variables to set before
+  running Ansible.
+  Usage example:
+
+    ```json
+    {
+      "ansible_env_vars": [ "ANSIBLE_HOST_KEY_CHECKING=False", "ANSIBLE_SSH_ARGS='-o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s'", "ANSIBLE_NOCOLOR=True" ]
+    }
+    ```
+
 - `command` (string) - The command to invoke ansible.
    Defaults to `ansible-playbook`.
+
+- `empty_groups` (array of strings) - The groups which should be present in
+  inventory file but remain empty.
+
+- `extra_arguments` (array of strings) - Extra arguments to pass to Ansible.
+  These arguments _will not_ be passed through a shell and arguments should
+  not be quoted. Usage example:
+
+    ```json
+    {
+      "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
+    }
+    ```
 
 - `groups` (array of strings) - The groups into which the Ansible host
   should be placed. When unspecified, the host is not associated with any
   groups.
 
-- `empty_groups` (array of strings) - The groups which should be present in
-  inventory file but remain empty.
-
 - `host_alias` (string) - The alias by which the Ansible host should be known.
   Defaults to `default`.
+
+- `inventory_directory` (string) - The directory in which to place the
+  temporary generated Ansible inventory file. By default, this is the
+  system-specific temporary file location.  The fully-qualified name of this
+  temporary file will be passed to the `-i` argument of the `ansible` command
+  when this provisioner runs ansible.  Specify this if you have an existing
+  inventory directory with `host_vars` `group_vars` that you would like to use
+  in the playbook that this provisioner will run.
+
+- `local_port` (string) - The port on which to attempt to listen for SSH
+  connections. This value is a starting point.  The provisioner will attempt
+  listen for SSH connections on the first available of ten ports, starting at
+  `local_port`. A system-chosen port is used when `local_port` is missing or
+  empty.
+
+- `sftp_command` (string) - The command to run on the machine being provisioned
+  by Packer to handle the SFTP protocol that Ansible will use to transfer
+  files. The command should read and write on stdin and stdout, respectively.
+  Defaults to `/usr/lib/sftp-server -e`.
+
+- `skip_version_check` (bool) - Check if ansible is installed prior to running.
+  Set this to `true`, for example, if you're going to install ansible during
+  the packer run.
 
 - `ssh_host_key_file` (string) - The SSH key that will be used to run the SSH
   server on the host machine to forward commands to the target machine. Ansible
@@ -76,51 +119,8 @@ Optional Parameters:
   this key is generated, the corresponding private key is passed to
   `ansible-playbook` with the `--private-key` option.
 
-- `local_port` (string) - The port on which to attempt to listen for SSH
-  connections. This value is a starting point.  The provisioner will attempt
-  listen for SSH connections on the first available of ten ports, starting at
-  `local_port`. A system-chosen port is used when `local_port` is missing or
-  empty.
-
-- `sftp_command` (string) - The command to run on the machine being provisioned
-  by Packer to handle the SFTP protocol that Ansible will use to transfer
-  files. The command should read and write on stdin and stdout, respectively.
-  Defaults to `/usr/lib/sftp-server -e`.
-
-- `use_sftp` (boolean) - Whether to use SFTP. When false,
-  `ANSIBLE_SCP_IF_SSH=True` will be automatically added to `ansible_env_vars`.
-  Defaults to false.
-
-- `extra_arguments` (array of strings) - Extra arguments to pass to Ansible.
-  These arguments _will not_ be passed through a shell and arguments should
-  not be quoted. Usage example:
-
-    ```json
-    {
-      "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
-    }
-    ```
-
-- `ansible_env_vars` (array of strings) - Environment variables to set before
-  running Ansible.
-  Usage example:
-
-    ```json
-    {
-      "ansible_env_vars": [ "ANSIBLE_HOST_KEY_CHECKING=False", "ANSIBLE_SSH_ARGS='-o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s'", "ANSIBLE_NOCOLOR=True" ]
-    }
-    ```
-
 - `user` (string) - The `ansible_user` to use. Defaults to the user running
   packer.
-
-- `inventory_directory` (string) - The directory in which to place the
-  temporary generated Ansible inventory file. By default, this is the
-  system-specific temporary file location.  The fully-qualified name of this
-  temporary file will be passed to the `-i` argument of the `ansible` command
-  when this provisioner runs ansible.  Specify this if you have an existing
-  inventory directory with `host_vars` `group_vars` that you would like to use
-  in the playbook that this provisioner will run.
 
 ## Default Extra Variables
 


### PR DESCRIPTION
add flag to control ansible version check. This is useful if you're going to install ansible as part of the packer build.

also alpha-sort config options