### PR TITLE
Option to keep ISO attached for live distributions

### DIFF
--- a/builder/virtualbox/common/step_export.go
+++ b/builder/virtualbox/common/step_export.go
@@ -31,14 +31,14 @@ func (s *StepExport) Run(_ context.Context, state multistep.StateBag) multistep.
 	// If ISO export is configured, ensure this option is propagated to VBoxManage.
 	if s.Bundling.BundleISO {
 		foundISOOption := false
-		
+
 		for _, option := range s.ExportOpts {
 			if option == "--iso" || option == "-I" {
 				foundISOOption = true
 				break
 			}
 		}
-		
+
 		if !foundISOOption {
 			s.ExportOpts = append(s.ExportOpts, "--iso")
 		}

--- a/builder/virtualbox/common/step_export.go
+++ b/builder/virtualbox/common/step_export.go
@@ -22,11 +22,28 @@ type StepExport struct {
 	Format         string
 	OutputDir      string
 	ExportOpts     []string
+	Bundling       VBoxBundleConfig
 	SkipNatMapping bool
 	SkipExport     bool
 }
 
 func (s *StepExport) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	// If ISO export is configured, ensure this option is propagated to VBoxManage.
+	if s.Bundling.BundleISO {
+		foundISOOption := false
+		
+		for _, option := range s.ExportOpts {
+			if option == "--iso" || option == "-I" {
+				foundISOOption = true
+				break
+			}
+		}
+		
+		if !foundISOOption {
+			s.ExportOpts = append(s.ExportOpts, "--iso")
+		}
+	}
+
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 	vmName := state.Get("vmName").(string)

--- a/builder/virtualbox/common/step_export.go
+++ b/builder/virtualbox/common/step_export.go
@@ -29,18 +29,10 @@ type StepExport struct {
 
 func (s *StepExport) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	// If ISO export is configured, ensure this option is propagated to VBoxManage.
-	if s.Bundling.BundleISO {
-		foundISOOption := false
-
-		for _, option := range s.ExportOpts {
-			if option == "--iso" || option == "-I" {
-				foundISOOption = true
-				break
-			}
-		}
-
-		if !foundISOOption {
+	for _, option := range s.ExportOpts {
+		if option == "--iso" || option == "-I" {
 			s.ExportOpts = append(s.ExportOpts, "--iso")
+			break
 		}
 	}
 

--- a/builder/virtualbox/common/step_remove_devices.go
+++ b/builder/virtualbox/common/step_remove_devices.go
@@ -19,7 +19,7 @@ import (
 //   vmName string
 //
 // Produces:
-type StepRemoveDevices struct{
+type StepRemoveDevices struct {
 	Bundling VBoxBundleConfig
 }
 

--- a/builder/virtualbox/common/vboxbundle_config.go
+++ b/builder/virtualbox/common/vboxbundle_config.go
@@ -1,0 +1,13 @@
+package common
+
+import (
+	"github.com/hashicorp/packer/template/interpolate"
+)
+
+type VBoxBundleConfig struct {
+  BundleISO      bool `mapstructure:"bundle_iso"`
+}
+
+func (c *VBoxBundleConfig) Prepare(ctx *interpolate.Context) []error {
+	return nil
+}

--- a/builder/virtualbox/common/vboxbundle_config.go
+++ b/builder/virtualbox/common/vboxbundle_config.go
@@ -5,7 +5,7 @@ import (
 )
 
 type VBoxBundleConfig struct {
-  BundleISO      bool `mapstructure:"bundle_iso"`
+	BundleISO bool `mapstructure:"bundle_iso"`
 }
 
 func (c *VBoxBundleConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/virtualbox/common/vboxbundle_config_test.go
+++ b/builder/virtualbox/common/vboxbundle_config_test.go
@@ -13,8 +13,8 @@ func TestVBoxBundleConfigPrepare_VBoxBundle(t *testing.T) {
 		t.Fatalf("err: %#v", errs)
 	}
 
-	if !reflect.DeepEqual(c, VBoxBundleConfig{BundleISO: false}) {
-		t.Fatalf("bad: %#v", c.BundleISO)
+	if !reflect.DeepEqual(*c, VBoxBundleConfig{BundleISO: false}) {
+		t.Fatalf("bad: %#v", c)
 	}
 
 	// Test with a good one
@@ -29,7 +29,7 @@ func TestVBoxBundleConfigPrepare_VBoxBundle(t *testing.T) {
 		BundleISO: true,
 	}
 
-	if !reflect.DeepEqual(c, expected) {
+	if !reflect.DeepEqual(*c, expected) {
 		t.Fatalf("bad: %#v", c)
 	}
 }

--- a/builder/virtualbox/common/vboxbundle_config_test.go
+++ b/builder/virtualbox/common/vboxbundle_config_test.go
@@ -14,7 +14,7 @@ func TestVBoxBundleConfigPrepare_VBoxBundle(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(c, VBoxBundleConfig{BundleISO: false}) {
-		t.Fatalf("bad: %#v", c.VBoxBundle)
+		t.Fatalf("bad: %#v", c.BundleISO)
 	}
 
 	// Test with a good one

--- a/builder/virtualbox/common/vboxbundle_config_test.go
+++ b/builder/virtualbox/common/vboxbundle_config_test.go
@@ -26,7 +26,7 @@ func TestVBoxBundleConfigPrepare_VBoxBundle(t *testing.T) {
 	}
 
 	expected := VBoxBundleConfig{
-    BundleISO: true,
+		BundleISO: true,
 	}
 
 	if !reflect.DeepEqual(c, expected) {

--- a/builder/virtualbox/common/vboxbundle_config_test.go
+++ b/builder/virtualbox/common/vboxbundle_config_test.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVBoxBundleConfigPrepare_VBoxBundle(t *testing.T) {
+	// Test with empty
+	c := new(VBoxBundleConfig)
+	errs := c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("err: %#v", errs)
+	}
+
+	if !reflect.DeepEqual(c, VBoxBundleConfig{BundleISO: false}) {
+		t.Fatalf("bad: %#v", c.VBoxBundle)
+	}
+
+	// Test with a good one
+	c = new(VBoxBundleConfig)
+	c.BundleISO = true
+	errs = c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("err: %#v", errs)
+	}
+
+	expected := VBoxBundleConfig{
+    BundleISO: true,
+	}
+
+	if !reflect.DeepEqual(c, expected) {
+		t.Fatalf("bad: %#v", c)
+	}
+}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -39,6 +39,7 @@ type Config struct {
 	vboxcommon.VBoxManageConfig     `mapstructure:",squash"`
 	vboxcommon.VBoxManagePostConfig `mapstructure:",squash"`
 	vboxcommon.VBoxVersionConfig    `mapstructure:",squash"`
+	vboxcommon.VBoxBundleConfig     `mapstructure:",squash"`
 
 	DiskSize               uint   `mapstructure:"disk_size"`
 	GuestAdditionsMode     string `mapstructure:"guest_additions_mode"`
@@ -94,6 +95,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, b.config.ShutdownConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.SSHConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.HWConfig.Prepare(&b.config.ctx)...)
+	errs = packer.MultiErrorAppend(errs, b.config.VBoxBundleConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxManageConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxManagePostConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxVersionConfig.Prepare(&b.config.ctx)...)
@@ -277,7 +279,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Timeout: b.config.ShutdownTimeout,
 			Delay:   b.config.PostShutdownDelay,
 		},
-		new(vboxcommon.StepRemoveDevices),
+		&vboxcommon.StepRemoveDevices{
+			Bundling: b.config.VBoxBundleConfig,
+		},
 		&vboxcommon.StepVBoxManage{
 			Commands: b.config.VBoxManagePost,
 			Ctx:      b.config.ctx,
@@ -286,6 +290,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Format:         b.config.Format,
 			OutputDir:      b.config.OutputDir,
 			ExportOpts:     b.config.ExportOpts.ExportOpts,
+			Bundling:       b.config.VBoxBundleConfig,
 			SkipNatMapping: b.config.SSHSkipNatMapping,
 			SkipExport:     b.config.SkipExport,
 		},

--- a/website/source/docs/builders/virtualbox-iso.html.md.erb
+++ b/website/source/docs/builders/virtualbox-iso.html.md.erb
@@ -316,6 +316,11 @@ builder.
     except that it is run after the virtual machine is shutdown, and before the
     virtual machine is exported.
 
+-   `bundle_iso` (boolean) - Defaults to `false`. When enabled, Packer includes
+    any attached ISO disc devices into the final virtual machine. Useful for
+    some live distributions that require installation media to continue to be
+    attached after installation.
+
 -   `virtualbox_version_file` (string) - The path within the virtual machine to
     upload a file that contains the VirtualBox version that was used to create
     the machine. This information can be useful for provisioning. By default


### PR DESCRIPTION
Expose the `--iso` option for `VBoxManage export` up to virtualbox-iso builder configuration as `"bundle_iso"`, and ensure that the remove device step does not detach the ISO when this option is enabled. This option helps some operating systems like SmartOS and TAILS, that require installation media to continue to be present even after installation in order to successfully boot.

Closes #5949
