### PR TITLE
Revert "Universally provide POSIX semantics for the `shell` provision…

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -101,7 +101,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.ExecuteCommand == "" {
-		p.config.ExecuteCommand = "chmod +x {{.Path}}; env {{.Vars}} {{.Path}}"
+		p.config.ExecuteCommand = "chmod +x {{.Path}}; {{.Vars}} {{.Path}}"
 	}
 
 	if p.config.ExpectDisconnect == nil {

--- a/website/source/docs/provisioners/shell.html.md
+++ b/website/source/docs/provisioners/shell.html.md
@@ -66,7 +66,7 @@ Optional parameters:
     as well, which are covered in the section below.
 
 -   `execute_command` (string) - The command to use to execute the script. By
-    default this is `chmod +x {{ .Path }}; env {{ .Vars }} {{ .Path }}`. The value
+    default this is `chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}`. The value
     of this is treated as [configuration
     template](/docs/templates/engine.html). There are two
     available variables: `Path`, which is the path to the script to run, and
@@ -126,14 +126,17 @@ is being piped in with the value of `packer`.
 By setting the `execute_command` to this, your script(s) can run with root
 privileges without worrying about password prompts.
 
-### `execute_command` Example
+### FreeBSD Example
 
-The following contrived example shows how to pass environment variables and
-change the permissions of the script to be executed:
+FreeBSD's default shell is `tcsh`, which deviates from POSIX semantics. In order
+for packer to pass environment variables you will need to change the
+`execute_command` to:
 
 ``` text
-chmod +x {{ .Path }}; chmod 0700 {{ .Path}}; env {{ .Vars }} {{ .Path }}
+chmod +x {{ .Path }}; env {{ .Vars }} {{ .Path }}
 ```
+
+Note the addition of `env` before `{{ .Vars }}`.
 
 ## Default Environmental Variables
 


### PR DESCRIPTION
…er."

This reverts commit 1ba7f9cc20d5947c7c562f799cebcf3b5601fcce.

Closes #5031

@sean- had to revert this but happy to merge back if it can be done in a way that doesn't break #5031.

It looks like when you do `./myscript.sh` it gets you bash, but if you run `env myscript.sh` you get sh. 