### PR TITLE
Support specifying licenses for Google Compute images

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	ImageDescription     string            `mapstructure:"image_description"`
 	ImageFamily          string            `mapstructure:"image_family"`
 	ImageLabels          map[string]string `mapstructure:"image_labels"`
+	ImageLicenses        []string          `mapstructure:"image_licenses"`
 	InstanceName         string            `mapstructure:"instance_name"`
 	Labels               map[string]string `mapstructure:"labels"`
 	MachineType          string            `mapstructure:"machine_type"`

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -309,6 +309,9 @@ func testConfig(t *testing.T) map[string]interface{} {
 			"label-1": "value-1",
 			"label-2": "value-2",
 		},
+		"image_licenses": []string{
+			"test-license",
+		},
 		"zone": "us-east1-a",
 	}
 }

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -11,7 +11,7 @@ import (
 type Driver interface {
 	// CreateImage creates an image from the given disk in Google Compute
 	// Engine.
-	CreateImage(name, description, family, zone, disk string, image_labels map[string]string) (<-chan *Image, <-chan error)
+	CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string) (<-chan *Image, <-chan error)
 
 	// DeleteImage deletes the image with the given name.
 	DeleteImage(name string) <-chan error

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -97,12 +97,13 @@ func NewDriverGCE(ui packer.Ui, p string, a *AccountFile) (Driver, error) {
 	}, nil
 }
 
-func (d *driverGCE) CreateImage(name, description, family, zone, disk string, image_labels map[string]string) (<-chan *Image, <-chan error) {
+func (d *driverGCE) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string) (<-chan *Image, <-chan error) {
 	gce_image := &compute.Image{
 		Description: description,
 		Name:        name,
 		Family:      family,
 		Labels:      image_labels,
+		Licenses:    image_licenses,
 		SourceDisk:  fmt.Sprintf("%s%s/zones/%s/disks/%s", d.service.BasePath, d.projectId, zone, disk),
 		SourceType:  "RAW",
 	}

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -9,9 +9,9 @@ type DriverMock struct {
 	CreateImageDesc            string
 	CreateImageFamily          string
 	CreateImageLabels          map[string]string
+	CreateImageLicenses        []string
 	CreateImageZone            string
 	CreateImageDisk            string
-	CreateImageResultLicenses  []string
 	CreateImageResultProjectId string
 	CreateImageResultSelfLink  string
 	CreateImageResultSizeGb    int64
@@ -82,11 +82,12 @@ type DriverMock struct {
 	WaitForInstanceErrCh <-chan error
 }
 
-func (d *DriverMock) CreateImage(name, description, family, zone, disk string, image_labels map[string]string) (<-chan *Image, <-chan error) {
+func (d *DriverMock) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string) (<-chan *Image, <-chan error) {
 	d.CreateImageName = name
 	d.CreateImageDesc = description
 	d.CreateImageFamily = family
 	d.CreateImageLabels = image_labels
+	d.CreateImageLicenses = image_licenses
 	d.CreateImageZone = zone
 	d.CreateImageDisk = disk
 	if d.CreateImageResultProjectId == "" {
@@ -106,7 +107,7 @@ func (d *DriverMock) CreateImage(name, description, family, zone, disk string, i
 		ch := make(chan *Image, 1)
 		ch <- &Image{
 			Labels:    d.CreateImageLabels,
-			Licenses:  d.CreateImageResultLicenses,
+			Licenses:  d.CreateImageLicenses,
 			Name:      name,
 			ProjectId: d.CreateImageResultProjectId,
 			SelfLink:  d.CreateImageResultSelfLink,

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -39,7 +39,7 @@ func (s *StepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 
 	imageCh, errCh := driver.CreateImage(
 		config.ImageName, config.ImageDescription, config.ImageFamily, config.Zone,
-		config.DiskName, config.ImageLabels)
+		config.DiskName, config.ImageLabels, config.ImageLicenses)
 	var err error
 	select {
 	case err = <-errCh:

--- a/builder/googlecompute/step_create_image_test.go
+++ b/builder/googlecompute/step_create_image_test.go
@@ -21,7 +21,6 @@ func TestStepCreateImage(t *testing.T) {
 	d := state.Get("driver").(*DriverMock)
 
 	// These are the values of the image the driver will return.
-	d.CreateImageResultLicenses = []string{"test-license"}
 	d.CreateImageResultProjectId = "test-project"
 	d.CreateImageResultSizeGb = 100
 
@@ -35,7 +34,6 @@ func TestStepCreateImage(t *testing.T) {
 	assert.True(t, ok, "Image in state is not an Image.")
 
 	// Verify created Image results.
-	assert.Equal(t, image.Licenses, d.CreateImageResultLicenses, "Created image licenses don't match the licenses returned by the driver.")
 	assert.Equal(t, image.Name, c.ImageName, "Created image does not match config name.")
 	assert.Equal(t, image.ProjectId, d.CreateImageResultProjectId, "Created image project does not match driver project.")
 	assert.Equal(t, image.SizeGb, d.CreateImageResultSizeGb, "Created image size does not match the size returned by the driver.")
@@ -47,6 +45,7 @@ func TestStepCreateImage(t *testing.T) {
 	assert.Equal(t, d.CreateImageZone, c.Zone, "Incorrect image zone passed to driver.")
 	assert.Equal(t, d.CreateImageDisk, c.DiskName, "Incorrect disk passed to driver.")
 	assert.Equal(t, d.CreateImageLabels, c.ImageLabels, "Incorrect image_labels passed to driver.")
+	assert.Equal(t, d.CreateImageLicenses, c.ImageLicenses, "Incorrect image_licenses passed to driver.")
 }
 
 func TestStepCreateImage_errorOnChannel(t *testing.T) {


### PR DESCRIPTION
This is needed to enable features such as the nested virtualization:
https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances