### PR TITLE
Align virtual disk size for qemu builder

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -144,7 +144,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	warnings := make([]string, 0)
 
 	if b.config.DiskSize == 0 {
-		b.config.DiskSize = 40000
+		b.config.DiskSize = 40960
 	}
 
 	if b.config.DiskCache == "" {

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -208,7 +208,7 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 		t.Fatalf("bad err: %s", err)
 	}
 
-	if b.config.DiskSize != 40000 {
+	if b.config.DiskSize != 40960 {
 		t.Fatalf("bad size: %d", b.config.DiskSize)
 	}
 

--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -157,7 +157,7 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     interface under these circumstances will cause the build to fail.
 
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
-    for the VM. By default, this is 40000 (about 40 GB).
+    for the VM. By default, this is 40960 (40 GB).
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for


### PR DESCRIPTION
When booting from a disk image, the Qemu builder resizes the disk to 40000
which is not a multiple of 1kB. This causes issues while booting from the image
causing the boot process to get stuck. Updating the default disk size to 40960 fixes this issue.