### PR TITLE
do not wait for rpc upload command to return

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -693,6 +693,11 @@ func (c *comm) scpSession(scpCommand string, f func(io.Writer, *bufio.Reader) er
 			// Otherwise, we have an ExitErorr, meaning we can just read
 			// the exit status
 			log.Printf("non-zero exit status: %d", exitErr.ExitStatus())
+			stdoutB, err := ioutil.ReadAll(stdoutR)
+			if err != nil {
+				return err
+			}
+			log.Printf("scp output: %s", stdoutB)
 
 			// If we exited with status 127, it means SCP isn't available.
 			// Return a more descriptive error for that.

--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -111,8 +111,7 @@ func (c *communicator) Start(cmd *packer.RemoteCmd) (err error) {
 
 		var finished CommandFinished
 		decoder := gob.NewDecoder(conn)
-		err = decoder.Decode(&finished)
-		if err != nil {
+		if err := decoder.Decode(&finished); err != nil {
 			log.Printf("[ERR] Error decoding response stream %d: %s",
 				responseStreamId, err)
 			cmd.SetExited(123)
@@ -130,12 +129,7 @@ func (c *communicator) Start(cmd *packer.RemoteCmd) (err error) {
 func (c *communicator) Upload(path string, r io.Reader, fi *os.FileInfo) (err error) {
 	// Pipe the reader through to the connection
 	streamId := c.mux.NextId()
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		serveSingleCopy("uploadData", c.mux, streamId, nil, r)
-	}()
+	go serveSingleCopy("uploadData", c.mux, streamId, nil, r)
 
 	args := CommunicatorUploadArgs{
 		Path:           path,
@@ -147,7 +141,6 @@ func (c *communicator) Upload(path string, r io.Reader, fi *os.FileInfo) (err er
 	}
 
 	err = c.client.Call("Communicator.Upload", &args, new(interface{}))
-	wg.Wait()
 	return
 }
 


### PR DESCRIPTION
Closes #5237

adds better debugging to scp commands and removes waitgroup from the upload command. I don't think it's needed there because it's done synchronously 