### PR TITLE
support default GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GITBRANCH:=$(shell git symbolic-ref --short HEAD 2>/dev/null)
 GOFMT_FILES?=$$(find . -not -path "./vendor/*" -name "*.go")
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
+GOPATH=$(shell go env GOPATH)
 
 # Get the git commit
 GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)


### PR DESCRIPTION
set GOPATH as an explicit Make variable instead of relying on the
environment variable so that contributors that use the default GOPATH
without setting the GOPATH environment variable can build the dev
target.