### PR TITLE
Update to how zone is extracted from metadata

### DIFF
--- a/builder/googlecompute/startup.go
+++ b/builder/googlecompute/startup.go
@@ -21,7 +21,7 @@ GetMetadata () {
   echo "$(curl -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/${1} 2> /dev/null)"
 }
 
-ZONE=$(GetMetadata zone | grep -oP "[^/]*$")
+ZONE=$(basename $(GetMetadata zone))
 
 SetMetadata () {
   gcloud compute instances add-metadata ${HOSTNAME} --metadata ${1}=${2} --zone ${ZONE}


### PR DESCRIPTION
Some images like Debian 7 do not support the `-P` arg for grep and the error below is thrown during the startup script.

```
grep: The -P option is not supported: libpcre.so.3 is not available
```

This replaces the grep with a call to `basename` which has the same effect.