### PR TITLE
Allow granular modification of sriov and ena enhanced networking opti…

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -213,9 +213,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if !b.config.FromScratch {
 		steps = append(steps,
 			&awscommon.StepSourceAMIInfo{
-				SourceAmi:          b.config.SourceAmi,
-				EnhancedNetworking: b.config.AMIEnhancedNetworking,
-				AmiFilters:         b.config.SourceAmiFilter,
+				SourceAmi:             b.config.SourceAmi,
+				EnableSriovNetSupport: b.config.SriovNetSupport,
+				EnableENASupport:      b.config.ENASupport,
+				AmiFilters:            b.config.SourceAmiFilter,
 			},
 			&StepCheckRootDevice{},
 		)

--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -253,7 +253,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Regions:             b.config.AMIRegions,
 		},
 		&StepRegisterAMI{
-			RootVolumeSize: b.config.RootVolumeSize,
+			RootVolumeSize:           b.config.RootVolumeSize,
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
 		},
 		&awscommon.StepCreateEncryptedAMICopy{
 			KeyID:             b.config.AMIKmsKeyId,

--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -213,10 +213,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if !b.config.FromScratch {
 		steps = append(steps,
 			&awscommon.StepSourceAMIInfo{
-				SourceAmi:             b.config.SourceAmi,
-				EnableSriovNetSupport: b.config.SriovNetSupport,
-				EnableENASupport:      b.config.ENASupport,
-				AmiFilters:            b.config.SourceAmiFilter,
+				SourceAmi:                b.config.SourceAmi,
+				EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+				EnableAMIENASupport:      b.config.AMIENASupport,
+				AmiFilters:               b.config.SourceAmiFilter,
 			},
 			&StepCheckRootDevice{},
 		)

--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -12,7 +12,9 @@ import (
 
 // StepRegisterAMI creates the AMI.
 type StepRegisterAMI struct {
-	RootVolumeSize int64
+	RootVolumeSize           int64
+	EnableAMIENASupport      bool
+	EnableAMISriovNetSupport bool
 }
 
 func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
@@ -75,11 +77,12 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 		registerOpts = buildRegisterOpts(config, image, newMappings)
 	}
 
-	if config.AMIEnhancedNetworking {
+	if s.EnableAMISriovNetSupport {
 		// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
 		registerOpts.SriovNetSupport = aws.String("simple")
-
+	}
+	if s.EnableAMIENASupport {
 		// Set EnaSupport to true
 		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
 		registerOpts.EnaSupport = aws.Bool(true)

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -17,9 +17,8 @@ type AMIConfig struct {
 	AMIRegions              []string          `mapstructure:"ami_regions"`
 	AMISkipRegionValidation bool              `mapstructure:"skip_region_validation"`
 	AMITags                 map[string]string `mapstructure:"tags"`
-	AMIEnhancedNetworking   bool              `mapstructure:"enhanced_networking"`
-	ENASupport              bool              `mapstructure:"ena_support"`
-	SriovNetSupport         bool              `mapstructure:"sriov_support"`
+	AMIENASupport           bool              `mapstructure:"ena_support"`
+	AMISriovNetSupport      bool              `mapstructure:"sriov_support"`
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 	AMIForceDeleteSnapshot  bool              `mapstructure:"force_delete_snapshot"`
 	AMIEncryptBootVolume    bool              `mapstructure:"encrypt_boot"`
@@ -104,12 +103,6 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 				}
 			}
 		}
-	}
-	// Backwards-compatibility hack. Enhanced networking used to be hardcoded to do this.
-	// If users want granular choice on ENA vs SR-IOV they must not set enhanced_networking.
-	if c.AMIEnhancedNetworking {
-		c.ENASupport = true
-		c.SriovNetSupport = true
 	}
 
 	if len(c.AMIName) < 3 || len(c.AMIName) > 128 {

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -18,6 +18,8 @@ type AMIConfig struct {
 	AMISkipRegionValidation bool              `mapstructure:"skip_region_validation"`
 	AMITags                 map[string]string `mapstructure:"tags"`
 	AMIEnhancedNetworking   bool              `mapstructure:"enhanced_networking"`
+	ENASupport              bool              `mapstructure:"ena_support"`
+	SriovNetSupport         bool              `mapstructure:"sriov_support"`
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 	AMIForceDeleteSnapshot  bool              `mapstructure:"force_delete_snapshot"`
 	AMIEncryptBootVolume    bool              `mapstructure:"encrypt_boot"`
@@ -102,6 +104,12 @@ func (c *AMIConfig) Prepare(ctx *interpolate.Context) []error {
 				}
 			}
 		}
+	}
+	// Backwards-compatibility hack. Enhanced networking used to be hardcoded to do this.
+	// If users want granular choice on ENA vs SR-IOV they must not set enhanced_networking.
+	if c.AMIEnhancedNetworking {
+		c.ENASupport = true
+		c.SriovNetSupport = true
 	}
 
 	if len(c.AMIName) < 3 || len(c.AMIName) > 128 {

--- a/builder/amazon/common/step_modify_ebs_instance.go
+++ b/builder/amazon/common/step_modify_ebs_instance.go
@@ -10,8 +10,8 @@ import (
 )
 
 type StepModifyEBSBackedInstance struct {
-	EnableENASupport      bool
-	EnableSriovNetSupport bool
+	EnableAMIENASupport      bool
+	EnableAMISriovNetSupport bool
 }
 
 func (s *StepModifyEBSBackedInstance) Run(state multistep.StateBag) multistep.StepAction {
@@ -21,7 +21,7 @@ func (s *StepModifyEBSBackedInstance) Run(state multistep.StateBag) multistep.St
 
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
-	if s.EnableSriovNetSupport {
+	if s.EnableAMISriovNetSupport {
 		ui.Say("Enabling Enhanced Networking (SR-IOV)...")
 		simple := "simple"
 		_, err := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
@@ -38,7 +38,7 @@ func (s *StepModifyEBSBackedInstance) Run(state multistep.StateBag) multistep.St
 
 	// Set EnaSupport to true.
 	// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
-	if s.EnableENASupport {
+	if s.EnableAMIENASupport {
 		ui.Say("Enabling Enhanced Networking (ENA)...")
 		_, err := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
 			InstanceId: instance.InstanceId,

--- a/builder/amazon/common/step_source_ami_info.go
+++ b/builder/amazon/common/step_source_ami_info.go
@@ -17,9 +17,10 @@ import (
 // Produces:
 //   source_image *ec2.Image - the source AMI info
 type StepSourceAMIInfo struct {
-	SourceAmi          string
-	EnhancedNetworking bool
-	AmiFilters         AmiFilterOptions
+	SourceAmi             string
+	EnableSriovNetSupport bool
+	EnableENASupport      bool
+	AmiFilters            AmiFilterOptions
 }
 
 // Build a slice of AMI filter options from the filters provided.
@@ -103,7 +104,7 @@ func (s *StepSourceAMIInfo) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Enhanced Networking can only be enabled on HVM AMIs.
 	// See http://goo.gl/icuXh5
-	if s.EnhancedNetworking && *image.VirtualizationType != "hvm" {
+	if (s.EnableENASupport || s.EnableSriovNetSupport) && *image.VirtualizationType != "hvm" {
 		err := fmt.Errorf("Cannot enable enhanced networking, source AMI '%s' is not HVM", s.SourceAmi)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/amazon/common/step_source_ami_info.go
+++ b/builder/amazon/common/step_source_ami_info.go
@@ -17,10 +17,10 @@ import (
 // Produces:
 //   source_image *ec2.Image - the source AMI info
 type StepSourceAMIInfo struct {
-	SourceAmi             string
-	EnableSriovNetSupport bool
-	EnableENASupport      bool
-	AmiFilters            AmiFilterOptions
+	SourceAmi                string
+	EnableAMISriovNetSupport bool
+	EnableAMIENASupport      bool
+	AmiFilters               AmiFilterOptions
 }
 
 // Build a slice of AMI filter options from the filters provided.
@@ -104,7 +104,7 @@ func (s *StepSourceAMIInfo) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Enhanced Networking can only be enabled on HVM AMIs.
 	// See http://goo.gl/icuXh5
-	if (s.EnableENASupport || s.EnableSriovNetSupport) && *image.VirtualizationType != "hvm" {
+	if (s.EnableAMIENASupport || s.EnableAMISriovNetSupport) && *image.VirtualizationType != "hvm" {
 		err := fmt.Errorf("Cannot enable enhanced networking, source AMI '%s' is not HVM", s.SourceAmi)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -115,10 +115,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.AMIForceDeregister,
 		},
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:             b.config.SourceAmi,
-			EnableSriovNetSupport: b.config.SriovNetSupport,
-			EnableENASupport:      b.config.ENASupport,
-			AmiFilters:            b.config.SourceAmiFilter,
+			SourceAmi:                b.config.SourceAmi,
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
+			AmiFilters:               b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -180,8 +180,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
-			EnableSriovNetSupport: b.config.SriovNetSupport,
-			EnableENASupport:      b.config.ENASupport,
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
 		},
 		&awscommon.StepDeregisterAMI{
 			AccessConfig:        &b.config.AccessConfig,

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -115,9 +115,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.AMIForceDeregister,
 		},
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:          b.config.SourceAmi,
-			EnhancedNetworking: b.config.AMIEnhancedNetworking,
-			AmiFilters:         b.config.SourceAmiFilter,
+			SourceAmi:             b.config.SourceAmi,
+			EnableSriovNetSupport: b.config.SriovNetSupport,
+			EnableENASupport:      b.config.ENASupport,
+			AmiFilters:            b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -179,7 +180,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
-			EnableEnhancedNetworking: b.config.AMIEnhancedNetworking,
+			EnableSriovNetSupport: b.config.SriovNetSupport,
+			EnableENASupport:      b.config.ENASupport,
 		},
 		&awscommon.StepDeregisterAMI{
 			AccessConfig:        &b.config.AccessConfig,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -129,9 +129,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.AMIForceDeregister,
 		},
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:          b.config.SourceAmi,
-			EnhancedNetworking: b.config.AMIEnhancedNetworking,
-			AmiFilters:         b.config.SourceAmiFilter,
+			SourceAmi:             b.config.SourceAmi,
+			EnableSriovNetSupport: b.config.SriovNetSupport,
+			EnableENASupport:      b.config.ENASupport,
+			AmiFilters:            b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -189,7 +190,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
-			EnableEnhancedNetworking: b.config.AMIEnhancedNetworking,
+			EnableSriovNetSupport: b.config.SriovNetSupport,
+			EnableENASupport:      b.config.ENASupport,
 		},
 		&StepSnapshotNewRootVolume{
 			NewRootMountPoint: b.config.RootDevice.SourceDeviceName,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -129,10 +129,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.AMIForceDeregister,
 		},
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:             b.config.SourceAmi,
-			EnableSriovNetSupport: b.config.SriovNetSupport,
-			EnableENASupport:      b.config.ENASupport,
-			AmiFilters:            b.config.SourceAmiFilter,
+			SourceAmi:                b.config.SourceAmi,
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
+			AmiFilters:               b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -190,8 +190,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
-			EnableSriovNetSupport: b.config.SriovNetSupport,
-			EnableENASupport:      b.config.ENASupport,
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
 		},
 		&StepSnapshotNewRootVolume{
 			NewRootMountPoint: b.config.RootDevice.SourceDeviceName,
@@ -204,8 +204,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Regions:             b.config.AMIRegions,
 		},
 		&StepRegisterAMI{
-			RootDevice:   b.config.RootDevice,
-			BlockDevices: b.config.BlockDevices.BuildAMIDevices(),
+			RootDevice:               b.config.RootDevice,
+			BlockDevices:             b.config.BlockDevices.BuildAMIDevices(),
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
 		},
 		&awscommon.StepCreateEncryptedAMICopy{
 			KeyID:             b.config.AMIKmsKeyId,

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -23,9 +23,9 @@ type Config struct {
 	awscommon.AccessConfig `mapstructure:",squash"`
 	awscommon.RunConfig    `mapstructure:",squash"`
 
-	VolumeMappings  []BlockDevice `mapstructure:"ebs_volumes"`
-	ENASupport      bool          `mapstructure:"ena_support"`
-	SriovNetSupport bool          `mapstructure:"sriov_support"`
+	VolumeMappings     []BlockDevice `mapstructure:"ebs_volumes"`
+	AMIENASupport      bool          `mapstructure:"ena_support"`
+	AMISriovNetSupport bool          `mapstructure:"sriov_support"`
 
 	launchBlockDevices awscommon.BlockDevices
 	ctx                interpolate.Context
@@ -104,10 +104,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:             b.config.SourceAmi,
-			EnableSriovNetSupport: b.config.SriovNetSupport,
-			EnableENASupport:      b.config.ENASupport,
-			AmiFilters:            b.config.SourceAmiFilter,
+			SourceAmi:                b.config.SourceAmi,
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
+			AmiFilters:               b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -166,8 +166,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
-			EnableSriovNetSupport: b.config.SriovNetSupport,
-			EnableENASupport:      b.config.ENASupport,
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
 		},
 	}
 

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -23,8 +23,9 @@ type Config struct {
 	awscommon.AccessConfig `mapstructure:",squash"`
 	awscommon.RunConfig    `mapstructure:",squash"`
 
-	VolumeMappings        []BlockDevice `mapstructure:"ebs_volumes"`
-	AMIEnhancedNetworking bool          `mapstructure:"enhanced_networking"`
+	VolumeMappings  []BlockDevice `mapstructure:"ebs_volumes"`
+	ENASupport      bool          `mapstructure:"ena_support"`
+	SriovNetSupport bool          `mapstructure:"sriov_support"`
 
 	launchBlockDevices awscommon.BlockDevices
 	ctx                interpolate.Context
@@ -103,9 +104,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:          b.config.SourceAmi,
-			EnhancedNetworking: b.config.AMIEnhancedNetworking,
-			AmiFilters:         b.config.SourceAmiFilter,
+			SourceAmi:             b.config.SourceAmi,
+			EnableSriovNetSupport: b.config.SriovNetSupport,
+			EnableENASupport:      b.config.ENASupport,
+			AmiFilters:            b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -164,7 +166,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
-			EnableEnhancedNetworking: b.config.AMIEnhancedNetworking,
+			EnableSriovNetSupport: b.config.SriovNetSupport,
+			EnableENASupport:      b.config.ENASupport,
 		},
 	}
 

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -200,9 +200,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.AMIForceDeregister,
 		},
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:          b.config.SourceAmi,
-			EnhancedNetworking: b.config.AMIEnhancedNetworking,
-			AmiFilters:         b.config.SourceAmiFilter,
+			SourceAmi:             b.config.SourceAmi,
+			EnableSriovNetSupport: b.config.SriovNetSupport,
+			EnableENASupport:      b.config.ENASupport,
+			AmiFilters:            b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -200,10 +200,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ForceDeregister: b.config.AMIForceDeregister,
 		},
 		&awscommon.StepSourceAMIInfo{
-			SourceAmi:             b.config.SourceAmi,
-			EnableSriovNetSupport: b.config.SriovNetSupport,
-			EnableENASupport:      b.config.ENASupport,
-			AmiFilters:            b.config.SourceAmiFilter,
+			SourceAmi:                b.config.SourceAmi,
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
+			AmiFilters:               b.config.SourceAmiFilter,
 		},
 		&awscommon.StepKeyPair{
 			Debug:                b.config.PackerDebug,
@@ -265,7 +265,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AMIName:             b.config.AMIName,
 			Regions:             b.config.AMIRegions,
 		},
-		&StepRegisterAMI{},
+		&StepRegisterAMI{
+			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
+			EnableAMIENASupport:      b.config.AMIENASupport,
+		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,
 			Regions:           b.config.AMIRegions,

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -10,7 +10,10 @@ import (
 	"github.com/mitchellh/multistep"
 )
 
-type StepRegisterAMI struct{}
+type StepRegisterAMI struct {
+	EnableAMIENASupport      bool
+	EnableAMISriovNetSupport bool
+}
 
 func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
@@ -29,12 +32,13 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 		registerOpts.VirtualizationType = aws.String(config.AMIVirtType)
 	}
 
-	if config.AMIEnhancedNetworking {
+	if s.EnableAMISriovNetSupport {
 		// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
 		registerOpts.SriovNetSupport = aws.String("simple")
-
-		// Set EnaSupport to true.
+	}
+	if s.EnableAMIENASupport {
+		// Set EnaSupport to true
 		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
 		registerOpts.EnaSupport = aws.Bool(true)
 	}

--- a/fix/fixer.go
+++ b/fix/fixer.go
@@ -31,6 +31,7 @@ func init() {
 		"sshkeypath":               new(FixerSSHKeyPath),
 		"manifest-filename":        new(FixerManifestFilename),
 		"amazon-shutdown_behavior": new(FixerAmazonShutdownBehavior),
+		"enhanced-networking":      new(FixerEnhancedNetworking),
 	}
 
 	FixerOrder = []string{
@@ -45,5 +46,6 @@ func init() {
 		"sshkeypath",
 		"manifest-filename",
 		"amazon-shutdown_behavior",
+		"enhanced-networking",
 	}
 }

--- a/fix/fixer_enhanced_networking.go
+++ b/fix/fixer_enhanced_networking.go
@@ -1,0 +1,45 @@
+package fix
+
+import (
+	"github.com/mitchellh/mapstructure"
+)
+
+// FixerEnhancedNetworking is a Fixer that replaces the "enhanced_networking" configuration key
+// with the clearer "ena_support".  This disambiguates ena_support from sriov_support.
+type FixerEnhancedNetworking struct{}
+
+func (FixerEnhancedNetworking) Fix(input map[string]interface{}) (map[string]interface{}, error) {
+	// Our template type we'll use for this fixer only
+	type template struct {
+		Builders []map[string]interface{}
+	}
+
+	// Decode the input into our structure, if we can
+	var tpl template
+	if err := mapstructure.Decode(input, &tpl); err != nil {
+		return nil, err
+	}
+
+	// Go through each builder and replace the enhanced_networking if we can
+	for _, builder := range tpl.Builders {
+		enhancedNetworkingRaw, ok := builder["enhanced_networking"]
+		if !ok {
+			continue
+		}
+		enhancedNetworkingString, ok := enhancedNetworkingRaw.(bool)
+		if !ok {
+			// TODO: error?
+			continue
+		}
+
+		delete(builder, "enhanced_networking")
+		builder["ena_support"] = enhancedNetworkingString
+	}
+
+	input["builders"] = tpl.Builders
+	return input, nil
+}
+
+func (FixerEnhancedNetworking) Synopsis() string {
+	return `Replaces "enhanced_networking" in builders with "ena_support"`
+}

--- a/fix/fixer_enhanced_networking_test.go
+++ b/fix/fixer_enhanced_networking_test.go
@@ -1,0 +1,64 @@
+package fix
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFixerEnhancedNetworking_Impl(t *testing.T) {
+	var _ Fixer = new(FixerEnhancedNetworking)
+}
+
+func TestFixerEnhancedNetworking(t *testing.T) {
+	cases := []struct {
+		Input    map[string]interface{}
+		Expected map[string]interface{}
+	}{
+		// Attach field == false
+		{
+			Input: map[string]interface{}{
+				"type":                "ebs",
+				"enhanced_networking": false,
+			},
+
+			Expected: map[string]interface{}{
+				"type":        "ebs",
+				"ena_support": false,
+			},
+		},
+
+		// Attach field == true
+		{
+			Input: map[string]interface{}{
+				"type":                "ebs",
+				"enhanced_networking": true,
+			},
+
+			Expected: map[string]interface{}{
+				"type":        "ebs",
+				"ena_support": true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		var f FixerEnhancedNetworking
+
+		input := map[string]interface{}{
+			"builders": []map[string]interface{}{tc.Input},
+		}
+
+		expected := map[string]interface{}{
+			"builders": []map[string]interface{}{tc.Expected},
+		}
+
+		output, err := f.Fix(input)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if !reflect.DeepEqual(output, expected) {
+			t.Fatalf("unexpected: %#v\nexpected: %#v\n", output, expected)
+		}
+	}
+}

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -128,12 +128,6 @@ each category, the available configuration keys are alphabetized.
     source AMI will be attached. This defaults to "" (empty string), which
     forces Packer to find an open device automatically.
 
--   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
-    `ec2:ModifyInstanceAttribute` to your AWS IAM policy. Note: you must make
-    sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking)
-
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
 

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -133,8 +133,6 @@ each category, the available configuration keys are alphabetized.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
--   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
-
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
 
@@ -298,7 +296,6 @@ each category, the available configuration keys are alphabetized.
     on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
     policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
-    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
     Default `false`.
 
 -   `tags` (object of key/value strings) - Tags applied to the AMI. This is a

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -128,6 +128,13 @@ each category, the available configuration keys are alphabetized.
     source AMI will be attached. This defaults to "" (empty string), which
     forces Packer to find an open device automatically.
 
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport)
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
+    Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
+
+-   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
+
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
 
@@ -286,6 +293,13 @@ each category, the available configuration keys are alphabetized.
 
     -   `most_recent` (bool) - Selects the newest created image when true.
         This is most useful for selecting a daily distro build.
+
+-   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
+    policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
+    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
+    Default `false`.
 
 -   `tags` (object of key/value strings) - Tags applied to the AMI. This is a
     [template engine](/docs/templates/engine.html)

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -170,8 +170,6 @@ builder.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
--   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
-
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
 
@@ -307,7 +305,6 @@ builder.
     on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
     policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
-    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
     Default `false`.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -165,11 +165,18 @@ builder.
     Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).
     Default `false`.
 
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport)
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
+    Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
+    If you want to set this, but not `sriov_support`, make sure to leave `enhanced_networking: false`.
+    Default `false`.
+
 -   `enhanced_networking` (boolean) - Enable enhanced
     networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
     `ec2:ModifyInstanceAttribute` to your AWS IAM policy. Note: you must make
     sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking)
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). To enable SriovNetSupport and ENA support independently, use `sriov_support` and `ena_support` instead of `enhanced_networking`.  Using `enhanced_networking: true` will automatically set both `sriov_support` and `ena_support` to `true`, overriding any values you set. Default `false`.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
@@ -301,6 +308,13 @@ builder.
     to `auto`. This tells Packer what sort of AMI you're launching to find the
     best spot price. This must be one of: `Linux/UNIX`, `SUSE Linux`, `Windows`,
     `Linux/UNIX (Amazon VPC)`, `SUSE Linux (Amazon VPC)`, `Windows (Amazon VPC)`
+
+-   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)
+    on HVM-compatible AMIs.   If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
+    policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
+    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
+    Default `false`.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be
     used for SSH with the machine. The key must match a key pair name loaded

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -168,15 +168,9 @@ builder.
 -   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport)
     on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
