### PR TITLE
request to add packerlicious to community tools

### DIFF
--- a/website/source/downloads-community.html.md
+++ b/website/source/downloads-community.html.md
@@ -41,6 +41,8 @@ power of Packer templates.
 
 - [racker](https://github.com/aspring/racker) - an opinionated Ruby DSL for generating Packer templates
 
+- [packerlicious](https://github.com/mayn/packerlicious) - a python library for generating Packer templates
+
 ## Other
 
 - [suitcase](https://github.com/tmclaugh/suitcase) - Packer based build system for CentOS OS images


### PR DESCRIPTION
I'd like you guys to meet packerlicious. A python library for generating packer templates. Why? because packer + python is delicious, and packerlicious was born.

https://github.com/mayn/packerlicious

At minimum please take a peek and drop me some feedback. 

(Not sure what the requirement are to get listed on the community tools page, understand if this doesn't make the cut.).

Thanks!