### PR TITLE
Fix docs on Alicloud builder

### DIFF
--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -35,9 +35,9 @@ builder.
     can also be sourced from the `ALICLOUD_REGION` environment variables.
 
 -   `instance_type` (string) - Type of the instance. For values, see [Instance
-    Type Table](). You can also obtain the latest instance type table by invoking
-    the [Querying Instance Type
-    Table](https://intl.aliyun.com/help/doc-detail/25620.htm?spm=a3c0i.o25499en.a3.6.Dr1bik)
+    Type Table](https://www.alibabacloud.com/help/doc-detail/25378.htm?spm=a3c0i.o25499en.a3.9.14a36ac8iYqKRA).
+    You can also obtain the latest instance type table by invoking the [Querying
+    Instance Type Table](https://intl.aliyun.com/help/doc-detail/25620.htm?spm=a3c0i.o25499en.a3.6.Dr1bik)
     interface.
 
 -   `image_name` (string) - The name of the user-defined image, \[2, 128\] English
@@ -80,45 +80,47 @@ builder.
     duplicated existing image, the source snapshot of this image will be delete
     either.
 
--   `disk_name` (string) - The value of disk name is blank by default. \[2, 128\]
-    English or Chinese characters, must begin with an uppercase/lowercase letter
-    or Chinese character. Can contain numbers, `.`, `_` and `-`. The disk name
-    will appear on the console. It cannot begin with `http://` or `https://`.
+-   `image_disk_mappings` (array of image disk mappings) - Add one or more data disks
+    to the image.
 
--   `disk_category` (string) - Category of the data disk. Optional values are:
-    -   cloud - general cloud disk
-    -   cloud\_efficiency - efficiency cloud disk
-    -   cloud\_ssd - cloud SSD
+    -   `disk_name` (string) - The value of disk name is blank by default. \[2, 128\]
+        English or Chinese characters, must begin with an uppercase/lowercase letter
+        or Chinese character. Can contain numbers, `.`, `_` and `-`. The disk name
+        will appear on the console. It cannot begin with `http://` or `https://`.
 
-    Default value: cloud.
+    -   `disk_category` (string) - Category of the data disk. Optional values are:
+        -   cloud - general cloud disk
+        -   cloud\_efficiency - efficiency cloud disk
+        -   cloud\_ssd - cloud SSD
 
--   `disk_size` (number) - Size of the system disk, in GB, values range:
-    -   cloud - 5 ~ 2000
-    -   cloud\_efficiency - 20 ~ 2048
-    -   cloud\_ssd - 20 ~ 2048
+        Default value: cloud.
 
-    The value should be equal to or greater than the size of the specific SnapshotId.
+    -   `disk_size` (number) - Size of the system disk, in GB, values range:
+        -   cloud - 5 ~ 2000
+        -   cloud\_efficiency - 20 ~ 2048
+        -   cloud\_ssd - 20 ~ 2048
 
--   `disk_snapshot_id` (string) - Snapshots are used to create the data disk
-    After this parameter is specified, Size is ignored. The actual size of the
-    created disk is the size of the specified snapshot.
+        The value should be equal to or greater than the size of the specific SnapshotId.
 
-    Snapshots from on or before July 15, 2013 cannot be used to create a disk.
+    -   `disk_snapshot_id` (string) - Snapshots are used to create the data disk
+        After this parameter is specified, Size is ignored. The actual size of the
+        created disk is the size of the specified snapshot.
 
--   `disk_description` (string) - The value of disk description is blank by default. \[2, 256\] characters. The disk description will appear on the console. It cannot begin with `http://` or `https://`.
+        Snapshots from on or before July 15, 2013 cannot be used to create a disk.
 
--   `disk_delete_with_instance` (string) - Whether or not the disk is released along with the instance:
--   True indicates that when the instance is released, this disk will be released with it
--   False indicates that when the instance is released, this disk will be retained.
+    -   `disk_description` (string) - The value of disk description is blank by default. \[2, 256\] characters. The disk description will appear on the console. It cannot begin with `http://` or `https://`.
 
--   `disk_device` (string) - Device information of the related instance: such as
-    `/dev/xvdb` It is null unless the Status is In\_use.
+    -   `disk_delete_with_instance` (string) - Whether or not the disk is released along with the instance:
+        -   True indicates that when the instance is released, this disk will be released with it
+        -   False indicates that when the instance is released, this disk will be retained.
+
+    -   `disk_device` (string) - Device information of the related instance: such as
+        `/dev/xvdb` It is null unless the Status is In\_use.
 
 -   `zone_id` (string) - ID of the zone to which the disk belongs.
 
--   `io_optimized` (boolean) - I/O optimized.
-
-    Default value: false for Generation I instances; true for other instances.
+-   `io_optimized` (boolean) - Whether an ECS instance is I/O optimized or not.
+    The default value is `false`.
 
 -   `force_stop_instance` (boolean) - Whether to force shutdown upon device restart.
     The default value is `false`.

--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -27,12 +27,10 @@ builder.
     but it can also be sourced from the `ALICLOUD_ACCESS_KEY` environment
     variable.
 
--   `secret_key` (string) - This is the Alicloud secret key. It must be provided,
-    but it can also be sourced from the `ALICLOUD_SECRET_KEY` environment
-    variable.
-
--   `region` (string) - This is the Alicloud region. It must be provided, but it
-    can also be sourced from the `ALICLOUD_REGION` environment variables.
+-   `image_name` (string) - The name of the user-defined image, \[2, 128\] English
+    or Chinese characters. It must begin with an uppercase/lowercase letter or
+    a Chinese character, and may contain numbers, `_` or `-`. It cannot begin with
+    `http://` or `https://`.
 
 -   `instance_type` (string) - Type of the instance. For values, see [Instance
     Type Table](https://www.alibabacloud.com/help/doc-detail/25378.htm?spm=a3c0i.o25499en.a3.9.14a36ac8iYqKRA).
@@ -40,53 +38,37 @@ builder.
     Instance Type Table](https://intl.aliyun.com/help/doc-detail/25620.htm?spm=a3c0i.o25499en.a3.6.Dr1bik)
     interface.
 
--   `image_name` (string) - The name of the user-defined image, \[2, 128\] English
-    or Chinese characters. It must begin with an uppercase/lowercase letter or
-    a Chinese character, and may contain numbers, `_` or `-`. It cannot begin with
-    `http://` or `https://`.
+-   `region` (string) - This is the Alicloud region. It must be provided, but it
+    can also be sourced from the `ALICLOUD_REGION` environment variables.
+
+-   `secret_key` (string) - This is the Alicloud secret key. It must be provided,
+    but it can also be sourced from the `ALICLOUD_SECRET_KEY` environment
+    variable.
 
 -   `source_image` (string) - This is the base image id which you want to create
     your customized images.
 
 ### Optional:
 
--   `skip_region_validation` (boolean) - The region validation can be skipped if this
-    value is true, the default value is false.
+-   `force_stop_instance` (boolean) - Whether to force shutdown upon device restart.
+    The default value is `false`.
 
--   `image_description` (string) - The description of the image, with a length
-    limit of 0 to 256 characters. Leaving it blank means null, which is the
-    default value. It cannot begin with `http://` or `https://`.
-
--   `image_version` (string) - The version number of the image, with a length limit
-    of 1 to 40 English characters.
-
--   `image_share_account` (array of string) - The IDs of to-be-added Aliyun
-    accounts to which the image is shared. The number of accounts is 1 to 10. If
-    number of accounts is greater than 10, this parameter is ignored.
-
--   `image_copy_regions` (array of string) - Copy to the destination regionIds.
+    If it is set to `false`, the system is shut down normally; if it is set to
+    `true`, the system is forced to shut down.
 
 -   `image_copy_names` (array of string) - The name of the destination image, \[2,
     128\] English or Chinese characters. It must begin with an uppercase/lowercase
     letter or a Chinese character, and may contain numbers, `_` or `-`. It cannot
     begin with `http://` or `https://`.
 
--   `image_force_delete` (boolean) - If this value is true, when the target image name
-    is duplicated with an existing image, it will delete the existing image and
-    then create the target image, otherwise, the creation will fail. The default
-    value is false.
+-   `image_copy_regions` (array of string) - Copy to the destination regionIds.
 
--   `image_force_delete_snapshots` (boolean) - If this value is true, when delete the
-    duplicated existing image, the source snapshot of this image will be delete
-    either.
+-   `image_description` (string) - The description of the image, with a length
+    limit of 0 to 256 characters. Leaving it blank means null, which is the
+    default value. It cannot begin with `http://` or `https://`.
 
 -   `image_disk_mappings` (array of image disk mappings) - Add one or more data disks
     to the image.
-
-    -   `disk_name` (string) - The value of disk name is blank by default. \[2, 128\]
-        English or Chinese characters, must begin with an uppercase/lowercase letter
-        or Chinese character. Can contain numbers, `.`, `_` and `-`. The disk name
-        will appear on the console. It cannot begin with `http://` or `https://`.
 
     -   `disk_category` (string) - Category of the data disk. Optional values are:
         -   cloud - general cloud disk
@@ -94,6 +76,20 @@ builder.
         -   cloud\_ssd - cloud SSD
 
         Default value: cloud.
+
+    -   `disk_delete_with_instance` (string) - Whether or not the disk is released along with the instance:
+        -   True indicates that when the instance is released, this disk will be released with it
+        -   False indicates that when the instance is released, this disk will be retained.
+
+    -   `disk_description` (string) - The value of disk description is blank by default. \[2, 256\] characters. The disk description will appear on the console. It cannot begin with `http://` or `https://`.
+
+    -   `disk_device` (string) - Device information of the related instance: such as
+        `/dev/xvdb` It is null unless the Status is In\_use.
+
+    -   `disk_name` (string) - The value of disk name is blank by default. \[2, 128\]
+        English or Chinese characters, must begin with an uppercase/lowercase letter
+        or Chinese character. Can contain numbers, `.`, `_` and `-`. The disk name
+        will appear on the console. It cannot begin with `http://` or `https://`.
 
     -   `disk_size` (number) - Size of the system disk, in GB, values range:
         -   cloud - 5 ~ 2000
@@ -108,54 +104,21 @@ builder.
 
         Snapshots from on or before July 15, 2013 cannot be used to create a disk.
 
-    -   `disk_description` (string) - The value of disk description is blank by default. \[2, 256\] characters. The disk description will appear on the console. It cannot begin with `http://` or `https://`.
+-   `image_force_delete` (boolean) - If this value is true, when the target image name
+    is duplicated with an existing image, it will delete the existing image and
+    then create the target image, otherwise, the creation will fail. The default
+    value is false.
 
-    -   `disk_delete_with_instance` (string) - Whether or not the disk is released along with the instance:
-        -   True indicates that when the instance is released, this disk will be released with it
-        -   False indicates that when the instance is released, this disk will be retained.
+-   `image_force_delete_snapshots` (boolean) - If this value is true, when delete the
+    duplicated existing image, the source snapshot of this image will be delete
+    either.
 
-    -   `disk_device` (string) - Device information of the related instance: such as
-        `/dev/xvdb` It is null unless the Status is In\_use.
+-   `image_share_account` (array of string) - The IDs of to-be-added Aliyun
+    accounts to which the image is shared. The number of accounts is 1 to 10. If
+    number of accounts is greater than 10, this parameter is ignored.
 
--   `zone_id` (string) - ID of the zone to which the disk belongs.
-
--   `io_optimized` (boolean) - Whether an ECS instance is I/O optimized or not.
-    The default value is `false`.
-
--   `force_stop_instance` (boolean) - Whether to force shutdown upon device restart.
-    The default value is `false`.
-
-    If it is set to `false`, the system is shut down normally; if it is set to
-    `true`, the system is forced to shut down.
-
--   `security_group_id` (string) - ID of the security group to which a newly
-    created instance belongs. Mutual access is allowed between instances in one
-    security group. If not specified, the newly created instance will be added to
-    the default security group. If the default group doesn’t exist, or the number
-    of instances in it has reached the maximum limit, a new security group will
-    be created automatically.
-
--   `security_group_name` (string) - The security group name. The default value is
-    blank. \[2, 128\] English or Chinese characters, must begin with an
-    uppercase/lowercase letter or Chinese character. Can contain numbers, `.`,
-    `_` or `-`. It cannot begin with `http://` or `https://`.
-
--   `user_data` (string) - The UserData of an instance must be encoded in `Base64`
-    format, and the maximum size of the raw data is `16 KB`.
-
--   `user_data_file` (string) - The file name of the userdata.
-
--   `vpc_id` (string) - VPC ID allocated by the system.
-
--   `vpc_name` (string) - The VPC name. The default value is blank. \[2, 128\]
-    English or Chinese characters, must begin with an uppercase/lowercase letter
-    or Chinese character. Can contain numbers, `_` and `-`. The disk description
-    will appear on the console. Cannot begin with `http://` or `https://`.
-
--   `vpc_cidr_block` (string) - Value options: `192.168.0.0/16` and `172.16.0.0/16`.
-    When not specified, the default value is `172.16.0.0/16`.
-
--   `vswitch_id` (string) - The ID of the VSwitch to be used.
+-   `image_version` (string) - The version number of the image, with a length limit
+    of 1 to 40 English characters.
 
 -   `instance_name` (string) - Display name of the instance, which is a string of
     2 to 128 Chinese or English characters. It must begin with an
@@ -173,7 +136,6 @@ builder.
     For the regions out of China, currently only support `PayByTraffic`, you must
     set it manfully.
 
-
 -   `internet_max_bandwidth_out` (string) - Maximum outgoing bandwidth to the public
     network, measured in Mbps (Mega bit per second).
 
@@ -181,15 +143,52 @@ builder.
     -   PayByBandwidth: \[0, 100\]. If this parameter is not specified, API automatically sets it to 0 Mbps.
     -   PayByTraffic: \[1, 100\]. If this parameter is not specified, an error is returned.
 
--   `temporary_key_pair_name` (string) - The name of the temporary key pair to
-    generate. By default, Packer generates a name that looks like `packer_<UUID>`,
-    where `<UUID>` is a 36 character unique identifier.
+-   `io_optimized` (boolean) - Whether an ECS instance is I/O optimized or not.
+    The default value is `false`.
+
+-   `security_group_id` (string) - ID of the security group to which a newly
+    created instance belongs. Mutual access is allowed between instances in one
+    security group. If not specified, the newly created instance will be added to
+    the default security group. If the default group doesn’t exist, or the number
+    of instances in it has reached the maximum limit, a new security group will
+    be created automatically.
+
+-   `security_group_name` (string) - The security group name. The default value is
+    blank. \[2, 128\] English or Chinese characters, must begin with an
+    uppercase/lowercase letter or Chinese character. Can contain numbers, `.`,
+    `_` or `-`. It cannot begin with `http://` or `https://`.
 
 -   `security_token` (string) - STS access token, can be set through template or by exporting
      as environment vairalbe such "export SecurityToken=value".
 
+-   `skip_region_validation` (boolean) - The region validation can be skipped if this
+    value is true, the default value is false.
+
+-   `temporary_key_pair_name` (string) - The name of the temporary key pair to
+    generate. By default, Packer generates a name that looks like `packer_<UUID>`,
+    where `<UUID>` is a 36 character unique identifier.
+
 -   `TLSHandshakeTimeout` (int) - When happen "net/http: TLS handshake timeout" problem, set this environment variable
      to a bigger such as "export TLSHandshakeTimeout=30", it will set the TLS handshake timeout value to 30s.
+
+-   `user_data` (string) - The UserData of an instance must be encoded in `Base64`
+    format, and the maximum size of the raw data is `16 KB`.
+
+-   `user_data_file` (string) - The file name of the userdata.
+
+-   `vpc_cidr_block` (string) - Value options: `192.168.0.0/16` and `172.16.0.0/16`.
+    When not specified, the default value is `172.16.0.0/16`.
+
+-   `vpc_id` (string) - VPC ID allocated by the system.
+
+-   `vpc_name` (string) - The VPC name. The default value is blank. \[2, 128\]
+    English or Chinese characters, must begin with an uppercase/lowercase letter
+    or Chinese character. Can contain numbers, `_` and `-`. The disk description
+    will appear on the console. Cannot begin with `http://` or `https://`.
+
+-   `vswitch_id` (string) - The ID of the VSwitch to be used.
+
+-   `zone_id` (string) - ID of the zone to which the disk belongs.
 
 ## Basic Example
 


### PR DESCRIPTION
- Fix the link to instance types page.
- Disk configurations should go into `image_disk_mappings` array. ([relevant code](https://github.com/hashicorp/packer/blob/ebe995c/builder/alicloud/ecs/image_config.go#L24))
- If `io_optimized` is not set, it's always `false`. (NOT inferred by instance type - [relavant code](https://github.com/hashicorp/packer/blob/7a189a8/builder/alicloud/ecs/step_create_instance.go#L39-L42))