### PR TITLE
iso_config: allow for subdirs in hash sum files

### DIFF
--- a/common/iso_config.go
+++ b/common/iso_config.go
@@ -140,9 +140,20 @@ func (c *ISOConfig) parseCheckSumFile(rd *bufio.Reader) error {
 	if err != nil {
 		return err
 	}
+
+	checksumurl, err := url.Parse(c.ISOChecksumURL)
+	if err != nil {
+		return err
+	}
+
+	relpath, err := filepath.Rel(filepath.Dir(checksumurl.Path), u.Path)
+	if err != nil {
+		return err
+	}
+
 	filename := filepath.Base(u.Path)
 
-	errNotFound := fmt.Errorf("No checksum for %q found at: %s", filename, c.ISOChecksumURL)
+	errNotFound := fmt.Errorf("No checksum for %q or %q found at: %s", filename, relpath, c.ISOChecksumURL)
 	for {
 		line, err := rd.ReadString('\n')
 		if err != nil && line == "" {
@@ -154,7 +165,8 @@ func (c *ISOConfig) parseCheckSumFile(rd *bufio.Reader) error {
 		}
 		if strings.ToLower(parts[0]) == c.ISOChecksumType {
 			// BSD-style checksum
-			if parts[1] == fmt.Sprintf("(%s)", filename) {
+			if parts[1] == fmt.Sprintf("(%s)", filename) || parts[1] == fmt.Sprintf("(%s)", relpath) ||
+				parts[1] == fmt.Sprintf("(./%s)", relpath) {
 				c.ISOChecksum = parts[3]
 				return nil
 			}
@@ -164,7 +176,7 @@ func (c *ISOConfig) parseCheckSumFile(rd *bufio.Reader) error {
 				// Binary mode
 				parts[1] = parts[1][1:]
 			}
-			if parts[1] == filename {
+			if parts[1] == filename || parts[1] == relpath || parts[1] == "./"+relpath {
 				c.ISOChecksum = parts[0]
 				return nil
 			}


### PR DESCRIPTION
Allow hash sum files and ISOs to be in different directories as Ubuntu does.

Signed-off-by: Pavel Boldin <boldin.pavel@gmail.com>
Closes: #5577 
