### PR TITLE
[WIP] Escape of chars special to PowerShell in user data

### DIFF
--- a/fix/fixer.go
+++ b/fix/fixer.go
@@ -34,6 +34,7 @@ func init() {
 		"amazon-shutdown_behavior":   new(FixerAmazonShutdownBehavior),
 		"amazon-enhanced-networking": new(FixerAmazonEnhancedNetworking),
 		"docker-email":               new(FixerDockerEmail),
+		"powershell-escapes":         new(FixerPowerShellEscapes),
 	}
 
 	FixerOrder = []string{
@@ -51,5 +52,6 @@ func init() {
 		"amazon-shutdown_behavior",
 		"amazon-enhanced-networking",
 		"docker-email",
+		"powershell-escapes",
 	}
 }

--- a/fix/fixer_powershell_escapes.go
+++ b/fix/fixer_powershell_escapes.go
@@ -1,0 +1,73 @@
+package fix
+
+import (
+	"github.com/mitchellh/mapstructure"
+	"strings"
+)
+
+// FixerPowerShellEscapes removes the PowerShell escape character from user
+// environment variables and elevated username and password strings
+type FixerPowerShellEscapes struct{}
+
+func (FixerPowerShellEscapes) Fix(input map[string]interface{}) (map[string]interface{}, error) {
+	type template struct {
+		Provisioners []interface{}
+	}
+
+	var psUnescape = strings.NewReplacer(
+		"`$", "$",
+		"`\"", "\"",
+		"``", "`",
+		"`'", "'",
+	)
+
+	// Decode the input into our structure, if we can
+	var tpl template
+	if err := mapstructure.WeakDecode(input, &tpl); err != nil {
+		return nil, err
+	}
+
+	for i, raw := range tpl.Provisioners {
+		var provisioners map[string]interface{}
+		if err := mapstructure.Decode(raw, &provisioners); err != nil {
+			// Ignore errors, could be a non-map
+			continue
+		}
+
+		if ok := provisioners["type"] == "powershell"; !ok {
+			continue
+		}
+
+		if _, ok := provisioners["elevated_user"]; ok {
+			provisioners["elevated_user"] = psUnescape.Replace(provisioners["elevated_user"].(string))
+		}
+		if _, ok := provisioners["elevated_password"]; ok {
+			provisioners["elevated_password"] = psUnescape.Replace(provisioners["elevated_password"].(string))
+		}
+		if raw, ok := provisioners["environment_vars"]; ok {
+			var env_vars []string
+			if err := mapstructure.Decode(raw, &env_vars); err != nil {
+				continue
+			}
+			env_vars_unescaped := make([]interface{}, len(env_vars))
+			for j, env_var := range env_vars {
+				env_vars_unescaped[j] = psUnescape.Replace(env_var)
+			}
+			// Replace with unescaped environment variables
+			provisioners["environment_vars"] = env_vars_unescaped
+		}
+
+		// Write all changes back to template
+		tpl.Provisioners[i] = provisioners
+	}
+
+	if len(tpl.Provisioners) > 0 {
+		input["provisioners"] = tpl.Provisioners
+	}
+
+	return input, nil
+}
+
+func (FixerPowerShellEscapes) Synopsis() string {
+	return `Removes PowerShell escapes from user env vars and elevated username and password strings`
+}

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -8,14 +8,12 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"sort"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/common/uuid"
@@ -347,8 +345,6 @@ func (p *Provisioner) prepareEnvVars(elevated bool) (envVarPath string, err erro
 }
 
 func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
-	var buf bytes.Buffer
-	escapedEnvVarValue := ""
 	flattened = ""
 	envVars := make(map[string]string)
 
@@ -363,16 +359,7 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 	// Split vars into key/value components
 	for _, envVar := range p.config.Vars {
 		keyValue := strings.SplitN(envVar, "=", 2)
-		// Escape chars special to PS in each env var value
-		err := escapeSpecialPS(&buf, []byte(keyValue[1]))
-		if err != nil {
-			fmt.Printf("An error occured escaping chars special to PowerShell in env var value %s", keyValue[1])
-		}
-		escapedEnvVarValue = buf.String()
-		buf.Reset()
-
-		log.Printf("Env var %s converted to %s after escaping chars special to PS", keyValue[1], escapedEnvVarValue)
-		envVars[keyValue[0]] = escapedEnvVarValue
+		envVars[keyValue[0]] = keyValue[1]
 	}
 
 	// Create a list of env var keys in sorted order
