### PR TITLE
Disabling automatic checkpoints in hyperv-iso builder

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -213,8 +213,25 @@ New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHD
 			return err
 		}
 
+		err = DisableAutomaticCheckpoints(vmName)
+
+		if err != nil {
+			return err
+		}
+
 		return DeleteAllDvdDrives(vmName)
 	}
+}
+
+func DisableAutomaticCheckpoints(vmName string) error {
+	var script = `
+param([string]$vmName)
+if ((Get-Command Set-Vm).Parameters["AutomaticCheckpointsEnabled"]) { 
+	Set-Vm -Name $vmName -AutomaticCheckpointsEnabled $false }
+`
+	var ps powershell.PowerShellCmd
+	err := ps.Run(script, vmName)
+	return err
 }
 
 func SetVirtualMachineCpuCount(vmName string, cpu uint) error {


### PR DESCRIPTION
Closes #5371 by disabling automatic checkpoints on systems that support it.

### Work checklist
- [x] Test results - same scripts as in #5371 
- [x] Test results - same scripts succeed on Windows 10 1703 which doesn't have auto checkpoints


### Test results - Build succeeds on a Windows 10 Insider machine

```none
==> hyperv-iso: Running post-processor: vagrant
==> hyperv-iso (vagrant): Creating Vagrant box for 'hyperv' provider
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Hard Disks\WindowsServer2016Insider.vhdx to C:\Users\plang\AppData\Local\Temp\packer364298891\Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.VMRS
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.VMRS to C:\Users\plang\AppData\Local\Temp\packer364298891\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.VMRS
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.vmcx
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.vmcx to C:\Users\plang\AppData\Local\Temp\packer364298891\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.vmcx
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.vmgs
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.vmgs to C:\Users\plang\AppData\Local\Temp\packer364298891\Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.vmgs
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\box.xml
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\box.xml to C:\Users\plang\AppData\Local\Temp\packer364298891\Virtual Machines\box.xml
    hyperv-iso (vagrant): Using custom Vagrantfile: vagrantfile-windows_2016.template
    hyperv-iso (vagrant): Compressing: Vagrantfile
    hyperv-iso (vagrant): Compressing: Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Compressing: Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.VMRS
    hyperv-iso (vagrant): Compressing: Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.vmcx
    hyperv-iso (vagrant): Compressing: Virtual Machines\A3AC8AB5-43AD-4FE3-95BB-1E7919B203F1.vmgs
    hyperv-iso (vagrant): Compressing: Virtual Machines\box.xml
    hyperv-iso (vagrant): Compressing: metadata.json
Build 'hyperv-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> hyperv-iso: 'hyperv' provider box: windows_2016_insider_hyperv.box
```

Double checking box contents:

```none
Rename-Item windows_2016_insider_hyperv.box rs3_release_16296_insider_hyperv-nocheckpoint.b
ox
vagrant box add --name rs3_release_16296_insider_hyperv-nocheckpoint rs3_release_16296_insider_hyperv-nocheckpoint.box
==> box: Box file was not detected as metadata. Adding it directly...
==> box: Adding box 'rs3_release_16296_insider_hyperv-nocheckpoint' (v0) for provider:
    box: Unpacking necessary files from: file://D:/source/packer-windows/rs3_release_16296_insider_hyperv-nocheckpoint.box
    box: Progress: 100% (Rate: 427M/s, Estimated time remaining: --:--:--)
==> box: Successfully added box 'rs3_release_16296_insider_hyperv-nocheckpoint' (v0) for 'hyperv'!
```

Now it only has one VHDX as expected:

```none
    Directory: D:\.vagrant.d\boxes\rs3_release_16296_insider_hyperv-nocheckpoint\0\hyperv\Virtual Hard Disks


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        9/21/2017   3:26 PM    11647582208 WindowsServer2016Insider.vhdx
```

And `vagrant init`, `vagrant up` can import & start the VM again:

```none
vagrant up
Bringing machine 'default' up with 'hyperv' provider...
==> default: Verifying Hyper-V is enabled...
==> default: Configured startup memory is 4096
==> default: Configured cpus number is 4
==> default: Configured enable virtualization extensions is true
==> default: Importing a Hyper-V instance
    default: Please choose a switch to attach to your Hyper-V instance.
    default: If none of these are appropriate, please open the Hyper-V manager
    default: to create a new virtual switch.
    default:
    default: 1) HvsiIcs
    default: 2) DockerNAT
    default: 3) nat
    default: 4) Default Switch
    default: 5) Ethernet
    default:
    default: What switch would you like to use? 5
    default: Cloning virtual hard drive...
    default: Creating and registering the VM...
    default: Setting VM Integration Services
    default: Successfully imported a VM with name: WindowsServer2016Insider
==> default: Starting the machine...
```

### Test results - Windows 10 1703
This doesn't support the new auto checkpoint feature. It works as expected

```none
==> hyperv-iso: Running post-processor: vagrant
==> hyperv-iso (vagrant): Creating Vagrant box for 'hyperv' provider
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Hard Disks\WindowsServer2016Insider.vhdx to C:\Users\Patrick\AppData\Local\T
emp\packer241205263\Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\4B63D131-33B1-4DA9-99BD-E76B4D827A14.VMRS
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\4B63D131-33B1-4DA9-99BD-E76B4D827A14.VMRS to C:\Users\Patrick\AppDa
ta\Local\Temp\packer241205263\Virtual Machines\4B63D131-33B1-4DA9-99BD-E76B4D827A14.VMRS
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\4B63D131-33B1-4DA9-99BD-E76B4D827A14.vmcx
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\4B63D131-33B1-4DA9-99BD-E76B4D827A14.vmcx to C:\Users\Patrick\AppDa
ta\Local\Temp\packer241205263\Virtual Machines\4B63D131-33B1-4DA9-99BD-E76B4D827A14.vmcx
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\box.xml
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\box.xml to C:\Users\Patrick\AppData\Local\Temp\packer241205263\Virt
ual Machines\box.xml
    hyperv-iso (vagrant): Using custom Vagrantfile: vagrantfile-windows_2016.template
    hyperv-iso (vagrant): Compressing: Vagrantfile
    hyperv-iso (vagrant): Compressing: Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Compressing: Virtual Machines\4B63D131-33B1-4DA9-99BD-E76B4D827A14.VMRS
    hyperv-iso (vagrant): Compressing: Virtual Machines\4B63D131-33B1-4DA9-99BD-E76B4D827A14.vmcx
    hyperv-iso (vagrant): Compressing: Virtual Machines\box.xml
    hyperv-iso (vagrant): Compressing: metadata.json
Build 'hyperv-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> hyperv-iso: 'hyperv' provider box: windows_2016_insider_hyperv.box
PS 09/21/2017 22:18:18 C:\Users\Patrick\Source\packer-windows
>vagrant box add --name windows_2016_insider_16278 .\windows_2016_insider_hyperv.box
==> box: Box file was not detected as metadata. Adding it directly...
==> box: Adding box 'windows_2016_insider_16278' (v0) for provider:
    box: Unpacking necessary files from: file://C:/Users/Patrick/Source/packer-windows/windows_2016_insider_hyperv.box
    box: Progress: 100% (Rate: 357M/s, Estimated time remaining: --:--:--)
==> box: Successfully added box 'windows_2016_insider_16278' (v0) for 'hyperv'!
PS 09/21/2017 22:25:19 C:\Users\Patrick\Source\packer-windows
>mkdir \vagrant\16278


    Directory: C:\vagrant


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----        9/21/2017  10:26 PM                16278


PS 09/21/2017 22:26:11 C:\Users\Patrick\Source\packer-windows
>cd \vagrant\16278
PS 09/21/2017 22:26:16 C:\vagrant\16278
>vagrant init windows_2016_insider_16278
A `Vagrantfile` has been placed in this directory. You are now
ready to `vagrant up` your first virtual environment! Please read
the comments in the Vagrantfile as well as documentation on
`vagrantup.com` for more information on using Vagrant.
PS 09/21/2017 22:26:30 C:\vagrant\16278
>vagrant up
Bringing machine 'default' up with 'hyperv' provider...
==> default: Verifying Hyper-V is enabled...
==> default: Importing a Hyper-V instance
    default: Please choose a switch to attach to your Hyper-V instance.
    default: If none of these are appropriate, please open the Hyper-V manager
    default: to create a new virtual switch.
    default:
    default: 1) Ethernet
    default: 2) pfSense-Internal
    default: 3) hyperv_Private
    default: 4) Wifi
    default: 5) nat
    default: 6) DemoNet
    default:
    default: What switch would you like to use? 4
    default: Cloning virtual hard drive...
    default: Creating and registering the VM...
    default: Setting VM Integration Services
    default: Successfully imported a VM with name: WindowsServer2016Insider
==> default: Starting the machine...
==> default: Waiting for the machine to report its IP address...
    default: Timeout: 120 seconds
    default: IP: 169.254.21.109
==> default: Waiting for machine to boot. This may take a few minutes...
    default: WinRM address: 192.168.1.133:5985
    default: WinRM username: vagrant
    default: WinRM execution_time_limit: PT2H
    default: WinRM transport: negotiate
==> default: Machine booted and ready!
```

Signed-off-by: Patrick Lang <plang@microsoft.com>
