### PR TITLE
conditionally set tar header on go >= 1.10

### DIFF
--- a/post-processor/vagrant/tar_fix.go
+++ b/post-processor/vagrant/tar_fix.go
@@ -1,0 +1,9 @@
+// +build !go1.10
+
+package vagrant
+
+import "archive/tar"
+
+func setHeaderFormat(header *tar.Header) {
+	// no-op
+}

--- a/post-processor/vagrant/tar_fix_go110.go
+++ b/post-processor/vagrant/tar_fix_go110.go
@@ -1,0 +1,12 @@
+// +build go1.10
+
+package vagrant
+
+import "archive/tar"
+
+func setHeaderFormat(header *tar.Header) {
+	// We have to set the Format explicitly because of a bug in
+	// libarchive. This affects eg. the tar in macOS listing huge
+	// files with zero byte length.
+	header.Format = tar.FormatGNU
+}

--- a/post-processor/vagrant/util.go
+++ b/post-processor/vagrant/util.go
@@ -126,10 +126,8 @@ func DirToBox(dst, dir string, ui packer.Ui, level int) error {
 			return err
 		}
 
-		// We have to set the Format explicitly because of a bug in
-		// libarchive. This affects eg. the tar in macOS listing huge
-		// files with zero byte length.
-		header.Format = tar.FormatGNU
+		// workaround for large archive formats on go >=1.10
+		setHeaderFormat(header)
 
 		// We have to set the Name explicitly because it is supposed to
 		// be a relative path to the root. Otherwise, the tar ends up


### PR DESCRIPTION
Fix builds on go < 1.10

It's debatable if we should even support earlier versions of go, but this fix is simple and I'd rather not break earlier versions while there are still bugs being worked out on the current version.

Add-on to #6084