### PR TITLE
Update Oracle Cloud name in README to Oracle Cloud Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ comes out of the box with support for the following platforms:
 * Hyper-V
 * 1&1
 * OpenStack
-* Oracle Bare Metal Cloud Services
+* Oracle Cloud Infrastructure
 * Parallels
 * ProfitBricks
 * QEMU. Both KVM and Xen images.

--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -28,7 +28,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		return warnings, errs
 	}
 	b.config = c
-
 	return warnings, nil
 }
 

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -65,6 +65,7 @@ type Config struct {
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	c := new(Config)
+	c.ctx.Funcs = TemplateFuncs
 	err := config.Decode(c, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &c.ctx,

--- a/builder/googlecompute/template_funcs.go
+++ b/builder/googlecompute/template_funcs.go
@@ -1,0 +1,38 @@
+package googlecompute
+
+import (
+	"strings"
+	"text/template"
+)
+
+func isalphanumeric(b byte) bool {
+	if '0' <= b && b <= '9' {
+		return true
+	}
+	if 'a' <= b && b <= 'z' {
+		return true
+	}
+	return false
+}
+
+// Clean up image name by replacing invalid characters with "-"
+// and converting upper cases to lower cases
+func templateCleanImageName(s string) string {
+	if reImageFamily.MatchString(s) {
+		return s
+	}
+	b := []byte(strings.ToLower(s))
+	newb := make([]byte, len(b))
+	for i := range newb {
+		if isalphanumeric(b[i]) {
+			newb[i] = b[i]
+		} else {
+			newb[i] = '-'
+		}
+	}
+	return string(newb)
+}
+
+var TemplateFuncs = template.FuncMap{
+	"clean_image_name": templateCleanImageName,
+}

--- a/builder/googlecompute/template_funcs_test.go
+++ b/builder/googlecompute/template_funcs_test.go
@@ -1,0 +1,45 @@
+package googlecompute
+
+import "testing"
+
+func Test_templateCleanImageName(t *testing.T) {
+	vals := []struct {
+		origName string
+		expected string
+	}{
+		// test that valid name is unchanged
+		{
+			origName: "abcde-012345xyz",
+			expected: "abcde-012345xyz",
+		},
+
+		//test that capital letters are converted to lowercase
+		{
+			origName: "ABCDE-012345xyz",
+			expected: "abcde-012345xyz",
+		},
+		// test that periods and colons are converted to hyphens
+		{
+			origName: "abcde-012345v1.0:0",
+			expected: "abcde-012345v1-0-0",
+		},
+		// Name starting with number is not valid, but not in scope of this
+		// function to correct
+		{
+			origName: "012345v1.0:0",
+			expected: "012345v1-0-0",
+		},
+		// Name over 64 chars is not valid, but not corrected by this function.
+		{
+			origName: "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
+			expected: "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
+		},
+	}
+
+	for _, v := range vals {
+		name := templateCleanImageName(v.origName)
+		if name != v.expected {
+			t.Fatalf("template names do not match: expected %s got %s\n", v.expected, name)
+		}
+	}
+}

--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -50,6 +50,28 @@ Here is a full list of the available functions for reference.
     function will replace illegal characters with a '-" character. Example usage
     since ":" is not a legal AMI name is: `{{isotime | clean_ami_name}}`.
 
+#### Specific to Google Compute builders:
+
+-   `clean_image_name` - GCE image names can only contain certain characters and
+    the maximum length is 63. This function will convert upper cases to lower cases
+    and replace illegal characters with a "-" character.
+    Example:
+
+    `"mybuild-{{isotime | clean_image_name}}"`
+    will become
+    `mybuild-2017-10-18t02-06-30z`.
+
+    Note: Valid GCE image names must match the regex
+    `(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)`
+
+    This engine does not guarantee that the final image name will match the
+    regex; it will not truncate your name if it exceeds 63 characters, and it
+    will not valiate that the beginning and end of the engine's output are
+    valid. For example,
+    `"image_name": {{isotime | clean_image_name}}"` will cause your build to
+    fail because the image name will start with a number, which is why in the
+    above example we prepend the isotime with "mybuild".
+
 ## Template variables
 
 Template variables are special variables automatically set by Packer at build time. Some builders, provisioners and other components have template variables that are available only for that component. Template variables are recognizable because they're prefixed by a period, such as `{{ .Name }}`. For example, when using the [`shell`](/docs/builders/vmware-iso.html) builder template variables are available to customize the [`execute_command`](/docs/provisioners/shell.html#execute_command) parameter used to determine how Packer will run the shell command.


### PR DESCRIPTION
Update the name of the Oracle Cloud in [README.md](https://github.com/hashicorp/packer/blob/master/README.md) from _Oracle Bare Metal Cloud Services_ to _Oracle Cloud Infrastructure_.

More information can be seen here:
* #4554
* https://cloud.oracle.com/cloud-infrastructure
