### PR TITLE
build: Allow multi-platform dev with Vagrantfile; add FreeBSD support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,50 +1,89 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$script = <<SCRIPT
-# Fetch from https://golang.org/dl
-TARBALL="https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz"
-
-UNTARPATH="/opt"
-GOROOT="${UNTARPATH}/go"
-GOPATH="${UNTARPATH}/gopath"
-
-# Install Go
-if [ ! -d ${GOROOT} ]; then
-  sudo wget --progress=bar:force --output-document - ${TARBALL} |\
-    tar xfz - -C ${UNTARPATH}
-fi
-
-# Setup the GOPATH
-sudo mkdir -p ${GOPATH}
-cat <<EOF >/tmp/gopath.sh
-export GOROOT="${GOROOT}"
-export GOPATH="${GOPATH}"
-export PATH="${GOROOT}/bin:${GOPATH}/bin:\$PATH"
-EOF
-sudo mv /tmp/gopath.sh /etc/profile.d/gopath.sh
-
-# Make sure the GOPATH is usable by vagrant
-sudo chown -R vagrant:vagrant ${GOROOT}
-sudo chown -R vagrant:vagrant ${GOPATH}
-
-# Install some other stuff we need
-sudo apt-get update
-sudo apt-get install -y curl make git mercurial bzr zip
-SCRIPT
+LINUX_BASE_BOX = "bento/ubuntu-16.04"
+FREEBSD_BASE_BOX = "jen20/FreeBSD-12.0-CURRENT"
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "bento/ubuntu-14.04"
+	# Compilation and development boxes
+	config.vm.define "linux", autostart: true, primary: true do |vmCfg|
+		vmCfg.vm.box = LINUX_BASE_BOX
+		vmCfg.vm.hostname = "linux"
+		vmCfg = configureProviders vmCfg,
+			cpus: suggestedCPUCores()
 
-  config.vm.provision "shell", inline: $script
+		vmCfg.vm.synced_folder ".", "/vagrant", disabled: true
+		vmCfg.vm.synced_folder '.',
+			'/opt/gopath/src/github.com/hashicorp/packer'
 
-  config.vm.synced_folder ".", "/vagrant", disabled: true
+		vmCfg.vm.provision "shell",
+			privileged: true,
+			inline: 'rm -f /home/vagrant/linux.iso'
 
-  ["vmware_fusion", "vmware_workstation"].each do |p|
-    config.vm.provider "p" do |v|
-      v.vmx["memsize"] = "2048"
-      v.vmx["numvcpus"] = "2"
-      v.vmx["cpuid.coresPerSocket"] = "1"
-    end
-  end
+		vmCfg.vm.provision "shell",
+			privileged: true,
+			path: './scripts/vagrant-linux-priv-go.sh'
+
+		vmCfg.vm.provision "shell",
+			privileged: true,
+			path: './scripts/vagrant-linux-priv-config.sh'
+
+		vmCfg.vm.provision "shell",
+			privileged: false,
+			path: './scripts/vagrant-linux-unpriv-bootstrap.sh'
+	end
+
+	config.vm.define "freebsd", autostart: false, primary: false do |vmCfg|
+		vmCfg.vm.box = FREEBSD_BASE_BOX
+		vmCfg.vm.hostname = "freebsd"
+		vmCfg = configureProviders vmCfg,
+			cpus: suggestedCPUCores()
+
+		vmCfg.vm.synced_folder ".", "/vagrant", disabled: true
+		vmCfg.vm.synced_folder '.',
+			'/opt/gopath/src/github.com/hashicorp/packer',
+			type: "nfs",
+			bsd__nfs_options: ['noatime']
+
+		vmCfg.vm.provision "shell",
+			privileged: true,
+			path: './scripts/vagrant-freebsd-priv-config.sh'
+
+		vmCfg.vm.provision "shell",
+			privileged: false,
+			path: './scripts/vagrant-freebsd-unpriv-bootstrap.sh'
+	end
+end
+
+def configureProviders(vmCfg, cpus: "2", memory: "2048")
+	vmCfg.vm.provider "virtualbox" do |v|
+		v.memory = memory
+		v.cpus = cpus
+	end
+
+	["vmware_fusion", "vmware_workstation"].each do |p|
+		vmCfg.vm.provider p do |v|
+			v.enable_vmrun_ip_lookup = false
+			v.vmx["memsize"] = memory
+			v.vmx["numvcpus"] = cpus
+		end
+	end
+
+	vmCfg.vm.provider "virtualbox" do |v|
+		v.memory = memory
+		v.cpus = cpus
+	end
+
+	return vmCfg
+end
+
+def suggestedCPUCores()
+	case RbConfig::CONFIG['host_os']
+	when /darwin/
+		Integer(`sysctl -n hw.ncpu`) / 2
+	when /linux/
+		Integer(`cat /proc/cpuinfo | grep processor | wc -l`) / 2
+	else
+		2
+	end
 end

