### PR TITLE
use non-escapable strings for user provided values

### DIFF
--- a/provisioner/powershell/elevated.go
+++ b/provisioner/powershell/elevated.go
@@ -60,7 +60,7 @@ $t.XmlText = @'
 '@
 if (Test-Path variable:global:ProgressPreference){$ProgressPreference="SilentlyContinue"}
 $f = $s.GetFolder("\")
-$f.RegisterTaskDefinition($name, $t, 6, "{{.User}}", "{{.Password}}", 1, $null) | Out-Null
+$f.RegisterTaskDefinition($name, $t, 6, '{{.User}}', '{{.Password}}', 1, $null) | Out-Null
 $t = $f.GetTask("\$name")
 $t.Run($null) | Out-Null
 $timeout = 10


### PR DESCRIPTION
Provides values to the RegisterTaskDefinition function using single quotes so if our password or username happens to include a `$` the logic still works.

Closes #5258
