### PR TITLE
docs: reference generic integer/boolean datatype across docs

### DIFF
--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -50,7 +50,7 @@ builder.
 
 ### Optional:
 
--   `skip_region_validation` (bool) - The region validation can be skipped if this
+-   `skip_region_validation` (boolean) - The region validation can be skipped if this
     value is true, the default value is false.
 
 -   `image_description` (string) - The description of the image, with a length
@@ -71,12 +71,12 @@ builder.
     letter or a Chinese character, and may contain numbers, `_` or `-`. It cannot
     begin with `http://` or `https://`.
 
--   `image_force_delete` (bool) - If this value is true, when the target image name
+-   `image_force_delete` (boolean) - If this value is true, when the target image name
     is duplicated with an existing image, it will delete the existing image and
     then create the target image, otherwise, the creation will fail. The default
     value is false.
 
--   `image_force_delete_snapshots` (bool) - If this value is true, when delete the
+-   `image_force_delete_snapshots` (boolean) - If this value is true, when delete the
     duplicated existing image, the source snapshot of this image will be delete
     either.
 
@@ -116,11 +116,11 @@ builder.
 
 -   `zone_id` (string) - ID of the zone to which the disk belongs.
 
--   `io_optimized` (bool) - I/O optimized.
+-   `io_optimized` (boolean) - I/O optimized.
 
     Default value: false for Generation I instances; true for other instances.
 
--   `force_stop_instance` (bool) - Whether to force shutdown upon device restart.
+-   `force_stop_instance` (boolean) - Whether to force shutdown upon device restart.
     The default value is `false`.
 
     If it is set to `false`, the system is shut down normally; if it is set to

--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -92,7 +92,7 @@ builder.
 
     Default value: cloud.
 
--   `disk_size` (int) - Size of the system disk, in GB, values range:
+-   `disk_size` (number) - Size of the system disk, in GB, values range:
     -   cloud - 5 ~ 2000
     -   cloud\_efficiency - 20 ~ 2048
     -   cloud\_ssd - 20 ~ 2048

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -289,7 +289,7 @@ each category, the available configuration keys are alphabetized.
     -   `owners` (array of strings) - This scopes the AMIs to certain Amazon account IDs.
         This is helpful to limit the AMIs to a trusted third party, or to your own account.
 
