### PR TITLE
Added role in amazon-import

### DIFF
--- a/post-processor/amazon-import/post-processor.go
+++ b/post-processor/amazon-import/post-processor.go
@@ -34,6 +34,7 @@ type Config struct {
 	Users       []string          `mapstructure:"ami_users"`
 	Groups      []string          `mapstructure:"ami_groups"`
 	LicenseType string            `mapstructure:"license_type"`
+	RoleName    string            `mapstructure:"role_name"`
 
 	ctx interpolate.Context
 }
@@ -61,6 +62,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	// Set defaults
 	if p.config.S3Key == "" {
 		p.config.S3Key = "packer-import-{{timestamp}}.ova"
+	}
+
+	if p.config.RoleName == "" {
+		p.config.RoleName = "vmimport"
 	}
 
 	errs := new(packer.MultiError)
@@ -164,6 +169,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 				},
 			},
 		},
+		RoleName: &p.config.RoleName,
 	}
 
 	if p.config.LicenseType != "" {

--- a/website/source/docs/post-processors/amazon-import.html.md
+++ b/website/source/docs/post-processors/amazon-import.html.md
@@ -70,6 +70,8 @@ Optional:
 -   `mfa_code` (string) - The MFA [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
     code. This should probably be a user variable since it changes all the time.
 
+-   `role_name` (string) - The name of the role to use when not using the default role, 'vmimport'
+
 -   `s3_key_name` (string) - The name of the key in `s3_bucket_name` where the
     OVA file will be copied to for import. If not specified, this will default
     to "packer-import-{{timestamp}}.ova". This key (ie, the uploaded OVA) will


### PR DESCRIPTION
Fixes #5814 

Allows the specification of role in amazon-import. If no role is provided, the default "vmimport" is used.
