### PR TITLE
Fixes the DHCP lease and configuration pathfinders for VMware Player.

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -296,7 +296,7 @@ func (d *VmwareDriver) GuestAddress(state multistep.StateBag) (string, error) {
 			return "", errors.New("couldn't find MAC address in VMX")
 		}
 	}
-	log.Printf("GuestAddress: Found MAC address in VMX: %s", macAddress)
+	log.Printf("GuestAddress found MAC address in VMX: %s", macAddress)
 
 	res, err := net.ParseMAC(macAddress)
 	if err != nil {
@@ -320,7 +320,7 @@ func (d *VmwareDriver) GuestIP(state multistep.StateBag) (string, error) {
 
 	// log them to see what was detected
 	for _, device := range devices {
-		log.Printf("GuestIP(%s): Discovered device: %s", network, device)
+		log.Printf("GuestIP discovered device matching %s: %s", network, device)
 	}
 
 	// we were unable to find the device, maybe it's a custom one...
@@ -338,7 +338,7 @@ func (d *VmwareDriver) GuestIP(state multistep.StateBag) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		log.Printf("GuestIP(%s): Discovered custom device: %s", network, device)
+		log.Printf("GuestIP discovered custom device matching %s: %s", network, device)
 	}
 
 	// figure out our MAC address for looking up the guest address
@@ -424,7 +424,7 @@ func (d *VmwareDriver) HostAddress(state multistep.StateBag) (string, error) {
 
 	// log them to see what was detected
 	for _, device := range devices {
-		log.Printf("HostAddress(%s): Discovered device: %s", network, device)
+		log.Printf("HostAddress discovered device matching %s: %s", network, device)
 	}
 
 	// we were unable to find the device, maybe it's a custom one...
@@ -442,7 +442,7 @@ func (d *VmwareDriver) HostAddress(state multistep.StateBag) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		log.Printf("HostAddress(%s): Discovered custom device: %s", network, device)
+		log.Printf("HostAddress discovered custom device matching %s: %s", network, device)
 	}
 
 	var lastError error
@@ -503,7 +503,7 @@ func (d *VmwareDriver) HostIP(state multistep.StateBag) (string, error) {
 
 	// log them to see what was detected
 	for _, device := range devices {
-		log.Printf("HostIP(%s): Discovered device: %s", network, device)
+		log.Printf("HostIP discovered device matching %s: %s", network, device)
 	}
 
 	// we were unable to find the device, maybe it's a custom one...
@@ -521,7 +521,7 @@ func (d *VmwareDriver) HostIP(state multistep.StateBag) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		log.Printf("HostIP(%s): Discovered custom device: %s", network, device)
+		log.Printf("HostIP discovered custom device matching %s: %s", network, device)
 	}
 
 	var lastError error

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -296,6 +296,7 @@ func (d *VmwareDriver) GuestAddress(state multistep.StateBag) (string, error) {
 			return "", errors.New("couldn't find MAC address in VMX")
 		}
 	}
