### PR TITLE
Try out CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+workflows:
+  version: 2
+  main:
+    jobs:
+      - go-current
+      - go-previous
+      - go-latest
+base: &base
+  working_directory: /go/src/github.com/hashicorp/packer
+  steps:
+    - checkout
+    - run:
+        name: "All Commands"
+        command: |
+          make deps
+          GOMAXPROCS=2 make ci
+version: 2
+jobs:
+  go-current:
+    docker:
+      - image: circleci/golang:1.8
+    <<: *base
+  go-previous:
+    docker:
+      - image: circleci/golang:1.7
+    <<: *base
+  go-latest:
+    docker:
+      - image: circleci/golang:1
+    <<: *base


### PR DESCRIPTION
I thought it would be interesting to try building Packer on CircleCI to see if there were any improvements that could be done. The immediate result is decreased build time.

Here's a build time comparison (avg last two builds):

| | Travis CI | CircleCI |
| --- | --- | -- |
| Longest Build | 3min 54sec | 1min 25sec |
| Go v1.8.x | 2min 54sec | 1min 23sec |
| Go v1.x | 3min 25sec | 0min 59sec |

You can view the two builds I ran on CircleCI [here](https://circleci.com/gh/felicianotech/workflows/packer/tree/circleci).

Packer is an open-source project so 4 build containers are provided for free. Another improvement that could be done here would be to add the JUnit Go package in order to store test results with CircleCI and display them over time in graphs.

If there's anything I missed or any questions, please let me know.