### PR TITLE
Nest the additional field of `ami_root_device`

### DIFF
--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -55,9 +55,9 @@ builder.
     the root device of the AMI. This looks like the mappings in `ami_block_device_mapping`,
     except with an additional field:
 
--   `source_device_name` (string) - The device name of the block device on the
-    source instance to be used as the root device for the AMI. This must correspond
-    to a block device in `launch_block_device_mapping`.
+    -   `source_device_name` (string) - The device name of the block device on the
+        source instance to be used as the root device for the AMI. This must correspond
+        to a block device in `launch_block_device_mapping`.
 
 ### Optional:
 


### PR DESCRIPTION
The additional field of `ami_root_device` was not nested and as a result looked like an independent required option.
