### PR TITLE
Fix windows filepath in docker-toolbox call.  

### DIFF
--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -227,6 +228,11 @@ func (d *DockerDriver) StartContainer(config *ContainerConfig) (string, error) {
 		args = append(args, "--privileged")
 	}
 	for host, guest := range config.Volumes {
+		if runtime.GOOS == "windows" {
+			// docker-toolbox can't handle the normal C:\filepath format in CLI
+			host = strings.Replace(host, "\\", "/", -1)
+			host = strings.Replace(host, "C:/", "/c/", 1)
+		}
 		args = append(args, "-v", fmt.Sprintf("%s:%s", host, guest))
 	}
 	for _, v := range config.RunCommand {


### PR DESCRIPTION
de-mangle windows file-path to something docker can handle.  Tested with docker toolbox and docker for windows.  This make the packer docker builder work as well for docker toolbox as for docker for windows, which admittedly isn't great.

Closes #4887
