### PR TITLE
Change EBS builder to do tag-on-creation

### DIFF
--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -152,12 +152,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AvailabilityZone:         b.config.AvailabilityZone,
 			BlockDevices:             b.config.BlockDevices,
 			Tags:                     b.config.RunTags,
+			VolumeTags:               b.config.VolumeRunTags,
 			Ctx:                      b.config.ctx,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
-		},
-		&awscommon.StepTagEBSVolumes{
-			VolumeRunTags: b.config.VolumeRunTags,
-			Ctx:           b.config.ctx,
 		},
 		&awscommon.StepGetPassword{
 			Debug:   b.config.PackerDebug,


### PR DESCRIPTION
The EBS builder will now use the tag-on-creation pattern, so
that it's possible to restrict packer to only create volumes that are
properly tagged by using an AWS policy.

No tests needed, since this only shifts some plumbing around.