### PR TITLE
Adds config option to specify hyper-v secure boot template

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -82,7 +82,7 @@ type Driver interface {
 
 	SetVirtualMachineDynamicMemory(string, bool) error
 
-	SetVirtualMachineSecureBoot(string, bool) error
+	SetVirtualMachineSecureBoot(string, bool, string) error
 
 	SetVirtualMachineVirtualizationExtensions(string, bool) error
 

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -160,10 +160,11 @@ type DriverMock struct {
 	SetVirtualMachineDynamicMemory_Enable bool
 	SetVirtualMachineDynamicMemory_Err    error
 
-	SetVirtualMachineSecureBoot_Called bool
-	SetVirtualMachineSecureBoot_VmName string
-	SetVirtualMachineSecureBoot_Enable bool
-	SetVirtualMachineSecureBoot_Err    error
+	SetVirtualMachineSecureBoot_Called       bool
+	SetVirtualMachineSecureBoot_VmName       string
+	SetVirtualMachineSecureBoot_TemplateName string
+	SetVirtualMachineSecureBoot_Enable       bool
+	SetVirtualMachineSecureBoot_Err          error
 
 	SetVirtualMachineVirtualizationExtensions_Called bool
 	SetVirtualMachineVirtualizationExtensions_VmName string
@@ -446,10 +447,11 @@ func (d *DriverMock) SetVirtualMachineDynamicMemory(vmName string, enable bool) 
 	return d.SetVirtualMachineDynamicMemory_Err
 }
 
-func (d *DriverMock) SetVirtualMachineSecureBoot(vmName string, enable bool) error {
+func (d *DriverMock) SetVirtualMachineSecureBoot(vmName string, enable bool, templateName string) error {
 	d.SetVirtualMachineSecureBoot_Called = true
 	d.SetVirtualMachineSecureBoot_VmName = vmName
 	d.SetVirtualMachineSecureBoot_Enable = enable
+	d.SetVirtualMachineSecureBoot_TemplateName = templateName
 	return d.SetVirtualMachineSecureBoot_Err
 }
 

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -202,8 +202,8 @@ func (d *HypervPS4Driver) SetVirtualMachineDynamicMemory(vmName string, enable b
 	return hyperv.SetVirtualMachineDynamicMemory(vmName, enable)
 }
 
-func (d *HypervPS4Driver) SetVirtualMachineSecureBoot(vmName string, enable bool) error {
-	return hyperv.SetVirtualMachineSecureBoot(vmName, enable)
+func (d *HypervPS4Driver) SetVirtualMachineSecureBoot(vmName string, enable bool, templateName string) error {
+	return hyperv.SetVirtualMachineSecureBoot(vmName, enable, templateName)
 }
 
 func (d *HypervPS4Driver) SetVirtualMachineVirtualizationExtensions(vmName string, enable bool) error {

--- a/builder/hyperv/common/step_clone_vm.go
+++ b/builder/hyperv/common/step_clone_vm.go
@@ -27,6 +27,7 @@ type StepCloneVM struct {
 	EnableMacSpoofing              bool
 	EnableDynamicMemory            bool
 	EnableSecureBoot               bool
+	SecureBootTemplate             string
 	EnableVirtualizationExtensions bool
 	MacAddress                     string
 }
@@ -99,7 +100,8 @@ func (s *StepCloneVM) Run(_ context.Context, state multistep.StateBag) multistep
 	}
 
 	if generation == 2 {
-		err = driver.SetVirtualMachineSecureBoot(s.VMName, s.EnableSecureBoot)
+
+		err = driver.SetVirtualMachineSecureBoot(s.VMName, s.EnableSecureBoot, s.SecureBootTemplate)
 		if err != nil {
 			err := fmt.Errorf("Error setting secure boot: %s", err)
 			state.Put("error", err)

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -27,6 +27,7 @@ type StepCreateVM struct {
 	EnableMacSpoofing              bool
 	EnableDynamicMemory            bool
 	EnableSecureBoot               bool
+	SecureBootTemplate             string
 	EnableVirtualizationExtensions bool
 	AdditionalDiskSize             []uint
 	DifferencingDisk               bool
@@ -102,7 +103,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	if s.Generation == 2 {
-		err = driver.SetVirtualMachineSecureBoot(s.VMName, s.EnableSecureBoot)
+		err = driver.SetVirtualMachineSecureBoot(s.VMName, s.EnableSecureBoot, s.SecureBootTemplate)
 		if err != nil {
 			err := fmt.Errorf("Error setting secure boot: %s", err)
 			state.Put("error", err)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -91,6 +91,7 @@ type Config struct {
 	EnableMacSpoofing              bool   `mapstructure:"enable_mac_spoofing"`
 	EnableDynamicMemory            bool   `mapstructure:"enable_dynamic_memory"`
 	EnableSecureBoot               bool   `mapstructure:"enable_secure_boot"`
+	SecureBootTemplate             string `mapstructure:"secure_boot_template"`
 	EnableVirtualizationExtensions bool   `mapstructure:"enable_virtualization_extensions"`
 	TempPath                       string `mapstructure:"temp_path"`
 
@@ -373,6 +374,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			EnableMacSpoofing:              b.config.EnableMacSpoofing,
 			EnableDynamicMemory:            b.config.EnableDynamicMemory,
 			EnableSecureBoot:               b.config.EnableSecureBoot,
+			SecureBootTemplate:             b.config.SecureBootTemplate,
 			EnableVirtualizationExtensions: b.config.EnableVirtualizationExtensions,
 			AdditionalDiskSize:             b.config.AdditionalDiskSize,
 			DifferencingDisk:               b.config.DifferencingDisk,

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -86,10 +86,11 @@ type Config struct {
 	VlanId                         string `mapstructure:"vlan_id"`
 	Cpu                            uint   `mapstructure:"cpu"`
 	Generation                     uint
-	EnableMacSpoofing              bool `mapstructure:"enable_mac_spoofing"`
-	EnableDynamicMemory            bool `mapstructure:"enable_dynamic_memory"`
-	EnableSecureBoot               bool `mapstructure:"enable_secure_boot"`
-	EnableVirtualizationExtensions bool `mapstructure:"enable_virtualization_extensions"`
+	EnableMacSpoofing              bool   `mapstructure:"enable_mac_spoofing"`
+	EnableDynamicMemory            bool   `mapstructure:"enable_dynamic_memory"`
+	EnableSecureBoot               bool   `mapstructure:"enable_secure_boot"`
+	SecureBootTemplate             string `mapstructure:"secure_boot_template"`
+	EnableVirtualizationExtensions bool   `mapstructure:"enable_virtualization_extensions"`
 
 	Communicator string `mapstructure:"communicator"`
 
@@ -405,6 +406,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			EnableMacSpoofing:              b.config.EnableMacSpoofing,
 			EnableDynamicMemory:            b.config.EnableDynamicMemory,
 			EnableSecureBoot:               b.config.EnableSecureBoot,
+			SecureBootTemplate:             b.config.SecureBootTemplate,
 			EnableVirtualizationExtensions: b.config.EnableVirtualizationExtensions,
 			MacAddress:                     b.config.MacAddress,
 		},

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -504,7 +504,7 @@ Hyper-V\Set-VMNetworkAdapter -VMName $vmName -MacAddressSpoofing $enableMacSpoof
 	return err
 }
 
-func SetVirtualMachineSecureBoot(vmName string, enableSecureBoot bool) error {
+func SetVirtualMachineSecureBoot(vmName string, enableSecureBoot bool, templateName string) error {
 	var script = `
 param([string]$vmName, $enableSecureBoot)
 Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBoot
@@ -517,7 +517,11 @@ Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBoot
 		enableSecureBootString = "On"
 	}
 
-	err := ps.Run(script, vmName, enableSecureBootString)
+	if templateName == "" {
+		templateName = "MicrosoftWindows"
+	}
+
+	err := ps.Run(script, vmName, enableSecureBootString, templateName)
 	return err
 }
 
@@ -594,12 +598,12 @@ if (Test-Path -Path ([IO.Path]::Combine($path, $vmName, 'Virtual Machines', '*.V
     # SCSI controllers are stored in the scsi XML container
     if ((Hyper-V\Get-VMFirmware -VM $vm).SecureBoot -eq [Microsoft.HyperV.PowerShell.OnOffState]::On)
     {
-      $config.configuration.secure_boot_enabled.'#text' = 'True'
-    }
+	  $config.configuration.secure_boot_enabled.'#text' = 'True'
+	}
     else
     {
       $config.configuration.secure_boot_enabled.'#text' = 'False'
-    }
+	}
   }
 
   $vm_controllers | ForEach {

--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -111,8 +111,11 @@ can be configured for this builder.
 -   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual machine.
     This defaults to false.
 
--   `enable_secure_boot` (boolean) - If true enable secure boot for virtual machine.
-    This defaults to false.
+-   `enable_secure_boot` (boolean) - If true enable secure boot for virtual machine. This defaults to false.
+
+-    `secure_boot_template` (string) - The secure boot template to be configured. Valid values are "MicrosoftWindows" (Windows) or 
+     "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
+
 
 -   `enable_virtualization_extensions` (boolean) - If true enable virtualization extensions for virtual machine.
     This defaults to false. For nested virtualization you need to enable mac spoofing, disable dynamic memory

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -104,8 +104,10 @@ can be configured for this builder.
 -   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual
     machine. This defaults to false.
 
--   `enable_secure_boot` (boolean) - If true enable secure boot for virtual
-    machine. This defaults to false.
+-   `enable_secure_boot` (boolean) - If true enable secure boot for virtual machine. This defaults to false.
+
+-    `secure_boot_template` (string) - The secure boot template to be configured. Valid values are "MicrosoftWindows" (Windows) or 
+     "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
 
 -   `enable_virtualization_extensions` (boolean) - If true enable virtualization
     extensions for virtual machine. This defaults to false. For nested


### PR DESCRIPTION
 This change adds an additional property called "secure_boot_template" for the packer "Hyper-V" provider, which allows a user to specify a secure boot template if "enable_secure_boot" is set to "true". The default secure boot template is "MicrosoftWindows", which only works for Windows operating systems. In order to enable secure boot on Hyper-V gen 2 Linux VM's, the  "MicrosoftUEFICertificateAuthority" template has to be configured.

example config using the new property:

{
  "variables": {
    "vm_name": "ubuntu-xenial",
    "cpu": "2",
    "ram_size": "1024",
    "disk_size": "21440",
    "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.1-server-amd64.iso",
    "iso_checksum_type": "sha1",
    "iso_checksum": "DE5EE8665048F009577763EFBF4A6F0558833E59"
  },
  "builders": [
    {
      "vm_name":"{{user `vm_name`}}",
      "type": "hyperv-iso",
      "disk_size": "{{user `disk_size`}}",
      "guest_additions_mode": "disable",
      "iso_url": "{{user `iso_url`}}",
      "iso_checksum_type": "{{user `iso_checksum_type`}}",
      "iso_checksum": "{{user `iso_checksum`}}",
      "communicator":"ssh",
      "ssh_username": "packer",
      "ssh_password": "packer",
      "ssh_timeout" : "4h",
      "http_directory": "./",
      "boot_wait": "5s",
      "boot_command": [
        "<esc><wait10><esc><esc><enter><wait>",
        "set gfxpayload=1024x768<enter>",
        "linux /install/vmlinuz ",
        "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/hyperv-taliesins.cfg ",
        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
        "hostname={{.Name}} ",
        "fb=false debconf/frontend=noninteractive ",
        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
        "keyboard-configuration/variant=USA console-setup/ask_detect=false <enter>",
        "initrd /install/initrd.gz<enter>",
        "boot<enter>"
      ],
      "shutdown_command": "echo 'packer' | sudo -S -E shutdown -P now",
      "ram_size": "{{user `ram_size`}}",
      "cpu": "{{user `cpu`}}",
      "generation": 2,
      **"enable_secure_boot": true**
      **"secure_boot_template": "MicrosoftUEFICertificateAuthority"**
    }
]
}

This could be documented as follows on the [hyperv-vmcx](https://www.packer.io/docs/builders/hyperv-vmcx.html) and [hyperv-iso](https://www.packer.io/docs/builders/hyperv-iso.html) pages:

- enable_secure_boot (boolean) - If true enable secure boot for virtual machine. This defaults to false.
- secure_boot_template (string) - The secure boot template to be configured. Valid values are "MicrosoftWindows" (Windows) or "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".

Closes #5087 
