### PR TITLE
Support ISO detach after create instance

### DIFF
--- a/builder/cloudstack/builder.go
+++ b/builder/cloudstack/builder.go
@@ -64,6 +64,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&stepCreateInstance{
 			Ctx: b.config.ctx,
 		},
+		&stepDetachIso{
+			DetachISO:     b.config.DetachISO,
+			DetachISOWait: b.config.DetachISOWait,
+		},
 		&stepSetupNetworking{},
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,

--- a/builder/cloudstack/step_detach_iso.go
+++ b/builder/cloudstack/step_detach_iso.go
@@ -1,0 +1,53 @@
+package cloudstack
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/packer/packer"
+	"github.com/mitchellh/multistep"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+)
+
+type stepDetachIso struct {
+	DetachISO     bool
+	DetachISOWait time.Duration
+}
+
+func (s *stepDetachIso) Run(state multistep.StateBag) multistep.StepAction {
+	client := state.Get("client").(*cloudstack.CloudStackClient)
+	config := state.Get("config").(*Config)
+	ui := state.Get("ui").(packer.Ui)
+
+	if !config.DetachISO {
+		return multistep.ActionContinue
+	}
+
+	instanceId := state.Get("instance_id").(string)
+	params := client.VirtualMachine.NewListVirtualMachinesParams()
+	params.SetId(instanceId)
+	vmId, err := client.VirtualMachine.ListVirtualMachines(params)
+	if err != nil {
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	isoId := vmId.VirtualMachines[0].Isoid
+	if isoId == "" {
+		// No ISO image attached
+		return multistep.ActionContinue
+	}
+
+	ui.Say(fmt.Sprintf("Waiting for %v before detaching ISO from virtual machine...", config.DetachISOWait))
+	time.Sleep(config.DetachISOWait)
+	ui.Say("Detaching ISO...")
+	_, err = client.ISO.DetachIso(client.ISO.NewDetachIsoParams(instanceId))
+	if err != nil {
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepDetachIso) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
Detach the ISO from  so that after installation the instance will not boot
back into the ISO and thus fail the installation.

This creates two new configurable options; detach_iso (boolean) and detach_iso_wait (string)

The default for detach_iso is false, so that it will change current behavior.

The default for detach_iso_wait is 10 seconds, which should be ok for most cases.

@svanharmelen Would you like to review this, please?