### PR TITLE
Fix missing comma in docs for LXD builder

### DIFF
--- a/website/source/docs/builders/lxd.html.md
+++ b/website/source/docs/builders/lxd.html.md
@@ -30,7 +30,7 @@ Below is a fully functioning example.
       "type": "lxd",
       "name": "lxd-xenial",
       "image": "ubuntu-daily:xenial",
-      "output_image": "ubuntu-xenial"
+      "output_image": "ubuntu-xenial",
       "publish_properties": {
         "description": "Trivial repackage with Packer"
       }


### PR DESCRIPTION
This PR is trivial. I used the example in the LXD builder's documentation as a starting point and noticed a missing comma. 😄