### PR TITLE
Add playbook_files to execute multiple ansible playbooks with ansible-local.

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -38,6 +38,9 @@ type Config struct {
 	// The main playbook file to execute.
 	PlaybookFile string `mapstructure:"playbook_file"`
 
+	// The playbook files to execute.
+	PlaybookFiles []string `mapstructure:"playbook_files"`
+
 	// An array of local paths of playbook files to upload.
 	PlaybookPaths []string `mapstructure:"playbook_paths"`
 
@@ -63,6 +66,8 @@ type Config struct {
 
 type Provisioner struct {
 	config Config
+
+	playbookFiles []string
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
@@ -76,6 +81,9 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	// Reset the state.
+	p.playbookFiles = make([]string, 0, len(p.config.PlaybookFiles))
 
 	// Defaults
 	if p.config.Command == "" {
@@ -91,9 +99,32 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	// Validation
 	var errs *packer.MultiError
-	err = validateFileConfig(p.config.PlaybookFile, "playbook_file", true)
-	if err != nil {
-		errs = packer.MultiErrorAppend(errs, err)
+
+	// Check that either playbook_file or playbook_files is specified
+	if len(p.config.PlaybookFiles) != 0 && p.config.PlaybookFile != "" {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("Either playbook_file or playbook_files can be specified, not both"))
+	}
+	if len(p.config.PlaybookFiles) == 0 && p.config.PlaybookFile == "" {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("Either playbook_file or playbook_files must be specified"))
+	}
+	if p.config.PlaybookFile != "" {
+		err = validateFileConfig(p.config.PlaybookFile, "playbook_file", true)
+		if err != nil {
+			errs = packer.MultiErrorAppend(errs, err)
+		}
+	}
+
+	for _, playbookFile := range p.config.PlaybookFiles {
+		if err := validateFileConfig(playbookFile, "playbook_files", true); err != nil {
+			errs = packer.MultiErrorAppend(errs, err)
+		} else {
+			playbookFile, err := filepath.Abs(playbookFile)
+			if err != nil {
+				errs = packer.MultiErrorAppend(errs, err)
+			} else {
+				p.playbookFiles = append(p.playbookFiles, playbookFile)
+			}
+		}
 	}
 
 	// Check that the inventory file exists, if configured
@@ -166,11 +197,15 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		}
 	}
 
-	ui.Message("Uploading main Playbook file...")
-	src := p.config.PlaybookFile
-	dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(src)))
-	if err := p.uploadFile(ui, comm, dst, src); err != nil {
-		return fmt.Errorf("Error uploading main playbook: %s", err)
+	if p.config.PlaybookFile != "" {
+		ui.Message("Uploading main Playbook file...")
+		src := p.config.PlaybookFile
+		dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(src)))
+		if err := p.uploadFile(ui, comm, dst, src); err != nil {
+			return fmt.Errorf("Error uploading main playbook: %s", err)
+		}
+	} else if err := p.provisionPlaybookFiles(ui, comm); err != nil {
+		return err
 	}
 
 	if len(p.config.InventoryFile) == 0 {
@@ -201,16 +236,16 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 
 	if len(p.config.GalaxyFile) > 0 {
 		ui.Message("Uploading galaxy file...")
-		src = p.config.GalaxyFile
-		dst = filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(src)))
+		src := p.config.GalaxyFile
+		dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(src)))
 		if err := p.uploadFile(ui, comm, dst, src); err != nil {
 			return fmt.Errorf("Error uploading galaxy file: %s", err)
 		}
 	}
 
 	ui.Message("Uploading inventory file...")
-	src = p.config.InventoryFile
-	dst = filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(src)))
+	src := p.config.InventoryFile
+	dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(src)))
 	if err := p.uploadFile(ui, comm, dst, src); err != nil {
 		return fmt.Errorf("Error uploading inventory file: %s", err)
 	}
@@ -269,6 +304,44 @@ func (p *Provisioner) Cancel() {
 	os.Exit(0)
 }
 
