### PR TITLE
Adjustments to analytics scripts

### DIFF
--- a/website/source/assets/javascripts/analytics.js
+++ b/website/source/assets/javascripts/analytics.js
@@ -1,9 +1,14 @@
 document.addEventListener('DOMContentLoaded', function() {
-  track('.downloads .download a', function(el) {
+  track('.downloads .download .details li a', function(el) {
+    var m = el.href.match(/packer_(\d+\.\d+\.\d+)_(.*?)_(.*?)\.zip/)
     return {
       event: 'Download',
       category: 'Button',
-      label: 'Packer | v' + el.href.match(/\/(\d+\.\d+\.\d+)\//)[1]
+      label: 'Packer | v' + m[1] + ' | ' + m[2] + ' | ' + m[3],
+      version: m[1],
+      os: m[2],
+      architecture: m[3],
+      product: 'packer'
     }
   })
 })

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -34,13 +34,6 @@
     <![endif]-->
     <%= javascript_include_tag "application" %>
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NR2SD7C');</script>
-
     <!-- Typekit script to import Klavika font -->
     <script src="https://use.typekit.net/wxf7mfi.js"></script>
     <script>try{Typekit.load({ async: true });}catch(e){}</script>


### PR DESCRIPTION
A couple quick adjustments after getting back some data from the initial deploy!

- Remove existing GTM tag from head to prevent double tracking
- Adjust selector to not try to track links in "note" blocks
- Send a cleaner breakdown of download parameters for easier analysis