### PR TITLE
Docker Example Typo

### DIFF
--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -303,7 +303,7 @@ nearly-identical sequence definitions, as demonstrated by the example below:
     [
       {
         "type": "docker-tag",
-        "repository": "hashicorp/packer",
+        "repository": "hashicorp/packer1",
         "tag": "0.7"
       },
       "docker-push"
@@ -311,7 +311,7 @@ nearly-identical sequence definitions, as demonstrated by the example below:
     [
       {
         "type": "docker-tag",
-        "repository": "hashicorp/packer",
+        "repository": "hashicorp/packer2",
         "tag": "0.7"
       },
       "docker-push"


### PR DESCRIPTION
I think the intention was to show you can tag, and push the same image to multiple repos, but the example given is to the same repo, twice. This change updates the example so it uses `hashicorp/packer1`, and `hashicorp/packer2`.