-    If you want to set this, but not `sriov_support`, make sure to leave `enhanced_networking: false`.
-    Default `false`.
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
--   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
-    `ec2:ModifyInstanceAttribute` to your AWS IAM policy. Note: you must make
-    sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). To enable SriovNetSupport and ENA support independently, use `sriov_support` and `ena_support` instead of `enhanced_networking`.  Using `enhanced_networking: true` will automatically set both `sriov_support` and `ena_support` to `true`, overriding any values you set. Default `false`.
+-   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
@@ -310,7 +304,7 @@ builder.
     `Linux/UNIX (Amazon VPC)`, `SUSE Linux (Amazon VPC)`, `Windows (Amazon VPC)`
 
 -   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)
-    on HVM-compatible AMIs.   If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
     policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
     If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -163,8 +163,6 @@ builder.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
--   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
-
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
 
@@ -300,7 +298,6 @@ builder.
     on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
     policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
-    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
     Default `false`.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -161,15 +161,9 @@ builder.
 -   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport)
     on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
-    If you want to set this, but not `sriov_support`, make sure to leave `enhanced_networking: false`.
-    Default `false`.
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
--   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
-    `ec2:ModifyInstanceAttribute` to your AWS IAM policy. Note: you must make
-    sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). To enable SriovNetSupport and ENA support independently, use `sriov_support` and `ena_support` instead of `enhanced_networking`.  Using `enhanced_networking: true` will automatically set both `sriov_support` and `ena_support` to `true`, overriding any values you set. Default `false`.
+-   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
@@ -303,7 +297,7 @@ builder.
     `Linux/UNIX (Amazon VPC)`, `SUSE Linux (Amazon VPC)`, `Windows (Amazon VPC)`
 
 -   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)
