### PR TITLE
use build name to ensure that winrm password and other shared state i…

### DIFF
--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -21,9 +21,10 @@ import (
 // StepGetPassword reads the password from a Windows server and sets it
 // on the WinRM config.
 type StepGetPassword struct {
-	Debug   bool
-	Comm    *communicator.Config
-	Timeout time.Duration
+	Debug     bool
+	Comm      *communicator.Config
+	Timeout   time.Duration
+	BuildName string
 }
 
 func (s *StepGetPassword) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -94,13 +95,13 @@ WaitLoop:
 			"Password (since debug is enabled): %s", s.Comm.WinRMPassword))
 	}
 	// store so that we can access this later during provisioning
-	commonhelper.SetSharedState("winrm_password", s.Comm.WinRMPassword)
+	commonhelper.SetSharedState("winrm_password", s.Comm.WinRMPassword, s.BuildName)
 
 	return multistep.ActionContinue
 }
 
 func (s *StepGetPassword) Cleanup(multistep.StateBag) {
-	commonhelper.RemoveSharedStateFile("winrm_password")
+	commonhelper.RemoveSharedStateFile("winrm_password", s.BuildName)
 }
 
 func (s *StepGetPassword) waitForPassword(state multistep.StateBag, cancel <-chan struct{}) (string, error) {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -193,9 +193,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		instanceStep,
 		&awscommon.StepGetPassword{
-			Debug:   b.config.PackerDebug,
-			Comm:    &b.config.RunConfig.Comm,
-			Timeout: b.config.WindowsPasswordTimeout,
+			Debug:     b.config.PackerDebug,
+			Comm:      &b.config.RunConfig.Comm,
+			Timeout:   b.config.WindowsPasswordTimeout,
+			BuildName: b.config.PackerBuildName,
 		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -207,9 +207,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		instanceStep,
 		&awscommon.StepGetPassword{
-			Debug:   b.config.PackerDebug,
-			Comm:    &b.config.RunConfig.Comm,
-			Timeout: b.config.WindowsPasswordTimeout,
+			Debug:     b.config.PackerDebug,
+			Comm:      &b.config.RunConfig.Comm,
+			Timeout:   b.config.WindowsPasswordTimeout,
+			BuildName: b.config.PackerBuildName,
 		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -186,9 +186,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Ctx:           b.config.ctx,
 		},
 		&awscommon.StepGetPassword{
-			Debug:   b.config.PackerDebug,
-			Comm:    &b.config.RunConfig.Comm,
-			Timeout: b.config.WindowsPasswordTimeout,
+			Debug:     b.config.PackerDebug,
+			Comm:      &b.config.RunConfig.Comm,
+			Timeout:   b.config.WindowsPasswordTimeout,
+			BuildName: b.config.PackerBuildName,
 		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -269,9 +269,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		instanceStep,
 		&awscommon.StepGetPassword{
-			Debug:   b.config.PackerDebug,
-			Comm:    &b.config.RunConfig.Comm,
-			Timeout: b.config.WindowsPasswordTimeout,
+			Debug:     b.config.PackerDebug,
+			Comm:      &b.config.RunConfig.Comm,
+			Timeout:   b.config.WindowsPasswordTimeout,
+			BuildName: b.config.PackerBuildName,
 		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -177,7 +177,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			NewStepDeployTemplate(azureClient, ui, b.config, deploymentName, GetVirtualMachineDeployment),
 			NewStepGetIPAddress(azureClient, ui, endpointConnectType),
 			&StepSaveWinRMPassword{
-				Password: b.config.tmpAdminPassword,
+				Password:  b.config.tmpAdminPassword,
+				BuildName: b.config.PackerBuildName,
 			},
 			&communicator.StepConnectWinRM{
 				Config: &b.config.Comm,

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -359,7 +359,7 @@ func setRuntimeValues(c *Config) {
 
 	c.tmpAdminPassword = tempName.AdminPassword
 	// store so that we can access this later during provisioning
-	commonhelper.SetSharedState("winrm_password", c.tmpAdminPassword)
+	commonhelper.SetSharedState("winrm_password", c.tmpAdminPassword, c.PackerConfig.PackerBuildName)
 
 	c.tmpCertificatePassword = tempName.CertificatePassword
 	if c.TempComputeName == "" {

--- a/builder/azure/arm/step_save_winrm_password.go
+++ b/builder/azure/arm/step_save_winrm_password.go
@@ -8,15 +8,16 @@ import (
 )
 
 type StepSaveWinRMPassword struct {
-	Password string
+	Password  string
+	BuildName string
 }
 
 func (s *StepSaveWinRMPassword) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	// store so that we can access this later during provisioning
-	commonhelper.SetSharedState("winrm_password", s.Password)
+	commonhelper.SetSharedState("winrm_password", s.Password, s.BuildName)
 	return multistep.ActionContinue
 }
 
 func (s *StepSaveWinRMPassword) Cleanup(multistep.StateBag) {
-	commonhelper.RemoveSharedStateFile("winrm_password")
+	commonhelper.RemoveSharedStateFile("winrm_password", s.BuildName)
 }

--- a/common/step_http_server.go
+++ b/common/step_http_server.go
@@ -76,20 +76,20 @@ func (s *StepHTTPServer) Run(_ context.Context, state multistep.StateBag) multis
 }
 
 func SetHTTPPort(port string) error {
-	return common.SetSharedState("port", port)
+	return common.SetSharedState("port", port, "")
 }
 
 func SetHTTPIP(ip string) error {
-	return common.SetSharedState("ip", ip)
+	return common.SetSharedState("ip", ip, "")
 }
 
 func GetHTTPAddr() string {
-	ip, err := common.RetrieveSharedState("ip")
+	ip, err := common.RetrieveSharedState("ip", "")
 	if err != nil {
 		return ""
 	}
 
-	port, err := common.RetrieveSharedState("port")
+	port, err := common.RetrieveSharedState("port", "")
 	if err != nil {
 		return ""
 	}
@@ -101,6 +101,6 @@ func (s *StepHTTPServer) Cleanup(multistep.StateBag) {
 		// Close the listener so that the HTTP server stops
 		s.l.Close()
 	}
-	common.RemoveSharedStateFile("port")
-	common.RemoveSharedStateFile("ip")
+	common.RemoveSharedStateFile("port", "")
+	common.RemoveSharedStateFile("ip", "")
 }

--- a/helper/common/shared_state.go
+++ b/helper/common/shared_state.go
@@ -9,23 +9,23 @@ import (
 
 // Used to set variables which we need to access later in the build, where
 // state bag and config information won't work
-func sharedStateFilename(suffix string) string {
+func sharedStateFilename(suffix string, buildName string) string {
 	uuid := os.Getenv("PACKER_RUN_UUID")
-	return filepath.Join(os.TempDir(), fmt.Sprintf("packer-%s-%s", uuid, suffix))
+	return filepath.Join(os.TempDir(), fmt.Sprintf("packer-%s-%s-%s", uuid, suffix, buildName))
 }
 
-func SetSharedState(key string, value string) error {
-	return ioutil.WriteFile(sharedStateFilename(key), []byte(value), 0600)
+func SetSharedState(key string, value string, buildName string) error {
+	return ioutil.WriteFile(sharedStateFilename(key, buildName), []byte(value), 0600)
 }
 
-func RetrieveSharedState(key string) (string, error) {
-	value, err := ioutil.ReadFile(sharedStateFilename(key))
+func RetrieveSharedState(key string, buildName string) (string, error) {
+	value, err := ioutil.ReadFile(sharedStateFilename(key, buildName))
 	if err != nil {
 		return "", err
 	}
 	return string(value), nil
 }
 
-func RemoveSharedStateFile(key string) {
-	os.Remove(sharedStateFilename(key))
+func RemoveSharedStateFile(key string, buildName string) {
+	os.Remove(sharedStateFilename(key, buildName))
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -377,7 +377,7 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 
 	// interpolate environment variables
 	p.config.ctx.Data = &EnvVarsTemplate{
-		WinRMPassword: getWinRMPassword(),
+		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
 	}
 	// Split vars into key/value components
 	for _, envVar := range p.config.Vars {
@@ -445,7 +445,7 @@ func (p *Provisioner) createCommandTextNonPrivileged() (command string, err erro
 	p.config.ctx.Data = &ExecuteCommandTemplate{
 		Path:          p.config.RemotePath,
 		Vars:          envVarPath,
-		WinRMPassword: getWinRMPassword(),
+		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
 	}
 	command, err = interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 
@@ -457,8 +457,8 @@ func (p *Provisioner) createCommandTextNonPrivileged() (command string, err erro
 	return command, nil
 }
 
-func getWinRMPassword() string {
-	winRMPass, _ := commonhelper.RetrieveSharedState("winrm_password")
+func getWinRMPassword(buildName string) string {
+	winRMPass, _ := commonhelper.RetrieveSharedState("winrm_password", buildName)
 	return winRMPass
 }
 
@@ -472,7 +472,7 @@ func (p *Provisioner) createCommandTextPrivileged() (command string, err error) 
 	p.config.ctx.Data = &ExecuteCommandTemplate{
 		Path:          p.config.RemotePath,
 		Vars:          envVarPath,
-		WinRMPassword: getWinRMPassword(),
+		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
 	}
 	command, err = interpolate.Render(p.config.ElevatedExecuteCommand, &p.config.ctx)
 	if err != nil {
@@ -530,7 +530,7 @@ func (p *Provisioner) generateElevatedRunner(command string) (uploadedPath strin
 	}
 	// Replace ElevatedPassword for winrm users who used this feature
 	p.config.ctx.Data = &EnvVarsTemplate{
-		WinRMPassword: getWinRMPassword(),
+		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
 	}
 
 	p.config.ElevatedPassword, _ = interpolate.Render(p.config.ElevatedPassword, &p.config.ctx)


### PR DESCRIPTION
This should guarantee the files are unique for the shared state. cc @rickard-von-essen @mwhooker 