### PR TITLE
Extend upload and subsequent dot sourcing of env vars to non-elevated Powershell cmd

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -113,7 +113,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.EnvVarFormat == "" {
-		p.config.EnvVarFormat = `$env:%s=\"%s\"; `
+		p.config.EnvVarFormat = `$env:%s="%s"; `
 	}
 
 	if p.config.ElevatedEnvVarFormat == "" {
@@ -121,7 +121,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.ExecuteCommand == "" {
-		p.config.ExecuteCommand = `powershell -executionpolicy bypass "& { if (Test-Path variable:global:ProgressPreference){$ProgressPreference='SilentlyContinue'};{{.Vars}}&'{{.Path}}';exit $LastExitCode }"`
+		p.config.ExecuteCommand = `powershell -executionpolicy bypass "& { if (Test-Path variable:global:ProgressPreference){$ProgressPreference='SilentlyContinue'};. {{.Vars}}; &'{{.Path}}';exit $LastExitCode }"`
 	}
 
 	if p.config.ElevatedExecuteCommand == "" {
@@ -331,6 +331,19 @@ func (p *Provisioner) retryable(f func() error) error {
 	}
 }
 
+// Enviroment variables required within the remote environment are uploaded within a PS script and
+// then enabled by 'dot sourcing' the script immediately prior to execution of the main command
+func (p *Provisioner) prepareEnvVars(elevated bool) (envVarPath string, err error) {
+	// Collate all required env vars into a plain string with required formatting applied
+	flattenedEnvVars := p.createFlattenedEnvVars(elevated)
+	// Create a powershell script on the target build fs containing the flattened env vars
+	envVarPath, err = p.uploadEnvVars(flattenedEnvVars)
+	if err != nil {
+		return "", err
+	}
+	return
+}
+
 func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 	flattened = ""
 	envVars := make(map[string]string)
@@ -367,6 +380,19 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 	return
 }
 
