### PR TITLE
update tests and docs for Ansible 2.4

### DIFF
--- a/test/fixtures/provisioner-ansible/connection_plugins/packer.py
+++ b/test/fixtures/provisioner-ansible/connection_plugins/packer.py
@@ -2,15 +2,23 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.connection.ssh import Connection as SSHConnection
+from ansible import constants as C
 
 class Connection(SSHConnection):
     ''' ssh based connections for powershell via packer'''
 
     transport = 'packer'
-    has_pipelining = True
-    become_methods = []
+    module_implementation_preferences = ('.ps1', '.exe', '')
+    become_methods = ['runas']
     allow_executable = False
-    module_implementation_preferences = ('.ps1', '')
 
     def __init__(self, *args, **kwargs):
+        self._shell_type = 'powershell'
+
         super(Connection, self).__init__(*args, **kwargs)
+
+        self.host = self._play_context.remote_addr
+        self.port = self._play_context.port
+        self.user = self._play_context.remote_user
+        self.control_path = C.ANSIBLE_SSH_CONTROL_PATH
+        self.control_path_dir = C.ANSIBLE_SSH_CONTROL_PATH_DIR

--- a/test/fixtures/provisioner-ansible/winrm.json
+++ b/test/fixtures/provisioner-ansible/winrm.json
@@ -6,7 +6,7 @@
         "playbook_file": "./win-playbook.yml",
         "extra_arguments": [
           "--connection", "packer",
-          "--extra-vars", "ansible_shell_type=powershell ansible_shell_executable=None"
+          "--extra-vars", "ansible_shell_executable=None"
         ]
       }
     ],

--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -183,18 +183,26 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.connection.ssh import Connection as SSHConnection
+from ansible import constants as C
 
 class Connection(SSHConnection):
     ''' ssh based connections for powershell via packer'''
 
     transport = 'packer'
-    has_pipelining = True
-    become_methods = []
+    module_implementation_preferences = ('.ps1', '.exe', '')
+    become_methods = ['runas']
     allow_executable = False
-    module_implementation_preferences = ('.ps1', '')
 
     def __init__(self, *args, **kwargs):
+        self._shell_type = 'powershell'
+
         super(Connection, self).__init__(*args, **kwargs)
+
+        self.host = self._play_context.remote_addr
+        self.port = self._play_context.port
+        self.user = self._play_context.remote_user
+        self.control_path = C.ANSIBLE_SSH_CONTROL_PATH
+        self.control_path_dir = C.ANSIBLE_SSH_CONTROL_PATH_DIR
 ```
 
 This template should build a Windows Server 2012 image on Google Cloud Platform:
@@ -208,7 +216,7 @@ This template should build a Windows Server 2012 image on Google Cloud Platform:
       "playbook_file": "./win-playbook.yml",
       "extra_arguments": [
         "--connection", "packer",
-        "--extra-vars", "ansible_shell_type=powershell ansible_shell_executable=None"
+        "--extra-vars", "ansible_shell_executable=None"
       ]
     }
   ],


### PR DESCRIPTION
Update the ansible-remote provisioner's connection plugin for
provisioning Windows nodes in response to recent changes to the
connection and action plugins in Ansible.
* Add '.exe' extension to the module implementation preferences.
* Set properties for connection related properties similarly to the
  changes that were made in Ansible's ssh connection since Ansible 2.2.
* Set become_methods value correctly for Windows.
* Use the new _shell_type property instead of setting the
  ansible_shell_type remote host parameter with extra_vars.

Closes #4904 

This is a pre-emptive PR in anticipation of the release of ansible/ansible#25012 in Ansible 2.3.2 and 2.4.