### PR TITLE
use flag -version instead of -v to install chef-solo on Windows

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -33,7 +33,7 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	},
 	provisioner.WindowsOSType: {
 		executeCommand: "c:/opscode/chef/bin/chef-solo.bat --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; Install-Project{{if .Version}} -v {{.Version}}{{end}}\"",
+		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; Install-Project{{if .Version}} -version {{.Version}}{{end}}\"",
 		stagingDir:     "C:/Windows/Temp/packer-chef-solo",
 	},
 }


### PR DESCRIPTION
When using the `chef-solo` provisioner on Windows we are getting the following error

```
amazon-ebs: Install-Project : Parameter cannot be processed because the parameter name 'v' is ambiguous. Possible matches include: -version -Verbose
```

After reviewing the [install script](https://omnitruck.chef.io/install.ps1), I believe the parameter should be changed to `-version`.  
