### PR TITLE
Winrm no proxy

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -76,9 +76,22 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		c.RunTags = make(map[string]string)
 	}
 
+	if c.SSHPrivateIp && c.SSHInterface {
+		errs = append(errs, errors.New("ssh_interface and ssh_private_ip should not both be specified"))
+	}
+
 	// Legacy configurable
 	if c.SSHPrivateIp {
 		c.SSHInterface = "private_ip"
+	}
+
+	// Valadating ssh_interface
+	if c.SSHInterface != "public_ip" ||
+		c.SSHInterface != "private_ip" ||
+		c.SSHInterface != "public_dns" ||
+		c.SSHInterface != "private_dns" ||
+		c.SSHInterface != "" {
+		errs = append(errs, errors.New("Unknown interface type: %s", SSHInterface))
 	}
 
 	// Validation

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -54,7 +54,7 @@ type RunConfig struct {
 	Comm           communicator.Config `mapstructure:",squash"`
 	SSHKeyPairName string              `mapstructure:"ssh_keypair_name"`
 	SSHPrivateIp   bool                `mapstructure:"ssh_private_ip"`
-	SSHInterface   string              `mapstructure:"ssh_interface`
+	SSHInterface   string              `mapstructure:"ssh_interface"`
 }
 
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -76,7 +76,9 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		c.RunTags = make(map[string]string)
 	}
 
