### PR TITLE
Add support for tags

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -28,11 +28,17 @@ type Template struct {
 	RawContents []byte
 }
 
+type Tagged struct {
+	Tags []string
+}
+
 // Builder represents a builder configured in the template
 type Builder struct {
 	Name   string
 	Type   string
 	Config map[string]interface{}
+
+	Tagged `mapstructure:",squash"`
 }
 
 // PostProcessor represents a post-processor within the template.
@@ -42,6 +48,8 @@ type PostProcessor struct {
 	Type              string
 	KeepInputArtifact bool `mapstructure:"keep_input_artifact"`
 	Config            map[string]interface{}
+
+	Tagged `mapstructure:",squash"`
 }
 
 // Provisioner represents a provisioner within the template.
@@ -52,6 +60,8 @@ type Provisioner struct {
 	Config      map[string]interface{}
 	Override    map[string]interface{}
 	PauseBefore time.Duration `mapstructure:"pause_before"`
+
+	Tagged `mapstructure:",squash"`
 }
 
 // Push represents the configuration for pushing the template to Atlas.
@@ -178,6 +188,26 @@ func (o *OnlyExcept) Validate(t *Template) error {
 	}
 
 	return err
+}
+
+func (t *Tagged) Matches(tags []string) bool {
+	for _, assignedTag := range t.Tags {
+		for _, requestedTag := range tags {
+			if assignedTag == requestedTag {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (t *Tagged) Always() bool {
+	for _, tag := range t.Tags {
+		if tag == "always" {
+			return true
+		}
+	}
+	return false
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
I would like to add to Packer support for finer grained control over which of builders/provisioners/post-processors are run by `packer build`. I thought about using tags, similar as it is done e.g. in ansible and which has already been suggested in #2679. However, before writing all the code and tests I would like to review my idea upfront with someone.

My current approach, which this PR roughly sketches, is to pass the tags to template parsing routines, so that the template returned by `template.ParseFile()` contains only those elements which match specified tags.

However, I have a few doubts about this:
1. Isn't this too early? is this ok that not the whole template but only selected elements will go through template validation? (I believe that there is some additional template validation after parsing) Why `-only`/`-exclude` wasn't done at this level?
2. I would like to make not passing required variable not stop the build unless they are really used by the tagged elements. I could either extend the variable definition to allow tagging them as well (keeping backward compat. of course) or maybe decision whether variable is required or not could be postponed to template interpolation?
3. I am still not sure how it would go with `-only` and `-exclude` options.

If anyone is interested in this idea, please review not so much the code (this is only PoC) but rather the approach. Thanks.

I attach [test template](https://gist.githubusercontent.com/localghost/f4c61ea5b42f1fbf69509584a0110b57/raw/6d55715aef2612a958348c90b13f28eaefbc3226/test.json) which can be tested like so, e.g.:
`packer build -tags foo test.json`
`packer build -skip-tags bar test.json`