### PR TITLE
Fix aws credentials

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -96,7 +96,7 @@ func (c *AccessConfig) Session() (*session.Session, error) {
 
 	creds := credentials.NewChainCredentials(providers)
 
-	config := aws.NewConfig().WithMaxRetries(11).WithCredentialsChainVerboseErrors(true)
+	config := aws.NewConfig().WithCredentialsChainVerboseErrors(true)
 
 	if c.RawRegion != "" {
 		config = config.WithRegion(c.RawRegion)

--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -123,14 +123,6 @@ This is a preferred approach over any other when running in EC2 as you can
 avoid hard coding credentials. Instead these are leased on-the-fly by Packer,
 which reduces the chance of leakage.
 
-The default deadline for the EC2 metadata API endpoint is 100 milliseconds,
-which can be overidden by setting the `AWS_METADATA_TIMEOUT` environment
-variable. The variable expects a positive golang Time.Duration string, which is
-a sequence of decimal numbers and a unit suffix; valid suffixes are `ns`
-(nanoseconds), `us` (microseconds), `ms` (milliseconds), `s` (seconds), `m`
-(minutes), and `h` (hours). Examples of valid inputs: `100ms`, `250ms`, `1s`,
-`2.5s`, `2.5m`, `1m30s`.
-
 The following policy document provides the minimal set permissions necessary
 for Packer to work:
 


### PR DESCRIPTION
Fixes #5976, fixes #5954


I think this will fix #5986 but need to verify.

Unfortunately in an attempt to get assume role working, I moved the `WithCredentials` call below where it would have had any effect. This allowed the SDK's default behavior to kick in, which fixed assume role, but had the unintended side-effect of breaking everything else.

This deprecates the skip_metadata_api_check option, but I don't think it's necessary. Happy to hear comments about this