### PR TITLE
fix panic that occurs when ami_block_device_mappings and does not exp…

### DIFF
--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -25,7 +25,8 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Registering the AMI...")
 
-	blockDevicesExcludingRoot := make([]*ec2.BlockDeviceMapping, 0, len(s.BlockDevices)-1)
+	// Defensive coding to make sure we only add the root volume once
+	blockDevicesExcludingRoot := make([]*ec2.BlockDeviceMapping, 0, len(s.BlockDevices))
 	for _, blockDevice := range s.BlockDevices {
 		if *blockDevice.DeviceName == s.RootDevice.SourceDeviceName {
 			continue

--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -25,17 +25,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Registering the AMI...")
 
-	// Defensive coding to make sure we only add the root volume once
-	blockDevicesExcludingRoot := make([]*ec2.BlockDeviceMapping, 0, len(s.BlockDevices))
-	for _, blockDevice := range s.BlockDevices {
-		if *blockDevice.DeviceName == s.RootDevice.SourceDeviceName {
-			continue
-		}
-
-		blockDevicesExcludingRoot = append(blockDevicesExcludingRoot, blockDevice)
-	}
-
-	blockDevicesExcludingRoot = append(blockDevicesExcludingRoot, s.RootDevice.createBlockDeviceMapping(snapshotId))
+	blockDevicesExcludingRoot := DeduplicateRootVolume(s.BlockDevices, s.RootDevice, snapshotId)
 
 	registerOpts := &ec2.RegisterImageInput{
 		Name:                &config.AMIName,
@@ -125,4 +115,19 @@ func (s *StepRegisterAMI) Cleanup(state multistep.StateBag) {
 		ui.Error(fmt.Sprintf("Error deregistering AMI, may still be around: %s", err))
 		return
 	}
+}
+
+func DeduplicateRootVolume(BlockDevices []*ec2.BlockDeviceMapping, RootDevice RootBlockDevice, snapshotId string) []*ec2.BlockDeviceMapping {
+	// Defensive coding to make sure we only add the root volume once
+	blockDevicesExcludingRoot := make([]*ec2.BlockDeviceMapping, 0, len(BlockDevices))
+	for _, blockDevice := range BlockDevices {
+		if *blockDevice.DeviceName == RootDevice.SourceDeviceName {
+			continue
+		}
+
+		blockDevicesExcludingRoot = append(blockDevicesExcludingRoot, blockDevice)
+	}
+
+	blockDevicesExcludingRoot = append(blockDevicesExcludingRoot, RootDevice.createBlockDeviceMapping(snapshotId))
+	return blockDevicesExcludingRoot
 }

--- a/builder/amazon/ebssurrogate/step_register_ami_test.go
+++ b/builder/amazon/ebssurrogate/step_register_ami_test.go
@@ -1,0 +1,37 @@
+package ebssurrogate
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func GetStringPointer() *string {
+	tmp := "/dev/name"
+	return &tmp
+}
+
+func GetTestDevice() *ec2.BlockDeviceMapping {
+	TestDev := ec2.BlockDeviceMapping{
+		DeviceName: GetStringPointer(),
+	}
+	return &TestDev
+}
+
+func TestStepRegisterAmi_DeduplicateRootVolume(t *testing.T) {
+	TestRootDevice := RootBlockDevice{}
+	TestRootDevice.SourceDeviceName = "/dev/name"
+
+	blockDevices := []*ec2.BlockDeviceMapping{}
+	blockDevicesExcludingRoot := DeduplicateRootVolume(blockDevices, TestRootDevice, "12342351")
+	if len(blockDevicesExcludingRoot) != 1 {
+		t.Fatalf("Unexpected length of block devices list")
+	}
+
+	TestBlockDevice := GetTestDevice()
+	blockDevices = append(blockDevices, TestBlockDevice)
+	blockDevicesExcludingRoot = DeduplicateRootVolume(blockDevices, TestRootDevice, "12342351")
+	if len(blockDevicesExcludingRoot) != 1 {
+		t.Fatalf("Unexpected length of block devices list")
+	}
+}


### PR DESCRIPTION
fix error that happens if ami_block_device_mappings is empty
Closes #5053 

@mwhooker I know we talked about moving the defensive coding to a validation step but it actually makes more intuitive sense to me here, rather than cluttering up the main builder.
cc @jen20 since I see you worked on this part of the code most recently.