### PR TITLE
core: iso_checksum_url should strip query param

### DIFF
--- a/common/iso_config.go
+++ b/common/iso_config.go
@@ -136,7 +136,13 @@ func (c *ISOConfig) Prepare(ctx *interpolate.Context) (warnings []string, errs [
 }
 
 func (c *ISOConfig) parseCheckSumFile(rd *bufio.Reader) error {
-	errNotFound := fmt.Errorf("No checksum for %q found at: %s", filepath.Base(c.ISOUrls[0]), c.ISOChecksumURL)
+	u, err := url.Parse(c.ISOUrls[0])
+	if err != nil {
+		return err
+	}
+	filename := filepath.Base(u.Path)
+
+	errNotFound := fmt.Errorf("No checksum for %q found at: %s", filename, c.ISOChecksumURL)
 	for {
 		line, err := rd.ReadString('\n')
 		if err != nil && line == "" {
@@ -148,7 +154,7 @@ func (c *ISOConfig) parseCheckSumFile(rd *bufio.Reader) error {
 		}
 		if strings.ToLower(parts[0]) == c.ISOChecksumType {
 			// BSD-style checksum
-			if parts[1] == fmt.Sprintf("(%s)", filepath.Base(c.ISOUrls[0])) {
+			if parts[1] == fmt.Sprintf("(%s)", filename) {
 				c.ISOChecksum = parts[3]
 				return nil
 			}
@@ -158,7 +164,7 @@ func (c *ISOConfig) parseCheckSumFile(rd *bufio.Reader) error {
 				// Binary mode
 				parts[1] = parts[1][1:]
 			}
-			if parts[1] == filepath.Base(c.ISOUrls[0]) {
+			if parts[1] == filename {
 				c.ISOChecksum = parts[0]
 				return nil
 			}

--- a/common/iso_config_test.go
+++ b/common/iso_config_test.go
@@ -152,6 +152,25 @@ func TestISOConfigPrepare_ISOChecksumURL(t *testing.T) {
 		t.Fatalf("should've found \"bar0\" got: %s", i.ISOChecksum)
 	}
 
+	// Test good - ISOChecksumURL GNU style with query parameters
+	i = testISOConfig()
+	i.ISOChecksum = ""
+	i.RawSingleISOUrl = "http://www.packer.io/the-OS.iso?stuff=boo"
+
+	cs_file, _ = ioutil.TempFile("", "packer-test-")
+	ioutil.WriteFile(cs_file.Name(), []byte(cs_gnu_style), 0666)
+	i.ISOChecksumURL = fmt.Sprintf("%s%s", filePrefix, cs_file.Name())
+	warns, err = i.Prepare(nil)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if i.ISOChecksum != "bar0" {
+		t.Fatalf("should've found \"bar0\" got: %s", i.ISOChecksum)
+	}
 }
 
 func TestISOConfigPrepare_ISOChecksumType(t *testing.T) {


### PR DESCRIPTION
When iso_urls contains query parameters these should be stripped when
searching the content of iso_checksum_url for a maching checksum.

Closes #5176