### PR TITLE
azure: delete keyvault deployment

### DIFF
--- a/builder/azure/arm/step_delete_resource_group.go
+++ b/builder/azure/arm/step_delete_resource_group.go
@@ -37,54 +37,19 @@ func (s *StepDeleteResourceGroup) deleteResourceGroup(state multistep.StateBag, 
 	if state.Get(constants.ArmIsExistingResourceGroup).(bool) {
 		s.say("\nThe resource group was not created by Packer, only deleting individual resources ...")
 		var deploymentName = state.Get(constants.ArmDeploymentName).(string)
-		if deploymentName != "" {
-			maxResources := int32(maxResourcesToDelete)
-			deploymentOperations, err := s.client.DeploymentOperationsClient.List(resourceGroupName, deploymentName, &maxResources)
+		err = s.deleteDeploymentResources(deploymentName, resourceGroupName)
+		if err != nil {
+			return err
+		}
+
+		if keyVaultDeploymentName, ok := state.GetOk(constants.ArmKeyVaultDeploymentName); ok {
+			err = s.deleteDeploymentResources(keyVaultDeploymentName.(string), resourceGroupName)
 			if err != nil {
-				s.say(fmt.Sprintf("Error deleting resources.  Please delete them manually.\n\n"+
-					"Name: %s\n"+
-					"Error: %s", resourceGroupName, err))
-				s.error(err)
-			}
-			for _, deploymentOperation := range *deploymentOperations.Value {
-				// Sometimes an empty operation is added to the list by Azure
-				if deploymentOperation.Properties.TargetResource == nil {
-					continue
-				}
-				s.say(fmt.Sprintf(" -> %s : '%s'",
-					*deploymentOperation.Properties.TargetResource.ResourceType,
-					*deploymentOperation.Properties.TargetResource.ResourceName))
-				var networkDeleteFunction func(string, string, <-chan struct{}) (<-chan autorest.Response, <-chan error)
-				switch *deploymentOperation.Properties.TargetResource.ResourceType {
-				case "Microsoft.Compute/virtualMachines":
-					_, errChan := s.client.VirtualMachinesClient.Delete(resourceGroupName, *deploymentOperation.Properties.TargetResource.ResourceName, nil)
-					err := <-errChan
-					if err != nil {
-						s.say(fmt.Sprintf("Error deleting resource.  Please delete manually.\n\n"+
-							"Name: %s\n"+
-							"Error: %s", *deploymentOperation.Properties.TargetResource.ResourceName, err.Error()))
-						s.error(err)
-					}
-				case "Microsoft.Network/networkInterfaces":
-					networkDeleteFunction = s.client.InterfacesClient.Delete
-				case "Microsoft.Network/virtualNetworks":
-					networkDeleteFunction = s.client.VirtualNetworksClient.Delete
-				case "Microsoft.Network/publicIPAddresses":
-					networkDeleteFunction = s.client.PublicIPAddressesClient.Delete
-				}
-				if networkDeleteFunction != nil {
-					_, errChan := networkDeleteFunction(resourceGroupName, *deploymentOperation.Properties.TargetResource.ResourceName, nil)
-					err := <-errChan
-					if err != nil {
-						s.say(fmt.Sprintf("Error deleting resource.  Please delete manually.\n\n"+
-							"Name: %s\n"+
-							"Error: %s", *deploymentOperation.Properties.TargetResource.ResourceName, err.Error()))
-						s.error(err)
-					}
-				}
+				return err
 			}
 		}
-		return err
+
+		return nil
 	} else {
 		s.say("\nThe resource group was created by Packer, deleting ...")
 		_, errChan := s.client.GroupsClient.Delete(resourceGroupName, cancelCh)
@@ -94,6 +59,61 @@ func (s *StepDeleteResourceGroup) deleteResourceGroup(state multistep.StateBag, 
 			s.say(s.client.LastError.Error())
 		}
 		return err
+	}
+}
+
+func (s *StepDeleteResourceGroup) deleteDeploymentResources(deploymentName, resourceGroupName string) error {
+	maxResources := int32(maxResourcesToDelete)
+
+	deploymentOperations, err := s.client.DeploymentOperationsClient.List(resourceGroupName, deploymentName, &maxResources)
+	if err != nil {
+		s.reportIfError(err, resourceGroupName)
+		return err
+	}
+
+	for _, deploymentOperation := range *deploymentOperations.Value {
+		// Sometimes an empty operation is added to the list by Azure
+		if deploymentOperation.Properties.TargetResource == nil {
+			continue
+		}
+		s.say(fmt.Sprintf(" -> %s : '%s'",
+			*deploymentOperation.Properties.TargetResource.ResourceType,
+			*deploymentOperation.Properties.TargetResource.ResourceName))
+
+		var networkDeleteFunction func(string, string, <-chan struct{}) (<-chan autorest.Response, <-chan error)
+		resourceName := *deploymentOperation.Properties.TargetResource.ResourceName
+
+		switch *deploymentOperation.Properties.TargetResource.ResourceType {
+		case "Microsoft.Compute/virtualMachines":
+			_, errChan := s.client.VirtualMachinesClient.Delete(resourceGroupName, resourceName, nil)
+			err := <-errChan
+			s.reportIfError(err, resourceName)
+		case "Microsoft.KeyVault/vaults":
+			_, err := s.client.VaultClientDelete.Delete(resourceGroupName, resourceName)
+			s.reportIfError(err, resourceName)
+		case "Microsoft.Network/networkInterfaces":
+			networkDeleteFunction = s.client.InterfacesClient.Delete
+		case "Microsoft.Network/virtualNetworks":
+			networkDeleteFunction = s.client.VirtualNetworksClient.Delete
+		case "Microsoft.Network/publicIPAddresses":
+			networkDeleteFunction = s.client.PublicIPAddressesClient.Delete
+		}
+		if networkDeleteFunction != nil {
+			_, errChan := networkDeleteFunction(resourceGroupName, resourceName, nil)
+			err := <-errChan
+			s.reportIfError(err, resourceName)
+		}
+	}
+
+	return nil
+}
+
+func (s *StepDeleteResourceGroup) reportIfError(err error, resourceName string) {
+	if err != nil {
+		s.say(fmt.Sprintf("Error deleting resource. Please delete manually.\n\n"+
+			"Name: %s\n"+
+			"Error: %s", resourceName, err.Error()))
+		s.error(err)
 	}
 }
 

--- a/builder/azure/arm/step_deploy_template_test.go
+++ b/builder/azure/arm/step_deploy_template_test.go
@@ -61,6 +61,7 @@ func TestStepDeployTemplateShouldTakeStepArgumentsFromStateBag(t *testing.T) {
 		},
 		say:   func(message string) {},
 		error: func(e error) {},
+		name:  "--deployment-name--",
 	}
 
 	stateBag := createTestStateBagStepValidateTemplate()
