### PR TITLE
create LXC container with specified config_file

### DIFF
--- a/builder/lxc/step_lxc_create.go
+++ b/builder/lxc/step_lxc_create.go
@@ -28,7 +28,7 @@ func (s *stepLxcCreate) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	commands := make([][]string, 3)
-	commands[0] = append(config.EnvVars, []string{"lxc-create", "-n", name, "-t", config.Name, "--"}...)
+	commands[0] = append(config.EnvVars, []string{"lxc-create", "-n", name, "-t", config.Name, "-f", config.ConfigFile, "--"}...)
 	commands[0] = append(commands[0], config.Parameters...)
 	// prevent tmp from being cleaned on boot, we put provisioning scripts there
 	// todo: wait for init to finish before moving on to provisioning instead of this


### PR DESCRIPTION
The LXC builder has a required `config_file` parameter which
is only relevant when exporting the container and not during the
build process. Currently, the only way to pass runtime configuration
settings to the container is to put them in `/etc/lxc/default.conf`.

This change uses the same configuration file during the
container's creation so that one may have more control over settings
passed to the container during the initial build.