### PR TITLE
Use system context env var to set path for elevated PS env vars file

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -417,7 +417,7 @@ func (p *Provisioner) createCommandTextPrivileged() (command string, err error) 
 	// we'll be dot-sourcing this later
 	envVarReader := strings.NewReader(flattenedEnvVars)
 	uuid := uuid.TimeOrderedUUID()
-	envVarPath := fmt.Sprintf(`${env:TEMP}\packer-env-vars-%s.ps1`, uuid)
+	envVarPath := fmt.Sprintf(`${env:SYSTEMROOT}\Temp\packer-env-vars-%s.ps1`, uuid)
 	log.Printf("Uploading env vars to %s", envVarPath)
 	err = p.communicator.Upload(envVarPath, envVarReader, nil)
 	if err != nil {


### PR DESCRIPTION
Using $env:Temp to specify the path for the location of the env vars file for the elevated command causes issues when the elevated command is being run as a different user from the user the provisioner is being run under.

Since $env:Temp will be evaluated differently for the two users we end up with the env var file being uploaded to one location, while the provisioner looks in another. Clearly, since the two locations are different, the provisioner will not be able to read and subsequently 'dot source' the file containing the env vars.

Using an environment variable valid in the system context means the path will be the same for both users.

Closes #5368 
