### PR TITLE
Add support for salt_bin_dir

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -61,6 +61,9 @@ type Config struct {
 	// Arguments to pass to salt-call
 	SaltCallArgs string `mapstructure:"salt_call_args"`
 
+	// Directory containing salt-call
+	SaltBinDir string `mapstructure:"salt_bin_dir"`
+
 	// Command line args passed onto salt-call
 	CmdArgs string ""
 
@@ -281,7 +284,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	}
 
 	ui.Message(fmt.Sprintf("Running: salt-call --local %s", p.config.CmdArgs))
-	cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("salt-call --local %s", p.config.CmdArgs))}
+	cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("%s --local %s", filepath.Join(p.config.SaltBinDir, "salt-call"), p.config.CmdArgs))}
 	if err = cmd.StartWithUi(comm, ui); err != nil || cmd.ExitStatus != 0 {
 		if err == nil {
 			err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus)

--- a/website/source/docs/provisioners/salt-masterless.html.md
+++ b/website/source/docs/provisioners/salt-masterless.html.md
@@ -86,3 +86,6 @@ Optional:
     [salt-call](https://docs.saltstack.com/ref/cli/salt-call.html) documentation for more
     information. By default no additional arguments (besides the ones Packer generates)
     are passed to `salt-call`.
+
+- `salt_bin_dir` (string) - Path to the `salt-call` executable. Useful if it is not
+    on the PATH.


### PR DESCRIPTION
Allows specifying the path to salt-call, useful if it isn't on the PATH.
