### PR TITLE
azure: support concurrent deployments in the same resource group

### DIFF
--- a/builder/azure/arm/TestVirtualMachineDeployment05.approved.txt
+++ b/builder/azure/arm/TestVirtualMachineDeployment05.approved.txt
@@ -105,8 +105,6 @@
     "addressPrefix": "10.0.0.0/16",
     "apiVersion": "2015-06-15",
     "location": "[resourceGroup().location]",
-    "nicName": "packerNic",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -29,11 +29,9 @@ type Builder struct {
 }
 
 const (
-	DefaultNicName             = "packerNic"
-	DefaultPublicIPAddressName = "packerPublicIP"
-	DefaultSasBlobContainer    = "system/Microsoft.Compute"
-	DefaultSasBlobPermission   = "r"
-	DefaultSecretName          = "packerKeyVaultSecret"
+	DefaultSasBlobContainer  = "system/Microsoft.Compute"
+	DefaultSasBlobPermission = "r"
+	DefaultSecretName        = "packerKeyVaultSecret"
 )
 
 func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
@@ -303,8 +301,8 @@ func (b *Builder) configureStateBag(stateBag multistep.StateBag) {
 		stateBag.Put(constants.ArmKeyVaultDeploymentName, fmt.Sprintf("kv%s", b.config.tmpDeploymentName))
 	}
 	stateBag.Put(constants.ArmKeyVaultName, b.config.tmpKeyVaultName)
-	stateBag.Put(constants.ArmNicName, DefaultNicName)
-	stateBag.Put(constants.ArmPublicIPAddressName, DefaultPublicIPAddressName)
+	stateBag.Put(constants.ArmNicName, b.config.tmpNicName)
+	stateBag.Put(constants.ArmPublicIPAddressName, b.config.tmpPublicIPAddressName)
 	if b.config.TempResourceGroupName != "" && b.config.BuildResourceGroupName != "" {
 		stateBag.Put(constants.ArmDoubleResourceGroupNameSet, true)
 	}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -130,9 +130,13 @@ type Config struct {
 	tmpCertificatePassword string
 	tmpResourceGroupName   string
 	tmpComputeName         string
+	tmpNicName             string
+	tmpPublicIPAddressName string
 	tmpDeploymentName      string
 	tmpKeyVaultName        string
 	tmpOSDiskName          string
+	tmpSubnetName          string
+	tmpVirtualNetworkName  string
 	tmpWinRMCertificateUrl string
 
 	useDeviceLogin bool
@@ -366,7 +370,11 @@ func setRuntimeValues(c *Config) {
 	} else if c.TempResourceGroupName != "" && c.BuildResourceGroupName == "" {
 		c.tmpResourceGroupName = c.TempResourceGroupName
 	}
+	c.tmpNicName = tempName.NicName
+	c.tmpPublicIPAddressName = tempName.PublicIPAddressName
 	c.tmpOSDiskName = tempName.OSDiskName
+	c.tmpSubnetName = tempName.SubnetName
+	c.tmpVirtualNetworkName = tempName.VirtualNetworkName
 	c.tmpKeyVaultName = tempName.KeyVaultName
 }
 

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -34,13 +34,20 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 		AdminUsername:              &template.TemplateParameter{Value: config.UserName},
 		AdminPassword:              &template.TemplateParameter{Value: config.Password},
 		DnsNameForPublicIP:         &template.TemplateParameter{Value: config.tmpComputeName},
+		NicName:                    &template.TemplateParameter{Value: config.tmpNicName},
 		OSDiskName:                 &template.TemplateParameter{Value: config.tmpOSDiskName},
+		PublicIPAddressName:        &template.TemplateParameter{Value: config.tmpPublicIPAddressName},
+		SubnetName:                 &template.TemplateParameter{Value: config.tmpSubnetName},
 		StorageAccountBlobEndpoint: &template.TemplateParameter{Value: config.storageAccountBlobEndpoint},
