### PR TITLE
[WIP] Simplify handling of VMware disk operations by collating disk requirements and unifying treatment

### DIFF
--- a/builder/vmware/common/step_compact_disk.go
+++ b/builder/vmware/common/step_compact_disk.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
+	"os"
 
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -33,12 +35,41 @@ func (s StepCompactDisk) Run(_ context.Context, state multistep.StateBag) multis
 		return multistep.ActionContinue
 	}
 
-	ui.Say("Compacting all attached disk images")
+	ui.Say("Compacting all attached virtual disks...")
 	for i, diskPath := range diskPaths {
-		ui.Message(fmt.Sprintf("Compacting disk image %d", i+1))
+		ui.Message(fmt.Sprintf("Compacting virtual disk %d", i+1))
+		// Get the file size of the virtual disk prior to compaction
+		fi, err := os.Stat(diskPath)
+		if err != nil {
+			state.Put("error", fmt.Errorf("Error getting virtual disk file info pre compaction: %s", err))
+			return multistep.ActionHalt
+		}
+		diskFileSizeStart := fi.Size()
+		// Defragment and compact the disk
 		if err := driver.CompactDisk(diskPath); err != nil {
 			state.Put("error", fmt.Errorf("Error compacting disk: %s", err))
 			return multistep.ActionHalt
+		}
+		// Get the file size of the virtual disk post compaction
+		fi, err = os.Stat(diskPath)
+		if err != nil {
+			state.Put("error", fmt.Errorf("Error getting virtual disk file info post compaction: %s", err))
+			return multistep.ActionHalt
+		}
+		diskFileSizeEnd := fi.Size()
+		// Report compaction results
+		log.Printf("Before compaction the disk file size was: %d", diskFileSizeStart)
+		log.Printf("After compaction the disk file size was: %d", diskFileSizeEnd)
+		if diskFileSizeStart > 0 {
+			percentChange := ((float64(diskFileSizeEnd) / float64(diskFileSizeStart)) * 100.0) - 100.0
+			switch {
+			case percentChange < 0:
+				ui.Message(fmt.Sprintf("Compacting reduced the disk file size by %.2f%%", math.Abs(percentChange)))
+			case percentChange == 0:
+				ui.Message(fmt.Sprintf("The compacting operation left the disk file size unchanged"))
+			case percentChange > 0:
+				ui.Message(fmt.Sprintf("WARNING: Compacting increased the disk file size by %.2f%%", percentChange))
+			}
 		}
 	}
 

