### PR TITLE
Turbolinks adjustments

### DIFF
--- a/website/source/assets/javascripts/analytics.js
+++ b/website/source/assets/javascripts/analytics.js
@@ -1,4 +1,6 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('turbolinks:load', function() {
+  analytics.page()
+
   track('.downloads .download .details li a', function(el) {
     var m = el.href.match(/packer_(\d+\.\d+\.\d+)_(.*?)_(.*?)\.zip/)
     return {

--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require jquery
+//= require turbolinks
 
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -27,11 +27,18 @@
 
     <title><%= title_for(current_page) %></title>
 
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="https://use.typekit.net/wxf7mfi.css">
     <%= stylesheet_link_tag "application" %>
 
-    <!-- Typekit script to import Klavika font -->
-    <script src="https://use.typekit.net/wxf7mfi.js"></script>
-    <script>try{Typekit.load({ async: true });}catch(e){}</script>
+    <!-- Site scripts -->
+    <!--[if lt IE 9]><%= javascript_include_tag "ie-compat", defer: true %><![endif]-->
+    <%= javascript_include_tag "application", defer: true %>
+
+    <!-- Analytics scrpts -->
+    <script defer>
+      !function(){var e=window.analytics=window.analytics||[];if(!e.initialize)if(e.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{e.invoked=!0,e.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"],e.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),e.push(a),e}};for(var t=0;t<e.methods.length;t++){var a=e.methods[t];e[a]=e.factory(a)}e.load=function(e){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+e+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(t,a)},e.SNIPPET_VERSION="4.0.0",e.load("<%= segmentId %>")}}();var om597a24292a958,om597a24292a958_poll=function(){var e=0;return function(t,a){clearInterval(e),e=setInterval(t,a)}}();!function(e,t,a){if(e.getElementById(a))om597a24292a958_poll(function(){if(window.om_loaded&&!om597a24292a958)return(om597a24292a958=new OptinMonsterApp).init({s:"35109.597a24292a958",staging:0,dev:0,beta:0})},25);else{var n=!1,o=e.createElement("script");o.id=a,o.src="//a.optnmstr.com/app/js/api.min.js",o.async=!0,o.onload=o.onreadystatechange=function(){if(!(n||this.readyState&&"loaded"!==this.readyState&&"complete"!==this.readyState))try{n=om_loaded=!0,(om597a24292a958=new OptinMonsterApp).init({s:"35109.597a24292a958",staging:0,dev:0,beta:0}),o.onload=o.onreadystatechange=null}catch(e){}},(document.getElementsByTagName("head")[0]||document.documentElement).appendChild(o)}}(document,0,"omapi-script");
+    </script>
 
     <%= yield_content :head %>
   </head>
@@ -106,22 +113,6 @@
       </div>
     </div>
 
-    <!--[if lt IE 9]>
-      <%= javascript_include_tag "ie-compat" %>
-    <![endif]-->
-    <%= javascript_include_tag "application" %>
-    
-    <script>
-      // analytics.js
-      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
-      analytics.load("<%= segmentId %>");
-      analytics.page();
-      }}();
-      // optinmonster
-      var om597a24292a958,om597a24292a958_poll=function(){var b=0;return function(d,c){clearInterval(b);b=setInterval(d,c)}}();
-      !function(b,d,c){if(b.getElementById(c))om597a24292a958_poll(function(){if(window.om_loaded&&!om597a24292a958)return om597a24292a958=new OptinMonsterApp,om597a24292a958.init({s:"35109.597a24292a958",staging:0,dev:0,beta:0})},25);else{var e=!1,a=b.createElement(d);a.id=c;a.src="//a.optnmstr.com/app/js/api.min.js";a.async=!0;a.onload=a.onreadystatechange=function(){if(!(e||this.readyState&&"loaded"!==this.readyState&&"complete"!==this.readyState))try{e=om_loaded=!0,om597a24292a958=new OptinMonsterApp,
-      om597a24292a958.init({s:"35109.597a24292a958",staging:0,dev:0,beta:0}),a.onload=a.onreadystatechange=null}catch(f){}};(document.getElementsByTagName("head")[0]||document.documentElement).appendChild(a)}}(document,"script","omapi-script");
-    </script>
     <script type="application/ld+json">
       {
         "@context": "http://schema.org",


### PR DESCRIPTION
So I initially proposed removing turbolinks since it is known to frequently conflicts with client-side javascript and cause problems, and it was drastically distorting our web analytics. However, after a lengthy discussion in the engineering channel, we have decided to work around turbolinks, rather then eliminating it. In short, this is due to the performance benefits it brings for internet users with very slow connections, and the fact that, since this is a simple static docs site, there shouldn't be too many other pieces of javascript that turbolinks conflicts with in the future.

This pull request keeps turbolinks, but makes a couple adjustments to fix the analytics reporting, and optimize initial page load performance.

First, instead of running a page track when the page initially loads, the page track event was moved inside a turbolinks load hook. This ensures that each page view is properly represented within the analytics, and that there are no double page loads being tracked.

Second, all scripts were moved to the `<head>` section, since turbolinks replaces the body, including scripts, on each page load, and this avoids loading the same scripts multiple times. Script tags are blocking for the html parser, which means this typically has a negative impact on performance. This was mitigated by ensuring that all script tags have a `defer` attribute, which ensures that the parser does not treat the script tags as blocking, and renders the html as quickly as possible. More information on this script tag attribute [can be found here](https://bitsofco.de/async-vs-defer/).

This should be as ideal of a compromise as we can get between initial page load speed, subsequent page load speed, and accuracy of analytics. The only thing to be noted for the future is to be extra careful when adding any javascript to this, or other HashiCorp docs sites - while turbolinks does have its benefits and use cases, it still is very likely to interfere with client-side javascript, and extra care must be taken to work around it when introducing new javascript to sites that use it.