### PR TITLE
Add Snapcraft packaging of packer.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: packer
+version: git
+summary: Packer - Build Automated Machine Images
+description: |
+  Packer is easy to use and automates the creation of any type of machine
+  image. It embraces modern configuration management by encouraging you to use
+  automated scripts to install and configure the software within your
+  Packer-made images. Packer brings machine images into the modern age,
+  unlocking untapped potential and opening new opportunities.
+
+grade: stable
+confinement: classic
+
+apps:
+  packer:
+    command: packer
+
+parts:
+  packer:
+    source: .
+    plugin: go
+    go-importpath: github.com/hashicorp/packer
+    after: [go]


### PR DESCRIPTION
If you're not already familiar with Snaps, you can read more about them here: https://snapcraft.io/

Basically, packing Packer as a Snap would allow it to be run on any OS that supports Snap packages... I'm running SolusOS, which does not have a native Packer package... but packaged as a Snap, I can install and use Packer.

As far as I can tell, Packer will require the `classic` Snap confinement (which essentially gives it full permission to access anything on the system on which it is installed; necessary for accessing things like VirtualBox, etc.), which means the Snap folks will have to manually approve the Snap in the Snap Store. Sounds like this is a fairly low-overhead process, though, and need only be done once.

I've experimented with building Packer as a snap myself (`snap search packer`, and look for the `spirotot` author), but I haven't published a Snap to the Snap Store with the `classic` confinement yet because if anyone is going to publish a Packer Snap with the `classic` confinement, I think it makes most sense for it to be you, Hashicorp. That being said, I _have_ been testing/using my dev build of a Packer Snap on SolusOS without issue.

Last thing: you can have Snapcraft automatically build/package Packer for you, and it's really easy to set up. See here: https://build.snapcraft.io/

Let me know if you have any questions -- I'll do what I can to answer them!
