### PR TITLE
enable vsphere-template post processor to work with export behavior 

### DIFF
--- a/builder/vmware/iso/artifact.go
+++ b/builder/vmware/iso/artifact.go
@@ -4,6 +4,12 @@ import (
 	"fmt"
 )
 
+const (
+	ArtifactConfFormat         = "artifact.conf.format"
+	ArtifactConfKeepRegistered = "artifact.conf.keep_registered"
+	ArtifactConfSkipExport     = "artifact.conf.skip_export"
+)
+
 // Artifact is the result of running the VMware builder, namely a set
 // of files associated with the resulting machine.
 type Artifact struct {
@@ -11,6 +17,7 @@ type Artifact struct {
 	id        string
 	dir       OutputDir
 	f         []string
+	config    map[string]string
 }
 
 func (a *Artifact) BuilderId() string {
@@ -30,7 +37,7 @@ func (a *Artifact) String() string {
 }
 
 func (a *Artifact) State(name string) interface{} {
-	return nil
+	return a.config[name]
 }
 
 func (a *Artifact) Destroy() error {

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	vmwcommon "github.com/hashicorp/packer/builder/vmware/common"
@@ -343,7 +344,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	// Compile the artifact list
 	var files []string
-	if b.config.RemoteType != "" && b.config.Format != "" {
+	if b.config.RemoteType != "" && b.config.Format != "" && !b.config.SkipExport {
 		dir = new(vmwcommon.LocalOutputDir)
 		dir.SetOutputDir(exportOutputPath)
 		files, err = dir.ListFiles()
@@ -360,11 +361,17 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		builderId = BuilderIdESX
 	}
 
+	config := make(map[string]string)
+	config[ArtifactConfKeepRegistered] = strconv.FormatBool(b.config.KeepRegistered)
+	config[ArtifactConfFormat] = b.config.Format
+	config[ArtifactConfSkipExport] = strconv.FormatBool(b.config.SkipExport)
+
 	return &Artifact{
 		builderId: builderId,
 		id:        b.config.VMName,
 		dir:       dir,
 		f:         files,
+		config:    config,
 	}, nil
 }
 

--- a/builder/vmware/iso/step_register.go
+++ b/builder/vmware/iso/step_register.go
@@ -51,7 +51,7 @@ func (s *StepRegister) Cleanup(state multistep.StateBag) {
 	}
 
 	if remoteDriver, ok := driver.(RemoteDriver); ok {
-		if s.Format == "" {
+		if s.Format == "" || config.SkipExport {
 			ui.Say("Unregistering virtual machine...")
 			if err := remoteDriver.Unregister(s.registeredPath); err != nil {
 				ui.Error(fmt.Sprintf("Error unregistering VM: %s", err))

--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -88,13 +88,6 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		return nil, false, fmt.Errorf("Unknown artifact type, can't build box: %s", artifact.BuilderId())
 	}
 
-	source := ""
-	for _, path := range artifact.Files() {
-		if strings.HasSuffix(path, ".vmx") {
-			source = path
-			break
-		}
-	}
 	// In some occasions the VM state is powered on and if we immediately try to mark as template
 	// (after the ESXi creates it) it will fail. If vSphere is given a few seconds this behavior doesn't reappear.
 	ui.Message("Waiting 10s for VMware vSphere to start")
@@ -119,12 +112,10 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		},
 		&stepMarkAsTemplate{
 			VMName: artifact.Id(),
-			Source: source,
 		},
 	}
 	runner := common.NewRunnerWithPauseFn(steps, p.config.PackerConfig, ui, state)
 	runner.Run(state)
-
 	if rawErr, ok := state.GetOk("error"); ok {
 		return nil, false, rawErr.(error)
 	}


### PR DESCRIPTION
Use the vm disk path information to re-create the vmx datastore path. Also check the attributes from the artifact to check if its possible to use the post-processor with the actual configuration.

Closes #5529