### PR TITLE
vmware-iso builder: Add logging on connection refused network errors

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -221,6 +221,8 @@ func (d *ESX5Driver) VNCAddress(_ string, portMin, portMax uint) (string, uint, 
 			if e, ok := err.(*net.OpError); ok {
 				if e.Timeout() {
 					log.Printf("Timeout connecting to: %s (check firewall rules)", address)
+				} else if strings.Contains(e.Error(), "connection refused") {
+					log.Printf("Connection refused when connecting to: %s (check firewall rules)", address)
 				} else {
 					vncPort = port
 					break
@@ -301,6 +303,9 @@ func (d *ESX5Driver) CommHost(state multistep.StateBag) (string, error) {
 			if e, ok := err.(*net.OpError); ok {
 				if e.Timeout() {
 					log.Printf("Timeout connecting to %s", record["IPAddress"])
+					continue
+				} else if strings.Contains(e.Error(), "connection refused") {
+					log.Printf("Connection refused when connecting to: %s", record["IPAddress"])
 					continue
 				}
 			}


### PR DESCRIPTION
Right now packer's vmware-iso builder doesn't log network errors that are due to a hard connection refused (like an iptables REJECT instead of DROP), only Timeout is tested. The silencing of that kind of error can cause users to investigate the wrong problem.

Here's an example of such a problem without this patch:

```
2017/07/20 16:10:20 packer-io: 2017/07/20 16:10:20 opening new ssh session
2017/07/20 16:10:20 packer-io: 2017/07/20 16:10:20 starting remote command: esxcli --formatter csv network vm port list -w 510201
2017/07/20 16:10:21 packer-io: 2017/07/20 16:10:21 [DEBUG] Error getting WinRM host: No interface on the VM has an IP address ready
[...]
repeated over several screens since this is WinRM trying to provision in a loop
```

When running the command manually, I noticed that there is an IP Address ready for the VM it's just that packer can't connect to it due to a firewall that issues ICMP port unreachable in response to packer's packets. Added a simple `else if` to log that case.

With the patch, the output will be like the following:
```
<date> Connection refused when connecting to: 10.xx.xx.yy
<date> [DEBUG] Error getting WinRM host: No interface on the VM has an IP address ready
```