### PR TITLE
Adds Support to configure hyper-v disk block size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
-## UNRELEASED
+## 1.2.1 (February 23, 2918)
 
-## BUG FIXES:
+### BUG FIXES:
 * builder/amazon: Fix issues using assume role [GH-5914]
+* builder/vmware-esxi: Fall back to "nat" if driver does not impelment a NetworkMapper [GH-5916]
+* builder/vmware: Fix VMware Workstation methodology for finding dhcp.conf and dhcpd.leases files [GH-5882]
+* provisioner/ansible-local: Fix conflicting escaping schemes for vars provided
+ to "--extra-vars" [GH-5888]
+
+### IMPROVEMENTS:
+* builder/oracle-classic: Implement winRM communicator for oracle-classic builder [GH-5918]
+* builder/oracle-classic: Add snapshot_timeout option to builder [GH-5930]
 
 
 ## 1.2.0 (February 9, 2018)

--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -66,9 +66,9 @@ type Driver interface {
 
 	DeleteVirtualSwitch(string) error
 
-	CreateVirtualMachine(string, string, string, string, int64, int64, string, uint, bool) error
+	CreateVirtualMachine(string, string, string, string, int64, int64, int64, string, uint, bool) error
 
-	AddVirtualMachineHardDrive(string, string, string, int64, string) error
+	AddVirtualMachineHardDrive(string, string, string, int64, int64, string) error
 
 	CloneVirtualMachine(string, string, string, bool, string, string, string, int64, string) error
 

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -112,6 +112,7 @@ type DriverMock struct {
 	AddVirtualMachineHardDrive_VhdFile        string
 	AddVirtualMachineHardDrive_VhdName        string
 	AddVirtualMachineHardDrive_VhdSizeBytes   int64
+	AddVirtualMachineHardDrive_VhdBlockSize   int64
 	AddVirtualMachineHardDrive_ControllerType string
 	AddVirtualMachineHardDrive_Err            error
 
@@ -122,6 +123,7 @@ type DriverMock struct {
 	CreateVirtualMachine_VhdPath          string
 	CreateVirtualMachine_Ram              int64
 	CreateVirtualMachine_DiskSize         int64
+	CreateVirtualMachine_DiskBlockSize    int64
 	CreateVirtualMachine_SwitchName       string
 	CreateVirtualMachine_Generation       uint
 	CreateVirtualMachine_DifferentialDisk bool
@@ -377,17 +379,18 @@ func (d *DriverMock) CreateVirtualSwitch(switchName string, switchType string) (
 	return d.CreateVirtualSwitch_Return, d.CreateVirtualSwitch_Err
 }
 
-func (d *DriverMock) AddVirtualMachineHardDrive(vmName string, vhdFile string, vhdName string, vhdSizeBytes int64, controllerType string) error {
+func (d *DriverMock) AddVirtualMachineHardDrive(vmName string, vhdFile string, vhdName string, vhdSizeBytes int64, vhdDiskBlockSize int64, controllerType string) error {
 	d.AddVirtualMachineHardDrive_Called = true
 	d.AddVirtualMachineHardDrive_VmName = vmName
 	d.AddVirtualMachineHardDrive_VhdFile = vhdFile
 	d.AddVirtualMachineHardDrive_VhdName = vhdName
 	d.AddVirtualMachineHardDrive_VhdSizeBytes = vhdSizeBytes
+	d.AddVirtualMachineHardDrive_VhdSizeBytes = vhdDiskBlockSize
 	d.AddVirtualMachineHardDrive_ControllerType = controllerType
 	return d.AddVirtualMachineHardDrive_Err
 }
 
-func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdPath string, ram int64, diskSize int64, switchName string, generation uint, diffDisks bool) error {
+func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdPath string, ram int64, diskSize int64, diskBlockSize int64, switchName string, generation uint, diffDisks bool) error {
 	d.CreateVirtualMachine_Called = true
 	d.CreateVirtualMachine_VmName = vmName
 	d.CreateVirtualMachine_Path = path
@@ -395,6 +398,7 @@ func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddriveP
 	d.CreateVirtualMachine_VhdPath = vhdPath
 	d.CreateVirtualMachine_Ram = ram
 	d.CreateVirtualMachine_DiskSize = diskSize
+	d.CreateVirtualMachine_DiskBlockSize = diskBlockSize
 	d.CreateVirtualMachine_SwitchName = switchName
 	d.CreateVirtualMachine_Generation = generation
 	d.CreateVirtualMachine_DifferentialDisk = diffDisks

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -174,12 +174,12 @@ func (d *HypervPS4Driver) CreateVirtualSwitch(switchName string, switchType stri
 	return hyperv.CreateVirtualSwitch(switchName, switchType)
 }
 
-func (d *HypervPS4Driver) AddVirtualMachineHardDrive(vmName string, vhdFile string, vhdName string, vhdSizeBytes int64, controllerType string) error {
-	return hyperv.AddVirtualMachineHardDiskDrive(vmName, vhdFile, vhdName, vhdSizeBytes, controllerType)
+func (d *HypervPS4Driver) AddVirtualMachineHardDrive(vmName string, vhdFile string, vhdName string, vhdSizeBytes int64, diskBlockSize int64, controllerType string) error {
+	return hyperv.AddVirtualMachineHardDiskDrive(vmName, vhdFile, vhdName, vhdSizeBytes, diskBlockSize, controllerType)
 }
 
-func (d *HypervPS4Driver) CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdPath string, ram int64, diskSize int64, switchName string, generation uint, diffDisks bool) error {
-	return hyperv.CreateVirtualMachine(vmName, path, harddrivePath, vhdPath, ram, diskSize, switchName, generation, diffDisks)
+func (d *HypervPS4Driver) CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdPath string, ram int64, diskSize int64, diskBlockSize int64, switchName string, generation uint, diffDisks bool) error {
+	return hyperv.CreateVirtualMachine(vmName, path, harddrivePath, vhdPath, ram, diskSize, diskBlockSize, switchName, generation, diffDisks)
 }
 
 func (d *HypervPS4Driver) CloneVirtualMachine(cloneFromVmxcPath string, cloneFromVmName string, cloneFromSnapshotName string, cloneAllSnapshots bool, vmName string, path string, harddrivePath string, ram int64, switchName string) error {

--- a/builder/hyperv/iso/builder_test.go
+++ b/builder/hyperv/iso/builder_test.go
@@ -23,6 +23,7 @@ func testConfig() map[string]interface{} {
 		"ssh_username":            "foo",
 		"ram_size":                64,
 		"disk_size":               256,
+		"disk_block_size":         1,
 		"guest_additions_mode":    "none",
 		"disk_additional_size":    "50000,40000,30000",
 		packer.BuildNameConfigKey: "foo",
@@ -83,6 +84,58 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 
 	if b.config.DiskSize != 256 {
 		t.Fatalf("bad size: %d", b.config.DiskSize)
+	}
+}
+
+func TestBuilderPrepare_DiskBlockSize(t *testing.T) {
+	var b Builder
+	config := testConfig()
+	expected_default_block_size := uint(32)
+	expected_min_block_size := uint(0)
+	expected_max_block_size := uint(256)
+
+	// Test default with empty disk_block_size
+	delete(config, "disk_block_size")
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("bad err: %s", err)
+	}
+	if b.config.DiskBlockSize != expected_default_block_size {
+		t.Fatalf("bad default block size with empty config: %d. Expected %d", b.config.DiskBlockSize, expected_default_block_size)
+	}
+
+	test_sizes := []uint{0, 1, 32, 256, 512, 1 * 1024, 32 * 1024}
+	for _, test_size := range test_sizes {
+		config["disk_block_size"] = test_size
+		b = Builder{}
+		warns, err = b.Prepare(config)
+		if test_size > expected_max_block_size || test_size < expected_min_block_size {
+			if len(warns) > 0 {
+				t.Fatalf("bad, should have no warns: %#v", warns)
+			}
+			if err == nil {
+				t.Fatalf("bad, should have error but didn't. disk_block_size=%d outside expected valid range [%d,%d]", test_size, expected_min_block_size, expected_max_block_size)
+			}
+		} else {
+			if len(warns) > 0 {
+				t.Fatalf("bad: %#v", warns)
+			}
+			if err != nil {
+				t.Fatalf("bad, should not have error: %s", err)
+			}
+			if test_size == 0 {
+				if b.config.DiskBlockSize != expected_default_block_size {
+					t.Fatalf("bad default block size with 0 value config: %d. Expected: %d", b.config.DiskBlockSize, expected_default_block_size)
+				}
+			} else {
+				if b.config.DiskBlockSize != test_size {
+					t.Fatalf("bad block size with 0 value config: %d. Expected: %d", b.config.DiskBlockSize, expected_default_block_size)
+				}
+			}
+		}
 	}
 }
 

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -877,9 +877,9 @@ Hyper-V\Get-VMNetworkAdapter -VMName $vmName | Hyper-V\Connect-VMNetworkAdapter 
 func AddVirtualMachineHardDiskDrive(vmName string, vhdRoot string, vhdName string, vhdSizeBytes int64, vhdBlockSize int64, controllerType string) error {
 
 	var script = `
-param([string]$vmName,[string]$vhdRoot, [string]$vhdName, [string]$vhdSizeInBytes,[string]$vhdBlockSizeInBize [string]$controllerType)
+param([string]$vmName,[string]$vhdRoot, [string]$vhdName, [string]$vhdSizeInBytes,[string]$vhdBlockSizeInByte [string]$controllerType)
 $vhdPath = Join-Path -Path $vhdRoot -ChildPath $vhdName
-Hyper-V\New-VHD -path $vhdPath -SizeBytes $vhdSizeInBytes -BlockSizeBytes $vhdBlockSizeInBize
+Hyper-V\New-VHD -path $vhdPath -SizeBytes $vhdSizeInBytes -BlockSizeBytes $vhdBlockSizeInByte
 Hyper-V\Add-VMHardDiskDrive -VMName $vmName -path $vhdPath -controllerType $controllerType
 `
 	var ps powershell.PowerShellCmd

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -231,7 +231,7 @@ if ($harddrivePath){
 }
 `
 		var ps powershell.PowerShellCmd
-		if err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatBool(diffDisks)); err != nil {
+		if err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), strconv.FormatInt(diskBlockSize, 10), switchName, strconv.FormatBool(diffDisks)); err != nil {
 			return err
 		}
 

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -53,22 +53,6 @@ $ip
 	return cmdOut, err
 }
 
-//func CreateVirtualHardDiskDrive(vmName string, diskPath string, diskSize int64, diskBlockSize int64, generation uint) (uint, uint, error) {
-//
-//		var script = `
-//param([string]$vmName, [string]$path,
-//
-//
-//[long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName, [int]$generation)
-//$vhdx = $vmName + '.vhdx'
-//$vhdPath = Join-Path -Path $path -ChildPath $vhdx
-//New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName -Generation $generation
-//`
-//		var ps powershell.PowerShellCmd
-//		err := ps.Run(script, vmName, path, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatInt(int64(generation), 10))
-//		return err
-//}
-
 func CreateDvdDrive(vmName string, isoPath string, generation uint) (uint, uint, error) {
 	var ps powershell.PowerShellCmd
 	var script string

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -53,6 +53,22 @@ $ip
 	return cmdOut, err
 }
 
+//func CreateVirtualHardDiskDrive(vmName string, diskPath string, diskSize int64, diskBlockSize int64, generation uint) (uint, uint, error) {
+//
+//		var script = `
+//param([string]$vmName, [string]$path,
+//
+//
+//[long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName, [int]$generation)
+//$vhdx = $vmName + '.vhdx'
+//$vhdPath = Join-Path -Path $path -ChildPath $vhdx
+//New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName -Generation $generation
+//`
+//		var ps powershell.PowerShellCmd
+//		err := ps.Run(script, vmName, path, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatInt(int64(generation), 10))
+//		return err
+//}
+
 func CreateDvdDrive(vmName string, isoPath string, generation uint) (uint, uint, error) {
 	var ps powershell.PowerShellCmd
 	var script string
@@ -187,45 +203,47 @@ Set-VMFloppyDiskDrive -VMName $vmName -Path $null
 	return err
 }
 
-func CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdRoot string, ram int64, diskSize int64, switchName string, generation uint, diffDisks bool) error {
+func CreateVirtualMachine(vmName string, path string, harddrivePath string, vhdRoot string, ram int64, diskSize int64, diskBlockSize int64, switchName string, generation uint, diffDisks bool) error {
 
 	if generation == 2 {
 		var script = `
-param([string]$vmName, [string]$path, [string]$harddrivePath, [string]$vhdRoot, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName, [int]$generation, [string]$diffDisks)
+param([string]$vmName, [string]$path, [string]$harddrivePath, [string]$vhdRoot, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [long]$vhdBlockSizeBytes, [string]$switchName, [int]$generation, [string]$diffDisks)
 $vhdx = $vmName + '.vhdx'
 $vhdPath = Join-Path -Path $vhdRoot -ChildPath $vhdx
 if ($harddrivePath){
 	if($diffDisks -eq "true"){
-		New-VHD -Path $vhdPath -ParentPath $harddrivePath -Differencing
+		New-VHD -Path $vhdPath -ParentPath $harddrivePath -Differencing -BlockSizeBytes $vhdBlockSizeBytes
 	} else {
 		Copy-Item -Path $harddrivePath -Destination $vhdPath
 	}
 	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName -Generation $generation
 } else {
-	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName -Generation $generation
+	New-VHD -Path $vhdPath -SizeBytes $newVHDSizeBytes -BlockSizeBytes $vhdBlockSizeBytes
+	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName -Generation $generation
 }
 `
 		var ps powershell.PowerShellCmd
-		if err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), switchName, strconv.FormatInt(int64(generation), 10), strconv.FormatBool(diffDisks)); err != nil {
+		if err := ps.Run(script, vmName, path, harddrivePath, vhdRoot, strconv.FormatInt(ram, 10), strconv.FormatInt(diskSize, 10), strconv.FormatInt(diskBlockSize, 10), switchName, strconv.FormatInt(int64(generation), 10), strconv.FormatBool(diffDisks)); err != nil {
 			return err
 		}
 
 		return DisableAutomaticCheckpoints(vmName)
 	} else {
 		var script = `
-param([string]$vmName, [string]$path, [string]$harddrivePath, [string]$vhdRoot, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [string]$switchName, [string]$diffDisks)
+param([string]$vmName, [string]$path, [string]$harddrivePath, [string]$vhdRoot, [long]$memoryStartupBytes, [long]$newVHDSizeBytes, [long]$vhdBlockSizeBytes, [string]$switchName, [string]$diffDisks)
 $vhdx = $vmName + '.vhdx'
 $vhdPath = Join-Path -Path $vhdRoot -ChildPath $vhdx
 if ($harddrivePath){
 	if($diffDisks -eq "true"){
-		New-VHD -Path $vhdPath -ParentPath $harddrivePath -Differencing
+		New-VHD -Path $vhdPath -ParentPath $harddrivePath -Differencing -BlockSizeBytes $vhdBlockSizeBytes
 	}
 	else{
 		Copy-Item -Path $harddrivePath -Destination $vhdPath
 	}
 	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName
 } else {
-	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHDPath $vhdPath -NewVHDSizeBytes $newVHDSizeBytes -SwitchName $switchName
+	New-VHD -Path $vhdPath -SizeBytes $newVHDSizeBytes -BlockSizeBytes $vhdBlockSizeBytes
+	New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -VHDPath $vhdPath -SwitchName $switchName
 }
 `
 		var ps powershell.PowerShellCmd
@@ -872,16 +890,16 @@ Get-VMNetworkAdapter -VMName $vmName | Connect-VMNetworkAdapter -SwitchName $swi
 	return err
 }
 
-func AddVirtualMachineHardDiskDrive(vmName string, vhdRoot string, vhdName string, vhdSizeBytes int64, controllerType string) error {
+func AddVirtualMachineHardDiskDrive(vmName string, vhdRoot string, vhdName string, vhdSizeBytes int64, vhdBlockSize int64, controllerType string) error {
 
 	var script = `
-param([string]$vmName,[string]$vhdRoot, [string]$vhdName, [string]$vhdSizeInBytes, [string]$controllerType)
+param([string]$vmName,[string]$vhdRoot, [string]$vhdName, [string]$vhdSizeInBytes,[string]$vhdBlockSizeInBize [string]$controllerType)
 $vhdPath = Join-Path -Path $vhdRoot -ChildPath $vhdName
-New-VHD $vhdPath -SizeBytes $vhdSizeInBytes
+New-VHD -path $vhdPath -SizeBytes $vhdSizeInBytes -BlockSizeBytes $vhdBlockSizeInBize
 Add-VMHardDiskDrive -VMName $vmName -path $vhdPath -controllerType $controllerType
 `
 	var ps powershell.PowerShellCmd
-	err := ps.Run(script, vmName, vhdRoot, vhdName, strconv.FormatInt(vhdSizeBytes, 10), controllerType)
+	err := ps.Run(script, vmName, vhdRoot, vhdName, strconv.FormatInt(vhdSizeBytes, 10), strconv.FormatInt(vhdBlockSize, 10), controllerType)
 	return err
 }
 

--- a/website/source/docs/builders/hyperv-iso.html.md
+++ b/website/source/docs/builders/hyperv-iso.html.md
@@ -230,6 +230,9 @@ can be configured for this builder.
 -   `temp_path` (string) - This is the temporary path in which Packer will create the virtual
     machine. Default value is system `%temp%`
 
+-   `disk_block_size` (string) - The block size of the VHD to be created. 
+    Recommended disk block size for Linux hyper-v guests is 1 MiB. This defaults to "32 MiB".
+
 ## Boot Command
 
 The `boot_command` configuration is very important: it specifies the keys


### PR DESCRIPTION
_Note: I've merged and tested the change implemented by @evancox10 myself, since I need this feature and there was no progress after September 2017. The credit for implementing this goes to @evancox10._

This adds the option to specify the VHD block size for hyper-v builders. This is particularly required for Linux VM disk size optimization as described here: [tuning-linux-file-systems-on-dynamic-vhdx-files](https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/best-practices-for-running-linux-on-hyper-v#tuning-linux-file-systems-on-dynamic-vhdx-files). The default value is 32 MiB, Microsofts recommendation is 1 MiB.

example config using the new property:


```json
{
"variables": {
"vm_name": "ubuntu-xenial",
"cpu": "2",
"ram_size": "1024",
"disk_size": "21440",
"iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.1-server-amd64.iso",
"iso_checksum_type": "sha1",
"iso_checksum": "DE5EE8665048F009577763EFBF4A6F0558833E59"
},
"builders": [
{
"vm_name":"{{user vm_name}}",
"type": "hyperv-iso",
"disk_size": "{{user disk_size}}",
**"disk_block_size": "1",**
"guest_additions_mode": "disable",
"iso_url": "{{user iso_url}}",
"iso_checksum_type": "{{user iso_checksum_type}}",
"iso_checksum": "{{user iso_checksum}}",
"communicator":"ssh",
"ssh_username": "packer",
"ssh_password": "packer",
"ssh_timeout" : "4h",
"http_directory": "./",
"boot_wait": "5s",
"boot_command": [
"",
"set gfxpayload=1024x768",
"linux /install/vmlinuz ",
"preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/hyperv-taliesins.cfg ",
"debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
"hostname={{.Name}} ",
"fb=false debconf/frontend=noninteractive ",
"keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
"keyboard-configuration/variant=USA console-setup/ask_detect=false ",
"initrd /install/initrd.gz",
"boot"
],
"shutdown_command": "echo 'packer' | sudo -S -E shutdown -P now",
"ram_size": "{{user ram_size}}",
"cpu": "{{user cpu}}",
"generation": 2,
"enable_secure_boot": true
}
]
}
```

This could be documented as follows on the hyperv-vmcx and hyperv-iso pages:

disk_block_size (string) - The block size of the VHD to be created. Recommended disk block size for Linux hyper-v guests is 1 MiB. This defaults to "32 MiB".

Closes #4549 

