### PR TITLE
fix nasty edge case where we can't find guest additions on windows if they are on a different drive

### DIFF
--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -2,8 +2,6 @@ package ovf
 
 import (
 	"fmt"
-	"net/url"
-	"os"
 	"strings"
 
 	vboxcommon "github.com/hashicorp/packer/builder/virtualbox/common"
@@ -103,14 +101,12 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("source_path is invalid: %s", err))
 		}
-		// file must exist now.
-		fileURL, _ := url.Parse(c.SourcePath)
-		if fileURL.Scheme == "file" {
-			if _, err := os.Stat(fileURL.Path); err != nil {
-				errs = packer.MultiErrorAppend(errs,
-					fmt.Errorf("source file needs to exist at time of config validation: %s", err))
-			}
+		fileExists, err := common.FileExistsLocally(c.SourcePath)
+		if err != nil {
+			packer.MultiErrorAppend(errs,
+				fmt.Errorf("Source file needs to exist at time of config validation: %s", err))
 		}
+
 	}
 
 	validMode := false

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -101,10 +101,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("source_path is invalid: %s", err))
 		}
-		_, err := common.FileExistsLocally(c.SourcePath)
-		if err != nil {
+		fileOK := common.FileExistsLocally(c.SourcePath)
+		if !fileOK {
 			packer.MultiErrorAppend(errs,
-				fmt.Errorf("Source file needs to exist at time of config validation: %s", err))
+				fmt.Errorf("Source file needs to exist at time of config validation!"))
 		}
 
 	}

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -101,7 +101,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("source_path is invalid: %s", err))
 		}
