### PR TITLE
allow users of AWS to use the dynamically-generated admin password wh…

### DIFF
--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -92,11 +93,15 @@ WaitLoop:
 		ui.Message(fmt.Sprintf(
 			"Password (since debug is enabled): %s", s.Comm.WinRMPassword))
 	}
+	// store so that we can access this later during provisioning
+	commonhelper.SetSharedState("winrm_password", s.Comm.WinRMPassword)
 
 	return multistep.ActionContinue
 }
 
-func (s *StepGetPassword) Cleanup(multistep.StateBag) {}
+func (s *StepGetPassword) Cleanup(multistep.StateBag) {
+	commonhelper.RemoveSharedStateFile("winrm_password")
+}
 
 func (s *StepGetPassword) waitForPassword(state multistep.StateBag, cancel <-chan struct{}) (string, error) {
 	ec2conn := state.Get("ec2").(*ec2.EC2)

--- a/helper/common/shared_state.go
+++ b/helper/common/shared_state.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Used to set variables which we need to access later in the build, where
+// state bag and config information won't work
+func sharedStateFilename(suffix string) string {
+	uuid := os.Getenv("PACKER_RUN_UUID")
+	return filepath.Join(os.TempDir(), fmt.Sprintf("packer-%s-%s", uuid, suffix))
+}
+
+func SetSharedState(key string, value string) error {
+	return ioutil.WriteFile(sharedStateFilename(key), []byte(value), 0644)
+}
+
+func RetrieveSharedState(key string) (string, error) {
+	value, err := ioutil.ReadFile(sharedStateFilename(key))
+	if err != nil {
+		return "", err
+	}
+	return string(value), nil
+}
+
+func RemoveSharedStateFile(key string) {
+	os.Remove(sharedStateFilename(key))
+}

--- a/helper/common/shared_state.go
+++ b/helper/common/shared_state.go
@@ -15,7 +15,7 @@ func sharedStateFilename(suffix string) string {
 }
 
 func SetSharedState(key string, value string) error {
-	return ioutil.WriteFile(sharedStateFilename(key), []byte(value), 0644)
+	return ioutil.WriteFile(sharedStateFilename(key), []byte(value), 0600)
 }
 
 func RetrieveSharedState(key string) (string, error) {

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -374,19 +374,14 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 	if httpAddr != "" {
 		envVars["PACKER_HTTP_ADDR"] = httpAddr
 	}
-	winRMPass, err := commonhelper.RetrieveSharedState("winrm_password")
-	// This shared state is only created by the amazon builder.
-	if err == nil {
-		envVars["AUTO_WINRM_PASSWORD"] = psEscape.Replace(winRMPass)
 
-	}
 	// interpolate environment variables
 	p.config.ctx.Data = &EnvVarsTemplate{
 		WinRMPassword: p.getWinRMPassword(),
 	}
 	// Split vars into key/value components
 	for _, envVar := range p.config.Vars {
-		envVar, err = interpolate.Render(envVar, &p.config.ctx)
+		envVar, err := interpolate.Render(envVar, &p.config.ctx)
 		if err != nil {
 			return
 		}

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -80,7 +80,11 @@ Optional parameters:
     as an environment variable. For example:
 
     ```json
-    "environment_vars": "WINRMPASS={{.WinRMPassword}}",
+      {
+        "type": "powershell",
+        "environment_vars": "WINRMPASS={{.WinRMPassword}}",
+        "inline": ["Write-Host \"Automatically generated aws password is: $Env:WINRMPASS\""]
+      },
     ```
 
 -   `execute_command` (string) - The command to use to execute the script. By

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -72,7 +72,16 @@ Optional parameters:
 -   `environment_vars` (array of strings) - An array of key/value pairs to
     inject prior to the execute\_command. The format should be `key=value`.
     Packer injects some environmental variables by default into the
-    environment, as well, which are covered in the section below.
+    environment, as well, which are covered in the section below. If you are
+    using AWS and would like to use the randomly-generated unique
+    If you are running on AWS and would like to access the AWS-generated
+    Administrator password that Packer uses to connect to the instance via
+    WinRM, you can use the template variable `{{.WinRMPassword}}` to set this
+    as an environment variable. For example:
+
+    ```json
+    "environment_vars": "WINRMPASS={{.WinRMPassword}}",
+    ```
 
 -   `execute_command` (string) - The command to use to execute the script. By
     default this is as follows:
@@ -89,7 +98,15 @@ Optional parameters:
 
 -   `elevated_user` and `elevated_password` (string) - If specified, the
     PowerShell script will be run with elevated privileges using the given
-    Windows user.
+    Windows user. If you are running a build on AWS and would like to run using
+    the AWS-generated password that Packer uses to connect to the instance via,
+    WinRM, you may do so by using the template variable {{.WinRMPassword}}.
+    For example:
+
+    ``` json
+    "elevated_user": "Administrator",
+    "elevated_password": "{{.WinRMPassword}}",
+    ```
 
 -   `remote_path` (string) - The path where the script will be uploaded to in
     the machine. This defaults to "c:/Windows/Temp/script.ps1". This value must


### PR DESCRIPTION
WIP: do not merge.

Packer allows AWS windows users to connect via winRM using the dynamically-generated Administrator password that AWS provides.  

This PR creates a new environment variable for the Powershell provisioner, AUTO_WINRM_PASSWORD, which the user can then access within their scripts. 

It also allows the user to run Powershell scripts with Elevated permissions, using the Administrator user and the dynamically-generated winRM password, by setting "elevated_password":".AUTO_WINRM_PASSWORD" in their config.

This is clunkier than I'd like; I'd hoped to set the variables using the template syntax `{{.WinRMPassword}}` but the template is interpolated long before the winRM password is generated, making this approach invalid.

Starts to address #5895, but that issue won't be truly addressed until you can also access this variable from the shell-local provisioner. I have code in the works to deduplicate the shell-local provisioner and post-processor, which will enable the shell-local provisioner to set env vars the same way the post-processor does; that's probably a prerequisite for this final step in addressing #5895.