### PR TITLE
Some fixes and changes for latest example docs

### DIFF
--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -201,7 +201,7 @@ how to validate and build templates into machine images.
 
 ## Some more examples:
 
-### Another Linux Example, with provisioners:
+### Another GNU/Linux Example, with provisioners:
 Create a file named `welcome.txt` and add the following:
 
 ```
@@ -319,7 +319,7 @@ amazon-ebs output will be in this color.
 
 ### A Windows Example
 
-As with the Linux example above, should you decide to follow along and
+As with the GNU/Linux example above, should you decide to follow along and
 build an AMI from the example template, provided you qualify for free tier
 usage, you should not be charged for actually building the AMI.
 However, please note that you will be charged for storage of the snapshot

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -513,5 +513,25 @@ us-east-1: ami-100fc56a
 
 And if you navigate to your EC2 dashboard you should see your shiny new AMI.
 
+Why stop there though?
+
+As you'll see, with one simple change to the template above, it's
+just as easy to create your own Windows 2008 or Windows 2016 AMIs. Just
+set the value for the name field within `source_ami_filter` as required:
+
+For Windows 2008 SP2:
+
+```
+          "name": "*Windows_Server-2008-SP2*English-64Bit-Base*",
+```
+
+For Windows 2016:
+
+```
+          "name": "*Windows_Server-2016-English-Full-Base*",
+```
+
+The bootstrapping and sample provisioning should work the same across all
+Windows server versions.
 
 [platforms]: /docs/builders/index.html

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -319,11 +319,17 @@ amazon-ebs output will be in this color.
 
 ### A Windows Example
 
-Note that this uses a larger instance. You will be charged for it. Also keep
-in mind that using windows AMIs incurs a fee that you don't get when you use
-linux AMIs.
+As with the Linux example above, should you decide to follow along and
+build an AMI from the example template, provided you qualify for free tier
+usage, you should not be charged for actually building the AMI.
+However, please note that you will be charged for storage of the snapshot
+associated with any AMI that you create.
+If you wish to avoid further charges, follow the steps in the [Managing the
+Image](/intro/getting-started/build-image.html#managing-the-image) section
+above to deregister the created AMI and delete the associated snapshot once
+you're done.
 
-You'll need to have a boostrapping file to enable ssh or winrm; here's a basic
+You'll need to have a bootstrapping file to enable ssh or winrm; here's a basic
 example of that file.
 
 ```powershell
@@ -398,11 +404,11 @@ windows in addition to the powershell and windows-restart provisioners:
       "access_key": "{{ user `aws_access_key` }}",
       "secret_key": "{{ user `aws_secret_key` }}",
       "region": "us-east-1",
-      "instance_type": "m3.medium",
+      "instance_type": "t2.micro",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "*WindowsServer2012R2*",
+          "name": "*Windows_Server-2012-R2*English-64Bit-Base*",
           "root-device-type": "ebs"
         },
         "most_recent": true,

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -338,9 +338,6 @@ example of that file.
 net user Administrator SuperS3cr3t!
 wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE
 