+func (p *Provisioner) provisionPlaybookFiles(ui packer.Ui, comm packer.Communicator) error {
+	var playbookDir string
+	if p.config.PlaybookDir != "" {
+		var err error
+		playbookDir, err = filepath.Abs(p.config.PlaybookDir)
+		if err != nil {
+			return err
+		}
+	}
+	for index, playbookFile := range p.playbookFiles {
+		if playbookDir != "" && strings.HasPrefix(playbookFile, playbookDir) {
+			p.playbookFiles[index] = strings.TrimPrefix(playbookFile, playbookDir)
+			continue
+		}
+		if err := p.provisionPlaybookFile(ui, comm, playbookFile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Provisioner) provisionPlaybookFile(ui packer.Ui, comm packer.Communicator, playbookFile string) error {
+	ui.Message(fmt.Sprintf("Uploading playbook file: %s", playbookFile))
+
+	remoteDir := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Dir(playbookFile)))
+	remotePlaybookFile := filepath.ToSlash(filepath.Join(p.config.StagingDir, playbookFile))
+
+	if err := p.createDir(ui, comm, remoteDir); err != nil {
+		return fmt.Errorf("Error uploading playbook file: %s [%s]", playbookFile, err)
+	}
+
+	if err := p.uploadFile(ui, comm, remotePlaybookFile, playbookFile); err != nil {
+		return fmt.Errorf("Error uploading playbook: %s [%s]", playbookFile, err)
+	}
+
+	return nil
+}
+
 func (p *Provisioner) executeGalaxy(ui packer.Ui, comm packer.Communicator) error {
 	rolesDir := filepath.ToSlash(filepath.Join(p.config.StagingDir, "roles"))
 	galaxyFile := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.GalaxyFile)))
@@ -291,7 +364,6 @@ func (p *Provisioner) executeGalaxy(ui packer.Ui, comm packer.Communicator) erro
 }
 
 func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator) error {
-	playbook := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.PlaybookFile)))
 	inventory := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.InventoryFile)))
 
 	extraArgs := fmt.Sprintf(" --extra-vars \"packer_build_name=%s packer_builder_type=%s packer_http_addr=%s\" ",
@@ -307,8 +379,28 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator) err
 		}
 	}
 
+	if p.config.PlaybookFile != "" {
+		playbookFile := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.PlaybookFile)))
+		if err := p.executeAnsiblePlaybook(ui, comm, playbookFile, extraArgs, inventory); err != nil {
+			return err
+		}
+	}
+
+	for _, playbookFile := range p.playbookFiles {
+		playbookFile = filepath.ToSlash(filepath.Join(p.config.StagingDir, playbookFile))
+		if err := p.executeAnsiblePlaybook(ui, comm, playbookFile, extraArgs, inventory); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Provisioner) executeAnsiblePlaybook(
+	ui packer.Ui, comm packer.Communicator, playbookFile, extraArgs, inventory string,
+) error {
 	command := fmt.Sprintf("cd %s && %s %s%s -c local -i %s",
-		p.config.StagingDir, p.config.Command, playbook, extraArgs, inventory)
+		p.config.StagingDir, p.config.Command, playbookFile, extraArgs, inventory,
+	)
 	ui.Message(fmt.Sprintf("Executing Ansible: %s", command))
 	cmd := &packer.RemoteCmd{
 		Command: command,

--- a/provisioner/ansible-local/provisioner_test.go
+++ b/provisioner/ansible-local/provisioner_test.go
@@ -73,6 +73,50 @@ func TestProvisionerPrepare_PlaybookFile(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_PlaybookFiles(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	config["playbook_file"] = ""
+	config["playbook_files"] = []string{}
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	playbook_file, err := ioutil.TempFile("", "playbook")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Remove(playbook_file.Name())
+
+	config["playbook_file"] = playbook_file.Name()
+	config["playbook_files"] = []string{"some_other_file"}
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	config["playbook_file"] = playbook_file.Name()
+	config["playbook_files"] = []string{}
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	config["playbook_file"] = ""
+	config["playbook_files"] = []string{playbook_file.Name()}
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestProvisionerPrepare_InventoryFile(t *testing.T) {
 	var p Provisioner
 	config := testConfig()


### PR DESCRIPTION
This PR introduces new configuration option for `ansible-local` provisioner that allows to execute multiple ansible playbooks with single `ansible-local` provisioner instance. Additionally, it makes the provisioner not upload playbook files if they are already uploaded implicitly via `playbook_dir`. The new option is exclusive with `playbook_file`. The PR does not change how `playbook_file` is handled to not break existing templates.

The PR is not complete, it misses changes in documentation and I would like to add more tests with mocked communicator and maybe a few acceptance tests with docker communicator. However, before doing that I would like to get feedback if this functionality has any chance of getting merged.

Details about how playbook passed via `playbooks_files` are handled:
1. Absolute path to each playbook on local host  is resolved
2. If `playbook_dir` is set, its abs path is resolved and each playbook is checked if its abs path starts with resolved path to `playbook_dir` (this check might fail even when playbook is in `playbook_dir` if they are passed via different symbolic links for example).
3. If playbook is not in `playbook_dir` then it gets uploaded to `staging_directory` to path mirroring its path on local host, e.g.: if local path is `/some/path/to/playbook` then the playbook will be uploaded to `staging_directory/some/path/to/playbook`.
4. The playbooks are executed in the order in which they appear in the template.