### PR TITLE
add workaround for azure bug.

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -114,6 +114,12 @@ var waitForRestart = func(p *Provisioner, comm packer.Communicator) error {
 	var cmd *packer.RemoteCmd
 	trycommand := TryCheckReboot
 	abortcommand := AbortReboot
+
+	// This sleep works around an azure/winrm bug. For more info see
+	// https://github.com/hashicorp/packer/issues/5257; we can remove the
+	// sleep when the underlying bug has been resolved.
+	time.Sleep(1 * time.Second)
+
 	// Stolen from Vagrant reboot checker
 	for {
 		log.Printf("Check if machine is rebooting...")


### PR DESCRIPTION
Adds a one-second sleep to the windows-restart provisioner.  This works around an azure/winrm bug here: https://github.com/Azure/go-ntlmssp/issues/9 that was causing reliable crashes every time a user ran the windows-restart provisioner on azure.

closes #5257 but doesn't address underlying cause, which is outside of our wheelhouse.