+	log.Printf("GuestAddress: Found MAC address in VMX: %s", macAddress)
 
 	res, err := net.ParseMAC(macAddress)
 	if err != nil {
@@ -317,6 +318,11 @@ func (d *VmwareDriver) GuestIP(state multistep.StateBag) (string, error) {
 	network := state.Get("vmnetwork").(string)
 	devices, err := netmap.NameIntoDevices(network)
 
+	// log them to see what was detected
+	for _, device := range devices {
+		log.Printf("GuestIP(%s): Discovered device: %s", network, device)
+	}
+
 	// we were unable to find the device, maybe it's a custom one...
 	// so, check to see if it's in the .vmx configuration
 	if err != nil || network == "custom" {
@@ -332,6 +338,7 @@ func (d *VmwareDriver) GuestIP(state multistep.StateBag) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		log.Printf("GuestIP(%s): Discovered custom device: %s", network, device)
 	}
 
 	// figure out our MAC address for looking up the guest address
@@ -415,6 +422,11 @@ func (d *VmwareDriver) HostAddress(state multistep.StateBag) (string, error) {
 	network := state.Get("vmnetwork").(string)
 	devices, err := netmap.NameIntoDevices(network)
 
+	// log them to see what was detected
+	for _, device := range devices {
+		log.Printf("HostAddress(%s): Discovered device: %s", network, device)
+	}
+
 	// we were unable to find the device, maybe it's a custom one...
 	// so, check to see if it's in the .vmx configuration
 	if err != nil || network == "custom" {
@@ -430,6 +442,7 @@ func (d *VmwareDriver) HostAddress(state multistep.StateBag) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		log.Printf("HostAddress(%s): Discovered custom device: %s", network, device)
 	}
 
 	var lastError error
@@ -488,6 +501,11 @@ func (d *VmwareDriver) HostIP(state multistep.StateBag) (string, error) {
 	network := state.Get("vmnetwork").(string)
 	devices, err := netmap.NameIntoDevices(network)
 
+	// log them to see what was detected
+	for _, device := range devices {
+		log.Printf("HostIP(%s): Discovered device: %s", network, device)
+	}
+
 	// we were unable to find the device, maybe it's a custom one...
 	// so, check to see if it's in the .vmx configuration
 	if err != nil || network == "custom" {
@@ -503,6 +521,7 @@ func (d *VmwareDriver) HostIP(state multistep.StateBag) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		log.Printf("HostIP(%s): Discovered custom device: %s", network, device)
 	}
 
 	var lastError error

--- a/builder/vmware/common/driver_fusion5.go
+++ b/builder/vmware/common/driver_fusion5.go
@@ -3,6 +3,7 @@ package common
 import (
 	"errors"
 	"fmt"
+	"log"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -157,6 +158,7 @@ func (d *Fusion5Driver) Verify() error {
 		if _, err := os.Stat(pathNetworking); err != nil {
 			return nil, fmt.Errorf("Could not find networking conf file: %s", pathNetworking)
 		}
+		log.Printf("Located networkmapper configuration file using Fusion5: %s", pathNetworking)
 
 		fd, err := os.Open(pathNetworking)
 		if err != nil {

--- a/builder/vmware/common/driver_fusion5.go
+++ b/builder/vmware/common/driver_fusion5.go
@@ -3,8 +3,8 @@ package common
 import (
 	"errors"
 	"fmt"
-	"log"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/builder/vmware/common/driver_fusion6.go
+++ b/builder/vmware/common/driver_fusion6.go
@@ -83,6 +83,7 @@ func (d *Fusion6Driver) Verify() error {
 		if _, err := os.Stat(pathNetworking); err != nil {
 			return nil, fmt.Errorf("Could not find networking conf file: %s", pathNetworking)
 		}
+		log.Printf("Located networkmapper configuration file using Fusion6: %s", pathNetworking)
 
 		fd, err := os.Open(pathNetworking)
 		if err != nil {

--- a/builder/vmware/common/driver_player5.go
+++ b/builder/vmware/common/driver_player5.go
@@ -201,14 +201,9 @@ func (d *Player5Driver) Verify() error {
 		if _, err := os.Stat(pathNetmap); err != nil {
 			return nil, fmt.Errorf("Could not find netmap conf file: %s", pathNetmap)
 		}
+		log.Printf("Located networkmapper configuration file using Player: %s", pathNetmap)
 
-		fd, err := os.Open(pathNetmap)
-		if err != nil {
-			return nil, err
-		}
-		defer fd.Close()
-
-		return ReadNetworkMap(fd)
+		return ReadNetmapConfig(pathNetmap)
 	}
 	return nil
 }

--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -162,14 +162,9 @@ func (d *Workstation9Driver) Verify() error {
 		if _, err := os.Stat(pathNetmap); err != nil {
 			return nil, fmt.Errorf("Could not find netmap conf file: %s", pathNetmap)
 		}
+		log.Printf("Located networkmapper configuration file using Workstation: %s", pathNetmap)
 
-		fd, err := os.Open(pathNetmap)
-		if err != nil {
-			return nil, err
-		}
-		defer fd.Close()
-
-		return ReadNetworkMap(fd)
+		return ReadNetmapConfig(pathNetmap)
 	}
 	return nil
 }


### PR DESCRIPTION
This also adds some logs that output how packer determines the interfaces found for a chosen network and locates the different files that its detection depends on.

Closes Issue #5882 for VMware Player.