### PR TITLE
Link VHD instead of copy where allowed by OS

### DIFF
--- a/post-processor/vagrant/util.go
+++ b/post-processor/vagrant/util.go
@@ -51,6 +51,23 @@ func CopyContents(dst, src string) error {
 	return nil
 }
 
+// Creates a (hard) link to a file, ensuring that all parent directories also exist.
+func LinkFile(dst, src string) error {
+	dstDir, _ := filepath.Split(dst)
+	if dstDir != "" {
+		err := os.MkdirAll(dstDir, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := os.Link(src, dst); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // DirToBox takes the directory and compresses it into a Vagrant-compatible
 // box. This function does not perform checks to verify that dir is
 // actually a proper box. This is an expected precondition.

--- a/post-processor/vagrant/util.go
+++ b/post-processor/vagrant/util.go
@@ -32,7 +32,7 @@ func CopyContents(dst, src string) error {
 
 	dstDir, _ := filepath.Split(dst)
 	if dstDir != "" {
-		err := os.MkdirAll(dstDir, os.ModePerm)
+		err := os.MkdirAll(dstDir, 0755)
 		if err != nil {
 			return err
 		}
@@ -55,7 +55,7 @@ func CopyContents(dst, src string) error {
 func LinkFile(dst, src string) error {
 	dstDir, _ := filepath.Split(dst)
 	if dstDir != "" {
-		err := os.MkdirAll(dstDir, os.ModePerm)
+		err := os.MkdirAll(dstDir, 0755)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, the HyperV variant of the Vagrant post-processor copied the VHD to a temporary directory before packaging it up into the box file. This incurs an often unnecessary and gigantic file copy I/O to make the VHD copy.

The PR makes Packer first attempt to hardlink the VHD instead. If it fails, it falls back to the copy (this is expected mainly when the Vagrant post-processor temp path is on a different filesystem from the VHD storage temp path).

The change took my build from 106 minutes to 92 minutes (13% savings).