-    on HVM-compatible AMIs.   If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
     policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
     If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -158,11 +158,18 @@ builder.
     Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).
     Default `false`.
 
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport)
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
+    Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
+    If you want to set this, but not `sriov_support`, make sure to leave `enhanced_networking: false`.
+    Default `false`.
+
 -   `enhanced_networking` (boolean) - Enable enhanced
     networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
     `ec2:ModifyInstanceAttribute` to your AWS IAM policy. Note: you must make
     sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking)
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). To enable SriovNetSupport and ENA support independently, use `sriov_support` and `ena_support` instead of `enhanced_networking`.  Using `enhanced_networking: true` will automatically set both `sriov_support` and `ena_support` to `true`, overriding any values you set. Default `false`.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
@@ -294,6 +301,13 @@ builder.
     to `auto`. This tells Packer what sort of AMI you're launching to find the
     best spot price. This must be one of: `Linux/UNIX`, `SUSE Linux`, `Windows`,
     `Linux/UNIX (Amazon VPC)`, `SUSE Linux (Amazon VPC)`, `Windows (Amazon VPC)`
+
+-   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)
+    on HVM-compatible AMIs.   If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
+    policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
+    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
+    Default `false`.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be
     used for SSH with the machine. The key must match a key pair name loaded

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -109,8 +109,6 @@ builder.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
--   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
-
 -   `iam_instance_profile` (string) - The name of an [IAM instance
     profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
     to launch the EC2 instance with.
@@ -213,7 +211,6 @@ builder.
     on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
     policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
-    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
     Default `false`.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -107,15 +107,9 @@ builder.
 -   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport)
     on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
