### PR TITLE
Make azurerm "temp key vault name" specifiable.

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -96,8 +96,8 @@ type Config struct {
 	ResourceGroupName                 string             `mapstructure:"resource_group_name"`
 	StorageAccount                    string             `mapstructure:"storage_account"`
 	TempComputeName                   string             `mapstructure:"temp_compute_name"`
-	TempResourceGroupName             string             `mapstructure:"temp_resource_group_name"`
 	TempKeyVaultName                  string             `mapstructure:"temp_key_vault_name"`
+	TempResourceGroupName             string             `mapstructure:"temp_resource_group_name"`
 	BuildResourceGroupName            string             `mapstructure:"build_resource_group_name"`
 	storageAccountBlobEndpoint        string
 	CloudEnvironmentName              string `mapstructure:"cloud_environment_name"`
@@ -349,6 +349,11 @@ func setRuntimeValues(c *Config) {
 	} else {
 		c.tmpComputeName = c.TempComputeName
 	}
+	if c.TempKeyVaultName == "" {
+		c.tmpKeyVaultName = tempName.KeyVaultName
+	} else {
+		c.tmpKeyVaultName = c.TempKeyVaultName
+	}
 	c.tmpDeploymentName = tempName.DeploymentName
 	// Only set tmpResourceGroupName if no name has been specified
 	if c.TempResourceGroupName == "" && c.BuildResourceGroupName == "" {
@@ -357,11 +362,6 @@ func setRuntimeValues(c *Config) {
 		c.tmpResourceGroupName = c.TempResourceGroupName
 	}
 	c.tmpOSDiskName = tempName.OSDiskName
-	if c.TempKeyVaultName == "" {
-		c.tmpKeyVaultName = tempName.KeyVaultName
-	} else {
-		c.tmpKeyVaultName = c.TempKeyVaultName
-	}
 }
 
 func setUserNamePassword(c *Config) {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -357,7 +357,7 @@ func setRuntimeValues(c *Config) {
 		c.tmpResourceGroupName = c.TempResourceGroupName
 	}
 	c.tmpOSDiskName = tempName.OSDiskName
-	if c.tmpKeyVaultName == "" {
+	if c.TempKeyVaultName == "" {
 		c.tmpKeyVaultName = tempName.KeyVaultName
 	} else {
 		c.tmpKeyVaultName = c.TempKeyVaultName

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -97,6 +97,7 @@ type Config struct {
 	StorageAccount                    string             `mapstructure:"storage_account"`
 	TempComputeName                   string             `mapstructure:"temp_compute_name"`
 	TempResourceGroupName             string             `mapstructure:"temp_resource_group_name"`
+	TempKeyVaultName                  string             `mapstructure:"temp_key_vault_name"`
 	BuildResourceGroupName            string             `mapstructure:"build_resource_group_name"`
 	storageAccountBlobEndpoint        string
 	CloudEnvironmentName              string `mapstructure:"cloud_environment_name"`
@@ -356,7 +357,11 @@ func setRuntimeValues(c *Config) {
 		c.tmpResourceGroupName = c.TempResourceGroupName
 	}
 	c.tmpOSDiskName = tempName.OSDiskName
-	c.tmpKeyVaultName = tempName.KeyVaultName
+	if c.tmpKeyVaultName == "" {
+		c.tmpKeyVaultName = tempName.KeyVaultName
+	} else {
+		c.tmpKeyVaultName = c.TempKeyVaultName
+	}
 }
 
 func setUserNamePassword(c *Config) {

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -912,6 +912,7 @@ func TestConfigShouldRejectTempAndBuildResourceGroupName(t *testing.T) {
 		"subscription_id":        "ignore",
 		"communicator":           "none",
 
+    "temp_key_vault_name":    "kvn00",
 		// custom may define one or the other, but not both
 		"temp_resource_group_name":  "rgn00",
 		"build_resource_group_name": "rgn00",

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -912,7 +912,6 @@ func TestConfigShouldRejectTempAndBuildResourceGroupName(t *testing.T) {
 		"subscription_id":        "ignore",
 		"communicator":           "none",
 
-    "temp_key_vault_name":    "kvn00",
 		// custom may define one or the other, but not both
 		"temp_resource_group_name":  "rgn00",
 		"build_resource_group_name": "rgn00",

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -158,6 +158,11 @@ Providing `temp_resource_group_name` or `location` in combination with `build_re
     assigned.  Knowing the resource group and VM name allows one to execute commands to update the VM during a Packer
     build, e.g. attach a resource disk to the VM.
 
+-   `temp_key_vault_name` (string) temporary key vault name assigned to the Certificate Store for WinRM access to a windows VM.
+    If this value is not set, a random value will be assigned. Knowing the key vault name allows you to identify the URL
+    specifically and whitelist it in a proxy.
+
+
 -   `tenant_id` (string) The account identifier with which your `client_id` and `subscription_id` are associated. If not
     specified, `tenant_id` will be looked up using `subscription_id`.
 


### PR DESCRIPTION
Due to a peculiar infosec policy at my client, where packer connects through a proxy that is not permitted to contain wildcards on the host paths, we need to provide a temp_key_vault_name attribute for windows/arm builds. As such we need a way to define a ahead of the run, the keyvault name.

by specifying temp_key_vault_name xxx we then get connections to:

https://xxx.vault.azure.net

when unspecified we still get the usual pkrkv$RANDOM behaviour.