### PR TITLE
builder/triton: Wait for ImageCreation State

### DIFF
--- a/builder/triton/driver_triton.go
+++ b/builder/triton/driver_triton.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"time"
-
 	"sort"
+	"time"
 
 	"github.com/hashicorp/packer/packer"
 	"github.com/joyent/triton-go/client"
@@ -200,7 +199,7 @@ func (d *driverTriton) WaitForImageCreation(imageId string, timeout time.Duratio
 			if image == nil {
 				return false, err
 			}
-			return image.OS != "", err
+			return image.State == "active", err
 		},
 		3*time.Second,
 		timeout,


### PR DESCRIPTION
It was reported to Joyent that sometimes the Packer UI reports that an image was created, but it is not subsequently available.

This PR changes Packer to wait for the state of the image to be `active` to make sure that it is ready for use prior to reporting the image ID.

```
==> triton: Stopping source machine (61647c3c-f2bf-4e30-b4bc-f076d3b01522)...
==> triton: Waiting for source machine to stop (61647c3c-f2bf-4e30-b4bc-f076d3b01522)...
==> triton: Creating image from source machine...
==> triton: Waiting for image to become available...
==> triton: Deleting source machine...
==> triton: Waiting for source machine to be deleted...
Build 'triton' finished.

==> Builds finished. The artifacts of successful builds are:
--> triton: Image was created: c2537582-34c7-42ea-bd11-b6ed499d5831
```