### PR TITLE
Update amazon run_config.go absent ssh_private_key_file error

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -98,9 +98,9 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.SSHKeyPairName != "" {
 		if c.Comm.Type == "winrm" && c.Comm.WinRMPassword == "" && c.Comm.SSHPrivateKey == "" {
-			errs = append(errs, errors.New("A private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name."))
+			errs = append(errs, errors.New("ssh_private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name."))
 		} else if c.Comm.SSHPrivateKey == "" && !c.Comm.SSHAgentAuth {
-			errs = append(errs, errors.New("A private_key_file must be provided or ssh_agent_auth enabled when ssh_keypair_name is specified."))
+			errs = append(errs, errors.New("ssh_private_key_file must be provided or ssh_agent_auth enabled when ssh_keypair_name is specified."))
 		}
 	}
 


### PR DESCRIPTION
Make error output for amazon run_config include required key name.

Old error message:
A private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name.

New error message:
ssh_private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name.

