### PR TITLE
builder/virtualbox-ovf retry removing VM.

### DIFF
--- a/builder/virtualbox/iso/step_create_vm.go
+++ b/builder/virtualbox/iso/step_create_vm.go
@@ -2,10 +2,10 @@ package iso
 
 import (
 	"fmt"
+
 	vboxcommon "github.com/hashicorp/packer/builder/virtualbox/common"
 	"github.com/hashicorp/packer/packer"
 	"github.com/mitchellh/multistep"
-	"time"
 )
 
 // This step creates the actual virtual machine.
@@ -73,18 +73,8 @@ func (s *stepCreateVM) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	ui.Say("Unregistering and deleting virtual machine...")
-	var err error = nil
-	for i := 0; i < 5; i++ {
-		err = driver.Delete(s.vmName)
-		if err == nil {
-			break
-		}
-
-		time.Sleep(1 * time.Second * time.Duration(i))
-	}
-
-	if err != nil {
-		ui.Error(fmt.Sprintf("Error deleting virtual machine: %s", err))
+	ui.Say("Deregistering and deleting VM...")
+	if err := driver.Delete(s.vmName); err != nil {
+		ui.Error(fmt.Sprintf("Error deleting VM: %s", err))
 	}
 }

--- a/builder/virtualbox/ovf/step_import.go
+++ b/builder/virtualbox/ovf/step_import.go
@@ -2,6 +2,7 @@ package ovf
 
 import (
 	"fmt"
+
 	vboxcommon "github.com/hashicorp/packer/builder/virtualbox/common"
 	"github.com/hashicorp/packer/packer"
 	"github.com/mitchellh/multistep"
@@ -49,7 +50,7 @@ func (s *StepImport) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	ui.Say("Unregistering and deleting imported VM...")
+	ui.Say("Deregistering and deleting imported VM...")
 	if err := driver.Delete(s.vmName); err != nil {
 		ui.Error(fmt.Sprintf("Error deleting VM: %s", err))
 	}

--- a/common/retry.go
+++ b/common/retry.go
@@ -9,17 +9,21 @@ import (
 var RetryExhaustedError error = fmt.Errorf("Function never succeeded in Retry")
 
 // RetryableFunc performs an action and returns a bool indicating whether the
-// function is done, or if it should keep retrying, and an erorr which will
+// function is done, or if it should keep retrying, and an error which will
 // abort the retry and be returned by the Retry function. The 0-indexed attempt
 // is passed with each call.
 type RetryableFunc func(uint) (bool, error)
 
-// Retry retries a function up to numTries times with exponential backoff.
-// If numTries == 0, retry indefinitely. If interval == 0, Retry will not delay retrying and there will be
-// no exponential backoff. If maxInterval == 0, maxInterval is set to +Infinity.
-// Intervals are in seconds.
-// Returns an error if initial > max intervals, if retries are exhausted, or if the passed function returns
-// an error.
+/*
+Retry retries a function up to numTries times with exponential backoff.
+If numTries == 0, retry indefinitely.
+If interval == 0, Retry will not delay retrying and there will be no
+exponential backoff.
+If maxInterval == 0, maxInterval is set to +Infinity.
+Intervals are in seconds.
+Returns an error if initial > max intervals, if retries are exhausted, or if the passed function returns
+an error.
+*/
 func Retry(initialInterval float64, maxInterval float64, numTries uint, function RetryableFunc) error {
 	if maxInterval == 0 {
 		maxInterval = math.Inf(1)


### PR DESCRIPTION
moves behavior from builder/virtualbox-iso into the driver
so it is automatically available to callers.

Closes #5501