-    If you want to set this, but not `sriov_support`, make sure to leave `enhanced_networking: false`.
-    Default `false`.
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
--   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
-    `ec2:ModifyInstanceAttribute` to your AWS IAM policy. Note: you must make
-    sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). To enable SriovNetSupport and ENA support independently, use `sriov_support` and `ena_support` instead of `enhanced_networking`.  Using `enhanced_networking: true` will automatically set both `sriov_support` and `ena_support` to `true`, overriding any values you set. Default `false`.
+-   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
 
 -   `iam_instance_profile` (string) - The name of an [IAM instance
     profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
@@ -216,7 +210,7 @@ builder.
     `Linux/UNIX (Amazon VPC)`, `SUSE Linux (Amazon VPC)` or `Windows (Amazon VPC)`
 
 -   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)
-    on HVM-compatible AMIs.   If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
     policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
     If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -104,11 +104,18 @@ builder.
     Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).
     Default `false`.
 
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport)
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
+    Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
+    If you want to set this, but not `sriov_support`, make sure to leave `enhanced_networking: false`.
+    Default `false`.
+
 -   `enhanced_networking` (boolean) - Enable enhanced
     networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
     `ec2:ModifyInstanceAttribute` to your AWS IAM policy. Note: you must make
     sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking)
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). To enable SriovNetSupport and ENA support independently, use `sriov_support` and `ena_support` instead of `enhanced_networking`.  Using `enhanced_networking: true` will automatically set both `sriov_support` and `ena_support` to `true`, overriding any values you set. Default `false`.
 
 -   `iam_instance_profile` (string) - The name of an [IAM instance
     profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
@@ -207,6 +214,13 @@ builder.
     to `auto`. This tells Packer what sort of AMI you're launching to find the
     best spot price. This must be one of: `Linux/UNIX`, `SUSE Linux`, `Windows`,
     `Linux/UNIX (Amazon VPC)`, `SUSE Linux (Amazon VPC)` or `Windows (Amazon VPC)`
+
+-   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)
+    on HVM-compatible AMIs.   If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
+    policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
+    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
+    Default `false`.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be
     used for SSH with the machine. By default, this is blank, and Packer will

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -194,8 +194,6 @@ builder.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
--   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
-
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Defaults to `false`.
 