--- a/builder/vmware/common/step_compact_disk.go
+++ b/builder/vmware/common/step_compact_disk.go
@@ -14,7 +14,7 @@ import (
 //
 // Uses:
 //   driver Driver
-//   full_disk_path string
+//   disk_full_paths ([]string) - The full paths to all created disks
 //   ui     packer.Ui
 //
 // Produces:
@@ -26,28 +26,19 @@ type StepCompactDisk struct {
 func (s StepCompactDisk) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
-	full_disk_path := state.Get("full_disk_path").(string)
+	diskPaths := state.Get("disk_full_paths").([]string)
 
 	if s.Skip {
 		log.Println("Skipping disk compaction step...")
 		return multistep.ActionContinue
 	}
 
-	ui.Say("Compacting the disk image")
-	if err := driver.CompactDisk(full_disk_path); err != nil {
-		state.Put("error", fmt.Errorf("Error compacting disk: %s", err))
-		return multistep.ActionHalt
-	}
-
-	if state.Get("additional_disk_paths") != nil {
-		if moreDisks := state.Get("additional_disk_paths").([]string); len(moreDisks) > 0 {
-			for i, path := range moreDisks {
-				ui.Say(fmt.Sprintf("Compacting additional disk image %d", i+1))
-				if err := driver.CompactDisk(path); err != nil {
-					state.Put("error", fmt.Errorf("Error compacting additional disk %d: %s", i+1, err))
-					return multistep.ActionHalt
-				}
-			}
+	ui.Say("Compacting all attached disk images")
+	for i, diskPath := range diskPaths {
+		ui.Message(fmt.Sprintf("Compacting disk image %d", i+1))
+		if err := driver.CompactDisk(diskPath); err != nil {
+			state.Put("error", fmt.Errorf("Error compacting disk: %s", err))
+			return multistep.ActionHalt
 		}
 	}
 

--- a/builder/vmware/common/step_compact_disk_test.go
+++ b/builder/vmware/common/step_compact_disk_test.go
@@ -15,7 +15,8 @@ func TestStepCompactDisk(t *testing.T) {
 	state := testState(t)
 	step := new(StepCompactDisk)
 
-	state.Put("full_disk_path", "foo")
+	diskPaths := []string{"foo"}
+	state.Put("disk_full_paths", diskPaths)
 
 	driver := state.Get("driver").(*DriverMock)
 
@@ -41,7 +42,8 @@ func TestStepCompactDisk_skip(t *testing.T) {
 	step := new(StepCompactDisk)
 	step.Skip = true
 
-	state.Put("full_disk_path", "foo")
+	diskPaths := []string{"foo"}
+	state.Put("disk_full_paths", diskPaths)
 
 	driver := state.Get("driver").(*DriverMock)
 

--- a/builder/vmware/iso/step_create_disk.go
+++ b/builder/vmware/iso/step_create_disk.go
@@ -3,6 +3,7 @@ package iso
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 
 	vmwcommon "github.com/hashicorp/packer/builder/vmware/common"
@@ -18,7 +19,7 @@ import (
 //   ui     packer.Ui
 //
 // Produces:
-//   full_disk_path (string) - The full path to the created disk.
+//   disk_full_paths ([]string) - The full paths to all created disks
 type stepCreateDisk struct{}
 
 func (stepCreateDisk) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -26,39 +27,39 @@ func (stepCreateDisk) Run(_ context.Context, state multistep.StateBag) multistep
 	driver := state.Get("driver").(vmwcommon.Driver)
 	ui := state.Get("ui").(packer.Ui)
 
-	ui.Say("Creating virtual machine disk")
-	full_disk_path := filepath.Join(config.OutputDir, config.DiskName+".vmdk")
-	if err := driver.CreateDisk(full_disk_path, fmt.Sprintf("%dM", config.DiskSize), config.DiskAdapterType, config.DiskTypeId); err != nil {
-		err := fmt.Errorf("Error creating disk: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
+	ui.Say("Creating required virtual machine disks")
 
-	state.Put("full_disk_path", full_disk_path)
-
+	// Users can configure disks at several locations in the template so
+	// first collate all the disk requirements
+	var diskPaths, diskSizes []string
+	// The 'main' or 'default' disk
+	diskPaths = append(diskPaths, filepath.Join(config.OutputDir, config.DiskName+".vmdk"))
+	diskSizes = append(diskSizes, fmt.Sprintf("%dM", uint64(config.DiskSize)))
+	// Additional disks
 	if len(config.AdditionalDiskSize) > 0 {
-		// stash the disk paths we create
-		additional_paths := make([]string, len(config.AdditionalDiskSize))
-
-		ui.Say("Creating additional hard drives...")
-		for i, additionalsize := range config.AdditionalDiskSize {
-			additionalpath := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d.vmdk", config.DiskName, i+1))
-			size := fmt.Sprintf("%dM", uint64(additionalsize))
-
-			if err := driver.CreateDisk(additionalpath, size, config.DiskAdapterType, config.DiskTypeId); err != nil {
-				err := fmt.Errorf("Error creating additional disk: %s", err)
-				state.Put("error", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-
-			additional_paths[i] = additionalpath
+		for i, diskSize := range config.AdditionalDiskSize {
+			path := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d.vmdk", config.DiskName, i+1))
+			diskPaths = append(diskPaths, path)
+			size := fmt.Sprintf("%dM", uint64(diskSize))
+			diskSizes = append(diskSizes, size)
 		}
-
-		state.Put("additional_disk_paths", additional_paths)
 	}
 
+	// Create all required disks
+	for i, diskPath := range diskPaths {
+		log.Printf("[INFO] Creating disk with Path: %s and Size: %s", diskPath, diskSizes[i])
+		// Additional disks currently use the same adapter type and disk
+		// type as specified for the main disk
+		if err := driver.CreateDisk(diskPath, diskSizes[i], config.DiskAdapterType, config.DiskTypeId); err != nil {
+			err := fmt.Errorf("Error creating disk: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	// Stash the disk paths so we can retrieve later e.g. when compacting
+	state.Put("disk_full_paths", diskPaths)
 	return multistep.ActionContinue
 }
 

--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -115,13 +115,13 @@ func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	// Write out the relative, host filesystem paths to the disks
-	var diskFullPaths []string
+	var diskPaths []string
 	for _, diskFilename := range diskFilenames {
 		log.Printf("Found attached disk with filename: %s", diskFilename)
-		diskFullPaths = append(diskFullPaths, filepath.Join(s.OutputDir, diskFilename))
+		diskPaths = append(diskPaths, filepath.Join(s.OutputDir, diskFilename))
 	}
 
-	if len(diskFullPaths) == 0 {
+	if len(diskPaths) == 0 {
 		state.Put("error", fmt.Errorf("Could not enumerate disk info from the vmx file"))
 		return multistep.ActionHalt
 	}
@@ -139,10 +139,7 @@ func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multiste
 
 	// Stash all required information in our state bag
 	state.Put("vmx_path", vmxPath)
-	// What disks get assigned to what key doesn't actually matter here
-	// since it's unimportant to the way the disk compaction step works
-	state.Put("full_disk_path", diskFullPaths[0])
-	state.Put("additional_disk_paths", diskFullPaths[1:])
+	state.Put("disk_full_paths", diskPaths)
 	state.Put("vmnetwork", networkType)
 
 	return multistep.ActionContinue

--- a/builder/vmware/vmx/step_clone_vmx_test.go
+++ b/builder/vmware/vmx/step_clone_vmx_test.go
@@ -88,17 +88,11 @@ func TestStepCloneVMX(t *testing.T) {
 		t.Fatalf("bad path to vmx: %#v", vmxPath)
 	}
 
-	if diskPath, ok := state.GetOk("full_disk_path"); !ok {
-		t.Fatal("should set full_disk_path")
-	} else if diskPath != diskPaths[0] {
-		t.Fatalf("bad disk path: %#v", diskPath)
-	}
-
-	if stateDiskPaths, ok := state.GetOk("additional_disk_paths"); !ok {
-		t.Fatal("should set additional_disk_paths")
+	if stateDiskPaths, ok := state.GetOk("disk_full_paths"); !ok {
+		t.Fatal("should set disk_full_paths")
 	} else {
-		assert.ElementsMatchf(t, stateDiskPaths.([]string), diskPaths[1:],
-			"%s\nshould contain the same elements as:\n%s", stateDiskPaths.([]string), diskPaths[1:])
+		assert.ElementsMatchf(t, stateDiskPaths.([]string), diskPaths,
+			"%s\nshould contain the same elements as:\n%s", stateDiskPaths.([]string), diskPaths)
 	}
 
 	// Test we got the network type


### PR DESCRIPTION
This PR attempts to address two issues:

* As discussed in #6074 [HERE](https://github.com/hashicorp/packer/pull/6074#discussion_r178926918) the separate treatment of the 'default' disk and 'additional disks' doesn't appear to have any clear benefit and actually adds some unwanted complexity/repetition.
This PR simplifies things a bit by collating all disk requirements together. All the disk paths are now stored in the statebag within a single key. This allows a slight simplification of the code within the create, compact and cloning disk steps as the operations can be unified.

* Additionally, at present it is difficult to determine whether the disk compaction step actually did anything or not. Currently, the only options seem to be to compare and contrast the disk size between runs with `skip_compaction` set to true and then false (not really desirable), or to set a `watch -d 'ls -l output-directory'` on the output directory and (hopefully!) catch any change in the disk size.
To make things easier, this PR now outputs the compaction result to the user/UI. Note that if the disk is already as compact as it can be then the disk size will be unchanged by the compaction process. Although I've never seen this behaviour, it's also apparently possible for the compacting process to result in a larger file size for the disk...

As usual, feedback and suggestions for improvement are welcome.