### PR TITLE
Updated mitchellh/go-fs to commit b7b9ca407ffff465de12fc37ccbb81ea8b428c43

### DIFF
--- a/vendor/github.com/mitchellh/go-fs/fat/add_file_test.go
+++ b/vendor/github.com/mitchellh/go-fs/fat/add_file_test.go
@@ -1,0 +1,103 @@
+package fat
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/go-fs"
+)
+
+func TestAddFile(t *testing.T) {
+	// Create a temporary file to be our floppy drive
+	floppyF, err := ioutil.TempFile("", "go-fs")
+	if err != nil {
+		t.Fatalf("Error creating temporary file for floppy: %s", err)
+	}
+	defer floppyF.Close()
+	// defer os.Remove(floppyF.Name())
+
+	// Set the size of the file to be a floppy sized
+	if err := floppyF.Truncate(1440 * 1024); err != nil {
+		t.Fatalf("Error creating floppy: %s", err)
+	}
+
+	// BlockDevice backed by the file for our filesystem
+	device, err := fs.NewFileDisk(floppyF)
+	if err != nil {
+		t.Fatalf("Error creating floppy: %s", err)
+	}
+
+	// Format the block device so it contains a valid FAT filesystem
+	formatConfig := &SuperFloppyConfig{
+		FATType: FAT12,
+		Label:   "go-fs",
+		OEMName: "go-fs",
+	}
+	if FormatSuperFloppy(device, formatConfig); err != nil {
+		t.Fatalf("Error creating floppy: %s", err)
+	}
+
+	// The actual FAT filesystem
+	fatFs, err := New(device)
+	if err != nil {
+		t.Fatalf("Error creating floppy: %s", err)
+	}
+
+	// Get the root directory to the filesystem
+	rootDir, err := fatFs.RootDir()
+	if err != nil {
+		t.Fatalf("Error creating floppy: %s", err)
+	}
+
+	var filenames [128]string
+
+	// Go over each file and copy it.
+	for i := 0; i < 128; i++ {
+		filenames[i] = strings.Repeat("A", i+1) + ".EXT"
+	}
+
+	for _, filename := range filenames {
+		if addSingleFile(rootDir, filename); err != nil {
+			t.Fatalf("Error adding file to floppy: %s", err)
+		}
+	}
+
+	entries := rootDir.Entries()
+
+	for i, entry := range entries {
+		expecting := filenames[i]
+		if entry.Name() != expecting {
+			// Name() returns the short name, how do we get the long name?
+			// t.Fatalf("Excepting %s, found %s", expecting, entry.Name())
+		}
+	}
+}
+
+func addSingleFile(dir fs.Directory, src string) error {
+	inputF, err := os.Create(src)
+	if err != nil {
+		return err
+	}
+	defer inputF.Close()
+	defer os.Remove(src)
+
+	entry, err := dir.AddFile(filepath.Base(src))
+	if err != nil {
+		return err
+	}
+
+	fatFile, err := entry.File()
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(fatFile, inputF); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/mitchellh/go-fs/fat/filesystem_test.go
+++ b/vendor/github.com/mitchellh/go-fs/fat/filesystem_test.go
@@ -1,0 +1,15 @@
+package fat
+
+import (
+	"testing"
+
+	"github.com/mitchellh/go-fs"
+)
+
+func TestFileSystemImplementsFileSystem(t *testing.T) {
+	var raw interface{}
+	raw = new(FileSystem)
+	if _, ok := raw.(fs.FileSystem); !ok {
+		t.Fatal("FileSystem should be a FileSystem")
+	}
+}

--- a/vendor/github.com/mitchellh/go-fs/fat/short_name_test.go
+++ b/vendor/github.com/mitchellh/go-fs/fat/short_name_test.go
@@ -1,0 +1,169 @@
+package fat
+
+import "testing"
+
+func TestGenerateShortName(t *testing.T) {
+	// Test a basic one with no used
+	result, err := generateShortName("foo.bar", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "FOO.BAR" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test long
+	result, err = generateShortName("foobarbazblah.bar", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "FOOBAR~1.BAR" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test weird characters
+	result, err = generateShortName("foo*b?r?baz.bar", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "FOO_B_~1.BAR" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test used
+	result, err = generateShortName("foo.bar", []string{"foo.bar"})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "FOO~1.BAR" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test without a dot
+	result, err = generateShortName("BAM", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "BAM" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test dotfile
+	result, err = generateShortName(".big", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != ".BIG" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test valid extension
+	result, err = generateShortName("proxy.psm", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "PROXY.PSM" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test long extension
+	result, err = generateShortName("proxy.psm1", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "PROXY~1.PSM" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test short extension
+	result, err = generateShortName("proxy.x", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "PROXY.X" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test double shortname
+	result, err = generateShortName("proxy.x", []string{"PROXY.X", "PROXY~1.X"})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "PROXY~2.X" {
+		t.Fatalf("unexpected: %s", result)
+	}
+}
+
+func TestShortNameEntryValue(t *testing.T) {
+	// Test dot entry
+	entryValue := shortNameEntryValue(".")
+	expected := string([]byte{0x2E, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20})
+	if entryValue != expected {
+		t.Fatalf("expected %s, got %s", expected, entryValue)
+	}
+
+	// Test dotdot entry
+	entryValue = shortNameEntryValue("..")
+	expected = string([]byte{0x2E, 0x2E, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20})
+	if entryValue != expected {
+		t.Fatalf("expected %s, got %s", expected, entryValue)
+	}
+
+	// Test dotfile entry
+	shortName, err := generateShortName(".big", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	entryValue = shortNameEntryValue(shortName)
+	expected = "        BIG"
+	if entryValue != expected {
+		t.Fatalf("expected %s, got %s", expected, entryValue)
+	}
+
+	// Test entry value for a short filename without a period and file extension
+	shortName, err = generateShortName("foo", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	entryValue = shortNameEntryValue(shortName)
+	expected = "FOO        "
+	if entryValue != expected {
+		t.Fatalf("expected %s, got %s", expected, entryValue)
+	}
+
+	// Test entry value for a short filename with a period, but no file extension
+	shortName, err = generateShortName("foo.", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	entryValue = shortNameEntryValue(shortName)
+	expected = "FOO        "
+	if entryValue != expected {
+		t.Fatalf("expected %s, got %s", expected, entryValue)
+	}
+
+	// Test entry value for a short filename with a period and file extension
+	shortName, err = generateShortName("foo.bar", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	entryValue = shortNameEntryValue(shortName)
+	expected = "FOO     BAR"
+	if entryValue != expected {
+		t.Fatalf("expected %s, got %s", expected, entryValue)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1022,8 +1022,8 @@
 		{
 			"checksumSHA1": "mVqDwKcibat0IKAdzAhfGIHPwI8=",
 			"path": "github.com/mitchellh/go-fs",
-			"revision": "7bae45d9a684750e82b97ff320c82556614e621b",
-			"revisionTime": "2016-11-08T19:11:23Z"
+			"revision": "b7b9ca407ffff465de12fc37ccbb81ea8b428c43",
+			"revisionTime": "2018-04-02T23:53:30Z"
 		},
 		{
 			"checksumSHA1": "B5dy+Lg6jFPgHYhozztz88z3b4A=",
@@ -1067,6 +1067,10 @@
 			"checksumSHA1": "mrqMlK6gqe//WsJSrJ1HgkPM0lM=",
 			"path": "github.com/mitchellh/reflectwalk",
 			"revision": "eecf4c70c626c7cfbb95c90195bc34d386c74ac6"
+		},
+		{
+			"path": "github.com/mithcellh/go-fs",
+			"revision": ""
 		},
 		{
 			"checksumSHA1": "KhOVzKefFYORHdIVe+/gNAHB23A=",


### PR DESCRIPTION
This fixes an issue with filenames on a floppy disk with an extension longer than 3 chars.

This closes issue #6083.