### PR TITLE
Hyper-V Builder - Add support for temp_path directive to override system %temp%

### DIFF
--- a/builder/hyperv/common/step_create_tempdir.go
+++ b/builder/hyperv/common/step_create_tempdir.go
@@ -2,14 +2,16 @@ package common
 
 import (
 	"fmt"
-	"github.com/hashicorp/packer/packer"
-	"github.com/mitchellh/multistep"
 	"io/ioutil"
 	"os"
+
+	"github.com/hashicorp/packer/packer"
+	"github.com/mitchellh/multistep"
 )
 
 type StepCreateTempDir struct {
-	dirPath string
+	TempPath string
+	dirPath  string
 }
 
 func (s *StepCreateTempDir) Run(state multistep.StateBag) multistep.StepAction {
@@ -17,8 +19,11 @@ func (s *StepCreateTempDir) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Creating temporary directory...")
 
-	tempDir := os.TempDir()
-	packerTempDir, err := ioutil.TempDir(tempDir, "packerhv")
+	if s.TempPath == "" {
+		s.TempPath = os.TempDir()
+	}
+
+	packerTempDir, err := ioutil.TempDir(s.TempPath, "packerhv")
 	if err != nil {
 		err := fmt.Errorf("Error creating temporary directory: %s", err)
 		state.Put("error", err)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -90,6 +90,7 @@ type Config struct {
 	EnableDynamicMemory            bool     `mapstructure:"enable_dynamic_memory"`
 	EnableSecureBoot               bool     `mapstructure:"enable_secure_boot"`
 	EnableVirtualizationExtensions bool     `mapstructure:"enable_virtualization_extensions"`
+	TempPath                       string   `mapstructure:"temp_path"`
 
 	Communicator string `mapstructure:"communicator"`
 
@@ -303,7 +304,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	state.Put("ui", ui)
 
 	steps := []multistep.Step{
-		&hypervcommon.StepCreateTempDir{},
+		&hypervcommon.StepCreateTempDir{
+			TempPath: b.config.TempPath,
+		},
 		&hypervcommon.StepOutputDir{
 			Force: b.config.PackerForce,
 			Path:  b.config.OutputDir,

--- a/website/source/docs/builders/hyperv-iso.html.md
+++ b/website/source/docs/builders/hyperv-iso.html.md
@@ -197,6 +197,9 @@ can be configured for this builder.
     machine, without the file extension. By default this is "packer-BUILDNAME",
     where "BUILDNAME" is the name of the build.
 
+-   `temp_path` (string) - This is the temporary path in which Packer will create the virtual
+    machine
+
 ## Boot Command
 
 The `boot_command` configuration is very important: it specifies the keys

--- a/website/source/docs/builders/hyperv-iso.html.md
+++ b/website/source/docs/builders/hyperv-iso.html.md
@@ -198,7 +198,7 @@ can be configured for this builder.
     where "BUILDNAME" is the name of the build.
 
 -   `temp_path` (string) - This is the temporary path in which Packer will create the virtual
-    machine
+    machine. Default value is system `%temp%`
 
 ## Boot Command
 


### PR DESCRIPTION
This PR adds support for overriding Packer's Hyper-V temp path in which the virtual machine files are created.

The configuration directive ``temp_path`` has been added, which will override the default behavior of using the system ``%temp%`` path.

Closes #5075 