### PR TITLE
Fix build image section fenced example formatting

### DIFF
--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -203,11 +203,13 @@ how to validate and build templates into machine images.
 
 ### Another Linux Example, with provisioners:
 Create a file named `welcome.txt` and add the following:
+
 ```
 WELCOME TO PACKER!
 ```
 
 Create a file named `example.sh` and add the following:
+
 ```
 #!/bin/bash
 echo "hello
@@ -215,6 +217,7 @@ echo "hello
 
 Set your access key and id as environment variables, so we don't need to pass 
 them in through the command line:
+
 ```
 export AWS_ACCESS_KEY_ID=MYACCESSKEYID
 export AWS_SECRET_ACCESS_KEY=MYSECRETACCESSKEY


### PR DESCRIPTION
The formatting for this page didn't appear to be correct.

<img width="861" alt="screen shot 2017-10-15 at 16 49 09" src="https://user-images.githubusercontent.com/1774239/31586440-f5f7e1d6-b1c8-11e7-8b35-9c2771956ae6.png">
