### PR TITLE
Avoid installation parameter conflict on Windows

### DIFF
--- a/provisioner/chef-solo/provisioner.go
+++ b/provisioner/chef-solo/provisioner.go
@@ -33,7 +33,7 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	},
 	provisioner.WindowsOSType: {
 		executeCommand: "c:/opscode/chef/bin/chef-solo.bat --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; Install-Project{{if .Version}} -v {{.Version}}{{end}}\"",
+		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; Install-Project{{if .Version}} -version {{.Version}}{{end}}\"",
 		stagingDir:     "C:/Windows/Temp/packer-chef-solo",
 	},
 }


### PR DESCRIPTION
When installing a specific version of chef-solo use the full name of the "version" parameter on installation to avoid conflict with "verbose"