### PR TITLE
Use SDK's InstanceReady waiter

### DIFF
--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -231,10 +231,10 @@ func (s *StepRunSpotInstance) Run(state multistep.StateBag) multistep.StepAction
 
 	ui.Message(fmt.Sprintf("Instance ID: %s", instanceId))
 	ui.Say(fmt.Sprintf("Waiting for instance (%v) to become ready...", instanceId))
-	describeInstanceStatus := &ec2.DescribeInstanceStatusInput{
+	describeInstance := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{aws.String(instanceId)},
 	}
-	if err := ec2conn.WaitUntilInstanceStatusOk(describeInstanceStatus); err != nil {
+	if err := ec2conn.WaitUntilInstanceRunning(describeInstance); err != nil {
 		err := fmt.Errorf("Error waiting for instance (%s) to become ready: %s", instanceId, err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -115,7 +115,6 @@ Packer to work:
         "ec2:DeregisterImage",
         "ec2:DescribeImageAttribute",
         "ec2:DescribeImages",
-        "ec2:DescribeInstanceStatus",
         "ec2:DescribeInstances",
         "ec2:DescribeRegions",
         "ec2:DescribeSecurityGroups",


### PR DESCRIPTION
Closes #5705

This replaces our home grown instance ready waiter with the one from the SDK. This brings build times back to where they were in the previous release, but without the errors.

I cannot for the life of me reproduce the error with this patch, but since the error isn't falsifiable, it's going to be hard to tell if this fixes it completely. I'll keep running builds in a loop and see if I see any problems, but I think we'll probably be good with this patch