### PR TITLE
vagrant: Correct name of vim package for FreeBSD

### DIFF
--- a/scripts/vagrant-freebsd-priv-config.sh
+++ b/scripts/vagrant-freebsd-priv-config.sh
@@ -17,7 +17,7 @@ EOT
 pkg update
 
 pkg install -y \
-       editors/vim-lite \
+       editors/vim-console \
        devel/git \
        devel/gmake \
        lang/go \


### PR DESCRIPTION
The non-X11-linked version of vim recently changed name from vim-lite to
vim-console, which was preventing bootstrap.