### PR TITLE
add session level keep-alives for ssh communicator

### DIFF
--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	SSHProxyPort              int           `mapstructure:"ssh_proxy_port"`
 	SSHProxyUsername          string        `mapstructure:"ssh_proxy_username"`
 	SSHProxyPassword          string        `mapstructure:"ssh_proxy_password"`
+	SSHKeepAliveInterval      time.Duration `mapstructure:"ssh_keep_alive_interval"`
 
 	// WinRM
 	WinRMUser               string        `mapstructure:"winrm_username"`
@@ -129,6 +130,10 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 
 	if c.SSHTimeout == 0 {
 		c.SSHTimeout = 5 * time.Minute
+	}
+
+	if c.SSHKeepAliveInterval == 0 {
+		c.SSHKeepAliveInterval = 5 * time.Second
 	}
 
 	if c.SSHHandshakeAttempts == 0 {

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -182,6 +182,7 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, cancel <-chan stru
 			Pty:        s.Config.SSHPty,
 			DisableAgentForwarding: s.Config.SSHDisableAgentForwarding,
 			UseSftp:                s.Config.SSHFileTransferMethod == "sftp",
+			KeepAliveInterval:      s.Config.SSHKeepAliveInterval,
 		}
 
 		log.Println("[INFO] Attempting SSH connection...")

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -91,6 +91,10 @@ The SSH communicator has the following options:
 -   `ssh_host` (string) - The address to SSH to. This usually is automatically
     configured by the builder.
 
+*   `ssh_keep_alive_interval` (string) - How often to send "keep alive"
+    messages to the server. Set to a negative value (`-1`) to disable. Example value:
+    "10s". Defaults to "5s".
+
 -   `ssh_password` (string) - A plaintext password to use to authenticate
     with SSH.
 

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -92,7 +92,7 @@ The SSH communicator has the following options:
     configured by the builder.
 
 *   `ssh_keep_alive_interval` (string) - How often to send "keep alive"
-    messages to the server. Set to a negative value (`-1`) to disable. Example value:
+    messages to the server. Set to a negative value (`-1s`) to disable. Example value:
     "10s". Defaults to "5s".
 
 -   `ssh_password` (string) - A plaintext password to use to authenticate


### PR DESCRIPTION
This PR adds session-level keep-alives so prevent the remote server from disconnecting us while no output is being generated.

Closes #5829, closes #5646, and closes #4777


created a test AMI with

```
{
    "_comment": "this generates an image that disconnects idle ssh conns after 15s",
    "builders": [
        {
            "ami_name": "packer-qs-{{timestamp}}",
            "instance_type": "t2.micro",
            "region": "us-east-1",
            "source_ami_filter": {
                "filters": {
                    "name": "*ubuntu-xenial-16.04-amd64-server-*",
                    "root-device-type": "ebs",
                    "virtualization-type": "hvm"
                },
                "most_recent": true,
                "owners": [
                    "099720109477"
                ]
            },
            "ssh_username": "ubuntu",
            "type": "amazon-ebs"
        }
    ],
    "provisioners": [
        {
            "inline": [
                "sudo echo 'ClientAliveInterval 15' | sudo tee -a /etc/ssh/sshd_config",
                "sudo echo 'ClientAliveCountMax 0' | sudo tee -a /etc/ssh/sshd_config",
                "sudo sed -i'' 's/TCPKeepAlive yes/TCPKeepAlive no/' /etc/ssh/sshd_config",
                "sudo systemctl reload sshd"
            ],
            "type": "shell"
        }
    ]
}
```

and tested with

```
{
    "_comment": "this tries to get disconnected.
    "builders": [
        {
            "ami_name": "packer-qs-{{timestamp}}",
            "instance_type": "t2.micro",
            "region": "us-east-1",
            "source_ami": "ami-<<AMI FROM ABOVE>>",
            "ssh_username": "ubuntu",
            "type": "amazon-ebs"
        }
    ],
    "provisioners": [
        {
            "type": "shell",
            "inline": [
                "sleep 60",
                "echo done"
            ]
        }
    ]
}
```