### PR TITLE
add clarity to error message in vsphere-template postprocessor

### DIFF
--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -89,7 +89,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
 	if _, ok := builtins[artifact.BuilderId()]; !ok {
-		return nil, false, fmt.Errorf("Unknown artifact type, can't build box: %s", artifact.BuilderId())
+		return nil, false, fmt.Errorf("The Packer vSphere Template post-processor "+
+			"can only take an artifact from the VMware-iso builder, built on "+
+			"ESXi (i.e. remote) or an artifact from the vSphere post-processor. "+
+			"Artifact type %s does not fit this requirement", artifact.BuilderId())
 	}
 
 	f := artifact.State(iso.ArtifactConfFormat)


### PR DESCRIPTION
Make error message clearer when a user attempts to use the vSphere-template post-processor with a non-vSphere builder. This new error message mirrors the language in the docs.

Closes #6027 