### PR TITLE
add echo test to winrm connection.

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -197,8 +197,6 @@ var waitForCommunicator = func(p *Provisioner) error {
 
 		log.Printf("Connected to machine")
 		stdoutToRead := buf2.String()
-		buf2.Reset()
-		buf.Reset()
 		if !strings.Contains(stdoutToRead, "restarted.") {
 			log.Printf("echo didn't succeed; retrying...")
 			continue


### PR DESCRIPTION
Run an "echo" command when connecting winRM to make sure that it's ready to run commands, before moving on from the connecting step.

Closes #5298
