### PR TITLE
Use docker cp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ packer-test*.log
 
 .idea/
 *.iml
+Thumbs.db

--- a/communicator/none/communicator.go
+++ b/communicator/none/communicator.go
@@ -2,9 +2,10 @@ package none
 
 import (
 	"errors"
-	"github.com/hashicorp/packer/packer"
 	"io"
 	"os"
+
+	"github.com/hashicorp/packer/packer"
 )
 
 type comm struct {


### PR DESCRIPTION
Changed the Upload func in the Docker communicator to use the docker cp command instead of copying files into a mounted volume and then copying to the correct location in the container.

Closes #5263 
