### PR TITLE
Re-factor version command to use version.FormattedVersion() function.

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -1,18 +1,16 @@
 package command
 
 import (
-	"bytes"
 	"fmt"
+
+	"github.com/hashicorp/packer/version"
 )
 
 // VersionCommand is a Command implementation prints the version.
 type VersionCommand struct {
 	Meta
 
-	Revision          string
-	Version           string
-	VersionPrerelease string
-	CheckFunc         VersionCheckFunc
+	CheckFunc VersionCheckFunc
 }
 
 // VersionCheckFunc is the callback called by the Version command to
@@ -29,25 +27,15 @@ type VersionCheckInfo struct {
 }
 
 func (c *VersionCommand) Help() string {
-	return ""
+	return "Prints the Packer version, and checks for new release."
 }
 
 func (c *VersionCommand) Run(args []string) int {
-	c.Ui.Machine("version", c.Version)
-	c.Ui.Machine("version-prelease", c.VersionPrerelease)
-	c.Ui.Machine("version-commit", c.Revision)
+	c.Ui.Machine("version", version.Version)
+	c.Ui.Machine("version-prelease", version.VersionPrerelease)
+	c.Ui.Machine("version-commit", version.GitCommit)
 
-	var versionString bytes.Buffer
-	fmt.Fprintf(&versionString, "Packer v%s", c.Version)
-	if c.VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, "-%s", c.VersionPrerelease)
-
-		if c.Revision != "" {
-			fmt.Fprintf(&versionString, " (%s)", c.Revision)
-		}
-	}
-
-	c.Ui.Say(versionString.String())
+	c.Ui.Say(fmt.Sprintf("Packer v%s", version.FormattedVersion()))
 
 	// If we have a version check function, then let's check for
 	// the latest version as well.

--- a/commands.go
+++ b/commands.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/hashicorp/packer/command"
-	"github.com/hashicorp/packer/version"
 	"github.com/mitchellh/cli"
 )
 
@@ -50,11 +49,8 @@ func init() {
 
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{
-				Meta:              *CommandMeta,
-				Revision:          version.GitCommit,
-				Version:           version.Version,
-				VersionPrerelease: version.VersionPrerelease,
-				CheckFunc:         commandVersionCheck,
+				Meta:      *CommandMeta,
+				CheckFunc: commandVersionCheck,
 			}, nil
 		},
 


### PR DESCRIPTION
This commit removes surplus code which is almost a duplicate of the code
available in the version package by favouring the package implementation
instead.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>