### PR TITLE
Hyper-V builder: Add support for differencing disk

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -64,7 +64,7 @@ type Driver interface {
 
 	DeleteVirtualSwitch(string) error
 
-	CreateVirtualMachine(string, string, string, string, int64, int64, string, uint) error
+	CreateVirtualMachine(string, string, string, string, int64, int64, string, uint, bool) error
 
 	AddVirtualMachineHardDrive(string, string, string, int64, string) error
 

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -110,16 +110,17 @@ type DriverMock struct {
 	AddVirtualMachineHardDrive_ControllerType string
 	AddVirtualMachineHardDrive_Err            error
 
-	CreateVirtualMachine_Called        bool
-	CreateVirtualMachine_VmName        string
-	CreateVirtualMachine_Path          string
-	CreateVirtualMachine_HarddrivePath string
-	CreateVirtualMachine_VhdPath       string
-	CreateVirtualMachine_Ram           int64
-	CreateVirtualMachine_DiskSize      int64
-	CreateVirtualMachine_SwitchName    string
-	CreateVirtualMachine_Generation    uint
-	CreateVirtualMachine_Err           error
+	CreateVirtualMachine_Called           bool
+	CreateVirtualMachine_VmName           string
+	CreateVirtualMachine_Path             string
+	CreateVirtualMachine_HarddrivePath    string
+	CreateVirtualMachine_VhdPath          string
+	CreateVirtualMachine_Ram              int64
+	CreateVirtualMachine_DiskSize         int64
+	CreateVirtualMachine_SwitchName       string
+	CreateVirtualMachine_Generation       uint
+	CreateVirtualMachine_DifferentialDisk bool
+	CreateVirtualMachine_Err              error
 
 	CloneVirtualMachine_Called                bool
 	CloneVirtualMachine_CloneFromVmxcPath     string
@@ -374,7 +375,7 @@ func (d *DriverMock) AddVirtualMachineHardDrive(vmName string, vhdFile string, v
 	return d.AddVirtualMachineHardDrive_Err
 }
 
-func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdPath string, ram int64, diskSize int64, switchName string, generation uint) error {
+func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdPath string, ram int64, diskSize int64, switchName string, generation uint, diffDisks bool) error {
 	d.CreateVirtualMachine_Called = true
 	d.CreateVirtualMachine_VmName = vmName
 	d.CreateVirtualMachine_Path = path
@@ -384,6 +385,7 @@ func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddriveP
 	d.CreateVirtualMachine_DiskSize = diskSize
 	d.CreateVirtualMachine_SwitchName = switchName
 	d.CreateVirtualMachine_Generation = generation
+	d.CreateVirtualMachine_DifferentialDisk = diffDisks
 	return d.CreateVirtualMachine_Err
 }
 

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -174,8 +174,8 @@ func (d *HypervPS4Driver) AddVirtualMachineHardDrive(vmName string, vhdFile stri
 	return hyperv.AddVirtualMachineHardDiskDrive(vmName, vhdFile, vhdName, vhdSizeBytes, controllerType)
 }
 
-func (d *HypervPS4Driver) CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdPath string, ram int64, diskSize int64, switchName string, generation uint) error {
-	return hyperv.CreateVirtualMachine(vmName, path, harddrivePath, vhdPath, ram, diskSize, switchName, generation)
+func (d *HypervPS4Driver) CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdPath string, ram int64, diskSize int64, switchName string, generation uint, diffDisks bool) error {
+	return hyperv.CreateVirtualMachine(vmName, path, harddrivePath, vhdPath, ram, diskSize, switchName, generation, diffDisks)
 }
 
 func (d *HypervPS4Driver) CloneVirtualMachine(cloneFromVmxcPath string, cloneFromVmName string, cloneFromSnapshotName string, cloneAllSnapshots bool, vmName string, path string, harddrivePath string, ram int64, switchName string) error {

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -27,6 +27,7 @@ type StepCreateVM struct {
 	EnableSecureBoot               bool
 	EnableVirtualizationExtensions bool
 	AdditionalDiskSize             []uint
+	DifferencingDisk               bool
 }
 
 func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
@@ -54,7 +55,7 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 	ramSize := int64(s.RamSize * 1024 * 1024)
 	diskSize := int64(s.DiskSize * 1024 * 1024)
 
-	err := driver.CreateVirtualMachine(s.VMName, path, harddrivePath, vhdPath, ramSize, diskSize, s.SwitchName, s.Generation)
+	err := driver.CreateVirtualMachine(s.VMName, path, harddrivePath, vhdPath, ramSize, diskSize, s.SwitchName, s.Generation, s.DifferencingDisk)
 	if err != nil {
 		err := fmt.Errorf("Error creating virtual machine: %s", err)
 		state.Put("error", err)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -94,6 +94,9 @@ type Config struct {
 
 	SkipCompaction bool `mapstructure:"skip_compaction"`
 
+	// Use differencing disk
+	DifferencingDisk bool `mapstructure:"differencing_disk"`
+
 	ctx interpolate.Context
 }
 
@@ -353,6 +356,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			EnableSecureBoot:               b.config.EnableSecureBoot,
 			EnableVirtualizationExtensions: b.config.EnableVirtualizationExtensions,
 			AdditionalDiskSize:             b.config.AdditionalDiskSize,
+			DifferencingDisk:               b.config.DifferencingDisk,
 		},
 		&hypervcommon.StepEnableIntegrationService{},
 

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -76,6 +76,9 @@ type Config struct {
 	// By default this is "packer-BUILDNAME", where "BUILDNAME" is the name of the build.
 	VMName string `mapstructure:"vm_name"`
 
+	// Use differencing disk
+	DifferencingDisk bool `mapstructure:"differencing_disk"`
+
 	BootCommand                    []string `mapstructure:"boot_command"`
 	SwitchName                     string   `mapstructure:"switch_name"`
 	SwitchVlanId                   string   `mapstructure:"switch_vlan_id"`


### PR DESCRIPTION
Adds support for differencing disks in Hyper-V builder.

use "differencing_disk": "true" in your builder step to use this feature.