### PR TITLE
Explicitly specify `zoneid` when calling CloudStack's `associateIpAddress`

### DIFF
--- a/builder/cloudstack/step_configure_networking.go
+++ b/builder/cloudstack/step_configure_networking.go
@@ -74,6 +74,8 @@ func (s *stepSetupNetworking) Run(state multistep.StateBag) multistep.StepAction
 			p.SetNetworkid(network.Id)
 		}
 
+		p.SetZoneid(config.Zone)
+
 		// Associate a new public IP address.
 		ipAddr, err := client.Address.AssociateIpAddress(p)
 		if err != nil {


### PR DESCRIPTION
In Apache CloudStack, when allocating public IP address, just specifying one of either zoneid, networkid or vpcid is sufficient because a network in CloudStack cannot span multiple zones.

https://cloudstack.apache.org/api/apidocs-4.7/user/associateIpAddress.html

However, I ran into an issue when running `cloudstack` builder against a Japanese CloudStack provider (IDC Frontier; a Yahoo Japan's subsidiary). According to their support staff, they are running customized version of Accelerite CloudStack 4.7, and they are customizing the behavior of `associateIpAddress` to make `zoneid` as a mandatory parameter to keep compatibility with their own custom services.

http://docs.idcf.jp/cloud/api/address/#associateipaddress-a (only Japanese page available 😞 )

I confirmed that Packer just worked fine even with IDC Frontier's CloudStack if I applied this patch. Generally speaking, explicitly specifying `zoneid` must be just harmless since the address needs to be allocated within the zone where temporary instance will run.

