### PR TITLE
Add option keep_registered to virtualbox-ovf builder

### DIFF
--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	SourcePath           string   `mapstructure:"source_path"`
 	TargetPath           string   `mapstructure:"target_path"`
 	VMName               string   `mapstructure:"vm_name"`
+	KeepRegistered       bool     `mapstructure:"keep_registered"`
 	SkipExport           bool     `mapstructure:"skip_export"`
 
 	ctx interpolate.Context

--- a/builder/virtualbox/ovf/step_import.go
+++ b/builder/virtualbox/ovf/step_import.go
@@ -40,6 +40,14 @@ func (s *StepImport) Cleanup(state multistep.StateBag) {
 
 	driver := state.Get("driver").(vboxcommon.Driver)
 	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("config").(*Config)
+
+	_, cancelled := state.GetOk(multistep.StateCancelled)
+	_, halted := state.GetOk(multistep.StateHalted)
+	if (config.KeepRegistered) && (!cancelled && !halted) {
+		ui.Say("Keeping virtual machine registered with VirtualBox host (keep_registered = true)")
+		return
+	}
 
 	ui.Say("Unregistering and deleting imported VM...")
 	if err := driver.Delete(s.vmName); err != nil {

--- a/builder/virtualbox/ovf/step_import_test.go
+++ b/builder/virtualbox/ovf/step_import_test.go
@@ -12,7 +12,10 @@ func TestStepImport_impl(t *testing.T) {
 
 func TestStepImport(t *testing.T) {
 	state := testState(t)
+	c := testConfig(t)
+	config, _, _ := NewConfig(c)
 	state.Put("vm_path", "foo")
+	state.Put("config", config)
 	step := new(StepImport)
 	step.Name = "bar"
 
@@ -42,6 +45,14 @@ func TestStepImport(t *testing.T) {
 	}
 
 	// Test cleanup
+	config.KeepRegistered = true
+	step.Cleanup(state)
+
+	if driver.DeleteCalled {
+		t.Fatal("delete should not be called")
+	}
+
+	config.KeepRegistered = false
 	step.Cleanup(state)
 	if !driver.DeleteCalled {
 		t.Fatal("delete should be called")

--- a/website/source/docs/builders/virtualbox-ovf.html.md
+++ b/website/source/docs/builders/virtualbox-ovf.html.md
@@ -202,6 +202,9 @@ builder.
     `VBoxManage import`. This can be useful for passing "keepallmacs" or
     "keepnatmacs" options for existing ovf images.
 
+-   `keep_registered` (boolean) - Set this to `true` if you would like to keep
+    the VM registered with virtualbox. Defaults to `false`.
+
 -   `output_directory` (string) - This is the path to the directory where the
     resulting virtual machine will be created. This may be relative or absolute.
     If relative, the path is relative to the working directory when `packer`


### PR DESCRIPTION
Adding the option keep_registered to the virtualbox-ovf builder.
As the virtualbox-iso builder already has this option it was mostly a copy-paste job.