### PR TITLE
add fallback mechanism so that default isn't overriding given auth files

### DIFF
--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -58,27 +58,28 @@ type Driver interface {
 }
 
 type InstanceConfig struct {
-	AcceleratorType   string
-	AcceleratorCount  int64
-	Address           string
-	Description       string
-	DiskSizeGb        int64
-	DiskType          string
-	Image             *Image
-	Labels            map[string]string
-	MachineType       string
-	Metadata          map[string]string
-	Name              string
-	Network           string
-	NetworkProjectId  string
-	OmitExternalIP    bool
-	OnHostMaintenance string
-	Preemptible       bool
-	Region            string
-	Scopes            []string
-	Subnetwork        string
-	Tags              []string
-	Zone              string
+	AcceleratorType     string
+	AcceleratorCount    int64
+	Address             string
+	Description         string
+	DiskSizeGb          int64
+	DiskType            string
+	Image               *Image
+	Labels              map[string]string
+	MachineType         string
+	Metadata            map[string]string
+	Name                string
+	Network             string
+	NetworkProjectId    string
+	OmitExternalIP      bool
+	OnHostMaintenance   string
+	Preemptible         bool
+	Region              string
+	Scopes              []string
+	ServiceAccountEmail string
+	Subnetwork          string
+	Tags                []string
+	Zone                string
 }
 
 // WindowsPasswordConfig is the data structue that GCE needs to encrypt the created

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -14,15 +14,13 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/api/compute/v1"
-
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/version"
-
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
+	compute "google.golang.org/api/compute/v1"
 )
 
 // driverGCE is a Driver implementation that actually talks to GCE.
@@ -380,7 +378,7 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 		},
 		ServiceAccounts: []*compute.ServiceAccount{
 			{
-				Email:  "default",
+				Email:  c.ServiceAccountEmail,
 				Scopes: c.Scopes,
 			},
 		},

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -98,29 +98,34 @@ func (s *StepCreateInstance) Run(_ context.Context, state multistep.StateBag) mu
 
 	var errCh <-chan error
 	var metadata map[string]string
+	ServiceAccountEmail := c.Account.ClientEmail
+	if ServiceAccountEmail == "" {
+		ServiceAccountEmail = "default"
+	}
 	metadata, err = c.createInstanceMetadata(sourceImage, sshPublicKey)
 	errCh, err = d.RunInstance(&InstanceConfig{
-		AcceleratorType:   c.AcceleratorType,
-		AcceleratorCount:  c.AcceleratorCount,
-		Address:           c.Address,
-		Description:       "New instance created by Packer",
-		DiskSizeGb:        c.DiskSizeGb,
-		DiskType:          c.DiskType,
-		Image:             sourceImage,
-		Labels:            c.Labels,
-		MachineType:       c.MachineType,
-		Metadata:          metadata,
-		Name:              name,
-		Network:           c.Network,
-		NetworkProjectId:  c.NetworkProjectId,
-		OmitExternalIP:    c.OmitExternalIP,
-		OnHostMaintenance: c.OnHostMaintenance,
-		Preemptible:       c.Preemptible,
-		Region:            c.Region,
-		Scopes:            c.Scopes,
-		Subnetwork:        c.Subnetwork,
-		Tags:              c.Tags,
-		Zone:              c.Zone,
+		AcceleratorType:     c.AcceleratorType,
+		AcceleratorCount:    c.AcceleratorCount,
+		Address:             c.Address,
+		Description:         "New instance created by Packer",
+		DiskSizeGb:          c.DiskSizeGb,
+		DiskType:            c.DiskType,
+		Image:               sourceImage,
+		Labels:              c.Labels,
+		MachineType:         c.MachineType,
+		Metadata:            metadata,
+		Name:                name,
+		Network:             c.Network,
+		NetworkProjectId:    c.NetworkProjectId,
+		OmitExternalIP:      c.OmitExternalIP,
+		OnHostMaintenance:   c.OnHostMaintenance,
+		Preemptible:         c.Preemptible,
+		Region:              c.Region,
+		ServiceAccountEmail: ServiceAccountEmail,
+		Scopes:              c.Scopes,
+		Subnetwork:          c.Subnetwork,
+		Tags:                c.Tags,
+		Zone:                c.Zone,
 	})
 
 	if err == nil {


### PR DESCRIPTION
Don't always set email to "default" because this breaks things if the user has deleted the default service account.
Closes #5825