### PR TITLE
preserve left-side whitespace in output

### DIFF
--- a/packer/communicator.go
+++ b/packer/communicator.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/mitchellh/iochan"
 )
@@ -154,11 +155,11 @@ OutputLoop:
 	// Make sure we finish off stdout/stderr because we may have gotten
 	// a message from the exit channel before finishing these first.
 	for output := range stdoutCh {
-		ui.Message(strings.TrimSpace(output))
+		ui.Message(r.cleanOutputLine(output))
 	}
 
 	for output := range stderrCh {
-		ui.Message(strings.TrimSpace(output))
+		ui.Message(r.cleanOutputLine(output))
 	}
 
 	return nil
@@ -196,7 +197,7 @@ func (r *RemoteCmd) Wait() {
 // UI output when we're reading from a remote command.
 func (r *RemoteCmd) cleanOutputLine(line string) string {
 	// Trim surrounding whitespace
-	line = strings.TrimSpace(line)
+	line = strings.TrimRightFunc(line, unicode.IsSpace)
 
 	// Trim up to the first carriage return, since that text would be
 	// lost anyways.


### PR DESCRIPTION
Previously we were trimming left and right side whitespace before outputting to the UI. This changes so we only trim whitespace on the right side. This potentially breaks backwards compatibility, so will target for 1.1.0.

I'm also not entirely clear on the reason for trimming whitespace in the first place, so it's possible I will discover the reason and have to close this PR.

Before:

```
    amazon-ebs: ___________
    amazon-ebs: < hellooooo >
    amazon-ebs: -----------
    amazon-ebs: \   ^__^
    amazon-ebs: \  (oo)\_______
    amazon-ebs: (__)\       )\/\
    amazon-ebs: ||----w |
    amazon-ebs: ||     ||
```

after:

```
    amazon-ebs:  ___________
    amazon-ebs: < hellooooo >
    amazon-ebs:  -----------
    amazon-ebs:         \   ^__^
    amazon-ebs:          \  (oo)\_______
    amazon-ebs:             (__)\       )\/\
    amazon-ebs:                 ||----w |
    amazon-ebs:                 ||     ||
```

Closes #5147