### PR TITLE
Fix owner of files uploaded to docker container run as non-root.

### DIFF
--- a/builder/docker/communicator_test.go
+++ b/builder/docker/communicator_test.go
@@ -209,12 +209,12 @@ func TestLargeDownload(t *testing.T) {
 
 }
 
-// TestUploadOwner verifies that owner of uploaded files is the user the container is running as.
-func TestUploadOwner(t *testing.T) {
+// TestFixUploadOwner verifies that owner of uploaded files is the user the container is running as.
+func TestFixUploadOwner(t *testing.T) {
 	ui := packer.TestUi(t)
 	cache := &packer.FileCache{CacheDir: os.TempDir()}
 
-	tpl, err := template.Parse(strings.NewReader(testUploadOwnerTemplate))
+	tpl, err := template.Parse(strings.NewReader(testFixUploadOwnerTemplate))
 	if err != nil {
 		t.Fatalf("Unable to parse config: %s", err)
 	}
@@ -346,7 +346,7 @@ const dockerLargeBuilderConfig = `
 }
 `
 
-const testUploadOwnerTemplate = `
+const testFixUploadOwnerTemplate = `
 {
   "builders": [
     {

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -23,20 +23,21 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 
-	Author       string
-	Changes      []string
-	Commit       bool
-	ContainerDir string `mapstructure:"container_dir"`
-	Discard      bool
-	ExecUser     string `mapstructure:"exec_user"`
-	ExportPath   string `mapstructure:"export_path"`
-	Image        string
-	Message      string
-	Privileged   bool `mapstructure:"privileged"`
-	Pty          bool
-	Pull         bool
-	RunCommand   []string `mapstructure:"run_command"`
-	Volumes      map[string]string
+	Author         string
+	Changes        []string
+	Commit         bool
+	ContainerDir   string `mapstructure:"container_dir"`
+	Discard        bool
+	ExecUser       string `mapstructure:"exec_user"`
+	ExportPath     string `mapstructure:"export_path"`
+	Image          string
+	Message        string
+	Privileged     bool `mapstructure:"privileged"`
+	Pty            bool
+	Pull           bool
+	RunCommand     []string `mapstructure:"run_command"`
+	Volumes        map[string]string
+	FixUploadOwner bool `mapstructure:"fix_upload_owner"`
 
 	// This is used to login to dockerhub to pull a private base container. For
 	// pushing to dockerhub, see the docker post-processors
@@ -53,6 +54,8 @@ type Config struct {
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	c := new(Config)
+
+	c.FixUploadOwner = true
 
 	var md mapstructure.Metadata
 	err := config.Decode(c, &config.DecodeOpts{

--- a/builder/docker/step_connect_docker.go
+++ b/builder/docker/step_connect_docker.go
@@ -1,7 +1,10 @@
 package docker
 
 import (
+	"fmt"
 	"github.com/mitchellh/multistep"
+	"os/exec"
+	"strings"
 )
 
 type StepConnectDocker struct{}
@@ -19,14 +22,21 @@ func (s *StepConnectDocker) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
+	containerUser, err := getContainerUser(containerId)
+	if err != nil {
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
 	// Create the communicator that talks to Docker via various
 	// os/exec tricks.
 	comm := &Communicator{
-		ContainerID:  containerId,
-		HostDir:      tempDir,
-		ContainerDir: config.ContainerDir,
-		Version:      version,
-		Config:       config,
+		ContainerID:   containerId,
+		HostDir:       tempDir,
+		ContainerDir:  config.ContainerDir,
+		Version:       version,
+		Config:        config,
+		ContainerUser: containerUser,
 	}
 
 	state.Put("communicator", comm)
@@ -34,3 +44,16 @@ func (s *StepConnectDocker) Run(state multistep.StateBag) multistep.StepAction {
 }
 
 func (s *StepConnectDocker) Cleanup(state multistep.StateBag) {}
+
+func getContainerUser(containerId string) (string, error) {
+	inspectArgs := []string{"docker", "inspect", "--format", "{{.Config.User}}", containerId}
+	stdout, err := exec.Command(inspectArgs[0], inspectArgs[1:]...).Output()
+	if err != nil {
+		errStr := fmt.Sprintf("Failed to inspect the container: %s", err)
+		if ee, ok := err.(*exec.ExitError); ok {
+			errStr = fmt.Sprintf("%s, %s", errStr, ee.Stderr)
+		}
+		return "", fmt.Errorf(errStr)
+	}
+	return strings.TrimSpace(string(stdout)), nil
+}

--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -211,6 +211,10 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
 -   `container_dir` (string) - The directory inside container to mount
      temp directory from host server for work [file provisioner](/docs/provisioners/file.html).
      By default this is set to `/packer-files`.
+     
+-   `fix_upload_owner` (boolean) - If true, files uploaded to the container will
+    be owned by the user the container is running as. If false, the owner will depend
+    on the version of docker installed in the system. Defaults to true.
 
 ## Using the Artifact: Export
 


### PR DESCRIPTION
Change owner of the files/scripts uploaded to the container, by docker builder, to user the container is running as.

Workaround for #5307 
