### PR TITLE
digitalocean: learn to create and snapshot volumes

### DIFF
--- a/builder/digitalocean/artifact.go
+++ b/builder/digitalocean/artifact.go
@@ -1,6 +1,7 @@
 package digitalocean
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -8,17 +9,22 @@ import (
 	"strings"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/packer/packer"
 )
 
-type Artifact struct {
+// A map from volume snapshot names to volume snapshot IDs
+type snapshot struct {
 	// The name of the snapshot
-	snapshotName string
+	name string
+	// The ID of the snapshot
+	id string
+	// The name of the regions in which the snapshot is available
+	regions []string
+}
 
-	// The ID of the image
-	snapshotId int
-
-	// The name of the region
-	regionNames []string
+type Artifact struct {
+	droplet snapshot
+	volumes []snapshot
 
 	// The client for making API calls
 	client *godo.Client
@@ -34,11 +40,26 @@ func (*Artifact) Files() []string {
 }
 
 func (a *Artifact) Id() string {
-	return fmt.Sprintf("%s:%s", strings.Join(a.regionNames[:], ","), strconv.FormatUint(uint64(a.snapshotId), 10))
+	parts := make([]string, 0, len(a.volumes))
+	for _, snapshot := range append([]snapshot{a.droplet}, a.volumes...) {
+		parts = append(parts, fmt.Sprintf("%s:%s",
+			strings.Join(snapshot.regions, ","), snapshot.id))
+	}
+	return strings.Join(parts, ",")
 }
 
 func (a *Artifact) String() string {
-	return fmt.Sprintf("A snapshot was created: '%v' (ID: %v) in regions '%v'", a.snapshotName, a.snapshotId, strings.Join(a.regionNames[:], ","))
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "A droplet snapshot was created: '%s' (ID: %s) in regions '%v'",
+		a.droplet.name, a.droplet.id, strings.Join(a.droplet.regions, ","))
+	if len(a.volumes) > 0 {
+		fmt.Fprintf(&buf, "\nVolume snapshots were created:")
+		for _, s := range a.volumes {
+			fmt.Fprintf(&buf, "\n'%s' (ID: %s) in regions '%s'",
+				s.name, s.id, strings.Join(s.regions, ","))
+		}
+	}
+	return buf.String()
 }
 
 func (a *Artifact) State(name string) interface{} {
@@ -46,7 +67,34 @@ func (a *Artifact) State(name string) interface{} {
 }
 
 func (a *Artifact) Destroy() error {
-	log.Printf("Destroying image: %d (%s)", a.snapshotId, a.snapshotName)
-	_, err := a.client.Images.Delete(context.TODO(), a.snapshotId)
-	return err
+	var errors []error
+
+	log.Printf("Destroying droplet snapshot: %s (%s)", a.droplet.id, a.droplet.name)
+	imageId, err := strconv.Atoi(a.droplet.id)
+	if err != nil {
+		errors = append(errors, err)
+	} else {
+		_, err := a.client.Images.Delete(context.TODO(), imageId)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	for _, s := range a.volumes {
+		log.Printf("Destroying volume snapshot: %s (%s)", s.id, s.name)
+		_, err := a.client.Storage.DeleteSnapshot(context.TODO(), s.id)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		if len(errors) == 1 {
+			return errors[0]
+		} else {
+			return &packer.MultiError{Errors: errors}
+		}
+	}
+
+	return nil
 }

--- a/builder/digitalocean/artifact_test.go
+++ b/builder/digitalocean/artifact_test.go
@@ -14,38 +14,58 @@ func TestArtifact_Impl(t *testing.T) {
 	}
 }
 
-func TestArtifactId(t *testing.T) {
-	a := &Artifact{"packer-foobar", 42, []string{"sfo", "tor1"}, nil}
-	expected := "sfo,tor1:42"
-
-	if a.Id() != expected {
-		t.Fatalf("artifact ID should match: %v", expected)
-	}
-}
-
-func TestArtifactIdWithoutMultipleRegions(t *testing.T) {
-	a := &Artifact{"packer-foobar", 42, []string{"sfo"}, nil}
-	expected := "sfo:42"
-
-	if a.Id() != expected {
-		t.Fatalf("artifact ID should match: %v", expected)
-	}
-}
-
-func TestArtifactString(t *testing.T) {
-	a := &Artifact{"packer-foobar", 42, []string{"sfo", "tor1"}, nil}
-	expected := "A snapshot was created: 'packer-foobar' (ID: 42) in regions 'sfo,tor1'"
-
-	if a.String() != expected {
-		t.Fatalf("artifact string should match: %v", expected)
-	}
-}
-
-func TestArtifactStringWithoutMultipleRegions(t *testing.T) {
-	a := &Artifact{"packer-foobar", 42, []string{"sfo"}, nil}
-	expected := "A snapshot was created: 'packer-foobar' (ID: 42) in regions 'sfo'"
-
-	if a.String() != expected {
-		t.Fatalf("artifact string should match: %v", expected)
+func TestArtifactIdString(t *testing.T) {
+	for i, testCase := range []struct {
+		artifact       Artifact
+		expectedId     string
+		expectedString string
+	}{
+		{
+			Artifact{
+				droplet: snapshot{"packer-foobar", "42", []string{"sfo"}},
+			},
+			"sfo:42",
+			"A droplet snapshot was created: 'packer-foobar' (ID: 42) in regions 'sfo'",
+		},
+		{
+			Artifact{
+				droplet: snapshot{"packer-foobar", "42", []string{"sfo", "tor1"}},
+			},
+			"sfo,tor1:42",
+			"A droplet snapshot was created: 'packer-foobar' (ID: 42) in regions 'sfo,tor1'",
+		},
+		{
+			Artifact{
+				droplet: snapshot{"packer-foobar", "42", []string{"sfo", "tor1"}},
+				volumes: []snapshot{
+					{"packer-foobar-v0", "volid0", []string{"nyc1"}},
+				},
+			},
+			"sfo,tor1:42,nyc1:volid0",
+			`A droplet snapshot was created: 'packer-foobar' (ID: 42) in regions 'sfo,tor1'
+Volume snapshots were created:
+'packer-foobar-v0' (ID: volid0) in regions 'nyc1'`,
+		},
+		{
+			Artifact{
+				droplet: snapshot{"packer-foobar", "42", []string{"sfo", "tor1"}},
+				volumes: []snapshot{
+					{"packer-foobar-v0", "volid0", []string{"nyc1"}},
+					{"packer-foobar-v1", "volid1", []string{"nyc1", "nyc3"}},
+				},
+			},
+			"sfo,tor1:42,nyc1:volid0,nyc1,nyc3:volid1",
+			`A droplet snapshot was created: 'packer-foobar' (ID: 42) in regions 'sfo,tor1'
+Volume snapshots were created:
+'packer-foobar-v0' (ID: volid0) in regions 'nyc1'
+'packer-foobar-v1' (ID: volid1) in regions 'nyc1,nyc3'`,
+		},
+	} {
+		if e, a := testCase.expectedId, testCase.artifact.Id(); e != a {
+			t.Errorf("#%d: expected id %q, but got %q", i, e, a)
+		}
+		if e, a := testCase.expectedString, testCase.artifact.String(); e != a {
+			t.Errorf("#%d: expected string %q, but got %q", i, e, a)
+		}
 	}
 }

--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -25,11 +25,14 @@ const testBuilderAccBasic = `
 {
 	"builders": [{
 		"type": "test",
-		"region": "nyc2",
+		"region": "nyc1",
 		"size": "512mb",
-		"image": "ubuntu-12-04-x64",
-		"user_date": "",
-		"user_date_file": ""
+		"image": "ubuntu-16-04-x64",
+		"ssh_username": "root",
+		"volumes": [
+			{ "size": 5 },
+			{ "size": 10 }
+		]
 	}]
 }
 `

--- a/builder/digitalocean/builder_test.go
+++ b/builder/digitalocean/builder_test.go
@@ -15,6 +15,10 @@ func testConfig() map[string]interface{} {
 		"size":         "512mb",
 		"ssh_username": "root",
 		"image":        "foo",
+		"volumes": []map[string]interface{}{
+			{"size": 20},
+			{"size": 40},
+		},
 	}
 }
 
@@ -322,4 +326,19 @@ func TestBuilderPrepare_DropletName(t *testing.T) {
 		t.Fatal("should have error")
 	}
 
+}
+
+func TestBuilderPrepare_Volumes(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test default
+	delete(config["volumes"].([]map[string]interface{})[0], "size")
+	warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatalf("should error")
+	}
 }

--- a/builder/digitalocean/step_create_droplet.go
+++ b/builder/digitalocean/step_create_droplet.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"io/ioutil"
 
@@ -13,6 +14,7 @@ import (
 
 type stepCreateDroplet struct {
 	dropletId int
+	volumeIds []string
 }
 
 func (s *stepCreateDroplet) Run(state multistep.StateBag) multistep.StepAction {
@@ -20,6 +22,7 @@ func (s *stepCreateDroplet) Run(state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	c := state.Get("config").(Config)
 	sshKeyId := state.Get("ssh_key_id").(int)
+	volumeIds := state.Get("volume_ids").([]string)
 
 	// Create the droplet based on configuration
 	ui.Say("Creating droplet...")
@@ -35,6 +38,11 @@ func (s *stepCreateDroplet) Run(state multistep.StateBag) multistep.StepAction {
 		userData = string(contents)
 	}
 
+	volumes := []godo.DropletCreateVolume{}
+	for _, volumeId := range volumeIds {
+		volumes = append(volumes, godo.DropletCreateVolume{ID: volumeId})
+	}
+
 	droplet, _, err := client.Droplets.Create(context.TODO(), &godo.DropletCreateRequest{
 		Name:   c.DropletName,
 		Region: c.Region,
@@ -48,6 +56,7 @@ func (s *stepCreateDroplet) Run(state multistep.StateBag) multistep.StepAction {
 		PrivateNetworking: c.PrivateNetworking,
 		Monitoring:        c.Monitoring,
 		UserData:          userData,
+		Volumes:           volumes,
 	})
 	if err != nil {
 		err := fmt.Errorf("Error creating droplet: %s", err)
@@ -56,8 +65,9 @@ func (s *stepCreateDroplet) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	// We use this in cleanup
+	// We use these in cleanup
 	s.dropletId = droplet.ID
+	s.volumeIds = droplet.VolumeIDs
 
 	// Store the droplet id for later
 	state.Put("droplet_id", droplet.ID)
@@ -73,6 +83,29 @@ func (s *stepCreateDroplet) Cleanup(state multistep.StateBag) {
 
 	client := state.Get("client").(*godo.Client)
 	ui := state.Get("ui").(packer.Ui)
+
+	// Manually wait for any attached volumes to detach before destroying the
+	// image. Destroying a volume that's attached to a droplet throws an error.
+	// (Destroying a droplet before destroying its volumes would theoretically
+	// work, but the DigitalOcean API provides no way to wait for a droplet to
+	// be destroyed.)
+	if len(s.volumeIds) > 0 {
+		ui.Say("Detaching volumes...")
+		for i, volumeId := range s.volumeIds {
+			action, _, err := client.StorageActions.DetachByDropletID(context.TODO(), volumeId, s.dropletId)
+			if err != nil {
+				ui.Error(fmt.Sprintf(
+					"Error detaching volume %d. You may need to destroy it manually: %s",
+					i, err))
+			}
+			ui.Say(fmt.Sprintf("Waiting for volume %d to detach...", i))
+			if err := waitForActionState(godo.ActionCompleted, s.dropletId, action.ID,
+				client, time.Minute); err != nil {
+				err := fmt.Errorf("Error waiting for volume %d to detach: %s", i, err)
+				ui.Error(err.Error())
+			}
+		}
+	}
 
 	// Destroy the droplet we just created
 	ui.Say("Destroying droplet...")

--- a/builder/digitalocean/step_create_volumes.go
+++ b/builder/digitalocean/step_create_volumes.go
@@ -1,0 +1,67 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/packer/packer"
+	"github.com/mitchellh/multistep"
+)
+
+type stepCreateVolumes struct {
+	volumeIDs []string
+}
+
+func (s *stepCreateVolumes) Run(state multistep.StateBag) multistep.StepAction {
+	client := state.Get("client").(*godo.Client)
+	ui := state.Get("ui").(packer.Ui)
+	c := state.Get("config").(Config)
+
+	if len(c.Volumes) == 0 {
+		return multistep.ActionContinue
+	}
+
+	// Create the volumes based on configuration
+	ui.Say("Creating volumes...")
+
+	for _, vc := range c.Volumes {
+		volume, _, err := client.Storage.CreateVolume(context.TODO(), &godo.VolumeCreateRequest{
+			Name:          vc.VolumeName,
+			SizeGigaBytes: vc.Size,
+			Region:        c.Region,
+			SnapshotID:    vc.BaseSnapshotID,
+		})
+		if err != nil {
+			err := fmt.Errorf("Error creating volume: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		s.volumeIDs = append(s.volumeIDs, volume.ID)
+	}
+
+	// Store the droplet id for later
+	state.Put("volume_ids", s.volumeIDs)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepCreateVolumes) Cleanup(state multistep.StateBag) {
+	if len(s.volumeIDs) == 0 {
+		return
+	}
+
+	client := state.Get("client").(*godo.Client)
+	ui := state.Get("ui").(packer.Ui)
+
+	ui.Say("Destroying volumes...")
+	for _, volumeID := range s.volumeIDs {
+		_, err := client.Storage.DeleteVolume(context.TODO(), volumeID)
+		if err != nil {
+			ui.Error(fmt.Sprintf(
+				"Error destroying volume %q. Please destroy it manually: %s",
+				volumeID, err))
+		}
+	}
+}

--- a/builder/digitalocean/step_snapshot_volumes.go
+++ b/builder/digitalocean/step_snapshot_volumes.go
@@ -1,0 +1,48 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/packer/packer"
+	"github.com/mitchellh/multistep"
+)
+
+type stepSnapshotVolumes struct{}
+
+func (s *stepSnapshotVolumes) Run(state multistep.StateBag) multistep.StepAction {
+	client := state.Get("client").(*godo.Client)
+	ui := state.Get("ui").(packer.Ui)
+	c := state.Get("config").(Config)
+	volumeIDs := state.Get("volume_ids").([]string)
+
+	volumeSnapshots := []snapshot{}
+	for i := range volumeIDs {
+		snap, _, err := client.Storage.CreateSnapshot(context.TODO(), &godo.SnapshotCreateRequest{
+			Name:     c.Volumes[i].SnapshotName,
+			VolumeID: volumeIDs[i],
+		})
+		if err != nil {
+			err := fmt.Errorf("Error creating snapshot for volume %d: %s", i, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		volumeSnapshots = append(volumeSnapshots, snapshot{
+			id:      snap.ID,
+			name:    snap.Name,
+			regions: []string{c.Region},
+		})
+		log.Printf("Volume %d snapshot ID: %s", i, snap.ID)
+	}
+
+	state.Put("volume_snapshots", volumeSnapshots)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepSnapshotVolumes) Cleanup(state multistep.StateBag) {
+	// no cleanup
+}

--- a/website/source/docs/builders/digitalocean.html.md
+++ b/website/source/docs/builders/digitalocean.html.md
@@ -86,6 +86,41 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the Droplet.
 
+-   `volumes` (array of objects) - Block storage volumes to attach to the
+    droplet and to snapshot after the build.
+    Example:
+
+    ```json
+    {
+        "volumes": [
+            {
+                "size": 10
+            },
+            {
+                "size": 20,
+                "volume_name": "packer-vol",
+                "snapshot_name": "vol-{{timestamp}}"
+            }
+        ]
+    }
+    ```
+
+    -   `size` (number) - The size of the volume in GiB. Required.
+
+    -   `snapshot_name` (string) - The name of the resulting snapshot that will
+        appear in your account. This must be unique. The default is to append
+        `-volN` to the droplet snapshot name, where `N` is the index of the
+        volume in the array.
+
+    -   `base_snapshot_id` (string) - The ID of an existing volume snapshot to
+        create the volume from. If left empty, DigitalOcean creates a blank,
+        unformatted volume.
+
+    -   `volume_name` (string) - The name assigned to the volume during the
+        build process. This affects the name of the device in the `/dev/disk`
+        directory. See DigitalOcean's [How To Use Block Storage](https://www.digitalocean.com/community/tutorials/how-to-use-block-storage-on-digitalocean)
+        tutorial for details.
+
 ## Basic Example
 
 Here is a basic example. It is completely valid as soon as you enter your own


### PR DESCRIPTION
Teach the DigitalOcean builder to create block storage volumes and snapshot them after the build.

This is particularly useful for high CPU instances, where the instance only has access to 20GB of local SSD. 