### PR TITLE
Revert "Fix #5335"

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -304,7 +304,7 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator) err
 	playbook := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.PlaybookFile)))
 	inventory := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.InventoryFile)))
 
-	extraArgs := fmt.Sprintf(" --extra-vars \\\"packer_build_name=%s packer_builder_type=%s packer_http_addr=%s\\\" ",
+	extraArgs := fmt.Sprintf(" --extra-vars \"packer_build_name=%s packer_builder_type=%s packer_http_addr=%s\" ",
 		p.config.PackerBuildName, p.config.PackerBuilderType, common.GetHTTPAddr())
 	if len(p.config.ExtraArguments) > 0 {
 		extraArgs = extraArgs + strings.Join(p.config.ExtraArguments, " ")


### PR DESCRIPTION
Reverts hashicorp/packer#5703

Looks like 1.2.0 had two conflicting updates: #5703 added escapes, and an enhancement we added after merging #5703 removed the need for those escapes.  

Closes #5885 