### PR TITLE
Allow Ansible to use a custom inventory file

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -56,7 +56,7 @@ type Config struct {
 	SkipVersionCheck     bool     `mapstructure:"skip_version_check"`
 	UseSFTP              bool     `mapstructure:"use_sftp"`
 	InventoryDirectory   string   `mapstructure:"inventory_directory"`
-	inventoryFile        string
+	InventoryFile        string   `mapstructure:"inventory_file"`
 }
 
 type Provisioner struct {
@@ -266,7 +266,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 
 	go p.adapter.Serve()
 
-	if len(p.config.inventoryFile) == 0 {
+	if len(p.config.InventoryFile) == 0 {
 		tf, err := ioutil.TempFile(p.config.InventoryDirectory, "packer-provisioner-ansible")
 		if err != nil {
 			return fmt.Errorf("Error preparing inventory file: %s", err)
@@ -295,9 +295,9 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 			return fmt.Errorf("Error preparing inventory file: %s", err)
 		}
 		tf.Close()
-		p.config.inventoryFile = tf.Name()
+		p.config.InventoryFile = tf.Name()
 		defer func() {
-			p.config.inventoryFile = ""
+			p.config.InventoryFile = ""
 		}()
 	}
 
@@ -320,7 +320,7 @@ func (p *Provisioner) Cancel() {
 
 func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, privKeyFile string) error {
 	playbook, _ := filepath.Abs(p.config.PlaybookFile)
-	inventory := p.config.inventoryFile
+	inventory := p.config.InventoryFile
 	if len(p.config.InventoryDirectory) > 0 {
 		inventory = p.config.InventoryDirectory
 	}

--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -81,8 +81,13 @@ Optional Parameters:
     should be placed. When unspecified, the host is not associated with any
     groups.
 
+-   `inventory_file` (string) - The inventory file to use during provisioning.
+    When unspecified, Packer will create a temporary inventory file and will
+    use the `host_alias`.
+
 -   `host_alias` (string) - The alias by which the Ansible host should be known.
-    Defaults to `default`.
+    Defaults to `default`. This setting is ignored when using a custom inventory
+    file.
 
 -   `inventory_directory` (string) - The directory in which to place the
     temporary generated Ansible inventory file. By default, this is the


### PR DESCRIPTION
A custom inventory file was supported but the configuration option was not exposed.
I needed a custom inventory file so I made the option public.