### PR TITLE
Make expunge optional and improve logging output

### DIFF
--- a/builder/cloudstack/config.go
+++ b/builder/cloudstack/config.go
@@ -27,9 +27,10 @@ type Config struct {
 	HTTPGetOnly  bool          `mapstructure:"http_get_only"`
 	SSLNoVerify  bool          `mapstructure:"ssl_no_verify"`
 
+	CIDRList          []string `mapstructure:"cidr_list"`
 	DiskOffering      string   `mapstructure:"disk_offering"`
 	DiskSize          int64    `mapstructure:"disk_size"`
-	CIDRList          []string `mapstructure:"cidr_list"`
+	Expunge           bool     `mapstructure:"expunge"`
 	Hypervisor        string   `mapstructure:"hypervisor"`
 	InstanceName      string   `mapstructure:"instance_name"`
 	Keypair           string   `mapstructure:"keypair"`

--- a/builder/cloudstack/step_configure_networking.go
+++ b/builder/cloudstack/step_configure_networking.go
@@ -163,7 +163,6 @@ func (s *stepSetupNetworking) Run(state multistep.StateBag) multistep.StepAction
 	}
 
 	ui.Message("Networking has been setup!")
-
 	return multistep.ActionContinue
 }
 
@@ -235,6 +234,5 @@ func (s *stepSetupNetworking) Cleanup(state multistep.StateBag) {
 	}
 
 	ui.Message("Networking has been cleaned!")
-
 	return
 }

--- a/builder/cloudstack/step_prepare_config.go
+++ b/builder/cloudstack/step_prepare_config.go
@@ -138,7 +138,6 @@ func (s *stepPrepareConfig) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	ui.Message("Config has been prepared!")
-
 	return multistep.ActionContinue
 }
 

--- a/builder/cloudstack/step_shutdown_instance.go
+++ b/builder/cloudstack/step_shutdown_instance.go
@@ -35,7 +35,6 @@ func (s *stepShutdownInstance) Run(state multistep.StateBag) multistep.StepActio
 	}
 
 	ui.Message("Instance has been shutdown!")
-
 	return multistep.ActionContinue
 }
 

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -83,6 +83,9 @@ builder.
 -   `disk_size` (int) - The size (in GB) of the root disk of the new instance.
     This option is only available when using `source_template`.
 
+-   `expunge` (boolean) - Set to `true` to expunge the instance when it is
+    destroyed. Defaults to `false`.
+
 -   `http_directory` (string) - Path to a directory to serve using an
     HTTP server. The files in this directory will be available over HTTP that
     will be requestable from the virtual machine. This is useful for hosting


### PR DESCRIPTION
@rickard-von-essen in a way this PR introduces a backwards incompatibility, yet it is a very minor one... Currently the default is to set the `expunge` options to `true`, which means if you destroy the instance it will be expunged immediately.

This PR changes the default to `false` which means that when you delete the instance it will not be expunged immediately, but after the timeout configured in your CloudStack setup. So it will still be expunged, just not immediately anymore.

What do you think abou that? I guess the only possible impact could be that when you are iterating/testing a new build, have a fixed hostname and try to restart a new build before the configured expunge timeout has passed, the expunge has not yet taken place and you will get an error that you cannot create the new instance because one with that name already exists.

In those cases people will have to set the `expunge` option to `true` in their templates.

Closes #5097 
