### PR TITLE
builder/docker: respect rsync semantics when uploading directories.

### DIFF
--- a/builder/docker/step_connect_docker.go
+++ b/builder/docker/step_connect_docker.go
@@ -22,7 +22,7 @@ func (s *StepConnectDocker) Run(state multistep.StateBag) multistep.StepAction {
 	// Create the communicator that talks to Docker via various
 	// os/exec tricks.
 	comm := &Communicator{
-		ContainerId:  containerId,
+		ContainerID:  containerId,
 		HostDir:      tempDir,
 		ContainerDir: config.ContainerDir,
 		Version:      version,


### PR DESCRIPTION
packer.json
```
{
	"builders": [
	{
		"discard": true,
			"image": "ubuntu:xenial",
			"type": "docker",
			"name": "goobar"
	}
	],
	"provisioners": [
	{
		"type": "file",
		"source": "5234",
		"destination": "/tmp/"
	},
	{
		"type": "shell",
		"inline": ["echo should see directory 5234", "ls -lR /tmp"]
	},
	{
		"type": "file",
		"source": "5234/",
		"destination": "/tmp/"
	},
	{
		"type": "shell",
		"inline": ["echo should see directories src and dst", "ls -lR /tmp"]
	}
	]
}
```

```
ls -R 5234
dst src

5234/dst:

5234/src:
```

```
packer build 5234.json
goobar output will be in this color.

==> goobar: Creating a temporary directory for sharing data...
==> goobar: Pulling Docker image: ubuntu:xenial
    goobar: xenial: Pulling from library/ubuntu
    goobar: Digest: sha256:34471448724419596ca4e890496d375801de21b0e67b81a77fd6155ce001edad
    goobar: Status: Image is up to date for ubuntu:xenial
==> goobar: Starting docker container...
    goobar: Run command: docker run -v /Users/mwhooker/.packer.d/tmp/packer-docker852406007:/packer-files -d -i -t ubuntu:xenial /bin/bash
    goobar: Container ID: 84582aeaf1aa5365cb8d473d35f9825ab73b20b17694a01b79869c23b4ea0c02
==> goobar: Uploading 5234 => /tmp/
==> goobar: Provisioning with shell script: /var/folders/yy/ff0tkhr141xdxvxf5fz43kmw0000gn/T/packer-shell781791643
    goobar: should see directory 5234
    goobar: /tmp:
    goobar: total 8
    goobar: drwxr-xr-x 4 501 dialout 4096 Aug  9 22:59 5234
    goobar: -rwxr-xr-x 1 501 dialout   56 Sep 12 21:38 script_2231.sh
    goobar:
    goobar: /tmp/5234:
    goobar: total 8
    goobar: drwxr-xr-x 2 501 dialout 4096 Aug  9 23:04 dst
    goobar: drwxr-xr-x 2 501 dialout 4096 Aug  9 23:02 src
    goobar:
    goobar: /tmp/5234/dst:
    goobar: total 0
    goobar:
    goobar: /tmp/5234/src:
    goobar: total 0
==> goobar: Uploading 5234/ => /tmp/
==> goobar: Provisioning with shell script: /var/folders/yy/ff0tkhr141xdxvxf5fz43kmw0000gn/T/packer-shell159819209
    goobar: should see directories src and dst
    goobar: /tmp:
    goobar: total 16
    goobar: drwxr-xr-x 4 501 dialout 4096 Aug  9 22:59 5234
    goobar: drwxr-xr-x 2 501 dialout 4096 Aug  9 23:04 dst
    goobar: -rwxr-xr-x 1 501 dialout   65 Sep 12 21:38 script_7995.sh
    goobar: drwxr-xr-x 2 501 dialout 4096 Aug  9 23:02 src
    goobar:
    goobar: /tmp/5234:
    goobar: total 8
    goobar: drwxr-xr-x 2 501 dialout 4096 Aug  9 23:04 dst
    goobar: drwxr-xr-x 2 501 dialout 4096 Aug  9 23:02 src
    goobar:
    goobar: /tmp/5234/dst:
    goobar: total 0
    goobar:
    goobar: /tmp/5234/src:
    goobar: total 0
    goobar:
    goobar: /tmp/dst:
    goobar: total 0
    goobar:
    goobar: /tmp/src:
    goobar: total 0
==> goobar: Killing the container: 84582aeaf1aa5365cb8d473d35f9825ab73b20b17694a01b79869c23b4ea0c02
Build 'goobar' finished.

==> Builds finished. The artifacts of successful builds are:
--> goobar: Exported Docker file:
```

see #5234 