### PR TITLE
docker-push post-processor: adding flag to remove the local image

### DIFF
--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -22,6 +22,7 @@ type Config struct {
 	LoginServer            string `mapstructure:"login_server"`
 	EcrLogin               bool   `mapstructure:"ecr_login"`
 	docker.AwsAccessConfig `mapstructure:",squash"`
+	Remove                 bool
 
 	ctx interpolate.Context
 }
@@ -103,6 +104,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	ui.Message("Pushing: " + name)
 	if err := driver.Push(name); err != nil {
 		return nil, false, err
+	}
+
+	if p.config.Remove {
+		ui.Say(fmt.Sprintf("Docker image: %s will be removed", name))
+		return artifact, false, nil
 	}
 
 	return nil, false, nil

--- a/website/source/docs/post-processors/docker-push.html.md
+++ b/website/source/docs/post-processors/docker-push.html.md
@@ -48,6 +48,8 @@ This post-processor has only optional configuration:
 
 -   `login_server` (string) - The server address to login to.
 
+-   `remove` (boolean) - If it's true, the pushed image will be remove from your local machine. Default is false.
+
 Note: When using *Docker Hub* or *Quay* registry servers, `login` must to be
 set to `true` and `login_email`, `login_username`, **and** `login_password`
 must to be set to your registry credentials. When using Docker Hub,


### PR DESCRIPTION
This change add the possibility to remove the docker image from the local machine after that the `docker-push` post-processor pushes it to a registry.

Closes #5361

