### PR TITLE
remove copyright notice

### DIFF
--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/artifact_test.go
+++ b/builder/azure/arm/artifact_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/authenticate.go
+++ b/builder/azure/arm/authenticate.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/builder_test.go
+++ b/builder/azure/arm/builder_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/capture_template.go
+++ b/builder/azure/arm/capture_template.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 type CaptureTemplateParameter struct {

--- a/builder/azure/arm/capture_template_test.go
+++ b/builder/azure/arm/capture_template_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/openssh_key_pair.go
+++ b/builder/azure/arm/openssh_key_pair.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/openssh_key_pair_test.go
+++ b/builder/azure/arm/openssh_key_pair_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step.go
+++ b/builder/azure/arm/step.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_capture_image.go
+++ b/builder/azure/arm/step_capture_image.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_capture_image_test.go
+++ b/builder/azure/arm/step_capture_image_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_create_resource_group.go
+++ b/builder/azure/arm/step_create_resource_group.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_create_resource_group_test.go
+++ b/builder/azure/arm/step_create_resource_group_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_delete_os_disk.go
+++ b/builder/azure/arm/step_delete_os_disk.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_delete_os_disk_test.go
+++ b/builder/azure/arm/step_delete_os_disk_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_delete_resource_group.go
+++ b/builder/azure/arm/step_delete_resource_group.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_delete_resource_group_test.go
+++ b/builder/azure/arm/step_delete_resource_group_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_deploy_template.go
+++ b/builder/azure/arm/step_deploy_template.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_deploy_template_test.go
+++ b/builder/azure/arm/step_deploy_template_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_get_certificate.go
+++ b/builder/azure/arm/step_get_certificate.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_get_certificate_test.go
+++ b/builder/azure/arm/step_get_certificate_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_get_ip_address.go
+++ b/builder/azure/arm/step_get_ip_address.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_get_ip_address_test.go
+++ b/builder/azure/arm/step_get_ip_address_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_get_os_disk.go
+++ b/builder/azure/arm/step_get_os_disk.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_get_os_disk_test.go
+++ b/builder/azure/arm/step_get_os_disk_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_power_off_compute.go
+++ b/builder/azure/arm/step_power_off_compute.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_power_off_compute_test.go
+++ b/builder/azure/arm/step_power_off_compute_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_set_certificate.go
+++ b/builder/azure/arm/step_set_certificate.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_set_certificate_test.go
+++ b/builder/azure/arm/step_set_certificate_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_test.go
+++ b/builder/azure/arm/step_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_validate_template.go
+++ b/builder/azure/arm/step_validate_template.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/step_validate_template_test.go
+++ b/builder/azure/arm/step_validate_template_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/tempname.go
+++ b/builder/azure/arm/tempname.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/arm/tempname_test.go
+++ b/builder/azure/arm/tempname_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package arm
 
 import (

--- a/builder/azure/common/constants/stateBag.go
+++ b/builder/azure/common/constants/stateBag.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package constants
 
 // complete flags

--- a/builder/azure/common/constants/targetplatforms.go
+++ b/builder/azure/common/constants/targetplatforms.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package constants
 
 // Target types

--- a/builder/azure/common/gluestrings.go
+++ b/builder/azure/common/gluestrings.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package common
 
 // removes overlap between the end of a and the start of b and

--- a/builder/azure/common/gluestrings_test.go
+++ b/builder/azure/common/gluestrings_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package common
 
 import (

--- a/builder/azure/common/interruptible_task.go
+++ b/builder/azure/common/interruptible_task.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package common
 
 import (

--- a/builder/azure/common/interruptible_task_test.go
+++ b/builder/azure/common/interruptible_task_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package common
 
 import (

--- a/builder/azure/common/lin/ssh.go
+++ b/builder/azure/common/lin/ssh.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package lin
 
 import (

--- a/builder/azure/common/lin/step_create_cert.go
+++ b/builder/azure/common/lin/step_create_cert.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package lin
 
 import (

--- a/builder/azure/common/lin/step_generalize_os.go
+++ b/builder/azure/common/lin/step_generalize_os.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package lin
 
 import (

--- a/builder/azure/common/logutil/logfields.go
+++ b/builder/azure/common/logutil/logfields.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package logutil
 
 import "fmt"

--- a/builder/azure/common/randomstring.go
+++ b/builder/azure/common/randomstring.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package common
 
 import (

--- a/builder/azure/common/randomstring_test.go
+++ b/builder/azure/common/randomstring_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package common
 
 import (

--- a/builder/azure/common/state_bag.go
+++ b/builder/azure/common/state_bag.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package common
 
 import "github.com/mitchellh/multistep"

--- a/builder/azure/common/template/template_parameters.go
+++ b/builder/azure/common/template/template_parameters.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package template
 
 // The intent of these types to facilitate interchange with Azure in the

--- a/builder/azure/common/template/template_parameters_test.go
+++ b/builder/azure/common/template/template_parameters_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 package template
 
 import (

--- a/builder/azure/common/vault.go
+++ b/builder/azure/common/vault.go
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See the LICENSE file in builder/azure for license information.
-
 // NOTE: vault APIs do not yet exist in the SDK, but once they do this code
 // should be removed.
 


### PR DESCRIPTION
We'd like to remove the copyright notice from the source file because we believe it is distracting and unnecessary, and given the existence of the LICENSE file, it should provide Microsoft no additional protection. This is our policy, currently, but it did not exist when the Azure builder was written.

This is how all of our other 3rd party builders work.

Please let us know if this is acceptable @boumenot 