### PR TITLE
Mention network config for HTTPIP template variable

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.md
+++ b/website/source/docs/builders/vmware-iso.html.md
@@ -485,7 +485,11 @@ available variables are:
 -   `HTTPIP` and `HTTPPort` - The IP and port, respectively of an HTTP server
     that is started serving the directory specified by the `http_directory`
     configuration parameter. If `http_directory` isn't specified, these will be
-    blank!
+    blank! Note that for the `HTTPIP` to be resolved correctly your VM's network 
+    configuration has to include a `host-only` or `nat` type network interface.
+    If you are using this feature, it is recommended to leave the default network
+    configuration while you are building the VM, and use the `vmx_data_post` hook 
+    to modify the network configuration after the VM is done building.
 
 Example boot command. This is actually a working boot command used to start an
 Ubuntu 12.04 installer:


### PR DESCRIPTION
See for example https://github.com/hashicorp/packer/issues/4091#issuecomment-257506571

I lost a couple hours troubleshooting this, before I found the above issue comment, so I think it's definitely a good thing to mention in the docs. 