### PR TITLE
website: Recommend vagrantcloud version from var

### DIFF
--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -93,7 +93,8 @@ post-processor.
 ```json
 {
   "variables": {
-    "cloud_token": "{{ env `ATLAS_TOKEN` }}"
+    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
+    "version": "1.0.{{timestamp}}"
   },
   "post-processors": [
     [
@@ -107,7 +108,7 @@ post-processor.
         "type": "vagrant-cloud",
         "box_tag": "hashicorp/precise64",
         "access_token": "{{user `cloud_token`}}",
-        "version": "1.0.{{timestamp}}"
+        "version": "{{user `version`}}"
       }
     ]
   ]


### PR DESCRIPTION
When using multiple builders, the post-processor could yield different results for the `{{timestamp}}` interpolation.

By using a variable instead, the version will be consistent across all builders.

https://github.com/hashicorp/packer/issues/4973