### PR TITLE
Add vagrant post-processor support for Google

### DIFF
--- a/post-processor/vagrant/google.go
+++ b/post-processor/vagrant/google.go
@@ -1,0 +1,42 @@
+package vagrant
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/hashicorp/packer/packer"
+)
+
+type googleVagrantfileTemplate struct {
+	Image string ""
+}
+
+type GoogleProvider struct{}
+
+func (p *GoogleProvider) KeepInputArtifact() bool {
+	return true
+}
+
+func (p *GoogleProvider) Process(ui packer.Ui, artifact packer.Artifact, dir string) (vagrantfile string, metadata map[string]interface{}, err error) {
+	// Create the metadata
+	metadata = map[string]interface{}{"provider": "google"}
+
+	// Build up the template data to build our Vagrantfile
+	tplData := &googleVagrantfileTemplate{}
+	tplData.Image = artifact.Id()
+
+	// Build up the Vagrantfile
+	var contents bytes.Buffer
+	t := template.Must(template.New("vf").Parse(defaultGoogleVagrantfile))
+	err = t.Execute(&contents, tplData)
+	vagrantfile = contents.String()
+	return
+}
+
+var defaultGoogleVagrantfile = `
+Vagrant.configure("2") do |config|
+  config.vm.provider :google do |google|
+    google.image = "{{ .Image }}"
+  end
+end
+`

--- a/post-processor/vagrant/google_test.go
+++ b/post-processor/vagrant/google_test.go
@@ -1,0 +1,36 @@
+package vagrant
+
+import (
+	"github.com/hashicorp/packer/packer"
+	"strings"
+	"testing"
+)
+
+func TestGoogleProvider_impl(t *testing.T) {
+	var _ Provider = new(GoogleProvider)
+}
+
+func TestGoogleProvider_KeepInputArtifact(t *testing.T) {
+	p := new(GoogleProvider)
+
+	if !p.KeepInputArtifact() {
+		t.Fatal("should keep input artifact")
+	}
+}
+
+func TestGoogleProvider_ArtifactId(t *testing.T) {
+	p := new(GoogleProvider)
+	ui := testUi()
+	artifact := &packer.MockArtifact{
+		IdValue: "packer-1234",
+	}
+
+	vagrantfile, _, err := p.Process(ui, artifact, "foo")
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	result := `google.image = "packer-1234"`
+	if !strings.Contains(vagrantfile, result) {
+		t.Fatalf("wrong substitution: %s", vagrantfile)
+	}
+}

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -25,6 +25,7 @@ var builtins = map[string]string{
 	"mitchellh.vmware":          "vmware",
 	"mitchellh.vmware-esx":      "vmware",
 	"pearkes.digitalocean":      "digitalocean",
+	"packer.googlecompute":      "google",
 	"packer.parallels":          "parallels",
 	"MSOpenTech.hyperv":         "hyperv",
 	"transcend.qemu":            "libvirt",
@@ -232,6 +233,8 @@ func providerForName(name string) Provider {
 		return new(HypervProvider)
 	case "libvirt":
 		return new(LibVirtProvider)
+	case "google":
+		return new(GoogleProvider)
 	default:
 		return nil
 	}

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -32,6 +32,7 @@ providers.
 
 -   AWS
 -   DigitalOcean
+-   Google
 -   Hyper-V
 -   Parallels
 -   QEMU
@@ -100,8 +101,8 @@ Specify overrides within the `override` configuration by provider name:
 In the example above, the compression level will be set to 1 except for VMware,
 where it will be set to 0.
 
-The available provider names are: `aws`, `digitalocean`, `virtualbox`, `vmware`,
-and `parallels`.
+The available provider names are: `aws`, `digitalocean`, `google`, `virtualbox`,
+`vmware`, and `parallels`.
 
 ## Input Artifacts
 


### PR DESCRIPTION
Add the ability to create Google vagrant boxes
using the vagrant post-processor. The Google
plugin for vagrant is linked below.

https://github.com/mitchellh/vagrant-google