### PR TITLE
Disable the usage of the XHCI bus for USB on the vmware-iso builder.

### DIFF
--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -716,7 +716,6 @@ tools.upgrade.policy = "upgradeAtPowerCycle"
 // USB
 usb.pciSlotNumber = "32"
 usb.present = "{{ .Usb_Present }}"
-usb_xhci.present = "TRUE"
 
 // Serial
 serial0.present = "{{ .Serial_Present }}"

--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -357,7 +357,9 @@ builder.
     By default the upload path is set to `{{.Flavor}}.iso`. This setting is not
     used when `remote_type` is "esx5".
 
--   `usb` (boolean) - Enable VMware's USB bus for the VM.
+-   `usb` (boolean) - Enable VMware's USB bus for the guest VM. To enable usage
+    of the XHCI bus for USB 3 (5 Gbit/s), one can use the `vmx_data` option to
+    enable it by specifying "true" for the `usb_xhci.present` property.
 
 -   `version` (string) - The [vmx hardware
     version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746)


### PR DESCRIPTION
Some platforms with incomplete xhci implementations (i.e. FreeBSD) will poll the bus despite there being no usb devices available (a correct xhci implementation would not need to poll). This PR will disable usage of xhci by default and also includes documentation on how one can re-enable xhci using the `vmx_data` option.

The only downside of disabling xhci is that USB transfers will be slower than 5 Gbit/s which shouldn't be too important.

This closes issue #5961.