### PR TITLE
builder/docker: set user during exec.

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -23,19 +23,20 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 
+	Author       string
+	Changes      []string
 	Commit       bool
+	ContainerDir string `mapstructure:"container_dir"`
 	Discard      bool
+	ExecUser     string `mapstructure:"exec_user"`
 	ExportPath   string `mapstructure:"export_path"`
 	Image        string
+	Message      string
+	Privileged   bool `mapstructure:"privileged"`
 	Pty          bool
 	Pull         bool
 	RunCommand   []string `mapstructure:"run_command"`
 	Volumes      map[string]string
-	Privileged   bool `mapstructure:"privileged"`
-	Author       string
-	Changes      []string
-	Message      string
-	ContainerDir string `mapstructure:"container_dir"`
 
 	// This is used to login to dockerhub to pull a private base container. For
 	// pushing to dockerhub, see the docker post-processors

--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -174,6 +174,10 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
     `login_password` will be ignored. For more information see the
     [section on ECR](#amazon-ec2-container-registry).
 
+*   `exec_user` (string) - Username or UID (format: <name|uid>[:<group|gid>])
+    to run remote commands with. You may need this if you get permission errors
+    trying to run the `shell` or other  provisioners.
+
 -   `login` (boolean) - Defaults to false. If true, the builder will login in
     order to pull the image. The builder only logs in for the duration of
     the pull. It always logs out afterwards. For log into ECR see `ecr_login`.


### PR DESCRIPTION
Add `exec_user` option to control what user `docker exec` is run as.

closes #5307