### PR TITLE
azure: private SSH private key for debug

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -180,6 +180,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if b.config.PackerDebug {
 		ui.Message(fmt.Sprintf("temp admin user: '%s'", b.config.UserName))
 		ui.Message(fmt.Sprintf("temp admin password: '%s'", b.config.Password))
+
+		if b.config.sshPrivateKey != "" {
+			ui.Message(fmt.Sprintf("temp private ssh key: '%s'", b.config.sshPrivateKey))
+		}
 	}
 
 	b.runner = packerCommon.NewRunner(steps, b.config.PackerConfig, ui)


### PR DESCRIPTION
Print the private SSH key for debug builds.  Customers need a way to access VMs during a debug build, and without the private SSH key they cannot connect to the VM.

Closes: #4939