-# Turn off PowerShell execution policy restrictions
-Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope LocalMachine
-
 # First, make sure WinRM can't be connected to
 netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=block
 

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -450,6 +450,14 @@ windows in addition to the powershell and windows-restart provisioners:
 }
 ```
 
+Set your access key and id as environment variables, so we don't need to pass
+them in through the command line:
+
+```
+export AWS_ACCESS_KEY_ID=MYACCESSKEYID
+export AWS_SECRET_ACCESS_KEY=MYSECRETACCESSKEY
+```
+
 Then `packer build firstrun.json`
 
 You should see output like this:

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -408,6 +408,29 @@ Start-Service -Name WinRM
 
 Save the above code in a file named `bootstrap_win.txt`.
 
+-> **A quick aside/warning:**  
+Windows administrators in the know might be wondering why we haven't simply
+used a `winrm quickconfig -q` command in the script above, as this would
+*automatically* set up all of the required elements necessary for connecting
+over WinRM. Why all the extra effort to configure things manually?  
+Well, long and short, use of the `winrm quickconfig -q` command can sometimes
+cause the Packer build to fail shortly after the WinRM connection is
+established. How?  
+1. Among other things, as well as setting up the listener for WinRM, the
+quickconfig command also configures the firewall to allow management messages
+to be sent over HTTP.  
+2. This undoes the previous command in the script that configured the
+firewall to prevent this access.  
+3. The upshot is that the system is configured and ready to accept WinRM
+connections earlier than intended.    
+4. If Packer establishes its WinRM connection immediately after execution of
+the 'winrm quickconfig -q' command, the later commands within the script that
+restart the WinRM service will unceremoniously pull the rug out from under
+the connection.  
+5. While Packer does *a lot* to ensure the stability of its connection in to
+your instance, this sort of abuse can prove to be too much and *may* cause
+your Packer build to stall irrecoverably or fail!
+
 Now we've got the business of getting Packer connected to our instance
 taken care of, let's get on with the *real* reason we're doing all this,
 which is actually configuring and customizing the instance. Again, we do this

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -407,7 +407,7 @@ windows in addition to the powershell and windows-restart provisioners:
       "type": "amazon-ebs",
       "access_key": "{{ user `aws_access_key` }}",
       "secret_key": "{{ user `aws_secret_key` }}",
-      "region": "us-east-1",
+      "region": "{{ user `region` }}",
       "instance_type": "t2.micro",
       "source_ami_filter": {
         "filters": {

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -370,14 +370,15 @@ Here's an example of a `sample_script.ps1` that will work with the environment
 variables we will set in our packer config; copy the contents into your own
 `sample_script.ps1` and provide the path to it in your packer config:
 
-```
-Write-Output("PACKER_BUILD_NAME is automatically set for you,)
-Write-Output("or you can set it in your builder variables; )
-Write-Output("the default for this builder is: " + $Env:PACKER_BUILD_NAME )
-Write-Output("Remember that escaping variables in powershell requires backticks: )
-Write-Output("for example, VAR1 from our config is " + $Env:VAR1 )
-Write-Output("Likewise, VAR2 is " + $Env:VAR2 )
-Write-Output("and VAR3 is " + $Env:VAR3 )
+```powershell
+Write-Host "PACKER_BUILD_NAME is automatically set for you, " -NoNewline
+Write-Host "or you can set it in your builder variables; " -NoNewline
+Write-Host "The default for this builder is:" $Env:PACKER_BUILD_NAME
+
+Write-Host "Use backticks as the escape character when required in powershell:"
+Write-Host "For example, VAR1 from our config is:" $Env:VAR1
+Write-Host "Likewise, VAR2 is:" $Env:VAR2
+Write-Host "Finally, VAR3 is:" $Env:VAR3
 ```
 
 Next you need to create a packer config that will use this bootstrap file. See
@@ -418,7 +419,7 @@ windows in addition to the powershell and windows-restart provisioners:
     {
       "type": "powershell",
       "environment_vars": ["DEVOPS_LIFE_IMPROVER=PACKER"],
-      "inline": "Write-Output(\"HELLO NEW USER; WELCOME TO $Env:DEVOPS_LIFE_IMPROVER\")"
+      "inline": "Write-Host \"HELLO NEW USER; WELCOME TO $Env:DEVOPS_LIFE_IMPROVER\""
     },
     {
       "type": "windows-restart"

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -457,38 +457,39 @@ You should see output like this:
 ```
 amazon-ebs output will be in this color.
 
-==> amazon-ebs: Prevalidating AMI Name: packer-demo-1507234504
-    amazon-ebs: Found Image ID: ami-d79776ad
-==> amazon-ebs: Creating temporary keypair: packer_59d692c8-81f9-6a15-2502-0ca730980bed
-==> amazon-ebs: Creating temporary security group for this instance: packer_59d692f0-dd01-6879-d8f8-7765327f5365
-==> amazon-ebs: Authorizing access to port 5985 on the temporary security group...
+==> amazon-ebs: Prevalidating AMI Name: packer-demo-1507933843
+    amazon-ebs: Found Image ID: ami-23d93c59
+==> amazon-ebs: Creating temporary keypair: packer_59e13e94-203a-1bca-5327-bebf0d5ad15a
+==> amazon-ebs: Creating temporary security group for this instance: packer_59e13ea9-3220-8dab-29c0-ed7f71e221a1
+==> amazon-ebs: Authorizing access to port 5985 from 0.0.0.0/0 in the temporary security group...
 ==> amazon-ebs: Launching a source AWS instance...
 ==> amazon-ebs: Adding tags to source instance
     amazon-ebs: Adding tag: "Name": "Packer Builder"
-    amazon-ebs: Instance ID: i-04467596029d0a2ff
-==> amazon-ebs: Waiting for instance (i-04467596029d0a2ff) to become ready...
+    amazon-ebs: Instance ID: i-0349406ac85f02166
+==> amazon-ebs: Waiting for instance (i-0349406ac85f02166) to become ready...
 ==> amazon-ebs: Skipping waiting for password since WinRM password set...
 ==> amazon-ebs: Waiting for WinRM to become available...
     amazon-ebs: WinRM connected.
 ==> amazon-ebs: Connected to WinRM!
 ==> amazon-ebs: Provisioning with Powershell...
-==> amazon-ebs: Provisioning with powershell script: /var/folders/8t/0yb5q0_x6mb2jldqq_vjn3lr0000gn/T/packer-powershell-provisioner079851514
+==> amazon-ebs: Provisioning with powershell script: /var/folders/15/d0f7gdg13rnd1cxp7tgmr55c0000gn/T/packer-powershell-provisioner175214995
     amazon-ebs: HELLO NEW USER; WELCOME TO PACKER
 ==> amazon-ebs: Restarting Machine
 ==> amazon-ebs: Waiting for machine to restart...
-    amazon-ebs: WIN-164614OO21O restarted.
+    amazon-ebs: WIN-TEM0TDL751M restarted.
 ==> amazon-ebs: Machine successfully restarted, moving on
 ==> amazon-ebs: Provisioning with Powershell...
-==> amazon-ebs: Provisioning with powershell script: ./scripts/sample_script.ps1
-    amazon-ebs: PACKER_BUILD_NAME is automatically set for you, or you can set it in your builder variables; the default for this builder is: amazon-ebs
-    amazon-ebs: Remember that escaping variables in powershell requires backticks; for example VAR1 from our config is A$Dollar
-    amazon-ebs: Likewise, VAR2 is A`Backtick
-    amazon-ebs: and VAR3 is A'SingleQuote
+==> amazon-ebs: Provisioning with powershell script: ./sample_script.ps1
+    amazon-ebs: PACKER_BUILD_NAME is automatically set for you, or you can set it in your builder variables; The default for this builder is: amazon-ebs
+    amazon-ebs: Use backticks as the escape character when required in powershell:
+    amazon-ebs: For example, VAR1 from our config is: A$Dollar
+    amazon-ebs: Likewise, VAR2 is: A`Backtick
+    amazon-ebs: Finally, VAR3 is: A'SingleQuote
 ==> amazon-ebs: Stopping the source instance...
     amazon-ebs: Stopping instance, attempt 1
 ==> amazon-ebs: Waiting for the instance to stop...
-==> amazon-ebs: Creating the AMI: packer-demo-1507234504
-    amazon-ebs: AMI: ami-2970b753
+==> amazon-ebs: Creating the AMI: packer-demo-1507933843
+    amazon-ebs: AMI: ami-100fc56a
 ==> amazon-ebs: Waiting for AMI to become ready...
 ==> amazon-ebs: Terminating the source AWS instance...
 ==> amazon-ebs: Cleaning up any extra volumes...
@@ -499,7 +500,7 @@ Build 'amazon-ebs' finished.
 
 ==> Builds finished. The artifacts of successful builds are:
 --> amazon-ebs: AMIs were created:
-us-east-1: ami-2970b753
+us-east-1: ami-100fc56a
 ```
 
 And if you navigate to your EC2 dashboard you should see your shiny new AMI.

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -327,6 +327,7 @@ You'll need to have a boostrapping file to enable ssh or winrm; here's a basic
 example of that file.
 
 ```powershell
+<powershell>
 # set administrator password
 net user Administrator SuperS3cr3t!
 wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE
@@ -353,6 +354,7 @@ set-service winrm -startupType automatic
 # Finally, allow WinRM connections and start the service
 netsh advfirewall firewall set rule name="WinRM" new action=allow
 net start winrm
+</powershell>
 ```
 
 

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -12,7 +12,7 @@ description: |-
 # Build an Image
 
 With Packer installed, let's just dive right into it and build our first image.
-Our first image will be an [Amazon EC2 AMI](https://aws.amazon.com/ec2/) 
+Our first image will be an [Amazon EC2 AMI](https://aws.amazon.com/ec2/).
 This is just an example. Packer can create images for [many platforms][platforms].
 
 If you don't have an AWS account, [create one now](https://aws.amazon.com/free/).
@@ -160,7 +160,7 @@ typically represent an ID (such as in the case of an AMI) or a set of files
 (such as for a VMware virtual machine). In this example, we only have a single
 artifact: the AMI in us-east-1 that was created.
 
-This AMI is ready to use. If you wanted you could go and launch this AMI right 
+This AMI is ready to use. If you wanted you could go and launch this AMI right
 now and it would work great.
 
 -> **Note:** Your AMI ID will surely be different than the one above. If you
@@ -203,18 +203,21 @@ how to validate and build templates into machine images.
 
 ### Another Linux Example, with provisioners:
 Create a file named `welcome.txt` and add the following:
+
 ```
 WELCOME TO PACKER!
 ```
 
 Create a file named `example.sh` and add the following:
-```
+
+```bash
 #!/bin/bash
-echo "hello
+echo "hello"
 ```
 
-Set your access key and id as environment variables, so we don't need to pass 
+Set your access key and id as environment variables, so we don't need to pass
 them in through the command line:
+
 ```
 export AWS_ACCESS_KEY_ID=MYACCESSKEYID
 export AWS_SECRET_ACCESS_KEY=MYSECRETACCESSKEY
@@ -222,7 +225,7 @@ export AWS_SECRET_ACCESS_KEY=MYSECRETACCESSKEY
 
 Now save the following text in a file named `firstrun.json`:
 
-```
+```json
 {
     "variables": {
         "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
@@ -272,10 +275,10 @@ Now save the following text in a file named `firstrun.json`:
 
 and to build, run `packer build firstrun.json`
 
-Note that if you wanted to use a `source_ami` instead of a `source_ami_filter` 
+Note that if you wanted to use a `source_ami` instead of a `source_ami_filter`
 it might look something like this: `"source_ami": "ami-fce3c696",`
 
-Your output will look like this: 
+Your output will look like this:
 
 ```
 amazon-ebs output will be in this color.
@@ -314,16 +317,16 @@ amazon-ebs output will be in this color.
 ==> amazon-ebs: Waiting for AMI to become ready...
 ```
 
-### A windows example
+### A Windows Example
 
-Note that this uses a larger instance.  You will be charged for it. Also keep 
-in mind that using windows AMIs incurs a fee that you don't get when you use 
+Note that this uses a larger instance. You will be charged for it. Also keep
+in mind that using windows AMIs incurs a fee that you don't get when you use
 linux AMIs.
 
-You'll need to have a boostrapping file to enable ssh or winrm; here's a basic 
+You'll need to have a boostrapping file to enable ssh or winrm; here's a basic
 example of that file.
 
-```
+```powershell
 # set administrator password
 net user Administrator SuperS3cr3t!
 wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE
@@ -353,16 +356,16 @@ net start winrm
 ```
 
 
-Save the above code in a file named `bootstrap_win.txt`.  
+Save the above code in a file named `bootstrap_win.txt`.
 
-The example config below shows the two different ways of using the powershell 
-provisioner: `inline` and `script`.  
-The first example, `inline`, allows you to provide short snippets of code, and 
-will create the script file for you.  The second example allows you to run more 
-complex code by providing the path to a script to run on the guest vm.  
+The example config below shows the two different ways of using the powershell
+provisioner: `inline` and `script`.
+The first example, `inline`, allows you to provide short snippets of code, and
+will create the script file for you.  The second example allows you to run more
+complex code by providing the path to a script to run on the guest vm.
 
-Here's an example of a `sample_script.ps1` that will work with the environment 
-variables we will set in our packer config; copy the contents into your own 
+Here's an example of a `sample_script.ps1` that will work with the environment
+variables we will set in our packer config; copy the contents into your own
 `sample_script.ps1` and provide the path to it in your packer config:
 
 ```
@@ -375,39 +378,40 @@ Write-Output("Likewise, VAR2 is " + $Env:VAR2 )
 Write-Output("and VAR3 is " + $Env:VAR3 )
 ```
 
-Next you need to create a packer config that will use this bootstrap file. See 
-the example below, which contains examples of using source_ami_filter for 
+Next you need to create a packer config that will use this bootstrap file. See
+the example below, which contains examples of using source_ami_filter for
 windows in addition to the powershell and windows-restart provisioners:
 
-```
+```json
 {
   "variables": {
-        "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-        "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-        "region":         "us-east-1"
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "region":         "us-east-1"
   },
   "builders": [
-  {
-    "type": "amazon-ebs",
-    "access_key": "{{ user `aws_access_key` }}",
-    "secret_key": "{{ user `aws_secret_key` }}",
-    "region": "us-east-1",
-    "instance_type": "m3.medium",
-    "source_ami_filter": {
-      "filters": {
-        "virtualization-type": "hvm",
-        "name": "*WindowsServer2012R2*",
-        "root-device-type": "ebs"
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{ user `aws_access_key` }}",
+      "secret_key": "{{ user `aws_secret_key` }}",
+      "region": "us-east-1",
+      "instance_type": "m3.medium",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "*WindowsServer2012R2*",
+          "root-device-type": "ebs"
+        },
+        "most_recent": true,
+        "owners": "amazon"
       },
-      "most_recent": true,
-      "owners": "amazon"
-    },    
-    "ami_name": "packer-demo-{{timestamp}}",
-    "user_data_file": "./bootstrap_win.txt",
-    "communicator": "winrm",
-    "winrm_username": "Administrator",
-    "winrm_password": "SuperS3cr3t!"
-  }],
+      "ami_name": "packer-demo-{{timestamp}}",
+      "user_data_file": "./bootstrap_win.txt",
+      "communicator": "winrm",
+      "winrm_username": "Administrator",
+      "winrm_password": "SuperS3cr3t!"
+    }
+  ],
   "provisioners": [
     {
       "type": "powershell",


### PR DESCRIPTION
Fixes and changes (mainly) for new Amazon Windows build examples from #5427.

This follows on from the discussions and initial (unsuccessful) attempts I made at changing scripts in that PR. I've now figured out why the changes weren't working on AWS - sorry @SwampDragons for any pain I caused there!
The examples are now *definitely* working with all the changes - for quick reference see the templates and scripts I used to test with [here](https://github.com/DanHam/packer-testing/tree/master/aws/windows).

The changes go a bit beyond the discussion in #5427... I guess I got a bit carried away as I was working through the examples so feel free to chop and change as required.