### PR TITLE
Fixes the assumption that all the VMware builder's drivers will implement a network mapper for mapping a network name to it's corresponding device.

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -147,6 +147,29 @@ func (d *ESX5Driver) ToolsInstall() error {
 }
 
 func (d *ESX5Driver) Verify() error {
+	// Ensure that NetworkMapper is nil, since the mapping of device<->network
+	// is handled by ESX and thus can't be performed by packer unless we
+	// query things.
+
+	// FIXME: If we want to expose the network devices to the user, then we can
+	// probably use esxcli to enumerate the portgroup and switchId
+	d.base.NetworkMapper = nil
+
+	// Be safe/friendly and overwrite the rest of the utility functions with
+	// log functions despite the fact that these shouldn't be called anyways.
+	d.base.DhcpLeasesPath = func(device string) string {
+		log.Printf("Unexpected error, ESX5 driver attempted to call DhcpLeasesPath(%#v)\n", device)
+		return ""
+	}
+	d.base.DhcpConfPath = func(device string) string {
+		log.Printf("Unexpected error, ESX5 driver attempted to call DhcpConfPath(%#v)\n", device)
+		return ""
+	}
+	d.base.VmnetnatConfPath = func(device string) string {
+		log.Printf("Unexpected error, ESX5 driver attempted to call VmnetnatConfPath(%#v)\n", device)
+		return ""
+	}
+
 	checks := []func() error{
 		d.connect,
 		d.checkSystemVersion,


### PR DESCRIPTION
The ESX5 driver doesn't have a way of mapping the network name to its device name because a .vmx template uses different field names for it and so packer let's ESX handle filling this in. This patch will check to see if the driver that packer determines is missing a NetworkMapper implementation (by checking for nil). If it is, then fall back to using "nat" despite ESX not using the network type at all. This is what packer did prior to exposing the network type to the user back in version 1.1.3.

This closes issue #5916.