### PR TITLE
make force_deregister work in all regions, not just original region.

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -245,9 +245,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepEarlyCleanup{},
 		&StepSnapshot{},
 		&awscommon.StepDeregisterAMI{
+			AccessConfig:        &b.config.AccessConfig,
 			ForceDeregister:     b.config.AMIForceDeregister,
 			ForceDeleteSnapshot: b.config.AMIForceDeleteSnapshot,
 			AMIName:             b.config.AMIName,
+			Regions:             b.config.AMIRegions,
 		},
 		&StepRegisterAMI{
 			RootVolumeSize: b.config.RootVolumeSize,

--- a/builder/amazon/common/step_deregister_ami.go
+++ b/builder/amazon/common/step_deregister_ami.go
@@ -10,59 +10,76 @@ import (
 )
 
 type StepDeregisterAMI struct {
+	AccessConfig        *AccessConfig
 	ForceDeregister     bool
 	ForceDeleteSnapshot bool
 	AMIName             string
+	Regions             []string
 }
 
 func (s *StepDeregisterAMI) Run(state multistep.StateBag) multistep.StepAction {
-	ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packer.Ui)
+	regions := s.Regions
+	if len(regions) == 0 {
+		regions = append(regions, s.AccessConfig.RawRegion)
+	}
 
 	// Check for force deregister
 	if s.ForceDeregister {
-		resp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
-			Filters: []*ec2.Filter{{
-				Name:   aws.String("name"),
-				Values: []*string{aws.String(s.AMIName)},
-			}}})
+		for _, region := range regions {
+			// get new connection for each region in which we need to deregister vms
+			session, err := s.AccessConfig.Session()
+			if err != nil {
+				return multistep.ActionHalt
+			}
 
-		if err != nil {
-			err := fmt.Errorf("Error describing AMI: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
+			regionconn := ec2.New(session.Copy(&aws.Config{
+				Region: aws.String(region)},
+			))
 
-		// Deregister image(s) by name
-		for _, i := range resp.Images {
-			_, err := ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
-				ImageId: i.ImageId,
-			})
+			resp, err := regionconn.DescribeImages(&ec2.DescribeImagesInput{
+				Filters: []*ec2.Filter{{
+					Name:   aws.String("name"),
+					Values: []*string{aws.String(s.AMIName)},
+				}}})
 
 			if err != nil {
-				err := fmt.Errorf("Error deregistering existing AMI: %s", err)
+				err := fmt.Errorf("Error describing AMI: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
-			ui.Say(fmt.Sprintf("Deregistered AMI %s, id: %s", s.AMIName, *i.ImageId))
 
-			// Delete snapshot(s) by image
-			if s.ForceDeleteSnapshot {
-				for _, b := range i.BlockDeviceMappings {
-					if b.Ebs != nil && aws.StringValue(b.Ebs.SnapshotId) != "" {
-						_, err := ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
-							SnapshotId: b.Ebs.SnapshotId,
-						})
+			// Deregister image(s) by name
+			for _, i := range resp.Images {
+				_, err := regionconn.DeregisterImage(&ec2.DeregisterImageInput{
+					ImageId: i.ImageId,
+				})
 
-						if err != nil {
-							err := fmt.Errorf("Error deleting existing snapshot: %s", err)
-							state.Put("error", err)
-							ui.Error(err.Error())
-							return multistep.ActionHalt
+				if err != nil {
+					err := fmt.Errorf("Error deregistering existing AMI: %s", err)
+					state.Put("error", err)
+					ui.Error(err.Error())
+					return multistep.ActionHalt
+				}
+				ui.Say(fmt.Sprintf("Deregistered AMI %s, id: %s", s.AMIName, *i.ImageId))
+
+				// Delete snapshot(s) by image
+				if s.ForceDeleteSnapshot {
+					for _, b := range i.BlockDeviceMappings {
+						if b.Ebs != nil && aws.StringValue(b.Ebs.SnapshotId) != "" {
+							_, err := regionconn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+								SnapshotId: b.Ebs.SnapshotId,
+							})
+
+							if err != nil {
+								err := fmt.Errorf("Error deleting existing snapshot: %s", err)
+								state.Put("error", err)
+								ui.Error(err.Error())
+								return multistep.ActionHalt
+							}
+							ui.Say(fmt.Sprintf("Deleted snapshot: %s", *b.Ebs.SnapshotId))
 						}
-						ui.Say(fmt.Sprintf("Deleted snapshot: %s", *b.Ebs.SnapshotId))
 					}
 				}
 			}

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -182,9 +182,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			EnableEnhancedNetworking: b.config.AMIEnhancedNetworking,
 		},
 		&awscommon.StepDeregisterAMI{
+			AccessConfig:        &b.config.AccessConfig,
 			ForceDeregister:     b.config.AMIForceDeregister,
 			ForceDeleteSnapshot: b.config.AMIForceDeleteSnapshot,
 			AMIName:             b.config.AMIName,
+			Regions:             b.config.AMIRegions,
 		},
 		&stepCreateAMI{},
 		&awscommon.StepCreateEncryptedAMICopy{

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -195,9 +195,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			NewRootMountPoint: b.config.RootDevice.SourceDeviceName,
 		},
 		&awscommon.StepDeregisterAMI{
+			AccessConfig:        &b.config.AccessConfig,
 			ForceDeregister:     b.config.AMIForceDeregister,
 			ForceDeleteSnapshot: b.config.AMIForceDeleteSnapshot,
 			AMIName:             b.config.AMIName,
+			Regions:             b.config.AMIRegions,
 		},
 		&StepRegisterAMI{
 			RootDevice:   b.config.RootDevice,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -258,9 +258,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Debug: b.config.PackerDebug,
 		},
 		&awscommon.StepDeregisterAMI{
+			AccessConfig:        &b.config.AccessConfig,
 			ForceDeregister:     b.config.AMIForceDeregister,
 			ForceDeleteSnapshot: b.config.AMIForceDeleteSnapshot,
 			AMIName:             b.config.AMIName,
+			Regions:             b.config.AMIRegions,
 		},
 		&StepRegisterAMI{},
 		&awscommon.StepAMIRegionCopy{


### PR DESCRIPTION
In step_deregister_ami the code assumed we were only working in one region, which meant that the deregister wouldn't happen in any other regions being touched.  This PR changes that by repeating the deregister step for each region in the "ami_regions" provided in the packer config (if there is no "ami_regions" in the config, it falls back on the "region")
Closes #3399 
