### PR TITLE
Fix Oracle OCI builder ignores region value provided in OCI config file

### DIFF
--- a/builder/oracle/oci/client/config.go
+++ b/builder/oracle/oci/client/config.go
@@ -182,7 +182,7 @@ func BaseTestConfig() (*ini.File, *os.File, error) {
 	// Build ini
 	cfg := ini.Empty()
 	section, _ := cfg.NewSection("DEFAULT")
-	section.NewKey("region", "us-phoenix-1")
+	section.NewKey("region", "us-ashburn-1")
 	section.NewKey("tenancy", "ocid1.tenancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	section.NewKey("user", "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	section.NewKey("fingerprint", "3c:b6:44:d7:49:1a:ac:bf:de:7d:76:22:a7:f5:df:55")

--- a/builder/oracle/oci/client/config_test.go
+++ b/builder/oracle/oci/client/config_test.go
@@ -82,7 +82,7 @@ func TestNewConfigDefaultsPopulated(t *testing.T) {
 	}
 
 	if adminConfig.Region != "us-ashburn-1" {
-		t.Errorf("Expected 'us-phoenix-1', got '%s'", adminConfig.Region)
+		t.Errorf("Expected 'us-ashburn-1', got '%s'", adminConfig.Region)
 	}
 }
 

--- a/builder/oracle/oci/client/config_test.go
+++ b/builder/oracle/oci/client/config_test.go
@@ -81,7 +81,7 @@ func TestNewConfigDefaultsPopulated(t *testing.T) {
 		t.Fatal("Expected ADMIN config to exist in map")
 	}
 
-	if adminConfig.Region != "us-phoenix-1" {
+	if adminConfig.Region != "us-ashburn-1" {
 		t.Errorf("Expected 'us-phoenix-1', got '%s'", adminConfig.Region)
 	}
 }

--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -101,7 +101,10 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 
 	if c.Region != "" {
 		accessCfg.Region = c.Region
-	} else {
+	}
+
+	// Default if the template nor the API config contains a region.
+	if accessCfg.Region == "" {
 		accessCfg.Region = "us-phoenix-1"
 	}
 

--- a/builder/oracle/oci/config_test.go
+++ b/builder/oracle/oci/config_test.go
@@ -122,6 +122,20 @@ func TestConfig(t *testing.T) {
 
 	})
 
+	t.Run("RegionNotDefaultedToPHXWhenSetInOCISettings", func(t *testing.T) {
+		raw := testConfig(cfgFile)
+		c, errs := NewConfig(raw)
+		if errs != nil {
+			t.Fatalf("err: %+v", errs)
+		}
+
+		expected := "us-ashburn-1"
+		if c.AccessCfg.Region != expected {
+			t.Errorf("Expected region: %s, got %s.", expected, c.AccessCfg.Region)
+		}
+
+	})
+
 	// Test the correct errors are produced when required template keys are
 	// omitted.
 	requiredKeys := []string{"availability_domain", "base_image_ocid", "shape", "subnet_ocid"}


### PR DESCRIPTION
Only default the OCI builder region to `us-phoenix-1` when no value is present in the packer template _and_ the OCI config file.

Closes: #5401 

/cc @mwhooker @owainlewis