### PR TITLE
fix bug introduced by 5221

### DIFF
--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -173,7 +173,7 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 
 	// Make the directory, then copy into it
 	cmd := &packer.RemoteCmd{
-		Command: fmt.Sprintf("set -e; mkdir -p %s; command cp -R %s/ %s",
+		Command: fmt.Sprintf("set -e; mkdir -p %s; command cp -R %s/. %s",
 			containerDst, containerSrc, containerDst),
 	}
 	if err := c.Start(cmd); err != nil {


### PR DESCRIPTION
Previous implementation with trailing slash wasn't platform agnostic; that use of cp only works on OSX but not Linux.  I've tested that the new implementation works with dotfiles and empty directories.

Closes #5243
