### PR TITLE
Windows Support for salt-masterless provisioner #5432

### DIFF
--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -13,6 +13,7 @@ type guestOSTypeCommand struct {
 	chmod     string
 	mkdir     string
 	removeDir string
+	statPath  string
 }
 
 var guestOSTypeCommands = map[string]guestOSTypeCommand{
@@ -20,11 +21,13 @@ var guestOSTypeCommands = map[string]guestOSTypeCommand{
 		chmod:     "chmod %s '%s'",
 		mkdir:     "mkdir -p '%s'",
 		removeDir: "rm -rf '%s'",
+		statPath:  "stat '%s'",
 	},
 	WindowsOSType: {
 		chmod:     "echo 'skipping chmod %s %s'", // no-op
 		mkdir:     "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s\"",
 		removeDir: "powershell.exe -Command \"rm %s -recurse -force\"",
+		statPath:  "powershell.exe -Commond \"test-path %s\"",
 	},
 }
 
@@ -62,6 +65,10 @@ func (g *GuestCommands) escapePath(path string) string {
 		return strings.Replace(path, " ", "` ", -1)
 	}
 	return path
+}
+
+func (g *GuestCommands) StatPath(path string) string {
+	return g.sudo(fmt.Sprintf(g.commands().statPath, g.escapePath(path)))
 }
 
 func (g *GuestCommands) sudo(cmd string) string {

--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -14,6 +14,7 @@ type guestOSTypeCommand struct {
 	mkdir     string
 	removeDir string
 	statPath  string
+	mvPath    string
 }
 
 var guestOSTypeCommands = map[string]guestOSTypeCommand{
@@ -22,12 +23,14 @@ var guestOSTypeCommands = map[string]guestOSTypeCommand{
 		mkdir:     "mkdir -p '%s'",
 		removeDir: "rm -rf '%s'",
 		statPath:  "stat '%s'",
+		mv:    		 "mv '%s' '%s'",
 	},
 	WindowsOSType: {
 		chmod:     "echo 'skipping chmod %s %s'", // no-op
 		mkdir:     "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s\"",
 		removeDir: "powershell.exe -Command \"rm %s -recurse -force\"",
-		statPath:  "powershell.exe -Commond \"test-path %s\"",
+		statPath:  "powershell.exe -Command \"test-path %s\"",
+		mv:    		 "powershell.exe -Command \"mv %s %s\"",
 	},
 }
 
@@ -69,6 +72,10 @@ func (g *GuestCommands) escapePath(path string) string {
 
 func (g *GuestCommands) StatPath(path string) string {
 	return g.sudo(fmt.Sprintf(g.commands().statPath, g.escapePath(path)))
+}
+
+func (g *GuestCommands) MovePath(srcPath string, dstPath) string {
+	return g.sudo(fmt.Sprintf(g.commands().mv, g.escapePath(srcPath), g.escapePath(dstPath)))
 }
 
 func (g *GuestCommands) sudo(cmd string) string {

--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -14,7 +14,7 @@ type guestOSTypeCommand struct {
 	mkdir     string
 	removeDir string
 	statPath  string
-	mvPath    string
+	mv    		string
 }
 
 var guestOSTypeCommands = map[string]guestOSTypeCommand{

--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -29,7 +29,7 @@ var guestOSTypeCommands = map[string]guestOSTypeCommand{
 		chmod:     "echo 'skipping chmod %s %s'", // no-op
 		mkdir:     "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s\"",
 		removeDir: "powershell.exe -Command \"rm %s -recurse -force -ErrorAction SilentlyContinue\"",
-		statPath:  "powershell.exe -Command \"test-path %s\"",
+		statPath:  "powershell.exe -Command { if (test-path %s) { exit 0 } else { exit 1 } }",
 		mv:        "powershell.exe -Command \"mv %s %s\"",
 	},
 }

--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -28,7 +28,7 @@ var guestOSTypeCommands = map[string]guestOSTypeCommand{
 	WindowsOSType: {
 		chmod:     "echo 'skipping chmod %s %s'", // no-op
 		mkdir:     "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s\"",
-		removeDir: "powershell.exe -Command \"rm %s -recurse -force -ErrorAction SilentlyContinue\"",
+		removeDir: "powershell.exe -Command \"rm %s -recurse -force\"",
 		statPath:  "powershell.exe -Command { if (test-path %s) { exit 0 } else { exit 1 } }",
 		mv:        "powershell.exe -Command \"mv %s %s\"",
 	},

--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -14,7 +14,7 @@ type guestOSTypeCommand struct {
 	mkdir     string
 	removeDir string
 	statPath  string
-	mv    		string
+	mv        string
 }
 
 var guestOSTypeCommands = map[string]guestOSTypeCommand{
@@ -23,14 +23,14 @@ var guestOSTypeCommands = map[string]guestOSTypeCommand{
 		mkdir:     "mkdir -p '%s'",
 		removeDir: "rm -rf '%s'",
 		statPath:  "stat '%s'",
-		mv:    		 "mv '%s' '%s'",
+		mv:        "mv '%s' '%s'",
 	},
 	WindowsOSType: {
 		chmod:     "echo 'skipping chmod %s %s'", // no-op
 		mkdir:     "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s\"",
-		removeDir: "powershell.exe -Command \"rm %s -recurse -force\"",
+		removeDir: "powershell.exe -Command \"rm %s -recurse -force -ErrorAction SilentlyContinue\"",
 		statPath:  "powershell.exe -Command \"test-path %s\"",
-		mv:    		 "powershell.exe -Command \"mv %s %s\"",
+		mv:        "powershell.exe -Command \"mv %s %s\"",
 	},
 }
 
@@ -74,7 +74,7 @@ func (g *GuestCommands) StatPath(path string) string {
 	return g.sudo(fmt.Sprintf(g.commands().statPath, g.escapePath(path)))
 }
 
-func (g *GuestCommands) MovePath(srcPath string, dstPath) string {
+func (g *GuestCommands) MovePath(srcPath string, dstPath string) string {
 	return g.sudo(fmt.Sprintf(g.commands().mv, g.escapePath(srcPath), g.escapePath(dstPath)))
 }
 

--- a/provisioner/guest_commands_test.go
+++ b/provisioner/guest_commands_test.go
@@ -118,3 +118,78 @@ func TestRemoveDir(t *testing.T) {
 		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
 	}
 }
+
+func TestStatPath(t *testing.T) {
+	// *nix
+	guestCmd, err := NewGuestCommands(UnixOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd := guestCmd.StatPath("/tmp/somedir")
+	if cmd != "stat '/tmp/somedir'" {
+		t.Fatalf("Unexpected Unix stat cmd: %s", cmd)
+	}
+
+	guestCmd, err = NewGuestCommands(UnixOSType, true)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd = guestCmd.StatPath("/tmp/somedir")
+	if cmd != "sudo stat '/tmp/somedir'" {
+		t.Fatalf("Unexpected Unix stat cmd: %s", cmd)
+	}
+
+	// Windows OS
+	guestCmd, err = NewGuestCommands(WindowsOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
+	}
+	cmd = guestCmd.StatPath("C:\\Temp\\SomeDir")
+	if cmd != "powershell.exe -Command { if (test-path C:\\Temp\\SomeDir) { exit 0 } else { exit 1 } }" {
+		t.Fatalf("Unexpected Windows stat cmd: %s", cmd)
+	}
+
+	// Windows OS w/ space in path
+	cmd = guestCmd.StatPath("C:\\Temp\\Some Dir")
+	if cmd != "powershell.exe -Command { if (test-path C:\\Temp\\Some` Dir) { exit 0 } else { exit 1 } }" {
+		t.Fatalf("Unexpected Windows stat cmd: %s", cmd)
+	}
+}
+
+func TestMovePath(t *testing.T) {
+	// *nix
+	guestCmd, err := NewGuestCommands(UnixOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd := guestCmd.MovePath("/tmp/somedir", "/tmp/newdir")
+	if cmd != "mv '/tmp/somedir' '/tmp/newdir'" {
+		t.Fatalf("Unexpected Unix move cmd: %s", cmd)
+	}
+
+	// sudo *nix
+	guestCmd, err = NewGuestCommands(UnixOSType, true)
+	if err != nil {
+		t.Fatalf("Failed to create new sudo GuestCommands for OS: %s", UnixOSType)
+	}
+	cmd = guestCmd.MovePath("/tmp/somedir", "/tmp/newdir")
+	if cmd != "sudo mv '/tmp/somedir' '/tmp/newdir'" {
+		t.Fatalf("Unexpected Unix sudo mv cmd: %s", cmd)
+	}
+
+	// Windows OS
+	guestCmd, err = NewGuestCommands(WindowsOSType, false)
+	if err != nil {
+		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
+	}
+	cmd = guestCmd.MovePath("C:\\Temp\\SomeDir", "C:\\Temp\\NewDir")
+	if cmd != "powershell.exe -Command \"mv C:\\Temp\\SomeDir C:\\Temp\\NewDir\"" {
+		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
+	}
+
+	// Windows OS w/ space in path
+	cmd = guestCmd.MovePath("C:\\Temp\\Some Dir", "C:\\Temp\\New Dir")
+	if cmd != "powershell.exe -Command \"mv C:\\Temp\\Some` Dir C:\\Temp\\New` Dir\"" {
+		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
+	}
+}

--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -302,8 +302,10 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		dst = p.guestOSTypeConfig.stateRoot
 	}
 
-	if err = p.removeDir(ui, comm, dst); err != nil {
-		return fmt.Errorf("Unable to clear salt tree: %s", err)
+	if err = p.statPath(ui, comm, dst); err != nil {
+		if err = p.removeDir(ui, comm, dst); err != nil {
+			return fmt.Errorf("Unable to clear salt tree: %s", err)
+		}
 	}
 
 	if err = p.moveFile(ui, comm, dst, src); err != nil {
@@ -326,9 +328,10 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			dst = p.guestOSTypeConfig.pillarRoot
 		}
 
-		// only remove path if it exists or windows throws a fit
-		if err = p.removeDir(ui, comm, dst); err != nil {
-			return fmt.Errorf("Unable to clear pillar root: %s", err)
+		if err = p.statPath(ui, comm, dst); err != nil {
+			if err = p.removeDir(ui, comm, dst); err != nil {
+				return fmt.Errorf("Unable to clear pillar root: %s", err)
+			}
 		}
 
 		if err = p.moveFile(ui, comm, dst, src); err != nil {

--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -412,7 +412,9 @@ func (p *Provisioner) uploadFile(ui packer.Ui, comm packer.Communicator, dst, sr
 
 func (p *Provisioner) moveFile(ui packer.Ui, comm packer.Communicator, dst, src string) error {
 	ui.Message(fmt.Sprintf("Moving %s to %s", src, dst))
-	cmd := &packer.RemoteCmd{Command: fmt.Sprintf(p.sudo("mv %s %s"), src, dst)}
+	cmd := &packer.RemoteCmd{
+		Command: p.guestCommands.MovePath(src, dst),
+	}
 	if err := cmd.StartWithUi(comm, ui); err != nil || cmd.ExitStatus != 0 {
 		if err == nil {
 			err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus)

--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -302,11 +302,8 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		dst = p.guestOSTypeConfig.stateRoot
 	}
 
-	// only remove state tree if it exists or windows throws a fit
-	if err = p.statPath(ui, comm, dst); err == nil {
-		if err = p.removeDir(ui, comm, dst); err != nil {
-			return fmt.Errorf("Unable to clear salt tree: %s", err)
-		}
+	if err = p.removeDir(ui, comm, dst); err != nil {
+		return fmt.Errorf("Unable to clear salt tree: %s", err)
 	}
 
 	if err = p.moveFile(ui, comm, dst, src); err != nil {
@@ -328,12 +325,12 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		} else {
 			dst = p.guestOSTypeConfig.pillarRoot
 		}
+
 		// only remove path if it exists or windows throws a fit
-		if err = p.statPath(ui, comm, dst); err == nil {
-			if err = p.removeDir(ui, comm, dst); err != nil {
-				return fmt.Errorf("Unable to clear pillar root: %s", err)
-			}
+		if err = p.removeDir(ui, comm, dst); err != nil {
+			return fmt.Errorf("Unable to clear pillar root: %s", err)
 		}
+
 		if err = p.moveFile(ui, comm, dst, src); err != nil {
 			return fmt.Errorf("Unable to move %s/pillar to %s: %s", p.config.TempConfigDir, dst, err)
 		}
@@ -410,7 +407,7 @@ func (p *Provisioner) uploadFile(ui packer.Ui, comm packer.Communicator, dst, sr
 	return nil
 }
 
-func (p *Provisioner) moveFile(ui packer.Ui, comm packer.Communicator, dst, src string) error {
+func (p *Provisioner) moveFile(ui packer.Ui, comm packer.Communicator, dst string, src string) error {
 	ui.Message(fmt.Sprintf("Moving %s to %s", src, dst))
 	cmd := &packer.RemoteCmd{
 		Command: p.guestCommands.MovePath(src, dst),

--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -130,7 +130,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	var ok bool
 	p.guestOSTypeConfig, ok = guestOSTypeConfigs[p.config.GuestOSType]
 	if !ok {
-		return fmt.Errorf("Invalid guest_os_type: \"$\"", p.config.GuestOSType)
+		return fmt.Errorf("Invalid guest_os_type: \"%s\"", p.config.GuestOSType)
 	}
 
 	p.guestCommands, err = provisioner.NewGuestCommands(p.config.GuestOSType, !p.config.DisableSudo)
@@ -356,7 +356,7 @@ func (p *Provisioner) Cancel() {
 
 // Prepends sudo to supplied command if config says to
 func (p *Provisioner) sudo(cmd string) string {
-	if p.config.DisableSudo || p.config.GuestOSType != provisioner.WindowsOSType {
+	if p.config.DisableSudo || (p.config.GuestOSType == provisioner.WindowsOSType) {
 		return cmd
 	}
 

--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -234,7 +234,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			return fmt.Errorf("Unable to download Salt: %s", err)
 		}
 		cmd = &packer.RemoteCmd{
-			Command: fmt.Sprintf(p.sudo(p.guestOSTypeConfig.bootstrapRunCmd), p.config.BootstrapArgs),
+			Command: fmt.Sprintf("%s %s", p.sudo(p.guestOSTypeConfig.bootstrapRunCmd), p.config.BootstrapArgs),
 		}
 		ui.Message(fmt.Sprintf("Installing Salt with command %s", cmd.Command))
 		if err = cmd.StartWithUi(comm, ui); err != nil {

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -309,3 +309,19 @@ func TestProvisionerPrepare_LogLevel(t *testing.T) {
 		t.Fatal("-l debug should be set in CmdArgs")
 	}
 }
+
+func TestProvisionerPrepare_GuestOSType(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	config["guest_os_type"] = "Windows"
+
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if p.config.GuestOSType != "windows" {
+		t.Fatalf("GuestOSType should be 'windows'")
+	}
+}

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -1,11 +1,12 @@
 package saltmasterless
 
 import (
-	"github.com/hashicorp/packer/packer"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/packer/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -31,7 +32,7 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if p.config.TempConfigDir != DefaultTempConfigDir {
+	if p.config.TempConfigDir != p.guestOSTypeConfig.tempDir {
 		t.Errorf("unexpected temp config dir: %s", p.config.TempConfigDir)
 	}
 }

--- a/website/source/docs/provisioners/salt-masterless.html.md
+++ b/website/source/docs/provisioners/salt-masterless.html.md
@@ -90,3 +90,5 @@ Optional:
 
 -   `salt_bin_dir` (string) - Path to the `salt-call` executable. Useful if it is not
     on the PATH.
+
+-   `guest_os_type` (string) - The target guest OS type, either "unix" or "windows".


### PR DESCRIPTION
Added Windows support for salt-masterless provisioner.  Also adds the ability to stat (StatPath) and mv (MovePath) to guest_commands

Closes #5432
