### PR TITLE
Add volume and run tags if in us-gov/china

### DIFF
--- a/builder/amazon/chroot/device_test.go
+++ b/builder/amazon/chroot/device_test.go
@@ -1,0 +1,10 @@
+package chroot
+
+import "testing"
+
+func TestDevicePrefixMatch(t *testing.T) {
+	/*
+		if devicePrefixMatch("nvme0n1") != "" {
+		}
+	*/
+}

--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -78,6 +79,21 @@ func (c *AccessConfig) Session() (*session.Session, error) {
 	}
 
 	return c.session, nil
+}
+
+func (c *AccessConfig) SessionRegion() string {
+	if c.session == nil {
+		panic("access config session should be set.")
+	}
+	return aws.StringValue(c.session.Config.Region)
+}
+
+func (c *AccessConfig) IsGovCloud() bool {
+	return strings.HasPrefix(c.SessionRegion(), "us-gov-")
+}
+
+func (c *AccessConfig) IsChinaCloud() bool {
+	return strings.HasPrefix(c.SessionRegion(), "cn-")
 }
 
 // metadataRegion returns the region from the metadata service

--- a/builder/amazon/common/access_config_test.go
+++ b/builder/amazon/common/access_config_test.go
@@ -2,6 +2,9 @@ package common
 
 import (
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 func testAccessConfig() *AccessConfig {
@@ -37,4 +40,21 @@ func TestAccessConfigPrepare_Region(t *testing.T) {
 	}
 	c.SkipValidation = false
 
+}
+
+func TestAccessConfigPrepare_RegionRestrictd(t *testing.T) {
+	c := testAccessConfig()
+
+	// Create a Session with a custom region
+	c.session = session.Must(session.NewSession(&aws.Config{
+		Region: aws.String("us-gov-west-1"),
+	}))
+
+	if err := c.Prepare(nil); err != nil {
+		t.Fatalf("shouldn't have err: %s", err)
+	}
+
+	if !c.IsGovCloud() {
+		t.Fatal("We should be in gov region.")
+	}
 }

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -17,7 +17,7 @@ type AMIConfig struct {
 	AMIProductCodes         []string          `mapstructure:"ami_product_codes"`
 	AMIRegions              []string          `mapstructure:"ami_regions"`
 	AMISkipRegionValidation bool              `mapstructure:"skip_region_validation"`
-	AMITags                 map[string]string `mapstructure:"tags"`
+	AMITags                 TagMap            `mapstructure:"tags"`
 	AMIENASupport           bool              `mapstructure:"ena_support"`
 	AMISriovNetSupport      bool              `mapstructure:"sriov_support"`
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
@@ -25,7 +25,7 @@ type AMIConfig struct {
 	AMIEncryptBootVolume    bool              `mapstructure:"encrypt_boot"`
 	AMIKmsKeyId             string            `mapstructure:"kms_key_id"`
 	AMIRegionKMSKeyIDs      map[string]string `mapstructure:"region_kms_key_ids"`
-	SnapshotTags            map[string]string `mapstructure:"snapshot_tags"`
+	SnapshotTags            TagMap            `mapstructure:"snapshot_tags"`
 	SnapshotUsers           []string          `mapstructure:"snapshot_users"`
 	SnapshotGroups          []string          `mapstructure:"snapshot_groups"`
 }

--- a/builder/amazon/common/tags.go
+++ b/builder/amazon/common/tags.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/template/interpolate"
+)
+
+type TagMap map[string]string
+type EC2Tags []*ec2.Tag
+
+func (t EC2Tags) Report(ui packer.Ui) {
+	for _, tag := range t {
+		ui.Message(fmt.Sprintf("Adding tag: \"%s\": \"%s\"",
+			aws.StringValue(tag.Key), aws.StringValue(tag.Value)))
+	}
+}
+
+func (t TagMap) IsSet() bool {
+	return len(t) > 0
+}
+
+func (t TagMap) EC2Tags(ctx interpolate.Context, region, sourceAMIID string) (EC2Tags, error) {
+	var ec2Tags []*ec2.Tag
+	ctx.Data = &BuildInfoTemplate{
+		SourceAMI:   sourceAMIID,
+		BuildRegion: region,
+	}
+	for key, value := range t {
+		interpolatedKey, err := interpolate.Render(key, &ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Error processing tag: %s:%s - %s", key, value, err)
+		}
+		interpolatedValue, err := interpolate.Render(value, &ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Error processing tag: %s:%s - %s", key, value, err)
+		}
+		ec2Tags = append(ec2Tags, &ec2.Tag{
+			Key:   aws.String(interpolatedKey),
+			Value: aws.String(interpolatedValue),
+		})
+	}
+	return ec2Tags, nil
+}

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -28,7 +28,7 @@ type Config struct {
 	awscommon.AMIConfig    `mapstructure:",squash"`
 	awscommon.BlockDevices `mapstructure:",squash"`
 	awscommon.RunConfig    `mapstructure:",squash"`
-	VolumeRunTags          map[string]string `mapstructure:"run_volume_tags"`
+	VolumeRunTags          awscommon.TagMap `mapstructure:"run_volume_tags"`
 
 	ctx interpolate.Context
 }
@@ -152,6 +152,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			IamInstanceProfile:                b.config.IamInstanceProfile,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 			InstanceType:                      b.config.InstanceType,
+			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			SubnetId:                          b.config.SubnetId,
 			Tags:                              b.config.RunTags,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -26,8 +26,8 @@ type Config struct {
 	awscommon.BlockDevices `mapstructure:",squash"`
 	awscommon.AMIConfig    `mapstructure:",squash"`
 
-	RootDevice    RootBlockDevice   `mapstructure:"ami_root_device"`
-	VolumeRunTags map[string]string `mapstructure:"run_volume_tags"`
+	RootDevice    RootBlockDevice  `mapstructure:"ami_root_device"`
+	VolumeRunTags awscommon.TagMap `mapstructure:"run_volume_tags"`
 
 	ctx interpolate.Context
 }
@@ -166,6 +166,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			IamInstanceProfile:                b.config.IamInstanceProfile,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 			InstanceType:                      b.config.InstanceType,
+			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			SubnetId:                          b.config.SubnetId,
 			Tags:                              b.config.RunTags,

--- a/builder/amazon/ebsvolume/block_device.go
+++ b/builder/amazon/ebsvolume/block_device.go
@@ -7,7 +7,7 @@ import (
 
 type BlockDevice struct {
 	awscommon.BlockDevice `mapstructure:"-,squash"`
-	Tags                  map[string]string `mapstructure:"tags"`
+	Tags                  awscommon.TagMap `mapstructure:"tags"`
 }
 
 func commonBlockDevices(mappings []BlockDevice, ctx *interpolate.Context) (awscommon.BlockDevices, error) {

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -149,6 +149,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			IamInstanceProfile:                b.config.IamInstanceProfile,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 			InstanceType:                      b.config.InstanceType,
+			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			SubnetId:                          b.config.SubnetId,
 			Tags:                              b.config.RunTags,

--- a/builder/amazon/ebsvolume/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebsvolume/step_tag_ebs_volumes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -44,14 +43,14 @@ func (s *stepTagEBSVolumes) Run(_ context.Context, state multistep.StateBag) mul
 				continue
 			}
 
-			tags, err := awscommon.ConvertToEC2Tags(mapping.Tags, *ec2conn.Config.Region, *sourceAMI.ImageId, s.Ctx)
+			tags, err := mapping.Tags.EC2Tags(s.Ctx, *ec2conn.Config.Region, *sourceAMI.ImageId)
 			if err != nil {
 				err := fmt.Errorf("Error tagging device %s with %s", mapping.DeviceName, err)
 				state.Put("error", err)
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
-			awscommon.ReportTags(ui, tags)
+			tags.Report(ui)
 
 			for _, v := range instance.BlockDeviceMappings {
 				if *v.DeviceName == mapping.DeviceName {

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -232,6 +232,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			EbsOptimized:             b.config.EbsOptimized,
 			IamInstanceProfile:       b.config.IamInstanceProfile,
 			InstanceType:             b.config.InstanceType,
+			IsRestricted:             b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                b.config.SourceAmi,
 			SubnetId:                 b.config.SubnetId,
 			Tags:                     b.config.RunTags,


### PR DESCRIPTION
We can't tag on instance creation when we're in "restricted" regions,
so let's add the tags after the resources have been created.

Adds methods to AccessConfig to detect if we're in China or US Gov
regions (i.e. "restricted").

Also turns tag:tag maps into a type, and moves methods around validating
and converting them to ec2Tags to methods of the type.

Fixes #5447 