### PR TITLE
Accelerator api support for googlecompute builder

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	AccountFile string `mapstructure:"account_file"`
 	ProjectId   string `mapstructure:"project_id"`
 
+	AcceleratorType      string            `mapstructure:"accelerator_type"`
+	AcceleratorCount     int64             `mapstructure:"accelerator_count"`
 	Address              string            `mapstructure:"address"`
 	DiskName             string            `mapstructure:"disk_name"`
 	DiskSizeGb           int64             `mapstructure:"disk_size"`

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -58,6 +58,8 @@ type Driver interface {
 }
 
 type InstanceConfig struct {
+	AcceleratorType   string
+	AcceleratorCount  int64
 	Address           string
 	Description       string
 	DiskSizeGb        int64

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v0.beta"
 
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/packer"
@@ -380,6 +380,15 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 		})
 	}
 
+	var guestAccelerators []*compute.AcceleratorConfig
+	if c.AcceleratorCount > 0 {
+		ac := &compute.AcceleratorConfig{
+			AcceleratorCount: c.AcceleratorCount,
+			AcceleratorType:  c.AcceleratorType,
+		}
+		guestAccelerators = append(guestAccelerators, ac)
+	}
+
 	// Create the instance information
 	instance := compute.Instance{
 		Description: c.Description,
@@ -397,7 +406,8 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 				},
 			},
 		},
-		MachineType: machineType.SelfLink,
+		GuestAccelerators: guestAccelerators,
+		MachineType:       machineType.SelfLink,
 		Metadata: &compute.Metadata{
 			Items: metadata,
 		},

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -99,6 +99,8 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 	var metadata map[string]string
 	metadata, err = c.createInstanceMetadata(sourceImage, sshPublicKey)
 	errCh, err = d.RunInstance(&InstanceConfig{
+		AcceleratorType:   c.AcceleratorType,
+		AcceleratorCount:  c.AcceleratorCount,
 		Address:           c.Address,
 		Description:       "New instance created by Packer",
 		DiskSizeGb:        c.DiskSizeGb,


### PR DESCRIPTION
Switch googlecompute builder to use compute/v0.beta and add support for accelerator api
