### PR TITLE
use sudo for cleaning up salt content created with sudo

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -384,7 +384,7 @@ func (p *Provisioner) createDir(ui packer.Ui, comm packer.Communicator, dir stri
 func (p *Provisioner) removeDir(ui packer.Ui, comm packer.Communicator, dir string) error {
 	ui.Message(fmt.Sprintf("Removing directory: %s", dir))
 	cmd := &packer.RemoteCmd{
-		Command: fmt.Sprintf("rm -rf '%s'", dir),
+		Command: fmt.Sprintf(p.sudo("rm -rf '%s'"), dir),
 	}
 	if err := cmd.StartWithUi(comm, ui); err != nil {
 		return err


### PR DESCRIPTION
Background:
- start from a base image that's never had `salt` installed (`/srv/` is missing/empty) (image "A")
- using `salt-masterless` provisioner and its support for the bootstrap script, create a new image that now will have `salt` installed (`/srv/` is populated) (image "B")
- try to run packer salt-masterless against image "B" to create image "C". I happen to be skipping the salt bootstrapper in this case, but it likely doesn't matter

Problem:
The `/srv` directory is owned by `root` and the non-root user used to install salt via sudo can't wipe out directories because of the perms/ownership:
```
[ec2-user@ip-10-4-131-125 ~]$ ls -la /srv
total 0
drwxr-xr-x.  4 root     root      32 Aug 12 01:24 .
dr-xr-xr-x. 18 root     root     238 Aug 11 21:02 ..
drwxrwxr-x.  2 ec2-user ec2-user 117 Aug 12 01:24 pillar
drwxrwxr-x.  4 ec2-user ec2-user  90 Aug 12 01:24 salt
```
This happens:
```
2017/08/11 17:41:51 ui:     amazon-ebs: Removing directory: /srv/salt
    amazon-ebs: Removing directory: /srv/salt
2017/08/11 17:41:51 packer: 2017/08/11 17:41:51 opening new ssh session
2017/08/11 17:41:51 packer: 2017/08/11 17:41:51 starting remote command: rm -rf '/srv/salt'
2017/08/11 17:41:51 packer: 2017/08/11 17:41:51 Remote command exited with '1': rm -rf '/srv/salt'
2017/08/11 17:41:51 packer: 2017/08/11 17:41:51 [INFO] RPC endpoint: Communicator ended with: 1
```

The _initial_ salt bootstrap driven install actually tries this same thing, but because `/srv/{salt,pillar}/` don't exist yet, the `rm -rf` of them succeeds. Then the directory is populated with `sudo` driven directory copies. All of this is shown here:
```
2017/08/11 17:04:33 packer: 2017/08/11 17:04:33 starting remote command: rm -rf '/srv/pillar'
2017/08/11 17:04:33 packer: 2017/08/11 17:04:33 [INFO] RPC endpoint: Communicator ended with: 0
2017/08/11 17:04:33 [INFO] 0 bytes written for 'stdout'
2017/08/11 17:04:33 [INFO] 0 bytes written for 'stderr'
2017/08/11 17:04:33 [INFO] RPC client: Communicator ended with: 0
2017/08/11 17:04:33 [INFO] RPC endpoint: Communicator ended with: 0
2017/08/11 17:04:33 packer: 2017/08/11 17:04:33 [INFO] 0 bytes written for 'stdout'
2017/08/11 17:04:33 packer: 2017/08/11 17:04:33 [INFO] 0 bytes written for 'stderr'
2017/08/11 17:04:33 packer: 2017/08/11 17:04:33 [INFO] RPC client: Communicator ended with: 0
2017/08/11 17:04:33 ui:     amazon-ebs: Moving /tmp/salt/pillar to /srv/pillar
    amazon-ebs: Moving /tmp/salt/pillar to /srv/pillar
2017/08/11 17:04:33 packer: 2017/08/11 17:04:33 opening new ssh session
2017/08/11 17:04:33 packer: 2017/08/11 17:04:33 starting remote command: sudo mv /tmp/salt/pillar /srv/pillar
```

Solution (via this patch):
Prepend the `rm` with `sudo`, produces the following success:
```
2017/08/11 21:24:48 ui:     amazon-ebs: Removing directory: /srv/pillar
    amazon-ebs: Removing directory: /srv/pillar
2017/08/11 21:24:48 packer: 2017/08/11 21:24:48 opening new ssh session
2017/08/11 21:24:48 packer: 2017/08/11 21:24:48 starting remote command: sudo rm -rf '/srv/pillar'
2017/08/11 21:24:49 packer: 2017/08/11 21:24:49 [INFO] RPC endpoint: Communicator ended with: 0
```
