### PR TITLE
make (relocatable) local website copy

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -7,6 +7,7 @@ build:
 		--rm \
 		--tty \
 		--volume "$(shell pwd):/website" \
+		-e MM_ENV=$(MM_ENV) \
 		hashicorp/middleman-hashicorp:${VERSION} \
 		bundle exec middleman build --verbose --clean
 

--- a/website/config.rb
+++ b/website/config.rb
@@ -111,4 +111,10 @@ helpers do
   def local_build?
     ENV['MM_ENV'] == 'local_build'
   end
+
+  # Returns path to root (for nav link)
+  # @return String
+  def path_to_root
+    local_build? ? '/index.html' : '/'
+  end
 end

--- a/website/config.rb
+++ b/website/config.rb
@@ -7,6 +7,13 @@ activate :hashicorp do |h|
   h.website_root = "website"
 end
 
+configure :build do
+  if local_build?
+    set :relative_links, true
+    activate :relative_assets
+  end
+end
+
 helpers do
   # Returns the FQDN of the image URL.
   #
@@ -97,5 +104,11 @@ helpers do
     end
 
     return classes.join(" ")
+  end
+
+  # Returns true iff environment is set to local_build
+  # @return Boolean
+  def local_build?
+    ENV['MM_ENV'] == 'local_build'
   end
 end

--- a/website/scripts/prepare-local-build.sh
+++ b/website/scripts/prepare-local-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd $scriptdir/..
+
+# transform regular anchor links to link_to helpers
+find source -name *.erb -exec \
+sed -r -i -e 's/<a href="\/([^"]+)">([^<]+)<\/a>/<%= link_to "\2", "\/\1" %>/' {} \;
+
+# transform anchor links with class attributes to link_to helpers
+find source -name *.erb -exec \
+sed -r -i -e \
+'s/<a class="([^"]+)" href="\/([^"]+)">([^<]+)<\/a>/<%= link_to "\3", "\/\2", :class => "\1" %>/' {} \;

--- a/website/source/assets/javascripts/local_application.js
+++ b/website/source/assets/javascripts/local_application.js
@@ -1,0 +1,4 @@
+//= require jquery
+
+//= require hashicorp/mega-nav
+//= require hashicorp/sidebar

--- a/website/source/layouts/_sidebar.erb
+++ b/website/source/layouts/_sidebar.erb
@@ -17,9 +17,7 @@
 
   <ul class="external nav sidebar-nav">
     <li>
-      <a href="/downloads.html">
-        <%= inline_svg "download.svg" %> Download
-      </a>
+      <%= link_to "#{inline_svg 'download.svg'} Download", "/downloads.html" %>
     </li>
     <li>
       <a href="https://github.com/hashicorp/packer">

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -32,14 +32,21 @@
     <!--[if lt IE 9]>
       <%= javascript_include_tag "ie-compat" %>
     <![endif]-->
-    <%= javascript_include_tag "application" %>
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NR2SD7C');</script>
+    <% if local_build? %>
+      <%= javascript_include_tag "local_application" %>
+    <% else %>
+      <%= javascript_include_tag "application" %>
+    <% end %>
+
+    <% if not local_build? %>
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-NR2SD7C');</script>
+    <% end %>
 
     <!-- Typekit script to import Klavika font -->
     <script src="https://use.typekit.net/wxf7mfi.js"></script>
@@ -118,16 +125,18 @@
       </div>
     </div>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <% if not local_build? %>
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-43075859-1', 'packer.io');
-      ga('require', 'linkid');
-      ga('send', 'pageview', location.pathname);
-    </script>
+        ga('create', 'UA-43075859-1', 'packer.io');
+        ga('require', 'linkid');
+        ga('send', 'pageview', location.pathname);
+      </script>
+    <% end %>
 
     <script type="application/ld+json">
       {

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -65,9 +65,7 @@
           <div class="col-xs-12">
             <div class="navbar-header">
               <div class="navbar-brand">
-                <a href="/">
-                  <%= inline_svg "logo-text.svg", height: 50, class: "logo" %>
-                </a>
+                <%= link_to "#{inline_svg 'logo-text.svg', height: 50, class: 'logo'}", path_to_root %>
               </div>
               <button class="navbar-toggle" type="button">
                 <span class="sr-only">Toggle navigation</span>
@@ -84,9 +82,7 @@
                   <li><a href="/docs/index.html">Docs</a></li>
                   <li><a href="/community.html">Community</a></li>
                   <li>
-                    <a href="/downloads.html">
-                      <%= inline_svg "download.svg" %> Download
-                    </a>
+                    <%= link_to "#{inline_svg 'download.svg'} Download", "/downloads.html" %>
                   </li>
                   <li>
                     <a href="https://github.com/hashicorp/packer">


### PR DESCRIPTION
I previously made a similar (and slightly more extensive) changes to terraform. The discussion is [here](https://github.com/hashicorp/terraform/pull/15054). As I understand it, @sethvargo & @apparentlymart would have been okay with it had HashiCorp not been right in the middle of splitting the providers out of the core.

Basically, this allows:

- building a copy of the website which can be browsed on the local filesystem, albeit with a script which isn't actually included in this change, and excepting a few links which will need to be manually modified. I haven't actually modified those here (although I can), because the more urgent use case is:

- using [dashing](https://github.com/technosophos/dashing) to cut a nice-looking, dash-compatible queryable docs package. Otherwise, the generated docs look awful. At least in a browser; I don't know how they look in Dash, although I doubt it can be very good.