### PR TITLE
Update windows_custom_image.json

### DIFF
--- a/examples/azure/windows_custom_image.json
+++ b/examples/azure/windows_custom_image.json
@@ -4,7 +4,7 @@
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
     "resource_group": "{{env `ARM_RESOURCE_GROUP`}}",
     "storage_account": "{{env `ARM_STORAGE_ACCOUNT`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
     "object_id": "{{env `ARM_OJBECT_ID`}}"
   },
   "builders": [

--- a/examples/azure/windows_custom_image.json
+++ b/examples/azure/windows_custom_image.json
@@ -5,6 +5,7 @@
     "resource_group": "{{env `ARM_RESOURCE_GROUP`}}",
     "storage_account": "{{env `ARM_STORAGE_ACCOUNT`}}",
     "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
+    "object_id": "{{env `ARM_OJBECT_ID`}}"
   },
   "builders": [
     {
@@ -15,6 +16,7 @@
       "resource_group_name": "{{user `resource_group`}}",
       "storage_account": "{{user `storage_account`}}",
       "subscription_id": "{{user `subscription_id`}}",
+      "object_id": "{{user `object_id`}}",
 
       "capture_container_name": "images",
       "capture_name_prefix": "packer",


### PR DESCRIPTION
object_id is not present in the file. Added it
Required, as per the docs: https://www.packer.io/docs/builders/azure.html#object_id
The other windows example shows this properly: https://github.com/hashicorp/packer/blob/master/examples/azure/windows.json
Similar to: https://github.com/hashicorp/packer/issues/4803
