### PR TITLE
vmware: Publish artifact ID

### DIFF
--- a/builder/vmware/common/artifact.go
+++ b/builder/vmware/common/artifact.go
@@ -14,13 +14,14 @@ const BuilderId = "mitchellh.vmware"
 // Artifact is the result of running the VMware builder, namely a set
 // of files associated with the resulting machine.
 type localArtifact struct {
+	id  string
 	dir string
 	f   []string
 }
 
 // NewLocalArtifact returns a VMware artifact containing the files
 // in the given directory.
-func NewLocalArtifact(dir string) (packer.Artifact, error) {
+func NewLocalArtifact(id string, dir string) (packer.Artifact, error) {
 	files := make([]string, 0, 5)
 	visit := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -37,6 +38,7 @@ func NewLocalArtifact(dir string) (packer.Artifact, error) {
 	}
 
 	return &localArtifact{
+		id:  id,
 		dir: dir,
 		f:   files,
 	}, nil
@@ -50,8 +52,8 @@ func (a *localArtifact) Files() []string {
 	return a.f
 }
 
-func (*localArtifact) Id() string {
-	return "VM"
+func (a *localArtifact) Id() string {
+	return a.id
 }
 
 func (a *localArtifact) String() string {

--- a/builder/vmware/common/artifact_test.go
+++ b/builder/vmware/common/artifact_test.go
@@ -29,13 +29,16 @@ func TestNewLocalArtifact(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	a, err := NewLocalArtifact(td)
+	a, err := NewLocalArtifact("vm1", td)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	if a.BuilderId() != BuilderId {
 		t.Fatalf("bad: %#v", a.BuilderId())
+	}
+	if a.Id() != "vm1" {
+		t.Fatalf("bad: %#v", a.Id())
 	}
 	if len(a.Files()) != 1 {
 		t.Fatalf("should length 1: %d", len(a.Files()))

--- a/builder/vmware/iso/artifact.go
+++ b/builder/vmware/iso/artifact.go
@@ -8,6 +8,7 @@ import (
 // of files associated with the resulting machine.
 type Artifact struct {
 	builderId string
+	id        string
 	dir       OutputDir
 	f         []string
 }
@@ -20,8 +21,8 @@ func (a *Artifact) Files() []string {
 	return a.f
 }
 
-func (*Artifact) Id() string {
-	return "VM"
+func (a *Artifact) Id() string {
+	return a.id
 }
 
 func (a *Artifact) String() string {

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -349,6 +349,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	return &Artifact{
 		builderId: builderId,
+		id:        b.config.VMName,
 		dir:       dir,
 		f:         files,
 	}, nil

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -142,7 +142,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, errors.New("Build was halted.")
 	}
 
-	return vmwcommon.NewLocalArtifact(b.config.OutputDir)
+	return vmwcommon.NewLocalArtifact(b.config.VMName, b.config.OutputDir)
 }
 
 // Cancel.


### PR DESCRIPTION
Publish `vm_name` configuration parameter as artifact ID of generated image. 
Right now "VM" string is hardcoded.

This change is invisible to users, but required to make [our plugin](https://github.com/JetBrains/packer-post-processor-teamcity) working.