### PR TITLE
azure: device login notes

### DIFF
--- a/website/source/docs/builders/azure-setup.html.md
+++ b/website/source/docs/builders/azure-setup.html.md
@@ -44,6 +44,8 @@ There are three pieces of information you must provide to enable device login mo
 
 > Device login mode is enabled by not setting client\_id and client\_secret.
 
+> Device login mode is for the public cloud only, and Linux VMs only.
+
 The device login flow asks that you open a web browser, navigate to <http://aka.ms/devicelogin>, and input the supplied
 code. This authorizes the Packer for Azure application to act on your behalf. An OAuth token will be created, and stored
 in the user's home directory (~/.azure/packer/oauth-TenantID.json). This token is used if the token file exists, and it


### PR DESCRIPTION
Device login is for public cloud only, and Linux only.  These points should be better emphasized in the docs.