### PR TITLE
Update gemfile.lock as part of update to middleman-hashicorp 0.3.37

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    autoprefixer-rails (8.1.0.1)
+    autoprefixer-rails (8.3.0)
       execjs
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.34)
+    middleman-hashicorp (0.3.37)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -113,9 +113,9 @@ GEM
     padrino-support (0.12.9)
       activesupport (>= 3.1)
     rack (1.6.9)
-    rack-livereload (0.3.16)
+    rack-livereload (0.3.17)
       rack
-    rack-test (0.8.3)
+    rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -137,7 +137,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (1.4.1)
-    turbolinks (5.1.0)
+    turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
     turbolinks-source (5.1.0)
     tzinfo (1.2.5)
@@ -153,7 +153,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.34)
+  middleman-hashicorp (= 0.3.37)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Updates the `website/Gemfile.lock` with the new middleman-hashicorp version and dependencies. 

@mwhooker I suspect this should have gone in with #6148...