### PR TITLE
Fixing auto checkpoints for generation 2 VMs. 

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -202,8 +202,11 @@ if ($harddrivePath){
 }
 `
 		var ps powershell.PowerShellCmd
-		err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatInt(int64(generation), 10))
-		return err
+		if err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatInt(int64(generation), 10)); err != nil {
+			return err
+		}
+		
+		return DisableAutomaticCheckpoints(vmName)
 	} else {
 		var script = `
 param([string]$vmName, [string]$path, [string]$harddrivePath, [string]$vhdRoot, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName)
@@ -217,15 +220,11 @@ if ($harddrivePath){
 }
 `
 		var ps powershell.PowerShellCmd
-		err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName)
-
-		if err != nil {
+		if err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName); err != nil {
 			return err
 		}
 
-		err = DisableAutomaticCheckpoints(vmName)
-
-		if err != nil {
+		if err := DisableAutomaticCheckpoints(vmName); err != nil {
 			return err
 		}
 
@@ -368,21 +367,18 @@ if ($vm) {
 
 func CloneVirtualMachine(cloneFromVmxcPath string, cloneFromVmName string, cloneFromSnapshotName string, cloneAllSnapshots bool, vmName string, path string, harddrivePath string, ram int64, switchName string) error {
 	if cloneFromVmName != "" {
-		err := ExportVmxcVirtualMachine(path, cloneFromVmName, cloneFromSnapshotName, cloneAllSnapshots)
-		if err != nil {
+		if err := ExportVmxcVirtualMachine(path, cloneFromVmName, cloneFromSnapshotName, cloneAllSnapshots); err != nil {
 			return err
 		}
 	}
 
 	if cloneFromVmxcPath != "" {
-		err := CopyVmxcVirtualMachine(path, cloneFromVmxcPath)
-		if err != nil {
+		if err := CopyVmxcVirtualMachine(path, cloneFromVmxcPath); err != nil {
 			return err
 		}
 	}
 
-	err := ImportVmxcVirtualMachine(path, vmName, harddrivePath, ram, switchName)
-	if err != nil {
+	if err := ImportVmxcVirtualMachine(path, vmName, harddrivePath, ram, switchName); err != nil {
 		return err
 	}
 

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -205,7 +205,7 @@ if ($harddrivePath){
 		if err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatInt(int64(generation), 10)); err != nil {
 			return err
 		}
-		
+
 		return DisableAutomaticCheckpoints(vmName)
 	} else {
 		var script = `


### PR DESCRIPTION
Resolves #5506

*Summary*
When I submitted the fix for #5371, I was using just generation 1 VMs that day and I neglected to check generation 2 VMs. I needed to do the same fix for generation 2 but missed it in testing. This applies the same fix to both cases and I have more thorough test results below.


*Background*
Hyper-V has 2 'generations' of VMs:
- Generation 1 uses BIOS boot. This is still the only one supported on Azure as far as I know. It has emulated IDE, networking and other devices in addition to the faster paravirtualized ones. It can run most OS's with these emulated devices, albeit slowly.
- Generation 2 uses UEFI boot. There are no emulated devices, but there is a native UEFI frame buffer and block devices. There aren't any emulated legacy devices like IDE or DEC21040 NICs - only paravirtualized.

In cases where you want to share the same Packer file between multiple builders - you probably want to use generation 1 because the setup steps for BIOS booted OSs seem to work more consistently between the different virtualization platforms. For fastest performance and to enable all features on Hyper-V, use generation 2.

Because there's a difference in features, some configs only work on generation 1 or 2. Packer (and Vagrant) need to account for this difference in cases like setting up the boot device and order.

*Boxes built*

What we're looking for here is each one only has a single VHD or VHDX file. If there are any AVHD/AVHDX files then a snapshot was created.