@@ -496,27 +483,10 @@ func (p *Provisioner) generateElevatedRunner(command string) (uploadedPath strin
 
 	buffer.Reset()
 
-	// Escape characters special to PowerShell in the ElevatedUser string
-	err = escapeSpecialPS(&buffer, []byte(p.config.ElevatedUser))
-	if err != nil {
-		fmt.Printf("Error escaping chars special to Powershell in ElevatedUser %s", p.config.ElevatedUser)
-	}
-	escapedElevatedUser := buffer.String()
-	log.Printf("Elevated user %s converted to %s after escaping chars special to PowerShell", p.config.ElevatedUser, escapedElevatedUser)
-	buffer.Reset()
-	// Escape characters special to PowerShell in the ElevatedPassword string
-	err = escapeSpecialPS(&buffer, []byte(p.config.ElevatedPassword))
-	if err != nil {
-		fmt.Printf("Error escaping chars special to Powershell in ElevatedPassword %s", p.config.ElevatedPassword)
-	}
-	escapedElevatedPassword := buffer.String()
-	log.Printf("Elevated password %s converted to %s after escaping chars special to PowerShell", p.config.ElevatedPassword, escapedElevatedPassword)
-	buffer.Reset()
-
 	// Generate command
 	err = elevatedTemplate.Execute(&buffer, elevatedOptions{
-		User:              escapedElevatedUser,
-		Password:          escapedElevatedPassword,
+		User:              p.config.ElevatedUser,
+		Password:          p.config.ElevatedPassword,
 		TaskName:          taskName,
 		TaskDescription:   "Packer elevated task",
 		LogFile:           logFile,
@@ -538,53 +508,4 @@ func (p *Provisioner) generateElevatedRunner(command string) (uploadedPath strin
 	// CMD formatted Path required for this op
 	path = fmt.Sprintf("%s-%s.ps1", "%TEMP%\\packer-elevated-shell", uuid)
 	return path, err
-}
-
-func escapeSpecialPS(w io.Writer, s []byte) error {
-	var esc []byte
-
-	last := 0
-	for i := 0; i < len(s); {
-		r, width := utf8.DecodeRune(s[i:])
-		i += width
-		switch r {
-		case '"':
-			esc = []byte("`\"") // Double quotes
-		case '\'':
-			esc = []byte("`'") // Single quotes
-		case '$':
-			esc = []byte("`$") // Dollar sign
-		case '`':
-			esc = []byte("``") // Backticks
-		default:
-			if !isInCharacterRange(r) || (r == 0xFFFD && width == 1) {
-				esc = []byte("\uFFFD") // Unicode replacement character
-				break
-			}
-			continue
-		}
-		if _, err := w.Write(s[last : i-width]); err != nil {
-			return err
-		}
-		if _, err := w.Write(esc); err != nil {
-			return err
-		}
-		last = i
-	}
-	if _, err := w.Write(s[last:]); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Decide whether the given rune is in the XML Character Range, per
-// the Char production of http://www.xml.com/axml/testaxml.htm,
-// Section 2.2 Characters.
-func isInCharacterRange(r rune) (inrange bool) {
-	return r == 0x09 ||
-		r == 0x0A ||
-		r == 0x0D ||
-		r >= 0x20 && r <= 0xDF77 ||
-		r >= 0xE000 && r <= 0xFFFD ||
-		r >= 0x10000 && r <= 0x10FFFF
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -24,6 +24,13 @@ import (
 
 var retryableSleep = 2 * time.Second
 
+var psEscape = strings.NewReplacer(
+	"$", "`$",
+	"\"", "`\"",
+	"`", "``",
+	"'", "`'",
+)
+
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
@@ -359,7 +366,13 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 	// Split vars into key/value components
 	for _, envVar := range p.config.Vars {
 		keyValue := strings.SplitN(envVar, "=", 2)
-		envVars[keyValue[0]] = keyValue[1]
+		// Escape chars special to PS in each env var value
+		escapedEnvVarValue := psEscape.Replace(keyValue[1])
+		if escapedEnvVarValue != keyValue[1] {
+			log.Printf("Env var %s converted to %s after escaping chars special to PS", keyValue[1],
+				escapedEnvVarValue)
+		}
+		envVars[keyValue[0]] = escapedEnvVarValue
 	}
 
 	// Create a list of env var keys in sorted order
@@ -480,13 +493,26 @@ func (p *Provisioner) generateElevatedRunner(command string) (uploadedPath strin
 	}
 	escapedCommand := buffer.String()
 	log.Printf("Command [%s] converted to [%s] for use in XML string", command, escapedCommand)
-
 	buffer.Reset()
+
+	// Escape chars special to PowerShell in the ElevatedUser string
+	escapedElevatedUser := psEscape.Replace(p.config.ElevatedUser)
+	if escapedElevatedUser != p.config.ElevatedUser {
+		log.Printf("Elevated user %s converted to %s after escaping chars special to PowerShell",
+			p.config.ElevatedUser, escapedElevatedUser)
+	}
+
+	// Escape chars special to PowerShell in the ElevatedPassword string
+	escapedElevatedPassword := psEscape.Replace(p.config.ElevatedPassword)
+	if escapedElevatedPassword != p.config.ElevatedPassword {
+		log.Printf("Elevated password %s converted to %s after escaping chars special to PowerShell",
+			p.config.ElevatedPassword, escapedElevatedPassword)
+	}
 
 	// Generate command
 	err = elevatedTemplate.Execute(&buffer, elevatedOptions{
-		User:              p.config.ElevatedUser,
-		Password:          p.config.ElevatedPassword,
+		User:              escapedElevatedUser,
+		Password:          escapedElevatedPassword,
 		TaskName:          taskName,
 		TaskDescription:   "Packer elevated task",
 		LogFile:           logFile,

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -518,6 +518,12 @@ func TestProvisioner_createFlattenedElevatedEnvVars_windows(t *testing.T) {
 		{"FOO=bar", "BAZ=qux"}, // Multiple user env vars
 		{"FOO=bar=baz"},        // User env var with value containing equals
 		{"FOO==bar"},           // User env var with value starting with equals
+		// Test escaping of characters special to PowerShell
+		{"FOO=bar$baz"},  // User env var with value containing dollar
+		{"FOO=bar\"baz"}, // User env var with value containing a double quote
+		{"FOO=bar'baz"},  // User env var with value containing a single quote
+		{"FOO=bar`baz"},  // User env var with value containing a backtick
+
 	}
 	expected := []string{
 		`$env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
@@ -525,6 +531,10 @@ func TestProvisioner_createFlattenedElevatedEnvVars_windows(t *testing.T) {
 		`$env:BAZ="qux"; $env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
 		`$env:FOO="bar=baz"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
 		`$env:FOO="=bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
+		"$env:FOO=\"bar`$baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:FOO=\"bar`\"baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:FOO=\"bar`'baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:FOO=\"bar``baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
 	}
 
 	p := new(Provisioner)
@@ -553,6 +563,11 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 		{"FOO=bar", "BAZ=qux"}, // Multiple user env vars
 		{"FOO=bar=baz"},        // User env var with value containing equals
 		{"FOO==bar"},           // User env var with value starting with equals
+		// Test escaping of characters special to PowerShell
+		{"FOO=bar$baz"},  // User env var with value containing dollar
+		{"FOO=bar\"baz"}, // User env var with value containing a double quote
+		{"FOO=bar'baz"},  // User env var with value containing a single quote
+		{"FOO=bar`baz"},  // User env var with value containing a backtick
 	}
 	expected := []string{
 		`$env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
@@ -560,6 +575,10 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 		`$env:BAZ="qux"; $env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
 		`$env:FOO="bar=baz"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
 		`$env:FOO="=bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
+		"$env:FOO=\"bar`$baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:FOO=\"bar`\"baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:FOO=\"bar`'baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:FOO=\"bar``baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
 	}
 
 	p := new(Provisioner)


### PR DESCRIPTION
This is a rough draft intended for discussion only. It follows on from the code and discussion in #5365 - namely auto escaping chars special to PowerShell in env vars and elevated usernames and passwords. I've also added the fix for #5368 as this was required for the demo template below to work OK.

Example:

```
  "provisioners": [
    {
      "type": "powershell",
      "inline": [
        "write-output \"Users still need to deal with special chars in commands themselves\"",
        "net user adminuser Super`$3cr3t /ADD",
        "net localgroup Administrators adminuser /add",
        "net user adminuser /ACTIVE:YES"
      ]
    },
    {
      "type": "powershell",
      "elevated_password": "Super$3cr3t",
      "elevated_user": "adminuser",
      "environment_vars": [
        "DOLLAR=A$Dollar",
        "BACKTICK=A`Backtick",
        "DBLQUOTE=A\"DoubleQuote",
        "SGLQUOTE=A'SingleQuote",
        "PSCODE=$(Write-Host \"PS Code in Env Vars should not be executed\")"
      ],
      "inline": [
        "write-output \"We didn't need to escape the dollar sign in the elevated password\"",
        "write-output \"DOLLAR is equal to $env:DOLLAR\"",
        "write-output \"BACKTICK is equal to $env:BACKTICK\"",
        "write-output \"DBLQUOTE is equal to $env:DBLQUOTE\"",
        "write-output \"SGLQUOTE is equal to $env:SGLQUOTE\"",
        "write-output \"The PowerShell code embedded in the env var was not executed\""
      ]
    },
```

This results in the following expected (and hopefully correct!) output:

```
==> virtualbox-iso: Connected to WinRM!
==> virtualbox-iso: Uploading VirtualBox version info (5.1.24)
==> virtualbox-iso: Provisioning with Powershell...
==> virtualbox-iso: Provisioning with powershell script: /var/folders/15/d0f7gdg13rnd1cxp7tgmr55c0000gn/T/packer-powershell-provisioner329677294
    virtualbox-iso: Users still need to deal with special chars in commands themselves
    virtualbox-iso: The command completed successfully.
    virtualbox-iso:
    virtualbox-iso: The command completed successfully.
    virtualbox-iso:
    virtualbox-iso: The command completed successfully.
    virtualbox-iso:
==> virtualbox-iso: Provisioning with Powershell...
==> virtualbox-iso: Provisioning with powershell script: /var/folders/15/d0f7gdg13rnd1cxp7tgmr55c0000gn/T/packer-powershell-provisioner232935784
    virtualbox-iso: We didn't need to escape the dollar sign in the elevated password
    virtualbox-iso: DOLLAR is equal to A$Dollar
    virtualbox-iso: BACKTICK is equal to A`Backtick
    virtualbox-iso: DBLQUOTE is equal to A"DoubleQuote
    virtualbox-iso: SGLQUOTE is equal to A'SingleQuote
    virtualbox-iso: The PowerShell code embedded in the env var was not executed
```

Notes:

* I've taken out the commit in #5365 that changed the env var formats to use single quotes
* I've based (blatantly ripped off!!!) the code that escapes chars special to PowerShell on the Go code that escapes chars special to XML - see the ```func escapeText``` [here](https://golang.org/src/encoding/xml/xml.go)
* I'm not sure about the character range used in ```func isInCharacterRange```. Clearly things work OK as is, but I wondered if that needed amending in some way to be 100% compatible/applicable to PowerShell.
* This should 'fix' #5258.
* I've expanded the tests to check env vars with chars special to PS are dealt with properly. Do we need to also test that elevated username and elevated passwords are escaped properly as well? I would probably need some help with this
* Users that have escaped chars special to PowerShell in their env vars or elevated_user or elevated_password will now need to remove the escape e.g.

```
      "elevated_user": "Administrator",
      "elevated_password": "Super`$3cr3t!"
```

Will just need to become:

```
      "elevated_user": "Administrator",
      "elevated_password": "Super$3cr3t!"
```

Closes #5471