### PR TITLE
Improving some details on the packer-on-cicd guide

### DIFF
--- a/website/source/guides/packer-on-cicd/build-virtualbox-image.html.md
+++ b/website/source/guides/packer-on-cicd/build-virtualbox-image.html.md
@@ -24,8 +24,8 @@ directly, but you may also fork it for the same results.
 ## 1. Provision a Bare-metal Machine
 
 For the purposes of this example, we will run on a bare-metal instance from
-[Packet.net](https://www.packet.net/). If you are a first time user of
-Packet.net, the Packet.net team has provided HashiCorp the coupon code `hashi25`
+[Packet](https://www.packet.net/). If you are a first time user of
+Packet, the Packet team has provided HashiCorp the coupon code `hashi25`
 which you can use for &#x24;25 off to test out this guide. You can use
 a `baremetal_0` server type for testing, but for regular use, the `baremetal_1`
 instance may be a better option.

--- a/website/source/guides/packer-on-cicd/build-virtualbox-image.html.md
+++ b/website/source/guides/packer-on-cicd/build-virtualbox-image.html.md
@@ -25,7 +25,7 @@ directly, but you may also fork it for the same results.
 
 For the purposes of this example, we will run on a bare-metal instance from
 [Packet.net](https://www.packet.net/). If you are a first time user of
-Packet.net, the Packet.net team has provided HashiCorp the coupon code `hash25`
+Packet.net, the Packet.net team has provided HashiCorp the coupon code `hashi25`
 which you can use for &#x24;25 off to test out this guide. You can use
 a `baremetal_0` server type for testing, but for regular use, the `baremetal_1`
 instance may be a better option.

--- a/website/source/guides/packer-on-cicd/build-virtualbox-image.html.md
+++ b/website/source/guides/packer-on-cicd/build-virtualbox-image.html.md
@@ -26,9 +26,10 @@ directly, but you may also fork it for the same results.
 For the purposes of this example, we will run on a bare-metal instance from
 [Packet](https://www.packet.net/). If you are a first time user of
 Packet, the Packet team has provided HashiCorp the coupon code `hashi25`
-which you can use for &#x24;25 off to test out this guide. You can use
-a `baremetal_0` server type for testing, but for regular use, the `baremetal_1`
-instance may be a better option.
+which you can use for &#x24;25 off to test out this guide and up to
+30&#x25; if you decide to
+reserve ongoing servers (email help@packet.net for details). You can use a `baremetal_0` server type for
+testing, but for regular use, the `baremetal_1` instance may be a better option.
 
 There is also a [Packet
 Provider](https://www.terraform.io/docs/providers/packet/index.html) in

--- a/website/source/guides/packer-on-cicd/upload-images-to-artifact.html.md
+++ b/website/source/guides/packer-on-cicd/upload-images-to-artifact.html.md
@@ -41,5 +41,5 @@ In your build configuration in TeamCity Server, add an additional **Build Step:
 Command Line** and set the **Script content** field to the following:
 
 ```shell
-awscli s3 cp . s3://bucket/ --exclude “*” --include “*.iso”
+awscli s3 cp . s3://bucket/ --exclude “*” --include “*.ovf"
 ```


### PR DESCRIPTION
Making minor doc updates to the "Build Immutable Infrastructure with Packer in CI/CD" guide:
- Fixing a typo in the packet coupon code
- Renaming "Packet.net" to just "Packet"
- Fixing the extension (from iso to ovf) for the output file for the S3 upload command