### PR TITLE
🎨 Fix typo in "copyed" -> "copied" usages.

### DIFF
--- a/builder/alicloud/ecs/step_region_copy_image.go
+++ b/builder/alicloud/ecs/step_region_copy_image.go
@@ -59,11 +59,11 @@ func (s *setpRegionCopyAlicloudImage) Cleanup(state multistep.StateBag) {
 		client := state.Get("client").(*ecs.Client)
 		alicloudImages := state.Get("alicloudimages").(map[string]string)
 		ui.Say(fmt.Sprintf("Stopping copy image because cancellation or error..."))
-		for copyedRegionId, copyedImageId := range alicloudImages {
-			if copyedRegionId == s.RegionId {
+		for copiedRegionId, copiedImageId := range alicloudImages {
+			if copiedRegionId == s.RegionId {
 				continue
 			}
-			if err := client.CancelCopyImage(common.Region(copyedRegionId), copyedImageId); err != nil {
+			if err := client.CancelCopyImage(common.Region(copiedRegionId), copiedImageId); err != nil {
 				ui.Say(fmt.Sprintf("Error cancelling copy image: %v", err))
 			}
 		}

--- a/builder/alicloud/ecs/step_share_image.go
+++ b/builder/alicloud/ecs/step_share_image.go
@@ -19,11 +19,11 @@ func (s *setpShareAlicloudImage) Run(state multistep.StateBag) multistep.StepAct
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 	alicloudImages := state.Get("alicloudimages").(map[string]string)
-	for copyedRegion, copyedImageId := range alicloudImages {
+	for copiedRegion, copiedImageId := range alicloudImages {
 		err := client.ModifyImageSharePermission(
 			&ecs.ModifyImageSharePermissionArgs{
-				RegionId:      common.Region(copyedRegion),
-				ImageId:       copyedImageId,
+				RegionId:      common.Region(copiedRegion),
+				ImageId:       copiedImageId,
 				AddAccount:    s.AlicloudImageShareAccounts,
 				RemoveAccount: s.AlicloudImageUNShareAccounts,
 			})
@@ -44,11 +44,11 @@ func (s *setpShareAlicloudImage) Cleanup(state multistep.StateBag) {
 		client := state.Get("client").(*ecs.Client)
 		alicloudImages := state.Get("alicloudimages").(map[string]string)
 		ui.Say("Restoring image share permission because cancellations or error...")
-		for copyedRegion, copyedImageId := range alicloudImages {
+		for copiedRegion, copiedImageId := range alicloudImages {
 			err := client.ModifyImageSharePermission(
 				&ecs.ModifyImageSharePermissionArgs{
-					RegionId:      common.Region(copyedRegion),
-					ImageId:       copyedImageId,
+					RegionId:      common.Region(copiedRegion),
+					ImageId:       copiedImageId,
 					AddAccount:    s.AlicloudImageUNShareAccounts,
 					RemoveAccount: s.AlicloudImageShareAccounts,
 				})

--- a/post-processor/vagrant/hyperv.go
+++ b/post-processor/vagrant/hyperv.go
@@ -68,7 +68,7 @@ func (p *HypervProvider) Process(ui packer.Ui, artifact packer.Artifact, dir str
 			}
 		}
 
-		ui.Message(fmt.Sprintf("Copyed %s to %s", path, dstPath))
+		ui.Message(fmt.Sprintf("Copied %s to %s", path, dstPath))
 	}
 
 	return


### PR DESCRIPTION
Noticed a typo in output when building Vagrant boxes:

```
==> hyperv-iso (vagrant): Creating Vagrant box for 'hyperv' provider
    hyperv-iso (vagrant): Copying: packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx
    hyperv-iso (vagrant): Copyed packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx to C:\Users\halo\AppData\
Local\Temp\packer667386879\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx
    hyperv-iso (vagrant): Copying: packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64_548657A0-80E7-4401-A171-2AA5
182DDFE2.avhdx
    hyperv-iso (vagrant): Copyed packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64_548657A0-80E7-4401-A171-2AA518
2DDFE2.avhdx to C:\Users\halo\AppData\Local\Temp\packer667386879\Virtual Hard Disks\ubuntu-16.04-amd64_548657A0-80E7-4401-A171-2AA5182
DDFE2.avhdx
```

This change fixes the typo `Copyed` as well as fixes the typo in other parts of the source. 

New output appears as:

```
==> hyperv-iso (vagrant): Creating Vagrant box for 'hyperv' provider
    hyperv-iso (vagrant): Copying: packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx
    hyperv-iso (vagrant): Copied packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx to C:\Users\halo\AppData\
Local\Temp\packer667386879\Virtual Hard Disks\ubuntu-16.04-amd64.vhdx
    hyperv-iso (vagrant): Copying: packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64_548657A0-80E7-4401-A171-2AA5
182DDFE2.avhdx
    hyperv-iso (vagrant): Copied packer-ubuntu-16.04-amd64-hyperv\Virtual Hard Disks\ubuntu-16.04-amd64_548657A0-80E7-4401-A171-2AA518
2DDFE2.avhdx to C:\Users\halo\AppData\Local\Temp\packer667386879\Virtual Hard Disks\ubuntu-16.04-amd64_548657A0-80E7-4401-A171-2AA5182
DDFE2.avhdx
```