### PR TITLE
Add ssh_password variable for vmware-iso and vmware-vmx to docs

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -42,6 +42,7 @@ self-install. Still, the example serves to show the basic configuration:
   "iso_checksum": "af5f788aee1b32c4b2634734309cc9e9",
   "iso_checksum_type": "md5",
   "ssh_username": "packer",
+  "ssh_password": "packer",
   "shutdown_command": "shutdown -P now"
 }
 ```
@@ -81,6 +82,9 @@ builder.
     this is an HTTP URL, Packer will download it and cache it between runs.
 
 -   `ssh_username` (string) - The username to use to SSH into the machine once
+    the OS is installed.
+
+-   `ssh_password` (string) - The password to use to SSH into the machine once
     the OS is installed.
 
 ### Optional:

--- a/website/source/docs/builders/vmware-vmx.html.md
+++ b/website/source/docs/builders/vmware-vmx.html.md
@@ -59,6 +59,9 @@ builder.
 -   `ssh_username` (string) - The username to use to SSH into the machine once
     the OS is installed.
 
+-   `ssh_password` (string) - The password to use to SSH into the machine once
+    the OS is installed.
+
 ### Optional:
 
 -   `boot_command` (array of strings) - This is an array of commands to type


### PR DESCRIPTION
I've just spent too long hunting around for the correct option to use to specify the SSH password to a VM built with the vmware-iso builder. I found the option I was after mentioned in the vmware-vmx in the example, but not documented. It existed fully in the virtualbox-iso builder docs, so I've copied it to the vmware-iso and vmware-vmx builder documentation for my future convenience.