### PR TITLE
remove sriov/ena support for spot instances

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -152,3 +152,7 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	return errs
 }
+
+func (c *RunConfig) IsSpotInstance() bool {
+	return c.SpotPrice != "" && c.SpotPrice != "0"
+}

--- a/builder/amazon/common/step_stop_ebs_instance.go
+++ b/builder/amazon/common/step_stop_ebs_instance.go
@@ -75,15 +75,12 @@ func (s *StepStopEBSBackedInstance) Run(state multistep.StateBag) multistep.Step
 		ui.Say("Automatic instance stop disabled. Please stop instance manually.")
 	}
 
-	// Wait for the instance to actual stop
+	// Wait for the instance to actually stop
 	ui.Say("Waiting for the instance to stop...")
-	stateChange := StateChangeConf{
-		Pending:   []string{"running", "pending", "stopping"},
-		Target:    "stopped",
-		Refresh:   InstanceStateRefreshFunc(ec2conn, *instance.InstanceId),
-		StepState: state,
-	}
-	_, err = WaitForState(&stateChange)
+	err = ec2conn.WaitUntilInstanceStopped(&ec2.DescribeInstancesInput{
+		InstanceIds: []*string{instance.InstanceId},
+	})
+
 	if err != nil {
 		err := fmt.Errorf("Error waiting for instance to stop: %s", err)
 		state.Put("error", err)

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -84,6 +84,13 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("no volume with name '%s' is found", b.config.RootDevice.SourceDeviceName))
 	}
 
+	if b.config.IsSpotInstance() && (b.config.AMIENASupport || b.config.AMISriovNetSupport) {
+		errs = packer.MultiErrorAppend(errs,
+			fmt.Errorf("Spot instances do not support modification, which is required "+
+				"when either `ena_support` or `sriov_support` are set. Please ensure "+
+				"you use an AMI that already has either SR-IOV or ENA enabled."))
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, errs
 	}
@@ -124,47 +131,46 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	state.Put("ui", ui)
 
 	var instanceStep multistep.Step
-	isSpotInstance := b.config.SpotPrice != "" && b.config.SpotPrice != "0"
 
-	if isSpotInstance {
+	if b.config.IsSpotInstance() {
 		instanceStep = &awscommon.StepRunSpotInstance{
-			Debug:                    b.config.PackerDebug,
-			ExpectedRootDevice:       "ebs",
-			SpotPrice:                b.config.SpotPrice,
-			SpotPriceProduct:         b.config.SpotPriceAutoProduct,
-			InstanceType:             b.config.InstanceType,
-			UserData:                 b.config.UserData,
-			UserDataFile:             b.config.UserDataFile,
-			SourceAMI:                b.config.SourceAmi,
-			IamInstanceProfile:       b.config.IamInstanceProfile,
-			SubnetId:                 b.config.SubnetId,
-			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
-			EbsOptimized:             b.config.EbsOptimized,
-			AvailabilityZone:         b.config.AvailabilityZone,
-			BlockDevices:             b.config.BlockDevices,
-			Tags:                     b.config.RunTags,
-			VolumeTags:               b.config.VolumeRunTags,
-			Ctx:                      b.config.ctx,
+			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
+			AvailabilityZone:                  b.config.AvailabilityZone,
+			BlockDevices:                      b.config.BlockDevices,
+			Ctx:                               b.config.ctx,
+			Debug:                             b.config.PackerDebug,
+			EbsOptimized:                      b.config.EbsOptimized,
+			ExpectedRootDevice:                "ebs",
+			IamInstanceProfile:                b.config.IamInstanceProfile,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
+			InstanceType:                      b.config.InstanceType,
+			SourceAMI:                         b.config.SourceAmi,
+			SpotPrice:                         b.config.SpotPrice,
+			SpotPriceProduct:                  b.config.SpotPriceAutoProduct,
+			SubnetId:                          b.config.SubnetId,
+			Tags:                              b.config.RunTags,
+			UserData:                          b.config.UserData,
+			UserDataFile:                      b.config.UserDataFile,
+			VolumeTags:                        b.config.VolumeRunTags,
 		}
 	} else {
 		instanceStep = &awscommon.StepRunSourceInstance{
-			Debug:                    b.config.PackerDebug,
-			ExpectedRootDevice:       "ebs",
-			InstanceType:             b.config.InstanceType,
-			UserData:                 b.config.UserData,
-			UserDataFile:             b.config.UserDataFile,
-			SourceAMI:                b.config.SourceAmi,
-			IamInstanceProfile:       b.config.IamInstanceProfile,
-			SubnetId:                 b.config.SubnetId,
-			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
-			EbsOptimized:             b.config.EbsOptimized,
-			AvailabilityZone:         b.config.AvailabilityZone,
-			BlockDevices:             b.config.BlockDevices,
-			Tags:                     b.config.RunTags,
-			VolumeTags:               b.config.VolumeRunTags,
-			Ctx:                      b.config.ctx,
+			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
+			AvailabilityZone:                  b.config.AvailabilityZone,
+			BlockDevices:                      b.config.BlockDevices,
+			Ctx:                               b.config.ctx,
+			Debug:                             b.config.PackerDebug,
+			EbsOptimized:                      b.config.EbsOptimized,
+			ExpectedRootDevice:                "ebs",
+			IamInstanceProfile:                b.config.IamInstanceProfile,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
+			InstanceType:                      b.config.InstanceType,
+			SourceAMI:                         b.config.SourceAmi,
+			SubnetId:                          b.config.SubnetId,
+			Tags:                              b.config.RunTags,
+			UserData:                          b.config.UserData,
+			UserDataFile:                      b.config.UserDataFile,
+			VolumeTags:                        b.config.VolumeRunTags,
 		}
 	}
 
@@ -212,7 +218,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&common.StepProvision{},
 		&awscommon.StepStopEBSBackedInstance{
-			Skip:                isSpotInstance,
+			Skip:                b.config.IsSpotInstance(),
 			DisableStopInstance: b.config.DisableStopInstance,
 		},
 		&awscommon.StepModifyEBSBackedInstance{


### PR DESCRIPTION
Follow-on to #5678

closes #2763
replaces #2900

This PR

- replaces custom wait code with code from upstream for spot instances and for instance termination
- disables `sriov_support` and `ena_support` when requesting a spot instance

For the last item: I haven't found a good way to run `modifyinstanceAttribute` on a spot instance. `modifyinstanceAttribute` requires the instance be stopped, and spot instances cannot be stopped, in the way we are running them. I see that there is recent [support for stopping spot instances](https://aws.amazon.com/about-aws/whats-new/2017/09/amazon-ec2-spot-can-now-stop-and-start-your-spot-instances/), but I believe that is for a different use-case. Since most modern AMIs support sriov/ena out of the box, choosing the proper AMI for your spot instances seems like the appropriate course.

I don't believe this change breaks any backwards-compatibility, since launching spot instances with `{ena,sriov}_support` has never worked.

Looking for thoughts and comments