### PR TITLE
builder/vmware: Add `disable_vnc` option

### DIFF
--- a/builder/vmware/common/run_config.go
+++ b/builder/vmware/common/run_config.go
@@ -8,8 +8,10 @@ import (
 )
 
 type RunConfig struct {
-	Headless    bool   `mapstructure:"headless"`
-	RawBootWait string `mapstructure:"boot_wait"`
+	Headless    bool     `mapstructure:"headless"`
+	RawBootWait string   `mapstructure:"boot_wait"`
+	DisableVNC  bool     `mapstructure:"disable_vnc"`
+	BootCommand []string `mapstructure:"boot_command"`
 
 	VNCBindAddress     string `mapstructure:"vnc_bind_address"`
 	VNCPortMin         uint   `mapstructure:"vnc_port_min"`
@@ -38,6 +40,11 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	var errs []error
 	var err error
+	if len(c.BootCommand) > 0 && c.DisableVNC {
+		errs = append(errs,
+			fmt.Errorf("A boot command cannot be used when vnc is disabled."))
+	}
+
 	if c.RawBootWait != "" {
 		c.BootWait, err = time.ParseDuration(c.RawBootWait)
 		if err != nil {

--- a/builder/vmware/common/step_clean_vmx.go
+++ b/builder/vmware/common/step_clean_vmx.go
@@ -21,6 +21,7 @@ import (
 //   <nothing>
 type StepCleanVMX struct {
 	RemoveEthernetInterfaces bool
+	SkipVNCDisable           bool
 }
 
 func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
@@ -59,8 +60,10 @@ func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
 		vmxData[ide+"clientdevice"] = "TRUE"
 	}
 
-	ui.Message("Disabling VNC server...")
-	vmxData["remotedisplay.vnc.enabled"] = "FALSE"
+	if !s.SkipVNCDisable {
+		ui.Message("Disabling VNC server...")
+		vmxData["remotedisplay.vnc.enabled"] = "FALSE"
+	}
 
 	if s.RemoveEthernetInterfaces {
 		ui.Message("Removing Ethernet Interfaces...")

--- a/builder/vmware/common/step_clean_vmx.go
+++ b/builder/vmware/common/step_clean_vmx.go
@@ -21,7 +21,7 @@ import (
 //   <nothing>
 type StepCleanVMX struct {
 	RemoveEthernetInterfaces bool
-	SkipVNCDisable           bool
+	VNCEnabled               bool
 }
 
 func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
@@ -60,7 +60,7 @@ func (s StepCleanVMX) Run(state multistep.StateBag) multistep.StepAction {
 		vmxData[ide+"clientdevice"] = "TRUE"
 	}
 
-	if !s.SkipVNCDisable {
+	if s.VNCEnabled {
 		ui.Message("Disabling VNC server...")
 		vmxData["remotedisplay.vnc.enabled"] = "FALSE"
 	}

--- a/builder/vmware/common/step_configure_vnc.go
+++ b/builder/vmware/common/step_configure_vnc.go
@@ -21,7 +21,7 @@ import (
 // Produces:
 //   vnc_port uint - The port that VNC is configured to listen on.
 type StepConfigureVNC struct {
-	Skip               bool
+	Enabled            bool
 	VNCBindAddress     string
 	VNCPortMin         uint
 	VNCPortMax         uint
@@ -77,7 +77,7 @@ func VNCPassword(skipPassword bool) string {
 }
 
 func (s *StepConfigureVNC) Run(state multistep.StateBag) multistep.StepAction {
-	if s.Skip {
+	if !s.Enabled {
 		log.Println("Skipping VNC configuration step...")
 		return multistep.ActionContinue
 	}

--- a/builder/vmware/common/step_configure_vnc.go
+++ b/builder/vmware/common/step_configure_vnc.go
@@ -21,6 +21,7 @@ import (
 // Produces:
 //   vnc_port uint - The port that VNC is configured to listen on.
 type StepConfigureVNC struct {
+	Skip               bool
 	VNCBindAddress     string
 	VNCPortMin         uint
 	VNCPortMax         uint
@@ -76,6 +77,11 @@ func VNCPassword(skipPassword bool) string {
 }
 
 func (s *StepConfigureVNC) Run(state multistep.StateBag) multistep.StepAction {
+	if s.Skip {
+		log.Println("Skipping VNC configuration step...")
+		return multistep.ActionContinue
+	}
+
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 	vmxPath := state.Get("vmx_path").(string)

--- a/builder/vmware/common/step_run.go
+++ b/builder/vmware/common/step_run.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/packer/packer"
 	"github.com/mitchellh/multistep"
-	"time"
 )
 
 // This step runs the created virtual machine.

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -39,9 +39,15 @@ type StepTypeBootCommand struct {
 	BootCommand []string
 	VMName      string
 	Ctx         interpolate.Context
+	Skip        bool
 }
 
 func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction {
+	if s.Skip {
+		log.Println("Skipping boot command step...")
+		return multistep.ActionContinue
+	}
+
 	debug := state.Get("debug").(bool)
 	driver := state.Get("driver").(Driver)
 	httpPort := state.Get("http_port").(uint)

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -36,14 +36,14 @@ type bootCommandTemplateData struct {
 // Produces:
 //   <nothing>
 type StepTypeBootCommand struct {
+	VNCEnabled  bool
 	BootCommand []string
 	VMName      string
 	Ctx         interpolate.Context
-	Skip        bool
 }
 
 func (s *StepTypeBootCommand) Run(state multistep.StateBag) multistep.StepAction {
-	if s.Skip {
+	if !s.VNCEnabled {
 		log.Println("Skipping boot command step...")
 		return multistep.ActionContinue
 	}

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -259,6 +259,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			HTTPPortMax: b.config.HTTPPortMax,
 		},
 		&vmwcommon.StepConfigureVNC{
+			Skip:               b.config.BootCommand == nil,
 			VNCBindAddress:     b.config.VNCBindAddress,
 			VNCPortMin:         b.config.VNCPortMin,
 			VNCPortMax:         b.config.VNCPortMax,
@@ -273,6 +274,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Headless:           b.config.Headless,
 		},
 		&vmwcommon.StepTypeBootCommand{
+			Skip:        b.config.BootCommand == nil,
 			BootCommand: b.config.BootCommand,
 			VMName:      b.config.VMName,
 			Ctx:         b.config.ctx,
@@ -303,6 +305,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&vmwcommon.StepCleanVMX{
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
+			SkipVNCDisable:           b.config.BootCommand == nil,
 		},
 		&StepUploadVMX{
 			RemoteType: b.config.RemoteType,

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -311,7 +311,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&vmwcommon.StepCleanVMX{
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
-			SkipVNCDisable:           b.config.DisableVNC,
+			VNCEnabled:               !b.config.DisableVNC,
 		},
 		&StepUploadVMX{
 			RemoteType: b.config.RemoteType,

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -80,6 +80,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			HTTPPortMax: b.config.HTTPPortMax,
 		},
 		&vmwcommon.StepConfigureVNC{
+			Enabled:            !b.config.DisableVNC,
 			VNCBindAddress:     b.config.VNCBindAddress,
 			VNCPortMin:         b.config.VNCPortMin,
 			VNCPortMax:         b.config.VNCPortMax,
@@ -91,6 +92,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Headless:           b.config.Headless,
 		},
 		&vmwcommon.StepTypeBootCommand{
+			VNCEnabled:  !b.config.DisableVNC,
 			BootCommand: b.config.BootCommand,
 			VMName:      b.config.VMName,
 			Ctx:         b.config.ctx,
@@ -121,6 +123,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&vmwcommon.StepCleanVMX{
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
+			SkipVNCDisable:           b.config.DisableVNC,
 		},
 	}
 

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -123,7 +123,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&vmwcommon.StepCleanVMX{
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,
-			SkipVNCDisable:           b.config.DisableVNC,
+			VNCEnabled:               !b.config.DisableVNC,
 		},
 	}
 

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -24,11 +24,10 @@ type Config struct {
 	vmwcommon.ToolsConfig    `mapstructure:",squash"`
 	vmwcommon.VMXConfig      `mapstructure:",squash"`
 
-	BootCommand    []string `mapstructure:"boot_command"`
-	RemoteType     string   `mapstructure:"remote_type"`
-	SkipCompaction bool     `mapstructure:"skip_compaction"`
-	SourcePath     string   `mapstructure:"source_path"`
-	VMName         string   `mapstructure:"vm_name"`
+	RemoteType     string `mapstructure:"remote_type"`
+	SkipCompaction bool   `mapstructure:"skip_compaction"`
+	SourcePath     string `mapstructure:"source_path"`
+	VMName         string `mapstructure:"vm_name"`
 
 	ctx interpolate.Context
 }
@@ -82,6 +81,12 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		warnings = append(warnings,
 			"A shutdown_command was not specified. Without a shutdown command, Packer\n"+
 				"will forcibly halt the virtual machine, which may result in data loss.")
+	}
+
+	if c.Headless && c.DisableVNC {
+		warnings = append(warnings,
+			"Headless mode uses VNC to retrieve output. Since VNC has been disabled,\n"+
+				"you won't be able to see any output.")
 	}
 
 	// Check for any errors.

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -114,6 +114,9 @@ builder.
     User's Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
     VMware clients. For ESXi, refer to the proper ESXi documentation.
 
+*   `disable_vnc` (bool) - Whether to create a VNC connection or not.
+    A `boot_command` cannot be used when this is `false`. Defaults to `false`.
+
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for
     unattended Windows installs, which look for an `Autounattend.xml` file on
@@ -446,10 +449,11 @@ various files locally, and uploads these to the remote machine. Packer currently
 uses SSH to communicate to the ESXi machine rather than the vSphere API. At some
 point, the vSphere API may be used.
 
-Packer also requires VNC if issuing boot commands during a build, which may be
+Packer also requires VNC to issue boot commands during a build, which may be
 disabled on some remote VMware Hypervisors. Please consult the appropriate
 documentation on how to update VMware Hypervisor's firewall to allow these
-connections.
+connections. VNC can be disabled by not setting a `boot_command` and setting
+`disable_vnc` to `true`.
 
 To use a remote VMware vSphere Hypervisor to build your virtual machine, fill in
 the required `remote_*` configurations:
@@ -481,8 +485,8 @@ modify as well:
 
 -   `format` (string) - Either "ovf", "ova" or "vmx", this specifies the output
     format of the exported virtual machine. This defaults to "ovf".
-    Before using this option, you need to install `ovftool`. This option 
-	works currently only with option remote_type set to "esx5".
+    Before using this option, you need to install `ovftool`. This option
+    works currently only with option remote_type set to "esx5".
 
 ### VNC port discovery
 

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -446,7 +446,7 @@ various files locally, and uploads these to the remote machine. Packer currently
 uses SSH to communicate to the ESXi machine rather than the vSphere API. At some
 point, the vSphere API may be used.
 
-Packer also requires VNC to issue boot commands during a build, which may be
+Packer also requires VNC if issuing boot commands during a build, which may be
 disabled on some remote VMware Hypervisors. Please consult the appropriate
 documentation on how to update VMware Hypervisor's firewall to allow these
 connections.

--- a/website/source/docs/builders/vmware-vmx.html.md
+++ b/website/source/docs/builders/vmware-vmx.html.md
@@ -71,6 +71,9 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is 10 seconds.
 
+*   `disable_vnc` (bool) - Whether to create a VNC connection or not.
+    A `boot_command` cannot be used when this is `false`. Defaults to `false`.
+
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for
     unattended Windows installs, which look for an `Autounattend.xml` file on


### PR DESCRIPTION
this replaces #5367 

Adds a new option to the vnc builders to control whether a vnc connection is made. Cannot be used when `boot_command` is given.

A few things to think about:

* I moved `BootCommand` under runconfig
* is `enable_vnc` a good name? It doesn't get grouped with the other vnc option in the docs, and it could be confusing the way it's used in the builder, because I do stuff like:
```
&StepXYZ{
    SkipVNC: !config.EnableVNC,
}
```