### PR TITLE
[vagrant] Remove redundant configuration block in Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,11 +69,6 @@ def configureProviders(vmCfg, cpus: "2", memory: "2048")
 		end
 	end
 
-	vmCfg.vm.provider "virtualbox" do |v|
-		v.memory = memory
-		v.cpus = cpus
-	end
-
 	return vmCfg
 end
 


### PR DESCRIPTION
### What does this PR do?
Removes a redundant block in the project's `Vagrantfile` — this looks like a simple copy/paste error:

```ruby
def configureProviders(vmCfg, cpus: "2", memory: "2048")
  vmCfg.vm.provider "virtualbox" do |v|
    v.memory = memory
    v.cpus = cpus
  end

  ["vmware_fusion", "vmware_workstation"].each do |p|
    vmCfg.vm.provider p do |v|
      v.enable_vmrun_ip_lookup = false
      v.vmx["memsize"] = memory
      v.vmx["numvcpus"] = cpus
    end
  end

  # *Duplicated*
  vmCfg.vm.provider "virtualbox" do |v|
    v.memory = memory
    v.cpus = cpus
  end

  return vmCfg
end
```