### PR TITLE
make vnc optional for vmware-iso builder

### DIFF
--- a/builder/vmware/common/step_clean_vmx.go
+++ b/builder/vmware/common/step_clean_vmx.go
@@ -21,6 +21,7 @@ import (
 //   <nothing>
 type StepCleanVMX struct {
 	RemoveEthernetInterfaces bool
+	SkipVNCDisable           bool
 }
 
 func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
@@ -59,8 +60,10 @@ func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
 		vmxData[ide+"clientdevice"] = "TRUE"
 	}
 
-	ui.Message("Disabling VNC server...")
-	vmxData["remotedisplay.vnc.enabled"] = "FALSE"
+	if !s.SkipVNCDisable {
+		ui.Message("Disabling VNC server...")
+		vmxData["remotedisplay.vnc.enabled"] = "FALSE"
+	}
 
 	if s.RemoveEthernetInterfaces {
 		ui.Message("Removing Ethernet Interfaces...")

--- a/builder/vmware/common/step_configure_vnc.go
+++ b/builder/vmware/common/step_configure_vnc.go
@@ -21,6 +21,7 @@ import (
 // Produces:
 //   vnc_port uint - The port that VNC is configured to listen on.
 type StepConfigureVNC struct {
+	Skip               bool
 	VNCBindAddress     string
 	VNCPortMin         uint
 	VNCPortMax         uint
@@ -76,6 +77,11 @@ func VNCPassword(skipPassword bool) string {
 }
 
 func (s *StepConfigureVNC) Run(state multistep.StateBag) multistep.StepAction {
+	if s.Skip {
+		log.Println("Skipping VNC configuration step...")
+		return multistep.ActionContinue
+	}
+
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 	vmxPath := state.Get("vmx_path").(string)

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -39,9 +39,15 @@ type StepTypeBootCommand struct {
 	BootCommand []string
 	VMName      string
 	Ctx         interpolate.Context
+	Skip        bool
 }
 
 func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction {
+	if s.Skip {
+		log.Println("Skipping boot command step...")
+		return multistep.ActionContinue
+	}
+
 	debug := state.Get("debug").(bool)
 	driver := state.Get("driver").(Driver)
 	httpPort := state.Get("http_port").(uint)

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -259,6 +259,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			HTTPPortMax: b.config.HTTPPortMax,
 		},
 		&vmwcommon.StepConfigureVNC{
+			Skip:               b.config.BootCommand == nil,
 			VNCBindAddress:     b.config.VNCBindAddress,
 			VNCPortMin:         b.config.VNCPortMin,
 			VNCPortMax:         b.config.VNCPortMax,
@@ -273,6 +274,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Headless:           b.config.Headless,
 		},
 		&vmwcommon.StepTypeBootCommand{
+			Skip:        b.config.BootCommand == nil,
 			BootCommand: b.config.BootCommand,
 			VMName:      b.config.VMName,
 			Ctx:         b.config.ctx,
@@ -303,6 +305,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&vmwcommon.StepCleanVMX{
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
+			SkipVNCDisable:           b.config.BootCommand == nil,
 		},
 		&StepUploadVMX{
 			RemoteType: b.config.RemoteType,

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -443,7 +443,7 @@ various files locally, and uploads these to the remote machine. Packer currently
 uses SSH to communicate to the ESXi machine rather than the vSphere API. At some
 point, the vSphere API may be used.
 
-Packer also requires VNC to issue boot commands during a build, which may be
+Packer also requires VNC if issuing boot commands during a build, which may be
 disabled on some remote VMware Hypervisors. Please consult the appropriate
 documentation on how to update VMware Hypervisor's firewall to allow these
 connections.


### PR DESCRIPTION
We needed to make VNC optional for the environment we were building in. Since we were not using the boot command to configure our image, it seemed to be the best option to skip vnc if the boot command is empty.

I successfully built a packer binary from this PR code and used it while testing in the environment that required these changes. I ran all the current tests but would like some assistance on any additional tests that I could help write. As I'm newer to the go language and this is a learning experience for me.

Also, this appears to be the follow-up to 2 other issues that were raised before 1.0.0 was released:
https://github.com/hashicorp/packer/issues/4514
https://github.com/hashicorp/packer/issues/3031
