### PR TITLE
ignore test -d command in ssh communicator if guest is windows

### DIFF
--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -603,10 +603,23 @@ func (c *comm) scpUploadSession(path string, input io.Reader, fi *os.FileInfo) e
 	}
 	cmd.Wait()
 	if stdout.Len() > 0 {
+		out := string(stdout.Bytes())
+		// this command will fail on windows guests
+		if !strings.Contains(out, "cmdlet") {
+			return fmt.Errorf("[ERROR] Unable to check whether remote path is a dir: %s", out)
+		} else {
+			log.Printf("The guest is a windows guest; ignoring 'test -d' command.")
+		}
 		return fmt.Errorf("%s", stdout.Bytes())
 	}
 	if stderr.Len() > 0 {
-		return fmt.Errorf("%s", stderr.Bytes())
+		errOut := string(stderr.Bytes())
+		// this command will fail on windows guests
+		if !strings.Contains(errOut, "cmdlet") {
+			return fmt.Errorf("[ERROR] Unable to check whether remote path is a dir: %s", errOut)
+		} else {
+			log.Printf("The guest is a windows guest; ignoring 'test -d' command.")
+		}
 	}
 	if cmd.ExitStatus == 0 {
 		return fmt.Errorf(


### PR DESCRIPTION
This checks the stderr and stdout of the file transfer script to make sure that we aren't erroring because the guest is windows. This change isn't necessary in the sftp or docker communicator code, because we don't error on stderr and stdout length, and the return value will not be 0 if this gets run on windows. 

Closes #5994
