### PR TITLE
don't panic if the communicator is none and the port is 0

### DIFF
--- a/builder/amazon/common/step_security_group.go
+++ b/builder/amazon/common/step_security_group.go
@@ -45,7 +45,9 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 
 	port := s.CommConfig.Port()
 	if port == 0 {
-		panic("port must be set to a non-zero value.")
+		if s.CommConfig.Type != "none" {
+			panic("port must be set to a non-zero value.")
+		}
 	}
 
 	// Create the group


### PR DESCRIPTION
If the port isn't set in StepSecurityGroup, we normally panic.  This doesn't make sense for the none communicator; this prevents the panic if the none communicator is being used
Closes #5213
