### PR TITLE
Set tar header format to tar.FormatGNU

### DIFF
--- a/post-processor/vagrant/util.go
+++ b/post-processor/vagrant/util.go
@@ -126,6 +126,11 @@ func DirToBox(dst, dir string, ui packer.Ui, level int) error {
 			return err
 		}
 
+		// We have to set the Format explicitly because of a bug in
+		// libarchive. This affects eg. the tar in macOS listing huge
+		// files with zero byte length.
+		header.Format = tar.FormatGNU
+
 		// We have to set the Name explicitly because it is supposed to
 		// be a relative path to the root. Otherwise, the tar ends up
 		// being a bunch of files in the root, even if they're actually


### PR DESCRIPTION
With Golang 1.10 a problem with macOS tar (bsdtar using libarchive) occured listing huge files as zero byte files. After some investigation in https://github.com/golang/go/issues/24599 we got some work around to set the tar header format explicitly to FormatGNU. Such tar files can be read and extracted with macOS tar.

Closes #5990