### PR TITLE
docs: (triton / alicloud-ecs) minor fix for links that aren't being rendered and incorrect datatype documented

### DIFF
--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -67,7 +67,7 @@ builder.
     limit of 0 to 256 characters. Leaving it blank means null, which is the
     default value. It cannot begin with `http://` or `https://`.
 
--   `image_disk_mappings` (array of image disk mappings) - Add one or more data disks
+-   `image_disk_mappings` (array of image disk mappings) - Add one or more data disks
     to the image.
 
     -   `disk_category` (string) - Category of the data disk. Optional values are:
@@ -77,7 +77,7 @@ builder.
 
         Default value: cloud.
 
-    -   `disk_delete_with_instance` (string) - Whether or not the disk is released along with the instance:
+    -   `disk_delete_with_instance` (boolean) - Whether or not the disk is released along with the instance:
         -   True indicates that when the instance is released, this disk will be released with it
         -   False indicates that when the instance is released, this disk will be retained.
 

--- a/website/source/docs/builders/triton.html.md
+++ b/website/source/docs/builders/triton.html.md
@@ -50,6 +50,7 @@ builder.
 
 -   `triton_account` (string) - The username of the Triton account to use when
     using the Triton Cloud API.
+
 -   `triton_key_id` (string) - The fingerprint of the public key of the SSH key
     pair to use for authentication with the Triton Cloud API. If
     `triton_key_material` is not set, it is assumed that the SSH agent has the


### PR DESCRIPTION
- correct website doc datatype for datatype alicloud `disk_delete_with_instance` see: https://github.com/hashicorp/packer/blob/master/builder/alicloud/ecs/image_config.go#L19
- correct 2 attribute links that are not currently rendering.
   - https://www.packer.io/docs/builders/triton.html#triton_account
   - https://www.packer.io/docs/alicloud-ecs.html#image_disk_mappings

### triton/triton_account showing as url link
<img width="838" alt="screen shot 2018-04-24 at 1 14 37 pm" src="https://user-images.githubusercontent.com/1252884/39211771-8c51e148-47c1-11e8-8bca-2f78ca262388.png">

### alicloud-ecs/image_disk_mappings showing as url link
<img width="783" alt="screen shot 2018-04-24 at 1 12 56 pm" src="https://user-images.githubusercontent.com/1252884/39211883-d82f9362-47c1-11e8-9cbb-94de1d44d2d9.png">
