### PR TITLE
[WIP] Allow temporary security group to have source CIDR block explicit

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -40,6 +40,7 @@ type RunConfig struct {
 	DisableStopInstance               bool              `mapstructure:"disable_stop_instance"`
 	SecurityGroupId                   string            `mapstructure:"security_group_id"`
 	SecurityGroupIds                  []string          `mapstructure:"security_group_ids"`
+	SecurityGroupSourceCidr           string            `mapstructure:"security_group_source_cidr"`
 	SubnetId                          string            `mapstructure:"subnet_id"`
 	TemporaryKeyPairName              string            `mapstructure:"temporary_key_pair_name"`
 	UserData                          string            `mapstructure:"user_data"`
@@ -113,6 +114,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 			c.SecurityGroupIds = []string{c.SecurityGroupId}
 			c.SecurityGroupId = ""
 		}
+	}
+
+	if c.SecurityGroupSourceCidr == "" {
+		c.SecurityGroupSourceCidr = "0.0.0.0/0"
 	}
 
 	if c.InstanceInitiatedShutdownBehavior == "" {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -132,6 +132,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SecurityGroupIds: b.config.SecurityGroupIds,
 			CommConfig:       &b.config.RunConfig.Comm,
 			VpcId:            b.config.VpcId,
+			SecurityGroupSourceCidr: b.config.SecurityGroupSourceCidr,
 		},
 		&stepCleanupVolumes{
 			BlockDevices: b.config.BlockDevices,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -146,6 +146,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SecurityGroupIds: b.config.SecurityGroupIds,
 			CommConfig:       &b.config.RunConfig.Comm,
 			VpcId:            b.config.VpcId,
+			SecurityGroupSourceCidr: b.config.SecurityGroupSourceCidr,
 		},
 		&awscommon.StepRunSourceInstance{
 			Debug:                    b.config.PackerDebug,

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -121,6 +121,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SecurityGroupIds: b.config.SecurityGroupIds,
 			CommConfig:       &b.config.RunConfig.Comm,
 			VpcId:            b.config.VpcId,
+			SecurityGroupSourceCidr: b.config.SecurityGroupSourceCidr,
 		},
 		&awscommon.StepRunSourceInstance{
 			Debug:                    b.config.PackerDebug,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -217,6 +217,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			CommConfig:       &b.config.RunConfig.Comm,
 			SecurityGroupIds: b.config.SecurityGroupIds,
 			VpcId:            b.config.VpcId,
+			SecurityGroupSourceCidr: b.config.SecurityGroupSourceCidr,
 		},
 		&awscommon.StepRunSourceInstance{
 			Debug:                    b.config.PackerDebug,

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -235,6 +235,11 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
+-   `security_group_source_cidr` (string) - An IPv4 CIDR block to be authorized
+    access to the instance, when packer is creating a temporary security group.
+    The default is `0.0.0.0/0` (ie, allow any IPv4 source). This is only used 
+    when `security_group_id` or `security_group_ids` is not specified.
+
 -   `shutdown_behavior` (string) - Automatically terminate instances on shutdown
     in case Packer exits ungracefully. Possible values are "stop" and "terminate",
     default is `stop`.

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -228,6 +228,11 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
+-   `security_group_source_cidr` (string) - An IPv4 CIDR block to be authorized
+    access to the instance, when packer is creating a temporary security group.
+    The default is `0.0.0.0/0` (ie, allow any IPv4 source). This is only used
+    when `security_group_id` or `security_group_ids` is not specified.
+
 -   `shutdown_behavior` (string) - Automatically terminate instances on shutdown
     incase packer exits ungracefully. Possible values are "stop" and "terminate",
     default is `stop`.

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -147,6 +147,11 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
+-   `security_group_source_cidr` (string) - An IPv4 CIDR block to be authorized
+    access to the instance, when packer is creating a temporary security group.
+    The default is `0.0.0.0/0` (ie, allow any IPv4 source). This is only used
+    when `security_group_id` or `security_group_ids` is not specified.
+
 -   `shutdown_behavior` (string) - Automatically terminate instances on shutdown
     in case Packer exits ungracefully. Possible values are `stop` and `terminate`.
     Defaults to `stop`.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -243,6 +243,11 @@ builder.
     described above. Note that if this is specified, you must omit the
     `security_group_id`.
 
+-   `security_group_source_cidr` (string) - An IPv4 CIDR block to be authorized
+    access to the instance, when packer is creating a temporary security group.
+    The default is `0.0.0.0/0` (ie, allow any IPv4 source). This is only used
+    when `security_group_id` or `security_group_ids` is not specified.
+
 -   `skip_region_validation` (boolean) - Set to true if you want to skip
     validation of the region configuration option. Defaults to `false`.
 


### PR DESCRIPTION
This is just WIP, it's not complete (as it doesn't really have tests).

The change allows the source cidr range authorized automatically in the temporary SG created on AWS to be provided by the user. In our use cases, we have a monitoring bot which tries to smack people when creating SGs with 0/0 as a source.

It's a half-way step between pre-creating an SG and an open-access SG as is currently the case.

Feedback needed.