### PR TITLE
builder/qemu: Avoid warning when using raw format

### DIFF
--- a/builder/qemu/step_resize_disk.go
+++ b/builder/qemu/step_resize_disk.go
@@ -21,6 +21,7 @@ func (s *stepResizeDisk) Run(_ context.Context, state multistep.StateBag) multis
 
 	command := []string{
 		"resize",
+		"-f", config.Format,
 		path,
 		fmt.Sprintf("%vM", config.DiskSize),
 	}


### PR DESCRIPTION
When using the raw image format and attempting to resize it we get the following error message:
```
WARNING: Image format was not specified for 'test.raw' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.
```
Specifying the format will remove this warning.