### PR TITLE
Website: add ssh_agent_auth to ssh communicator docs

### DIFF
--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -52,11 +52,15 @@ configuration parameters for that communicator. These are documented below.
 
 ## SSH Communicator
 
-The SSH communicator connects to the host via SSH. If you have an SSH
-agent enabled on the machine running Packer, it will automatically forward
-the SSH agent to the remote host.
+The SSH communicator connects to the host via SSH. If you have an SSH agent
+configured on the host running Packer, and SSH agent authentication is enabled
+in the communicator config, Packer will automatically forward the SSH agent
+to the remote host.
 
 The SSH communicator has the following options:
+
+-   `ssh_agent_auth` (boolean) - If true, the local SSH agent will be used to
+    authenticate connections to the remote host. Defaults to false.
 
 -   `ssh_bastion_agent_auth` (boolean) - If true, the local SSH agent will
     be used to authenticate with the bastion host. Defaults to false.


### PR DESCRIPTION
This is a tiny PR which adds ``ssh_agent_auth`` to the SSH communicator docs and clarifies the use of ssh-agent.

``ssh_agent_auth`` is mentioned in the documentation [for several builders](https://www.packer.io/docs/builders/amazon-ebs.html#ssh_agent_auth), but not in the [SSH communicator docs](https://www.packer.io/docs/templates/communicator.html#ssh-communicator) themselves, which are linked from the [null builder page](https://www.packer.io/docs/builders/null.html).