### PR TITLE
add super key (vmware builder)

### DIFF
--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -183,6 +183,8 @@ func vncSendString(c *vnc.ClientConn, original string) {
 	special["<rightAlt>"] = 0xFFEA
 	special["<rightCtrl>"] = 0xFFE4
 	special["<rightShift>"] = 0xFFE2
+	special["<leftSuper>"] = 0xFFEB
+	special["<rightSuper>"] = 0xFFEC
 
 	shiftedChars := "~!@#$%^&*()_+{}|:\"<>?"
 
@@ -231,6 +233,17 @@ func vncSendString(c *vnc.ClientConn, original string) {
 			continue
 		}
 
+		if strings.HasPrefix(original, "<leftSuperOn>") {
+			keyCode = special["<leftSuper>"]
+			original = original[len("<leftSuperOn>"):]
+			log.Printf("Special code '<leftSuperOn>' found, replacing with: %d", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(keyInterval)
+
+			continue
+		}
+
 		if strings.HasPrefix(original, "<leftAltOff>") {
 			keyCode = special["<leftAlt>"]
 			original = original[len("<leftAltOff>"):]
@@ -257,6 +270,17 @@ func vncSendString(c *vnc.ClientConn, original string) {
 			keyCode = special["<leftShift>"]
 			original = original[len("<leftShiftOff>"):]
 			log.Printf("Special code '<leftShiftOff>' found, replacing with: %d", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(keyInterval)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<leftSuperOff>") {
+			keyCode = special["<leftSuper>"]
+			original = original[len("<leftSuperOff>"):]
+			log.Printf("Special code '<leftSuperOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(keyInterval)
@@ -297,6 +321,17 @@ func vncSendString(c *vnc.ClientConn, original string) {
 			continue
 		}
 
+		if strings.HasPrefix(original, "<rightSuperOn>") {
+			keyCode = special["<rightSuper>"]
+			original = original[len("<rightSuperOn>"):]
+			log.Printf("Special code '<rightSuperOn>' found, replacing with: %d", keyCode)
+
+			c.KeyEvent(keyCode, true)
+			time.Sleep(keyInterval)
+
+			continue
+		}
+
 		if strings.HasPrefix(original, "<rightAltOff>") {
 			keyCode = special["<rightAlt>"]
 			original = original[len("<rightAltOff>"):]
@@ -323,6 +358,17 @@ func vncSendString(c *vnc.ClientConn, original string) {
 			keyCode = special["<rightShift>"]
 			original = original[len("<rightShiftOff>"):]
 			log.Printf("Special code '<rightShiftOff>' found, replacing with: %d", keyCode)
+
+			c.KeyEvent(keyCode, false)
+			time.Sleep(keyInterval)
+
+			continue
+		}
+
+		if strings.HasPrefix(original, "<rightSuperOff>") {
+			keyCode = special["<rightSuper>"]
+			original = original[len("<rightSuperOff>"):]
+			log.Printf("Special code '<rightSuperOff>' found, replacing with: %d", keyCode)
 
 			c.KeyEvent(keyCode, false)
 			time.Sleep(keyInterval)


### PR DESCRIPTION
Add the critical Super key as a `boot_command` term. This key works for Linux guests as the Super key, macOS guests as the Command key, and should work for Windows guests as the Windows key, though Windows deserves additional testing.

Note that other builders should also be upgraded to recognize the super key, like VirtualBox. This is just a quick proof of concept based on the current structure of the packer codebase.

Example usage: Raising the music menu in Ubuntu 16.04.

```json
{
  "builders": [
    {
      "type": "vmware-iso",
      "boot_command": [
        "<enter><wait10><wait10><wait10><wait10>",
        "<tab><spacebar><wait10><wait10><wait10>",
        "<leftSuperOn>m<leftSuperOff><wait10>",
        "<rightSuperOn>m<rightSuperOff>"
      ],
      "boot_wait": "10s",
      "disk_size": 81920,
      "guest_os_type": "ubuntu-64",
      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-desktop-amd64.iso",
      "iso_checksum_type": "sha256",
      "iso_checksum": "1384ac8f2c2a6479ba2a9cbe90a585618834560c477a699a4a7ebe7b5345ddc1",
      "ssh_username": "vagrant",
      "ssh_password": "vagrant",
      "ssh_wait_timeout": "1800s",
      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
      "vm_name": "packer-super-test",
      "vmx_data": {
        "memsize": "1024"
      }
    }
  ]
}
```

I also tested this PR with macOS guest, using ISO's generated from Apple hardware with https://github.com/mcandre/macos-isos . I'll be publishing my work in progress packer JSON configuration soon from a "macos" branch of my [packer-templates](https://github.com/mcandre/packer-templates/tree/macos).

Closes #5633