### PR TITLE
Some chances to log errors were missed inside step_create_floppy.go for floppy_files

### DIFF
--- a/common/step_create_floppy.go
+++ b/common/step_create_floppy.go
@@ -155,7 +155,10 @@ func (s *StepCreateFloppy) Run(state multistep.StateBag) multistep.StepAction {
 			}
 
 			for _, crawlfilename := range crawlDirectoryFiles {
-				s.Add(cache, crawlfilename)
+				if err = s.Add(cache, crawlfilename); err != nil {
+					state.Put("error", fmt.Errorf("Error adding file from floppy_files : %s : %s", filename, err))
+					return multistep.ActionHalt
+				}
 				s.FilesAdded[crawlfilename] = true
 			}
 
@@ -165,7 +168,10 @@ func (s *StepCreateFloppy) Run(state multistep.StateBag) multistep.StepAction {
 
 		// add just a single file
 		ui.Message(fmt.Sprintf("Copying file: %s", filename))
-		s.Add(cache, filename)
+		if err = s.Add(cache, filename); err != nil {
+			state.Put("error", fmt.Errorf("Error adding file from floppy_files : %s : %s", filename, err))
+			return multistep.ActionHalt
+		}
 		s.FilesAdded[filename] = true
 	}
 	ui.Message("Done copying files from floppy_files")


### PR DESCRIPTION
When I submitted my PR to `floppy_dirs` some time ago, some errors were not checked when adding files to a floppy via `StepCreateFloppy.Add(...)`. This was thought to not matter, because the idea was that `StepCreateFloppy` would continue to try and add files and only the ones that would fit would succeed (which matched the way that `floppy_files` had originally worked prior to `floppy_dirs`).

Unfortunately this is probably confusing for users in case of issues such as #5789. This is confusing in that if a user uses `floppy_files` to add a file past the filesystem limit, it will silently fail and everything will appear hunky-dory to them despite not all files being successfully added.

The line in [common/step_create_floppy.go:55](../tree/master/common/step_create_floppy.go#L55) sets the maximum size of a floppy to 1.44mb. If go-fs tries to add a file that pushes it past this limit, an error specifying "FAT FULL" will be returned. This PR ensures that `StepCreateFloppy.Add(...)` fails hard and thus the user will see this error when they're out of disk space on the floppy.