### PR TITLE
crash - markastemplate vsphere post-processor

### DIFF
--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -88,13 +88,6 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		return nil, false, fmt.Errorf("Unknown artifact type, can't build box: %s", artifact.BuilderId())
 	}
 
-	source := ""
-	for _, path := range artifact.Files() {
-		if strings.HasSuffix(path, ".vmx") {
-			source = path
-			break
-		}
-	}
 	// In some occasions the VM state is powered on and if we immediately try to mark as template
 	// (after the ESXi creates it) it will fail. If vSphere is given a few seconds this behavior doesn't reappear.
 	ui.Message("Waiting 10s for VMware vSphere to start")
@@ -119,7 +112,6 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		},
 		&stepMarkAsTemplate{
 			VMName: artifact.Id(),
-			Source: source,
 		},
 	}
 	runner := common.NewRunnerWithPauseFn(steps, p.config.PackerConfig, ui, state)

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -21,7 +21,7 @@ func (s *stepMarkAsTemplate) Run(state multistep.StateBag) multistep.StepAction 
 	folder := state.Get("folder").(*object.Folder)
 	dcPath := state.Get("dcPath").(string)
 
-	ui.Message(fmt.Sprintf("Unregistering template %s/%s", folder, s.VMName))
+	ui.Message(fmt.Sprintf("Unregistering template %s/%s", folder.InventoryPath, s.VMName))
 	if err := unregisterPreviousVM(cli, folder, s.VMName); err != nil {
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -3,12 +3,12 @@ package vsphere_template
 import (
 	"context"
 	"fmt"
-	"path"
 	"github.com/hashicorp/packer/packer"
 	"github.com/mitchellh/multistep"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
+	"path"
 )
 
 type stepMarkAsTemplate struct {


### PR DESCRIPTION
Closes #5529 : Revamped the process to mark the template of vsphere-template post-processor. Probably this implementation makes more sense.

