### PR TITLE
post-processor/checksum: properly interpolate output

### DIFF
--- a/post-processor/checksum/post-processor.go
+++ b/post-processor/checksum/post-processor.go
@@ -57,9 +57,10 @@ func getHash(t string) hash.Hash {
 
 func (p *PostProcessor) Configure(raws ...interface{}) error {
 	err := config.Decode(&p.config, &config.DecodeOpts{
-		Interpolate: true,
+		Interpolate:        true,
+		InterpolateContext: &p.config.ctx,
 		InterpolateFilter: &interpolate.RenderFilter{
-			Exclude: []string{},
+			Exclude: []string{"output"},
 		},
 	}, raws...)
 	if err != nil {


### PR DESCRIPTION
Fix a bug where "output" of checksum post-processor was not correctly
interpolating `{{.BuilderType}}`, `{{.BuildName}}`, and `{{.ChecksumType}}`.