### PR TITLE
Add pause_before to list of optional parameters

### DIFF
--- a/website/source/docs/provisioners/shell.html.md
+++ b/website/source/docs/provisioners/shell.html.md
@@ -83,6 +83,9 @@ Optional parameters:
     **Important:** If you customize this, be sure to include something like the
     `-e` flag, otherwise individual steps failing won't fail the provisioner.
 
+-   `pause_before` (string) - The amount of time Packer will wait before executing
+    the next script.
+
 -   `remote_folder` (string) - The folder where the uploaded script will reside on
     the machine. This defaults to '/tmp'.
 


### PR DESCRIPTION
The "pause_before" optional parameter is listed in the doc for the shell provisioner in the Handling Reboots section. The list of optional parameters should include an item for "pause_before" as well.

Update docs to include the "pause_before" optional parameter
