### PR TITLE
Make the googlecompute builder label the resulting image.

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	ImageName            string            `mapstructure:"image_name"`
 	ImageDescription     string            `mapstructure:"image_description"`
 	ImageFamily          string            `mapstructure:"image_family"`
+	ImageLabels          map[string]string `mapstructure:"image_labels"`
 	InstanceName         string            `mapstructure:"instance_name"`
 	Labels               map[string]string `mapstructure:"labels"`
 	MachineType          string            `mapstructure:"machine_type"`

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -305,7 +305,7 @@ func testConfig(t *testing.T) map[string]interface{} {
 		"source_image": "foo",
 		"ssh_username": "root",
 		"image_family": "bar",
-		"image_labels": string{
+		"image_labels": map[string]string{
 			"label-1": "value-1",
 			"label-2": "value-2",
 		},

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -305,7 +305,11 @@ func testConfig(t *testing.T) map[string]interface{} {
 		"source_image": "foo",
 		"ssh_username": "root",
 		"image_family": "bar",
-		"zone":         "us-east1-a",
+		"image_labels": string{
+			"label-1": "value-1",
+			"label-2": "value-2",
+		},
+		"zone": "us-east1-a",
 	}
 }
 

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -11,7 +11,7 @@ import (
 type Driver interface {
 	// CreateImage creates an image from the given disk in Google Compute
 	// Engine.
-	CreateImage(name, description, family, zone, disk string, labels map[string]string) (<-chan *Image, <-chan error)
+	CreateImage(name, description, family, zone, disk string, image_labels map[string]string) (<-chan *Image, <-chan error)
 
 	// DeleteImage deletes the image with the given name.
 	DeleteImage(name string) <-chan error

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -11,7 +11,7 @@ import (
 type Driver interface {
 	// CreateImage creates an image from the given disk in Google Compute
 	// Engine.
-	CreateImage(name, description, family, zone, disk string) (<-chan *Image, <-chan error)
+	CreateImage(name, description, family, zone, disk string, labels map[string]string) (<-chan *Image, <-chan error)
 
 	// DeleteImage deletes the image with the given name.
 	DeleteImage(name string) <-chan error

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -98,7 +98,7 @@ func NewDriverGCE(ui packer.Ui, p string, a *AccountFile) (Driver, error) {
 	}, nil
 }
 
-func (d *driverGCE) CreateImage(name, description, family, zone, disk string, labels map[string]string) (<-chan *Image, <-chan error) {
+func (d *driverGCE) CreateImage(name, description, family, zone, disk string, image_labels map[string]string) (<-chan *Image, <-chan error) {
 	gce_image := &compute.Image{
 		Description: description,
 		Name:        name,

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -98,11 +98,12 @@ func NewDriverGCE(ui packer.Ui, p string, a *AccountFile) (Driver, error) {
 	}, nil
 }
 
-func (d *driverGCE) CreateImage(name, description, family, zone, disk string) (<-chan *Image, <-chan error) {
+func (d *driverGCE) CreateImage(name, description, family, zone, disk string, labels map[string]string) (<-chan *Image, <-chan error) {
 	gce_image := &compute.Image{
 		Description: description,
 		Name:        name,
 		Family:      family,
+		Labels:      labels,
 		SourceDisk:  fmt.Sprintf("%s%s/zones/%s/disks/%s", d.service.BasePath, d.projectId, zone, disk),
 		SourceType:  "RAW",
 	}

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -103,7 +103,7 @@ func (d *driverGCE) CreateImage(name, description, family, zone, disk string, im
 		Description: description,
 		Name:        name,
 		Family:      family,
-		Labels:      labels,
+		Labels:      image_labels,
 		SourceDisk:  fmt.Sprintf("%s%s/zones/%s/disks/%s", d.service.BasePath, d.projectId, zone, disk),
 		SourceType:  "RAW",
 	}

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -81,7 +81,7 @@ type DriverMock struct {
 	WaitForInstanceErrCh <-chan error
 }
 
-func (d *DriverMock) CreateImage(name, description, family, zone, disk string, labels map[string]string) (<-chan *Image, <-chan error) {
+func (d *DriverMock) CreateImage(name, description, family, zone, disk string, image_labels map[string]string) (<-chan *Image, <-chan error) {
 	d.CreateImageName = name
 	d.CreateImageDesc = description
 	d.CreateImageFamily = family

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -81,7 +81,7 @@ type DriverMock struct {
 	WaitForInstanceErrCh <-chan error
 }
 
-func (d *DriverMock) CreateImage(name, description, family, zone, disk string) (<-chan *Image, <-chan error) {
+func (d *DriverMock) CreateImage(name, description, family, zone, disk string, labels map[string]string) (<-chan *Image, <-chan error) {
 	d.CreateImageName = name
 	d.CreateImageDesc = description
 	d.CreateImageFamily = family

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -8,6 +8,7 @@ type DriverMock struct {
 	CreateImageName            string
 	CreateImageDesc            string
 	CreateImageFamily          string
+	CreateImageLabels          map[string]string
 	CreateImageZone            string
 	CreateImageDisk            string
 	CreateImageResultLicenses  []string
@@ -85,6 +86,7 @@ func (d *DriverMock) CreateImage(name, description, family, zone, disk string, i
 	d.CreateImageName = name
 	d.CreateImageDesc = description
 	d.CreateImageFamily = family
+	d.CreateImageLabels = image_labels
 	d.CreateImageZone = zone
 	d.CreateImageDisk = disk
 	if d.CreateImageResultProjectId == "" {
@@ -103,6 +105,7 @@ func (d *DriverMock) CreateImage(name, description, family, zone, disk string, i
 	if resultCh == nil {
 		ch := make(chan *Image, 1)
 		ch <- &Image{
+			Labels:    d.CreateImageLabels,
 			Licenses:  d.CreateImageResultLicenses,
 			Name:      name,
 			ProjectId: d.CreateImageResultProjectId,

--- a/builder/googlecompute/image.go
+++ b/builder/googlecompute/image.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Image struct {
+	Labels    map[string]string
 	Licenses  []string
 	Name      string
 	ProjectId string

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -39,7 +39,7 @@ func (s *StepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 
 	imageCh, errCh := driver.CreateImage(
 		config.ImageName, config.ImageDescription, config.ImageFamily, config.Zone,
-		config.DiskName)
+		config.DiskName, config.Labels)
 	var err error
 	select {
 	case err = <-errCh:

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -39,7 +39,7 @@ func (s *StepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 
 	imageCh, errCh := driver.CreateImage(
 		config.ImageName, config.ImageDescription, config.ImageFamily, config.Zone,
-		config.DiskName, config.Labels)
+		config.DiskName, config.ImageLabels)
 	var err error
 	select {
 	case err = <-errCh:

--- a/builder/googlecompute/step_create_image_test.go
+++ b/builder/googlecompute/step_create_image_test.go
@@ -46,6 +46,7 @@ func TestStepCreateImage(t *testing.T) {
 	assert.Equal(t, d.CreateImageFamily, c.ImageFamily, "Incorrect image family passed to driver.")
 	assert.Equal(t, d.CreateImageZone, c.Zone, "Incorrect image zone passed to driver.")
 	assert.Equal(t, d.CreateImageDisk, c.DiskName, "Incorrect disk passed to driver.")
+	assert.Equal(t, d.CreateImageLabels, c.ImageLabels, "Incorrect image_labels passed to driver.")
 }
 
 func TestStepCreateImage_errorOnChannel(t *testing.T) {

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -198,6 +198,9 @@ builder.
     instead of a specific image name. The image family always returns its
     latest image that is not deprecated.
 
+-   `image_labels` (object of key/value strings) - Key/value pair labels to
+    apply to the created image.
+
 -   `image_name` (string) - The unique name of the resulting image. Defaults to
     `"packer-{{timestamp}}"`.
 
@@ -205,7 +208,7 @@ builder.
     this must be unique. Defaults to `"packer-{{uuid}}"`.
 
 -   `labels` (object of key/value strings) - Key/value pair labels to apply to
-    the launched instance and the created image.
+    the launched instance.
 
 -   `machine_type` (string) - The machine type. Defaults to `"n1-standard-1"`.
 

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -205,7 +205,7 @@ builder.
     this must be unique. Defaults to `"packer-{{uuid}}"`.
 
 -   `labels` (object of key/value strings) - Key/value pair labels to apply to
-    the launched instance.
+    the launched instance and the created image.
 
 -   `machine_type` (string) - The machine type. Defaults to `"n1-standard-1"`.
 


### PR DESCRIPTION
**This PR is incomplete; I'm keeping the boilerplate for the time being.**

... so that it's possible to find images matching particular characteristics more easily.

Original discussion from https://github.com/hashicorp/packer/pull/5308#issuecomment-330236440

Please include tests. Check out these examples:

- https://github.com/hashicorp/packer/blob/master/builder/virtualbox/common/ssh_config_test.go#L19-L37
- https://github.com/hashicorp/packer/blob/master/post-processor/compress/post-processor_test.go#L153-L182