### PR TITLE
fix changelog version 1.1.0 => 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## (UNRELEASED)
 
-## 1.1.0 (October 13, 2017)
+## 1.1.1 (October 13, 2017)
 
 ### IMPROVEMENTS:
 


### PR DESCRIPTION
latest release(v1.1.1) is showing as v1.1.0 in changelog

@mwhooker