### PR TITLE
fix later commands overwriting earlier commands

### DIFF
--- a/builder/virtualbox/common/step_type_boot_command.go
+++ b/builder/virtualbox/common/step_type_boot_command.go
@@ -182,92 +182,92 @@ func scancodes(message string) []string {
 		var scancode []string
 
 		if strings.HasPrefix(message, "<leftAltOn>") {
-			scancode = []string{"38"}
+			scancode = append(scancode, "38")
 			message = message[len("<leftAltOn>"):]
 			log.Printf("Special code '<leftAltOn>' found, replacing with: 38")
 		}
 
 		if strings.HasPrefix(message, "<leftCtrlOn>") {
-			scancode = []string{"1d"}
+			scancode = append(scancode, "1d")
 			message = message[len("<leftCtrlOn>"):]
 			log.Printf("Special code '<leftCtrlOn>' found, replacing with: 1d")
 		}
 
 		if strings.HasPrefix(message, "<leftShiftOn>") {
-			scancode = []string{"2a"}
+			scancode = append(scancode, "2a")
 			message = message[len("<leftShiftOn>"):]
 			log.Printf("Special code '<leftShiftOn>' found, replacing with: 2a")
 		}
 
 		if strings.HasPrefix(message, "<leftAltOff>") {
-			scancode = []string{"b8"}
+			scancode = append(scancode, "b8")
 			message = message[len("<leftAltOff>"):]
 			log.Printf("Special code '<leftAltOff>' found, replacing with: b8")
 		}
 
 		if strings.HasPrefix(message, "<leftCtrlOff>") {
-			scancode = []string{"9d"}
+			scancode = append(scancode, "9d")
 			message = message[len("<leftCtrlOff>"):]
 			log.Printf("Special code '<leftCtrlOff>' found, replacing with: 9d")
 		}
 
 		if strings.HasPrefix(message, "<leftShiftOff>") {
-			scancode = []string{"aa"}
+			scancode = append(scancode, "aa")
 			message = message[len("<leftShiftOff>"):]
 			log.Printf("Special code '<leftShiftOff>' found, replacing with: aa")
 		}
 
 		if strings.HasPrefix(message, "<rightAltOn>") {
-			scancode = []string{"e038"}
+			scancode = append(scancode, "e038")
 			message = message[len("<rightAltOn>"):]
 			log.Printf("Special code '<rightAltOn>' found, replacing with: e038")
 		}
 
 		if strings.HasPrefix(message, "<rightCtrlOn>") {
-			scancode = []string{"e01d"}
+			scancode = append(scancode, "e01d")
 			message = message[len("<rightCtrlOn>"):]
 			log.Printf("Special code '<rightCtrlOn>' found, replacing with: e01d")
 		}
 
 		if strings.HasPrefix(message, "<rightShiftOn>") {
-			scancode = []string{"36"}
+			scancode = append(scancode, "36")
 			message = message[len("<rightShiftOn>"):]
 			log.Printf("Special code '<rightShiftOn>' found, replacing with: 36")
 		}
 
 		if strings.HasPrefix(message, "<rightAltOff>") {
-			scancode = []string{"e0b8"}
+			scancode = append(scancode, "e0b8")
 			message = message[len("<rightAltOff>"):]
 			log.Printf("Special code '<rightAltOff>' found, replacing with: e0b8")
 		}
 
 		if strings.HasPrefix(message, "<rightCtrlOff>") {
-			scancode = []string{"e09d"}
+			scancode = append(scancode, "e09d")
 			message = message[len("<rightCtrlOff>"):]
 			log.Printf("Special code '<rightCtrlOff>' found, replacing with: e09d")
 		}
 
 		if strings.HasPrefix(message, "<rightShiftOff>") {
-			scancode = []string{"b6"}
+			scancode = append(scancode, "b6")
 			message = message[len("<rightShiftOff>"):]
 			log.Printf("Special code '<rightShiftOff>' found, replacing with: b6")
 		}
 
 		if strings.HasPrefix(message, "<wait>") {
 			log.Printf("Special code <wait> found, will sleep 1 second at this point.")
-			scancode = []string{"wait"}
+			scancode = append(scancode, "wait")
 			message = message[len("<wait>"):]
 		}
 
 		if strings.HasPrefix(message, "<wait5>") {
 			log.Printf("Special code <wait5> found, will sleep 5 seconds at this point.")
-			scancode = []string{"wait5"}
+			scancode = append(scancode, "wait5")
 			message = message[len("<wait5>"):]
 		}
 
 		if strings.HasPrefix(message, "<wait10>") {
 			log.Printf("Special code <wait10> found, will sleep 10 seconds at this point.")
-			scancode = []string{"wait10"}
+			scancode = append(scancode, "wait10")
 			message = message[len("<wait10>"):]
 		}
 
@@ -275,7 +275,7 @@ func scancodes(message string) []string {
 			for specialCode, specialValue := range special {
 				if strings.HasPrefix(message, specialCode) {
 					log.Printf("Special code '%s' found, replacing with: %s", specialCode, specialValue)
-					scancode = specialValue
+					scancode = append(scancode, specialValue...)
 					message = message[len(specialCode):]
 					break
 				}


### PR DESCRIPTION
Prevent later commands like `wait` from wiping out any earlier commands like `<leftAltOff>`.

Closes #6001