### PR TITLE
Reinforced the VMWare Workstation builder methodology for locating the dhcp.conf and dhcpd.leases files on Linux.

### DIFF
--- a/builder/vmware/common/driver_workstation_unix.go
+++ b/builder/vmware/common/driver_workstation_unix.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -50,7 +51,24 @@ func workstationDhcpLeasesPath(device string) string {
 		log.Printf("Error finding VMware root: %s", err)
 		return ""
 	}
-	return filepath.Join(base, device, "dhcpd/dhcpd.leases")
+
+	// Build the base path to VMware configuration for specified device: `/etc/vmware/${device}`
+	devicebase := filepath.Join(base, device)
+
+	// Walk through a list of paths searching for the correct permutation...
+	// ...as it appears that in >= WS14 and < WS14, the leases file may be labelled differently.
+
+	// Docs say we should expect: dhcpd/dhcpd.leases
+	paths := []string{"dhcpd/dhcpd.leases", "dhcpd/dhcp.leases", "dhcp/dhcpd.leases", "dhcp/dhcp.leases"}
+	for _, p := range paths {
+		fp := filepath.Join(devicebase, p)
+		if _, err := os.Stat(fp); !os.IsNotExist(err) {
+			return fp
+		}
+	}
+
+	log.Printf("Error finding VMWare DHCP Server Leases (dhcpd.leases) under device path: %s", devicebase)
+	return ""
 }
 
 func workstationDhcpConfPath(device string) string {
@@ -59,7 +77,24 @@ func workstationDhcpConfPath(device string) string {
 		log.Printf("Error finding VMware root: %s", err)
 		return ""
 	}
-	return filepath.Join(base, device, "dhcp/dhcp.conf")
+
+	// Build the base path to VMware configuration for specified device: `/etc/vmware/${device}`
+	devicebase := filepath.Join(base, device)
+
+	// Walk through a list of paths searching for the correct permutation...
+	// ...as it appears that in >= WS14 and < WS14, the dhcp config may be labelled differently.
+
+	// Docs say we should expect: dhcp/dhcp.conf
+	paths := []string{"dhcp/dhcp.conf", "dhcp/dhcpd.conf", "dhcpd/dhcp.conf", "dhcpd/dhcpd.conf"}
+	for _, p := range paths {
+		fp := filepath.Join(devicebase, p)
+		if _, err := os.Stat(fp); !os.IsNotExist(err) {
+			return fp
+		}
+	}
+
+	log.Printf("Error finding VMWare DHCP Server Configuration (dhcp.conf) under device path: %s", devicebase)
+	return ""
 }
 
 func workstationVmnetnatConfPath(device string) string {


### PR DESCRIPTION
It was reported that on WS14 on Linux, that the path may be different than stated in the documentation. This modifies `workstationDhcpConfPath` and `workstationDhcpLeasesPath` functions to walk through every permutation while attempting to find the correct file.

This reinforces the fix for issue #5882.