### PR TITLE
add user data and user data file to oracle oci builder

### DIFF
--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -35,6 +35,9 @@ func (d *driverOCI) CreateInstance(publicKey string) (string, error) {
 			"ssh_authorized_keys": publicKey,
 		},
 	}
+	if d.cfg.UserData != "" {
+		params.Metadata["user_data"] = d.cfg.UserData
+	}
 	instance, err := d.client.Compute.Instances.Launch(params)
 	if err != nil {
 		return "", err

--- a/website/source/docs/builders/oracle-oci.html.md
+++ b/website/source/docs/builders/oracle-oci.html.md
@@ -125,6 +125,15 @@ builder.
 
  -  `use_private_ip` (boolean) - Use private ip addresses to connect to the instance via ssh.
 
+ - `user_data` (string) - user_data to be used by cloud
+   init. See [the Oracle docs](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/LaunchInstanceDetails) for more details. Generally speaking, it is easier to use the `user_data_file`,
+   but you can use this option to put either the platintext data or the base64
+   encoded data directly into your Packer config.
+
+ - `user_data_file` (string) - Path to a file to be used as user_data by cloud
+   init. See [the Oracle docs](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/LaunchInstanceDetails) for more details. Example:
+   `"user_data_file": "./boot_config/myscript.sh"`
+
 
 ## Basic Example
 


### PR DESCRIPTION
add "user_data" and "user_data_file" options to the oracle OCI builder. 

To test:
create a file called test_user_data_file_oracle.sh that contains: 

```
#!/bin/sh

touch /tmp/test.txt
chmod 777 /tmp/test.txt
```

Then in the oracle OCI builder, add the option: 

```
"user_data_file": "./test_user_data_file_oracle.sh"
```

in your provisioners:

```
    "provisioners": [
        {
            "type": "shell",
            "inline": "ls -alh /tmp/"
        }
    ]
```

and sure enough, output includes:

```
2018/03/28 15:55:59 ui:     oracle-oci: -rwxrwxrwx.  1 root root    0 Mar 28 22:55 test.txt
```

Closes #5866 