### PR TITLE
[Hyper-V] Use differential disks and Inline disk creation to improve build time (a lot) and to reduce disk usage(a lot)

### DIFF
--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -28,6 +28,8 @@ type StepCreateVM struct {
 	EnableVirtualizationExtensions bool
 	AdditionalDiskSize             []uint
 	DifferencingDisk               bool
+	SkipExport                     bool
+	OutputDir                      string
 }
 
 func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
@@ -51,6 +53,12 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	vhdPath := state.Get("packerVhdTempDir").(string)
+
+	// inline vhd path if export is skipped
+	if s.SkipExport {
+		vhdPath = filepath.Join(s.OutputDir, "Virtual Hard Disks")
+	}
+
 	// convert the MB to bytes
 	ramSize := int64(s.RamSize * 1024 * 1024)
 	diskSize := int64(s.DiskSize * 1024 * 1024)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -94,6 +94,8 @@ type Config struct {
 
 	SkipCompaction bool `mapstructure:"skip_compaction"`
 
+	SkipExport bool `mapstructure:"skip_export"`
+
 	// Use differencing disk
 	DifferencingDisk bool `mapstructure:"differencing_disk"`
 
@@ -357,6 +359,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			EnableVirtualizationExtensions: b.config.EnableVirtualizationExtensions,
 			AdditionalDiskSize:             b.config.AdditionalDiskSize,
 			DifferencingDisk:               b.config.DifferencingDisk,
+			SkipExport:                     b.config.SkipExport,
+			OutputDir:                      b.config.OutputDir,
 		},
 		&hypervcommon.StepEnableIntegrationService{},
 
@@ -422,6 +426,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&hypervcommon.StepExportVm{
 			OutputDir:      b.config.OutputDir,
 			SkipCompaction: b.config.SkipCompaction,
+			SkipExport:     b.config.SkipExport,
 		},
 
 		// the clean up actions for each step will be executed reverse order

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -94,6 +94,8 @@ type Config struct {
 
 	SkipCompaction bool `mapstructure:"skip_compaction"`
 
+	SkipExport bool `mapstructure:"skip_export"`
+
 	ctx interpolate.Context
 }
 
@@ -469,6 +471,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&hypervcommon.StepExportVm{
 			OutputDir:      b.config.OutputDir,
 			SkipCompaction: b.config.SkipCompaction,
+			SkipExport:     b.config.SkipExport,
 		},
 
 		// the clean up actions for each step will be executed reverse order

--- a/website/source/docs/builders/hyperv-iso.html.md
+++ b/website/source/docs/builders/hyperv-iso.html.md
@@ -97,6 +97,12 @@ can be configured for this builder.
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40 GB.
 
+-   `differencing_disk` (boolean) - If true enables differencing disks. Only the changes will be written to the new disk. This is especially useful if your
+    source is a vhd/vhdx. This defaults to false.
+
+-   `skip_export` (boolean) - If true skips VM export. If you are interested only in the vhd/vhdx files, you can enable this option. This will create
+    inline disks which improves the build performance. There will not be any copying of source vhds to temp directory. This defauls to false.
+    
 -   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for virtual machine.
     This defaults to false.
 


### PR DESCRIPTION
There are some pain points to use VHD to VHD builder. This PR tries to resolve them. This PR uses https://github.com/hashicorp/packer/pull/5458
 

- **Time to create a VM before a new provisioner starts and the extra space needed.**

    - Current Behavior:
    The parent vhdx is copied to a %temp% location and a VM will be created from this and the same disk is provisioned(modified) The overhead is copying the VM and the extra disk space that is required. If we are using a 50 GB vhdx as a base image, we are copying the 50GB to the disk again before we start provisioning. It takes a while and uses extra 50GB space. As most people use SSD(as their OS drive for faster accessing), most of us cant afford to allocate this much disk space.

    - Proposed solution:
    Using differential disk we do not need to copy the base image to the %temp% location. Instead we create a differential disk whose parent is the base image (note that the base image is not modified). VM creation is instant. We start provisioning instantly. All the modifications are done only in the new disk which will be linked to the parent disk.

- **VM Export**
    - Current Behavior:
Once we finish provisioning, the VM will be exported. Packer makes a new copy of the vhdx that is provisioned in the %temp%\export folder. This again involves copying the entire vhdx file to %temp% location. This exported VM again will be copied to the <output_directory> that we specify. e.g. The size of provisioned VHD is 90 GB. This 90GB is copied twice. **Once**: To create an exported VM and **Again**: to copy the exported VM to the output directory. So we need 180 GB of free space in our SSD for this to happen.

    - Proposed solution:
We create inline differential disk and skip VM export. The new differential disk will directly be created in the <output_directory> and will be provisioned inline. So we can skip copying the provisioned disk again and again. As we deal with only vhdx files and we do not need an exported VM, we can skip exporting VM. 

This saves lot of time and hard disk space.

I would like people to try this out and see how this speeds up everything. Also feedback/suggestions are always welcome.

You need to use the following two properties to use differential disks and create inline disks.

> "differencing_disk": "true",
> "skip_export": "true",