### PR TITLE
Updated docs with more robust sysprep script for deprovisioning Windows on Azure

### DIFF
--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -216,6 +216,24 @@ The following provisioner snippet shows how to sysprep a Windows VM. Deprovision
 }
 ```
 
+In some circumstances the above isn't enough to reliably know that the sysprep is actually finished generalizing the image, the code below will wait for sysprep to write the image status in the registry and will exit after that. The possible states, in case you want to wait for another state, [are documented here](https://technet.microsoft.com/en-us/library/hh824815.aspx)
+
+``` json
+{
+    "provisioners": [
+    {
+        "type": "powershell",
+        "inline": [
+            "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit",
+            "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
+        ]
+    }
+  ]
+}
+
+
+```
+
 ### Linux
 
 The following provisioner snippet shows how to deprovision a Linux VM. Deprovision should be the last operation executed by a build.


### PR DESCRIPTION
I had some issues with my Windows images randomly failing and figured out a way to have the script check for the actual sysprep status in the registry before letting packer shut down the machine and capture the image.

There seems to be some kind of condition where `sysprep.exe /oobe /generalize /shutdown` isn't enough, so I went with `sysprep.exe /oobe /generalize /quit` and then have the Powershell script checking the registry setting to see when the image is _actually_ ready to be captured.

From one of my builds using this code:
[14:52:42][Step 1/1]     restapiserver: IMAGE_STATE_COMPLETE
[14:52:42][Step 1/1] 2017/09/25 12:52:45 ui:     restapiserver: IMAGE_STATE_COMPLETE
[14:52:42][Step 1/1] 2017/09/25 12:52:45 ui:     restapiserver: #< CLIXML
[14:52:42][Step 1/1]     restapiserver: #< CLIXML
[14:52:52][Step 1/1] 2017/09/25 12:52:55 ui:     restapiserver: IMAGE_STATE_UNDEPLOYABLE
[14:52:52][Step 1/1]     restapiserver: IMAGE_STATE_UNDEPLOYABLE
[14:53:02][Step 1/1] 2017/09/25 12:53:05 ui:     restapiserver: IMAGE_STATE_UNDEPLOYABLE
[14:53:02][Step 1/1]     restapiserver: IMAGE_STATE_UNDEPLOYABLE
[14:53:12][Step 1/1]     restapiserver: IMAGE_STATE_UNDEPLOYABLE
[14:53:12][Step 1/1] 2017/09/25 12:53:15 ui:     restapiserver: IMAGE_STATE_UNDEPLOYABLE
[14:53:22][Step 1/1]     restapiserver: IMAGE_STATE_UNDEPLOYABLE
[14:53:22][Step 1/1] 2017/09/25 12:53:25 ui:     restapiserver: IMAGE_STATE_UNDEPLOYABLE
[14:53:32][Step 1/1]     restapiserver: IMAGE_STATE_UNDEPLOYABLE

So you can see, even though the `sysprep.exe /generalize /oobe /quit` process is done, the sysprep isn't done yet. It goes from `IMAGE_STATE_COMPLETE` to `IMAGE_STATE_UNDEPLOYABLE` until it ends up at `IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE` where the loop breaks.

Let me know if this is helpful, it at least tripped me up quite a bit as random images were failing but now the image building is flawless for our needs.
