### PR TITLE
build solaris binary

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,7 +13,7 @@ cd $DIR
 
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm arm64"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd}
+XC_OS=${XC_OS:-linux darwin windows freebsd openbsd solaris}
 
 # Delete the old dir
 echo "==> Removing old directory..."


### PR DESCRIPTION
Closes #5241

`pkg/solaris_amd64/packer: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/amd64/ld.so.1, not stripped`