### PR TITLE
cloudstack: Multiple doc fixes

### DIFF
--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -42,9 +42,6 @@ builder.
     connect to the instance. Usually this will be the NAT address of your
     current location. Only required when `use_local_ip_address` is `false`.
 
--   `instance_name` (string) - The name of the instance. Defaults to
-    "packer-UUID" where UUID is dynamically generated.
-
 -   `network` (string) - The name or ID of the network to connect the instance
     to.
 
@@ -58,12 +55,6 @@ builder.
 
 -   `source_template` (string) - The name or ID of the template used as base
     template for the instance. This option is mutual explusive with `source_iso`.
-
--   `template_name` (string) - The name of the new template. Defaults to
-    "packer-{{timestamp}}" where timestamp will be the current time.
-
--   `template_display_text` (string) - The display text of the new template.
-    Defaults to the `template_name`.
 
 -   `template_os` (string) - The name or ID of the template OS for the new
     template that will be created.
@@ -111,6 +102,9 @@ builder.
     access the instance. The SSH key pair is assumed to be already available
     within CloudStack.
 
+-   `instance_name` (string) - The name of the instance. Defaults to
+    "packer-UUID" where UUID is dynamically generated.
+
 -   `project` (string) - The name or ID of the project to deploy the instance to.
 
 -   `public_ip_address` (string) - The public IP address or it's ID used for
@@ -120,8 +114,14 @@ builder.
 -   `ssl_no_verify` (boolean) - Set to `true` to skip SSL verification. Defaults
     to `false`.
 
+-   `template_display_text` (string) - The display text of the new template.
+    Defaults to the `template_name`.
+
 -   `template_featured` (boolean) - Set to `true` to indicate that the template
     is featured. Defaults to `false`.
+
+-   `template_name` (string) - The name of the new template. Defaults to
+    "packer-{{timestamp}}" where timestamp will be the current time.
 
 -   `template_public` (boolean) - Set to `true` to indicate that the template is
     available for all accounts. Defaults to `false`.

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -135,7 +135,14 @@ builder.
 -   `template_scalable` (boolean) - Set to `true` to indicate that the template
     contains tools to support dynamic scaling of VM cpu/memory. Defaults to `false`.
 
--   `user_data` (string) - User data to launch with the instance.
+-   `user_data` (string) - User data to launch with the instance. This is a
+    [template engine](/docs/templates/engine.html) see _User Data_ bellow for more
+    details.
+
+-   `user_data_file` (string) - Path to a file that will be used for the user
+    data when launching the instance. This file will be parsed as a
+    [template engine](/docs/templates/engine.html) see _User Data_ bellow for more
+    details.
 
 -   `use_local_ip_address` (boolean) - Set to `true` to indicate that the
     provisioners should connect to the local IP address of the instance.
@@ -147,7 +154,7 @@ The available variables are:
 -  `HTTPIP` and `HTTPPort` - The IP and port, respectively of an HTTP server
     that is started serving the directory specified by the `http_directory`
     configuration parameter. If `http_directory` isn't specified, these will be
-    blank!
+    blank.
 
 ## Basic Example
 

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -50,9 +50,9 @@ builder.
 -   `service_offering` (string) - The name or ID of the service offering used
     for the instance.
 
--   `soure_iso` (string) - The name or ID of an ISO that will be mounted before
+-   `source_iso` (string) - The name or ID of an ISO that will be mounted before
     booting the instance. This option is mutual exclusive with `source_template`.
-    When then is used `disk_offering` and `hypervisor` is required.
+    When using `source_iso`, both `disk_offering` and `hypervisor` are required.
 
 -   `source_template` (string) - The name or ID of the template used as base
     template for the instance. This option is mutual explusive with `source_iso`.

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -168,6 +168,8 @@ Here is a basic example.
   "source_iso": "CentOS-7.0-1406-x86_64-Minimal",
   "zone": "NL1",
 
+  "ssh_username": "root",
+
   "template_name": "Centos7-x86_64-KVM-Packer",
   "template_display_text": "Centos7-x86_64 KVM Packer",
   "template_featured": true,

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -52,6 +52,7 @@ builder.
 
 -   `soure_iso` (string) - The name or ID of an ISO that will be mounted before
     booting the instance. This option is mutual exclusive with `source_template`.
+    When then is used `disk_offering` and `hypervisor` is required.
 
 -   `source_template` (string) - The name or ID of the template used as base
     template for the instance. This option is mutual explusive with `source_iso`.


### PR DESCRIPTION
- Add note to source_iso about required options
- Add user_data_file to docs, and some clearification about templating
- Added missing `ssh_username` to the example
- Moved `instance_name`, `template_name`, and `template_display_name` to the
  optional section since the have default values.