### PR TITLE
add super basic s3 URI support to downloader

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -110,7 +110,7 @@ func DownloadableURL(original string) (string, error) {
 	url.Scheme = strings.ToLower(url.Scheme)
 
 	// Verify that the scheme is something we support in our common downloader.
-	supported := []string{"file", "http", "https"}
+	supported := []string{"file", "http", "https", "s3"}
 	found := false
 	for _, s := range supported {
 		if url.Scheme == s {


### PR DESCRIPTION
Added the ability to use s3 buckets for at least `iso_url` and `iso_urls`.  It could be expanded to use aws creds from within the template, but for now uses the environment.

I would add tests, but this is my first stab at modifying go code and it appears as though the tests would require having an s3 bucket with pre-defined files.  I have tested that the code is functional though in both `iso_*` options

There are no open issues for this functionality, it was just something I needed to allow me to store non-public ISO images in an accessible space.