### PR TITLE
Add troubleshooting steps to Ansible provisioner docs

### DIFF
--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -136,6 +136,16 @@ commonly useful Ansible variables:
     machine that the script is running on. This is useful if you want to run
     only certain parts of the playbook on systems built with certain builders.
 
+## Debugging
+
+To debug underlying issues with Ansible, add `"-vvvv"` to `"extra_arguments"` to enable verbose logging.
+
+``` json
+{
+  "extra_arguments": [ "-vvvv" ]
+}
+```
+
 ## Limitations
 
 ### Redhat / CentOS
@@ -230,4 +240,18 @@ This template should build a Windows Server 2012 image on Google Cloud Platform:
     }
   ]
 }
+```
+
+### Too many SSH keys
+
+SSH servers only allow you to attempt to authenticate a certain number of times. All of your loaded keys will be tried before the dynamically generated key. If you have too many SSH keys loaded in your `ssh-agent`, the Ansible provisioner may fail authentication with a message similar to this:
+
+```console
+    googlecompute: fatal: [default]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Warning: Permanently added '[127.0.0.1]:62684' (RSA) to the list of known hosts.\r\nReceived disconnect from 127.0.0.1 port 62684:2: too many authentication failures\r\nAuthentication failed.\r\n", "unreachable": true}
+```
+
+To unload all keys from your `ssh-agent`, run: 
+
+```console
+$ ssh-add -D
 ```


### PR DESCRIPTION
- Explain how to enable verbose Ansible output
- Add docs about the perils of having loaded too many SSH keys to ssh-agent

I wrote about my full troubleshooting steps at https://gist.github.com/danielcompton/ea0840d37d592b4d0a0cc1b53a8d87cb in case it's helpful to anyone else who reaches this issue. It looks like there's ways to enable pipelining, but I found it easier to disable it to get things working.