### PR TITLE
Parallels: skip missing paths when looking for unnecessary files

### DIFF
--- a/builder/parallels/common/artifact.go
+++ b/builder/parallels/common/artifact.go
@@ -29,6 +29,14 @@ func NewArtifact(dir string) (packer.Artifact, error) {
 	files := make([]string, 0, 5)
 	visit := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				// It's possible that the path in question existed prior to visit being invoked, but has
+				// since been deleted. This happens, for example, if you have the VM console open while
+				// building. Opening the console creates a <vm name>.app directory which is gone by the time
+				// visit is invoked, resulting in err being a "file not found" error. In this case, skip the
+				// entire path and continue to the next one.
+				return filepath.SkipDir
+			}
 			return err
 		}
 		for _, unnecessaryFile := range unnecessaryFiles {


### PR DESCRIPTION
In the `NewArtifact` function for Parallels, when walking and visiting, it's possible that the path in question existed prior to visit being invoked, but has since been deleted. This happens, for example, if you have the VM console open while building. Opening the console creates a <vm name>.app directory which is gone by the time visit is invoked, resulting in err being a "file not found" error. In this case, skip the entire path and continue to the next one.

Closes #5056 

cc @rickard-von-essen @legal90 