### PR TITLE
Bugfix 5852

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -327,7 +327,7 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 		p.config.PackerBuildName, p.config.PackerBuilderType),
 		"-i", inventory, playbook}
 	if len(privKeyFile) > 0 {
-		// Changed this from using --private-key to supplying -e ansible_ssh_private_key as the latter
+		// Changed this from using --private-key to supplying -e ansible_ssh_private_key_file as the latter
 		// is treated as a highest priority variable, and thus prevents overriding by dynamic variables
 		// as seen in #5852
 		// args = append(args, "--private-key", privKeyFile)

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -327,7 +327,11 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 		p.config.PackerBuildName, p.config.PackerBuilderType),
 		"-i", inventory, playbook}
 	if len(privKeyFile) > 0 {
-		args = append(args, "--private-key", privKeyFile)
+		// Changed this from using --private-key to supplying -e ansible_ssh_private_key as the latter
+		// is treated as a highest priority variable, and thus prevents overriding by dynamic variables
+		// as seen in #5852
+		// args = append(args, "--private-key", privKeyFile)
+		args = append(args, "-e", fmt.Sprintf("ansible_ssh_private_key_file=%s", privKeyFile))
 	}
 	args = append(args, p.config.ExtraArguments...)
 	if len(p.config.AnsibleEnvVars) > 0 {


### PR DESCRIPTION
Fixing the situation where --private-key can be overridden through inheritance.  By changing it from --private-key to an extra var passed at the command, it becomes highest priority and will prevent the issue from arising.

Closes #5852 