### PR TITLE
Add LXC to vagrant post-processor

### DIFF
--- a/post-processor/vagrant/lxc.go
+++ b/post-processor/vagrant/lxc.go
@@ -1,0 +1,34 @@
+package vagrant
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/hashicorp/packer/packer"
+)
+
+type LXCProvider struct{}
+
+func (p *LXCProvider) KeepInputArtifact() bool {
+	return false
+}
+
+func (p *LXCProvider) Process(ui packer.Ui, artifact packer.Artifact, dir string) (vagrantfile string, metadata map[string]interface{}, err error) {
+	// Create the metadata
+	metadata = map[string]interface{}{
+		"provider": "lxc",
+		"version":  "1.0.0",
+	}
+
+	// Copy all of the original contents into the temporary directory
+	for _, path := range artifact.Files() {
+		ui.Message(fmt.Sprintf("Copying: %s", path))
+
+		dstPath := filepath.Join(dir, filepath.Base(path))
+		if err = CopyContents(dstPath, path); err != nil {
+			return
+		}
+	}
+
+	return
+}

--- a/post-processor/vagrant/lxc_test.go
+++ b/post-processor/vagrant/lxc_test.go
@@ -1,0 +1,9 @@
+package vagrant
+
+import (
+	"testing"
+)
+
+func TestLXCProvider_impl(t *testing.T) {
+	var _ Provider = new(LXCProvider)
+}

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -30,6 +30,7 @@ var builtins = map[string]string{
 	"packer.parallels":          "parallels",
 	"MSOpenTech.hyperv":         "hyperv",
 	"transcend.qemu":            "libvirt",
+	"ustream.lxc":               "lxc",
 }
 
 type Config struct {
@@ -238,6 +239,8 @@ func providerForName(name string) Provider {
 		return new(LibVirtProvider)
 	case "google":
 		return new(GoogleProvider)
+	case "lxc":
+		return new(LXCProvider)
 	default:
 		return nil
 	}

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -34,6 +34,7 @@ providers.
 -   DigitalOcean
 -   Google
 -   Hyper-V
+-   LXC
 -   Parallels
 -   QEMU
 -   VirtualBox
@@ -101,8 +102,18 @@ Specify overrides within the `override` configuration by provider name:
 In the example above, the compression level will be set to 1 except for VMware,
 where it will be set to 0.
 
-The available provider names are: `aws`, `digitalocean`, `google`, `virtualbox`,
-`vmware`, and `parallels`.
+The available provider names are:
+
+- `aws`
+- `digitalocean`
+- `google`
+- `hyperv`
+- `parallels`
+- `libvirt`
+- `lxc`
+- `scaleway`
+- `virtualbox`
+- `vmware`
 
 ## Input Artifacts
 


### PR DESCRIPTION
This adds support for packaging up lxc containers in the vagrant post processor.