-		VMSize: &template.TemplateParameter{Value: config.VMSize},
-		VMName: &template.TemplateParameter{Value: config.tmpComputeName},
+		VirtualNetworkName:         &template.TemplateParameter{Value: config.tmpVirtualNetworkName},
+		VMSize:                     &template.TemplateParameter{Value: config.VMSize},
+		VMName:                     &template.TemplateParameter{Value: config.tmpComputeName},
 	}
 
-	builder, _ := template.NewTemplateBuilder(template.BasicTemplate)
+	builder, err := template.NewTemplateBuilder(template.BasicTemplate)
+	if err != nil {
+		return nil, err
+	}
 	osType := compute.Linux
 
 	switch config.OSType {

--- a/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -73,11 +85,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -85,7 +97,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -105,7 +117,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -126,7 +138,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -177,15 +189,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -75,11 +87,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -87,7 +99,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -108,7 +120,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -130,7 +142,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -182,15 +194,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment03.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment03.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -148,15 +160,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -146,15 +158,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment05.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment05.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -29,7 +41,7 @@
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -48,7 +60,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -64,7 +76,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -107,9 +119,7 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -71,11 +83,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -83,7 +95,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -102,7 +114,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -118,7 +130,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -166,15 +178,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment07.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment07.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -147,15 +159,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -146,15 +158,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment09.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment09.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -149,15 +161,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -40,10 +52,10 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -51,7 +63,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -65,7 +77,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -81,7 +93,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -127,9 +139,7 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -160,15 +172,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -161,15 +173,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/arm/tempname.go
+++ b/builder/azure/arm/tempname.go
@@ -19,6 +19,10 @@ type TempName struct {
 	KeyVaultName        string
 	ResourceGroupName   string
 	OSDiskName          string
+	NicName             string
+	SubnetName          string
+	PublicIPAddressName string
+	VirtualNetworkName  string
 }
 
 func NewTempName() *TempName {
@@ -29,6 +33,10 @@ func NewTempName() *TempName {
 	tempName.DeploymentName = fmt.Sprintf("pkrdp%s", suffix)
 	tempName.KeyVaultName = fmt.Sprintf("pkrkv%s", suffix)
 	tempName.OSDiskName = fmt.Sprintf("pkros%s", suffix)
+	tempName.NicName = fmt.Sprintf("pkrni%s", suffix)
+	tempName.PublicIPAddressName = fmt.Sprintf("pkrip%s", suffix)
+	tempName.SubnetName = fmt.Sprintf("pkrsn%s", suffix)
+	tempName.VirtualNetworkName = fmt.Sprintf("pkrvn%s", suffix)
 	tempName.ResourceGroupName = fmt.Sprintf("packer-Resource-Group-%s", suffix)
 
 	tempName.AdminPassword = common.RandomString(TempPasswordAlphabet, 32)

--- a/builder/azure/arm/tempname_test.go
+++ b/builder/azure/arm/tempname_test.go
@@ -20,14 +20,34 @@ func TestTempNameShouldCreatePrefixedRandomNames(t *testing.T) {
 		t.Errorf("Expected OSDiskName to begin with 'pkros', but got '%s'!", tempName.OSDiskName)
 	}
 
+	if strings.Index(tempName.NicName, "pkrni") != 0 {
+		t.Errorf("Expected NicName to begin with 'pkrni', but got '%s'!", tempName.NicName)
+	}
+
+	if strings.Index(tempName.PublicIPAddressName, "pkrip") != 0 {
+		t.Errorf("Expected PublicIPAddressName to begin with 'pkrip', but got '%s'!", tempName.PublicIPAddressName)
+	}
+
 	if strings.Index(tempName.ResourceGroupName, "packer-Resource-Group-") != 0 {
 		t.Errorf("Expected ResourceGroupName to begin with 'packer-Resource-Group-', but got '%s'!", tempName.ResourceGroupName)
+	}
+
+	if strings.Index(tempName.SubnetName, "pkrsn") != 0 {
+		t.Errorf("Expected SubnetName to begin with 'pkrip', but got '%s'!", tempName.SubnetName)
+	}
+
+	if strings.Index(tempName.VirtualNetworkName, "pkrvn") != 0 {
+		t.Errorf("Expected VirtualNetworkName to begin with 'pkrvn', but got '%s'!", tempName.VirtualNetworkName)
 	}
 }
 
 func TestTempNameShouldHaveSameSuffix(t *testing.T) {
 	tempName := NewTempName()
 	suffix := tempName.ComputeName[5:]
+
+	if strings.HasSuffix(tempName.ComputeName, suffix) != true {
+		t.Errorf("Expected ComputeName to end with '%s', but the value is '%s'!", suffix, tempName.ComputeName)
+	}
 
 	if strings.HasSuffix(tempName.DeploymentName, suffix) != true {
 		t.Errorf("Expected DeploymentName to end with '%s', but the value is '%s'!", suffix, tempName.DeploymentName)
@@ -37,8 +57,23 @@ func TestTempNameShouldHaveSameSuffix(t *testing.T) {
 		t.Errorf("Expected OSDiskName to end with '%s', but the value is '%s'!", suffix, tempName.OSDiskName)
 	}
 
+	if strings.HasSuffix(tempName.NicName, suffix) != true {
+		t.Errorf("Expected NicName to end with '%s', but the value is '%s'!", suffix, tempName.PublicIPAddressName)
+	}
+
+	if strings.HasSuffix(tempName.PublicIPAddressName, suffix) != true {
+		t.Errorf("Expected PublicIPAddressName to end with '%s', but the value is '%s'!", suffix, tempName.PublicIPAddressName)
+	}
+
 	if strings.HasSuffix(tempName.ResourceGroupName, suffix) != true {
 		t.Errorf("Expected ResourceGroupName to end with '%s', but the value is '%s'!", suffix, tempName.ResourceGroupName)
 	}
 
+	if strings.HasSuffix(tempName.SubnetName, suffix) != true {
+		t.Errorf("Expected SubnetName to end with '%s', but the value is '%s'!", suffix, tempName.SubnetName)
+	}
+
+	if strings.HasSuffix(tempName.VirtualNetworkName, suffix) != true {
+		t.Errorf("Expected VirtualNetworkName to end with '%s', but the value is '%s'!", suffix, tempName.VirtualNetworkName)
+	}
 }

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -461,12 +461,24 @@ const BasicTemplate = `{
     "dnsNameForPublicIP": {
       "type": "string"
     },
+	"nicName": {
+      "type": "string"
+	},
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+	},
+	"subnetName": {
+      "type": "string"
+	},
     "storageAccountBlobEndpoint": {
       "type": "string"
     },
+	"virtualNetworkName": {
+      "type": "string"
+	},
     "vmSize": {
       "type": "string"
     },
@@ -482,14 +494,12 @@ const BasicTemplate = `{
     "publicIPAddressApiVersion": "2017-04-01",
     "virtualNetworksApiVersion": "2017-04-01",
     "location": "[resourceGroup().location]",
-    "nicName": "packerNic",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetAddressPrefix": "10.0.0.0/24",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "vmStorageAccountContainerName": "images",
     "vnetID": "[resourceId(variables('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
@@ -498,7 +508,7 @@ const BasicTemplate = `{
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "location": "[variables('location')]",
       "properties": {
         "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
@@ -531,10 +541,10 @@ const BasicTemplate = `{
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "location": "[variables('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "properties": {
@@ -544,7 +554,7 @@ const BasicTemplate = `{
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -560,7 +570,7 @@ const BasicTemplate = `{
       "name": "[parameters('vmName')]",
       "location": "[variables('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "properties": {
         "hardwareProfile": {
@@ -584,7 +594,7 @@ const BasicTemplate = `{
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux00.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -148,15 +160,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux01.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux01.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -146,15 +158,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -29,7 +41,7 @@
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -48,7 +60,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -64,7 +76,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -108,9 +120,7 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows00.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -162,15 +174,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows01.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows01.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -185,15 +197,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
@@ -11,10 +11,22 @@
     "dnsNameForPublicIP": {
       "type": "string"
     },
+    "nicName": {
+      "type": "string"
+    },
     "osDiskName": {
       "type": "string"
     },
+    "publicIPAddressName": {
+      "type": "string"
+    },
     "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
       "type": "string"
     },
     "vmName": {
@@ -28,7 +40,7 @@
     {
       "apiVersion": "[variables('publicIPAddressApiVersion')]",
       "location": "[variables('location')]",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "properties": {
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
@@ -61,11 +73,11 @@
     {
       "apiVersion": "[variables('networkInterfacesApiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "location": "[variables('location')]",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "properties": {
         "ipConfigurations": [
           {
@@ -73,7 +85,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -87,7 +99,7 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "location": "[variables('location')]",
       "name": "[parameters('vmName')]",
@@ -103,7 +115,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             }
           ]
         },
@@ -178,15 +190,13 @@
     "location": "[resourceGroup().location]",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
-    "nicName": "packerNic",
     "publicIPAddressApiVersion": "2017-04-01",
-    "publicIPAddressName": "packerPublicIP",
     "publicIPAddressType": "Dynamic",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "subnetAddressPrefix": "10.0.0.0/24",
-    "subnetName": "packerSubnet",
+    "subnetName": "[parameters('subnetName')]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "virtualNetworkName": "packerNetwork",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "virtualNetworkResourceGroup": "[resourceGroup().name]",
     "virtualNetworksApiVersion": "2017-04-01",
     "vmStorageAccountContainerName": "images",

--- a/builder/azure/common/template/template_parameters.go
+++ b/builder/azure/common/template/template_parameters.go
@@ -24,9 +24,13 @@ type TemplateParameters struct {
 	KeyVaultName               *TemplateParameter `json:"keyVaultName,omitempty"`
 	KeyVaultSecretValue        *TemplateParameter `json:"keyVaultSecretValue,omitempty"`
 	ObjectId                   *TemplateParameter `json:"objectId,omitempty"`
+	NicName                    *TemplateParameter `json:"nicName,omitempty"`
 	OSDiskName                 *TemplateParameter `json:"osDiskName,omitempty"`
+	PublicIPAddressName        *TemplateParameter `json:"publicIPAddressName,omitempty"`
 	StorageAccountBlobEndpoint *TemplateParameter `json:"storageAccountBlobEndpoint,omitempty"`
+	SubnetName                 *TemplateParameter `json:"subnetName,omitempty"`
 	TenantId                   *TemplateParameter `json:"tenantId,omitempty"`
+	VirtualNetworkName         *TemplateParameter `json:"virtualNetworkName,omitempty"`
 	VMSize                     *TemplateParameter `json:"vmSize,omitempty"`
 	VMName                     *TemplateParameter `json:"vmName,omitempty"`
 }

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -374,9 +374,13 @@ The Azure builder creates the following random values at runtime.
 -   Compute Name: a random 15-character name prefixed with pkrvm; the name of the VM.
 -   Deployment Name: a random 15-character name prefixed with pkfdp; the name of the deployment.
 -   KeyVault Name: a random 15-character name prefixed with pkrkv.
+-   NIC Name: a random 15-character name prefixed with pkrni.
+-   Public IP Name: a random 15-character name prefixed with pkrip.
 -   OS Disk Name: a random 15-character name prefixed with pkros.
 -   Resource Group Name: a random 33-character name prefixed with packer-Resource-Group-.
+-   Subnet Name: a random 15-character name prefixed with pkrsn.
 -   SSH Key Pair: a 2,048-bit asymmetric key pair; can be overridden by the user.
+-   Virtual Network Name: a random 15-character name prefixed with pkrvn.
 
 The default alphabet used for random values is **0123456789bcdfghjklmnpqrstvwxyz**. The alphabet was reduced (no
 vowels) to prevent running afoul of Azure decency controls.


### PR DESCRIPTION
The Azure builder hard coded the NIC, Virtual Network, Subnet, and Public IP address name so concurrent builds in the same resource group were not supported.  These names are not randomized to support concurrency.

Closes #5659 