### PR TITLE
Add aws_profile option to docker-push ecr_login

### DIFF
--- a/builder/docker/ecr_login.go
+++ b/builder/docker/ecr_login.go
@@ -8,11 +8,8 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/packer/builder/amazon/common"
 )
 
 type AwsAccessConfig struct {
@@ -20,34 +17,7 @@ type AwsAccessConfig struct {
 	SecretKey string `mapstructure:"aws_secret_key"`
 	Token     string `mapstructure:"aws_token"`
 	Profile   string `mapstructure:"aws_profile"`
-}
-
-// Config returns a valid aws.Config object for access to AWS services, or
-// an error if the authentication and region couldn't be resolved
-func (c *AwsAccessConfig) config(region string) (*aws.Config, error) {
-	var creds *credentials.Credentials
-
-	config := aws.NewConfig().WithRegion(region).WithMaxRetries(11)
-	session, err := session.NewSession(config)
-	if err != nil {
-		return nil, err
-	}
-	creds = credentials.NewChainCredentials([]credentials.Provider{
-		&credentials.StaticProvider{Value: credentials.Value{
-			AccessKeyID:     c.AccessKey,
-			SecretAccessKey: c.SecretKey,
-			SessionToken:    c.Token,
-		}},
-		&credentials.EnvProvider{},
-		&credentials.SharedCredentialsProvider{
-			Filename: "",
-			Profile:  c.Profile,
-		},
-		&ec2rolecreds.EC2RoleProvider{
-			Client: ec2metadata.New(session),
-		},
-	})
-	return config.WithCredentials(creds), nil
+	cfg       *common.AccessConfig
 }
 
 // Get a login token for Amazon AWS ECR. Returns username and password
@@ -64,12 +34,15 @@ func (c *AwsAccessConfig) EcrGetLogin(ecrUrl string) (string, string, error) {
 
 	log.Println(fmt.Sprintf("Getting ECR token for account: %s in %s..", accountId, region))
 
-	awsConfig, err := c.config(region)
-	if err != nil {
-		return "", "", err
+	c.cfg = &common.AccessConfig{
+		AccessKey:   c.AccessKey,
+		ProfileName: c.Profile,
+		RawRegion:   region,
+		SecretKey:   c.SecretKey,
+		Token:       c.Token,
 	}
 
-	session, err := session.NewSession(awsConfig)
+	session, err := c.cfg.Session()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create session: %s", err)
 	}

--- a/builder/docker/ecr_login.go
+++ b/builder/docker/ecr_login.go
@@ -19,6 +19,7 @@ type AwsAccessConfig struct {
 	AccessKey string `mapstructure:"aws_access_key"`
 	SecretKey string `mapstructure:"aws_secret_key"`
 	Token     string `mapstructure:"aws_token"`
+	Profile   string `mapstructure:"aws_profile"`
 }
 
 // Config returns a valid aws.Config object for access to AWS services, or
@@ -38,7 +39,10 @@ func (c *AwsAccessConfig) config(region string) (*aws.Config, error) {
 			SessionToken:    c.Token,
 		}},
 		&credentials.EnvProvider{},
-		&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
+		&credentials.SharedCredentialsProvider{
+			Filename: "",
+			Profile:  c.Profile,
+		},
 		&ec2rolecreds.EC2RoleProvider{
 			Client: ec2metadata.New(session),
 		},

--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -162,6 +162,9 @@ You must specify (only) one of `commit`, `discard`, or `export_path`.
     probably don't need it. This will also be read from the `AWS_SESSION_TOKEN`
     environmental variable.
 
+-   `aws_profile` (string) - The AWS shared credentials profile used to communicate with AWS.
+    [Learn how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
+
 -   `changes` (array of strings) - Dockerfile instructions to add to the commit.
     Example of instructions are `CMD`, `ENTRYPOINT`, `ENV`, and `EXPOSE`. Example:
     `[ "USER ubuntu", "WORKDIR /app", "EXPOSE 8080" ]`

--- a/website/source/docs/post-processors/docker-push.html.md
+++ b/website/source/docs/post-processors/docker-push.html.md
@@ -30,6 +30,9 @@ This post-processor has only optional configuration:
     probably don't need it. This will also be read from the `AWS_SESSION_TOKEN`
     environmental variable.
 
+-   `aws_profile` (string) - The AWS shared credentials profile used to communicate with AWS.
+    [Learn how to set this.](/docs/builders/amazon.html#specifying-amazon-credentials)
+
 -   `ecr_login` (boolean) - Defaults to false. If true, the post-processor
     will login in order to push the image to
     [Amazon EC2 Container Registry (ECR)](https://aws.amazon.com/ecr/).


### PR DESCRIPTION
An aws_profile option is added to the AWS ECR login credentials
configuration to allow using shared AWS credentials stored in
a non-default profile.

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>