### PR TITLE
Fix 5559

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -48,12 +48,13 @@ func ChooseString(vals ...string) string {
 // which isn't a valid URL. DownloadableURL will return "file:///local/file.iso"
 func DownloadableURL(original string) (string, error) {
 	if runtime.GOOS == "windows" {
-		// If the distance to the first ":" is just one character, assume
-		// we're dealing with a drive letter and thus a file path.
+		// check for cygwin-style local paths.
 		if strings.Contains(original, "/cygdrive/") {
 			original := strings.Replace(original, "/cygdrive/", "", 1)
 			original = strings.Replace(original, "/", ":/", 1)
 		}
+		// If the distance to the first ":" is just one character, assume
+		// we're dealing with a drive letter and thus a file path.
 		idx := strings.Index(original, ":")
 		if idx == 1 {
 			original = "file:///" + original

--- a/common/config.go
+++ b/common/config.go
@@ -52,7 +52,7 @@ func DownloadableURL(original string) (string, error) {
 		// we're dealing with a drive letter and thus a file path.
 		if strings.Contains(original, "/cygdrive/") {
 			original := strings.Replace(original, "/cygdrive/", "", 1)
-			original = strings.Replace(original, "/", ":", 1)
+			original = strings.Replace(original, "/", ":/", 1)
 		}
 		idx := strings.Index(original, ":")
 		if idx == 1 {

--- a/common/config.go
+++ b/common/config.go
@@ -50,6 +50,10 @@ func DownloadableURL(original string) (string, error) {
 	if runtime.GOOS == "windows" {
 		// If the distance to the first ":" is just one character, assume
 		// we're dealing with a drive letter and thus a file path.
+		if strings.Contains(original, "/cygdrive/") {
+			original := strings.Replace(original, "/cygdrive/", "", 1)
+			original = strings.Replace(original, "/", ":", 1)
+		}
 		idx := strings.Index(original, ":")
 		if idx == 1 {
 			original = "file:///" + original


### PR DESCRIPTION
Allow windows user to use cygwin-style paths.
Don't merge yet; waiting on reporter of 5559 to test this patch.

closes #5559 