### PR TITLE
Correctly set aws region if given in template along with a profile.

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -40,7 +40,9 @@ func (c *AccessConfig) Session() (*session.Session, error) {
 		if err := os.Setenv("AWS_PROFILE", c.ProfileName); err != nil {
 			return nil, fmt.Errorf("Set env error: %s", err)
 		}
-	} else if c.RawRegion != "" {
+	}
+
+	if c.RawRegion != "" {
 		config = config.WithRegion(c.RawRegion)
 	} else if region := c.metadataRegion(); region != "" {
 		config = config.WithRegion(region)


### PR DESCRIPTION
Closes #5669