Windows Server (Generation 1) - [source](https://github.com/PatrickLang/packer-windows/blob/my/windows_2016_insider.json)

```none
==> hyperv-iso: Running post-processor: vagrant
==> hyperv-iso (vagrant): Creating Vagrant box for 'hyperv' provider
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Hard Disks\WindowsServer2016Insider.vhdx to C:\Users\patrick\AppData\Local\Temp\packer742510655\Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.VMRS
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.VMRS to C:\Users\patrick\AppData\Local\Temp\packer742510655\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.VMRS
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.vmcx
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.vmcx to C:\Users\patrick\AppData\Local\Temp\packer742510655\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.vmcx
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.vmgs
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.vmgs to C:\Users\patrick\AppData\Local\Temp\packer742510655\Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.vmgs
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\box.xml
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\box.xml to C:\Users\patrick\AppData\Local\Temp\packer742510655\Virtual Machines\box.xml
    hyperv-iso (vagrant): Using custom Vagrantfile: vagrantfile-windows_2016.template
    hyperv-iso (vagrant): Compressing: Vagrantfile
    hyperv-iso (vagrant): Compressing: Virtual Hard Disks\WindowsServer2016Insider.vhdx
    hyperv-iso (vagrant): Compressing: Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.VMRS
    hyperv-iso (vagrant): Compressing: Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.vmcx
    hyperv-iso (vagrant): Compressing: Virtual Machines\5195A042-B170-4586-A01C-B78E9A6C41D2.vmgs
    hyperv-iso (vagrant): Compressing: Virtual Machines\box.xml
    hyperv-iso (vagrant): Compressing: metadata.json
Build 'hyperv-iso' finished.
```

Ubuntu 14.04 (Generation 2) - [source](https://github.com/taliesins/packer-baseboxes/blob/master/hyperv-ubuntu-14.04.json)

```none
==> hyperv-iso (vagrant): Creating Vagrant box for 'hyperv' provider
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Hard Disks\ubuntu-trusty.vhdx
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Hard Disks\ubuntu-trusty.vhdx to C:\Users\patrick\AppData\Local\Temp\packer963711759\Virtual Hard Disks\ubuntu-trusty.vhdx
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.VMRS
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.VMRS to C:\Users\patrick\AppData\Local\Temp\packer963711759\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.VMRS
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.vmcx
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.vmcx to C:\Users\patrick\AppData\Local\Temp\packer963711759\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.vmcx
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.vmgs
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.vmgs to C:\Users\patrick\AppData\Local\Temp\packer963711759\Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.vmgs
    hyperv-iso (vagrant): Copying: output-hyperv-iso\Virtual Machines\box.xml
    hyperv-iso (vagrant): Copyed output-hyperv-iso\Virtual Machines\box.xml to C:\Users\patrick\AppData\Local\Temp\packer963711759\Virtual Machines\box.xml
    hyperv-iso (vagrant): Compressing: Vagrantfile
    hyperv-iso (vagrant): Compressing: Virtual Hard Disks\ubuntu-trusty.vhdx
    hyperv-iso (vagrant): Compressing: Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.VMRS
    hyperv-iso (vagrant): Compressing: Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.vmcx
    hyperv-iso (vagrant): Compressing: Virtual Machines\92FCCC90-B67E-46DC-98F2-58DE951F806E.vmgs
    hyperv-iso (vagrant): Compressing: Virtual Machines\box.xml
    hyperv-iso (vagrant): Compressing: metadata.json
Build 'hyperv-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> hyperv-iso: VM files in directory: output-hyperv-iso
--> hyperv-iso: 'hyperv' provider box: hyperv_ubuntu-14.04_chef.box
```

Ubuntu 16.04 (Generation 2) - [source](https://github.com/chef/bento/blob/master/ubuntu/ubuntu-16.04-amd64.json)

```none
==> hyperv-iso: Running post-processor: vagrant
==> hyperv-iso (vagrant): Creating Vagrant box for 'hyperv' provider
    hyperv-iso (vagrant): Copying: ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx
    hyperv-iso (vagrant): Copyed ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx to C:\Users\patrick\AppData\Local\Temp\packer188369363\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx
    hyperv-iso (vagrant): Copying: ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.VMRS
    hyperv-iso (vagrant): Copyed ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.VMRS to C:\Users\patrick\AppData\Local\Temp\packer188369363\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.VMRS
    hyperv-iso (vagrant): Copying: ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.vmcx
    hyperv-iso (vagrant): Copyed ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.vmcx to C:\Users\patrick\AppData\Local\Temp\packer188369363\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.vmcx
    hyperv-iso (vagrant): Copying: ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.vmgs
    hyperv-iso (vagrant): Copyed ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.vmgs to C:\Users\patrick\AppData\Local\Temp\packer188369363\Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.vmgs
    hyperv-iso (vagrant): Copying: ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Machines\box.xml
    hyperv-iso (vagrant): Copyed ..\builds\packer-ubuntu-16.04-amd64-hyperv\Virtual Machines\box.xml to C:\Users\patrick\AppData\Local\Temp\packer188369363\Virtual Machines\box.xml
    hyperv-iso (vagrant): Compressing: Vagrantfile
    hyperv-iso (vagrant): Compressing: Virtual Hard Disks\ubuntu-16.04-amd64.vhdx
    hyperv-iso (vagrant): Compressing: Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.VMRS
    hyperv-iso (vagrant): Compressing: Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.vmcx
    hyperv-iso (vagrant): Compressing: Virtual Machines\6E8D153A-78B3-42FC-ABCE-A33822CC9D47.vmgs
    hyperv-iso (vagrant): Compressing: Virtual Machines\box.xml
    hyperv-iso (vagrant): Compressing: metadata.json
Build 'hyperv-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> hyperv-iso: 'hyperv' provider box: ../builds/ubuntu-16.04.hyperv.box
```




*Verifying the boxes work with Vagrant*

Using Vagrant 2.0.0

```powershell
vagrant box add --name ubuntu-16.04 C:\Users\patrick\Source\bento\builds\ubuntu-16.04.hyperv.box
vagrant box add --name ubuntu-14.04_chef C:\Users\patrick\Source\packer-baseboxes\hyperv_ubuntu-14.04_chef.box
vagrant box add --name windowsserverinsider C:\Users\patrick\Source\packer-windows\windows_2016_insider_hyperv.box
```

```ruby
Vagrant.configure("2") do |config|
  config.vm.define "windows-gen1" do |ws|
    ws.vm.box = "windowsserverinsider"
    ws.vm.synced_folder ".", "/vagrant", disabled: true
  end

  config.vm.define "ubuntu14-gen2" do |u|
    u.vm.box = "ubuntu-14.04_chef"
    u.vm.synced_folder ".", "/vagrant", disabled: true
  end

  config.vm.define "ubuntu16-gen2" do |v|
    v.vm.box = "ubuntu-16.04"
    v.vm.synced_folder ".", "/vagrant", disabled: true
  end

end
```

`vagrant up` succeeded, and `vagrant status` shows:

```none
Current machine states:

windows-gen1              running (hyperv)
ubuntu14-gen2             running (hyperv)
ubuntu16-gen2             running (hyperv)
```
