### PR TITLE
aws: automatically decode encoded authorization messages if possible

### DIFF
--- a/builder/amazon/chroot/step_create_volume.go
+++ b/builder/amazon/chroot/step_create_volume.go
@@ -72,7 +72,7 @@ func (s *StepCreateVolume) Run(state multistep.StateBag) multistep.StepAction {
 
 	createVolumeResp, err := ec2conn.CreateVolume(createVolume)
 	if err != nil {
-		err := fmt.Errorf("Error creating root volume: %s", err)
+		err := fmt.Errorf("Error creating root volume: %s", awscommon.DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -100,7 +100,7 @@ func (s *StepCreateVolume) Run(state multistep.StateBag) multistep.StepAction {
 
 	_, err = awscommon.WaitForState(&stateChange)
 	if err != nil {
-		err := fmt.Errorf("Error waiting for volume: %s", err)
+		err := fmt.Errorf("Error waiting for volume: %s", awscommon.DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/chroot/step_instance_info.go
+++ b/builder/amazon/chroot/step_instance_info.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/packer"
 	"github.com/mitchellh/multistep"
 )
@@ -37,7 +38,7 @@ func (s *StepInstanceInfo) Run(state multistep.StateBag) multistep.StepAction {
 	// Query the entire instance metadata
 	instancesResp, err := ec2conn.DescribeInstances(&ec2.DescribeInstancesInput{InstanceIds: []*string{&identity.InstanceID}})
 	if err != nil {
-		err := fmt.Errorf("Error getting instance data: %s", err)
+		err := fmt.Errorf("Error getting instance data: %s", awscommon.DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -90,7 +90,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
 	if err != nil {
-		state.Put("error", fmt.Errorf("Error registering AMI: %s", err))
+		state.Put("error", fmt.Errorf("Error registering AMI: %s", awscommon.DecodeError(state, err)))
 		ui.Error(state.Get("error").(error).Error())
 		return multistep.ActionHalt
 	}
@@ -111,7 +111,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Waiting for AMI to become ready...")
 	if _, err := awscommon.WaitForState(&stateChange); err != nil {
-		err := fmt.Errorf("Error waiting for AMI: %s", err)
+		err := fmt.Errorf("Error waiting for AMI: %s", awscommon.DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/common/errors.go
+++ b/builder/amazon/common/errors.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/mitchellh/multistep"
+)
+
+var encodedFailureMessagePattern = regexp.MustCompile(`(?i).* Encoded authorization failure message: ([\w-]+)`)
+
+// DecodeError replaces encoded authorization messages with the
+// decoded results
+func DecodeError(state multistep.StateBag, err error) error {
+
+	if ae, ok := err.(awserr.Error); ok && ae.Code() == "UnauthorizedOperation" {
+		parts := encodedFailureMessagePattern.FindStringSubmatch(ae.Message())
+		if parts != nil && len(parts) > 1 {
+			stsConn := state.Get("sts").(*sts.STS)
+			result, decodeErr := stsConn.DecodeAuthorizationMessage(&sts.DecodeAuthorizationMessageInput{
+				EncodedMessage: aws.String(parts[1]),
+			})
+			if decodeErr == nil {
+				msg, ppErr := prettyPrint(aws.StringValue(result.DecodedMessage))
+				if ppErr != nil {
+					log.Printf("[WARN] Attempted to pretty print authorization message: %v", ppErr)
+					msg = aws.StringValue(result.DecodedMessage)
+				}
+
+				return fmt.Errorf("You are not authorized to perform this operation. Authorization failure message: \n%s",
+					msg)
+
+			}
+			log.Printf("[WARN] Attempted to decode authorization message, but received: %v", decodeErr)
+		}
+	}
+	return err
+}
+
+func prettyPrint(str string) (string, error) {
+	var out bytes.Buffer
+	err := json.Indent(&out, []byte(str), "", "  ")
+	return out.String(), err
+}

--- a/builder/amazon/common/errors_test.go
+++ b/builder/amazon/common/errors_test.go
@@ -1,0 +1,80 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/mitchellh/multistep"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+type mockSTS struct {
+}
+
+func (m *mockSTS) DecodeAuthorizationMessage(input *sts.DecodeAuthorizationMessageInput) (*sts.DecodeAuthorizationMessageOutput, error) {
+	return &sts.DecodeAuthorizationMessageOutput{
+		DecodedMessage: aws.String(`{
+			"allowed": false,
+			"explicitDeny": true,
+			"matchedStatements": {}
+		}`),
+	}, nil
+}
+
+func TestErrorsParsing_RequestFailure(t *testing.T) {
+
+	ae := awserr.New("UnauthorizedOperation",
+		`You are not authorized to perform this operation. Encoded authorization failure message: D9Q7oicjOMr9l2CC-NPP1FiZXK9Ijia1k-3l0siBFCcrK3oSuMFMkBIO5TNj0HdXE-WfwnAcdycFOohfKroNO6toPJEns8RFVfy_M_IjNGmrEFJ6E62pnmBW0OLrMsXxR9FQE4gB4gJzSM0AD6cV6S3FOfqYzWBRX-sQdOT4HryGkFNRoFBr9Xbp-tRwiadwkbdHdfnV9fbRkXmnwCdULml16NBSofC4ZPepLMKmIB5rKjwk-m179UUh2XA-J5no0si6XcRo5GbHQB5QfCIwSHL4vsro2wLZUd16-8OWKyr3tVlTbQe0ERZskqRqRQ5E28QuiBCVV6XstUyo-T4lBSr75Fgnyr3wCO-dS3b_5Ns3WzA2JD4E2AJOAStXIU8IH5YuKkAg7C-dJMuBMPpmKCBEXhNoHDwCyOo5PsV3xMlc0jSb0qYGpfst_TDDtejcZfn7NssUjxVq9qkdH-OXz2gPoQB-hX8ycmZCL5UZwKc3TCLUr7TGnudHjmnMrE9cUo-yTCWfyHPLprhiYhTCKW18EikJ0O1EKI3FJ_b4F19_jFBPARjSwQc7Ut6MNCVzrPdZGYSF6acj5gPaxdy9uSkVQwWXK7Pd5MFP7EBDE1_DgYbzodgwDO2PXeVFUbSLBHKWo_ebZS9ZX2nYPcGss_sYaly0ZVSIJXp7G58B5BoFVhvVH6jYnF9XiAOjMltuP_ycu1pQP1lki500RY3baLvfeYeAsB38XZHKEgWZzq7Fei-uh89q0cjJTmlVyrfRU3q6`,
+		fmt.Errorf("You can't do it!!"))
+	rf := awserr.NewRequestFailure(ae, 400, "abc-def-123-456")
+
+	state := new(multistep.BasicStateBag)
+	state.Put("sts", &mockSTS{})
+
+	result := DecodeError(state, rf)
+	if result == nil {
+		t.Error("Expected resulting error")
+	}
+	if !strings.Contains(result.Error(), "Authorization failure message:") {
+		t.Error("Exepcted authorization failure message")
+	}
+}
+
+func TestErrorsParsing_NonAuthorizationFailure(t *testing.T) {
+
+	ae := awserr.New("BadRequest",
+		`You did something wrong. Try again`,
+		fmt.Errorf("Request was no good."))
+	rf := awserr.NewRequestFailure(ae, 400, "abc-def-123-456")
+
+	state := new(multistep.BasicStateBag)
+	state.Put("sts", &mockSTS{})
+
+	result := DecodeError(state, rf)
+	if result == nil {
+		t.Error("Expected resulting error")
+	}
+	if result != rf {
+		t.Error("Expected original error to be returned unchanged")
+	}
+}
+
+func TestErrorsParsing_NonAWSError(t *testing.T) {
+
+	err := fmt.Errorf("Random error occurred")
+
+	state := new(multistep.BasicStateBag)
+	state.Put("sts", &mockSTS{})
+
+	result := DecodeError(state, err)
+	if result == nil {
+		t.Error("Expected resulting error")
+	}
+	if result != err {
+		t.Error("Expected original error to be returned unchanged")
+	}
+}

--- a/builder/amazon/common/step_create_tags.go
+++ b/builder/amazon/common/step_create_tags.go
@@ -46,7 +46,7 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 		}
 		session, err := session.NewSession(&awsConfig)
 		if err != nil {
-			err := fmt.Errorf("Error creating AWS session: %s", err)
+			err := fmt.Errorf("Error creating AWS session: %s", DecodeError(state, err))
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -60,7 +60,7 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 		})
 
 		if err != nil {
-			err := fmt.Errorf("Error retrieving details for AMI (%s): %s", ami, err)
+			err := fmt.Errorf("Error retrieving details for AMI (%s): %s", ami, DecodeError(state, err))
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -89,7 +89,7 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 		ui.Say("Creating AMI tags")
 		amiTags, err := ConvertToEC2Tags(s.Tags, *ec2conn.Config.Region, sourceAMI, s.Ctx)
 		if err != nil {
-			state.Put("error", err)
+			state.Put("error", DecodeError(state, err))
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
@@ -98,7 +98,7 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 		ui.Say("Creating snapshot tags")
 		snapshotTags, err := ConvertToEC2Tags(s.SnapshotTags, *ec2conn.Config.Region, sourceAMI, s.Ctx)
 		if err != nil {
-			state.Put("error", err)
+			state.Put("error", DecodeError(state, err))
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
@@ -138,7 +138,7 @@ func (s *StepCreateTags) Run(state multistep.StateBag) multistep.StepAction {
 
 		if err != nil {
 			err := fmt.Errorf("Error adding tags to Resources (%#v): %s", resourceIds, err)
-			state.Put("error", err)
+			state.Put("error", DecodeError(state, err))
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}

--- a/builder/amazon/common/step_deregister_ami.go
+++ b/builder/amazon/common/step_deregister_ami.go
@@ -44,7 +44,7 @@ func (s *StepDeregisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 				}}})
 
 			if err != nil {
-				err := fmt.Errorf("Error describing AMI: %s", err)
+				err := fmt.Errorf("Error describing AMI: %s", DecodeError(state, err))
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
@@ -57,7 +57,7 @@ func (s *StepDeregisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 				})
 
 				if err != nil {
-					err := fmt.Errorf("Error deregistering existing AMI: %s", err)
+					err := fmt.Errorf("Error deregistering existing AMI: %s", DecodeError(state, err))
 					state.Put("error", err)
 					ui.Error(err.Error())
 					return multistep.ActionHalt
@@ -73,7 +73,7 @@ func (s *StepDeregisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 							})
 
 							if err != nil {
-								err := fmt.Errorf("Error deleting existing snapshot: %s", err)
+								err := fmt.Errorf("Error deleting existing snapshot: %s", DecodeError(state, err))
 								state.Put("error", err)
 								ui.Error(err.Error())
 								return multistep.ActionHalt

--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -114,7 +114,7 @@ func (s *StepGetPassword) waitForPassword(state multistep.StateBag, cancel <-cha
 			InstanceId: instance.InstanceId,
 		})
 		if err != nil {
-			err := fmt.Errorf("Error retrieving auto-generated instance password: %s", err)
+			err := fmt.Errorf("Error retrieving auto-generated instance password: %s", DecodeError(state, err))
 			return "", err
 		}
 

--- a/builder/amazon/common/step_modify_ami_attributes.go
+++ b/builder/amazon/common/step_modify_ami_attributes.go
@@ -158,7 +158,7 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 		}
 		session, err := session.NewSession(&awsConfig)
 		if err != nil {
-			err := fmt.Errorf("Error creating AWS session: %s", err)
+			err := fmt.Errorf("Error creating AWS session: %s", DecodeError(state, err))
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -169,7 +169,7 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 			input.ImageId = &ami
 			_, err := regionconn.ModifyImageAttribute(input)
 			if err != nil {
-				err := fmt.Errorf("Error modify AMI attributes: %s", err)
+				err := fmt.Errorf("Error modify AMI attributes: %s", DecodeError(state, err))
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
@@ -192,7 +192,7 @@ func (s *StepModifyAMIAttributes) Run(state multistep.StateBag) multistep.StepAc
 				input.SnapshotId = &snapshot
 				_, err := regionconn.ModifySnapshotAttribute(input)
 				if err != nil {
-					err := fmt.Errorf("Error modify snapshot attributes: %s", err)
+					err := fmt.Errorf("Error modify snapshot attributes: %s", DecodeError(state, err))
 					state.Put("error", err)
 					ui.Error(err.Error())
 					return multistep.ActionHalt

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -34,7 +34,7 @@ func (s *StepPreValidate) Run(state multistep.StateBag) multistep.StepAction {
 		}}})
 
 	if err != nil {
-		err := fmt.Errorf("Error querying AMI: %s", err)
+		err := fmt.Errorf("Error querying AMI: %s", DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/common/step_security_group.go
+++ b/builder/amazon/common/step_security_group.go
@@ -33,7 +33,7 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 			},
 		)
 		if err != nil {
-			err := fmt.Errorf("Couldn't find specified security group: %s", err)
+			err := fmt.Errorf("Couldn't find specified security group: %s", DecodeError(state, err))
 			log.Printf("[DEBUG] %s", err.Error())
 			state.Put("error", err)
 			return multistep.ActionHalt
@@ -64,6 +64,7 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 
 	groupResp, err := ec2conn.CreateSecurityGroup(group)
 	if err != nil {
+		err = DecodeError(state, err)
 		ui.Error(err.Error())
 		state.Put("error", err)
 		return multistep.ActionHalt
@@ -98,7 +99,7 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	if err != nil {
-		err := fmt.Errorf("Error creating temporary security group: %s", err)
+		err := fmt.Errorf("Error creating temporary security group: %s", DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -113,7 +114,7 @@ func (s *StepSecurityGroup) Run(state multistep.StateBag) multistep.StepAction {
 	if err == nil {
 		log.Printf("[DEBUG] Found security group %s", s.createdGroupId)
 	} else {
-		err := fmt.Errorf("Timed out waiting for security group %s: %s", s.createdGroupId, err)
+		err := fmt.Errorf("Timed out waiting for security group %s: %s", s.createdGroupId, DecodeError(state, err))
 		log.Printf("[DEBUG] %s", err.Error())
 		state.Put("error", err)
 		return multistep.ActionHalt
@@ -142,7 +143,7 @@ func (s *StepSecurityGroup) Cleanup(state multistep.StateBag) {
 			break
 		}
 
-		log.Printf("Error deleting security group: %s", err)
+		log.Printf("Error deleting security group: %s", DecodeError(state, err))
 		time.Sleep(5 * time.Second)
 	}
 

--- a/builder/amazon/common/step_source_ami_info.go
+++ b/builder/amazon/common/step_source_ami_info.go
@@ -73,7 +73,7 @@ func (s *StepSourceAMIInfo) Run(state multistep.StateBag) multistep.StepAction {
 	log.Printf("Using AMI Filters %v", params)
 	imageResp, err := ec2conn.DescribeImages(params)
 	if err != nil {
-		err := fmt.Errorf("Error querying AMI: %s", err)
+		err := fmt.Errorf("Error querying AMI: %s", DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/common/step_stop_ebs_instance.go
+++ b/builder/amazon/common/step_stop_ebs_instance.go
@@ -65,7 +65,7 @@ func (s *StepStopEBSBackedInstance) Run(state multistep.StateBag) multistep.Step
 		})
 
 		if err != nil {
-			err := fmt.Errorf("Error stopping instance: %s", err)
+			err := fmt.Errorf("Error stopping instance: %s", DecodeError(state, err))
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
@@ -85,7 +85,7 @@ func (s *StepStopEBSBackedInstance) Run(state multistep.StateBag) multistep.Step
 	}
 	_, err = WaitForState(&stateChange)
 	if err != nil {
-		err := fmt.Errorf("Error waiting for instance to stop: %s", err)
+		err := fmt.Errorf("Error waiting for instance to stop: %s", DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -10,6 +10,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sts"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
@@ -83,7 +84,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, err
 	}
 	ec2conn := ec2.New(session)
-
+	stsconn := sts.New(session)
 	// If the subnet is specified but not the VpcId or AZ, try to determine them automatically
 	if b.config.SubnetId != "" && (b.config.AvailabilityZone == "" || b.config.VpcId == "") {
 		log.Printf("[INFO] Finding AZ and VpcId for the given subnet '%s'", b.config.SubnetId)
@@ -105,6 +106,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	state := new(multistep.BasicStateBag)
 	state.Put("config", b.config)
 	state.Put("ec2", ec2conn)
+	state.Put("sts", stsconn)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
 

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sts"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
@@ -97,13 +98,21 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, err
 	}
 	ec2conn := ec2.New(session)
+	stsconn := sts.New(session)
+
+	// Setup the state bag and initial state for the steps
+	state := new(multistep.BasicStateBag)
+	state.Put("sts", stsconn)
+	state.Put("ec2", ec2conn)
+	state.Put("hook", hook)
+	state.Put("ui", ui)
 
 	// If the subnet is specified but not the VpcId or AZ, try to determine them automatically
 	if b.config.SubnetId != "" && (b.config.AvailabilityZone == "" || b.config.VpcId == "") {
 		log.Printf("[INFO] Finding AZ and VpcId for the given subnet '%s'", b.config.SubnetId)
 		resp, err := ec2conn.DescribeSubnets(&ec2.DescribeSubnetsInput{SubnetIds: []*string{&b.config.SubnetId}})
 		if err != nil {
-			return nil, err
+			return nil, awscommon.DecodeError(state, err)
 		}
 		if b.config.AvailabilityZone == "" {
 			b.config.AvailabilityZone = *resp.Subnets[0].AvailabilityZone
@@ -115,12 +124,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		}
 	}
 
-	// Setup the state bag and initial state for the steps
-	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
-	state.Put("ec2", ec2conn)
-	state.Put("hook", hook)
-	state.Put("ui", ui)
 
 	// Build the steps
 	steps := []multistep.Step{

--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -70,7 +70,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Waiting for AMI to become ready...")
 	if _, err := awscommon.WaitForState(&stateChange); err != nil {
-		err := fmt.Errorf("Error waiting for AMI: %s", err)
+		err := fmt.Errorf("Error waiting for AMI: %s", awscommon.DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -78,7 +78,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	imagesResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{registerResp.ImageId}})
 	if err != nil {
-		err := fmt.Errorf("Error searching for AMI: %s", err)
+		err := fmt.Errorf("Error searching for AMI: %s", awscommon.DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
@@ -114,7 +114,7 @@ func (s *StepRegisterAMI) Cleanup(state multistep.StateBag) {
 	ui.Say("Deregistering the AMI because cancellation or error...")
 	deregisterOpts := &ec2.DeregisterImageInput{ImageId: s.image.ImageId}
 	if _, err := ec2conn.DeregisterImage(deregisterOpts); err != nil {
-		ui.Error(fmt.Sprintf("Error deregistering AMI, may still be around: %s", err))
+		ui.Error(fmt.Sprintf("Error deregistering AMI, may still be around: %s", awscommon.DecodeError(state, err)))
 		return
 	}
 }

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sts"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
@@ -168,13 +169,21 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, err
 	}
 	ec2conn := ec2.New(session)
+	stsconn := sts.New(session)
+
+	// Setup the state bag and initial state for the steps
+	state := new(multistep.BasicStateBag)
+	state.Put("ec2", ec2conn)
+	state.Put("sts", stsconn)
+	state.Put("hook", hook)
+	state.Put("ui", ui)
 
 	// If the subnet is specified but not the VpcId or AZ, try to determine them automatically
 	if b.config.SubnetId != "" && (b.config.AvailabilityZone == "" || b.config.VpcId == "") {
 		log.Printf("[INFO] Finding AZ and VpcId for the given subnet '%s'", b.config.SubnetId)
 		resp, err := ec2conn.DescribeSubnets(&ec2.DescribeSubnetsInput{SubnetIds: []*string{&b.config.SubnetId}})
 		if err != nil {
-			return nil, err
+			return nil, awscommon.DecodeError(state, err)
 		}
 		if b.config.AvailabilityZone == "" {
 			b.config.AvailabilityZone = *resp.Subnets[0].AvailabilityZone
@@ -186,12 +195,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		}
 	}
 
-	// Setup the state bag and initial state for the steps
-	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
-	state.Put("ec2", ec2conn)
-	state.Put("hook", hook)
-	state.Put("ui", ui)
 
 	// Build the steps
 	steps := []multistep.Step{

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -45,7 +45,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
 	if err != nil {
-		state.Put("error", fmt.Errorf("Error registering AMI: %s", err))
+		state.Put("error", fmt.Errorf("Error registering AMI: %s", awscommon.DecodeError(state, err)))
 		ui.Error(state.Get("error").(error).Error())
 		return multistep.ActionHalt
 	}
@@ -66,7 +66,7 @@ func (s *StepRegisterAMI) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Waiting for AMI to become ready...")
 	if _, err := awscommon.WaitForState(&stateChange); err != nil {
-		err := fmt.Errorf("Error waiting for AMI: %s", err)
+		err := fmt.Errorf("Error waiting for AMI: %s", awscommon.DecodeError(state, err))
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt


### PR DESCRIPTION
**Main Changes:**
   Add an error-decoding wrapper for the `amazon` builders that attempts to auto-decode any encoded error messages using the `sts:DecodeAuthorizationMessage` api. The net result is that if the role/principal is allowed to `sts:DecodeAuthorizationMessage`, then any encoded messages are auto-decoded and displayed directly in the logs in pretty-printed format.

This saves an extra step normally required to figure out what these cryptic messages mean.

**Before**:
```
Build 'amazon-ebs' errored: Error launching source instance: UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: 223e8OLcgbf297A_d_ySw4S3r167YSVenEb3XfhTAp1OVgX07cQ7mosjhjtbi7J7UfcNolz5RfHJoV5BTeVvh_6GHyItKPRFH5T2nzdd-lQXVuqtrpXJ_7m-7yqLukfX8r2aROrRhuiN0VncsXIgUA5inY7f5nvAsF7nKwA_mIMGi1bnSaruMrbKs_6F_kEUqHJv7oCJXqaozDRuuCarlfHfGiNro9TXdWtXS10sjrvEc6YVycK_nuirwNSYRyu96Pyglr6NjTlTi_KDWaSjvxYmdVWrdFjI6jcP68WAqLjTG6uXYb0UEFv5P8bbOnwUoC5Fdxs4kQ4gUlQtVLAsEvGt3fVYNhh52ptrbf7ZW5kCWiV9GEaumRk45h-By0rvpOCQd1z-OdEhPHb77PXfvHnswTNX5Mr1NhR1CtGbQIh7NbidEbTVhCc5nxov1LHZDSRyKbEviCIGJ9KBpWxUEVh5fYSCtBmgRxkaeTym_eESds8bIwRJ_hbNVtEI0Z9MYPDFUbzxtTquHjAeTFHTedK1WvmTDrrsa6B-xQ5vbTFYyL51Rt7j3FmwMNEl1HwlH_0qJOwO4zXqTpLLgbJ7iIZdnf65T-PqkJz_sIAJZfJXCR3JQr_ncWgblFdLp0gi0xKTQeQmux9Py05wGJ8t0g3qXTbTTWgmMrJNV5fxEPvCfVJediYz1HiivOvvqdm9GS_nnmdEgL5zQQdLQ2tdwToQJveKYOIcuVQ6JuKX9Jd5F15m5OBnj-KH8qiJvAHfMJL_
	status code: 403, request id: f618519f-b16d-4d48-b2bd-85b153563e41
```

**After**:
```
Build 'amazon-ebs' errored: Error launching source instance: UnauthorizedOperation: You are not authorized to perform this operation. Authorization failure message:
{
  "allowed": false,
  "explicitDeny": true,
  "matchedStatements": {
    "items": [
      {
        "statementId": "",
        "effect": "DENY",
        "principals": {
          "items": [
            {
              "value": "xxxxxxxxxx"
            }
          ]
        },
        "principalGroups": {
          "items": []
        },
        "actions": {
          "items": [
            {
              "value": "ec2:RunInstances"
            }
          ]
        },
        "resources": {

...<some details excluded to protect the innocent>...
```
**Note**: There is some discussion about adding this in the upstream, but nothing solid yet:
https://github.com/aws/aws-sdk-go/issues/1536