### PR TITLE
quick patch to make ansible work again

### DIFF
--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -71,10 +71,8 @@ func (c *communicator) Start(cmd *packer.RemoteCmd) (err error) {
 	var wg sync.WaitGroup
 
 	if cmd.Stdin != nil {
-		wg.Add(1)
 		args.StdinStreamId = c.mux.NextId()
 		go func() {
-			defer wg.Done()
 			serveSingleCopy("stdin", c.mux, args.StdinStreamId, nil, cmd.Stdin)
 		}()
 	}


### PR DESCRIPTION
Remove wait group on stdin copying.  This isn't needed to preserve log output for folks (the original ssh bug that #5089 was intended to solve) and including it causes ansible to freeze.

Closes #5142