### PR TITLE
fix test that flaked in a travis build recently

### DIFF
--- a/builder/googlecompute/step_create_instance_test.go
+++ b/builder/googlecompute/step_create_instance_test.go
@@ -229,10 +229,6 @@ func TestStepCreateInstance_errorTimeout(t *testing.T) {
 	state.Put("ssh_public_key", "key")
 
 	errCh := make(chan error, 1)
-	go func() {
-		<-time.After(10 * time.Millisecond)
-		errCh <- nil
-	}()
 
 	config := state.Get("config").(*Config)
 	config.stateTimeout = 1 * time.Microsecond


### PR DESCRIPTION
Removes code that caused race condition in normal operation of this test; We could also have set the errChan wait to be longer, but the code shouldn't return at all during normal execution of the test so maybe it's better not to have it at all.
