### PR TITLE
VCenter is now an argument to VSphere post-processor

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -33,9 +33,10 @@ type Config struct {
 	Password     string   `mapstructure:"password"`
 	ResourcePool string   `mapstructure:"resource_pool"`
 	Username     string   `mapstructure:"username"`
-	VMFolder     string   `mapstructure:"vm_folder"`
-	VMName       string   `mapstructure:"vm_name"`
-	VMNetwork    string   `mapstructure:"vm_network"`
+	VCenterIp    string   `mapstructure:"vcenter_ip"`
+	VMFolder  	 string   `mapstructure:"vm_folder"`
+	VMName    	 string   `mapstructure:"vm_name"`
+	VMNetwork 	 string   `mapstructure:"vm_network"`
 
 	ctx interpolate.Context
 }
@@ -111,13 +112,22 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 
 	password := url.QueryEscape(p.config.Password)
-	ovftool_uri := fmt.Sprintf("vi://%s:%s@%s/%s/host/%s",
-		url.QueryEscape(p.config.Username),
-		password,
-		p.config.Host,
-		p.config.Datacenter,
-		p.config.Cluster)
-
+	ovftool_uri := ""
+	if p.config.VCenterIp == "" {
+		ovftool_uri = fmt.Sprintf("vi://%s:%s@%s/%s/host/%s",
+			url.QueryEscape(p.config.Username),
+			password,
+			p.config.Host,
+			p.config.Datacenter,
+			p.config.Cluster)
+	} else {
+		ovftool_uri = fmt.Sprintf("vi://%s:%s@%s/%s/host/%s",
+			url.QueryEscape(p.config.Username),
+			password,
+			p.config.VCenterIp,
+			p.config.Datacenter,
+			p.config.Cluster)
+	}
 	if p.config.ResourcePool != "" {
 		ovftool_uri += "/Resources/" + p.config.ResourcePool
 	}

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestArgs(t *testing.T) {
+func TestArgsWithHost(t *testing.T) {
 	var p PostProcessor
 
 	p.config.Username = "me"
@@ -26,6 +26,40 @@ func TestArgs(t *testing.T) {
 		url.QueryEscape(p.config.Username),
 		url.QueryEscape(p.config.Password),
 		p.config.Host,
+		p.config.Datacenter,
+		p.config.Cluster)
+
+	if p.config.ResourcePool != "" {
+		ovftool_uri += "/Resources/" + p.config.ResourcePool
+	}
+
+	args, err := p.BuildArgs(source, ovftool_uri)
+	if err != nil {
+		t.Errorf("Error: %s", err)
+	}
+
+	t.Logf("ovftool %s", strings.Join(args, " "))
+}
+
+func TestArgsWithVCenter(t *testing.T) {
+	var p PostProcessor
+
+	p.config.Username = "me"
+	p.config.Password = "notpassword"
+	p.config.Datacenter = "mydc"
+	p.config.Cluster = "mycluster"
+	p.config.VMName = "my vm"
+	p.config.Datastore = "my datastore"
+	p.config.Insecure = true
+	p.config.DiskMode = "thin"
+	p.config.VCenterIp = "192.000.0.000"
+	p.config.VMFolder = "my folder"
+
+	source := "something.vmx"
+	ovftool_uri := fmt.Sprintf("vi://%s:%s@%s/%s/host/%s",
+		url.QueryEscape(p.config.Username),
+		url.QueryEscape(p.config.Password),
+		p.config.vCenterIp,
 		p.config.Datacenter,
 		p.config.Cluster)
 

--- a/website/source/docs/post-processors/vsphere.html.md
+++ b/website/source/docs/post-processors/vsphere.html.md
@@ -31,7 +31,7 @@ Required:
     *not required* if `resource_pool` is specified.
 
 -   `host` (string) - The vSphere host that will be contacted to perform the
-    VM upload.
+    VM upload. This is *not required* if `vcenter_ip` is specified.
 
 -   `password` (string) - Password to use to authenticate to the
     vSphere endpoint.
@@ -50,6 +50,8 @@ Optional:
     over an insecure connection. By default this is false.
 
 -   `resource_pool` (string) - The resource pool to upload the VM to.
+
+-   `vcenter_ip` (string) - The ip address of a vCenter server to upload the vm tos.
 
 -   `vm_folder` (string) - The folder within the datastore to store the VM.
 


### PR DESCRIPTION
This feature allows vcenter_ip to be used as a parameter instead of a host parameter to a VSphere post-processor.

Closes #4475