### PR TITLE
vnc port discovery timeout is 15 seconds

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -198,7 +198,7 @@ func (d *ESX5Driver) VNCAddress(_ string, portMin, portMax uint) (string, uint, 
 		}
 	}
 
-	vncTimeout := time.Duration(15)
+	vncTimeout := time.Duration(15 * time.Second)
 	envTimeout := os.Getenv("PACKER_ESXI_VNC_PROBE_TIMEOUT")
 	if envTimeout != "" {
 		if parsedTimeout, err := time.ParseDuration(envTimeout); err != nil {


### PR DESCRIPTION
#4919 improperly set default timeout to 15ns, instead of 15 seconds