+func (p *Provisioner) uploadEnvVars(flattenedEnvVars string) (envVarPath string, err error) {
+	// Upload all env vars to a powershell script on the target build file system
+	envVarReader := strings.NewReader(flattenedEnvVars)
+	uuid := uuid.TimeOrderedUUID()
+	envVarPath = fmt.Sprintf(`${env:SYSTEMROOT}\Temp\packer-env-vars-%s.ps1`, uuid)
+	log.Printf("Uploading env vars to %s", envVarPath)
+	err = p.communicator.Upload(envVarPath, envVarReader, nil)
+	if err != nil {
+		return "", fmt.Errorf("Error uploading ps script containing env vars: %s", err)
+	}
+	return
+}
+
 func (p *Provisioner) createCommandText() (command string, err error) {
 	// Return the interpolated command
 	if p.config.ElevatedUser == "" {
@@ -377,12 +403,15 @@ func (p *Provisioner) createCommandText() (command string, err error) {
 }
 
 func (p *Provisioner) createCommandTextNonPrivileged() (command string, err error) {
-	// Create environment variables to set before executing the command
-	flattenedEnvVars := p.createFlattenedEnvVars(false)
+	// Prepare everything needed to enable the required env vars within the remote environment
+	envVarPath, err := p.prepareEnvVars(false)
+	if err != nil {
+		return "", err
+	}
 
 	p.config.ctx.Data = &ExecuteCommandTemplate{
-		Vars: flattenedEnvVars,
 		Path: p.config.RemotePath,
+		Vars: envVarPath,
 	}
 	command, err = interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 
@@ -395,17 +424,10 @@ func (p *Provisioner) createCommandTextNonPrivileged() (command string, err erro
 }
 
 func (p *Provisioner) createCommandTextPrivileged() (command string, err error) {
-	// Can't double escape the env vars, lets create shiny new ones
-	flattenedEnvVars := p.createFlattenedEnvVars(true)
-	// Need to create a mini ps1 script containing all of the environment variables we want;
-	// we'll be dot-sourcing this later
-	envVarReader := strings.NewReader(flattenedEnvVars)
-	uuid := uuid.TimeOrderedUUID()
-	envVarPath := fmt.Sprintf(`${env:SYSTEMROOT}\Temp\packer-env-vars-%s.ps1`, uuid)
-	log.Printf("Uploading env vars to %s", envVarPath)
-	err = p.communicator.Upload(envVarPath, envVarReader, nil)
+	// Prepare everything needed to enable the required env vars within the remote environment
+	envVarPath, err := p.prepareEnvVars(false)
 	if err != nil {
-		return "", fmt.Errorf("Error preparing elevated powershell script: %s", err)
+		return "", err
 	}
 
 	p.config.ctx.Data = &ExecuteCommandTemplate{

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -1,8 +1,8 @@
 ---
 description: |
-    The shell Packer provisioner provisions machines built by Packer using shell
-    scripts. Shell provisioning is the easiest way to get software installed and
-    configured on a machine.
+    The shell Packer provisioner provisions machines built by Packer using
+    shell scripts. Shell provisioning is the easiest way to get software
+    installed and configured on a machine.
 layout: docs
 page_title: 'PowerShell - Provisioners'
 sidebar_current: 'docs-provisioners-powershell'
@@ -29,20 +29,21 @@ The example below is fully functional.
 ## Configuration Reference
 
 The reference of available configuration options is listed below. The only
-required element is either "inline" or "script". Every other option is optional.
+required element is either "inline" or "script". Every other option is
+optional.
 
 Exactly *one* of the following is required:
 
 -   `inline` (array of strings) - This is an array of commands to execute. The
-    commands are concatenated by newlines and turned into a single file, so they
-    are all executed within the same context. This allows you to change
+    commands are concatenated by newlines and turned into a single file, so
+    they are all executed within the same context. This allows you to change
     directories in one command and use something in the directory in the next
     and so on. Inline scripts are the easiest way to pull off simple tasks
     within the machine.
 
 -   `script` (string) - The path to a script to upload and execute in
-    the machine. This path can be absolute or relative. If it is relative, it is
-    relative to the working directory when Packer is executed.
+    the machine. This path can be absolute or relative. If it is relative, it
+    is relative to the working directory when Packer is executed.
 
 -   `scripts` (array of strings) - An array of scripts to execute. The scripts
     will be uploaded and executed in the order specified. Each script is
@@ -51,12 +52,12 @@ Exactly *one* of the following is required:
 
 Optional parameters:
 
--   `binary` (boolean) - If true, specifies that the script(s) are binary files,
-    and Packer should therefore not convert Windows line endings to Unix line
-    endings (if there are any). By default this is false.
+-   `binary` (boolean) - If true, specifies that the script(s) are binary
+    files, and Packer should therefore not convert Windows line endings to Unix
+    line endings (if there are any). By default this is false.
 
--   `elevated_execute_command` (string) - The command to use to execute the elevated
-    script. By default this is as follows:
+-   `elevated_execute_command` (string) - The command to use to execute the 
+    elevated script. By default this is as follows:
 
     ``` powershell
     powershell -executionpolicy bypass "& { if (Test-Path variable:global:ProgressPreference){$ProgressPreference='SilentlyContinue'};. {{.Vars}}; &'{{.Path}}'; exit $LastExitCode }"
@@ -65,32 +66,34 @@ Optional parameters:
     The value of this is treated as [configuration
     template](/docs/templates/engine.html). There are two
     available variables: `Path`, which is the path to the script to run, and
-    `Vars`, which is the location of a temp file containing the list of `environment_vars`, if configured.
+    `Vars`, which is the location of a temp file containing the list of
+    `environment_vars`, if configured.
 
 -   `environment_vars` (array of strings) - An array of key/value pairs to
     inject prior to the execute\_command. The format should be `key=value`.
-    Packer injects some environmental variables by default into the environment,
-    as well, which are covered in the section below.
+    Packer injects some environmental variables by default into the
+    environment, as well, which are covered in the section below.
 
 -   `execute_command` (string) - The command to use to execute the script. By
     default this is as follows:
 
     ``` powershell
-    powershell -executionpolicy bypass "& { if (Test-Path variable:global:ProgressPreference){$ProgressPreference='SilentlyContinue'};{{.Vars}}&'{{.Path}}';exit $LastExitCode }"
+    powershell -executionpolicy bypass "& { if (Test-Path variable:global:ProgressPreference){$ProgressPreference='SilentlyContinue'};. {{.Vars}}; &'{{.Path}}'; exit $LastExitCode }"
     ```
 
     The value of this is treated as [configuration
     template](/docs/templates/engine.html). There are two
     available variables: `Path`, which is the path to the script to run, and
-    `Vars`, which is the list of `environment_vars`, if configured.
+    `Vars`, which is the location of a temp file containing the list of
+    `environment_vars`, if configured.
 
 -   `elevated_user` and `elevated_password` (string) - If specified, the
     PowerShell script will be run with elevated privileges using the given
     Windows user.
 
 -   `remote_path` (string) - The path where the script will be uploaded to in
-    the machine. This defaults to "c:/Windows/Temp/script.ps1". This value must be a
-    writable location and any parent directories must already exist.
+    the machine. This defaults to "c:/Windows/Temp/script.ps1". This value must
+    be a writable location and any parent directories must already exist.
 
 -   `start_retry_timeout` (string) - The amount of time to attempt to *start*
     the remote process. By default this is "5m" or 5 minutes. This setting
@@ -111,9 +114,10 @@ commonly useful environmental variables:
     This is most useful when Packer is making multiple builds and you want to
     distinguish them slightly from a common provisioning script.
 
--   `PACKER_BUILDER_TYPE` is the type of the builder that was used to create the
-    machine that the script is running on. This is useful if you want to run
-    only certain parts of the script on systems built with certain builders.
+-   `PACKER_BUILDER_TYPE` is the type of the builder that was used to create
+    the machine that the script is running on. This is useful if you want to
+    run only certain parts of the script on systems built with certain
+    builders.
 
 -   `PACKER_HTTP_ADDR` If using a builder that provides an http server for file
     transfer (such as hyperv, parallels, qemu, virtualbox, and vmware), this


### PR DESCRIPTION
Extends (and largely rips off!) the work done in #5345  to upload and dot source env vars for elevated PowerShell cmds to non-elevated PowerShell cmds

Example template snippet to demo fix:

```json
{
  "variables": {
    "path_target": "C:\\Foobar\\",
  },
  "provisioners": [
    {
      "type": "powershell",
      "inline": [
        "write-output \"Users still need to deal with special chars in commands themselves\"",
        "net user adminuser Super`$3cr3t /ADD",
        "net localgroup Administrators adminuser /add",
        "net user adminuser /ACTIVE:YES"
      ]
    },
    {
      "type": "powershell",
      "elevated_password": "Super`$3cr3t",
      "elevated_user": "adminuser",
      "environment_vars": [
        "PATH_TARGET={{user `path_target`}}"
      ],
      "inline": "write-output \"ELEVATED PS: PATH_TARGET is $env:PATH_TARGET\""
    },
    { "type": "powershell",
      "environment_vars": [
        "PATH_TARGET={{user `path_target`}}"
      ],
      "inline": "write-output \"NON PRIVILEGED PS: PATH_TARGET is $env:PATH_TARGET\""
    },
    { "type": "powershell",
      "environment_vars": [
        "DOLLAR=dollar`$",
        "BACKTICK=backtick``",
        "SGLQUOTE=sglquote`'"
      ],
      "inline": [
        "write-output \"Users must still escape chars special to PS\"",
        "write-output \"in the user supplied env vars\"",
        "write-output \"Env var with dollar sign: $env:DOLLAR\"",
        "write-output \"Env var with backtick sign: $env:BACKTICK\"",
        "write-output \"Env var with single quote: $env:SGLQUOTE\""
      ]
    }
  ]
}
```

With the current version the non-privileged provisioner echoing the `PATH_TARGET` environment variable would fail. This is due to the fact that the env vars are embedded directly in the command string. This leads to problems due to the trailing slash in `C:\Foobar\` - see the discussion in #5471.

However, with the current version the elevated provisioner would **not** fail when asked to do the exact same thing. This is due to the fact that env vars are uploaded and 'dot sourced' for the elevated provisioner rather than being embedded directly in the command string. This means that we avoid having to escape any characters within the env vars that would otherwise cause a command with the env vars embedded to be interpreted incorrectly. 
However, note that this *doesn't* mean that we can neglect escaping characters special to PowerShell e.g. dollar signs, backticks etc. These characters will still need to be escaped (with backticks) to allow *PowerShell* to interpret them correctly.

This PR fixes the issue by extending the mechanism of uploading and dot sourcing the env vars to the non-privileged or std PowerShell command.

I've reconfigured the tests to accommodate the changes (they should all pass!) and written a new test for the new upload func. However, I would appreciate someone giving the changes a good look over - since we now don't embed *any* env vars in the command string directly, I'm aware that there may be some changes to be made?? I would also appreciate it if someone could give the new test a look over to confirm it is required/beneficial.

Closes #5471