-		fileExists, err := common.FileExistsLocally(c.SourcePath)
+		_, err := common.FileExistsLocally(c.SourcePath)
 		if err != nil {
 			packer.MultiErrorAppend(errs,
 				fmt.Errorf("Source file needs to exist at time of config validation: %s", err))

--- a/common/config.go
+++ b/common/config.go
@@ -135,16 +135,14 @@ func DownloadableURL(original string) (string, error) {
 //
 // myFile, err = common.DownloadableURL(c.SourcePath)
 // ...
-// fileExists, err := common.StatURL(myFile)
+// fileExists := common.StatURL(myFile)
 // possible output:
-// true, nil -- should occur if the file is present
-// false, nil -- should occur if the file is not present, but is not supposed to
-// be (e.g. the schema is http://, not file://)
-// true, error -- shouldn't occur ever
-// false, error -- should occur if there was an error stating the file, so the
+// true -- should occur if the file is present, or if the file is not present,
+// but is not supposed to be (e.g. the schema is http://, not file://)
+// false -- should occur if there was an error stating the file, so the
 // file is not present when it should be.
 
-func FileExistsLocally(original string) (bool, error) {
+func FileExistsLocally(original string) bool {
 	// original should be something like file://C:/my/path.iso
 
 	fileURL, _ := url.Parse(original)
@@ -163,11 +161,10 @@ func FileExistsLocally(original string) (bool, error) {
 		}
 		_, err := os.Stat(filePath)
 		if err != nil {
-			err = fmt.Errorf("could not stat file: %s\n", err)
-			return fileExists, err
+			return fileExists
 		} else {
 			fileExists = true
 		}
 	}
-	return fileExists, nil
+	return fileExists
 }

--- a/common/config.go
+++ b/common/config.go
@@ -74,12 +74,6 @@ func DownloadableURL(original string) (string, error) {
 				url.Path = url.Host
 				url.Host = ""
 			}
-
-			// For Windows absolute file paths, remove leading / prior to processing
-			// since net/url turns "C:/" into "/C:/"
-			if len(url.Path) > 0 && url.Path[0] == '/' {
-				url.Path = url.Path[1:len(url.Path)]
-			}
 		}
 
 		// Only do the filepath transformations if the file appears

--- a/common/config.go
+++ b/common/config.go
@@ -73,9 +73,9 @@ func DownloadableURL(original string) (string, error) {
 		if runtime.GOOS == "windows" {
 			// If the path is using Windows-style slashes, URL parses
 			// it into the host field.
-			if url.Path == "" && strings.Contains(url.Host, `\`) {
-				url.Path = url.Host
-				url.Host = ""
+			if u.Path == "" && strings.Contains(u.Host, `\`) {
+				u.Path = u.Host
+				u.Host = ""
 			}
 		}
 		// Only do the filepath transformations if the file appears

--- a/common/config.go
+++ b/common/config.go
@@ -69,6 +69,15 @@ func DownloadableURL(original string) (string, error) {
 	}
 
 	if u.Scheme == "file" {
+		// Windows file handling is all sorts of tricky...
+		if runtime.GOOS == "windows" {
+			// If the path is using Windows-style slashes, URL parses
+			// it into the host field.
+			if url.Path == "" && strings.Contains(url.Host, `\`) {
+				url.Path = url.Host
+				url.Host = ""
+			}
+		}
 		// Only do the filepath transformations if the file appears
 		// to actually exist.
 		if _, err := os.Stat(u.Path); err == nil {

--- a/common/config.go
+++ b/common/config.go
@@ -69,16 +69,6 @@ func DownloadableURL(original string) (string, error) {
 	}
 
 	if u.Scheme == "file" {
-		// Windows file handling is all sorts of tricky...
-		if runtime.GOOS == "windows" {
-			// If the path is using Windows-style slashes, URL parses
-			// it into the host field.
-			if u.Path == "" && strings.Contains(u.Host, `\`) {
-				u.Path = u.Host
-				u.Host = ""
-			}
-		}
-
 		// Only do the filepath transformations if the file appears
 		// to actually exist.
 		if _, err := os.Stat(u.Path); err == nil {

--- a/common/config.go
+++ b/common/config.go
@@ -119,3 +119,37 @@ func DownloadableURL(original string) (string, error) {
 
 	return url.String(), nil
 }
+
+// FileExistsLocally takes the URL output from DownloadableURL, and determines
+// whether it is present on the file system.
+// example usage:
+//
+// myFile, err = common.DownloadableURL(c.SourcePath)
+// ...
+// fileExists, err := common.StatURL(myFile)
+// possible output:
+// true, nil -- should occur if the file is present
+// false, nil -- should occur if the file is not present, but is not supposed to
+// be (e.g. the schema is http://, not file://)
+// true, error -- shouldn't occur ever
+// false, error -- should occur if there was an error stating the file, so the
+// file is not present when it should be.
+
+func FileExistsLocally(original string) (bool, error) {
+	fileURL, _ := url.Parse(original)
+	fileExists := false
+	err := nil
+
+	if fileURL.Scheme == "file" {
+		// Remove forward slash on absolute Windows file URLs before processing
+		if runtime.GOOS == "windows" && len(fileURL.Path) > 0 && fileURL.Path[0] == '/' {
+			filePath := fileURL.Path[1:]
+		}
+		if _, err := os.Stat(filePath); err != nil {
+			err = fmt.Errorf("source file needs to exist at time of config validation: %s", err)
+		} else {
+			fileExists = true
+		}
+	}
+	return fileExists, err
+}

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -208,6 +208,43 @@ func TestDownloadableURL_FilePaths(t *testing.T) {
 	}
 }
 
+func test_FileExistsLocally(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		dirCases := []struct {
+			Input  string
+			Output bool
+		}{
+			// file exists locally
+			{"file:///C:/Temp/SomeDir/myfile.txt", true},
+			// file is not supposed to exist locally
+			{"https://myfile.iso", true},
+			// file does not exist locally
+			{"file:///C/i/dont/exist", false},
+		}
+		// create absolute-pathed tempfile to play with
+		err := os.Mkdir("C:\\Temp\\SomeDir", 0755)
+		if err != nil {
+			t.Fatalf("err creating test dir: %s", err)
+		}
+		fi, err := os.Create("C:\\Temp\\SomeDir\\myfile.txt")
+		if err != nil {
+			t.Fatalf("err creating test file: %s", err)
+		}
+		fi.Close()
+		defer os.Remove("C:\\Temp\\SomeDir\\myfile.txt")
+		defer os.Remove("C:\\Temp\\SomeDir")
+
+		// Run through test cases to make sure they all parse correctly
+		for _, tc := range dirCases {
+			fileOK := FileExistsLocally(tc.Input)
+			if !fileOK {
+				t.Fatalf("Test Case failed: Expected %#v, received = %#v, input = %s",
+					tc.Output, fileOK, tc.Input)
+			}
+		}
+	}
+}
+
 func TestScrubConfig(t *testing.T) {
 	type Inner struct {
 		Baz string

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -93,6 +93,11 @@ func TestDownloadableURL_WindowsFiles(t *testing.T) {
 				"",
 				true,
 			},
+			{ // UNC paths; why not?
+				"\\\\?\\c:\\Temp\\SomeDir\\myfile.txt",
+				"",
+				true,
+			},
 			{
 				"file:///C:\\Temp\\SomeDir\\myfile.txt",
 				"file:///c:/Temp/SomeDir/myfile.txt",

--- a/common/download.go
+++ b/common/download.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 )
 
 // DownloadConfig is the configuration given to instantiate a new
@@ -128,6 +129,11 @@ func (d *DownloadClient) Get() (string, error) {
 		// This is a special case where we use a source file that already exists
 		// locally and we don't make a copy. Normally we would copy or download.
 		log.Printf("[DEBUG] Using local file: %s", finalPath)
+
+		// Remove forward slash on absolute Windows file URLs before processing
+		if runtime.GOOS == "windows" && len(finalPath) > 0 && finalPath[0] == '/' {
+			finalPath = finalPath[1:]
+		}
 
 		// Keep track of the source so we can make sure not to delete this later
 		sourcePath = finalPath


### PR DESCRIPTION
fixes #5713
fixes #5700

See the gloriously detailed comment here for context: https://github.com/hashicorp/packer/issues/5713#issuecomment-353263035

I've tested this on osx, as well as on windows both on the same and on a different drive.  I've confirmed that this fixes the issue reported in 5713, and it doesn't seem to break anything else.  Would love some sanity-check confirmation from other windows users that this has fixed things.
  
  