### PR TITLE
Fix use of automatically generated ssh key for Scaleway

### DIFF
--- a/builder/scaleway/ssh.go
+++ b/builder/scaleway/ssh.go
@@ -46,7 +46,7 @@ func sshConfig(state multistep.StateBag) (*ssh.ClientConfig, error) {
 	}
 
 	if config.Comm.SSHPrivateKey != "" {
-		if priv, ok := state.GetOk("privateKey"); ok {
+		if priv, ok := state.GetOk("private_key"); ok {
 			privateKey = priv.(string)
 		}
 		signer, err := ssh.ParsePrivateKey([]byte(privateKey))

--- a/builder/scaleway/ssh.go
+++ b/builder/scaleway/ssh.go
@@ -18,7 +18,6 @@ func commHost(state multistep.StateBag) (string, error) {
 
 func sshConfig(state multistep.StateBag) (*ssh.ClientConfig, error) {
 	config := state.Get("config").(Config)
-	var privateKey string
 
 	var auth []ssh.AuthMethod
 
@@ -45,11 +44,9 @@ func sshConfig(state multistep.StateBag) (*ssh.ClientConfig, error) {
 		)
 	}
 
-	if config.Comm.SSHPrivateKey != "" {
-		if priv, ok := state.GetOk("private_key"); ok {
-			privateKey = priv.(string)
-		}
-		signer, err := ssh.ParsePrivateKey([]byte(privateKey))
+	// Use key based auth if there is a private key in the state bag
+	if privateKey, ok := state.GetOk("private_key"); ok {
+		signer, err := ssh.ParsePrivateKey([]byte(privateKey.(string)))
 		if err != nil {
 			return nil, fmt.Errorf("Error setting up SSH config: %s", err)
 		}

--- a/builder/scaleway/step_create_ssh_key.go
+++ b/builder/scaleway/step_create_ssh_key.go
@@ -36,7 +36,7 @@ func (s *stepCreateSSHKey) Run(_ context.Context, state multistep.StateBag) mult
 			return multistep.ActionHalt
 		}
 
-		state.Put("privateKey", string(privateKeyBytes))
+		state.Put("private_key", string(privateKeyBytes))
 		state.Put("ssh_pubkey", "")
 
 		return multistep.ActionContinue
@@ -61,7 +61,7 @@ func (s *stepCreateSSHKey) Run(_ context.Context, state multistep.StateBag) mult
 	}
 
 	// Set the private key in the statebag for later
-	state.Put("privateKey", string(pem.EncodeToMemory(&priv_blk)))
+	state.Put("private_key", string(pem.EncodeToMemory(&priv_blk)))
 
 	pub, _ := ssh.NewPublicKey(&priv.PublicKey)
 	pub_sshformat := string(ssh.MarshalAuthorizedKey(pub))


### PR DESCRIPTION
When `ssh_private_key_file` is left out of the build template the Scaleway builder should automatically generate a ssh key and allow packer to connect with it.

Unfortunately, I believe this behaviour was broken by fc7d89eb79887f21cdb67a1e97f3e6e848134ce0. Please see #6232 for full details.

This PR hopefully restores the intended behaviour.  

I've tested using the two basic templates [here](https://github.com/DanHam/packer-testing/tree/master/scaleway) and the PR seems to work as intended. **However, the user reporting the issue has said they are able to test, so please wait on confirmation in #6232 that this fixes things before merging!**

Hopefully:
fixes: #6232  