### PR TITLE
Fixing Hyper-V ISO builder CopyExportedVirtualMachine PowerShell

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -649,9 +649,9 @@ func CopyExportedVirtualMachine(expPath string, outputPath string, vhdDir string
 
 	var script = `
 param([string]$srcPath, [string]$dstPath, [string]$vhdDirName, [string]$vmDir)
-Move-Item -Path $srcPath/*.* -Destination $dstPath
-Move-Item -Path $srcPath/$vhdDirName -Destination $dstPath
-Move-Item -Path $srcPath/$vmDir -Destination $dstPath
+Move-Item -Path (Join-Path (Get-Item $srcPath).FullName "*.*") -Destination $dstPath
+Move-Item -Path (Join-Path (Get-Item $srcPath).FullName $vhdDirName) -Destination $dstPath
+Move-Item -Path (Join-Path (Get-Item $srcPath).FullName $vmDir) -Destination $dstPath
 `
 
 	var ps powershell.PowerShellCmd


### PR DESCRIPTION
Script wasn't able to handle path that Packer used to create VM in the first place:

```
==> hyperv-iso: Copying to output dir...
==> hyperv-iso: Error exporting vm: PowerShell error: Move-Item : An object at the specified path C:\Users\HANNU~1.PIK does not exist.
==> hyperv-iso: At C:\Users\hannu.piki\AppData\Local\Temp\ps520830935.ps1:13 char:1
==> hyperv-iso: + Move-Item -Path "$srcPath/$vhdDirName" -Destination $dstPath -Verbose
==> hyperv-iso: + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> hyperv-iso:     + CategoryInfo          : InvalidArgument: (:) [Move-Item], PSArgumentException
==> hyperv-iso:     + FullyQualifiedErrorId : Argument,Microsoft.PowerShell.Commands.MoveItemCommand
```

Used path was ($srcPath):
C:\Users\HANNU~1.PIK\AppData\Local\Temp\packerhv616791918\export253729206\2016min
Real path was ((Get-Item $srcPath).FullName):
C:\Users\hannu.piki\AppData\Local\Temp\packerhv616791918\export253729206\2016min
