### PR TITLE
Add docker container dir to template

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -23,18 +23,19 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 
-	Commit     bool
-	Discard    bool
-	ExportPath string `mapstructure:"export_path"`
-	Image      string
-	Pty        bool
-	Pull       bool
-	RunCommand []string `mapstructure:"run_command"`
-	Volumes    map[string]string
-	Privileged bool `mapstructure:"privileged"`
-	Author     string
-	Changes    []string
-	Message    string
+	Commit       bool
+	Discard      bool
+	ExportPath   string `mapstructure:"export_path"`
+	Image        string
+	Pty          bool
+	Pull         bool
+	RunCommand   []string `mapstructure:"run_command"`
+	Volumes      map[string]string
+	Privileged   bool `mapstructure:"privileged"`
+	Author       string
+	Changes      []string
+	Message      string
+	ContainerDir string `mapstructure:"container_dir"`
 
 	// This is used to login to dockerhub to pull a private base container. For
 	// pushing to dockerhub, see the docker post-processors
@@ -110,6 +111,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		if fi, err := os.Stat(c.ExportPath); err == nil && fi.IsDir() {
 			errs = packer.MultiErrorAppend(errs, errExportPathNotFile)
 		}
+	}
+
+	if c.ContainerDir == "" {
+		c.ContainerDir = "/packer-files"
 	}
 
 	if c.EcrLogin && c.LoginServer == "" {

--- a/builder/docker/step_connect_docker.go
+++ b/builder/docker/step_connect_docker.go
@@ -24,7 +24,7 @@ func (s *StepConnectDocker) Run(state multistep.StateBag) multistep.StepAction {
 	comm := &Communicator{
 		ContainerId:  containerId,
 		HostDir:      tempDir,
-		ContainerDir: "/packer-files",
+		ContainerDir: config.ContainerDir,
 		Version:      version,
 		Config:       config,
 	}

--- a/builder/docker/step_run.go
+++ b/builder/docker/step_run.go
@@ -26,7 +26,7 @@ func (s *StepRun) Run(state multistep.StateBag) multistep.StepAction {
 	for host, container := range config.Volumes {
 		runConfig.Volumes[host] = container
 	}
-	runConfig.Volumes[tempDir] = "/packer-files"
+	runConfig.Volumes[tempDir] = config.ContainerDir
 
 	ui.Say("Starting docker container...")
 	containerId, err := driver.StartContainer(&runConfig)

--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -205,6 +205,10 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
     mount into this container. The key of the object is the host path, the value
     is the container path.
 
+-   `container_dir` (string) - The directory inside container to mount
+     temp directory from host server for work [file provisioner](/docs/provisioners/file.html).
+     By default this is set to `/packer-files`.
+
 ## Using the Artifact: Export
 
 Once the tar artifact has been generated, you will likely want to import, tag,


### PR DESCRIPTION
Hello!

We have same issue - https://github.com/hashicorp/packer/issues/1827 with remove packer-files directory from bulded templates.

And add ContainerDir  to template config as `container_dir` with default value "/packer-files".
With this option we can set it to /mnt or another dir, which not need to delete after template builded.

