### PR TITLE
Added Policyfile support to chef-client provisioner

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -56,8 +56,8 @@ type Config struct {
 	InstallCommand             string   `mapstructure:"install_command"`
 	KnifeCommand               string   `mapstructure:"knife_command"`
 	NodeName                   string   `mapstructure:"node_name"`
-  PolicyGroup                string   `mapstructure:"policy_group"`
-  PolicyName                 string   `mapstructure:"policy_name"`
+	PolicyGroup                string   `mapstructure:"policy_group"`
+	PolicyName                 string   `mapstructure:"policy_name"`
 	PreventSudo                bool     `mapstructure:"prevent_sudo"`
 	RunList                    []string `mapstructure:"run_list"`
 	ServerUrl                  string   `mapstructure:"server_url"`
@@ -84,8 +84,8 @@ type ConfigTemplate struct {
 	ClientKey                  string
 	EncryptedDataBagSecretPath string
 	NodeName                   string
-  PolicyGroup                string
-  PolicyName                 string
+	PolicyGroup                string
+	PolicyName                 string
 	ServerUrl                  string
 	SslVerifyMode              string
 	TrustedCertsDir            string
@@ -274,8 +274,8 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		remoteValidationKeyPath,
 		p.config.ValidationClientName,
 		p.config.ChefEnvironment,
-    p.config.PolicyGroup,
-    p.config.PolicyName,
+		p.config.PolicyGroup,
+		p.config.PolicyName,
 		p.config.SslVerifyMode,
 		p.config.TrustedCertsDir)
 	if err != nil {
@@ -380,8 +380,8 @@ func (p *Provisioner) createConfig(
 		ValidationKeyPath:          remoteKeyPath,
 		ValidationClientName:       validationClientName,
 		ChefEnvironment:            chefEnvironment,
-    PolicyGroup:                policyGroup,
-    PolicyName:                 policyName,
+		PolicyGroup:                policyGroup,
+		PolicyName:                 policyName,
 		SslVerifyMode:              sslVerifyMode,
 		TrustedCertsDir:            trustedCertsDir,
 		EncryptedDataBagSecretPath: encryptedDataBagSecretPath,

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -350,6 +350,8 @@ func (p *Provisioner) createConfig(
 	remoteKeyPath string,
 	validationClientName string,
 	chefEnvironment string,
+  policyGroup string,
+  policyName string,
 	sslVerifyMode string,
 	trustedCertsDir string) (string, error) {
 

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -56,6 +56,8 @@ type Config struct {
 	InstallCommand             string   `mapstructure:"install_command"`
 	KnifeCommand               string   `mapstructure:"knife_command"`
 	NodeName                   string   `mapstructure:"node_name"`
+  PolicyGroup                string   `mapstructure:"policy_group"`
+  PolicyName                 string   `mapstructure:"policy_name"`
 	PreventSudo                bool     `mapstructure:"prevent_sudo"`
 	RunList                    []string `mapstructure:"run_list"`
 	ServerUrl                  string   `mapstructure:"server_url"`
@@ -82,6 +84,8 @@ type ConfigTemplate struct {
 	ClientKey                  string
 	EncryptedDataBagSecretPath string
 	NodeName                   string
+  PolicyGroup                string
+  PolicyName                 string
 	ServerUrl                  string
 	SslVerifyMode              string
 	TrustedCertsDir            string
@@ -270,6 +274,8 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		remoteValidationKeyPath,
 		p.config.ValidationClientName,
 		p.config.ChefEnvironment,
+    p.config.PolicyGroup,
+    p.config.PolicyName,
 		p.config.SslVerifyMode,
 		p.config.TrustedCertsDir)
 	if err != nil {
@@ -374,6 +380,8 @@ func (p *Provisioner) createConfig(
 		ValidationKeyPath:          remoteKeyPath,
 		ValidationClientName:       validationClientName,
 		ChefEnvironment:            chefEnvironment,
+    PolicyGroup:                policyGroup,
+    PolicyName:                 policyName,
 		SslVerifyMode:              sslVerifyMode,
 		TrustedCertsDir:            trustedCertsDir,
 		EncryptedDataBagSecretPath: encryptedDataBagSecretPath,
@@ -687,6 +695,12 @@ validation_key "{{.ValidationKeyPath}}"
 node_name "{{.NodeName}}"
 {{if ne .ChefEnvironment ""}}
 environment "{{.ChefEnvironment}}"
+{{end}}
+{{if ne .PolicyGroup ""}}
+policy_group "{{.PolicyGroup}}"
+{{end}}
+{{if ne .PolicyName ""}}
+policy_name "{{.PolicyName}}"
 {{end}}
 {{if ne .SslVerifyMode ""}}
 ssl_verify_mode :{{.SslVerifyMode}}

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -350,8 +350,8 @@ func (p *Provisioner) createConfig(
 	remoteKeyPath string,
 	validationClientName string,
 	chefEnvironment string,
-  policyGroup string,
-  policyName string,
+	policyGroup string,
+	policyName string,
 	sslVerifyMode string,
 	trustedCertsDir string) (string, error) {
 


### PR DESCRIPTION
This change adds the `policy_group` and `policy_name` options to the Chef Client config. If these are set and the `chef_environment` is omitted, then (assuming the user has the `policy_group` and `policy_name` available on the specified Chef Server) it should run Chef Client in Policyfile mode.

Note, I didn't write any tests as I haven't written go before and wanted a little guidance on doing that if needed.

Closes #5574 
