### PR TITLE
make user retrieval for Ansible provisioner more robust

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -141,7 +142,12 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.User == "" {
-		p.config.User = os.Getenv("USER")
+		usr, err := user.Current()
+		if err != nil {
+			errs = packer.MultiErrorAppend(errs, err)
+		} else {
+			p.config.User = usr.Username
+		}
 	}
 	if p.config.User == "" {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("user: could not determine current user from environment."))

--- a/provisioner/ansible/provisioner_test.go
+++ b/provisioner/ansible/provisioner_test.go
@@ -76,6 +76,16 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.Remove(playbook_file.Name())
+
+	err = os.Unsetenv("USER")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestProvisionerPrepare_PlaybookFile(t *testing.T) {


### PR DESCRIPTION
Previously, the Ansible provisioner would look for the username from the `USER` environment variable. Unfortunately, this is not always set - particularly in Docker containers. It's very confusing to understand why the error is happening.

Switched to using Go's built-in `os/user` package for retrieving the current username. @rickard-von-essen had done this in #3276 in 7369841, but moved away from it in d59844f because, at the time, it wasn't possible to use that package with cross-compilation. This was fixed in https://github.com/golang/go/commit/795e712b72802ad49b7c077964046f79c4f6586e.
  
  