### PR TITLE
Add support for setting labels on GCE instance

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	ImageDescription     string            `mapstructure:"image_description"`
 	ImageFamily          string            `mapstructure:"image_family"`
 	InstanceName         string            `mapstructure:"instance_name"`
+	Labels               map[string]string `mapstructure:"labels"`
 	MachineType          string            `mapstructure:"machine_type"`
 	Metadata             map[string]string `mapstructure:"metadata"`
 	Network              string            `mapstructure:"network"`

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -65,6 +65,7 @@ type InstanceConfig struct {
 	DiskSizeGb        int64
 	DiskType          string
 	Image             *Image
+	Labels            map[string]string
 	MachineType       string
 	Metadata          map[string]string
 	Name              string

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -407,6 +407,7 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 			},
 		},
 		GuestAccelerators: guestAccelerators,
+		Labels:            c.Labels,
 		MachineType:       machineType.SelfLink,
 		Metadata: &compute.Metadata{
 			Items: metadata,

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -106,6 +106,7 @@ func (s *StepCreateInstance) Run(state multistep.StateBag) multistep.StepAction 
 		DiskSizeGb:        c.DiskSizeGb,
 		DiskType:          c.DiskType,
 		Image:             sourceImage,
+		Labels:            c.Labels,
 		MachineType:       c.MachineType,
 		Metadata:          metadata,
 		Name:              name,

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -204,6 +204,9 @@ builder.
 -   `instance_name` (string) - A name to give the launched instance. Beware that
     this must be unique. Defaults to `"packer-{{uuid}}"`.
 
+-   `labels` (object of key/value strings) - Labels applied to the launched
+    instance.
+
 -   `machine_type` (string) - The machine type. Defaults to `"n1-standard-1"`.
 
 -   `metadata` (object of key/value strings) - Metadata applied to the launched


### PR DESCRIPTION
This PR adds support for setting labels on the GCE instance started to perform a build:

```
{
  "builders": [
    {
      "type": "googlecompute",
      "account_file": "account.json",
      "project_id": "my project",
      "source_image": "debian-7-wheezy-v20150127",
      "zone": "us-central1-a",
      "labels": {
        "dd-monitoring": "disabled"
      }
    }
  ]
}
```