### PR TITLE
Fix vet issues with alicloud-import

### DIFF
--- a/post-processor/alicloud-import/post-processor.go
+++ b/post-processor/alicloud-import/post-processor.go
@@ -232,17 +232,18 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 						getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 				}
 				if _, err := ramClient.AttachPolicyToRole(ram.AttachPolicyToRoleRequest{
-					ram.PolicyRequest{
+					PolicyRequest: ram.PolicyRequest{
 						PolicyName: "AliyunECSImageImportRolePolicy",
 						PolicyType: "System",
-					}, "AliyunECSImageImportDefaultRole",
+					},
+					RoleName: "AliyunECSImageImportDefaultRole",
 				}); err != nil {
 					return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 						getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 				}
 			} else {
 				policyListResponse, err := ramClient.ListPoliciesForRole(ram.RoleQueryRequest{
-					"AliyunECSImageImportDefaultRole",
+					RoleName: "AliyunECSImageImportDefaultRole",
 				})
 				if err != nil {
 					return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
@@ -258,10 +259,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 				}
 				if isAliyunECSImageImportRolePolicyNotExit {
 					if _, err := ramClient.AttachPolicyToRole(ram.AttachPolicyToRoleRequest{
-						ram.PolicyRequest{
+						PolicyRequest: ram.PolicyRequest{
 							PolicyName: "AliyunECSImageImportRolePolicy",
 							PolicyType: "System",
-						}, "AliyunECSImageImportDefaultRole",
+						},
+						RoleName: "AliyunECSImageImportDefaultRole",
 					}); err != nil {
 						return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 							getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)


### PR DESCRIPTION
There were some really small vet issues in the alicloud-import package.

```
post-processor/alicloud-import/post-processor.go:234: github.com/hashicorp/packer/vendor/github.com/denverdino/aliyungo/ram.AttachPolicyToRoleRequest composite literal uses unkeyed fields
post-processor/alicloud-import/post-processor.go:244: github.com/hashicorp/packer/vendor/github.com/denverdino/aliyungo/ram.RoleQueryRequest composite literal uses unkeyed fields
post-processor/alicloud-import/post-processor.go:260: github.com/hashicorp/packer/vendor/github.com/denverdino/aliyungo/ram.AttachPolicyToRoleRequest composite literal uses unkeyed fields
```

We just looked up the source for these types and keyed the fields, and well, here you go. Hope this helps.