### PR TITLE
Fix typo in Manifest documentation

### DIFF
--- a/website/source/docs/post-processors/manifest.html.md
+++ b/website/source/docs/post-processors/manifest.html.md
@@ -17,7 +17,7 @@ The manifest post-processor is invoked each time a build completes and *updates*
 
 If packer is run with the `-force` flag the manifest file will be truncated automatically during each packer run. Otherwise, subsequent builds will be added to the file. You can use the timestamps to see which is the latest artifact.
 
-You can specify manifest more than once and write each build to its own file, or write all builds to the same file. For simple builds manifest only needs to be specified once (see below) but you can also chain it together with other post-processors such as Docker and Artifice.
+You can specify manifest more than once and write each build to its own file, or write all builds to the same file. For simple builds manifest only needs to be specified once (see below) but you can also chain it together with other post-processors such as Docker and Artifactory.
 
 ## Configuration
 


### PR DESCRIPTION
Change 'Artifice' into 'Artifactory'