-	if c.SSHPrivateIp && c.SSHInterface {
+	// Validation
+	errs := c.Comm.Prepare(ctx)
+	if c.SSHPrivateIp && c.SSHInterface != "" {
 		errs = append(errs, errors.New("ssh_interface and ssh_private_ip should not both be specified"))
 	}
 
@@ -86,16 +88,14 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 
 	// Valadating ssh_interface
-	if c.SSHInterface != "public_ip" ||
-		c.SSHInterface != "private_ip" ||
-		c.SSHInterface != "public_dns" ||
-		c.SSHInterface != "private_dns" ||
+	if c.SSHInterface != "public_ip" &&
+		c.SSHInterface != "private_ip" &&
+		c.SSHInterface != "public_dns" &&
+		c.SSHInterface != "private_dns" &&
 		c.SSHInterface != "" {
-		errs = append(errs, errors.New("Unknown interface type: %s", SSHInterface))
+		errs = append(errs, errors.New(fmt.Sprintf("Unknown interface type: %s", c.SSHInterface)))
 	}
 
-	// Validation
-	errs := c.Comm.Prepare(ctx)
 	if c.SSHKeyPairName != "" {
 		if c.Comm.Type == "winrm" && c.Comm.WinRMPassword == "" && c.Comm.SSHPrivateKey == "" {
 			errs = append(errs, errors.New("A private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name."))

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -54,6 +54,7 @@ type RunConfig struct {
 	Comm           communicator.Config `mapstructure:",squash"`
 	SSHKeyPairName string              `mapstructure:"ssh_keypair_name"`
 	SSHPrivateIp   bool                `mapstructure:"ssh_private_ip"`
+	SSHInterface   string              `mapstructure:"ssh_interface`
 }
 
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
@@ -73,6 +74,11 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.RunTags == nil {
 		c.RunTags = make(map[string]string)
+	}
+
+	// Legacy configurable
+	if c.SSHPrivateIp {
+		c.SSHInterface = "private_ip"
 	}
 
 	// Validation

--- a/builder/amazon/common/ssh.go
+++ b/builder/amazon/common/ssh.go
@@ -25,21 +25,40 @@ var (
 
 // SSHHost returns a function that can be given to the SSH communicator
 // for determining the SSH address based on the instance DNS name.
-func SSHHost(e ec2Describer, private bool) func(multistep.StateBag) (string, error) {
+func SSHHost(e ec2Describer, sshInterface string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		const tries = 2
 		// <= with current structure to check result of describing `tries` times
 		for j := 0; j <= tries; j++ {
 			var host string
 			i := state.Get("instance").(*ec2.Instance)
-			if i.VpcId != nil && *i.VpcId != "" {
-				if i.PublicIpAddress != nil && *i.PublicIpAddress != "" && !private {
+			if sshInterface != "" {
+				switch sshInterface {
+				case "public_ip":
+					if i.PublicIpAddress != nil {
+						host = *i.PublicIpAddress
+					}
+				case "private_ip":
+					if i.PrivateIpAddress != nil {
+						host = *i.PrivateIpAddress
+					}
+				case "public_dns":
+					if i.PublicDnsName != nil {
+						host = *i.PublicDnsName
+					}
+				case "private_dns":
+					if i.PrivateDnsName != nil {
+						host = *i.PrivateDnsName
+					}
+				default:
+					return "", fmt.Errorf("unknown interface type: %s", sshInterface)
+				}
+			} else if i.VpcId != nil && *i.VpcId != "" {
+				if i.PublicIpAddress != nil && *i.PublicIpAddress != "" {
 					host = *i.PublicIpAddress
 				} else if i.PrivateIpAddress != nil && *i.PrivateIpAddress != "" {
 					host = *i.PrivateIpAddress
 				}
-			} else if private && i.PrivateIpAddress != nil && *i.PrivateIpAddress != "" {
-				host = *i.PrivateIpAddress
 			} else if i.PublicDnsName != nil && *i.PublicDnsName != "" {
 				host = *i.PublicDnsName
 			}
@@ -63,7 +82,7 @@ func SSHHost(e ec2Describer, private bool) func(multistep.StateBag) (string, err
 			time.Sleep(sshHostSleepDuration)
 		}
 
-		return "", errors.New("couldn't determine IP address for instance")
+		return "", errors.New("couldn't determine address for instance")
 	}
 }
 

--- a/builder/amazon/common/ssh.go
+++ b/builder/amazon/common/ssh.go
@@ -51,7 +51,7 @@ func SSHHost(e ec2Describer, sshInterface string) func(multistep.StateBag) (stri
 						host = *i.PrivateDnsName
 					}
 				default:
-					return "", fmt.Errorf("unknown interface type: %s", sshInterface)
+					panic(fmt.Sprintf("Unknown interface type: %s", sshInterface))
 				}
 			} else if i.VpcId != nil && *i.VpcId != "" {
 				if i.PublicIpAddress != nil && *i.PublicIpAddress != "" {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -193,7 +193,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(
 				ec2conn,
-				b.config.SSHPrivateIp),
+				b.config.SSHInterface),
 			SSHConfig: awscommon.SSHConfig(
 				b.config.RunConfig.Comm.SSHAgentAuth,
 				b.config.RunConfig.Comm.SSHUsername,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -204,7 +204,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(
 				ec2conn,
-				b.config.SSHPrivateIp),
+				b.config.SSHInterface),
 			SSHConfig: awscommon.SSHConfig(
 				b.config.RunConfig.Comm.SSHAgentAuth,
 				b.config.RunConfig.Comm.SSHUsername,

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -181,7 +181,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(
 				ec2conn,
-				b.config.SSHPrivateIp),
+				b.config.SSHInterface),
 			SSHConfig: awscommon.SSHConfig(
 				b.config.RunConfig.Comm.SSHAgentAuth,
 				b.config.RunConfig.Comm.SSHUsername,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -268,7 +268,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(
 				ec2conn,
-				b.config.SSHPrivateIp),
+				b.config.SSHInterface),
 			SSHConfig: awscommon.SSHConfig(
 				b.config.RunConfig.Comm.SSHAgentAuth,
 				b.config.RunConfig.Comm.SSHUsername,

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -237,7 +237,7 @@ builder.
 
 -   `temporary_security_group_source_cidr` (string) - An IPv4 CIDR block to be authorized
     access to the instance, when packer is creating a temporary security group.
-    The default is `0.0.0.0/0` (ie, allow any IPv4 source). This is only used 
+    The default is `0.0.0.0/0` (ie, allow any IPv4 source). This is only used
     when `security_group_id` or `security_group_ids` is not specified.
 
 -   `shutdown_behavior` (string) - Automatically terminate instances on shutdown
@@ -328,8 +328,15 @@ builder.
     in AWS with the source instance, set the `ssh_keypair_name` field to the name
     of the key pair.
 
--   `ssh_private_ip` (boolean) - If true, then SSH will always use the private
-    IP if available. Also works for WinRM.
+-   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
+    IP if available. Also works for WinRM. Overrides `ssh_interface`.
+
+-   `ssh_interface` (string) - One of `PublicIpAddress`, `PrivateIpAddress`,
+    `PublicDnsName` or `PrivateDnsName`. If set, either the public IP address,
+    private IP address, public DNS name or private DNS name will used as the host for SSH.
+    The default behaviour if inside a VPC is to use the public IP address if available,
+    otherwise the private IP address will be used. If not in a VPC the public DNS name
+    will be used.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -331,8 +331,8 @@ builder.
 -   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
     IP if available. Also works for WinRM. Overrides `ssh_interface`.
 
--   `ssh_interface` (string) - One of `PublicIpAddress`, `PrivateIpAddress`,
-    `PublicDnsName` or `PrivateDnsName`. If set, either the public IP address,
+-   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
+    `public_dns` or `private_dns`. If set, either the public IP address,
     private IP address, public DNS name or private DNS name will used as the host for SSH.
     The default behaviour if inside a VPC is to use the public IP address if available,
     otherwise the private IP address will be used. If not in a VPC the public DNS name

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -338,8 +338,9 @@ builder.
     otherwise the private IP address will be used. If not in a VPC the public DNS name
     will be used.
 
-    If packer is configured for an outbound proxy. To configure WinRM traffic to bypass the proxy
-   `ssh_interface` can be set to `private_dns`.
+    Where Packer is configured for an outbound proxy but WinRM traffic should be direct
+    `ssh_interface` must be set to `private_dns` and `<region>.compute.internal` included
+    in the `NO_PROXY` environment variable.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -328,8 +328,8 @@ builder.
     in AWS with the source instance, set the `ssh_keypair_name` field to the name
     of the key pair.
 
--   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
-    IP if available. Also works for WinRM. Overrides `ssh_interface`.
+-   `ssh_private_ip` (boolean) - *Deprecated* use `ssh_interface` instead. If `true`,
+    then SSH will always use the private IP if available. Also works for WinRM.
 
 -   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
     `public_dns` or `private_dns`. If set, either the public IP address,
@@ -337,6 +337,9 @@ builder.
     The default behaviour if inside a VPC is to use the public IP address if available,
     otherwise the private IP address will be used. If not in a VPC the public DNS name
     will be used.
+
+    If packer is configured for an outbound proxy. To configure WinRM traffic to bypass the proxy
+   `ssh_interface` can be set to `private_dns`.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -321,8 +321,8 @@ builder.
     in AWS with the source instance, set the `ssh_keypair_name` field to the name
     of the key pair.
 
--   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
-    IP if available. Also works for WinRM. Overrides `ssh_interface`.
+-   `ssh_private_ip` (boolean) - *Deprecated* use `ssh_interface` instead. If `true`,
+    then SSH will always use the private IP if available. Also works for WinRM.
 
 -   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
     `public_dns` or `private_dns`. If set, either the public IP address,
@@ -330,6 +330,9 @@ builder.
     The default behaviour if inside a VPC is to use the public IP address if available,
     otherwise the private IP address will be used. If not in a VPC the public DNS name
     will be used.
+
+    If packer is configured for an outbound proxy. To configure WinRM traffic to bypass the proxy
+   `ssh_interface` can be set to `private_dns`.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -321,8 +321,15 @@ builder.
     in AWS with the source instance, set the `ssh_keypair_name` field to the name
     of the key pair.
 
--   `ssh_private_ip` (boolean) - If true, then SSH will always use the private
-    IP if available.
+-   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
+    IP if available. Also works for WinRM. Overrides `ssh_interface`.
+
+-   `ssh_interface` (string) - One of `PublicIpAddress`, `PrivateIpAddress`,
+    `PublicDnsName` or `PrivateDnsName`. If set, either the public IP address,
+    private IP address, public DNS name or private DNS name will used as the host for SSH.
+    The default behaviour if inside a VPC is to use the public IP address if available,
+    otherwise the private IP address will be used. If not in a VPC the public DNS name
+    will be used.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -331,8 +331,9 @@ builder.
     otherwise the private IP address will be used. If not in a VPC the public DNS name
     will be used.
 
-    If packer is configured for an outbound proxy. To configure WinRM traffic to bypass the proxy
-   `ssh_interface` can be set to `private_dns`.
+    Where Packer is configured for an outbound proxy but WinRM traffic should be direct
+    `ssh_interface` must be set to `private_dns` and `<region>.compute.internal` included
+    in the `NO_PROXY` environment variable.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -324,8 +324,8 @@ builder.
 -   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
     IP if available. Also works for WinRM. Overrides `ssh_interface`.
 
--   `ssh_interface` (string) - One of `PublicIpAddress`, `PrivateIpAddress`,
-    `PublicDnsName` or `PrivateDnsName`. If set, either the public IP address,
+-   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
+    `public_dns` or `private_dns`. If set, either the public IP address,
     private IP address, public DNS name or private DNS name will used as the host for SSH.
     The default behaviour if inside a VPC is to use the public IP address if available,
     otherwise the private IP address will be used. If not in a VPC the public DNS name

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -226,7 +226,14 @@ builder.
     must be specified with this.
 
 -   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
-    IP if available. Also works for WinRM.
+    IP if available. Also works for WinRM. Overrides `ssh_interface`.
+
+-   `ssh_interface` (string) - One of `PublicIpAddress`, `PrivateIpAddress`,
+    `PublicDnsName` or `PrivateDnsName`. If set, either the public IP address,
+    private IP address, public DNS name or private DNS name will used as the host for SSH.
+    The default behaviour if inside a VPC is to use the public IP address if available,
+    otherwise the private IP address will be used. If not in a VPC the public DNS name
+    will be used.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -228,8 +228,8 @@ builder.
 -   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
     IP if available. Also works for WinRM. Overrides `ssh_interface`.
 
--   `ssh_interface` (string) - One of `PublicIpAddress`, `PrivateIpAddress`,
-    `PublicDnsName` or `PrivateDnsName`. If set, either the public IP address,
+-   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
+    `public_dns` or `private_dns`. If set, either the public IP address,
     private IP address, public DNS name or private DNS name will used as the host for SSH.
     The default behaviour if inside a VPC is to use the public IP address if available,
     otherwise the private IP address will be used. If not in a VPC the public DNS name

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -225,8 +225,8 @@ builder.
     [`ssh_private_key_file`](/docs/templates/communicator.html#ssh_private_key_file)
     must be specified with this.
 
--   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
-    IP if available. Also works for WinRM. Overrides `ssh_interface`.
+-   `ssh_private_ip` (boolean) - *Deprecated* use `ssh_interface` instead. If `true`,
+    then SSH will always use the private IP if available. Also works for WinRM.
 
 -   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
     `public_dns` or `private_dns`. If set, either the public IP address,
@@ -234,6 +234,9 @@ builder.
     The default behaviour if inside a VPC is to use the public IP address if available,
     otherwise the private IP address will be used. If not in a VPC the public DNS name
     will be used.
+
+    If packer is configured for an outbound proxy. To configure WinRM traffic to bypass the proxy
+   `ssh_interface` can be set to `private_dns`.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -235,8 +235,9 @@ builder.
     otherwise the private IP address will be used. If not in a VPC the public DNS name
     will be used.
 
-    If packer is configured for an outbound proxy. To configure WinRM traffic to bypass the proxy
-   `ssh_interface` can be set to `private_dns`.
+    Where Packer is configured for an outbound proxy but WinRM traffic should be direct
+    `ssh_interface` must be set to `private_dns` and `<region>.compute.internal` included
+    in the `NO_PROXY` environment variable.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -329,8 +329,8 @@ builder.
     in AWS with the source instance, set the `ssh_keypair_name` field to the name
     of the key pair.
 
--   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
-    IP if available. Also works for WinRM. Overrides `ssh_interface`.
+-   `ssh_private_ip` (boolean) - *Deprecated* use `ssh_interface` instead. If `true`, 
+    then SSH will always use the private IP if available. Also works for WinRM.
 
 -   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
     `public_dns` or `private_dns`. If set, either the public IP address,
@@ -338,6 +338,9 @@ builder.
     The default behaviour if inside a VPC is to use the public IP address if available,
     otherwise the private IP address will be used. If not in a VPC the public DNS name
     will be used.
+
+    If packer is configured for an outbound proxy. To configure WinRM traffic to bypass the proxy
+   `ssh_interface` can be set to `private_dns`.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -329,8 +329,15 @@ builder.
     in AWS with the source instance, set the `ssh_keypair_name` field to the name
     of the key pair.
 
--   `ssh_private_ip` (boolean) - If true, then SSH will always use the private
-    IP if available. Also works for WinRM.
+-   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
+    IP if available. Also works for WinRM. Overrides `ssh_interface`.
+
+-   `ssh_interface` (string) - One of `PublicIpAddress`, `PrivateIpAddress`,
+    `PublicDnsName` or `PrivateDnsName`. If set, either the public IP address,
+    private IP address, public DNS name or private DNS name will used as the host for SSH.
+    The default behaviour if inside a VPC is to use the public IP address if available,
+    otherwise the private IP address will be used. If not in a VPC the public DNS name
+    will be used.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -332,8 +332,8 @@ builder.
 -   `ssh_private_ip` (boolean) - If `true`, then SSH will always use the private
     IP if available. Also works for WinRM. Overrides `ssh_interface`.
 
--   `ssh_interface` (string) - One of `PublicIpAddress`, `PrivateIpAddress`,
-    `PublicDnsName` or `PrivateDnsName`. If set, either the public IP address,
+-   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
+    `public_dns` or `private_dns`. If set, either the public IP address,
     private IP address, public DNS name or private DNS name will used as the host for SSH.
     The default behaviour if inside a VPC is to use the public IP address if available,
     otherwise the private IP address will be used. If not in a VPC the public DNS name

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -329,7 +329,7 @@ builder.
     in AWS with the source instance, set the `ssh_keypair_name` field to the name
     of the key pair.
 
--   `ssh_private_ip` (boolean) - *Deprecated* use `ssh_interface` instead. If `true`, 
+-   `ssh_private_ip` (boolean) - *Deprecated* use `ssh_interface` instead. If `true`,
     then SSH will always use the private IP if available. Also works for WinRM.
 
 -   `ssh_interface` (string) - One of `public_ip`, `private_ip`,
@@ -339,8 +339,9 @@ builder.
     otherwise the private IP address will be used. If not in a VPC the public DNS name
     will be used.
 
-    If packer is configured for an outbound proxy. To configure WinRM traffic to bypass the proxy
-   `ssh_interface` can be set to `private_dns`.
+    Where Packer is configured for an outbound proxy but WinRM traffic should be direct 
+    `ssh_interface` must be set to `private_dns` and `<region>.compute.internal` included
+    in the `NO_PROXY` environment variable.
 
 -   `subnet_id` (string) - If using VPC, the ID of the subnet, such as
     `subnet-12345def`, where Packer will launch the EC2 instance. This field is


### PR DESCRIPTION
**What ?**
Adds a new parameter `ssh_interface` to the Amazon builders. Valid values include `public_ip`, `private_ip`, `public_dns` or `private_dns`. If set, either the public IP address, private IP address, public DNS name or private DNS name will used as the host for SSH. The default behaviour if inside a VPC is to use the public IP address if available, otherwise the private IP address will be used. If not in a VPC the public DNS name will be used. This parameter is designed to replace `ssh_private_ip`. `ssh_private_ip` overrides `ssh_interface`.

Thanks to @meringu, @zl4bv and @tjnicholas for working on this with me. 👏 👍 😃 🎉 🎈 

This implementation was chosen rather than the one outlined in the issue #4857 as it is similar to the one seen in test kitchen. https://github.com/test-kitchen/kitchen-ec2#interface
Closes #4857

**Testing**
In a packer test project that uses winrm `ssh_interface` was set to `private_dns`. When the project was run behind a non transparent outbound proxy the AMI was created successfully. A project that uses SSH was also tested and produced an AMI successfully. Using the current release of packer the connection times out when using winrm.