### PR TITLE
parallels: Remove soon to be removed --vmtype flag

### DIFF
--- a/builder/parallels/iso/step_create_vm.go
+++ b/builder/parallels/iso/step_create_vm.go
@@ -27,7 +27,6 @@ func (s *stepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 		"create", name,
 		"--distribution", config.GuestOSType,
 		"--dst", config.OutputDir,
-		"--vmtype", "vm",
 		"--no-hdd",
 	}
 


### PR DESCRIPTION
In the next release of Parallels Desktop for Mac Pro Ed. the `prlctl createvm`
command doen't support the `--vmtype` flag anymore.