### PR TITLE
Update documentation to avoid confusion

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -109,7 +109,7 @@ builder.
 
 -   `disk_type_id` (string) - The type of VMware virtual disk to create. The
     default is "1", which corresponds to a growable virtual disk split in
-    2GB files. This option is for advanced usage, modify only if you know what
+    2GB files. For ESXi defaults to "zeroedthick". This option is for advanced usage, modify only if you know what
     you're doing. For more information, please consult the [Virtual Disk Manager
     User's Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
     VMware clients. For ESXi, refer to the proper ESXi documentation.


### PR DESCRIPTION
disk_type_id defaults to different values in local build and remote build.
Documentation should reflect to what value the remote build defaults.
https://github.com/hashicorp/packer/blob/master/builder/vmware/iso/builder.go#L115