### PR TITLE
Clean up tmp files created by tests

### DIFF
--- a/builder/alicloud/ecs/run_config_test.go
+++ b/builder/alicloud/ecs/run_config_test.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/packer/helper/communicator"
@@ -68,6 +69,7 @@ func TestRunConfigPrepare_UserData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.Remove(tf.Name())
 	defer tf.Close()
 
 	c.UserData = "foo"
@@ -92,6 +94,7 @@ func TestRunConfigPrepare_UserDataFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.Remove(tf.Name())
 	defer tf.Close()
 
 	c.UserDataFile = tf.Name()

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -119,6 +119,7 @@ func TestRunConfigPrepare_UserData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.Remove(tf.Name())
 	defer tf.Close()
 
 	c.UserData = "foo"
@@ -143,6 +144,7 @@ func TestRunConfigPrepare_UserDataFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.Remove(tf.Name())
 	defer tf.Close()
 
 	c.UserDataFile = tf.Name()

--- a/builder/amazon/instance/builder_test.go
+++ b/builder/amazon/instance/builder_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-func testConfig() map[string]interface{} {
+func testConfig() (config map[string]interface{}, tf *os.File) {
 	tf, err := ioutil.TempFile("", "packer")
 	if err != nil {
 		panic(err)
 	}
 
-	return map[string]interface{}{
+	config = map[string]interface{}{
 		"account_id":       "foo",
 		"ami_name":         "foo",
 		"instance_type":    "m1.small",
@@ -26,6 +26,8 @@ func testConfig() map[string]interface{} {
 		"x509_key_path":    tf.Name(),
 		"x509_upload_path": "/foo",
 	}
+
+	return config, tf
 }
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
@@ -38,7 +40,9 @@ func TestBuilder_ImplementsBuilder(t *testing.T) {
 
 func TestBuilderPrepare_AccountId(t *testing.T) {
 	b := &Builder{}
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	config["account_id"] = ""
 	warnings, err := b.Prepare(config)
@@ -74,7 +78,9 @@ func TestBuilderPrepare_AccountId(t *testing.T) {
 
 func TestBuilderPrepare_AMIName(t *testing.T) {
 	var b Builder
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	// Test good
 	config["ami_name"] = "foo"
@@ -111,7 +117,9 @@ func TestBuilderPrepare_AMIName(t *testing.T) {
 
 func TestBuilderPrepare_BundleDestination(t *testing.T) {
 	b := &Builder{}
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	config["bundle_destination"] = ""
 	warnings, err := b.Prepare(config)
@@ -129,7 +137,9 @@ func TestBuilderPrepare_BundleDestination(t *testing.T) {
 
 func TestBuilderPrepare_BundlePrefix(t *testing.T) {
 	b := &Builder{}
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	warnings, err := b.Prepare(config)
 	if len(warnings) > 0 {
@@ -146,7 +156,9 @@ func TestBuilderPrepare_BundlePrefix(t *testing.T) {
 
 func TestBuilderPrepare_InvalidKey(t *testing.T) {
 	var b Builder
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	// Add a random key
 	config["i_should_not_be_valid"] = true
@@ -161,7 +173,9 @@ func TestBuilderPrepare_InvalidKey(t *testing.T) {
 
 func TestBuilderPrepare_S3Bucket(t *testing.T) {
 	b := &Builder{}
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	config["s3_bucket"] = ""
 	warnings, err := b.Prepare(config)
@@ -184,7 +198,9 @@ func TestBuilderPrepare_S3Bucket(t *testing.T) {
 
 func TestBuilderPrepare_X509CertPath(t *testing.T) {
 	b := &Builder{}
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	config["x509_cert_path"] = ""
 	warnings, err := b.Prepare(config)
@@ -209,6 +225,7 @@ func TestBuilderPrepare_X509CertPath(t *testing.T) {
 		t.Fatalf("error tempfile: %s", err)
 	}
 	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	config["x509_cert_path"] = tf.Name()
 	warnings, err = b.Prepare(config)
@@ -222,7 +239,9 @@ func TestBuilderPrepare_X509CertPath(t *testing.T) {
 
 func TestBuilderPrepare_X509KeyPath(t *testing.T) {
 	b := &Builder{}
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	config["x509_key_path"] = ""
 	warnings, err := b.Prepare(config)
@@ -247,6 +266,7 @@ func TestBuilderPrepare_X509KeyPath(t *testing.T) {
 		t.Fatalf("error tempfile: %s", err)
 	}
 	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	config["x509_key_path"] = tf.Name()
 	warnings, err = b.Prepare(config)
@@ -260,7 +280,9 @@ func TestBuilderPrepare_X509KeyPath(t *testing.T) {
 
 func TestBuilderPrepare_X509UploadPath(t *testing.T) {
 	b := &Builder{}
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	config["x509_upload_path"] = ""
 	warnings, err := b.Prepare(config)

--- a/builder/googlecompute/step_create_ssh_key_test.go
+++ b/builder/googlecompute/step_create_ssh_key_test.go
@@ -55,6 +55,7 @@ func TestStepCreateSSHKey_debug(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.Remove(tf.Name())
 	tf.Close()
 
 	state := testState(t)

--- a/builder/googlecompute/step_create_windows_password_test.go
+++ b/builder/googlecompute/step_create_windows_password_test.go
@@ -75,6 +75,7 @@ func TestStepCreateOrResetWindowsPassword_debug(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.Remove(tf.Name())
 	tf.Close()
 
 	state := testState(t)

--- a/builder/parallels/common/driver_9_test.go
+++ b/builder/parallels/common/driver_9_test.go
@@ -16,6 +16,7 @@ func TestIPAddress(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	d := Parallels9Driver{
 		dhcpLeaseFile: tf.Name(),
@@ -62,9 +63,9 @@ func TestIPAddress(t *testing.T) {
 func TestXMLParseConfig(t *testing.T) {
 	td, err := ioutil.TempDir("", "configpvs")
 	if err != nil {
-		t.Fatalf("Error creating temp file: %s", err)
+		t.Fatalf("Error creating temp dir: %s", err)
 	}
-	defer os.Remove(td)
+	defer os.RemoveAll(td)
 
 	config := []byte(`
 <ExampleParallelsConfig>

--- a/builder/parallels/common/step_output_dir_test.go
+++ b/builder/parallels/common/step_output_dir_test.go
@@ -28,6 +28,8 @@ func TestStepOutputDir_impl(t *testing.T) {
 func TestStepOutputDir(t *testing.T) {
 	state := testState(t)
 	step := testStepOutputDir(t)
+	// Delete the test output directory when done
+	defer os.RemoveAll(step.Path)
 
 	// Test the run
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {

--- a/builder/virtualbox/common/step_output_dir_test.go
+++ b/builder/virtualbox/common/step_output_dir_test.go
@@ -28,6 +28,7 @@ func TestStepOutputDir_impl(t *testing.T) {
 func TestStepOutputDir(t *testing.T) {
 	state := testState(t)
 	step := testStepOutputDir(t)
+	defer os.RemoveAll(step.Path)
 
 	// Test the run
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
@@ -55,6 +56,7 @@ func TestStepOutputDir_exists(t *testing.T) {
 	if err := os.MkdirAll(step.Path, 0755); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
+	defer os.RemoveAll(step.Path)
 
 	// Test the run
 	if action := step.Run(context.Background(), state); action != multistep.ActionHalt {

--- a/builder/vmware/common/step_output_dir_test.go
+++ b/builder/vmware/common/step_output_dir_test.go
@@ -30,6 +30,8 @@ func TestStepOutputDir(t *testing.T) {
 	step := new(StepOutputDir)
 
 	dir := testOutputDir(t)
+	// Delete the test output directory when done
+	defer os.RemoveAll(dir.dir)
 	state.Put("dir", dir)
 
 	// Test the run
@@ -61,6 +63,7 @@ func TestStepOutputDir_existsNoForce(t *testing.T) {
 	if err := os.MkdirAll(dir.dir, 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.RemoveAll(dir.dir)
 
 	// Test the run
 	if action := step.Run(context.Background(), state); action != multistep.ActionHalt {
@@ -89,6 +92,7 @@ func TestStepOutputDir_existsForce(t *testing.T) {
 	if err := os.MkdirAll(dir.dir, 0755); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer os.RemoveAll(dir.dir)
 
 	// Test the run
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {

--- a/builder/vmware/common/step_shutdown_test.go
+++ b/builder/vmware/common/step_shutdown_test.go
@@ -85,6 +85,12 @@ func TestStepShutdown_command(t *testing.T) {
 	if comm.StartCmd.Command != "foo" {
 		t.Fatalf("bad: %#v", comm.StartCmd.Command)
 	}
+
+	// Clean up the created test output directory
+	dir := state.Get("dir").(*LocalOutputDir)
+	if err := dir.RemoveAll(); err != nil {
+		t.Fatalf("Error cleaning up directory: %s", err)
+	}
 }
 
 func TestStepShutdown_noCommand(t *testing.T) {
@@ -112,6 +118,12 @@ func TestStepShutdown_noCommand(t *testing.T) {
 
 	if comm.StartCalled {
 		t.Fatal("start should not be called")
+	}
+
+	// Clean up the created test output directory
+	dir := state.Get("dir").(*LocalOutputDir)
+	if err := dir.RemoveAll(); err != nil {
+		t.Fatalf("Error cleaning up directory: %s", err)
 	}
 }
 

--- a/common/download_test.go
+++ b/common/download_test.go
@@ -60,6 +60,7 @@ func TestDownloadClient_basic(t *testing.T) {
 		TargetPath: tf.Name(),
 		CopyFile:   true,
 	})
+	defer os.Remove(tf.Name())
 
 	path, err := client.Get()
 	if err != nil {
@@ -96,6 +97,7 @@ func TestDownloadClient_checksumBad(t *testing.T) {
 		Checksum:   checksum,
 		CopyFile:   true,
 	})
+	defer os.Remove(tf.Name())
 	if _, err := client.Get(); err == nil {
 		t.Fatal("should error")
 	}
@@ -121,6 +123,7 @@ func TestDownloadClient_checksumGood(t *testing.T) {
 		Checksum:   checksum,
 		CopyFile:   true,
 	})
+	defer os.Remove(tf.Name())
 	path, err := client.Get()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -191,6 +194,7 @@ func TestDownloadClient_resume(t *testing.T) {
 		TargetPath: tf.Name(),
 		CopyFile:   true,
 	})
+	defer os.Remove(tf.Name())
 	path, err := client.Get()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -211,7 +215,8 @@ func TestDownloadClient_usesDefaultUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tempfile error: %s", err)
 	}
-	defer os.Remove(tf.Name())
+	tf.Close()
+	os.Remove(tf.Name())
 
 	defaultUserAgent := ""
 	asserted := false
@@ -249,6 +254,7 @@ func TestDownloadClient_usesDefaultUserAgent(t *testing.T) {
 		TargetPath: tf.Name(),
 		CopyFile:   true,
 	}
+	defer os.Remove(tf.Name())
 
 	client := NewDownloadClient(config)
 	_, err = client.Get()
@@ -266,7 +272,8 @@ func TestDownloadClient_setsUserAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tempfile error: %s", err)
 	}
-	defer os.Remove(tf.Name())
+	tf.Close()
+	os.Remove(tf.Name())
 
 	asserted := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -281,6 +288,7 @@ func TestDownloadClient_setsUserAgent(t *testing.T) {
 		UserAgent:  "fancy user agent",
 		CopyFile:   true,
 	}
+	defer os.Remove(tf.Name())
 
 	client := NewDownloadClient(config)
 	_, err = client.Get()

--- a/common/iso_config_test.go
+++ b/common/iso_config_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"runtime"
 	"testing"
@@ -90,6 +91,8 @@ func TestISOConfigPrepare_ISOChecksumURL(t *testing.T) {
 	i = testISOConfig()
 	i.ISOChecksum = ""
 	cs_file, _ := ioutil.TempFile("", "packer-test-")
+	defer os.Remove(cs_file.Name())
+	defer cs_file.Close()
 	ioutil.WriteFile(cs_file.Name(), []byte(cs_bsd_style), 0666)
 	filePrefix := "file://"
 	if runtime.GOOS == "windows" {
@@ -112,6 +115,8 @@ func TestISOConfigPrepare_ISOChecksumURL(t *testing.T) {
 	i = testISOConfig()
 	i.ISOChecksum = ""
 	cs_file, _ = ioutil.TempFile("", "packer-test-")
+	defer os.Remove(cs_file.Name())
+	defer cs_file.Close()
 	ioutil.WriteFile(cs_file.Name(), []byte(cs_gnu_style), 0666)
 	i.ISOChecksumURL = fmt.Sprintf("%s%s", filePrefix, cs_file.Name())
 	warns, err = i.Prepare(nil)
@@ -130,6 +135,8 @@ func TestISOConfigPrepare_ISOChecksumURL(t *testing.T) {
 	i = testISOConfig()
 	i.ISOChecksum = ""
 	cs_file, _ = ioutil.TempFile("", "packer-test-")
+	defer os.Remove(cs_file.Name())
+	defer cs_file.Close()
 	ioutil.WriteFile(cs_file.Name(), []byte(cs_bsd_style_no_newline), 0666)
 	i.ISOChecksumURL = fmt.Sprintf("file://%s", cs_file.Name())
 	warns, err = i.Prepare(nil)
@@ -150,6 +157,8 @@ func TestISOConfigPrepare_ISOChecksumURL(t *testing.T) {
 
 	cs_dir, _ := ioutil.TempDir("", "packer-testdir-")
 	cs_file, _ = ioutil.TempFile(cs_dir, "packer-test-")
+	defer os.RemoveAll(cs_dir) // Removes the file as well
+	defer cs_file.Close()
 	ioutil.WriteFile(cs_file.Name(), []byte(cs_bsd_style_subdir), 0666)
 	i.ISOChecksumURL = fmt.Sprintf("%s%s", filePrefix, cs_file.Name())
 	i.RawSingleISOUrl = fmt.Sprintf("%s%s", cs_dir, "/subdir/the-OS.iso")
@@ -169,6 +178,8 @@ func TestISOConfigPrepare_ISOChecksumURL(t *testing.T) {
 	i = testISOConfig()
 	i.ISOChecksum = ""
 	cs_file, _ = ioutil.TempFile("", "packer-test-")
+	defer os.Remove(cs_file.Name())
+	defer cs_file.Close()
 	ioutil.WriteFile(cs_file.Name(), []byte(cs_gnu_style_no_newline), 0666)
 	i.ISOChecksumURL = fmt.Sprintf("file://%s", cs_file.Name())
 	warns, err = i.Prepare(nil)
@@ -189,6 +200,8 @@ func TestISOConfigPrepare_ISOChecksumURL(t *testing.T) {
 	i.RawSingleISOUrl = "http://www.packer.io/the-OS.iso?stuff=boo"
 
 	cs_file, _ = ioutil.TempFile("", "packer-test-")
+	defer os.Remove(cs_file.Name())
+	defer cs_file.Close()
 	ioutil.WriteFile(cs_file.Name(), []byte(cs_gnu_style), 0666)
 	i.ISOChecksumURL = fmt.Sprintf("%s%s", filePrefix, cs_file.Name())
 	warns, err = i.Prepare(nil)
@@ -208,6 +221,8 @@ func TestISOConfigPrepare_ISOChecksumURL(t *testing.T) {
 	i.ISOChecksum = ""
 
 	cs_file, _ = ioutil.TempFile(cs_dir, "packer-test-")
+	defer os.Remove(cs_file.Name())
+	defer cs_file.Close()
 	ioutil.WriteFile(cs_file.Name(), []byte(cs_gnu_style_subdir), 0666)
 	i.ISOChecksumURL = fmt.Sprintf("%s%s", filePrefix, cs_file.Name())
 	i.RawSingleISOUrl = fmt.Sprintf("%s%s", cs_dir, "/subdir/the-OS.iso")

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	//"log"
 	"os"
 	"regexp"
 	"strings"
@@ -30,6 +29,7 @@ func TestProvisionerPrepare_extractScript(t *testing.T) {
 	p := new(Provisioner)
 	_ = p.Prepare(config)
 	file, err := extractScript(p)
+	defer os.Remove(file)
 	if err != nil {
 		t.Fatalf("Should not be error: %s", err)
 	}
@@ -177,6 +177,7 @@ func TestProvisionerPrepare_Script(t *testing.T) {
 		t.Fatalf("error tempfile: %s", err)
 	}
 	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	config["script"] = tf.Name()
 	p = new(Provisioner)
@@ -203,6 +204,7 @@ func TestProvisionerPrepare_ScriptAndInline(t *testing.T) {
 		t.Fatalf("error tempfile: %s", err)
 	}
 	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	config["inline"] = []interface{}{"foo"}
 	config["script"] = tf.Name()
@@ -222,6 +224,7 @@ func TestProvisionerPrepare_ScriptAndScripts(t *testing.T) {
 		t.Fatalf("error tempfile: %s", err)
 	}
 	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	config["inline"] = []interface{}{"foo"}
 	config["scripts"] = []string{tf.Name()}
@@ -248,6 +251,7 @@ func TestProvisionerPrepare_Scripts(t *testing.T) {
 		t.Fatalf("error tempfile: %s", err)
 	}
 	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	config["scripts"] = []string{tf.Name()}
 	p = new(Provisioner)
@@ -444,6 +448,8 @@ func TestProvisionerProvision_Inline(t *testing.T) {
 func TestProvisionerProvision_Scripts(t *testing.T) {
 	tempFile, _ := ioutil.TempFile("", "packer")
 	defer os.Remove(tempFile.Name())
+	defer tempFile.Close()
+
 	config := testConfig()
 	delete(config, "inline")
 	config["scripts"] = []string{tempFile.Name()}
@@ -473,6 +479,8 @@ func TestProvisionerProvision_ScriptsWithEnvVars(t *testing.T) {
 	config := testConfig()
 	ui := testUi()
 	defer os.Remove(tempFile.Name())
+	defer tempFile.Close()
+
 	delete(config, "inline")
 
 	config["scripts"] = []string{tempFile.Name()}

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -13,15 +13,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testConfig() map[string]interface{} {
+func testConfig() (config map[string]interface{}, tf *os.File) {
 	tf, err := ioutil.TempFile("", "packer")
 	if err != nil {
 		panic(err)
 	}
 
-	return map[string]interface{}{
+	config = map[string]interface{}{
 		"manifest_file": tf.Name(),
 	}
+
+	return config, tf
 }
 
 func TestProvisioner_Impl(t *testing.T) {
@@ -33,7 +35,10 @@ func TestProvisioner_Impl(t *testing.T) {
 }
 
 func TestGuestOSConfig_empty_unix(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
+
 	p := new(Provisioner)
 	err := p.Prepare(config)
 	if err != nil {
@@ -58,7 +63,10 @@ func TestGuestOSConfig_empty_unix(t *testing.T) {
 }
 
 func TestGuestOSConfig_full_unix(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
+
 	p := new(Provisioner)
 	err := p.Prepare(config)
 	if err != nil {
@@ -95,7 +103,10 @@ func TestGuestOSConfig_full_unix(t *testing.T) {
 }
 
 func TestGuestOSConfig_empty_windows(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
+
 	config["guest_os_type"] = "windows"
 	p := new(Provisioner)
 	err := p.Prepare(config)
@@ -120,7 +131,10 @@ func TestGuestOSConfig_empty_windows(t *testing.T) {
 }
 
 func TestGuestOSConfig_full_windows(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
+
 	config["guest_os_type"] = "windows"
 	p := new(Provisioner)
 	err := p.Prepare(config)
@@ -158,7 +172,9 @@ func TestGuestOSConfig_full_windows(t *testing.T) {
 }
 
 func TestProvisionerPrepare_puppetBinDir(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "puppet_bin_dir")
 	p := new(Provisioner)
@@ -183,7 +199,9 @@ func TestProvisionerPrepare_puppetBinDir(t *testing.T) {
 }
 
 func TestProvisionerPrepare_hieraConfigPath(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "hiera_config_path")
 	p := new(Provisioner)
@@ -208,7 +226,9 @@ func TestProvisionerPrepare_hieraConfigPath(t *testing.T) {
 }
 
 func TestProvisionerPrepare_manifestFile(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "manifest_file")
 	p := new(Provisioner)
@@ -233,7 +253,9 @@ func TestProvisionerPrepare_manifestFile(t *testing.T) {
 }
 
 func TestProvisionerPrepare_manifestDir(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "manifestdir")
 	p := new(Provisioner)
@@ -258,7 +280,9 @@ func TestProvisionerPrepare_manifestDir(t *testing.T) {
 }
 
 func TestProvisionerPrepare_modulePaths(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "module_paths")
 	p := new(Provisioner)
@@ -291,7 +315,9 @@ func TestProvisionerPrepare_modulePaths(t *testing.T) {
 }
 
 func TestProvisionerPrepare_facterFacts(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "facter")
 	p := new(Provisioner)
@@ -346,7 +372,9 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 }
 
 func TestProvisionerPrepare_extraArguments(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	// Test with missing parameter
 	delete(config, "extra_arguments")
@@ -377,7 +405,9 @@ func TestProvisionerPrepare_extraArguments(t *testing.T) {
 }
 
 func TestProvisionerPrepare_stagingDir(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "staging_directory")
 	p := new(Provisioner)
@@ -405,7 +435,9 @@ func TestProvisionerPrepare_stagingDir(t *testing.T) {
 }
 
 func TestProvisionerPrepare_workingDir(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "working_directory")
 	p := new(Provisioner)
@@ -438,7 +470,10 @@ func TestProvisionerPrepare_workingDir(t *testing.T) {
 }
 
 func TestProvisionerProvision_extraArguments(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
+
 	ui := &packer.MachineReadableUi{
 		Writer: ioutil.Discard,
 	}

--- a/provisioner/puppet-server/provisioner_test.go
+++ b/provisioner/puppet-server/provisioner_test.go
@@ -8,15 +8,17 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-func testConfig() map[string]interface{} {
+func testConfig() (config map[string]interface{}, tf *os.File) {
 	tf, err := ioutil.TempFile("", "packer")
 	if err != nil {
 		panic(err)
 	}
 
-	return map[string]interface{}{
+	config = map[string]interface{}{
 		"puppet_server": tf.Name(),
 	}
+
+	return config, tf
 }
 
 func TestProvisioner_Impl(t *testing.T) {
@@ -28,7 +30,9 @@ func TestProvisioner_Impl(t *testing.T) {
 }
 
 func TestProvisionerPrepare_puppetBinDir(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "puppet_bin_dir")
 	p := new(Provisioner)
@@ -53,7 +57,9 @@ func TestProvisionerPrepare_puppetBinDir(t *testing.T) {
 }
 
 func TestProvisionerPrepare_clientPrivateKeyPath(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "client_private_key_path")
 	p := new(Provisioner)
@@ -86,7 +92,9 @@ func TestProvisionerPrepare_clientPrivateKeyPath(t *testing.T) {
 }
 
 func TestProvisionerPrepare_clientCertPath(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "client_cert_path")
 	p := new(Provisioner)
@@ -119,7 +127,9 @@ func TestProvisionerPrepare_clientCertPath(t *testing.T) {
 }
 
 func TestProvisionerPrepare_executeCommand(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "execute_command")
 	p := new(Provisioner)
@@ -130,7 +140,9 @@ func TestProvisionerPrepare_executeCommand(t *testing.T) {
 }
 
 func TestProvisionerPrepare_facterFacts(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "facter")
 	p := new(Provisioner)
@@ -185,7 +197,9 @@ func TestProvisionerPrepare_facterFacts(t *testing.T) {
 }
 
 func TestProvisionerPrepare_stagingDir(t *testing.T) {
-	config := testConfig()
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
 
 	delete(config, "staging_dir")
 	p := new(Provisioner)


### PR DESCRIPTION
Currently there are a large number of files and directories (around 140) left behind in the tmp directory after running a `make test`.

This PR ensures ~~*most* of~~ the temp files and directories generated by tests are cleaned up.

**EDIT:** ~~**The only tests that are still in need of a clean up should be those in builder/googlecompute.** Unfortunately, these tests are the main contributor to the detritus left in tmp and leave behind around 80 files!~~

There are other tmp files generated by `make test`. However, these are not generated by the test files directly. See #6199 which cleans up the tmp files generated by the main code behind the PowerShell and Windows-Shell provisioner's. The new winrm-password functionality also seems to be leaving a few tmp files behind...

**EDIT:** The Virtualbox builder is also leaving a tmp directory behind. I'm hoping to fix this with a future PR.

Pending approval, this PR should be OK as is... ~~googlecompute will have to wait.~~ 

**EDIT:** The clean up of tmp files left behind by the googlecompute builder tests is now done. 

As usual, feedback and suggestions for improvement are welcome.