### PR TITLE
Interpolate network and subnetwork values

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -82,7 +82,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	var errs *packer.MultiError
 
 	// Set defaults.
-	if c.Network == "" {
+	if c.Network == "" && c.Subnetwork == "" {
 		c.Network = "default"
 	}
 

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -86,6 +86,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		c.Network = "default"
 	}
 
+	if c.NetworkProjectId == "" {
+		c.NetworkProjectId = c.ProjectId
+	}
+
 	if c.DiskSizeGb == 0 {
 		c.DiskSizeGb = 10
 	}

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -298,55 +298,9 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 	}
 	// TODO(mitchellh): deprecation warnings
 
-	networkId := ""
-	subnetworkId := ""
-
-	// Apply network naming requirements per
-	// https://cloud.google.com/compute/docs/reference/latest/instances#resource
-	switch c.Network {
-	// It is possible to omit the network property as long as a subnet is
-	// specified. That will be validated later.
-	case "":
-		d.ui.Message(fmt.Sprintf("Network: will be inferred from subnetwork"))
-		break
-	// This special short name should be expanded.
-	case "default":
-		networkId = "global/networks/default"
-	// A value other than "default" was provided for the network name.
-	default:
-		// If the value doesn't contain a slash, we assume it's not a full or
-		// partial URL. We will expand it into a partial URL here and avoid
-		// making an API call to discover the network as it's common for the
-		// caller to not have permission against network discovery APIs.
-		if !strings.Contains(c.Network, "/") {
-			networkId = "projects/" + c.NetworkProjectId + "/global/networks/" + c.Network
-			d.ui.Message(fmt.Sprintf("Network name: %q was expanded to the partial URL %q", c.Network, networkId))
-		}
-	}
-
-	// Apply subnetwork naming requirements per
-	// https://cloud.google.com/compute/docs/reference/latest/instances#resource
-	switch c.Subnetwork {
-	case "":
-		// You can't omit both subnetwork and network
-		if networkId == "" {
-			return nil, fmt.Errorf("both network and subnetwork were empty.")
-		}
-		// An empty subnetwork is only valid for networks in legacy mode or
-		// auto-subnet mode. We could make an API call to get that information
-		// about the network, but it's common for the caller to not have
-		// permission to that API. We'll proceed assuming they're correct in
-		// omitting the subnetwork and let the compute.insert API surface an
-		// error about an invalid network configuration if it exists.
-		break
-	default:
-		// If the value doesn't contain a slash, we assume it's not a full or
-		// partial URL. We will expand it into a partial URL here and avoid
-		// making a call to discover the subnetwork.
-		if !strings.Contains(c.Subnetwork, "/") {
-			subnetworkId = "projects/" + c.NetworkProjectId + "/regions/" + c.Region + "/subnetworks/" + c.Subnetwork
-			d.ui.Message(fmt.Sprintf("Subnetwork: %q was expanded to the partial URL %q", c.Subnetwork, subnetworkId))
-		}
+	networkId, subnetworkId, err := getNetworking(c)
+	if err != nil {
+		return nil, err
 	}
 
 	var accessconfig *compute.AccessConfig
@@ -609,7 +563,6 @@ func (d *driverGCE) refreshZoneOp(zone string, op *compute.Operation) stateRefre
 	}
 }
 
-// stateRefreshFunc is used to refresh the state of a thing and is
 // used in conjunction with waitForState.
 type stateRefreshFunc func() (string, error)
 

--- a/builder/googlecompute/networking.go
+++ b/builder/googlecompute/networking.go
@@ -1,0 +1,59 @@
+package googlecompute
+
+import (
+	"fmt"
+	"strings"
+)
+
+// This method will build a network and subnetwork ID from the provided
+// instance config, and return them in that order.
+func getNetworking(c *InstanceConfig) (string, string, error) {
+	networkId := c.Network
+	subnetworkId := c.Subnetwork
+
+	// Apply network naming requirements per
+	// https://cloud.google.com/compute/docs/reference/latest/instances#resource
+	switch c.Network {
+	// It is possible to omit the network property as long as a subnet is
+	// specified. That will be validated later.
+	case "":
+		break
+	// This special short name should be expanded.
+	case "default":
+		networkId = "global/networks/default"
+	// A value other than "default" was provided for the network name.
+	default:
+		// If the value doesn't contain a slash, we assume it's not a full or
+		// partial URL. We will expand it into a partial URL here and avoid
+		// making an API call to discover the network as it's common for the
+		// caller to not have permission against network discovery APIs.
+		if !strings.Contains(c.Network, "/") {
+			networkId = "projects/" + c.NetworkProjectId + "/global/networks/" + c.Network
+		}
+	}
+
+	// Apply subnetwork naming requirements per
+	// https://cloud.google.com/compute/docs/reference/latest/instances#resource
+	switch c.Subnetwork {
+	case "":
+		// You can't omit both subnetwork and network
+		if networkId == "" {
+			return networkId, subnetworkId, fmt.Errorf("both network and subnetwork were empty.")
+		}
+		// An empty subnetwork is only valid for networks in legacy mode or
+		// auto-subnet mode. We could make an API call to get that information
+		// about the network, but it's common for the caller to not have
+		// permission to that API. We'll proceed assuming they're correct in
+		// omitting the subnetwork and let the compute.insert API surface an
+		// error about an invalid network configuration if it exists.
+		break
+	default:
+		// If the value doesn't contain a slash, we assume it's not a full or
+		// partial URL. We will expand it into a partial URL here and avoid
+		// making a call to discover the subnetwork.
+		if !strings.Contains(c.Subnetwork, "/") {
+			subnetworkId = "projects/" + c.NetworkProjectId + "/regions/" + c.Region + "/subnetworks/" + c.Subnetwork
+		}
+	}
+	return networkId, subnetworkId, nil
+}