@@ -70,10 +71,9 @@ func TestStepDeployTemplateShouldTakeStepArgumentsFromStateBag(t *testing.T) {
 		t.Fatalf("Expected the step to return 'ActionContinue', but got '%d'.", result)
 	}
 
-	var expectedDeploymentName = stateBag.Get(constants.ArmDeploymentName).(string)
 	var expectedResourceGroupName = stateBag.Get(constants.ArmResourceGroupName).(string)
 
-	if actualDeploymentName != expectedDeploymentName {
+	if actualDeploymentName != "--deployment-name--" {
 		t.Fatal("Expected StepValidateTemplate to source 'constants.ArmDeploymentName' from the state bag, but it did not.")
 	}
 

--- a/builder/azure/common/constants/stateBag.go
+++ b/builder/azure/common/constants/stateBag.go
@@ -15,6 +15,7 @@ const (
 	ArmComputeName                     string = "arm.ComputeName"
 	ArmImageParameters                 string = "arm.ImageParameters"
 	ArmCertificateUrl                  string = "arm.CertificateUrl"
+	ArmKeyVaultDeploymentName          string = "arm.KeyVaultDeploymentName"
 	ArmDeploymentName                  string = "arm.DeploymentName"
 	ArmNicName                         string = "arm.NicName"
 	ArmKeyVaultName                    string = "arm.KeyVaultName"


### PR DESCRIPTION
The Azure builder failed to cleanup KeyVaults when deploying Windows images that used an existing resource group.

Closes #5654