### PR TITLE
modify validation to allow user to have the original region in the am…

### DIFF
--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/packer/template/interpolate"
 )
@@ -85,7 +86,7 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 			if (accessConfig != nil) && (region == accessConfig.RawRegion) {
 				// make sure we don't try to copy to the region we originally
 				// create the AMI in.
-				fmt.Printf("Cannot copy AMI to AWS session region '%s', deleting it from `ami_regions`.", region)
+				log.Printf("Cannot copy AMI to AWS session region '%s', deleting it from `ami_regions`.", region)
 				continue
 			}
 			regions = append(regions, region)

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -11,6 +11,12 @@ func testAMIConfig() *AMIConfig {
 	}
 }
 
+func getFakeAccessConfig(region string) *AccessConfig {
+	return &AccessConfig{
+		RawRegion: region,
+	}
+}
+
 func TestAMIConfigPrepare_name(t *testing.T) {
 	c := testAMIConfig()
 	if err := c.Prepare(nil, nil); err != nil {
@@ -118,6 +124,15 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	if err := c.Prepare(nil, nil); err == nil {
 		t.Fatal("should have error b/c theres a region in in ami_regions that isn't in the key map")
 	}
+
+	// allow rawregion to exist in ami_regions list.
+	accessConf := getFakeAccessConfig("us-east-1")
+	c.AMIRegions = []string{"us-east-1", "us-west-1", "us-east-2"}
+	c.AMIRegionKMSKeyIDs = nil
+	if err := c.Prepare(accessConf, nil); err != nil {
+		t.Fatal("should allow user to have the raw region in ami_regions")
+	}
+
 }
 
 func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {


### PR DESCRIPTION
If `region` is present in `ami_regions`, remove `region` from `ami_regions` (former behavior was to throw an error, which was reported as a regression)

In order to manage this cleanly, I moved around some of the validation so that users are also allowed to have the original region present in the kms_key_ids map.

Closes #5625
