### PR TITLE
5887

### DIFF
--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -61,7 +61,6 @@ func (s *stepCreateAMI) Run(_ context.Context, state multistep.StateBag) multist
 	}
 
 	imagesResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
-
 	if err != nil {
 		err := fmt.Errorf("Error searching for AMI: %s", err)
 		state.Put("error", err)

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -54,7 +54,7 @@ func (s *stepCreateAMI) Run(_ context.Context, state multistep.StateBag) multist
 	if _, err := awscommon.WaitForState(&stateChange); err != nil {
 		imagesResp, _ := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
 		stateReason := imagesResp.Images[0].StateReason.Message
-		err := fmt.Errorf("Error waiting for AMI: %s. Cause: %s", err, *stateReason)
+		err := fmt.Errorf("Error waiting for AMI: %s. Root cause: %s", err, *stateReason)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt


### PR DESCRIPTION
It calls DescribeImages to return a DescribeImagesOutput, which is used to retrieve an Image object and access its StateReason. The Message string from the StateReason is added to the error message to provide more information to users.

Closes #5887

