### PR TITLE
Print in the output the temporary security group name too.

### DIFF
--- a/builder/amazon/common/step_security_group.go
+++ b/builder/amazon/common/step_security_group.go
@@ -49,8 +49,8 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	// Create the group
-	ui.Say("Creating temporary security group for this instance...")
-	groupName := fmt.Sprintf("packer %s", uuid.TimeOrderedUUID())
+	groupName := fmt.Sprintf("packer_%s", uuid.TimeOrderedUUID())
+	ui.Say(fmt.Sprintf("Creating temporary security group for this instance: %s", groupName))
 	log.Printf("Temporary group name: %s", groupName)
 	group := &ec2.CreateSecurityGroupInput{
 		GroupName:   &groupName,


### PR DESCRIPTION
This cosmetic PR adds to the printed output the temporary security group name in similar way as it's printed the SSH temporary key for consistency.

Before:
```
==> amazon-ebs: Creating temporary keypair: packer_593ad2ce-2fe3-a0cf-2def-ca36225362d5
==> amazon-ebs: Creating temporary security group for this instance...
```

After:
```
==> amazon-ebs: Creating temporary keypair: packer_593ae879-abf8-791d-274e-87f93ea94a8c
==> amazon-ebs: Creating temporary security group for this instance: packer_593ae87a-56b0-e8f7-a253-fdd0f559b4ba
```
