### PR TITLE
Elevated_execute_command

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -102,6 +102,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"execute_command",
+				"elevated_execute_command",
 			},
 		},
 	}, raws...)

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -55,13 +55,20 @@ Optional parameters:
     and Packer should therefore not convert Windows line endings to Unix line
     endings (if there are any). By default this is false.
 
+-   `elevated_execute_command` (string) - The command to use to execute the elevated
+    script. By default this is `powershell if (Test-Path variable:global:ProgressPreference){$ProgressPreference='SilentlyContinue'};{{.Vars}}&'{{.Path}}';exit $LastExitCode`.
+    The value of this is treated as [configuration
+    template](/docs/templates/engine.html). There are two
+    available variables: `Path`, which is the path to the script to run, and
+    `Vars`, which is the list of `environment_vars`, if configured.
+
 -   `environment_vars` (array of strings) - An array of key/value pairs to
     inject prior to the execute\_command. The format should be `key=value`.
     Packer injects some environmental variables by default into the environment,
     as well, which are covered in the section below.
 
 -   `execute_command` (string) - The command to use to execute the script. By
-    default this is `powershell "& { {{.Vars}}{{.Path}}; exit $LastExitCode}"`.
+    default this is `powershell if (Test-Path variable:global:ProgressPreference){$ProgressPreference='SilentlyContinue'};{{.Vars}}&'{{.Path}}';exit $LastExitCode`.
     The value of this is treated as [configuration
     template](/docs/templates/engine.html). There are two
     available variables: `Path`, which is the path to the script to run, and


### PR DESCRIPTION
elevated_execute_command was only partially implemented in the powershell provisioner.  Finish implementation and add to docs.

Fixes workaround for issue 4994, described here: https://github.com/hashicorp/packer/issues/4994#issuecomment-329556566