### PR TITLE
Revert "make sure that flagVars is not a nil map"

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -120,9 +120,6 @@ func (m *Meta) FlagSet(n string, fs FlagSetFlags) *flag.FlagSet {
 		f.Var((*kvflag.Flag)(&m.flagVars), "var", "")
 		f.Var((*kvflag.FlagJSON)(&m.flagVars), "var-file", "")
 	}
-	if len(m.flagVars) == 0 {
-		m.flagVars = make(map[string]string)
-	}
 
 	// Create an io.Writer that writes to our Ui properly for errors.
 	// This is kind of a hack, but it does the job. Basically: create


### PR DESCRIPTION
Reverts hashicorp/packer#5101

Closes #5232

I think my overactive pattern matching decided this was a bug when really it's under-specified behavior. I think we need to revert this because of the problems in the above issue. We'll have more control over variables if/when we implement HCL (i.e. variables could have properties like controlling default behavior when pushing), but for now I think it's best to leave things the way they were.

@SwampDragons and I agree that explicitly pushing variables is probably closer to correct than the current behavior, but I think we need to approach the fix with more caution