### PR TITLE
clearly state that url is wrong at validation stage of build

### DIFF
--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -2,6 +2,7 @@ package ovf
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -103,8 +104,9 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("source_path is invalid: %s", err))
 		}
 		// file must exist now.
-		if (len(c.SourcePath) > 7) && (c.SourcePath[:7] == "file://") {
-			if _, err := os.Stat(c.SourcePath[7:]); err != nil {
+		fileURL, _ := url.Parse(c.SourcePath)
+		if fileURL.Scheme == "file" {
+			if _, err := os.Stat(fileURL.Path); err != nil {
 				errs = packer.MultiErrorAppend(errs,
 					fmt.Errorf("source file needs to exist at time of config validation: %s", err))
 			}

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -2,6 +2,7 @@ package ovf
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	vboxcommon "github.com/hashicorp/packer/builder/virtualbox/common"
@@ -100,6 +101,13 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		c.SourcePath, err = common.DownloadableURL(c.SourcePath)
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("source_path is invalid: %s", err))
+		}
+		// file must exist now.
+		if (len(c.SourcePath) > 7) && (c.SourcePath[:7] == "file://") {
+			if _, err := os.Stat(c.SourcePath[7:]); err != nil {
+				errs = packer.MultiErrorAppend(errs,
+					fmt.Errorf("source file needs to exist at time of config validation: %s", err))
+			}
 		}
 	}
 

--- a/builder/virtualbox/ovf/config_test.go
+++ b/builder/virtualbox/ovf/config_test.go
@@ -65,14 +65,14 @@ func TestNewConfig_sourcePath(t *testing.T) {
 		t.Fatalf("should error with empty `source_path`")
 	}
 
-	// Okay, because it gets caught during download
+	// Want this to fail on validation
 	c = testConfig(t)
 	c["source_path"] = "/i/dont/exist"
 	_, warns, err = NewConfig(c)
 	if len(warns) > 0 {
 		t.Fatalf("bad: %#v", warns)
 	}
-	if err != nil {
+	if err == nil {
 		t.Fatalf("bad: %s", err)
 	}
 
@@ -84,7 +84,7 @@ func TestNewConfig_sourcePath(t *testing.T) {
 		t.Fatalf("bad: %#v", warns)
 	}
 	if err == nil {
-		t.Fatal("should error")
+		t.Fatal("Nonexistent source file should be caught in validation")
 	}
 
 	// Good

--- a/builder/virtualbox/ovf/config_test.go
+++ b/builder/virtualbox/ovf/config_test.go
@@ -73,7 +73,7 @@ func TestNewConfig_sourcePath(t *testing.T) {
 		t.Fatalf("bad: %#v", warns)
 	}
 	if err == nil {
-		t.Fatalf("bad: %s", err)
+		t.Fatalf("Nonexistant file should throw a validation error!")
 	}
 
 	// Bad

--- a/builder/virtualbox/ovf/config_test.go
+++ b/builder/virtualbox/ovf/config_test.go
@@ -84,7 +84,7 @@ func TestNewConfig_sourcePath(t *testing.T) {
 		t.Fatalf("bad: %#v", warns)
 	}
 	if err == nil {
-		t.Fatal("Nonexistent source file should be caught in validation")
+		t.Fatal("should error")
 	}
 
 	// Good

--- a/common/config.go
+++ b/common/config.go
@@ -131,5 +131,12 @@ func DownloadableURL(original string) (string, error) {
 		return "", fmt.Errorf("Unsupported URL scheme: %s", url.Scheme)
 	}
 
+	// if cleaned filepath does not exist, error out now.
+	if url.Scheme == "file" {
+		if _, err := os.Stat(url.Path); err != nil {
+			return "", fmt.Errorf("The filepath doesn't exist either as a "+
+				"relative or an absolute path: %s", err)
+		}
+	}
 	return url.String(), nil
 }

--- a/common/config.go
+++ b/common/config.go
@@ -96,6 +96,8 @@ func DownloadableURL(original string) (string, error) {
 			}
 
 			url.Path = filepath.Clean(url.Path)
+		} else {
+			return "", err
 		}
 
 		if runtime.GOOS == "windows" {
@@ -108,14 +110,6 @@ func DownloadableURL(original string) (string, error) {
 
 	// Make sure it is lowercased
 	url.Scheme = strings.ToLower(url.Scheme)
-
-	// This is to work around issue #5927. This can safely be removed once
-	// we distribute with a version of Go that fixes that bug.
-	//
-	// See: https://code.google.com/p/go/issues/detail?id=5927
-	if url.Path != "" && url.Path[0] != '/' {
-		url.Path = "/" + url.Path
-	}
 
 	// Verify that the scheme is something we support in our common downloader.
 	supported := []string{"file", "http", "https"}
@@ -131,12 +125,5 @@ func DownloadableURL(original string) (string, error) {
 		return "", fmt.Errorf("Unsupported URL scheme: %s", url.Scheme)
 	}
 
-	// if cleaned filepath does not exist, error out now.
-	if url.Scheme == "file" {
-		if _, err := os.Stat(url.Path); err != nil {
-			return "", fmt.Errorf("The filepath doesn't exist either as a "+
-				"relative or an absolute path: %s", err)
-		}
-	}
 	return url.String(), nil
 }

--- a/common/config.go
+++ b/common/config.go
@@ -96,8 +96,6 @@ func DownloadableURL(original string) (string, error) {
 			}
 
 			url.Path = filepath.Clean(url.Path)
-		} else {
-			return "", err
 		}
 
 		if runtime.GOOS == "windows" {


### PR DESCRIPTION
Error out if the filepath can't be found BEFORE we dry to access it for a build.
In response to #5572
