### PR TITLE
use InventoryDirectory as inventory when set

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -321,6 +321,9 @@ func (p *Provisioner) Cancel() {
 func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, privKeyFile string) error {
 	playbook, _ := filepath.Abs(p.config.PlaybookFile)
 	inventory := p.config.inventoryFile
+	if len(p.config.InventoryDirectory) > 0 {
+		inventory = p.config.InventoryDirectory
+	}
 	var envvars []string
 
 	args := []string{"--extra-vars", fmt.Sprintf("packer_build_name=%s packer_builder_type=%s",


### PR DESCRIPTION
Fixes the `ansible` provider so that it passes the `inventory_directory` configuration option to `ansible -i` when it is set. Prior to this fix, the `inventory_directory` option would correctly make the generated inventory in the specified directory, but then it would pass the path to the generated file within that directory to ansible, rather than the directory itself, which means ansible does not pay attention to any other files in that directory (seemingly eliminating the purpose of the option). 

This is, I believe, what @korotovsky was referring to in https://github.com/hashicorp/packer/pull/4760#issuecomment-308398658 

This PR simply changes the ansible executor code so that, when an `inventory_directory` is specified (len > 0), the path to that directory is passed to ansible as the inventory rather than path to the generated inventory file. This makes it possible to integrate packer ansible invocations with existing inventory directories (e.g. that contain additional `groups` definitions, `group_vars`, etc). 



