### PR TITLE
Fix post-restart powershell failure

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -21,8 +21,6 @@ import (
 	"github.com/hashicorp/packer/template/interpolate"
 )
 
-const DefaultRemotePath = "c:/Windows/Temp/script.ps1"
-
 var retryableSleep = 2 * time.Second
 
 type Config struct {
@@ -137,7 +135,8 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.RemotePath == "" {
-		p.config.RemotePath = DefaultRemotePath
+		uuid := uuid.TimeOrderedUUID()
+		p.config.RemotePath = fmt.Sprintf(`c:/Windows/Temp/script-%s.ps1`, uuid)
 	}
 
 	if p.config.Scripts == nil {

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -266,7 +266,6 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			if _, err := f.Seek(0, 0); err != nil {
 				return err
 			}
-
 			if err := comm.Upload(p.config.RemotePath, f, nil); err != nil {
 				return fmt.Errorf("Error uploading script: %s", err)
 			}

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -67,7 +67,8 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if p.config.RemotePath != DefaultRemotePath {
+	matched, _ := regexp.MatchString("c:/Windows/Temp/script-.*.ps1", p.config.RemotePath)
+	if !matched {
 		t.Errorf("unexpected remote path: %s", p.config.RemotePath)
 	}
 
@@ -471,6 +472,7 @@ func TestProvisionerProvision_Scripts(t *testing.T) {
 	config["scripts"] = []string{tempFile.Name()}
 	config["packer_build_name"] = "foobuild"
 	config["packer_builder_type"] = "footype"
+	config["remote_path"] = "c:/Windows/Temp/script.ps1"
 	ui := testUi()
 
 	p := new(Provisioner)
@@ -517,6 +519,7 @@ func TestProvisionerProvision_ScriptsWithEnvVars(t *testing.T) {
 	envVars[0] = "FOO=BAR"
 	envVars[1] = "BAR=BAZ"
 	config["environment_vars"] = envVars
+	config["remote_path"] = "c:/Windows/Temp/script.ps1"
 
 	p := new(Provisioner)
 	comm := new(packer.MockCommunicator)
@@ -626,6 +629,7 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 func TestProvision_createCommandText(t *testing.T) {
 
 	config := testConfig()
+	config["remote_path"] = "c:/Windows/Temp/script.ps1"
 	p := new(Provisioner)
 	comm := new(packer.MockCommunicator)
 	p.communicator = comm

--- a/provisioner/windows-restart/provisioner_test.go
+++ b/provisioner/windows-restart/provisioner_test.go
@@ -242,6 +242,7 @@ func TestProvision_waitForCommunicator(t *testing.T) {
 	p.comm = comm
 	p.ui = ui
 	comm.StartStderr = "WinRM terminated"
+	comm.StartStdout = "WIN-V4CEJ7MC5SN restarted."
 	comm.StartExitStatus = 1
 	p.Prepare(config)
 	err := waitForCommunicator(p)


### PR DESCRIPTION
Two fixes:  

1) There was a bug in powershell where if we ran one powershell script and then another, both were uploaded to the same remote path and the first script was cached somehow.  This meant that when the time came to run the second script, we'd actually be trying to rerun the first.  

This code change circumvents that problem by making sure every script uploaded is sent to a unique remote path (note that all of this is overridden if the user sets the "remote_path" option in the packer config)


2) Windows restart provisioner was not waiting for the computer to come fully online.  It'd check that the communicator could run an "echo <computername> restarted" command but wouldn't make sure the echo actually succeeded.  This led to the provisioner returning too soon, and the first powershell provisioner run post-reboot to fail.  I've modified the code to actually parse stdout and make sure the echo suceeded.

Closes #5064
Closes #4994 
