### PR TITLE
Fully qualify hyper-v powershell commands

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -12,7 +12,7 @@ func GetHostAdapterIpAddressForSwitch(switchName string) (string, error) {
 	var script = `
 param([string]$switchName, [int]$addressIndex)
 
-$HostVMAdapter = Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName
+$HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName
 if ($HostVMAdapter){
     $HostNetAdapter = Get-NetAdapter | ?{ $_.DeviceID -eq $HostVMAdapter.DeviceId }
     if ($HostNetAdapter){
@@ -36,7 +36,7 @@ func GetVirtualMachineNetworkAdapterAddress(vmName string) (string, error) {
 	var script = `
 param([string]$vmName, [int]$addressIndex)
 try {
-  $adapter = Get-VMNetworkAdapter -VMName $vmName -ErrorAction SilentlyContinue
+  $adapter = Hyper-V\Get-VMNetworkAdapter -VMName $vmName -ErrorAction SilentlyContinue
   $ip = $adapter.IPAddresses[$addressIndex]
   if($ip -eq $null) {
     return $false
@@ -59,8 +59,8 @@ func CreateDvdDrive(vmName string, isoPath string, generation uint) (uint, uint,
 
 	script = `
 param([string]$vmName, [string]$isoPath)
-$dvdController = Add-VMDvdDrive -VMName $vmName -path $isoPath -Passthru
-$dvdController | Set-VMDvdDrive -path $null
+$dvdController = Hyper-V\Add-VMDvdDrive -VMName $vmName -path $isoPath -Passthru
+$dvdController | Hyper-V\Set-VMDvdDrive -path $null
 $result = "$($dvdController.ControllerNumber),$($dvdController.ControllerLocation)"
 $result
 `
@@ -94,9 +94,9 @@ func MountDvdDrive(vmName string, path string, controllerNumber uint, controller
 
 	var script = `
 param([string]$vmName,[string]$path,[string]$controllerNumber,[string]$controllerLocation)
-$vmDvdDrive = Get-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
+$vmDvdDrive = Hyper-V\Get-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
 if (!$vmDvdDrive) {throw 'unable to find dvd drive'}
-Set-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation -Path $path
+Hyper-V\Set-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation -Path $path
 `
 
 	var ps powershell.PowerShellCmd
@@ -107,9 +107,9 @@ Set-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLo
 func UnmountDvdDrive(vmName string, controllerNumber uint, controllerLocation uint) error {
 	var script = `
 param([string]$vmName,[int]$controllerNumber,[int]$controllerLocation)
-$vmDvdDrive = Get-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
+$vmDvdDrive = Hyper-V\Get-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
 if (!$vmDvdDrive) {throw 'unable to find dvd drive'}
-Set-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation -Path $null
+Hyper-V\Set-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation -Path $null
 `
 
 	var ps powershell.PowerShellCmd
@@ -122,7 +122,7 @@ func SetBootDvdDrive(vmName string, controllerNumber uint, controllerLocation ui
 	if generation < 2 {
 		script := `
 param([string]$vmName)
-Set-VMBios -VMName $vmName -StartupOrder @("CD", "IDE","LegacyNetworkAdapter","Floppy")
+Hyper-V\Set-VMBios -VMName $vmName -StartupOrder @("CD", "IDE","LegacyNetworkAdapter","Floppy")
 `
 		var ps powershell.PowerShellCmd
 		err := ps.Run(script, vmName)
@@ -130,9 +130,9 @@ Set-VMBios -VMName $vmName -StartupOrder @("CD", "IDE","LegacyNetworkAdapter","F
 	} else {
 		script := `
 param([string]$vmName,[int]$controllerNumber,[int]$controllerLocation)
-$vmDvdDrive = Get-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
+$vmDvdDrive = Hyper-V\Get-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
 if (!$vmDvdDrive) {throw 'unable to find dvd drive'}
-Set-VMFirmware -VMName $vmName -FirstBootDevice $vmDvdDrive -ErrorAction SilentlyContinue
+Hyper-V\Set-VMFirmware -VMName $vmName -FirstBootDevice $vmDvdDrive -ErrorAction SilentlyContinue
 `
 		var ps powershell.PowerShellCmd
 		err := ps.Run(script, vmName, strconv.FormatInt(int64(controllerNumber), 10), strconv.FormatInt(int64(controllerLocation), 10))
@@ -143,9 +143,9 @@ Set-VMFirmware -VMName $vmName -FirstBootDevice $vmDvdDrive -ErrorAction Silentl
 func DeleteDvdDrive(vmName string, controllerNumber uint, controllerLocation uint) error {
 	var script = `
 param([string]$vmName,[int]$controllerNumber,[int]$controllerLocation)
-$vmDvdDrive = Get-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
+$vmDvdDrive = Hyper-V\Get-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
 if (!$vmDvdDrive) {throw 'unable to find dvd drive'}
-Remove-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
+Hyper-V\Remove-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -ControllerLocation $controllerLocation
 `
 
 	var ps powershell.PowerShellCmd
@@ -156,7 +156,7 @@ Remove-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -Controlle
 func DeleteAllDvdDrives(vmName string) error {
 	var script = `
 param([string]$vmName)
-Get-VMDvdDrive -VMName $vmName | Remove-VMDvdDrive
+Hyper-V\Get-VMDvdDrive -VMName $vmName | Hyper-V\Remove-VMDvdDrive
 `
 
 	var ps powershell.PowerShellCmd
@@ -167,7 +167,7 @@ Get-VMDvdDrive -VMName $vmName | Remove-VMDvdDrive
 func MountFloppyDrive(vmName string, path string) error {
 	var script = `
 param([string]$vmName, [string]$path)
-Set-VMFloppyDiskDrive -VMName $vmName -Path $path
+Hyper-V\Set-VMFloppyDiskDrive -VMName $vmName -Path $path
 `
 
 	var ps powershell.PowerShellCmd
@@ -179,7 +179,7 @@ func UnmountFloppyDrive(vmName string) error {
 
 	var script = `
 param([string]$vmName)
-Set-VMFloppyDiskDrive -VMName $vmName -Path $null
+Hyper-V\Set-VMFloppyDiskDrive -VMName $vmName -Path $null
 `
 
 	var ps powershell.PowerShellCmd
@@ -200,9 +200,9 @@ if ($harddrivePath){
 	} else {
 		Copy-Item -Path $harddrivePath -Destination $vhdPath
 	}
-	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName -Generation $generation
+	Hyper-V\New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName -Generation $generation
 } else {
-	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName -Generation $generation
+	Hyper-V\New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName -Generation $generation
 }
 `
 		var ps powershell.PowerShellCmd
@@ -223,9 +223,9 @@ if ($harddrivePath){
 	else{
 		Copy-Item -Path $harddrivePath -Destination $vhdPath
 	}
-	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName
+	Hyper-V\New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName
 } else {
-	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName
+	Hyper-V\New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName
 }
 `
 		var ps powershell.PowerShellCmd
@@ -244,8 +244,8 @@ if ($harddrivePath){
 func DisableAutomaticCheckpoints(vmName string) error {
 	var script = `
 param([string]$vmName)
-if ((Get-Command Set-Vm).Parameters["AutomaticCheckpointsEnabled"]) { 
-	Set-Vm -Name $vmName -AutomaticCheckpointsEnabled $false }
+if ((Get-Command Hyper-V\Set-Vm).Parameters["AutomaticCheckpointsEnabled"]) { 
+	Hyper-V\Set-Vm -Name $vmName -AutomaticCheckpointsEnabled $false }
 `
 	var ps powershell.PowerShellCmd
 	err := ps.Run(script, vmName)
@@ -265,22 +265,22 @@ if (Test-Path $WorkingPath) {
 $allSnapshots = [System.Boolean]::Parse($allSnapshotsString)
 
 if ($snapshotName) {
-    $snapshot = Get-VMSnapshot -VMName $vmName -Name $snapshotName
-    Export-VMSnapshot -VMSnapshot $snapshot -Path $exportPath -ErrorAction Stop
+    $snapshot = Hyper-V\Get-VMSnapshot -VMName $vmName -Name $snapshotName
+    Hyper-V\Export-VMSnapshot -VMSnapshot $snapshot -Path $exportPath -ErrorAction Stop
 } else {
     if (!$allSnapshots) {
         #Use last snapshot if one was not specified
-        $snapshot = Get-VMSnapshot -VMName $vmName | Select -Last 1
+        $snapshot = Hyper-V\Get-VMSnapshot -VMName $vmName | Select -Last 1
     } else {
         $snapshot = $null
     }
     
     if (!$snapshot) {
         #No snapshot clone
-        Export-VM -Name $vmName -Path $exportPath -ErrorAction Stop
+        Hyper-V\Export-VM -Name $vmName -Path $exportPath -ErrorAction Stop
     } else {
         #Snapshot clone
-        Export-VMSnapshot -VMSnapshot $snapshot -Path $exportPath -ErrorAction Stop
+        Hyper-V\Export-VMSnapshot -VMSnapshot $snapshot -Path $exportPath -ErrorAction Stop
     }
 }
 
@@ -322,7 +322,7 @@ Copy-Item $cloneFromVmxcPath $exportPath -Recurse -Force
 func SetVmNetworkAdapterMacAddress(vmName string, mac string) error {
 	var script = `
 param([string]$vmName, [string]$mac)
-Set-VMNetworkAdapter $vmName -staticmacaddress $mac
+Hyper-V\Set-VMNetworkAdapter $vmName -staticmacaddress $mac
 	`
 
 	var ps powershell.PowerShellCmd
@@ -359,24 +359,24 @@ if (!$VirtualMachinePath){
     $VirtualMachinePath = Get-ChildItem -Path $importPath -Filter *.xml -Recurse -ErrorAction SilentlyContinue | select -First 1 | %{$_.FullName}
 }
 
-$compatibilityReport = Compare-VM -Path $VirtualMachinePath -VirtualMachinePath $importPath -SmartPagingFilePath $importPath -SnapshotFilePath $importPath -VhdDestinationPath $VirtualHarddisksPath -GenerateNewId -Copy:$false
+$compatibilityReport = Hyper-V\Compare-VM -Path $VirtualMachinePath -VirtualMachinePath $importPath -SmartPagingFilePath $importPath -SnapshotFilePath $importPath -VhdDestinationPath $VirtualHarddisksPath -GenerateNewId -Copy:$false
 if ($vhdPath){
 	Copy-Item -Path $harddrivePath -Destination $vhdPath
 	$existingFirstHarddrive = $compatibilityReport.VM.HardDrives | Select -First 1
 	if ($existingFirstHarddrive) {
-		$existingFirstHarddrive | Set-VMHardDiskDrive -Path $vhdPath
+		$existingFirstHarddrive | Hyper-V\Set-VMHardDiskDrive -Path $vhdPath
 	} else {
-		Add-VMHardDiskDrive -VM $compatibilityReport.VM -Path $vhdPath
+		Hyper-V\Add-VMHardDiskDrive -VM $compatibilityReport.VM -Path $vhdPath
 	}	
 }
-Set-VMMemory -VM $compatibilityReport.VM -StartupBytes $memoryStartupBytes
+Hyper-V\Set-VMMemory -VM $compatibilityReport.VM -StartupBytes $memoryStartupBytes
 $networkAdaptor = $compatibilityReport.VM.NetworkAdapters | Select -First 1
-Disconnect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor
-Connect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor -SwitchName $switchName 
-$vm = Import-VM -CompatibilityReport $compatibilityReport
+Hyper-V\Disconnect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor
+Hyper-V\Connect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor -SwitchName $switchName 
+$vm = Hyper-V\Import-VM -CompatibilityReport $compatibilityReport
 
 if ($vm) {
-    $result = Rename-VM -VM $vm -NewName $VMName
+    $result = Hyper-V\Rename-VM -VM $vm -NewName $VMName
 }
 	`
 
@@ -409,7 +409,7 @@ func CloneVirtualMachine(cloneFromVmxcPath string, cloneFromVmName string, clone
 func GetVirtualMachineGeneration(vmName string) (uint, error) {
 	var script = `
 param([string]$vmName)
-$generation = Get-Vm -Name $vmName | %{$_.Generation}
+$generation = Hyper-V\Get-Vm -Name $vmName | %{$_.Generation}
 if (!$generation){
     $generation = 1
 }
@@ -437,7 +437,7 @@ func SetVirtualMachineCpuCount(vmName string, cpu uint) error {
 
 	var script = `
 param([string]$vmName, [int]$cpu)
-Set-VMProcessor -VMName $vmName -Count $cpu
+Hyper-V\Set-VMProcessor -VMName $vmName -Count $cpu
 `
 	var ps powershell.PowerShellCmd
 	err := ps.Run(script, vmName, strconv.FormatInt(int64(cpu), 10))
@@ -449,7 +449,7 @@ func SetVirtualMachineVirtualizationExtensions(vmName string, enableVirtualizati
 	var script = `
 param([string]$vmName, [string]$exposeVirtualizationExtensionsString)
 $exposeVirtualizationExtensions = [System.Boolean]::Parse($exposeVirtualizationExtensionsString)
-Set-VMProcessor -VMName $vmName -ExposeVirtualizationExtensions $exposeVirtualizationExtensions
+Hyper-V\Set-VMProcessor -VMName $vmName -ExposeVirtualizationExtensions $exposeVirtualizationExtensions
 `
 	exposeVirtualizationExtensionsString := "False"
 	if enableVirtualizationExtensions {
@@ -465,7 +465,7 @@ func SetVirtualMachineDynamicMemory(vmName string, enableDynamicMemory bool) err
 	var script = `
 param([string]$vmName, [string]$enableDynamicMemoryString)
 $enableDynamicMemory = [System.Boolean]::Parse($enableDynamicMemoryString)
-Set-VMMemory -VMName $vmName -DynamicMemoryEnabled $enableDynamicMemory
+Hyper-V\Set-VMMemory -VMName $vmName -DynamicMemoryEnabled $enableDynamicMemory
 `
 	enableDynamicMemoryString := "False"
 	if enableDynamicMemory {
@@ -479,7 +479,7 @@ Set-VMMemory -VMName $vmName -DynamicMemoryEnabled $enableDynamicMemory
 func SetVirtualMachineMacSpoofing(vmName string, enableMacSpoofing bool) error {
 	var script = `
 param([string]$vmName, $enableMacSpoofing)
-Set-VMNetworkAdapter -VMName $vmName -MacAddressSpoofing $enableMacSpoofing
+Hyper-V\Set-VMNetworkAdapter -VMName $vmName -MacAddressSpoofing $enableMacSpoofing
 `
 
 	var ps powershell.PowerShellCmd
@@ -496,7 +496,7 @@ Set-VMNetworkAdapter -VMName $vmName -MacAddressSpoofing $enableMacSpoofing
 func SetVirtualMachineSecureBoot(vmName string, enableSecureBoot bool) error {
 	var script = `
 param([string]$vmName, $enableSecureBoot)
-Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBoot
+Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBoot
 `
 
 	var ps powershell.PowerShellCmd
@@ -515,12 +515,12 @@ func DeleteVirtualMachine(vmName string) error {
 	var script = `
 param([string]$vmName)
 
-$vm = Get-VM -Name $vmName
+$vm = Hyper-V\Get-VM -Name $vmName
 if (($vm.State -ne [Microsoft.HyperV.PowerShell.VMState]::Off) -and ($vm.State -ne [Microsoft.HyperV.PowerShell.VMState]::OffCritical)) {
-    Stop-VM -VM $vm -TurnOff -Force -Confirm:$false
+    Hyper-V\Stop-VM -VM $vm -TurnOff -Force -Confirm:$false
 }
 
-Remove-VM -Name $vmName -Force -Confirm:$false
+Hyper-V\Remove-VM -Name $vmName -Force -Confirm:$false
 `
 
 	var ps powershell.PowerShellCmd
@@ -532,12 +532,12 @@ func ExportVirtualMachine(vmName string, path string) error {
 
 	var script = `
 param([string]$vmName, [string]$path)
-Export-VM -Name $vmName -Path $path
+Hyper-V\Export-VM -Name $vmName -Path $path
 
 if (Test-Path -Path ([IO.Path]::Combine($path, $vmName, 'Virtual Machines', '*.VMCX')))
 {
-  $vm = Get-VM -Name $vmName
-  $vm_adapter = Get-VMNetworkAdapter -VM $vm | Select -First 1
+  $vm = Hyper-V\Get-VM -Name $vmName
+  $vm_adapter = Hyper-V\Get-VMNetworkAdapter -VM $vm | Select -First 1
 
   $config = [xml]@"
 <?xml version="1.0" ?>
@@ -571,17 +571,17 @@ if (Test-Path -Path ([IO.Path]::Combine($path, $vmName, 'Virtual Machines', '*.V
 
   if ($vm.Generation -eq 1)
   {
-    $vm_controllers  = Get-VMIdeController -VM $vm
+    $vm_controllers  = Hyper-V\Get-VMIdeController -VM $vm
     $controller_type = $config.SelectSingleNode('/configuration/vm-controllers')
     # IDE controllers are not stored in a special XML container
   }
   else
   {
-    $vm_controllers  = Get-VMScsiController -VM $vm
+    $vm_controllers  = Hyper-V\Get-VMScsiController -VM $vm
     $controller_type = $config.CreateElement('scsi')
     $controller_type.SetAttribute('ChannelInstanceGuid', 'x')
     # SCSI controllers are stored in the scsi XML container
-    if ((Get-VMFirmware -VM $vm).SecureBoot -eq [Microsoft.HyperV.PowerShell.OnOffState]::On)
+    if ((Hyper-V\Get-VMFirmware -VM $vm).SecureBoot -eq [Microsoft.HyperV.PowerShell.OnOffState]::On)
     {
       $config.configuration.secure_boot_enabled.'#text' = 'True'
     }
@@ -663,9 +663,9 @@ func CreateVirtualSwitch(switchName string, switchType string) (bool, error) {
 
 	var script = `
 param([string]$switchName,[string]$switchType)
-$switches = Get-VMSwitch -Name $switchName -ErrorAction SilentlyContinue
+$switches = Hyper-V\Get-VMSwitch -Name $switchName -ErrorAction SilentlyContinue
 if ($switches.Count -eq 0) {
-  New-VMSwitch -Name $switchName -SwitchType $switchType
+  Hyper-V\New-VMSwitch -Name $switchName -SwitchType $switchType
   return $true
 }
 return $false
@@ -681,9 +681,9 @@ func DeleteVirtualSwitch(switchName string) error {
 
 	var script = `
 param([string]$switchName)
-$switch = Get-VMSwitch -Name $switchName -ErrorAction SilentlyContinue
+$switch = Hyper-V\Get-VMSwitch -Name $switchName -ErrorAction SilentlyContinue
 if ($switch -ne $null) {
-    $switch | Remove-VMSwitch -Force -Confirm:$false
+    $switch | Hyper-V\Remove-VMSwitch -Force -Confirm:$false
 }
 `
 
@@ -696,9 +696,9 @@ func StartVirtualMachine(vmName string) error {
 
 	var script = `
 param([string]$vmName)
-$vm = Get-VM -Name $vmName -ErrorAction SilentlyContinue
+$vm = Hyper-V\Get-VM -Name $vmName -ErrorAction SilentlyContinue
 if ($vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Off) {
-  Start-VM -Name $vmName -Confirm:$false
+  Hyper-V\Start-VM -Name $vmName -Confirm:$false
 }
 `
 
@@ -711,7 +711,7 @@ func RestartVirtualMachine(vmName string) error {
 
 	var script = `
 param([string]$vmName)
-Restart-VM $vmName -Force -Confirm:$false
+Hyper-V\Restart-VM $vmName -Force -Confirm:$false
 `
 
 	var ps powershell.PowerShellCmd
@@ -723,9 +723,9 @@ func StopVirtualMachine(vmName string) error {
 
 	var script = `
 param([string]$vmName)
-$vm = Get-VM -Name $vmName
+$vm = Hyper-V\Get-VM -Name $vmName
 if ($vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running) {
-    Stop-VM -VM $vm -Force -Confirm:$false
+    Hyper-V\Stop-VM -VM $vm -Force -Confirm:$false
 }
 `
 
@@ -756,7 +756,7 @@ func EnableVirtualMachineIntegrationService(vmName string, integrationServiceNam
 
 	var script = `
 param([string]$vmName,[string]$integrationServiceId)
-Get-VMIntegrationService -VmName $vmName | ?{$_.Id -match $integrationServiceId} | Enable-VMIntegrationService
+Hyper-V\Get-VMIntegrationService -VmName $vmName | ?{$_.Id -match $integrationServiceId} | Hyper-V\Enable-VMIntegrationService
 `
 
 	var ps powershell.PowerShellCmd
@@ -768,7 +768,7 @@ func SetNetworkAdapterVlanId(switchName string, vlanId string) error {
 
 	var script = `
 param([string]$networkAdapterName,[string]$vlanId)
-Set-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName $networkAdapterName -Access -VlanId $vlanId
+Hyper-V\Set-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName $networkAdapterName -Access -VlanId $vlanId
 `
 
 	var ps powershell.PowerShellCmd
@@ -780,7 +780,7 @@ func SetVirtualMachineVlanId(vmName string, vlanId string) error {
 
 	var script = `
 param([string]$vmName,[string]$vlanId)
-Set-VMNetworkAdapterVlan -VMName $vmName -Access -VlanId $vlanId
+Hyper-V\Set-VMNetworkAdapterVlan -VMName $vmName -Access -VlanId $vlanId
 `
 	var ps powershell.PowerShellCmd
 	err := ps.Run(script, vmName, vlanId)
@@ -792,7 +792,7 @@ func GetExternalOnlineVirtualSwitch() (string, error) {
 	var script = `
 $adapters = Get-NetAdapter -Physical -ErrorAction SilentlyContinue | Where-Object { $_.Status -eq 'Up' } | Sort-Object -Descending -Property Speed
 foreach ($adapter in $adapters) {
-  $switch = Get-VMSwitch -SwitchType External | Where-Object { $_.NetAdapterInterfaceDescription -eq $adapter.InterfaceDescription }
+  $switch = Hyper-V\Get-VMSwitch -SwitchType External | Where-Object { $_.NetAdapterInterfaceDescription -eq $adapter.InterfaceDescription }
 
   if ($switch -ne $null) {
     $switch.Name
@@ -822,10 +822,10 @@ $adapters = foreach ($name in $names) {
 }
 
 foreach ($adapter in $adapters) {
-  $switch = Get-VMSwitch -SwitchType External | where { $_.NetAdapterInterfaceDescription -eq $adapter.InterfaceDescription }
+  $switch = Hyper-V\Get-VMSwitch -SwitchType External | where { $_.NetAdapterInterfaceDescription -eq $adapter.InterfaceDescription }
 
   if ($switch -eq $null) {
-    $switch = New-VMSwitch -Name $switchName -NetAdapterName $adapter.Name -AllowManagementOS $true -Notes 'Parent OS, VMs, WiFi'
+    $switch = Hyper-V\New-VMSwitch -Name $switchName -NetAdapterName $adapter.Name -AllowManagementOS $true -Notes 'Parent OS, VMs, WiFi'
   }
 
   if ($switch -ne $null) {
@@ -834,7 +834,7 @@ foreach ($adapter in $adapters) {
 }
 
 if($switch -ne $null) {
-  Get-VMNetworkAdapter -VMName $vmName | Connect-VMNetworkAdapter -VMSwitch $switch
+  Hyper-V\Get-VMNetworkAdapter -VMName $vmName | Hyper-V\Connect-VMNetworkAdapter -VMSwitch $switch
 } else {
   Write-Error 'No internet adapters found'
 }
@@ -848,7 +848,7 @@ func GetVirtualMachineSwitchName(vmName string) (string, error) {
 
 	var script = `
 param([string]$vmName)
-(Get-VMNetworkAdapter -VMName $vmName).SwitchName
+(Hyper-V\Get-VMNetworkAdapter -VMName $vmName).SwitchName
 `
 
 	var ps powershell.PowerShellCmd
@@ -864,7 +864,7 @@ func ConnectVirtualMachineNetworkAdapterToSwitch(vmName string, switchName strin
 
 	var script = `
 param([string]$vmName,[string]$switchName)
-Get-VMNetworkAdapter -VMName $vmName | Connect-VMNetworkAdapter -SwitchName $switchName
+Hyper-V\Get-VMNetworkAdapter -VMName $vmName | Hyper-V\Connect-VMNetworkAdapter -SwitchName $switchName
 `
 
 	var ps powershell.PowerShellCmd
@@ -878,7 +878,7 @@ func AddVirtualMachineHardDiskDrive(vmName string, vhdRoot string, vhdName strin
 param([string]$vmName,[string]$vhdRoot, [string]$vhdName, [string]$vhdSizeInBytes, [string]$controllerType)
 $vhdPath = Join-Path -Path $vhdRoot -ChildPath $vhdName
 New-VHD $vhdPath -SizeBytes $vhdSizeInBytes
-Add-VMHardDiskDrive -VMName $vmName -path $vhdPath -controllerType $controllerType
+Hyper-V\Add-VMHardDiskDrive -VMName $vmName -path $vhdPath -controllerType $controllerType
 `
 	var ps powershell.PowerShellCmd
 	err := ps.Run(script, vmName, vhdRoot, vhdName, strconv.FormatInt(vhdSizeBytes, 10), controllerType)
@@ -889,8 +889,8 @@ func UntagVirtualMachineNetworkAdapterVlan(vmName string, switchName string) err
 
 	var script = `
 param([string]$vmName,[string]$switchName)
-Set-VMNetworkAdapterVlan -VMName $vmName -Untagged
-Set-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName $switchName -Untagged
+Hyper-V\Set-VMNetworkAdapterVlan -VMName $vmName -Untagged
+Hyper-V\Set-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName $switchName -Untagged
 `
 
 	var ps powershell.PowerShellCmd
@@ -902,7 +902,7 @@ func IsRunning(vmName string) (bool, error) {
 
 	var script = `
 param([string]$vmName)
-$vm = Get-VM -Name $vmName -ErrorAction SilentlyContinue
+$vm = Hyper-V\Get-VM -Name $vmName -ErrorAction SilentlyContinue
 $vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running
 `
 
@@ -921,7 +921,7 @@ func IsOff(vmName string) (bool, error) {
 
 	var script = `
 param([string]$vmName)
-$vm = Get-VM -Name $vmName -ErrorAction SilentlyContinue
+$vm = Hyper-V\Get-VM -Name $vmName -ErrorAction SilentlyContinue
 $vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Off
 `
 
@@ -940,7 +940,7 @@ func Uptime(vmName string) (uint64, error) {
 
 	var script = `
 param([string]$vmName)
-$vm = Get-VM -Name $vmName -ErrorAction SilentlyContinue
+$vm = Hyper-V\Get-VM -Name $vmName -ErrorAction SilentlyContinue
 $vm.Uptime.TotalSeconds
 `
 	var ps powershell.PowerShellCmd
@@ -959,7 +959,7 @@ func Mac(vmName string) (string, error) {
 	var script = `
 param([string]$vmName, [int]$adapterIndex)
 try {
-  $adapter = Get-VMNetworkAdapter -VMName $vmName -ErrorAction SilentlyContinue
+  $adapter = Hyper-V\Get-VMNetworkAdapter -VMName $vmName -ErrorAction SilentlyContinue
   $mac = $adapter[$adapterIndex].MacAddress
   if($mac -eq $null) {
     return ""
@@ -980,7 +980,7 @@ func IpAddress(mac string) (string, error) {
 	var script = `
 param([string]$mac, [int]$addressIndex)
 try {
-  $ip = Get-Vm | %{$_.NetworkAdapters} | ?{$_.MacAddress -eq $mac} | %{$_.IpAddresses[$addressIndex]}
+  $ip = Hyper-V\Get-Vm | %{$_.NetworkAdapters} | ?{$_.MacAddress -eq $mac} | %{$_.IpAddresses[$addressIndex]}
 
   if($ip -eq $null) {
     return ""
@@ -1001,9 +1001,9 @@ func TurnOff(vmName string) error {
 
 	var script = `
 param([string]$vmName)
-$vm = Get-VM -Name $vmName -ErrorAction SilentlyContinue
+$vm = Hyper-V\Get-VM -Name $vmName -ErrorAction SilentlyContinue
 if ($vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running) {
-  Stop-VM -Name $vmName -TurnOff -Force -Confirm:$false
+  Hyper-V\Stop-VM -Name $vmName -TurnOff -Force -Confirm:$false
 }
 `
 
@@ -1016,9 +1016,9 @@ func ShutDown(vmName string) error {
 
 	var script = `
 param([string]$vmName)
-$vm = Get-VM -Name $vmName -ErrorAction SilentlyContinue
+$vm = Hyper-V\Get-VM -Name $vmName -ErrorAction SilentlyContinue
 if ($vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running) {
-  Stop-VM -Name $vmName -Force -Confirm:$false
+  Hyper-V\Stop-VM -Name $vmName -Force -Confirm:$false
 }
 `
 
@@ -1036,7 +1036,7 @@ func TypeScanCodes(vmName string, scanCodes string) error {
 param([string]$vmName, [string]$scanCodes)
 	#Requires -Version 3
 
-	function Get-VMConsole
+	function Hyper-V\Get-VMConsole
 	{
 	    [CmdletBinding()]
 	    param (
@@ -1164,7 +1164,7 @@ param([string]$vmName, [string]$scanCodes)
 	    return $console
 	}
 
-	$vmConsole = Get-VMConsole -VMName $vmName
+	$vmConsole = Hyper-V\Get-VMConsole -VMName $vmName
 	$scanCodesToSend = ''
 	$scanCodes.Split(' ') | %{
 		$scanCode = $_

--- a/common/powershell/powershell.go
+++ b/common/powershell/powershell.go
@@ -240,7 +240,7 @@ param([string]$moduleName)
 func HasVirtualMachineVirtualizationExtensions() (bool, error) {
 
 	var script = `	
-(GET-Command Set-VMProcessor).parameters.keys -contains "ExposeVirtualizationExtensions"
+(GET-Command Hyper-V\Set-VMProcessor).parameters.keys -contains "ExposeVirtualizationExtensions"
 `
 
 	var ps PowerShellCmd
@@ -258,7 +258,7 @@ func DoesVirtualMachineExist(vmName string) (bool, error) {
 
 	var script = `
 param([string]$vmName)
-return (Get-VM | ?{$_.Name -eq $vmName}) -ne $null
+return (Hyper-V\Get-VM | ?{$_.Name -eq $vmName}) -ne $null
 `
 
 	var ps PowerShellCmd
@@ -276,7 +276,7 @@ func DoesVirtualMachineSnapshotExist(vmName string, snapshotName string) (bool, 
 
 	var script = `
 param([string]$vmName, [string]$snapshotName)
-return (Get-VMSnapshot -VMName $vmName | ?{$_.Name -eq $snapshotName}) -ne $null
+return (Hyper-V\Get-VMSnapshot -VMName $vmName | ?{$_.Name -eq $snapshotName}) -ne $null
 `
 
 	var ps PowerShellCmd
@@ -294,7 +294,7 @@ func IsVirtualMachineOn(vmName string) (bool, error) {
 
 	var script = `
 param([string]$vmName)
-$vm = Get-VM -Name $vmName -ErrorAction SilentlyContinue
+$vm = Hyper-V\Get-VM -Name $vmName -ErrorAction SilentlyContinue
 $vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running
 `
 
@@ -312,7 +312,7 @@ $vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running
 func GetVirtualMachineGeneration(vmName string) (uint, error) {
 	var script = `
 param([string]$vmName)
-$generation = Get-Vm -Name $vmName | %{$_.Generation}
+$generation = Hyper-V\Get-Vm -Name $vmName | %{$_.Generation}
 if (!$generation){
     $generation = 1
 }


### PR DESCRIPTION
A duplicate of PR #5225 

All hyper-v commands have been fully qualified to prevent collisions with VMWare PowerCLI commands which share the same command names. Fixes #5337 

More information on Qualified names in powershell can be found here: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_command_precedence?view=powershell-6#qualified-names

Have also tested this on my machine and it resolves the problem of using the hyper-v builder when PowerCLI is also installed. 