### PR TITLE
forcefully stop parallels vm.

### DIFF
--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -131,6 +131,7 @@ func NewDriver() (Driver, error) {
 	latestDriver := 11
 	version, _ := drivers[strconv.Itoa(latestDriver)].Version()
 	majVer, _ := strconv.Atoi(strings.SplitN(version, ".", 2)[0])
+	log.Printf("Parallels version: %s", version)
 	if majVer > latestDriver {
 		log.Printf("Your version of Parallels Desktop for Mac is %s, Packer will use driver for version %d.", version, latestDriver)
 		return drivers[strconv.Itoa(latestDriver)], nil

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -222,7 +222,7 @@ func (d *Parallels9Driver) IsRunning(name string) (bool, error) {
 
 // Stop forcibly stops the VM.
 func (d *Parallels9Driver) Stop(name string) error {
-	if err := d.Prlctl("stop", name); err != nil {
+	if err := d.Prlctl("stop", name, "--kill"); err != nil {
 		return err
 	}
 
@@ -275,7 +275,6 @@ func (d *Parallels9Driver) Version() (string, error) {
 	}
 
 	version := matches[1]
-	log.Printf("Parallels Desktop version: %s", version)
 	return version, nil
 }
 

--- a/builder/parallels/common/step_run.go
+++ b/builder/parallels/common/step_run.go
@@ -69,7 +69,7 @@ func (s *StepRun) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packer.Ui)
 
 	if running, _ := driver.IsRunning(s.vmName); running {
-		if err := driver.Prlctl("stop", s.vmName); err != nil {
+		if err := driver.Stop(s.vmName); err != nil {
 			ui.Error(fmt.Sprintf("Error stopping VM: %s", err))
 		}
 	}


### PR DESCRIPTION
also only output parallels version once.

cancelling packer while the OS is starting up does nothing, making the user cancel the build through parallels. This adds `--kill` to `prlctl stop`. This is supported in v9 http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Command%20Line%20Reference%20Guide.pdf

