### PR TITLE
[WIP] Handle HTTP download errors

### DIFF
--- a/common/download.go
+++ b/common/download.go
@@ -290,6 +290,8 @@ func (d *HTTPDownloader) Download(dst *os.File, src *url.URL) error {
 				}
 			}
 		}
+	} else if err != nil || (resp.StatusCode >= 400 && resp.StatusCode < 600) {
+		return fmt.Errorf("%s", resp.Status)
 	}
 
 	// Set the request to GET now, and redo the query to download
@@ -298,6 +300,8 @@ func (d *HTTPDownloader) Download(dst *os.File, src *url.URL) error {
 	resp, err = httpClient.Do(req)
 	if err != nil {
 		return err
+	} else if err != nil || (resp.StatusCode >= 400 && resp.StatusCode < 600) {
+		return fmt.Errorf("%s", resp.Status)
 	}
 
 	d.total = d.current + uint64(resp.ContentLength)

--- a/common/download_test.go
+++ b/common/download_test.go
@@ -170,6 +170,24 @@ func TestDownloadClient_checksumNoDownload(t *testing.T) {
 	}
 }
 
+func TestDownloadClient_notFound(t *testing.T) {
+	tf, _ := ioutil.TempFile("", "packer")
+	tf.Close()
+	os.Remove(tf.Name())
+
+	ts := httptest.NewServer(http.FileServer(http.Dir("./test-fixtures/root")))
+	defer ts.Close()
+
+	client := NewDownloadClient(&DownloadConfig{
+		Url:        ts.URL + "/not-found.txt",
+		TargetPath: tf.Name(),
+	})
+
+	if _, err := client.Get(); err == nil {
+		t.Fatal("should error")
+	}
+}
+
 func TestDownloadClient_resume(t *testing.T) {
 	tf, _ := ioutil.TempFile("", "packer")
 	tf.Write([]byte("w"))


### PR DESCRIPTION
Checks for HTTP error codes (400-599) in both HEAD and GET operations (a failure in the latter should be rare if the former worked but it still seems possible).

Closes #6203 