### PR TITLE
Show a message why VM export was skipped while building on VMWare Fusion

### DIFF
--- a/builder/vmware/iso/step_export.go
+++ b/builder/vmware/iso/step_export.go
@@ -45,6 +45,7 @@ func (s *StepExport) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	if c.RemoteType != "esx5" || s.Format == "" {
+		ui.Say("Skipping export of virtual machine (export is allowed only for ESXi and the format needs to be specified)...")
 		return multistep.ActionContinue
 	}
 

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -478,7 +478,8 @@ modify as well:
 
 -   `format` (string) - Either "ovf", "ova" or "vmx", this specifies the output
     format of the exported virtual machine. This defaults to "ovf".
-    Before using this option, you need to install `ovftool`.
+    Before using this option, you need to install `ovftool`. This option 
+	works currently only with option remote_type set to "esx5".
 
 ### VNC port discovery
 


### PR DESCRIPTION
Running VMWare ISO builder on VMWare Fusion or VMWare Workstation doesn't export VM in the specified format. The whole step is skipped, because this step is currently only executed on ESXi. 

There was no message and it wasn't described in the documentation.

I added a message which will be displayed to a user and note in the documentation about this limitation.