### PR TITLE
(Hyper-V) Enable a separate directory to be used for temporary VHDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ packer-test*.log
 .idea/
 *.iml
 Thumbs.db
+/packer.exe

--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -64,7 +64,7 @@ type Driver interface {
 
 	DeleteVirtualSwitch(string) error
 
-	CreateVirtualMachine(string, string, int64, int64, string, uint) error
+	CreateVirtualMachine(string, string, string, int64, int64, string, uint) error
 
 	DeleteVirtualMachine(string) error
 

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -166,8 +166,8 @@ func (d *HypervPS4Driver) CreateVirtualSwitch(switchName string, switchType stri
 	return hyperv.CreateVirtualSwitch(switchName, switchType)
 }
 
-func (d *HypervPS4Driver) CreateVirtualMachine(vmName string, path string, ram int64, diskSize int64, switchName string, generation uint) error {
-	return hyperv.CreateVirtualMachine(vmName, path, ram, diskSize, switchName, generation)
+func (d *HypervPS4Driver) CreateVirtualMachine(vmName string, path string, vhdPath string, ram int64, diskSize int64, switchName string, generation uint) error {
+	return hyperv.CreateVirtualMachine(vmName, path, vhdPath, ram, diskSize, switchName, generation)
 }
 
 func (d *HypervPS4Driver) DeleteVirtualMachine(vmName string) error {

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -30,12 +30,13 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 	ui.Say("Creating virtual machine...")
 
 	path := state.Get("packerTempDir").(string)
+	vhdPath := state.Get("packerVhdTempDir").(string)
 
 	// convert the MB to bytes
 	ramSize := int64(s.RamSize * 1024 * 1024)
 	diskSize := int64(s.DiskSize * 1024 * 1024)
 
-	err := driver.CreateVirtualMachine(s.VMName, path, ramSize, diskSize, s.SwitchName, s.Generation)
+	err := driver.CreateVirtualMachine(s.VMName, path, vhdPath, ramSize, diskSize, s.SwitchName, s.Generation)
 	if err != nil {
 		err := fmt.Errorf("Error creating virtual machine: %s", err)
 		state.Put("error", err)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -82,6 +82,11 @@ type Config struct {
 	EnableVirtualizationExtensions bool     `mapstructure:"enable_virtualization_extensions"`
 	TempPath                       string   `mapstructure:"temp_path"`
 
+	// A separate path can be used for storing the VM's disk image. The purpose is to enable
+	// reading and writing to take place on different physical disks (read from VHD temp path
+	// write to regular temp path while exporting the VM) to eliminate a single-disk bottleneck.
+	VhdTempPath string `mapstructure:"vhd_temp_path"`
+
 	Communicator string `mapstructure:"communicator"`
 
 	SkipCompaction bool `mapstructure:"skip_compaction"`
@@ -296,7 +301,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	steps := []multistep.Step{
 		&hypervcommon.StepCreateTempDir{
-			TempPath: b.config.TempPath,
+			TempPath:    b.config.TempPath,
+			VhdTempPath: b.config.VhdTempPath,
 		},
 		&hypervcommon.StepOutputDir{
 			Force: b.config.PackerForce,

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -187,27 +187,27 @@ Set-VMFloppyDiskDrive -VMName $vmName -Path $null
 	return err
 }
 
-func CreateVirtualMachine(vmName string, path string, ram int64, diskSize int64, switchName string, generation uint) error {
+func CreateVirtualMachine(vmName string, path string, vhdRoot string, ram int64, diskSize int64, switchName string, generation uint) error {
 
 	if generation == 2 {
 		var script = `
-param([string]$vmName, [string]$path, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName, [int]$generation)
+param([string]$vmName, [string]$path, [string]$vhdRoot, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName, [int]$generation)
 $vhdx = $vmName + '.vhdx'
-$vhdPath = Join-Path -Path $path -ChildPath $vhdx
+$vhdPath = Join-Path -Path $vhdRoot -ChildPath $vhdx
 New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName -Generation $generation
 `
 		var ps powershell.PowerShellCmd
-		err := ps.Run(script, vmName, path, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatInt(int64(generation), 10))
+		err := ps.Run(script, vmName, path, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatInt(int64(generation), 10))
 		return err
 	} else {
 		var script = `
-param([string]$vmName, [string]$path, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName)
+param([string]$vmName, [string]$path, [string]$vhdRoot, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName)
 $vhdx = $vmName + '.vhdx'
-$vhdPath = Join-Path -Path $path -ChildPath $vhdx
+$vhdPath = Join-Path -Path $vhdRoot -ChildPath $vhdx
 New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName
 `
 		var ps powershell.PowerShellCmd
-		err := ps.Run(script, vmName, path, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName)
+		err := ps.Run(script, vmName, path, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
The existing Hyper-V disk usage patterns are suboptimal in a few ways:

1. Thre are large sequential reads and writes to/from the same disk (https://github.com/hashicorp/packer/issues/5188). Using separate disks for read and write operations can provide improved performance.
1. During VM provisioning, random access patterns dominate but after VM export, sequential access patterns dominate. Different storage devices can be optimized for different access patterns, enabling additional efficiency if the different usages can take place on different devices.

Therefore this PR adds a `vhd_temp_path` parameter to the Hyper-V builder. This enables the VHD to be placed on a storage device optimized for random access, from which it is later exported to the regular Packer temp directory (`temp_path`) that can reside on a device optimized for sequential access.

Closes #5188