--- a/builder/googlecompute/networking_test.go
+++ b/builder/googlecompute/networking_test.go
@@ -1,0 +1,72 @@
+package googlecompute
+
+import (
+	"testing"
+)
+
+func TestGetNetworking(t *testing.T) {
+	cases := []struct {
+		c                  *InstanceConfig
+		expectedNetwork    string
+		expectedSubnetwork string
+		error              bool
+	}{
+		{
+			c: &InstanceConfig{
+				Network:          "default",
+				Subnetwork:       "",
+				NetworkProjectId: "project-id",
+				Region:           "region-id",
+			},
+			expectedNetwork:    "global/networks/default",
+			expectedSubnetwork: "",
+			error:              false,
+		},
+		{
+			c: &InstanceConfig{
+				Network:          "",
+				Subnetwork:       "",
+				NetworkProjectId: "project-id",
+				Region:           "region-id",
+			},
+			expectedNetwork:    "",
+			expectedSubnetwork: "",
+			error:              true,
+		},
+		{
+			c: &InstanceConfig{
+				Network:          "some/network/path",
+				Subnetwork:       "some/subnetwork/path",
+				NetworkProjectId: "project-id",
+				Region:           "region-id",
+			},
+			expectedNetwork:    "some/network/path",
+			expectedSubnetwork: "some/subnetwork/path",
+			error:              false,
+		},
+		{
+			c: &InstanceConfig{
+				Network:          "network-value",
+				Subnetwork:       "subnetwork-value",
+				NetworkProjectId: "project-id",
+				Region:           "region-id",
+			},
+			expectedNetwork:    "projects/project-id/global/networks/network-value",
+			expectedSubnetwork: "projects/project-id/regions/region-id/subnetworks/subnetwork-value",
+			error:              false,
+		},
+	}
+
+	for _, tc := range cases {
+		n, sn, err := getNetworking(tc.c)
+		if n != tc.expectedNetwork {
+			t.Errorf("Expected network %q but got network %q", tc.expectedNetwork, n)
+		}
+		if sn != tc.expectedSubnetwork {
+			t.Errorf("Expected subnetwork %q but got subnetwork %q", tc.expectedSubnetwork, sn)
+		}
+		if !tc.error && err != nil {
+			t.Errorf("Did not expect an error but got: %v", err)
+		}
+	}
+}

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -216,7 +216,10 @@ builder.
     instance.
 
 -   `network` (string) - The Google Compute network id or URL to use for the
-    launched instance. Defaults to `"default"`.
+    launched instance. Defaults to `"default"`. If the value is not a URL, it
+    will be interpolated to `projects/((network_project_id))/global/networks/((network))`.
+    This value is not required if a `subnet` is specified.
+
 
 -   `network_project_id` (string) - The project ID for the network and subnetwork
     to use for launched instance. Defaults to `project_id`.
@@ -259,7 +262,9 @@ builder.
 -   `subnetwork` (string) - The Google Compute subnetwork id or URL to use for
     the launched instance. Only required if the `network` has been created with
     custom subnetting. Note, the region of the subnetwork must match the `region`
-    or `zone` in which the VM is launched.
+    or `zone` in which the VM is launched. If the value is not a URL, it
+    will be interpolated to `projects/((network_project_id))/regions/((region))/subnetworks/((subnetwork))`
+
 
 -   `tags` (array of strings)
 


### PR DESCRIPTION
This change allows a user to specify the `network` or `subnetwork` for a
`googlecompute` builder as its short name (i.e., not a fully-qualified URL).
The short name is interpolated into a valid self-link using existing configuration.
This replaces the previous behavior where the short name was used to
make a `compute.(sub)networks.get` API call to retrieve the self-link, which
required API permissions commonly reserved for network admins.

URLs for `network` and `subnetwork` properties are interpolated if they
are not already partial or full URLs (i.e., they do not contain a '/' in
their name). Additionally, the `network` property is not required if `subnetwork`
is provided. These changes take advantage of the [API's support](https://cloud.google.com/compute/docs/reference/latest/instances#resource)
for partial resource URLs (e.g., `projects/project/global/networks/network`), and
its ability to infer `network` from `subnetwork`.

Previously, if a user did not provide the network or subnetwork as a
fully-qualified URL (i.e., self-link), the builder would make
`compute.(sub)networks.get` API calls with the provided identifier to
discover the self-link. This requires Packer to have permission to describe those
network resources, which is becoming less common as IAM is used more.
Specifically, a user may have permission to launch a VM into a
network/subnetwork, but will not have permission to call APIs to describe network
resources.