### PR TITLE
Natural order / align of AMI artifacts

### DIFF
--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -51,7 +51,7 @@ func (a *Artifact) String() string {
 	}
 
 	sort.Strings(amiStrings)
-	return fmt.Sprintf("AMIs were created:\n\n%s", strings.Join(amiStrings, "\n"))
+	return fmt.Sprintf("AMIs were created:\n%s\n", strings.Join(amiStrings, "\n"))
 }
 
 func (a *Artifact) State(name string) interface{} {

--- a/builder/amazon/common/artifact_test.go
+++ b/builder/amazon/common/artifact_test.go
@@ -48,9 +48,9 @@ func TestArtifactState_atlasMetadata(t *testing.T) {
 
 func TestArtifactString(t *testing.T) {
 	expected := `AMIs were created:
-
 east: foo
-west: bar`
+west: bar
+`
 
 	amis := make(map[string]string)
 	amis["east"] = "foo"


### PR DESCRIPTION
Hi.

This PR changes way that AMI artifacts are printed out after build. It is more natural to align artifacts to builder name rather than leave blank line. It caused me and others to make mistake taking copying wrong AMI id. Use case. I want to copy ami for front `ami-ffffff` and by mistake I copy `ami-tttttt` instead.

Effect will be to change this:
```
==> Builds finished. The artifacts of successful builds are:
--> tracker: AMIs were created:

us-east-1: ami-tttttt
--> front: AMIs were created:

us-east-1: ami-ffffff
```
Into this:
```
==> Builds finished. The artifacts of successful builds are:
--> tracker: AMIs were created:
us-east-1: ami-xxxxx

--> front: AMIs were created:
us-east-1: ami-xxxxx
```
