### PR TITLE
builder/openstack: Add instance_name config to OpenStack builder

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -52,6 +52,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, errs
 	}
 
+	// By default, instance name is same as image name
+	if b.config.InstanceName == "" {
+		b.config.InstanceName = b.config.ImageName
+	}
+
 	log.Println(common.ScrubConfig(b.config, b.config.Password))
 	return nil, nil
 }
@@ -82,7 +87,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SSHAgentAuth:         b.config.RunConfig.Comm.SSHAgentAuth,
 		},
 		&StepRunSourceServer{
-			Name:             b.config.ImageName,
+			Name:             b.config.InstanceName,
 			SourceImage:      b.config.SourceImage,
 			SourceImageName:  b.config.SourceImageName,
 			SecurityGroups:   b.config.SecurityGroups,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -30,6 +30,7 @@ type RunConfig struct {
 	Networks         []string          `mapstructure:"networks"`
 	UserData         string            `mapstructure:"user_data"`
 	UserDataFile     string            `mapstructure:"user_data_file"`
+	InstanceName     string            `mapstructure:"instance_name"`
 	InstanceMetadata map[string]string `mapstructure:"instance_metadata"`
 
 	ConfigDrive bool `mapstructure:"config_drive"`

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -118,6 +118,9 @@ builder.
 -   `metadata` (object of key/value strings) - Glance metadata that will be
     applied to the image.
 
+-   `instance_name` (string) - Name that is applied to the server instance
+    created by Packer. If this isn't specified, the default is same as `image_name`.
+
 -   `instance_metadata` (object of key/value strings) - Metadata that is
     applied to the server instance created by Packer. Also called server
     properties in some documentation. The strings have a max size of 255 bytes


### PR DESCRIPTION
RFC952 restricts hostname not to use underline(_) and period(.), so
private cloud with legacy DNS system does not allow just to use
image_name for name of server.

Add instance_name config option for servers which packer creates to
make instance_name configurable. If instance_name is not specified,
by default it works like the past using image_name for instance_name.

Test result
> ok      github.com/hashicorp/packer/builder/openstack   0.161s