### PR TITLE
Fixed a type-o in the VMWare builder when locating the dhcp configuration file on Linux.

### DIFF
--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -59,7 +59,7 @@ func workstationDhcpConfPath(device string) string {
 		log.Printf("Error finding VMware root: %s", err)
 		return ""
 	}
-	return filepath.Join(base, device, "dhcp/dhcpd.conf")
+	return filepath.Join(base, device, "dhcp/dhcp.conf")
 }
 
 func workstationVmnetnatConfPath(device string) string {


### PR DESCRIPTION
This closes issue #5882.

I checked the following links of the VMWare documentation and all of them use `dhcp.conf` (not `dhcpd.conf`).

https://pubs.vmware.com/workstation-9/index.jsp?topic=%2Fcom.vmware.ws.using.doc%2FGUID-04D783E1-3AB9-4D98-9891-2C58215905CC.html
https://pubs.vmware.com/workstation-10/index.jsp?topic=%2Fcom.vmware.ws.using.doc%2FGUID-04D783E1-3AB9-4D98-9891-2C58215905CC.html
https://pubs.vmware.com/workstation-11/index.jsp?topic=%2Fcom.vmware.ws.using.doc%2FGUID-04D783E1-3AB9-4D98-9891-2C58215905CC.html
https://docs.vmware.com/en/VMware-Workstation-Pro/12.0/com.vmware.ws.using.doc/GUID-04D783E1-3AB9-4D98-9891-2C58215905CC.html
