### PR TITLE
Powershell parameters 5098

### DIFF
--- a/provisioner/powershell/elevated.go
+++ b/provisioner/powershell/elevated.go
@@ -9,7 +9,7 @@ type elevatedOptions struct {
 	Password        string
 	TaskName        string
 	TaskDescription string
-	EncodedCommand  string
+	CommandText     string
 }
 
 var elevatedTemplate = template.Must(template.New("ElevatedCommand").Parse(`

--- a/provisioner/powershell/elevated.go
+++ b/provisioner/powershell/elevated.go
@@ -53,7 +53,7 @@ $t.XmlText = @'
   <Actions Context="Author">
     <Exec>
       <Command>cmd</Command>
-	  <Arguments>/c powershell.exe -EncodedCommand {{.EncodedCommand}} &gt; %SYSTEMROOT%\Temp\{{.TaskName}}.out 2&gt;&amp;1</Arguments>
+	  <Arguments>/c {{.CommandText}} &gt; %SYSTEMROOT%\Temp\{{.TaskName}}.out 2&gt;&amp;1</Arguments>
     </Exec>
   </Actions>
 </Task>

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -82,6 +82,11 @@ type Config struct {
 	// such as 3010 - "The requested operation is successful. Changes will not be effective until the system is rebooted."
 	ValidExitCodes []int `mapstructure:"valid_exit_codes"`
 
+	// What parameters to use when invoking powershell to run the encoded command.
+	// by default this is "-executionpolicy bypass" but you may want to add other options
+	// such as -NoProfile
+	PowershellParameters string `mapstructure:"powershell_parameters"`
+
 	ctx interpolate.Context
 }
 
@@ -150,6 +155,10 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if p.config.ValidExitCodes == nil {
 		p.config.ValidExitCodes = []int{0}
+	}
+
+	if p.config.PowershellParameters == "" {
+		p.config.PowershellParameters = "-executionpolicy bypass"
 	}
 
 	var errs error
@@ -405,7 +414,8 @@ func (p *Provisioner) generateCommandLineRunner(command string) (commandText str
 		return "", fmt.Errorf("Error encoding command: %s", err)
 	}
 
-	commandText = "powershell -executionpolicy bypass -encodedCommand " + base64EncodedCommand
+	commandText = "powershell " + p.config.PowershellParameters + " -encodedCommand " + base64EncodedCommand
+	log.Printf(commandText)
 
 	return commandText, nil
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -451,7 +451,7 @@ func (p *Provisioner) createCommandTextPrivileged() (command string, err error) 
 	}
 
 	// Return the path to the elevated shell wrapper
-	command = fmt.Sprintf("powershell -executionpolicy bypass -file \"%s\"", path)
+	command = fmt.Sprintf("powershell "+p.config.PowershellParameters+" -file \"%s\"", path)
 
 	return command, err
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -463,6 +463,7 @@ func (p *Provisioner) generateElevatedRunner(command string) (uploadedPath strin
 	var buffer bytes.Buffer
 
 	base64EncodedCommand, err := powershellEncode(command)
+	commandText := "powershell " + p.config.PowershellParameters + " -encodedCommand " + base64EncodedCommand
 	if err != nil {
 		return "", fmt.Errorf("Error encoding command: %s", err)
 	}
@@ -472,7 +473,7 @@ func (p *Provisioner) generateElevatedRunner(command string) (uploadedPath strin
 		Password:        p.config.ElevatedPassword,
 		TaskDescription: "Packer elevated task",
 		TaskName:        fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID()),
-		EncodedCommand:  base64EncodedCommand,
+		CommandText:     commandText,
 	})
 
 	if err != nil {

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -78,6 +78,8 @@ Optional parameters:
     PowerShell script will be run with elevated privileges using the given
     Windows user.
 
+-   `powershell_parameters` (string) - under the hood, the powershell provisioner plugs your script and variables into `execute_command` or `elevated_execute_command` and then encodes that entire thing and runs it with `"powershell -executionpolicy bypass -encodedCommand " + base64EncodedCommand`. `powershell_parameters` exists so you can modify this wrapping command; e.g. `"powershell_parameters": "-NoProfile -executionpolicy bypass"` would make the final command `"powershell -NoProfile -executionpolicy bypass -encodedCommand " + base64EncodedCommand` You can modify `powershell_parameters` in addition to `execute_command` or independently of it, depending on your specific needs.
+
 -   `remote_path` (string) - The path where the script will be uploaded to in
     the machine. This defaults to "c:/Windows/Temp/script.ps1". This value must be a
     writable location and any parent directories must already exist.


### PR DESCRIPTION
Allows you to configure the powershell parameters, such as executionpolicy, for the powershell command that wraps the encoded execute_command.
Closes #5098
