### PR TITLE
Add Intel HAXM support to QEMU builder

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -25,6 +25,7 @@ var accels = map[string]struct{}{
 	"kvm":  {},
 	"tcg":  {},
 	"xen":  {},
+	"hax":  {},
 }
 
 var netDevice = map[string]bool{
@@ -259,7 +260,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if _, ok := accels[b.config.Accelerator]; !ok {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("invalid accelerator, only 'kvm', 'tcg', 'xen', or 'none' are allowed"))
+			errs, errors.New("invalid accelerator, only 'kvm', 'tcg', 'xen', 'hax', or 'none' are allowed"))
 	}
 
 	if _, ok := netDevice[b.config.NetDevice]; !ok {

--- a/website/source/docs/builders/qemu.html.md
+++ b/website/source/docs/builders/qemu.html.md
@@ -110,9 +110,9 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
 ### Optional:
 
 -   `accelerator` (string) - The accelerator type to use when running the VM.
-    This may be `none`, `kvm`, `tcg`, or `xen`. The appropriate software must
-    already been installed on your build machine to use the accelerator you
-    specified. When no accelerator is specified, Packer will try to use `kvm`
+    This may be `none`, `kvm`, `tcg`, `hax`, or `xen`. The appropriate software 
+    must have already been installed on your build machine to use the accelerator 
+    you specified. When no accelerator is specified, Packer will try to use `kvm`
     if it is available but will default to `tcg` otherwise.
 
 -   `boot_command` (array of strings) - This is an array of commands to type


### PR DESCRIPTION
I was attempting to try and use the Intel HAXM accelerator with my Windows build, which is supported (in terms of availability and usage of the accelerator) by QEMU. 

I found that Packer was blocking the "hax" accelerator from being specified; an "invalid accelerator" message was being displayed, and the build would then fail. 

These changes remove the restriction.

Whilst there are a couple of issues currently open against QEMU and HAXM, the packer side of things shouldn't need to be modified beyond these changes once they are resolved in the relevant projects.

Current issues of note are:

1. The inability to allocate more than 4095M of RAM to the VM: https://github.com/intel/haxm/issues/13
2. The inability to attach a CDROM ISO: https://github.com/intel/haxm/issues/20