### PR TITLE
Update links in guides

### DIFF
--- a/website/source/guides/packer-on-cicd/build-image-in-cicd.html.md
+++ b/website/source/guides/packer-on-cicd/build-image-in-cicd.html.md
@@ -9,7 +9,7 @@ page_title: Build Images in CI/CD
 The following guides from our partners show how to use their services to build
 images with Packer.
 
-- How to Build Immutable Infrastructure with Packer and CircleCI Workflows (coming soon)
+- [How to Build Immutable Infrastructure with Packer and CircleCI Workflows](https://circleci.com/blog/how-to-build-immutable-infrastructure-with-packer-and-circleci-workflows/)
 - [Using Packer and Ansible to Build Immutable Infrastructure in CodeShip](https://blog.codeship.com/packer-ansible/)
 
 The majority of the [Packer Builders](/docs/builders/index.html) can run in

--- a/website/source/guides/packer-on-cicd/trigger-tfe.html.md
+++ b/website/source/guides/packer-on-cicd/trigger-tfe.html.md
@@ -48,12 +48,12 @@ complete and uploaded.
 1. Add a new step to the CI/CD pipeline.
 2. In the new step add a `curl` call to update the variables in the workspace
    using the [update variables
-   API](https://www.terraform.io/docs/enterprise-beta/api/variables.html#update-variables),
+   API](https://www.terraform.io/docs/enterprise/api/variables.html#update-variables),
    so that Terraform has a reference to the latest image. For the sample
    configuration above, the `aws_ami_id` variable should be updated to the AMI
    ID of the latest image.
 3. In that same step, add another `curl` call to [create a new run via the
-   API](https://www.terraform.io/docs/enterprise-beta/api/run.html#create-a-run).
+   API](https://www.terraform.io/docs/enterprise/api/run.html#create-a-run).
    A run performs a plan and apply on the last configuration version created,
    using the variables set in the workspace. In the previous step we update the
    variables, so the new run can be created using the previous configuration


### PR DESCRIPTION
This updates links for the "Build Immutable Infrastructure with Packer in CI/CD" guide to the Circle CI guide and Terraform Enterprise docs paths.