### PR TITLE
add support for hvf accelerator to qemu builder

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -27,6 +27,7 @@ var accels = map[string]struct{}{
 	"tcg":  {},
 	"xen":  {},
 	"hax":  {},
+	"hvf":  {},
 }
 
 var netDevice = map[string]bool{
@@ -255,7 +256,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if _, ok := accels[b.config.Accelerator]; !ok {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("invalid accelerator, only 'kvm', 'tcg', 'xen', 'hax', or 'none' are allowed"))
+			errs, errors.New("invalid accelerator, only 'kvm', 'tcg', 'xen', 'hax', 'hvf', or 'none' are allowed"))
 	}
 
 	if _, ok := netDevice[b.config.NetDevice]; !ok {

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -112,14 +112,20 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
 ### Optional:
 
 -   `accelerator` (string) - The accelerator type to use when running the VM.
-    This may be `none`, `kvm`, `tcg`, `hax`, or `xen`. The appropriate software
-    must have already been installed on your build machine to use the
+    This may be `none`, `kvm`, `tcg`, `hax`, `hvf`, or `xen`. The appropriate
+    software must have already been installed on your build machine to use the
     accelerator you specified. When no accelerator is specified, Packer will try
     to use `kvm` if it is available but will default to `tcg` otherwise.
 
     -&gt; The `hax` accelerator has issues attaching CDROM ISOs. This is an
     upstream issue which can be tracked
     [here](https://github.com/intel/haxm/issues/20).
+
+    -&gt; The `hvf` accelerator is new and experimental as of 
+    [QEMU 2.12.0](https://wiki.qemu.org/ChangeLog/2.12#Host_support).
+    You may encounter issues unrelated to Packer when using it.  You may need to
+    add [ "-global", "virtio-pci.disable-modern=on" ] to `qemuargs` depending on the
+    guest operating system.
 
 -   `boot_command` (array of strings) - This is an array of commands to type
     when the virtual machine is first booted. The goal of these commands should


### PR DESCRIPTION
This adds the newly released experimental 'hvf' accelerator as an option to the QEMU builder.  The accelerator adds support for Hypervisor.framework on macOS which significantly increases the performance of the QEMU builder on that platform.

Closes #6189 
