### PR TITLE
pass MacAddress to StepCreateVM

### DIFF
--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -378,6 +378,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DifferencingDisk:               b.config.DifferencingDisk,
 			SkipExport:                     b.config.SkipExport,
 			OutputDir:                      b.config.OutputDir,
+			MacAddress:                     b.config.MacAddress,
 		},
 		&hypervcommon.StepEnableIntegrationService{},
 


### PR DESCRIPTION
I noticed when creating a new VM from an ISO using Hyper-V the MAC address is read from the configuration but not passed to StepCreateVM so it is not actually set on the VM.

PS: I cannot build the current master branch (148f7d3) on my Windows machine using the default Go configuration:

```
PS C:\Users\mdono\go\src\github.com\hashicorp\packer> go build
go build github.com/hashicorp/packer/vendor/github.com/oracle/oci-go-sdk/core: C:\Go\pkg\tool\windows_amd64\compile.exe: fork/exec C:\Go\pkg\tool\windows_amd64\compile.exe: The filename or extension is too long.
```

The v1.2.2 tag builds fine. The same problem occurs using `go get`.