@@ -308,7 +306,6 @@ builder.
     on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
     policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
-    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
     Default `false`.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -189,6 +189,11 @@ builder.
     Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).
     Default `false`.
 
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport)
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM policy.
+    Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
+
 -   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
@@ -298,6 +303,13 @@ builder.
     to `auto`. This tells Packer what sort of AMI you're launching to find the
     best spot price. This must be one of: `Linux/UNIX`, `SUSE Linux`, `Windows`,
     `Linux/UNIX (Amazon VPC)`, `SUSE Linux (Amazon VPC)`, `Windows (Amazon VPC)`
+
+-   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)
+    on HVM-compatible AMIs. If true, add `ec2:ModifyInstanceAttribute` to your AWS IAM
+    policy. Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
+    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
+    If you want to set this, but not `ena_support`, make sure to leave `enhanced_networking: false`.
+    Default `false`.
 
 -   `ssh_keypair_name` (string) - If specified, this is the key that will be
     used for SSH with the machine. The key must match a key pair name loaded

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -189,11 +189,7 @@ builder.
     Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).
     Default `false`.
 
--   `enhanced_networking` (boolean) - Enable enhanced
-    networking (SriovNetSupport and ENA) on HVM-compatible AMIs. If true, add
-    `ec2:ModifyInstanceAttribute` to your AWS IAM policy. Note: you must make
-    sure enhanced networking is enabled on your instance. See [Amazon's
-    documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking)
+-   `enhanced_networking` (boolean) - deprecated. Default `false`. For now, setting to `true` will set `ena_support` to `true` in order to preserve backwards compatability.
 
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Defaults to `false`.


### PR DESCRIPTION
Old behavior for enhanced_networking: false and enhanced_networking: true does not change.  However, if user wants to enable either SR-IOV or ENA but not both, user can now use two new flags, sriov_networking and ena_networking, in lieu of the enhanced_networking flag.  

Updated docs for relevant builders.

Closes #5093 
