### PR TITLE
Add an example for FreeBSD

### DIFF
--- a/examples/azure/freebsd.json
+++ b/examples/azure/freebsd.json
@@ -40,7 +40,8 @@
     ],
     "inline_shebang": "/bin/sh -x",
     "type": "shell",
-    "skip_clean": "true"
+    "skip_clean": "true",
+    "expect_disconnect": "true"
   }]
 
 }

--- a/examples/azure/freebsd.json
+++ b/examples/azure/freebsd.json
@@ -1,0 +1,46 @@
+{
+  "variables": {
+    "client_id": "{{env `ARM_CLIENT_ID`}}",
+    "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+    "resource_group": "{{env `ARM_RESOURCE_GROUP`}}",
+    "storage_account": "{{env `ARM_STORAGE_ACCOUNT`}}",
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+    "ssh_user": "packer",
+    "ssh_pass": null
+  },
+  "builders": [{
+    "type": "azure-arm",
+
+    "client_id": "{{user `client_id`}}",
+    "client_secret": "{{user `client_secret`}}",
+    "resource_group_name": "{{user `resource_group`}}",
+    "storage_account": "{{user `storage_account`}}",
+    "subscription_id": "{{user `subscription_id`}}",
+
+    "capture_container_name": "images",
+    "capture_name_prefix": "packer",
+
+    "ssh_username": "{{user `ssh_user`}}",
+    "ssh_password": "{{user `ssh_pass`}}",
+
+    "os_type": "Linux",
+    "image_publisher": "MicrosoftOSTC",
+    "image_offer": "FreeBSD",
+    "image_sku": "11.1",
+    "image_version": "latest",
+
+    "location": "West US 2",
+    "vm_size": "Standard_DS2_v2"
+  }],
+  "provisioners": [{
+    "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+    "inline": [
+      "env ASSUME_ALWAYS_YES=YES pkg bootstrap",
+      "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+    ],
+    "inline_shebang": "/bin/sh -x",
+    "type": "shell",
+    "skip_clean": "true"
+  }]
+
+}


### PR DESCRIPTION
Hi - 

This is an example of using packer to create a FreeBSD image on Azure (FreeBSD 11.1).

I've attached here a full build using this file. 

[freebsd_packer_build.txt](https://github.com/hashicorp/packer/files/1925538/freebsd_packer_build.txt)

Thanks,
Diego