--- a/scripts/vagrant-freebsd-priv-config.sh
+++ b/scripts/vagrant-freebsd-priv-config.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+chown vagrant:wheel \
+       /opt/gopath \
+       /opt/gopath/src \
+       /opt/gopath/src/github.com \
+       /opt/gopath/src/github.com/hashicorp
+
+mkdir -p /usr/local/etc/pkg/repos
+
+cat <<EOT > /usr/local/etc/pkg/repos/FreeBSD.conf
+FreeBSD: {
+	url: "pkg+http://pkg.FreeBSD.org/\${ABI}/latest"
+}
+EOT
+
+pkg update
+
+pkg install -y \
+       editors/vim-lite \
+       devel/git \
+       devel/gmake \
+       lang/go \
+       security/ca_root_nss \
+       shells/bash
+
+chsh -s /usr/local/bin/bash vagrant
+chsh -s /usr/local/bin/bash root
+
+cat <<EOT >> /home/vagrant/.profile
+export GOPATH=/opt/gopath
+export PATH=\$GOPATH/bin:\$PATH
+
+cd /opt/gopath/src/github.com/hashicorp/packer
+EOT

--- a/scripts/vagrant-freebsd-unpriv-bootstrap.sh
+++ b/scripts/vagrant-freebsd-unpriv-bootstrap.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export GOPATH=/opt/gopath
+
+PATH=$GOPATH/bin:$PATH
+export PATH
+
+cd /opt/gopath/src/github.com/hashicorp/packer && gmake deps

--- a/scripts/vagrant-linux-priv-config.sh
+++ b/scripts/vagrant-linux-priv-config.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Update and ensure we have apt-add-repository
+apt-get update
+apt-get install -y software-properties-common
+
+apt-get install -y bzr \
+	curl \
+	git \
+	make \
+	mercurial \
+	zip
+
+# Ensure we cd into the working directory on login
+if ! grep "cd /opt/gopath/src/github.com/hashicorp/packer" /home/vagrant/.profile ; then
+	echo 'cd /opt/gopath/src/github.com/hashicorp/packer' >> /home/vagrant/.profile
+fi

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+function install_go() {
+	local go_version=1.9.2
+	local download=
+	
+	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"
+
+	if [ -d /usr/local/go ] ; then
+		return
+	fi
+
+	wget -q -O /tmp/go.tar.gz ${download}
+
+	tar -C /tmp -xf /tmp/go.tar.gz
+	sudo mv /tmp/go /usr/local
+	sudo chown -R root:root /usr/local/go
+}
+
+install_go
+	
+# Ensure that the GOPATH tree is owned by vagrant:vagrant
+mkdir -p /opt/gopath
+chown -R vagrant:vagrant /opt/gopath
+
+# Ensure Go is on PATH
+if [ ! -e /usr/bin/go ] ; then
+	ln -s /usr/local/go/bin/go /usr/bin/go
+fi
+if [ ! -e /usr/bin/gofmt ] ; then
+	ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt
+fi
+
+
+# Ensure new sessions know about GOPATH
+if [ ! -f /etc/profile.d/gopath.sh ] ; then
+	cat <<EOT > /etc/profile.d/gopath.sh
+export GOPATH="/opt/gopath"
+export PATH="/opt/gopath/bin:\$PATH"
+EOT
+	chmod 755 /etc/profile.d/gopath.sh
+fi

--- a/scripts/vagrant-linux-unpriv-bootstrap.sh
+++ b/scripts/vagrant-linux-unpriv-bootstrap.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cd /opt/gopath/src/github.com/hashicorp/packer && make deps


### PR DESCRIPTION
This commit rewrites the Vagrantfile for Packer in a similar manner to the work done for Nomad (hashicorp/nomad#3175) in order to make cross-platform development easier. It also adds support for a FreeBSD base box.

Provisioning scripts are separated out in order that they can be correctly linted. Each script is prefixed `vagrant`, then the operating system, then whether or not it expects to be run in a privileged shell.

Finally, dependencies have been bumped - Go 1.6 is switched out for the latest version (1.9.2).