### PR TITLE
change builderid for vmware to hashicorp.vmware

### DIFF
--- a/builder/vmware/common/artifact.go
+++ b/builder/vmware/common/artifact.go
@@ -9,7 +9,7 @@ import (
 )
 
 // BuilderId for the local artifacts
-const BuilderId = "mitchellh.vmware"
+const BuilderId = "hashicorp.vmware"
 
 // Artifact is the result of running the VMware builder, namely a set
 // of files associated with the resulting machine.


### PR DESCRIPTION
change the builderid for vmware to hashicorp.vmware

Test: 

go generate .
2018/03/20 19:24:41 Generated command/plugin.go
gofmt -w command/plugin.go
WARN: Acceptance tests will take a long time to run and may cost money. Ctrl-C if you want to cancel.
PACKER_ACC=1 go test -v ./builder/vmware/common/  -timeout=45m
=== RUN   TestLocalArtifact_impl
--- PASS: TestLocalArtifact_impl (0.00s)
=== RUN   TestNewLocalArtifact
--- PASS: TestNewLocalArtifact (0.00s)
=== RUN   TestDriverConfigPrepare
--- PASS: TestDriverConfigPrepare (0.00s)
=== RUN   TestDriverMock_impl
--- PASS: TestDriverMock_impl (0.00s)
=== RUN   TestWorkstationVersion_ws14
2018/03/20 19:24:42 Detected VMware WS version: 14
--- PASS: TestWorkstationVersion_ws14 (0.00s)
=== RUN   TestOutputConfigPrepare
--- PASS: TestOutputConfigPrepare (0.00s)
=== RUN   TestLocalOutputDir_impl
--- PASS: TestLocalOutputDir_impl (0.00s)
=== RUN   TestRunConfigPrepare
--- PASS: TestRunConfigPrepare (0.00s)
=== RUN   TestShutdownConfigPrepare_ShutdownCommand
--- PASS: TestShutdownConfigPrepare_ShutdownCommand (0.00s)
=== RUN   TestShutdownConfigPrepare_ShutdownTimeout
--- PASS: TestShutdownConfigPrepare_ShutdownTimeout (0.00s)
=== RUN   TestSSHConfigPrepare
--- PASS: TestSSHConfigPrepare (0.00s)
=== RUN   TestSSHConfigPrepare_SSHPrivateKey
--- PASS: TestSSHConfigPrepare_SSHPrivateKey (0.00s)
=== RUN   TestStepCleanVMX_impl
--- PASS: TestStepCleanVMX_impl (0.00s)
=== RUN   TestStepCleanVMX
2018/03/20 19:24:42 ui: Cleaning VMX prior to finishing up...
2018/03/20 19:24:42 ui: Unmounting floppy from VMX...
2018/03/20 19:24:42 Writing VMX to: /tmp/packer154761188
--- PASS: TestStepCleanVMX (0.00s)
=== RUN   TestStepCleanVMX_floppyPath
2018/03/20 19:24:42 ui: Cleaning VMX prior to finishing up...
2018/03/20 19:24:42 ui: Unmounting floppy from VMX...
2018/03/20 19:24:42 Deleting key: floppy0.present
2018/03/20 19:24:42 Deleting key: floppy0.filetype
2018/03/20 19:24:42 Writing VMX to: /tmp/packer705914355
--- PASS: TestStepCleanVMX_floppyPath (0.00s)
=== RUN   TestStepCleanVMX_isoPath
2018/03/20 19:24:42 ui: Cleaning VMX prior to finishing up...
2018/03/20 19:24:42 ui: Unmounting floppy from VMX...
2018/03/20 19:24:42 ui: Detaching ISO from CD-ROM device...
2018/03/20 19:24:42 Writing VMX to: /tmp/packer247788214
--- PASS: TestStepCleanVMX_isoPath (0.00s)
=== RUN   TestStepCleanVMX_ethernet
2018/03/20 19:24:42 ui: Cleaning VMX prior to finishing up...
2018/03/20 19:24:42 ui: Unmounting floppy from VMX...
2018/03/20 19:24:42 ui: Removing Ethernet Interfaces...
2018/03/20 19:24:42 Deleting key: ethernet0.addresstype
2018/03/20 19:24:42 Deleting key: ethernet0.bsdname
2018/03/20 19:24:42 Deleting key: ethernet0.connectiontype
2018/03/20 19:24:42 Deleting key: ethernet1.addresstype
2018/03/20 19:24:42 Deleting key: ethernet1.bsdname
2018/03/20 19:24:42 Deleting key: ethernet1.connectiontype
2018/03/20 19:24:42 Writing VMX to: /tmp/packer686410397
--- PASS: TestStepCleanVMX_ethernet (0.00s)
=== RUN   TestStepCompactDisk_impl
--- PASS: TestStepCompactDisk_impl (0.00s)
=== RUN   TestStepCompactDisk
2018/03/20 19:24:42 ui: Compacting the disk image
--- PASS: TestStepCompactDisk (0.00s)
=== RUN   TestStepCompactDisk_skip
2018/03/20 19:24:42 Skipping disk compaction step...
--- PASS: TestStepCompactDisk_skip (0.00s)
=== RUN   TestStepConfigureVMX_impl
--- PASS: TestStepConfigureVMX_impl (0.00s)
=== RUN   TestStepConfigureVMX
2018/03/20 19:24:42 Setting VMX: 'foo' = 'bar'
2018/03/20 19:24:42 Writing VMX to: /tmp/packer079888728
--- PASS: TestStepConfigureVMX (0.00s)
=== RUN   TestStepConfigureVMX_floppyPath
2018/03/20 19:24:42 Floppy path present, setting in VMX
2018/03/20 19:24:42 Writing VMX to: /tmp/packer150927575
--- PASS: TestStepConfigureVMX_floppyPath (0.00s)
=== RUN   TestStepConfigureVMX_generatedAddresses
2018/03/20 19:24:42 Writing VMX to: /tmp/packer717137994
2018/03/20 19:24:42 Writing VMX to: /tmp/packer717137994
--- PASS: TestStepConfigureVMX_generatedAddresses (0.00s)
=== RUN   TestStepConfigureVNC_implVNCAddressFinder
--- PASS: TestStepConfigureVNC_implVNCAddressFinder (0.00s)
=== RUN   TestStepConfigureVNC_UpdateVMX
--- PASS: TestStepConfigureVNC_UpdateVMX (0.00s)
=== RUN   TestStepOutputDir_impl
--- PASS: TestStepOutputDir_impl (0.00s)
=== RUN   TestStepOutputDir
--- PASS: TestStepOutputDir (0.00s)
=== RUN   TestStepOutputDir_existsNoForce
--- PASS: TestStepOutputDir_existsNoForce (0.00s)
=== RUN   TestStepOutputDir_existsForce
2018/03/20 19:24:42 ui: Deleting previous output directory...
--- PASS: TestStepOutputDir_existsForce (0.00s)
=== RUN   TestStepOutputDir_cancel
2018/03/20 19:24:42 ui: Deleting output directory...
--- PASS: TestStepOutputDir_cancel (0.00s)
=== RUN   TestStepOutputDir_halt
2018/03/20 19:24:42 ui: Deleting output directory...
--- PASS: TestStepOutputDir_halt (0.00s)
=== RUN   TestStepPrepareTools_impl
--- PASS: TestStepPrepareTools_impl (0.00s)
=== RUN   TestStepPrepareTools
--- PASS: TestStepPrepareTools (0.00s)
=== RUN   TestStepPrepareTools_esx5
--- PASS: TestStepPrepareTools_esx5 (0.00s)
=== RUN   TestStepPrepareTools_nonExist
--- PASS: TestStepPrepareTools_nonExist (0.00s)
=== RUN   TestStepRun_impl
--- PASS: TestStepRun_impl (0.00s)
=== RUN   TestStepRun
2018/03/20 19:24:42 ui: Starting virtual machine...
--- PASS: TestStepRun (0.00s)
=== RUN   TestStepRun_cleanupRunning
2018/03/20 19:24:42 ui: Starting virtual machine...
2018/03/20 19:24:42 ui: Stopping virtual machine...
--- PASS: TestStepRun_cleanupRunning (0.00s)
=== RUN   TestStepShutdown_impl
--- PASS: TestStepShutdown_impl (0.00s)
=== RUN   TestStepShutdown_command
2018/03/20 19:24:42 ui: Gracefully halting virtual machine...
2018/03/20 19:24:42 Executing shutdown command: foo
2018/03/20 19:24:42 Waiting max 10s for shutdown to complete
2018/03/20 19:24:42 ui: Waiting for VMware to clean up after itself...
2018/03/20 19:24:42 No more lock files found. VMware is clean.
2018/03/20 19:24:42 VM shut down.
--- PASS: TestStepShutdown_command (0.15s)
=== RUN   TestStepShutdown_noCommand
2018/03/20 19:24:42 ui: Forcibly halting virtual machine...
2018/03/20 19:24:42 ui: Waiting for VMware to clean up after itself...
2018/03/20 19:24:42 No more lock files found. VMware is clean.
2018/03/20 19:24:47 VM shut down.
--- PASS: TestStepShutdown_noCommand (5.00s)
=== RUN   TestStepShutdown_locks
2018/03/20 19:24:47 ui: Forcibly halting virtual machine...
2018/03/20 19:24:47 ui: Waiting for VMware to clean up after itself...
2018/03/20 19:24:47 Waiting on lock files: []string{"/tmp/packer212354281/nope.lck"}
2018/03/20 19:24:47 No more lock files found. VMware is clean.
2018/03/20 19:24:47 VM shut down.
--- PASS: TestStepShutdown_locks (0.15s)
=== RUN   TestStepSuppressMessages_impl
--- PASS: TestStepSuppressMessages_impl (0.00s)
=== RUN   TestStepSuppressMessages
2018/03/20 19:24:47 Suppressing messages in VMX
--- PASS: TestStepSuppressMessages (0.00s)
=== RUN   TestVMXConfigPrepare
--- PASS: TestVMXConfigPrepare (0.00s)
=== RUN   TestParseVMX
--- PASS: TestParseVMX (0.00s)
=== RUN   TestEncodeVMX
--- PASS: TestEncodeVMX (0.00s)
PASS
ok  	github.com/hashicorp/packer/builder/vmware/common	5.312s
