### PR TITLE
make restart command work correctly even if user has their own check …

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -216,10 +216,8 @@ var waitForCommunicator = func(p *Provisioner) error {
 		cmdModuleLoad := &packer.RemoteCmd{
 			Command: DefaultRestartCheckCommand,
 			Stdin:   nil,
-			Stdout:  &buf,
-			Stderr:  &buf}
+			Stdout:  &buf}
 
-		// cmdModuleLoad.StartWithUi(p.comm, p.ui)
 		p.comm.Start(cmdModuleLoad)
 		cmdModuleLoad.Wait()
 

--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -192,7 +192,7 @@ var waitForCommunicator = func(p *Provisioner) error {
 			return fmt.Errorf("Communicator wait canceled")
 		case <-time.After(retryableSleep):
 		}
-		if runCustomRestartCheck == true {
+		if runCustomRestartCheck {
 			// run user-configured restart check
 			err := cmdRestartCheck.StartWithUi(p.comm, p.ui)
 			if err != nil {

--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -175,6 +175,13 @@ WaitLoop:
 
 var waitForCommunicator = func(p *Provisioner) error {
 	runCustomRestartCheck := true
+	if p.config.RestartCheckCommand == DefaultRestartCheckCommand {
+		runCustomRestartCheck = false
+	}
+	// this is the user configurable command
+	cmdRestartCheck := &packer.RemoteCmd{Command: p.config.RestartCheckCommand}
+	log.Printf("Checking that communicator is connected with: '%s'",
+		cmdRestartCheck.Command)
 	for {
 		select {
 		case <-p.cancel:
@@ -183,16 +190,8 @@ var waitForCommunicator = func(p *Provisioner) error {
 		case <-time.After(retryableSleep):
 		}
 		if runCustomRestartCheck == true {
-			if p.config.RestartCheckCommand == DefaultRestartCheckCommand {
-				runCustomRestartCheck = false
-			}
-			// this is the user configurable command
-			cmdRestartCheck := &packer.RemoteCmd{Command: p.config.RestartCheckCommand}
-			log.Printf("Checking that communicator is connected with: '%s'",
-				cmdRestartCheck.Command)
 			// run user-configured restart check
 			err := cmdRestartCheck.StartWithUi(p.comm, p.ui)
-
 			if err != nil {
 				log.Printf("Communication connection err: %s", err)
 				continue

--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -223,7 +223,9 @@ var waitForCommunicator = func(p *Provisioner) error {
 		cmdModuleLoad.Wait()
 
 		stdoutToRead := stdout.String()
+		stderrToRead := stderr.String()
 		if !strings.Contains(stdoutToRead, "restarted.") {
+			log.Printf("Stderr is %s", stderrToRead)
 			log.Printf("echo didn't succeed; retrying...")
 			continue
 		}

--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -212,16 +212,17 @@ var waitForCommunicator = func(p *Provisioner) error {
 		// provisioning before powershell is actually ready.
 		// In this next check, we parse stdout to make sure that the command is
 		// actually running as expected.
-		var buf bytes.Buffer
+		var stdout, stderr bytes.Buffer
 		cmdModuleLoad := &packer.RemoteCmd{
 			Command: DefaultRestartCheckCommand,
 			Stdin:   nil,
-			Stdout:  &buf}
+			Stdout:  &stdout,
+			Stderr:  &stderr}
 
 		p.comm.Start(cmdModuleLoad)
 		cmdModuleLoad.Wait()
 
-		stdoutToRead := buf.String()
+		stdoutToRead := stdout.String()
 		if !strings.Contains(stdoutToRead, "restarted.") {
 			log.Printf("echo didn't succeed; retrying...")
 			continue

--- a/website/source/docs/provisioners/windows-restart.html.md
+++ b/website/source/docs/provisioners/windows-restart.html.md
@@ -42,7 +42,14 @@ Optional parameters:
     detect it is rebooting.
 
 -   `restart_check_command` (string) - A command to execute to check if the
-    restart succeeded. This will be done in a loop.
+    restart succeeded. This will be done in a loop. Example usage:
+
+``` json
+    {
+      "type": "windows-restart",
+      "restart_check_command": "powershell -command \"& {Write-Output 'restarted.'}\""
+    },
+```
 
 -   `restart_timeout` (string) - The timeout to wait for the restart. By
     default this is 5 minutes. Example value: `5m`. If you are installing


### PR DESCRIPTION
use default check for restart output regardless of user restart check.

Closes #5483
