### PR TITLE
Allow Selecting Container Optimized Images

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -170,7 +170,7 @@ func (d *driverGCE) DeleteDisk(zone, name string) (<-chan error, error) {
 }
 
 func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
-	projects := []string{d.projectId, "centos-cloud", "coreos-cloud", "debian-cloud", "google-containers", "opensuse-cloud", "rhel-cloud", "suse-cloud", "ubuntu-os-cloud", "windows-cloud", "gce-nvme"}
+	projects := []string{d.projectId, "centos-cloud", "coreos-cloud", "cos-cloud", "debian-cloud", "google-containers", "opensuse-cloud", "rhel-cloud", "suse-cloud", "ubuntu-os-cloud", "windows-cloud", "gce-nvme"}
 	var errs error
 	for _, project := range projects {
 		image, err := d.GetImageFromProject(project, name, fromFamily)


### PR DESCRIPTION
This updates the GCE driver to allow the Container-Optimized OS image families.

As far as I could tell there were no tests to update around this.  I did however end up manually testing it by way of using the newly compiled version to create an image that I was wanting using the new family.

I also hope this wasn't already open somewhere else.  I did a little hunting around and couldn't find that this was recorded anywhere as an already open PR or Issue.