### PR TITLE
Attach keypair before starting instance in alicloud builder

### DIFF
--- a/builder/alicloud/ecs/builder.go
+++ b/builder/alicloud/ecs/builder.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"fmt"
+
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/config"
@@ -146,9 +147,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		})
 	}
 	steps = append(steps,
+		&stepAttachKeyPar{},
 		&stepRunAlicloudInstance{},
 		&stepMountAlicloudDisk{},
-		&stepAttachKeyPar{},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,
 			Host: SSHHost(


### PR DESCRIPTION
[Documentation of `AttachKeyPair`](https://goo.gl/gC3srG) states that
attaching keypair to running instance takes effect after reboot.
So we need to attach keypair before starting instance to avoid an
additional restart.