### PR TITLE
builder/triton: Add support to Skip TLS Verification of Triton Certificate

### DIFF
--- a/website/source/docs/builders/triton.html.md
+++ b/website/source/docs/builders/triton.html.md
@@ -95,6 +95,11 @@ builder.
     
 -   `triton_user` (string) - The username of a user who has access to your Triton
     account. 
+    
+-   `insecure_skip_tls_verify` - (bool) This allows skipping TLS verification of 
+    the Triton endpoint. It is useful when connecting to a temporary Triton 
+    installation such as Cloud-On-A-Laptop which does not generally use a 
+    certificate signed by a trusted root CA. The default is `false`.
 
 -   `source_machine_firewall_enabled` (boolean) - Whether or not the firewall of
     the VM used to create an image of is enabled. The Triton firewall only


### PR DESCRIPTION
In order to allow Packer to connect to Private Triton installations
we now expose `insecure_skip_tls_verify` which, if set to true, will
allow the user to make requests to Triton installations that use a
certificate not signed by a trusted root CA