### PR TITLE
Update chef provisioner documentation

### DIFF
--- a/website/source/docs/provisioners/chef-client.html.md
+++ b/website/source/docs/provisioners/chef-client.html.md
@@ -212,7 +212,7 @@ readability) to install Chef. This command can be customized if you want to
 install Chef in another way.
 
 ``` text
-curl -L https://www.chef.io/chef/install.sh | \
+curl -L https:///omnitruck.chef.io/chef/install.sh | \
   {{if .Sudo}}sudo{{end}} bash
 ```
 


### PR DESCRIPTION
The URL has changed, see chef documentation https://docs.chef.io/install_omnibus.html