### PR TITLE
Fix 4915

### DIFF
--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -104,6 +104,21 @@ func (c *Communicator) uploadReader(dst string, src io.Reader) error {
 
 // uploadFile uses docker cp to copy the file from the host to the container
 func (c *Communicator) uploadFile(dst string, src io.Reader, fi *os.FileInfo) error {
+	// find out if it's a directory
+	testDirectoryCommand := fmt.Sprintf(`test -d "%s"`, dst)
+	cmd := &packer.RemoteCmd{Command: testDirectoryCommand}
+
+	err := c.Start(cmd)
+
+	if err != nil {
+		log.Printf("Unable to check whether remote path is a dir: %s", err)
+		return err
+	}
+	cmd.Wait()
+	if cmd.ExitStatus == 0 {
+		log.Printf("path is a directory; copying file into directory.")
+		dst = filepath.Join(dst, filepath.Base((*fi).Name()))
+	}
 
 	// command format: docker cp /path/to/infile containerid:/path/to/outfile
 	log.Printf("Copying to %s on container %s.", dst, c.ContainerID)

--- a/builder/lxc/communicator.go
+++ b/builder/lxc/communicator.go
@@ -81,7 +81,7 @@ func (c *LxcAttachCommunicator) Upload(dst string, r io.Reader, fi *os.FileInfo)
 			return err
 		}
 		defer os.Remove(adjustedTempName)
-		exitStatus := ShellCommand(mvCmd).Run()
+		ShellCommand(mvCmd).Run()
 		// change cpCmd to use new file name as source
 		cpCmd, err = c.CmdWrapper(fmt.Sprintf("sudo cp %s %s", adjustedTempName, dst))
 		if err != nil {

--- a/builder/lxd/communicator.go
+++ b/builder/lxd/communicator.go
@@ -54,7 +54,24 @@ func (c *Communicator) Start(cmd *packer.RemoteCmd) error {
 }
 
 func (c *Communicator) Upload(dst string, r io.Reader, fi *os.FileInfo) error {
-	cpCmd, err := c.CmdWrapper(fmt.Sprintf("lxc file push - %s", filepath.Join(c.ContainerName, dst)))
+	fileDestination := filepath.Join(c.ContainerName, dst)
+	// find out if the place we are pushing to is a directory
+	testDirectoryCommand := fmt.Sprintf(`test -d "%s"`, dst)
+	cmd := &packer.RemoteCmd{Command: testDirectoryCommand}
+	err := c.Start(cmd)
+
+	if err != nil {
+		log.Printf("Unable to check whether remote path is a dir: %s", err)
+		return err
+	}
+	cmd.Wait()
+
+	if cmd.ExitStatus == 0 {
+		log.Printf("path is a directory; copying file into directory.")
+		fileDestination = filepath.Join(c.ContainerName, dst, (*fi).Name())
+	}
+
+	cpCmd, err := c.CmdWrapper(fmt.Sprintf("lxc file push - %s", fileDestination))
 	if err != nil {
 		return err
 	}

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -377,14 +377,30 @@ func (c *comm) connectToAgent() {
 
 func (c *comm) sftpUploadSession(path string, input io.Reader, fi *os.FileInfo) error {
 	sftpFunc := func(client *sftp.Client) error {
-		return sftpUploadFile(path, input, client, fi)
+		return c.sftpUploadFile(path, input, client, fi)
 	}
 
 	return c.sftpSession(sftpFunc)
 }
 
-func sftpUploadFile(path string, input io.Reader, client *sftp.Client, fi *os.FileInfo) error {
+func (c *comm) sftpUploadFile(path string, input io.Reader, client *sftp.Client, fi *os.FileInfo) error {
 	log.Printf("[DEBUG] sftp: uploading %s", path)
+
+	// find out if destination is a directory (this is to replicate rsync behavior)
+	testDirectoryCommand := fmt.Sprintf(`test -d "%s"`, path)
+	cmd := &packer.RemoteCmd{Command: testDirectoryCommand}
+
+	err := c.Start(cmd)
+
+	if err != nil {
+		log.Printf("Unable to check whether remote path is a dir: %s", err)
+		return err
+	}
+	cmd.Wait()
+	if cmd.ExitStatus == 0 {
+		log.Printf("path is a directory; copying file into directory.")
+		path = filepath.Join(path, filepath.Base((*fi).Name()))
+	}
 
 	f, err := client.Create(path)
 	if err != nil {
@@ -436,7 +452,7 @@ func (c *comm) sftpUploadDirSession(dst string, src string, excl []string) error
 				return nil
 			}
 
-			return sftpVisitFile(finalDst, path, info, client)
+			return c.sftpVisitFile(finalDst, path, info, client)
 		}
 
 		return filepath.Walk(src, walkFunc)
@@ -445,7 +461,7 @@ func (c *comm) sftpUploadDirSession(dst string, src string, excl []string) error
 	return c.sftpSession(sftpFunc)
 }
 
-func sftpMkdir(path string, client *sftp.Client, fi os.FileInfo) error {
+func (c *comm) sftpMkdir(path string, client *sftp.Client, fi os.FileInfo) error {
 	log.Printf("[DEBUG] sftp: creating dir %s", path)
 
 	if err := client.Mkdir(path); err != nil {
@@ -463,16 +479,16 @@ func sftpMkdir(path string, client *sftp.Client, fi os.FileInfo) error {
 	return nil
 }
 
-func sftpVisitFile(dst string, src string, fi os.FileInfo, client *sftp.Client) error {
+func (c *comm) sftpVisitFile(dst string, src string, fi os.FileInfo, client *sftp.Client) error {
 	if !fi.IsDir() {
 		f, err := os.Open(src)
 		if err != nil {
 			return err
 		}
 		defer f.Close()
-		return sftpUploadFile(dst, f, client, &fi)
+		return c.sftpUploadFile(dst, f, client, &fi)
 	} else {
-		err := sftpMkdir(dst, client, fi)
+		err := c.sftpMkdir(dst, client, fi)
 		return err
 	}
 }
@@ -533,7 +549,7 @@ func (c *comm) scpUploadSession(path string, input io.Reader, fi *os.FileInfo) e
 	target_dir := filepath.Dir(path)
 	target_file := filepath.Base(path)
 
-	// find out if it's a directory
+	// find out if destination is a directory (this is to replicate rsync behavior)
 	testDirectoryCommand := fmt.Sprintf(`test -d "%s"`, path)
 	cmd := &packer.RemoteCmd{Command: testDirectoryCommand}
 

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -550,8 +550,6 @@ func (c *comm) scpUploadSession(path string, input io.Reader, fi *os.FileInfo) e
 		target_file = filepath.Base((*fi).Name())
 	}
 
-	log.Printf("target_file was %s", target_file)
-
 	// On windows, filepath.Dir uses backslash seperators (ie. "\tmp").
 	// This does not work when the target host is unix.  Switch to forward slash
 	// which works for unix and windows

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -122,7 +122,7 @@ func runCommand(shell *winrm.Shell, cmd *winrm.Command, rc *packer.RemoteCmd) {
 }
 
 // Upload implementation of communicator.Communicator interface
-func (c *Communicator) Upload(path string, input io.Reader, _ *os.FileInfo) error {
+func (c *Communicator) Upload(path string, input io.Reader, fi *os.FileInfo) error {
 	wcp, err := c.newCopyClient()
 	if err != nil {
 		return err

--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -127,6 +127,23 @@ func (c *Communicator) Upload(path string, input io.Reader, _ *os.FileInfo) erro
 	if err != nil {
 		return err
 	}
+
+	// Get information about destination path
+	endpoint := winrm.NewEndpoint(c.endpoint.Host, c.endpoint.Port, c.config.Https, c.config.Insecure, nil, nil, nil, c.config.Timeout)
+	client, err := winrm.NewClient(endpoint, c.config.Username, c.config.Password)
+	if err != nil {
+		return fmt.Errorf("Was unable to create winrm client: %s", err)
+	}
+	stdout, _, _, err := client.RunWithString(fmt.Sprintf("powershell -Command \"(Get-Item %s) -is [System.IO.DirectoryInfo]\"", path), "")
+	if err != nil {
+		return fmt.Errorf("Couldn't determine whether destination was a folder or file: %s", err)
+	}
+	if strings.Contains(stdout, "True") {
+		// The path exists and is a directory.
+		// Upload file into the directory instead of overwriting.
+		path = filepath.Join(path, filepath.Base((*fi).Name()))
+	}
+
 	log.Printf("Uploading file to '%s'", path)
 	return wcp.Write(path, input)
 }

--- a/communicator/winrm/communicator_test.go
+++ b/communicator/winrm/communicator_test.go
@@ -48,6 +48,12 @@ func newMockWinRMServer(t *testing.T) *winrmtest.Remote {
 		func(out, err io.Writer) int {
 			return 0
 		})
+	wrm.CommandFunc(
+		winrmtest.MatchText(`powershell -Command "(Get-Item C:/Temp/packer.cmd) -is [System.IO.DirectoryInfo]"`),
+		func(out, err io.Writer) int {
+			out.Write([]byte("False"))
+			return 0
+		})
 
 	return wrm
 }


### PR DESCRIPTION
Make file uploads in all communicators behave as rsync would -- if a file myfile.txt is given a destination of /path/to/dir or /path/to/dir/, then it is uploaded to /path/to/dir/myfile.txt 

Previously, when the destination was provided as /path/to/dir without the trailing slash, but the directory already existed, the file upload would behave unpredictably; sometimes failing, sometimes overwriting the directory with a file.

Closes #4915