-    -   `most_recent` (bool) - Selects the newest created image when true.
+    -   `most_recent` (boolean) - Selects the newest created image when true.
         This is most useful for selecting a daily distro build.
 
 -   `sriov_support` (boolean) - Enable enhanced networking (SriovNetSupport but not ENA)

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -171,7 +171,7 @@ each category, the available configuration keys are alphabetized.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 
-    -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
+    -   `iops` (number) - The number of I/O operations per second (IOPS) that the
         volume supports. See the documentation on
         [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
         for more information
@@ -186,7 +186,7 @@ each category, the available configuration keys are alphabetized.
         Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
         for more information
 
-    -   `volume_size` (integer) - The size of the volume, in GiB. Required if not
+    -   `volume_size` (number) - The size of the volume, in GiB. Required if not
         specifying a `snapshot_id`
 
     -   `volume_type` (string) - The volume type. gp2 for General Purpose (SSD)
@@ -213,7 +213,7 @@ each category, the available configuration keys are alphabetized.
     where the `.Device` variable is replaced with the name of the device where
     the volume is attached.
 
--   `mount_partition` (integer) - The partition number containing the
+-   `mount_partition` (number) - The partition number containing the
     / partition. By default this is the first partition of the volume.
 
 -   `mount_options` (array of strings) - Options to supply the `mount` command
@@ -239,7 +239,7 @@ each category, the available configuration keys are alphabetized.
     mount and copy steps. The device and mount path are provided by
     `{{.Device}}` and `{{.MountPath}}`.
 
--   `root_volume_size` (integer) - The size of the root volume in GB for the
+-   `root_volume_size` (number) - The size of the root volume in GB for the
     chroot environment and the resulting AMI. Default size is the snapshot size
     of the `source_ami` unless `from_scratch` is `true`, in which case
     this field must be defined.

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -87,7 +87,7 @@ builder.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 
-    -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
+    -   `iops` (number) - The number of I/O operations per second (IOPS) that the
         volume supports. See the documentation on
         [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
         for more information
@@ -102,7 +102,7 @@ builder.
         Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
         for more information
 
-    -   `volume_size` (integer) - The size of the volume, in GiB. Required if not
+    -   `volume_size` (number) - The size of the volume, in GiB. Required if not
         specifying a `snapshot_id`
 
     -   `volume_type` (string) - The volume type. `gp2` for General Purpose (SSD)

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -290,7 +290,7 @@ builder.
     -   `owners` (array of strings) - This scopes the AMIs to certain Amazon account IDs.
         This is helpful to limit the AMIs to a trusted third party, or to your own account.
 
-    -   `most_recent` (bool) - Selects the newest created image when true.
+    -   `most_recent` (boolean) - Selects the newest created image when true.
         This is most useful for selecting a daily distro build.
 
 -   `spot_price` (string) - The maximum hourly price to pay for a spot instance

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -80,7 +80,7 @@ builder.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 
-    -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
+    -   `iops` (number) - The number of I/O operations per second (IOPS) that the
         volume supports. See the documentation on
         [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
         for more information
@@ -95,7 +95,7 @@ builder.
         Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
         for more information
 
-    -   `volume_size` (integer) - The size of the volume, in GiB. Required if not
+    -   `volume_size` (number) - The size of the volume, in GiB. Required if not
         specifying a `snapshot_id`
 
     -   `volume_type` (string) - The volume type. `gp2` for General Purpose (SSD)

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -283,7 +283,7 @@ builder.
     -   `owners` (array of strings) - This scopes the AMIs to certain Amazon account IDs.
         This is helpful to limit the AMIs to a trusted third party, or to your own account.
 
-    -   `most_recent` (bool) - Selects the newest created image when true.
+    -   `most_recent` (boolean) - Selects the newest created image when true.
         This is most useful for selecting a daily distro build.
 
 -   `spot_price` (string) - The maximum hourly price to pay for a spot instance

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -196,7 +196,7 @@ builder.
     -   `owners` (array of strings) - This scopes the AMIs to certain Amazon account IDs.
         This is helpful to limit the AMIs to a trusted third party, or to your own account.
 
-    -   `most_recent` (bool) - Selects the newest created image when true.
+    -   `most_recent` (boolean) - Selects the newest created image when true.
         This is most useful for selecting a daily distro build.
 
 -   `spot_price` (string) - The maximum hourly price to pay for a spot instance

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -67,7 +67,7 @@ builder.
     -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
         deleted on instance termination
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
-    -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
+    -   `iops` (number) - The number of I/O operations per second (IOPS) that the
         volume supports. See the documentation on
         [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
         for more information
@@ -78,7 +78,7 @@ builder.
         [Block Device
         Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
         for more information
-    -   `volume_size` (integer) - The size of the volume, in GiB. Required if not
+    -   `volume_size` (number) - The size of the volume, in GiB. Required if not
         specifying a `snapshot_id`
     -   `volume_type` (string) - The volume type. `gp2` for General Purpose (SSD)
         volumes, `io1` for Provisioned IOPS (SSD) volumes, and `standard` for Magnetic

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -288,7 +288,7 @@ builder.
     -   `owners` (array of strings) - This scopes the AMIs to certain Amazon account IDs.
         This is helpful to limit the AMIs to a trusted third party, or to your own account.
 
-    -   `most_recent` (bool) - Selects the newest created image when true.
+    -   `most_recent` (boolean) - Selects the newest created image when true.
         This is most useful for selecting a daily distro build.
 
 -   `snapshot_tags` (object of key/value strings) - Tags to apply to snapshot.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -109,7 +109,7 @@ builder.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 
-    -   `iops` (integer) - The number of I/O operations per second (IOPS) that the
+    -   `iops` (number) - The number of I/O operations per second (IOPS) that the
         volume supports. See the documentation on
         [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
         for more information
@@ -124,7 +124,7 @@ builder.
         Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
         for more information
 
-    -   `volume_size` (integer) - The size of the volume, in GiB. Required if not
+    -   `volume_size` (number) - The size of the volume, in GiB. Required if not
         specifying a `snapshot_id`
 
     -   `volume_type` (string) - The volume type. `gp2` for General Purpose (SSD)

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -120,7 +120,7 @@ When creating a managed image the following two options are required.
     Windows; this variable is not used by non-Windows builds. See `Windows`
     behavior for `os_type`, below.
 
--   `os_disk_size_gb` (int32) Specify the size of the OS disk in GB (gigabytes).  Values of zero or less than zero are
+-   `os_disk_size_gb` (number) Specify the size of the OS disk in GB (gigabytes).  Values of zero or less than zero are
     ignored.
 
 -   `os_type` (string) If either `Linux` or `Windows` is specified Packer will

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -66,7 +66,7 @@ builder.
 
 ### Optional:
 
--   `async_timeout` (int) - The time duration to wait for async calls to
+-   `async_timeout` (number) - The time duration to wait for async calls to
     finish. Defaults to 30m.
 
 -   `cidr_list` (array) - List of CIDR's that will have access to the new
@@ -83,7 +83,7 @@ builder.
     instance. This option is only available (and also required) when using
     `source_iso`.
 
--   `disk_size` (int) - The size (in GB) of the root disk of the new instance.
+-   `disk_size` (number) - The size (in GB) of the root disk of the new instance.
     This option is only available when using `source_template`.
 
 -   `expunge` (boolean) - Set to `true` to expunge the instance when it is
@@ -100,7 +100,7 @@ builder.
     their CloudStack API. If using such a provider, you need to set this to `true`
     in order for the provider to only make GET calls and no POST calls.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
     `http_directory`. Because Packer often runs in parallel, Packer will choose
     a randomly available port in this range to run the HTTP server. If you want

--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -174,7 +174,7 @@ builder.
     Not required if you run Packer on a GCE instance with a service account.
     Instructions for creating file or using service accounts are above.
 
--   `accelerator_count` (int) - Number of guest accelerator cards to add to the launched instance.
+-   `accelerator_count` (number) - Number of guest accelerator cards to add to the launched instance.
 
 -   `accelerator_type` (string) - Full or partial URL of the guest accelerator type. GPU accelerators can only be used with
     `"on_host_maintenance": "TERMINATE"` option set.
@@ -186,7 +186,7 @@ builder.
 -   `disk_name` (string) - The name of the disk, if unset the instance name will be
     used.
 
--   `disk_size` (integer) - The size of the disk in GB. This defaults to `10`,
+-   `disk_size` (number) - The size of the disk in GB. This defaults to `10`,
     which is 10GB.
 
 -   `disk_type` (string) - Type of disk used to back your instance, like `pd-ssd` or `pd-standard`. Defaults to `pd-standard`.

--- a/website/source/docs/builders/hyperv-iso.html.md
+++ b/website/source/docs/builders/hyperv-iso.html.md
@@ -91,16 +91,16 @@ can be configured for this builder.
 -   `disk_size` (integer) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40 GB.
 
--   `enable_dynamic_memory` (bool) - If true enable dynamic memory for virtual machine.
+-   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for virtual machine.
     This defaults to false.
 
--   `enable_mac_spoofing` (bool) - If true enable mac spoofing for virtual machine.
+-   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual machine.
     This defaults to false.
 
--   `enable_secure_boot` (bool) - If true enable secure boot for virtual machine.
+-   `enable_secure_boot` (boolean) - If true enable secure boot for virtual machine.
     This defaults to false.
 
--   `enable_virtualization_extensions` (bool) - If true enable virtualization extensions for virtual machine.
+-   `enable_virtualization_extensions` (boolean) - If true enable virtualization extensions for virtual machine.
     This defaults to false. For nested virtualization you need to enable mac spoofing, disable dynamic memory
     and have at least 4GB of RAM for virtual machine.
 
@@ -187,7 +187,7 @@ can be configured for this builder.
     If it doesn't shut down in this time, it is an error. By default, the timeout
     is "5m", or five minutes.
 
--   `skip_compaction` (bool) - If true skip compacting the hard disk for virtual machine when
+-   `skip_compaction` (boolean) - If true skip compacting the hard disk for virtual machine when
     exporting. This defaults to false.
 
 -   `switch_name` (string) - The name of the switch to connect the virtual machine to. Be defaulting

--- a/website/source/docs/builders/hyperv-iso.html.md
+++ b/website/source/docs/builders/hyperv-iso.html.md
@@ -85,10 +85,10 @@ can be configured for this builder.
     five seconds and one minute 30 seconds, respectively. If this isn't specified,
     the default is 10 seconds.
 
--   `cpu` (integer) - The number of cpus the virtual machine should use. If this isn't specified,
+-   `cpu` (number) - The number of cpus the virtual machine should use. If this isn't specified,
     the default is 1 cpu.
 
--   `disk_size` (integer) - The size, in megabytes, of the hard disk to create
+-   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40 GB.
 
 -   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for virtual machine.
@@ -122,7 +122,7 @@ can be configured for this builder.
     The maximum summary size of all files in the listed directories are the
     same as in `floppy_files`.
 
--   `generation` (integer) - The Hyper-V generation for the virtual machine. By
+-   `generation` (number) - The Hyper-V generation for the virtual machine. By
     default, this is 1. Generation 2 Hyper-V virtual machines do not support
     floppy drives. In this scenario use `secondary_iso_images` instead. Hard
     drives and dvd drives will also be scsi and not ide.
@@ -141,7 +141,7 @@ can be configured for this builder.
     available as variables in `boot_command`. This is covered in more detail
     below.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the `http_directory`.
     Because Packer often runs in parallel, Packer will choose a randomly available
     port in this range to run the HTTP server. If you want to force the HTTP
@@ -168,7 +168,7 @@ can be configured for this builder.
     By default this is "output-BUILDNAME" where "BUILDNAME" is the name
     of the build.
 
--   `ram_size` (integer) - The size, in megabytes, of the ram to create
+-   `ram_size` (number) - The size, in megabytes, of the ram to create
     for the VM. By default, this is 1 GB.
 
 -   `secondary_iso_images` (array of strings) - A list of iso paths to attached to a

--- a/website/source/docs/builders/hyperv-vmcx.html.md
+++ b/website/source/docs/builders/hyperv-vmcx.html.md
@@ -93,7 +93,7 @@ can be configured for this builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is 10 seconds.
 
--   `cpu` (integer) - The number of cpus the virtual machine should use. If
+-   `cpu` (number) - The number of cpus the virtual machine should use. If
     this isn't specified, the default is 1 cpu.
 
 -   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for virtual
@@ -143,7 +143,7 @@ can be configured for this builder.
     available as variables in `boot_command`. This is covered in more detail
     below.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
     `http_directory`. Because Packer often runs in parallel, Packer will choose
     a randomly available port in this range to run the HTTP server. If you want
@@ -187,7 +187,7 @@ can be configured for this builder.
     running the builder. By default this is "output-BUILDNAME" where
     "BUILDNAME" is the name of the build.
 
--   `ram_size` (integer) - The size, in megabytes, of the ram to create for the
+-   `ram_size` (number) - The size, in megabytes, of the ram to create for the
     VM. By default, this is 1 GB.
 
 *   `secondary_iso_images` (array of strings) - A list of iso paths to attached

--- a/website/source/docs/builders/hyperv-vmcx.html.md
+++ b/website/source/docs/builders/hyperv-vmcx.html.md
@@ -96,16 +96,16 @@ can be configured for this builder.
 -   `cpu` (integer) - The number of cpus the virtual machine should use. If
     this isn't specified, the default is 1 cpu.
 
--   `enable_dynamic_memory` (bool) - If true enable dynamic memory for virtual
+-   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for virtual
     machine. This defaults to false.
 
--   `enable_mac_spoofing` (bool) - If true enable mac spoofing for virtual
+-   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual
     machine. This defaults to false.
 
--   `enable_secure_boot` (bool) - If true enable secure boot for virtual
+-   `enable_secure_boot` (boolean) - If true enable secure boot for virtual
     machine. This defaults to false.
 
--   `enable_virtualization_extensions` (bool) - If true enable virtualization
+-   `enable_virtualization_extensions` (boolean) - If true enable virtualization
     extensions for virtual machine. This defaults to false. For nested
     virtualization you need to enable mac spoofing, disable dynamic memory and
     have at least 4GB of RAM for virtual machine.
@@ -208,7 +208,7 @@ can be configured for this builder.
     doesn't shut down in this time, it is an error. By default, the timeout is
     "5m", or five minutes.
 
--   `skip_compaction` (bool) - If true skip compacting the hard disk for
+-   `skip_compaction` (boolean) - If true skip compacting the hard disk for
     virtual machine when exporting. This defaults to false.
 
 -   `switch_name` (string) - The name of the switch to connect the virtual

--- a/website/source/docs/builders/lxc.html.md
+++ b/website/source/docs/builders/lxc.html.md
@@ -87,7 +87,7 @@ Below is a fully functioning example.
 
 ### Optional:
 
--  `target_runlevel` (int) - The minimum run level to wait for the container to
+-  `target_runlevel` (number) - The minimum run level to wait for the container to
    reach. Note some distributions (Ubuntu) simulate run levels and may report
    5 rather than 3.
 

--- a/website/source/docs/builders/oneandone.html.md
+++ b/website/source/docs/builders/oneandone.html.md
@@ -35,7 +35,7 @@ builder.
 
 -   `image_name` (string) - Resulting image. If "image\_name" is not provided Packer will generate it
 
--   `retries` (int) - Number of retries Packer will make status requests while waiting for the build to complete. Default value "600".
+-   `retries` (number) - Number of retries Packer will make status requests while waiting for the build to complete. Default value "600".
 
 -   `url` (string) - Endpoint for the 1&1 REST API. Default URL "<https://cloudpanel-api.1and1.com/v1>"
 

--- a/website/source/docs/builders/parallels-iso.html.md
+++ b/website/source/docs/builders/parallels-iso.html.md
@@ -100,7 +100,7 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is 10 seconds.
 
--   `disk_size` (integer) - The size, in megabytes, of the hard disk to create
+-   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40000 (about 40 GB).
 
 -   `disk_type` (string) - The type for image file based virtual disk drives,
@@ -151,7 +151,7 @@ builder.
     will be started. The address and port of the HTTP server will be available
     as variables in `boot_command`. This is covered in more detail below.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
     `http_directory`. Because Packer often runs in parallel, Packer will choose
     a randomly available port in this range to run the HTTP server. If you want

--- a/website/source/docs/builders/profitbricks.html.md
+++ b/website/source/docs/builders/profitbricks.html.md
@@ -31,7 +31,7 @@ builder.
 
 ### Optional
 
--   `cores` (integer) - Amount of CPU cores to use for this build. Defaults to "4".
+-   `cores` (number) - Amount of CPU cores to use for this build. Defaults to "4".
 
 -   `disk_size` (string) - Amount of disk space for this image in GB. Defaults to "50"
 
@@ -39,7 +39,7 @@ builder.
 
 -   `location` (string) - Defaults to "us/las".
 
--   `ram` (integer) - Amount of RAM to use for this image. Defaults to "2048".
+-   `ram` (number) - Amount of RAM to use for this image. Defaults to "2048".
 
 -   `retries` (string) - Number of retries Packer will make status requests while waiting for the build to complete. Default value 120 seconds.
 

--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -156,7 +156,7 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     *must* choose one of the other listed interfaces. Using the "scsi"
     interface under these circumstances will cause the build to fail.
 
--   `disk_size` (integer) - The size, in megabytes, of the hard disk to create
+-   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40000 (about 40 GB).
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
@@ -196,7 +196,7 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     will be started. The address and port of the HTTP server will be available
     as variables in `boot_command`. This is covered in more detail below.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
     `http_directory`. Because Packer often runs in parallel, Packer will choose
     a randomly available port in this range to run the HTTP server. If you want
@@ -326,7 +326,7 @@ default port of `5985` or whatever value you have the service set to listen on.
 -   `skip_compaction` (boolean) - Packer compacts the QCOW2 image using `qemu-img convert`.
     Set this option to `true` to disable compacting. Defaults to `false`.
 
--   `ssh_host_port_min` and `ssh_host_port_max` (integer) - The minimum and
+-   `ssh_host_port_min` and `ssh_host_port_max` (number) - The minimum and
     maximum port to use for the SSH port on the host machine which is forwarded
     to the SSH port on the guest machine. Because Packer often runs in parallel,
     Packer will choose a randomly available port in this range to use as the
@@ -341,7 +341,7 @@ default port of `5985` or whatever value you have the service set to listen on.
     to for VNC. By default packer will use 127.0.0.1 for this. If you wish to bind
     to all interfaces use 0.0.0.0
 
--   `vnc_port_min` and `vnc_port_max` (integer) - The minimum and maximum port
+-   `vnc_port_min` and `vnc_port_max` (number) - The minimum and maximum port
     to use for VNC access to the virtual machine. The builder uses VNC to type
     the initial `boot_command`. Because Packer generally runs in parallel,
     Packer uses a randomly chosen port in this range that appears available. By

--- a/website/source/docs/builders/virtualbox-iso.html.md
+++ b/website/source/docs/builders/virtualbox-iso.html.md
@@ -92,7 +92,7 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is 10 seconds.
 
--   `disk_size` (integer) - The size, in megabytes, of the hard disk to create
+-   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40000 (about 40 GB).
 
 -   `export_opts` (array of strings) - Additional options to pass to the
@@ -193,7 +193,7 @@ builder.
     is attached to an AHCI SATA controller. When set to "scsi", the drive is
     attached to an LsiLogic SCSI controller.
 
--   `sata_port_count` (integer) - The number of ports available on any SATA
+-   `sata_port_count` (number) - The number of ports available on any SATA
     controller created, defaults to 1. VirtualBox supports up to 30 ports on a
     maximum of 1 SATA controller. Increasing this value can be useful if you
     want to attach additional drives.
@@ -219,7 +219,7 @@ builder.
     will be started. The address and port of the HTTP server will be available
     as variables in `boot_command`. This is covered in more detail below.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
     `http_directory`. Because Packer often runs in parallel, Packer will choose
     a randomly available port in this range to run the HTTP server. If you want
@@ -275,7 +275,7 @@ builder.
     not export the VM. Useful if the build output is not the resultant image,
     but created inside the VM.
 
--   `ssh_host_port_min` and `ssh_host_port_max` (integer) - The minimum and
+-   `ssh_host_port_min` and `ssh_host_port_max` (number) - The minimum and
     maximum port to use for the SSH port on the host machine which is forwarded
     to the SSH port on the guest machine. Because Packer often runs in parallel,
     Packer will choose a randomly available port in this range to use as the
@@ -315,7 +315,7 @@ builder.
     binded to for VRDP. By default packer will use 127.0.0.1 for this. If you
     wish to bind to all interfaces use 0.0.0.0
 
--   `vrdp_port_min` and `vrdp_port_max` (integer) - The minimum and maximum port
+-   `vrdp_port_min` and `vrdp_port_max` (number) - The minimum and maximum port
     to use for VRDP access to the virtual machine. Packer uses a randomly chosen
     port in this range that appears available. By default this is 5900 to 6000.
     The minimum and maximum ports are inclusive.

--- a/website/source/docs/builders/virtualbox-ovf.html.md
+++ b/website/source/docs/builders/virtualbox-ovf.html.md
@@ -187,7 +187,7 @@ builder.
     will be started. The address and port of the HTTP server will be available
     as variables in `boot_command`. This is covered in more detail below.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
     `http_directory`. Because Packer often runs in parallel, Packer will choose
     a randomly available port in this range to run the HTTP server. If you want
@@ -234,7 +234,7 @@ builder.
     not export the VM. Useful if the build output is not the resultant image,
     but created inside the VM.
 
--   `ssh_host_port_min` and `ssh_host_port_max` (integer) - The minimum and
+-   `ssh_host_port_min` and `ssh_host_port_max` (number) - The minimum and
     maximum port to use for the SSH port on the host machine which is forwarded
     to the SSH port on the guest machine. Because Packer often runs in parallel,
     Packer will choose a randomly available port in this range to use as the
@@ -278,7 +278,7 @@ builder.
 -   `vrdp_bind_address` (string / IP address) - The IP address that should be
     binded to for VRDP. By default packer will use 127.0.0.1 for this.
 
--   `vrdp_port_min` and `vrdp_port_max` (integer) - The minimum and maximum port
+-   `vrdp_port_min` and `vrdp_port_max` (number) - The minimum and maximum port
     to use for VRDP access to the virtual machine. Packer uses a randomly chosen
     port in this range that appears available. By default this is 5900 to 6000.
     The minimum and maximum ports are inclusive.

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -114,7 +114,7 @@ builder.
     User's Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
     VMware clients. For ESXi, refer to the proper ESXi documentation.
 
-*   `disable_vnc` (bool) - Whether to create a VNC connection or not.
+*   `disable_vnc` (boolean) - Whether to create a VNC connection or not.
     A `boot_command` cannot be used when this is `false`. Defaults to `false`.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -102,7 +102,7 @@ builder.
     fixed-size virtual hard disks, so the actual file representing the disk will
     not use the full size unless it is full.
 
--   `disk_size` (integer) - The size of the hard disk for the VM in megabytes.
+-   `disk_size` (number) - The size of the hard disk for the VM in megabytes.
     The builder uses expandable, not fixed-size virtual hard disks, so the
     actual file representing the disk will not use the full size unless it
     is full. By default this is set to 40,000 (about 40 GB).
@@ -156,7 +156,7 @@ builder.
     will be started. The address and port of the HTTP server will be available
     as variables in `boot_command`. This is covered in more detail below.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
     `http_directory`. Because Packer often runs in parallel, Packer will choose
     a randomly available port in this range to run the HTTP server. If you want
@@ -298,7 +298,7 @@ builder.
 -   `vnc_disable_password` (boolean) - Don't auto-generate a VNC password that is
     used to secure the VNC communication with the VM.
 
--   `vnc_port_min` and `vnc_port_max` (integer) - The minimum and maximum port
+-   `vnc_port_min` and `vnc_port_max` (number) - The minimum and maximum port
     to use for VNC access to the virtual machine. The builder uses VNC to type
     the initial `boot_command`. Because Packer generally runs in parallel,
     Packer uses a randomly chosen port in this range that appears available. By

--- a/website/source/docs/builders/vmware-vmx.html.md
+++ b/website/source/docs/builders/vmware-vmx.html.md
@@ -107,7 +107,7 @@ builder.
     will be started. The address and port of the HTTP server will be available
     as variables in `boot_command`. This is covered in more detail below.
 
--   `http_port_min` and `http_port_max` (integer) - These are the minimum and
+-   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
     `http_directory`. Because Packer often runs in parallel, Packer will choose
     a randomly available port in this range to run the HTTP server. If you want
@@ -174,7 +174,7 @@ builder.
 -   `vnc_disable_password` (boolean) - Don't auto-generate a VNC password that is
     used to secure the VNC communication with the VM.
 
--   `vnc_port_min` and `vnc_port_max` (integer) - The minimum and maximum port
+-   `vnc_port_min` and `vnc_port_max` (number) - The minimum and maximum port
     to use for VNC access to the virtual machine. The builder uses VNC to type
     the initial `boot_command`. Because Packer generally runs in parallel,
     Packer uses a randomly chosen port in this range that appears available. By

--- a/website/source/docs/builders/vmware-vmx.html.md
+++ b/website/source/docs/builders/vmware-vmx.html.md
@@ -71,7 +71,7 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is 10 seconds.
 
-*   `disable_vnc` (bool) - Whether to create a VNC connection or not.
+*   `disable_vnc` (boolean) - Whether to create a VNC connection or not.
     A `boot_command` cannot be used when this is `false`. Defaults to `false`.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy

--- a/website/source/docs/other/core-configuration.html.md
+++ b/website/source/docs/other/core-configuration.html.md
@@ -32,7 +32,7 @@ The format of the configuration file is basic JSON.
 Below is the list of all available configuration parameters for the core
 configuration file. None of these are required, since all have sane defaults.
 
--   `plugin_min_port` and `plugin_max_port` (integer) - These are the minimum and
+-   `plugin_min_port` and `plugin_max_port` (number) - These are the minimum and
     maximum ports that Packer uses for communication with plugins, since plugin
     communication happens over TCP connections on your local host. By default
     these are 10,000 and 25,000, respectively. Be sure to set a fairly wide range

--- a/website/source/docs/post-processors/alicloud-import.html.md
+++ b/website/source/docs/post-processors/alicloud-import.html.md
@@ -77,7 +77,7 @@ two categories: required and optional parameters.
     and then create the target image, otherwise, the creation will fail. The
     default value is false.
 
--   `image_system_size` (int) - Size of the system disk, in GB, values range:
+-   `image_system_size` (number) - Size of the system disk, in GB, values range:
     -   cloud - 5 ~ 2000
     -   cloud\_efficiency - 20 ~ 2048
     -   cloud\_ssd - 20 ~ 2048

--- a/website/source/docs/post-processors/alicloud-import.html.md
+++ b/website/source/docs/post-processors/alicloud-import.html.md
@@ -72,7 +72,7 @@ two categories: required and optional parameters.
     limit of 0 to 256 characters. Leaving it blank means null, which is the
     default value. It cannot begin with <http://> or <https://>.
 
--   `image_force_delete` (bool) - If this value is true, when the target image
+-   `image_force_delete` (boolean) - If this value is true, when the target image
     name is duplicated with an existing image, it will delete the existing image
     and then create the target image, otherwise, the creation will fail. The
     default value is false.

--- a/website/source/docs/post-processors/compress.html.md
+++ b/website/source/docs/post-processors/compress.html.md
@@ -35,7 +35,7 @@ you will need to specify the `output` option.
 -   `format` (string) - Disable archive format autodetection and use provided
     string.
 
--   `compression_level` (integer) - Specify the compression level, for
+-   `compression_level` (number) - Specify the compression level, for
     algorithms that support it, from 1 through 9 inclusive. Typically higher
     compression levels take longer but produce smaller files. Defaults to `6`
 

--- a/website/source/docs/post-processors/googlecompute-export.html.md
+++ b/website/source/docs/post-processors/googlecompute-export.html.md
@@ -34,7 +34,7 @@ permissions to the GCS `paths`.
 
 ### Optional
 
--   `keep_input_artifact` (bool) - If true, do not delete the Google Compute Engine
+-   `keep_input_artifact` (boolean) - If true, do not delete the Google Compute Engine
     (GCE) image being exported.
 
 ## Basic Example

--- a/website/source/docs/post-processors/manifest.html.md
+++ b/website/source/docs/post-processors/manifest.html.md
@@ -24,7 +24,7 @@ You can specify manifest more than once and write each build to its own file, or
 ### Optional:
 
 -   `output` (string) The manifest will be written to this file. This defaults to `packer-manifest.json`.
--   `strip_path` (bool) Write only filename without the path to the manifest file. This defaults to false.
+-   `strip_path` (boolean) Write only filename without the path to the manifest file. This defaults to false.
 
 ### Example Configuration
 

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -52,7 +52,7 @@ However, if you want to configure things a bit more, the post-processor does
 expose some configuration options. The available options are listed below, with
 more details about certain options in following sections.
 
--   `compression_level` (integer) - An integer representing the compression
+-   `compression_level` (number) - An integer representing the compression
     level to use when creating the Vagrant box. Valid values range from 0 to 9,
     with 0 being no compression and 9 being the best compression. By default,
     compression is enabled at level 6.

--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -103,7 +103,7 @@ Optional Parameters:
     files. The command should read and write on stdin and stdout, respectively.
     Defaults to `/usr/lib/sftp-server -e`.
 
--   `skip_version_check` (bool) - Check if ansible is installed prior to running.
+-   `skip_version_check` (boolean) - Check if ansible is installed prior to running.
     Set this to `true`, for example, if you're going to install ansible during
     the packer run.
 

--- a/website/source/docs/provisioners/converge.html.md
+++ b/website/source/docs/provisioners/converge.html.md
@@ -59,14 +59,14 @@ Optional parameters:
     various
     [configuration template variables](/docs/templates/engine.html) available.
 
--   `prevent_sudo` (bool) - stop Converge from running with adminstrator
+-   `prevent_sudo` (boolean) - stop Converge from running with adminstrator
     privileges via sudo
 
 -   `bootstrap_command` (string) - the command used to bootstrap Converge. This
     has various
     [configuration template variables](/docs/templates/engine.html) available.
 
--   `prevent_bootstrap_sudo` (bool) - stop Converge from bootstrapping with
+-   `prevent_bootstrap_sudo` (boolean) - stop Converge from bootstrapping with
     administrator privileges via sudo
 
 ### Module Directories

--- a/website/source/docs/provisioners/shell.html.md
+++ b/website/source/docs/provisioners/shell.html.md
@@ -72,7 +72,7 @@ Optional parameters:
     available variables: `Path`, which is the path to the script to run, and
     `Vars`, which is the list of `environment_vars`, if configured.
 
--   `expect_disconnect` (bool) - Defaults to `false`. Whether to error if the
+-   `expect_disconnect` (boolean) - Defaults to `false`. Whether to error if the
     server disconnects us. A disconnect might happen if you restart the ssh
     server or reboot the host.
 

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -67,7 +67,7 @@ The SSH communicator has the following options:
 -   `ssh_bastion_password` (string) - The password to use to authenticate
     with the bastion host.
 
--   `ssh_bastion_port` (integer) - The port of the bastion host. Defaults to 1.  
+-   `ssh_bastion_port` (number) - The port of the bastion host. Defaults to 1.
 
 -   `ssh_bastion_private_key_file` (string) - A private key file to use
     to authenticate with the bastion host.
@@ -81,7 +81,7 @@ The SSH communicator has the following options:
 -   `ssh_file_transfer_method` (`scp` or `sftp`) - How to transfer files, Secure
     copy (default) or SSH File Transfer Protocol.
 
--   `ssh_handshake_attempts` (integer) - The number of handshakes to attempt
+-   `ssh_handshake_attempts` (number) - The number of handshakes to attempt
     with SSH once it can connect. This defaults to 10.
 
 -   `ssh_host` (string) - The address to SSH to. This usually is automatically
@@ -90,7 +90,7 @@ The SSH communicator has the following options:
 -   `ssh_password` (string) - A plaintext password to use to authenticate
     with SSH.
 
--   `ssh_port` (integer) - The port to connect to SSH. This defaults to 22.
+-   `ssh_port` (number) - The port to connect to SSH. This defaults to 22.
 
 -   `ssh_private_key_file` (string) - Path to a PEM encoded private key
     file to use to authenticate with SSH.
@@ -111,7 +111,7 @@ The WinRM communicator has the following options.
 
 -   `winrm_host` (string) - The address for WinRM to connect to.
 
--   `winrm_port` (integer) - The WinRM port to connect to. This defaults to
+-   `winrm_port` (number) - The WinRM port to connect to. This defaults to
     5985 for plain unencrypted connection and 5986 for SSL when `winrm_use_ssl` is set to true.
 
 -   `winrm_username` (string) - The username to use to connect to WinRM.


### PR DESCRIPTION
Closes #5468

attribute types referencing `int` and `bool` were replaced with `integer` and `boolean`.

Not sure how much discussion is needed on #5468, this pr will at minimum server as a talking point as there are quite a bit reference to golang spec `bool`, `int`.
