### PR TITLE
cloudstack: Allow reading api_url, api_key, and secret_key from env vars

### DIFF
--- a/builder/cloudstack/config.go
+++ b/builder/cloudstack/config.go
@@ -79,6 +79,21 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 	var errs *packer.MultiError
 
 	// Set some defaults.
+	if c.APIURL == "" {
+		// Default to environment variable for api_url, if it exists
+		c.APIURL = os.Getenv("CLOUDSTACK_API_URL")
+	}
+
+	if c.APIKey == "" {
+		// Default to environment variable for api_key, if it exists
+		c.APIKey = os.Getenv("CLOUDSTACK_API_KEY")
+	}
+
+	if c.SecretKey == "" {
+		// Default to environment variable for secret_key, if it exists
+		c.SecretKey = os.Getenv("CLOUDSTACK_SECRET_KEY")
+	}
+
 	if c.AsyncTimeout == 0 {
 		c.AsyncTimeout = 30 * time.Minute
 	}

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -34,8 +34,12 @@ builder.
 ### Required:
 
 -   `api_url` (string) - The CloudStack API endpoint we will connect to.
+    It can also be specified via environment variable `CLOUDSTACK_API_URL`,
+    if set.
 
--   `api_key` (string) - The API key used to sign all API requests.
+-   `api_key` (string) - The API key used to sign all API requests. It
+    can also be specified via environment variable `CLOUDSTACK_API_KEY`,
+    if set.
 
 -   `cidr_list` (array) - List of CIDR's that will have access to the new
     instance. This is needed in order for any provisioners to be able to
@@ -49,6 +53,8 @@ builder.
     to.
 
 -   `secret_key` (string) - The secret key used to sign all API requests.
+    It can also be specified via environment variable `CLOUDSTACK_SECRET_KEY`,
+    if set.
 
 -   `service_offering` (string) - The name or ID of the service offering used
     for the instance.


### PR DESCRIPTION
If unset reads:

- `api_url` from `CLOUDSTACK_API_URL`
- `api_key` from `CLOUDSTACK_API_KEY`
- `secret_key` from `CLOUDSTACK_SECRET_KEY`