### PR TITLE
Switch web analytics to segment

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.32"
+gem "middleman-hashicorp", "0.3.34"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.32)
+    middleman-hashicorp (0.3.34)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -153,7 +153,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.32)
+  middleman-hashicorp (= 0.3.34)
 
 BUNDLED WITH
    1.16.1

--- a/website/Makefile
+++ b/website/Makefile
@@ -8,7 +8,7 @@ build:
 		--tty \
 		--volume "$(shell pwd):/website" \
 		hashicorp/middleman-hashicorp:${VERSION} \
-		bundle exec middleman build --verbose --clean
+		ENV=production bundle exec middleman build --verbose --clean
 
 website:
 	@echo "==> Starting website in Docker..."

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.32"
+VERSION?="0.3.34"
 
 build:
 	@echo "==> Starting build in Docker..."
@@ -7,8 +7,9 @@ build:
 		--rm \
 		--tty \
 		--volume "$(shell pwd):/website" \
+		-e "ENV=production" \
 		hashicorp/middleman-hashicorp:${VERSION} \
-		ENV=production bundle exec middleman build --verbose --clean
+		bundle exec middleman build --verbose --clean
 
 website:
 	@echo "==> Starting website in Docker..."

--- a/website/config.rb
+++ b/website/config.rb
@@ -8,6 +8,16 @@ activate :hashicorp do |h|
 end
 
 helpers do
+  # Returns a segment tracking ID such that local development is not
+  # tracked to production systems.
+  def segmentId()
+    if (ENV['ENV'] == 'production')
+      'AjXdfmTTk1I9q9dfyePuDFHBrz1tCO3l'
+    else
+      '0EXTgkNx0Ydje2PGXVbRhpKKoe5wtzcE'
+    end
+  end
+
   # Returns the FQDN of the image URL.
   #
   # @param [String] path

--- a/website/source/assets/javascripts/analytics.js
+++ b/website/source/assets/javascripts/analytics.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  track('.downloads .download a', el => {
+    return {
+      event: 'Download',
+      category: 'Button',
+      label: `Packer | v${el.href.match(/\/(\d+\.\d+\.\d+)\//)[1]}`
+    }
+  })
+})

--- a/website/source/assets/javascripts/analytics.js
+++ b/website/source/assets/javascripts/analytics.js
@@ -1,9 +1,9 @@
-document.addEventListener('DOMContentLoaded', () => {
-  track('.downloads .download a', el => {
+document.addEventListener('DOMContentLoaded', function() {
+  track('.downloads .download a', function(el) {
     return {
       event: 'Download',
       category: 'Button',
-      label: `Packer | v${el.href.match(/\/(\d+\.\d+\.\d+)\//)[1]}`
+      label: 'Packer | v' + el.href.match(/\/(\d+\.\d+\.\d+)\//)[1]
     }
   })
 })

--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -3,3 +3,6 @@
 
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar
+//= require hashicorp/analytics
+
+//= require analytics

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -119,14 +119,16 @@
     </div>
 
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-43075859-1', 'packer.io');
-      ga('require', 'linkid');
-      ga('send', 'pageview', location.pathname);
+      // ga async load
+      window['GoogleAnalyticsObject'] = 'ga';
+      window['ga'] = window['ga'] || function() {
+        (window['ga'].q = window['ga'].q || []).push(arguments)
+      };
+      // analytics.js
+      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
+      analytics.load("<%= segmentId %>");
+      analytics.page();
+      }}();
     </script>
 
     <script type="application/ld+json">

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -130,7 +130,12 @@
       analytics.page();
       }}();
     </script>
-
+    <script>
+      // optinmonster
+      var om597a24292a958,om597a24292a958_poll=function(){var b=0;return function(d,c){clearInterval(b);b=setInterval(d,c)}}();
+      !function(b,d,c){if(b.getElementById(c))om597a24292a958_poll(function(){if(window.om_loaded&&!om597a24292a958)return om597a24292a958=new OptinMonsterApp,om597a24292a958.init({s:"35109.597a24292a958",staging:0,dev:0,beta:0})},25);else{var e=!1,a=b.createElement(d);a.id=c;a.src="//a.optnmstr.com/app/js/api.min.js";a.async=!0;a.onload=a.onreadystatechange=function(){if(!(e||this.readyState&&"loaded"!==this.readyState&&"complete"!==this.readyState))try{e=om_loaded=!0,om597a24292a958=new OptinMonsterApp,
+      om597a24292a958.init({s:"35109.597a24292a958",staging:0,dev:0,beta:0}),a.onload=a.onreadystatechange=null}catch(f){}};(document.getElementsByTagName("head")[0]||document.documentElement).appendChild(a)}}(document,"script","omapi-script");
+    </script>
     <script type="application/ld+json">
       {
         "@context": "http://schema.org",


### PR DESCRIPTION
We're going through a process of switching over to using segment for our analytics. Segment will still send data to google analytics, so it should behave the same as before for those relying on the GA interface, but segment has the ability also to send the data elsewhere, so we can integrate cleanly with other analytics tooling as well.

This PR switches over from pure GA to segment. In production, data will be logged to the same GA property as before, and in development it won't be logged to GA at all, to prevent pollution. I added a "production" environment flag to the make build command to adjust for this. Let me know if there's a better way to accomplish this!