### PR TITLE
Add `/downloads.html` to the outdated version message

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -62,7 +62,7 @@ func (c *VersionCommand) Run(args []string) int {
 		if info.Outdated {
 			c.Ui.Say(fmt.Sprintf(
 				"\nYour version of Packer is out of date! The latest version\n"+
-					"is %s. You can update by downloading from www.packer.io",
+					"is %s. You can update by downloading from www.packer.io/downloads.html",
 				info.Latest))
 		}
 	}


### PR DESCRIPTION
I thought it would be more helpful if the message pointed directly to the downloads page.

Also made this change to terraform