### PR TITLE
Randomize osDisk name for Azure Managed Image builds.

### DIFF
--- a/builder/azure/arm/TestVirtualMachineDeployment05.approved.txt
+++ b/builder/azure/arm/TestVirtualMachineDeployment05.approved.txt
@@ -90,7 +90,7 @@
             "image": {
               "uri": "https://localhost/custom.vhd"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"

--- a/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
@@ -167,7 +167,7 @@
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage",
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             }

--- a/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
@@ -171,7 +171,7 @@
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage",
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             }

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment03.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment03.approved.json
@@ -144,7 +144,7 @@
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage",
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             }

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
@@ -141,7 +141,7 @@
             "image": {
               "uri": "https://localhost/custom.vhd"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment05.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment05.approved.json
@@ -102,7 +102,7 @@
             "image": {
               "uri": "https://localhost/custom.vhd"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
@@ -156,7 +156,7 @@
             "image": {
               "uri": "https://localhost/custom.vhd"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment07.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment07.approved.json
@@ -142,7 +142,7 @@
             "image": {
               "uri": "https://localhost/custom.vhd"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
@@ -144,7 +144,7 @@
             "managedDisk": {
               "storageAccountType": "Standard_LRS"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux"
           }
         }

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment09.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment09.approved.json
@@ -147,7 +147,7 @@
             "managedDisk": {
               "storageAccountType": "Standard_LRS"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux"
           }
         }

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
@@ -125,7 +125,7 @@
             "managedDisk": {
               "storageAccountType": "Standard_LRS"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux"
           }
         }

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
@@ -156,7 +156,7 @@
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage",
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             }

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
@@ -159,7 +159,7 @@
             "managedDisk": {
               "storageAccountType": "Standard_LRS"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux"
           }
         }

--- a/builder/azure/common/template/TestBuildLinux02.approved.txt
+++ b/builder/azure/common/template/TestBuildLinux02.approved.txt
@@ -103,7 +103,7 @@
         "storageProfile": {
           "osDisk": {
             "osType": "Linux",
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             },

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -111,7 +111,6 @@ func (s *TemplateBuilder) SetManagedDiskUrl(managedImageId string, storageAccoun
 	profile.ImageReference = &compute.ImageReference{
 		ID: &managedImageId,
 	}
-	profile.OsDisk.Name = to.StringPtr("osdisk")
 	profile.OsDisk.OsType = s.osType
 	profile.OsDisk.CreateOption = compute.FromImage
 	profile.OsDisk.Vhd = nil
@@ -136,7 +135,6 @@ func (s *TemplateBuilder) SetManagedMarketplaceImage(location, publisher, offer,
 		Version:   &version,
 		//ID:        &imageID,
 	}
-	profile.OsDisk.Name = to.StringPtr("osdisk")
 	profile.OsDisk.OsType = s.osType
 	profile.OsDisk.CreateOption = compute.FromImage
 	profile.OsDisk.Vhd = nil
@@ -583,7 +581,7 @@ const BasicTemplate = `{
         },
         "storageProfile": {
           "osDisk": {
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             },

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux00.approved.json
@@ -144,7 +144,7 @@
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage",
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             }

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux01.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux01.approved.json
@@ -141,7 +141,7 @@
             "image": {
               "uri": "http://azure/custom.vhd"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
@@ -103,7 +103,7 @@
             "image": {
               "uri": "http://azure/custom.vhd"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Linux",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows00.approved.json
@@ -158,7 +158,7 @@
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage",
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             }

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows01.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows01.approved.json
@@ -183,7 +183,7 @@
             "managedDisk": {
               "storageAccountType": "Premium_LRS"
             },
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "osType": "Windows"
           }
         }

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
@@ -174,7 +174,7 @@
           "osDisk": {
             "caching": "ReadWrite",
             "createOption": "FromImage",
-            "name": "osdisk",
+            "name": "[parameters('osDiskName')]",
             "vhd": {
               "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
             }


### PR DESCRIPTION
Closes #6115 

Deletes hardcoded `osdisk` name for osDisk in Azure Managed Image builds.
This will enable packer to use randomly generated name for osDisk and will enable simultaneous builds within one resource group.