### PR TITLE
Fix recurring bug #3878, make destination ESXi host selectable in con…

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -3,9 +3,13 @@ package vsphere
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
+	"os"
 	"os/exec"
+	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/hashicorp/packer/common"
@@ -19,6 +23,18 @@ var builtins = map[string]string{
 	"mitchellh.vmware-esx": "vmware",
 }
 
+var ovftool string = "ovftool"
+
+var (
+	// Regular expression to validate RFC1035 hostnames from full fqdn or simple hostname.
+	// For example "packer-esxi1". Requires proper DNS setup and/or correct DNS search domain setting.
+	hostnameRegex = regexp.MustCompile(`^[[:alnum:]][[:alnum:]\-]{0,61}[[:alnum:]]|[[:alpha:]]$`)
+
+	// Simple regular expression to validate IPv4 values.
+	// For example "192.168.1.1".
+	ipv4Regex = regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`)
+)
+
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
@@ -27,6 +43,7 @@ type Config struct {
 	Datastore    string   `mapstructure:"datastore"`
 	DiskMode     string   `mapstructure:"disk_mode"`
 	Host         string   `mapstructure:"host"`
+	ESXiHost     string   `mapstructure:"esxi_host"`
 	Insecure     bool     `mapstructure:"insecure"`
 	Options      []string `mapstructure:"options"`
 	Overwrite    bool     `mapstructure:"overwrite"`
@@ -64,7 +81,11 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	// Accumulate any errors
 	errs := new(packer.MultiError)
 
-	if _, err := exec.LookPath("ovftool"); err != nil {
+	if runtime.GOOS == "windows" {
+		ovftool = "ovftool.exe"
+	}
+
+	if _, err := exec.LookPath(ovftool); err != nil {
 		errs = packer.MultiErrorAppend(
 			errs, fmt.Errorf("ovftool not found: %s", err))
 	}
@@ -122,6 +143,14 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		ovftool_uri += "/Resources/" + p.config.ResourcePool
 	}
 
+	if p.config.ESXiHost != "" {
+		if ipv4Regex.MatchString(p.config.ESXiHost) {
+			ovftool_uri += "/?ip=" + p.config.ESXiHost
+		} else if hostnameRegex.MatchString(p.config.ESXiHost) {
+			ovftool_uri += "/?dns=" + p.config.ESXiHost
+		}
+	}
+
 	args, err := p.BuildArgs(source, ovftool_uri)
 	if err != nil {
 		ui.Message(fmt.Sprintf("Failed: %s\n", err))
@@ -129,16 +158,26 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	ui.Message(fmt.Sprintf("Uploading %s to vSphere", source))
 
-	log.Printf("Starting ovftool with parameters: %s", p.filterLog(strings.Join(args, " ")))
+	log.Printf("Starting ovftool with parameters: %s",
+		strings.Replace(
+			strings.Join(args, " "),
+			password,
+			"<password>",
+			-1))
 
-	var out bytes.Buffer
-	cmd := exec.Command("ovftool", args...)
-	cmd.Stdout = &out
+	var errWriter io.Writer
+	var errOut bytes.Buffer
+	cmd := exec.Command(ovftool, args...)
+	errWriter = io.MultiWriter(os.Stderr, &errOut)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = errWriter
+
 	if err := cmd.Run(); err != nil {
-		return nil, false, fmt.Errorf("Failed: %s\n%s\n", err, p.filterLog(out.String()))
+		err := fmt.Errorf("Error uploading virtual machine: %s\n%s\n", err, p.filterLog(errOut.String()))
+		return nil, false, err
 	}
 
-	ui.Message(p.filterLog(out.String()))
+	ui.Message(p.filterLog(errOut.String()))
 
 	artifact = NewArtifact(p.config.Datastore, p.config.VMFolder, p.config.VMName, artifact.Files())
 

--- a/website/source/docs/post-processors/vsphere.html.md
+++ b/website/source/docs/post-processors/vsphere.html.md
@@ -43,6 +43,11 @@ Required:
 
 Optional:
 
+-   `esxi_host` (string) - Target vSphere host. Used to assign specific esx host
+    to upload the resulting VM to, when a vCenter Server is used as `host`. Can be
+    either a hostname (e.g. "packer-esxi1", requires proper DNS setup and/or correct
+    DNS search domain setting) or an ipv4 address.
+
 -   `disk_mode` (string) - Target disk format. See `ovftool` manual for
     available options. By default, "thick" will be used.
 


### PR DESCRIPTION
Fix recurring bug #3878, make destination ESXi host selectable in config, more informative error output.

- This commit makes the destination ESXi Host selectable in configuration json, via the "esxi_host"
parameter (optional), which can be an ipv4 address or the dns name of the esxi host to register the VM.

- Also when failing, the post-processor prints out the error output of the ovftool, so debugging can be easier.

- Closes #3878