### PR TITLE
builder/triton: Add ability to create temporary firewall rule

### DIFF
--- a/builder/triton/builder.go
+++ b/builder/triton/builder.go
@@ -62,6 +62,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	steps := []multistep.Step{
 		&StepCreateSourceMachine{},
+		&StepCreateMachineFirewallRule{},
 		&communicator.StepConnect{
 			Config: &config.Comm,
 			Host:   commHost,

--- a/builder/triton/driver.go
+++ b/builder/triton/driver.go
@@ -12,6 +12,8 @@ type Driver interface {
 	DeleteMachine(machineId string) error
 	GetMachineIP(machineId string) (string, error)
 	StopMachine(machineId string) error
+	CreateFirewallRule(rule string) (string, error)
+	DeleteFirewallRule(ruleId string) error
 	WaitForImageCreation(imageId string, timeout time.Duration) error
 	WaitForMachineDeletion(machineId string, timeout time.Duration) error
 	WaitForMachineState(machineId string, state string, timeout time.Duration) error

--- a/builder/triton/driver_mock.go
+++ b/builder/triton/driver_mock.go
@@ -25,6 +25,11 @@ type DriverMock struct {
 	StopMachineId  string
 	StopMachineErr error
 
+	CreateFirewalRuleId   string
+	CreateFirewallRuleErr error
+
+	DeleteFirewallRuleErr error
+
 	WaitForImageCreationErr error
 
 	WaitForMachineDeletionErr error
@@ -92,6 +97,18 @@ func (d *DriverMock) StopMachine(machineId string) error {
 	d.StopMachineId = machineId
 
 	return d.StopMachineErr
+}
+
+func (d *DriverMock) CreateFirewallRule(rule string) (string, error) {
+	if d.CreateFirewallRuleErr != nil {
+		return "", d.CreateFirewallRuleErr
+	}
+
+	return "ruleId", nil
+}
+
+func (d *DriverMock) DeleteFirewallRule(ruleId string) error {
+	return d.CreateFirewallRuleErr
 }
 
 func (d *DriverMock) WaitForImageCreation(machineId string, timeout time.Duration) error {

--- a/builder/triton/driver_triton.go
+++ b/builder/triton/driver_triton.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/packer/packer"
 	"github.com/joyent/triton-go/client"
 	"github.com/joyent/triton-go/compute"
+	"github.com/joyent/triton-go/network"
 )
 
 type driverTriton struct {
@@ -138,6 +139,27 @@ func (d *driverTriton) StopMachine(machineId string) error {
 	computeClient, _ := d.client.Compute()
 	return computeClient.Instances().Stop(context.Background(), &compute.StopInstanceInput{
 		InstanceID: machineId,
+	})
+}
+
+func (d *driverTriton) CreateFirewallRule(rule string) (string, error) {
+	networkClient, _ := d.client.Network()
+	result, err := networkClient.Firewall().CreateRule(context.Background(), &network.CreateRuleInput{
+		Enabled:     true,
+		Rule:        rule,
+		Description: "Temporary Firewall Rule added by Packer",
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return result.ID, nil
+}
+
+func (d *driverTriton) DeleteFirewallRule(ruleId string) error {
+	networkClient, _ := d.client.Network()
+	return networkClient.Firewall().DeleteRule(context.Background(), &network.DeleteRuleInput{
+		ID: ruleId,
 	})
 }
 

--- a/builder/triton/source_machine_config.go
+++ b/builder/triton/source_machine_config.go
@@ -9,14 +9,15 @@ import (
 // SourceMachineConfig represents the configuration to run a machine using
 // the SDC API in order for provisioning to take place.
 type SourceMachineConfig struct {
-	MachineName            string             `mapstructure:"source_machine_name"`
-	MachinePackage         string             `mapstructure:"source_machine_package"`
-	MachineImage           string             `mapstructure:"source_machine_image"`
-	MachineNetworks        []string           `mapstructure:"source_machine_networks"`
-	MachineMetadata        map[string]string  `mapstructure:"source_machine_metadata"`
-	MachineTags            map[string]string  `mapstructure:"source_machine_tags"`
-	MachineFirewallEnabled bool               `mapstructure:"source_machine_firewall_enabled"`
-	MachineImageFilters    MachineImageFilter `mapstructure:"source_machine_image_filter"`
+	MachineName            string                `mapstructure:"source_machine_name"`
+	MachinePackage         string                `mapstructure:"source_machine_package"`
+	MachineImage           string                `mapstructure:"source_machine_image"`
+	MachineNetworks        []string              `mapstructure:"source_machine_networks"`
+	MachineMetadata        map[string]string     `mapstructure:"source_machine_metadata"`
+	MachineTags            map[string]string     `mapstructure:"source_machine_tags"`
+	MachineFirewallEnabled bool                  `mapstructure:"source_machine_firewall_enabled"`
+	MachineFirewallDetails MachineFirewallDetail `mapstructure:"source_machine_firewall_detail"`
+	MachineImageFilters    MachineImageFilter    `mapstructure:"source_machine_image_filter"`
 }
 
 type MachineImageFilter struct {
@@ -30,8 +31,17 @@ type MachineImageFilter struct {
 	Type       string
 }
 
+type MachineFirewallDetail struct {
+	SourceAddress string `mapstructure:"source"`
+	Port          int
+}
+
 func (m *MachineImageFilter) Empty() bool {
 	return m.Name == "" && m.OS == "" && m.Version == "" && m.State == "" && m.Owner == "" && m.Type == ""
+}
+
+func (m *MachineFirewallDetail) Empty() bool {
+	return m.SourceAddress == "" || m.Port == 0
 }
 
 // Prepare performs basic validation on a SourceMachineConfig struct.

--- a/builder/triton/step_create_machine_firewall_rule.go
+++ b/builder/triton/step_create_machine_firewall_rule.go
@@ -1,0 +1,67 @@
+package triton
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/packer"
+	"github.com/mitchellh/multistep"
+)
+
+type StepCreateMachineFirewallRule struct{}
+
+func (s *StepCreateMachineFirewallRule) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(Config)
+	driver := state.Get("driver").(Driver)
+	ui := state.Get("ui").(packer.Ui)
+
+	if config.MachineFirewallDetails.Empty() {
+		ui.Say("No firewall to configure!")
+		return multistep.ActionContinue
+	}
+
+	firewallRule := createFirewallRuleString(config.MachineFirewallDetails.SourceAddress, state.Get("machine").(string), config.MachineFirewallDetails.Port)
+	ui.Say(fmt.Sprintf("Creating Firewall Rule: %s", firewallRule))
+
+	ruleId, err := driver.CreateFirewallRule(firewallRule)
+	if err != nil {
+		state.Put("error", fmt.Errorf("Problem creating firewall rule: %s", err))
+		return multistep.ActionHalt
+	}
+
+	state.Put("firewall_rule_id", ruleId)
+
+	return multistep.ActionContinue
+}
+
+func createFirewallRuleString(sourceAddress, machineId string, port int) string {
+	sourceType := ""
+	if sourceAddress != "any" {
+		sourceType = "ip"
+	}
+	return fmt.Sprintf("FROM %s %s TO vm %s ALLOW tcp PORT %d", sourceType, sourceAddress, machineId, port)
+}
+
+func (s *StepCreateMachineFirewallRule) Cleanup(state multistep.StateBag) {
+	ui := state.Get("ui").(packer.Ui)
+	driver := state.Get("driver").(Driver)
+	config := state.Get("config").(Config)
+
+	if config.MachineFirewallDetails.Empty() {
+		return
+	}
+
+	ui.Say("Deleting Firewall Rule")
+
+	ruleId, ok := state.GetOk("firewall_rule_id")
+	if !ok {
+		return
+	}
+
+	err := driver.DeleteFirewallRule(ruleId.(string))
+	if err != nil {
+		state.Put("error", fmt.Errorf("Problem deleting firewall rule: %s", err))
+		return
+	}
+
+	return
+}

--- a/website/source/docs/builders/triton.html.md
+++ b/website/source/docs/builders/triton.html.md
@@ -100,6 +100,24 @@ builder.
     firewall rules. Unless you have a global rule defined in Triton which allows
     SSH traffic enabling the firewall will interfere with the SSH provisioner.
     The default is `false`.
+    
+-   `source_machine_firewall_detail` (object) - Gives the ability to create a temporary
+    firewall rule that allows access to the source machine when `source_machine_firewall_enabled`
+    is enabled. Example:
+    
+    ```json
+    {
+      "source_machine_firewall_detail": {
+        "port": 22,
+        "source": "any"
+      }
+    }
+    ```
+    The source can either be `any` or an IP address. It will create a corresponding
+    firewall rule that looks as follows:
+    `FROM any TO vm <machine UUID> ALLOW tcp PORT 22` that will
+    get deployed to Triton. The lifecycle of this firewall rule is only for the
+    duration of the packer run.
 -   `source_machine_metadata` (object of key/value strings) - Triton metadata
     applied to the VM used to create the image. Metadata can be used to pass
     configuration information to the VM without the need for networking. See


### PR DESCRIPTION
Fixes: #5707

When `source_machine_firewall_enabled` is true, we would like to offer the user the ability
to configure a temporary firewall rule that will allow the box to be provisioned correctly.
The firewall rule is only kept for the duration of the packer run after which time it is deleted

This will follow the format:

```
    {
      "source_machine_firewall_detail": {
        "port": 22,
        "source": "any"
      }
    }
```

It will create the corresponding rule:

```
FROM any TO vm d181f866-7e8d-6fc2-d4e9-93be8b353549 ALLOW tcp PORT 22
```

I can see it in action as follows:

```
==> triton: Waiting for source machine to become available...
==> triton: Creating Firewall Rule: FROM  any TO vm d181f866-7e8d-6fc2-d4e9-93be8b353549 ALLOW tcp PORT 22
==> triton: Waiting for SSH to become available...
==> triton: Connected to SSH!
```

and I can see it cleans itself up at the end of the run:

```
==> triton: Stopping source machine (d181f866-7e8d-6fc2-d4e9-93be8b353549)...
==> triton: Waiting for source machine to stop (d181f866-7e8d-6fc2-d4e9-93be8b353549)...
==> triton: Creating image from source machine...
==> triton: Waiting for image to become available...
==> triton: Deleting source machine...
==> triton: Waiting for source machine to be deleted...
==> triton: Deleting Firewall Rule
Build 'triton' finished.
```