### PR TITLE
Do 6078

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -176,6 +176,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			NewStepValidateTemplate(azureClient, ui, b.config, GetVirtualMachineDeployment),
 			NewStepDeployTemplate(azureClient, ui, b.config, deploymentName, GetVirtualMachineDeployment),
 			NewStepGetIPAddress(azureClient, ui, endpointConnectType),
+			&StepSaveWinRMPassword{
+				Password: b.config.tmpAdminPassword,
+			},
 			&communicator.StepConnectWinRM{
 				Config: &b.config.Comm,
 				Host: func(stateBag multistep.StateBag) (string, error) {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/packer/builder/azure/common/constants"
 	"github.com/hashicorp/packer/builder/azure/pkcs12"
 	"github.com/hashicorp/packer/common"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
@@ -357,6 +358,9 @@ func setRuntimeValues(c *Config) {
 	var tempName = NewTempName()
 
 	c.tmpAdminPassword = tempName.AdminPassword
+	// store so that we can access this later during provisioning
+	commonhelper.SetSharedState("winrm_password", c.tmpAdminPassword)
+
 	c.tmpCertificatePassword = tempName.CertificatePassword
 	if c.TempComputeName == "" {
 		c.tmpComputeName = tempName.ComputeName

--- a/builder/azure/arm/step_save_winrm_password.go
+++ b/builder/azure/arm/step_save_winrm_password.go
@@ -1,0 +1,22 @@
+package arm
+
+import (
+	"context"
+
+	commonhelper "github.com/hashicorp/packer/helper/common"
+	"github.com/hashicorp/packer/helper/multistep"
+)
+
+type StepSaveWinRMPassword struct {
+	Password string
+}
+
+func (s *StepSaveWinRMPassword) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	// store so that we can access this later during provisioning
+	commonhelper.SetSharedState("winrm_password", s.Password)
+	return multistep.ActionContinue
+}
+
+func (s *StepSaveWinRMPassword) Cleanup(multistep.StateBag) {
+	commonhelper.RemoveSharedStateFile("winrm_password")
+}

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -72,10 +72,9 @@ Optional parameters:
 -   `environment_vars` (array of strings) - An array of key/value pairs to
     inject prior to the execute\_command. The format should be `key=value`.
     Packer injects some environmental variables by default into the
-    environment, as well, which are covered in the section below. If you are
-    using AWS and would like to use the randomly-generated unique
-    If you are running on AWS and would like to access the AWS-generated
-    Administrator password that Packer uses to connect to the instance via
+    environment, as well, which are covered in the section below.
+    If you are running on AWS or Azure and would like to access the generated
+    password that Packer uses to connect to the instance via
     WinRM, you can use the template variable `{{.WinRMPassword}}` to set this
     as an environment variable. For example:
 


### PR DESCRIPTION
Add new step that sets the randomly generated Azure WinRM password in state so it can be used in the powershell provisioner.

Closes #6078 
