### PR TITLE
Adding details to PACKER_BUILD_NAME to have it clear in the documentation how the variable is created

### DIFF
--- a/website/source/docs/post-processors/shell-local.html.md
+++ b/website/source/docs/post-processors/shell-local.html.md
@@ -82,7 +82,8 @@ In addition to being able to specify custom environmental variables using the
 `environment_vars` configuration, the provisioner automatically defines certain
 commonly useful environmental variables:
 
--   `PACKER_BUILD_NAME` is set to the name of the build that Packer is running.
+-   `PACKER_BUILD_NAME` is set to the
+    [name of the build](/docs/templates/builders.html#named-builds) that Packer is running.
     This is most useful when Packer is making multiple builds and you want to
     distinguish them slightly from a common provisioning script.
 

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -110,7 +110,8 @@ In addition to being able to specify custom environmental variables using the
 `environment_vars` configuration, the provisioner automatically defines certain
 commonly useful environmental variables:
 
--   `PACKER_BUILD_NAME` is set to the name of the build that Packer is running.
+-   `PACKER_BUILD_NAME` is set to the
+    [name of the build](/docs/templates/builders.html#named-builds) that Packer is running.
     This is most useful when Packer is making multiple builds and you want to
     distinguish them slightly from a common provisioning script.
 

--- a/website/source/docs/provisioners/shell.html.md
+++ b/website/source/docs/provisioners/shell.html.md
@@ -150,7 +150,8 @@ In addition to being able to specify custom environmental variables using the
 `environment_vars` configuration, the provisioner automatically defines certain
 commonly useful environmental variables:
 
--   `PACKER_BUILD_NAME` is set to the name of the build that Packer is running.
+-   `PACKER_BUILD_NAME` is set to the
+    [name of the build](/docs/templates/builders.html#named-builds) that Packer is running.
     This is most useful when Packer is making multiple builds and you want to
     distinguish them slightly from a common provisioning script.
 

--- a/website/source/docs/provisioners/windows-shell.html.md
+++ b/website/source/docs/provisioners/windows-shell.html.md
@@ -81,7 +81,8 @@ In addition to being able to specify custom environmental variables using the
 `environment_vars` configuration, the provisioner automatically defines certain
 commonly useful environmental variables:
 
--   `PACKER_BUILD_NAME` is set to the name of the build that Packer is running.
+-   `PACKER_BUILD_NAME` is set to the
+    [name of the build](/docs/templates/builders.html#named-builds) that Packer is running.
     This is most useful when Packer is making multiple builds and you want to
     distinguish them slightly from a common provisioning script.
 


### PR DESCRIPTION
Adding details to `PACKER_BUILD_NAME` to have it clear in the documentation how the variable is created.

It's not clear from the section about `PACKER_BUILD_NAME` ...

Prevents from creating bugs like: #6016 