### PR TITLE
fix directory permissions when using sudo

### DIFF
--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -400,6 +400,15 @@ func (p *Provisioner) createDir(ui packer.Ui, comm packer.Communicator, dir stri
 		return fmt.Errorf("Non-zero exit status.")
 	}
 
+	// Chmod the directory to 0777 just so that we can access it as our user
+	cmd = &packer.RemoteCmd{Command: p.guestCommands.Chmod(dir, "0777")}
+	if err := cmd.StartWithUi(comm, ui); err != nil {
+		return err
+	}
+	if cmd.ExitStatus != 0 {
+		return fmt.Errorf("Non-zero exit status. See output above for more info.")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#5252 added our sudo preferences to all remote commands. If creating the manifest directory with sudo, we could no longer upload to it using the packer user. This borrows logic from the chef provisioner to make created directories `0777`. Closes #5347