### PR TITLE
[WIP] LXD fixes and feature requests

### DIFF
--- a/builder/lxd/step_lxd_launch.go
+++ b/builder/lxd/step_lxd_launch.go
@@ -3,6 +3,7 @@ package lxd
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -17,22 +18,35 @@ func (s *stepLxdLaunch) Run(_ context.Context, state multistep.StateBag) multist
 
 	name := config.ContainerName
 	image := config.Image
+	profile := fmt.Sprintf("--profile=%s", config.Profile)
 
-	args := []string{
-		"launch", "--ephemeral=false", image, name,
+	launch_args := []string{
+		"launch", "--ephemeral=false", profile, image, name,
+	}
+
+	for k, v := range config.LaunchConfig {
+		launch_args = append(launch_args, fmt.Sprintf("--config %s=%s", k, v))
 	}
 
 	ui.Say("Creating container...")
-	_, err := LXDCommand(args...)
+	_, err := LXDCommand(launch_args...)
 	if err != nil {
 		err := fmt.Errorf("Error creating container: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
+	sleep_seconds, err := strconv.Atoi(config.InitSleep)
+	if err != nil {
+		err := fmt.Errorf("Error parsing InitSleep into int: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
 	// TODO: Should we check `lxc info <container>` for "Running"?
 	// We have to do this so /tmp doesn't get cleared and lose our provisioner scripts.
-	time.Sleep(1 * time.Second)
+	time.Sleep(time.Duration(sleep_seconds) * time.Second)
 
 	return multistep.ActionContinue
 }
@@ -41,12 +55,12 @@ func (s *stepLxdLaunch) Cleanup(state multistep.StateBag) {
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
-	args := []string{
+	cleanup_args := []string{
 		"delete", "--force", config.ContainerName,
 	}
 
 	ui.Say("Unregistering and deleting deleting container...")
-	if _, err := LXDCommand(args...); err != nil {
+	if _, err := LXDCommand(cleanup_args...); err != nil {
 		ui.Error(fmt.Sprintf("Error deleting container: %s", err))
 	}
 }


### PR DESCRIPTION
- Allows the sleep timeout to be easily configurable, defaults to `3` seconds (so you don't have to make a bash provisioner to sleep) 
- Allows the config to specify the LXD profile to use (defaults to `default`)
- Allows you to specify `lxc launch --config foo=bar...`

@snesbittsea let me know if this would scratch your itch.

TODO: docs once we determine this is a reasonably shaped answer.

Closes  https://github.com/hashicorp/packer/issues/6025
Closes https://github.com/hashicorp/packer/issues/6030
Closes https://github.com/hashicorp/packer/issues/6031