### PR TITLE
fix docs mountpoint typo

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -335,7 +335,7 @@ chroot by Packer:
 These default mounts are usually good enough for anyone and are sane defaults.
 However, if you want to change or add the mount points, you may using the
 `chroot_mounts` configuration. Here is an example configuration which only
-mounts `/prod` and `/dev`:
+mounts `/proc` and `/dev`:
 
 ``` json
 {


### PR DESCRIPTION
Fixed a type in the aws chroot docs that used `prod` instead of `proc`.
