### PR TITLE
Specify "bios.hddOrder" during the CreateVMX step for the vmware-iso builder.

### DIFF
--- a/builder/vmware/common/step_clean_vmx.go
+++ b/builder/vmware/common/step_clean_vmx.go
@@ -47,7 +47,7 @@ func (s StepCleanVMX) Run(_ context.Context, state multistep.StateBag) multistep
 	}
 	vmxData["floppy0.present"] = "FALSE"
 
-	devRe := regexp.MustCompile(`^ide\d:\d\.`)
+	devRe := regexp.MustCompile(`^(ide|sata)\d:\d\.`)
 	for k, v := range vmxData {
 		ide := devRe.FindString(k)
 		if ide == "" || v != "cdrom-image" {

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -21,6 +21,8 @@ type vmxTemplateData struct {
 	ISOPath string
 	Version string
 
+	HDD_BootOrder string
+
 	SCSI_Present         string
 	SCSI_diskAdapterType string
 	SATA_Present         string

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -396,6 +396,8 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 
 	/// Use the disk adapter type that the user specified to tweak the .vmx
 	//  Also sync the cdrom adapter type according to what's common for that disk type.
+	//  XXX: If the cdrom type is modified, make sure to update common/step_clean_vmx.go
+	//       so that it will regex the correct cdrom device for removal.
 	diskAdapterType := strings.ToLower(config.DiskAdapterType)
 	switch diskAdapterType {
 	case "ide":

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -382,6 +382,7 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 		NVME_Present:         "FALSE",
 
 		DiskType:              "scsi",
+		HDD_BootOrder:         "scsi0:0",
 		CDROMType:             "ide",
 		CDROMType_MasterSlave: "0",
 
@@ -404,17 +405,20 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 		templateData.DiskType = "ide"
 		templateData.CDROMType = "ide"
 		templateData.CDROMType_MasterSlave = "1"
+		templateData.HDD_BootOrder = "ide0:0"
 	case "sata":
 		templateData.SATA_Present = "TRUE"
 		templateData.DiskType = "sata"
 		templateData.CDROMType = "sata"
 		templateData.CDROMType_MasterSlave = "1"
+		templateData.HDD_BootOrder = "sata0:0"
 	case "nvme":
 		templateData.NVME_Present = "TRUE"
 		templateData.DiskType = "nvme"
 		templateData.SATA_Present = "TRUE"
 		templateData.CDROMType = "sata"
 		templateData.CDROMType_MasterSlave = "0"
+		templateData.HDD_BootOrder = "nvme0:0"
 	case "scsi":
 		diskAdapterType = "lsilogic"
 		fallthrough
@@ -424,6 +428,7 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 		templateData.DiskType = "scsi"
 		templateData.CDROMType = "ide"
 		templateData.CDROMType_MasterSlave = "0"
+		templateData.HDD_BootOrder = "scsi0:0"
 	}
 
 	/// Handle the cdrom adapter type. If the disk adapter type and the
@@ -643,7 +648,8 @@ func (s *stepCreateVMX) Cleanup(multistep.StateBag) {
 // do so by specifying in the builder configuration.
 const DefaultVMXTemplate = `
 .encoding = "UTF-8"
-bios.bootOrder = "hdd,CDROM"
+bios.bootOrder = "hdd,cdrom"
+bios.hddOrder = "{{ .HDD_BootOrder }}"
 checkpoint.vmState = ""
 cleanShutdown = "TRUE"
 config.version = "8"


### PR DESCRIPTION
Apparently ESX does some strange tampering with "bios.bootOrder" if "bios.hddOrder" is not defined resulting in "bios.bootOrder" being modified to just "cdrom" instead of what packer specifies it as ("hdd,cdrom"). This is strange because at the time the template is complete, the `CleanVMX` step should have disabled the cdrom so if ESX was trying to tamper with the boot order according to what devices were available, then "cdrom" should not be in its list.

Anyways, this hardcodes the "bios.hddOrder" field in the .vmx based on which disk device was specified using the suggestion by @GMZwinge which is expected to result in ESX leaving the "bios.bootOrder" as-is.

This also patches another issue that results in the cdrom-device not being properly removed by the `CleanVMX` step (common/step_clean_vmx.go). That issue will manifest itself if the cdrom-device is something other than IDE due to the way the regex was written.

This might close issue #6197.