### PR TITLE
Update the deprecation date

### DIFF
--- a/website/source/docs/commands/push.html.md
+++ b/website/source/docs/commands/push.html.md
@@ -10,8 +10,8 @@ sidebar_current: 'docs-commands-push'
 # `push` Command
 
 !&gt; The Packer and Artifact Registry features of Atlas will no longer be
-actively developed or maintained and will be fully decommissioned on Friday,
-March 30, 2018. Please see our [guide on building immutable infrastructure with
+actively developed or maintained and will be fully decommissioned on Thursday,
+May 31, 2018. Please see our [guide on building immutable infrastructure with
 Packer on CI/CD](/guides/packer-on-cicd/) for ideas on implementing these
 features yourself.
 

--- a/website/source/docs/commands/push.html.md
+++ b/website/source/docs/commands/push.html.md
@@ -10,8 +10,8 @@ sidebar_current: 'docs-commands-push'
 # `push` Command
 
 !&gt; The Packer and Artifact Registry features of Atlas will no longer be
-actively developed or maintained and will be fully decommissioned on Thursday,
-May 31, 2018. Please see our [guide on building immutable infrastructure with
+actively developed or maintained and will be fully decommissioned.
+Please see our [guide on building immutable infrastructure with
 Packer on CI/CD](/guides/packer-on-cicd/) for ideas on implementing these
 features yourself.
 

--- a/website/source/docs/post-processors/atlas.html.md
+++ b/website/source/docs/post-processors/atlas.html.md
@@ -11,8 +11,8 @@ sidebar_current: 'docs-post-processors-atlas'
 # Atlas Post-Processor
 
 !&gt; The Packer and Artifact Registry features of Atlas will no longer be
-actively developed or maintained and will be fully decommissioned on Thursday,
-May 31, 2018. Please see our [guide on building immutable infrastructure with
+actively developed or maintained and will be fully decommissioned.
+Please see our [guide on building immutable infrastructure with
 Packer on CI/CD](/guides/packer-on-cicd/) for ideas on implementing these
 features yourself.
 

--- a/website/source/docs/post-processors/atlas.html.md
+++ b/website/source/docs/post-processors/atlas.html.md
@@ -11,8 +11,8 @@ sidebar_current: 'docs-post-processors-atlas'
 # Atlas Post-Processor
 
 !&gt; The Packer and Artifact Registry features of Atlas will no longer be
-actively developed or maintained and will be fully decommissioned on Friday,
-March 30, 2018. Please see our [guide on building immutable infrastructure with
+actively developed or maintained and will be fully decommissioned on Thursday,
+May 31, 2018. Please see our [guide on building immutable infrastructure with
 Packer on CI/CD](/guides/packer-on-cicd/) for ideas on implementing these
 features yourself.
 

--- a/website/source/docs/templates/push.html.md
+++ b/website/source/docs/templates/push.html.md
@@ -10,8 +10,8 @@ sidebar_current: 'docs-templates-push'
 # Template Push
 
 !&gt; The Packer and Artifact Registry features of Atlas will no longer be
-actively developed or maintained and will be fully decommissioned on Friday,
-March 30, 2018. Please see our [guide on building immutable infrastructure with
+actively developed or maintained and will be fully decommissioned on Thursday,
+May 31, 2018. Please see our [guide on building immutable infrastructure with
 Packer on CI/CD](/guides/packer-on-cicd/) for ideas on implementing these
 features yourself.
 

--- a/website/source/docs/templates/push.html.md
+++ b/website/source/docs/templates/push.html.md
@@ -10,8 +10,8 @@ sidebar_current: 'docs-templates-push'
 # Template Push
 
 !&gt; The Packer and Artifact Registry features of Atlas will no longer be
-actively developed or maintained and will be fully decommissioned on Thursday,
-May 31, 2018. Please see our [guide on building immutable infrastructure with
+actively developed or maintained and will be fully decommissioned.
+Please see our [guide on building immutable infrastructure with
 Packer on CI/CD](/guides/packer-on-cicd/) for ideas on implementing these
 features yourself.
 


### PR DESCRIPTION
This updates the notifications on the doc website with the updated deprecation date, which is now May 31st instead of March 30th,