### PR TITLE
Add menu key

### DIFF
--- a/builder/virtualbox/common/step_type_boot_command.go
+++ b/builder/virtualbox/common/step_type_boot_command.go
@@ -91,7 +91,16 @@ func (s *StepTypeBootCommand) Run(_ context.Context, state multistep.StateBag) m
 				return multistep.ActionHalt
 			}
 
-			if err := driver.VBoxManage("controlvm", vmName, "keyboardputscancode", code); err != nil {
+			var codes []string
+
+			for i := 0; i < len(code)/2; i++ {
+				codes = append(codes, code[i*2:i*2+2])
+			}
+
+			args := []string{"controlvm", vmName, "keyboardputscancode"}
+			args = append(args, codes...)
+
+			if err := driver.VBoxManage(args...); err != nil {
 				err := fmt.Errorf("Error sending boot command: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())

--- a/builder/virtualbox/common/step_type_boot_command.go
+++ b/builder/virtualbox/common/step_type_boot_command.go
@@ -155,6 +155,7 @@ func scancodes(message string) []string {
 	special["<end>"] = []string{"4f", "cf"}
 	special["<pageUp>"] = []string{"49", "c9"}
 	special["<pageDown>"] = []string{"51", "d1"}
+	special["<menu>"] = []string{"e05d", "e0cd"}
 	special["<leftAlt>"] = []string{"38", "b8"}
 	special["<leftCtrl>"] = []string{"1d", "9d"}
 	special["<leftShift>"] = []string{"2a", "aa"}
@@ -190,6 +191,12 @@ func scancodes(message string) []string {
 	for len(message) > 0 {
 		var scancode []string
 
+		if strings.HasPrefix(message, "<menuOn>") {
+			scancode = []string{"e05d"}
+			message = message[len("<menuOn>"):]
+			log.Printf("Special code '<menuOn>' found, replacing with: e05d")
+		}
+
 		if strings.HasPrefix(message, "<leftAltOn>") {
 			scancode = []string{"38"}
 			message = message[len("<leftAltOn>"):]
@@ -206,6 +213,12 @@ func scancodes(message string) []string {
 			scancode = []string{"2a"}
 			message = message[len("<leftShiftOn>"):]
 			log.Printf("Special code '<leftShiftOn>' found, replacing with: 2a")
+		}
+
+		if strings.HasPrefix(message, "<menuOff>") {
+			scancode = []string{"e0cd"}
+			message = message[len("<menuOff>"):]
+			log.Printf("Special code '<menuOff>' found, replacing with: e0cd")
 		}
 
 		if strings.HasPrefix(message, "<leftAltOff>") {

--- a/builder/virtualbox/common/step_type_boot_command.go
+++ b/builder/virtualbox/common/step_type_boot_command.go
@@ -155,7 +155,7 @@ func scancodes(message string) []string {
 	special["<end>"] = []string{"4f", "cf"}
 	special["<pageUp>"] = []string{"49", "c9"}
 	special["<pageDown>"] = []string{"51", "d1"}
-	special["<menu>"] = []string{"e05d", "e0cd"}
+	special["<menu>"] = []string{"e05d", "e0dd"}
 	special["<leftAlt>"] = []string{"38", "b8"}
 	special["<leftCtrl>"] = []string{"1d", "9d"}
 	special["<leftShift>"] = []string{"2a", "aa"}


### PR DESCRIPTION
The menu key is the only way to navigate to the Terminal from the keyboard in Haiku guests, or any other application for that matter. So it is helpful for packer to be able to signal this key in `boot_command`s, in order to provision Haiku boxes.