### PR TITLE
use xargs when checking formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,14 @@ dev: deps ## Build and install a development build
 fmt: ## Format Go code
 	@$(GOFMT_FILES) | xargs gofmt -w -s
 
-fmt-check: UNFORMATTED_FILES=$(shell $(GOFMT_FILES) | xargs gofmt -s -l)
 fmt-check: ## Check go code formatting
+	$(eval UNFORMATTED_FILES := $(shell $(GOFMT_FILES) | xargs gofmt -s -l))
+	$(eval UNFORMATTED_COUNT := $(words $(UNFORMATTED_FILES)))
 	@echo -n "==> Checking that code complies with gofmt requirements... "
-	@[ $(words $(UNFORMATTED_FILES)) -eq 0 ] && echo "passed" || \
+	@[ $(UNFORMATTED_COUNT) -eq 0 ] && echo "passed" || \
 		echo -e "failed\nRun \`make fmt\` to reformat the following files:"
 	@$(foreach item, $(UNFORMATTED_FILES), echo "  $(item)"; )
-	@[ $(words $(UNFORMATTED_FILES)) -eq 0 ] || exit 1
+	@[ $(UNFORMATTED_COUNT) -eq 0 ] || exit 1
 
 fmt-docs:
 	@find ./website/source/docs -name "*.md" -exec pandoc --wrap auto --columns 79 --atx-headers -s -f "markdown_github+yaml_metadata_block" -t "markdown_github+yaml_metadata_block" {} -o {} \;

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ fmt: ## Format Go code
 fmt-check: UNFORMATTED_FILES=$(shell $(GOFMT_FILES) | xargs gofmt -s -l)
 fmt-check: ## Check go code formatting
 	@echo -n "==> Checking that code complies with gofmt requirements... "
-	@[ -z "$(UNFORMATTED_FILES)" ] && echo "passed" || \
+	@[ $(words $(UNFORMATTED_FILES)) -eq 0 ] && echo "passed" || \
 		echo -e "failed\nRun \`make fmt\` to reformat the following files:"
-	@$(foreach item, $(UNFORMATTED_FILES), echo $(item); )
-	@[ -z "$(UNFORMATTED_FILES)" ] || exit 1
+	@$(foreach item, $(UNFORMATTED_FILES), echo "  $(item)"; )
+	@[ $(words $(UNFORMATTED_FILES)) -eq 0 ] || exit 1
 
 fmt-docs:
 	@find ./website/source/docs -name "*.md" -exec pandoc --wrap auto --columns 79 --atx-headers -s -f "markdown_github+yaml_metadata_block" -t "markdown_github+yaml_metadata_block" {} -o {} \;

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 GOPATH=$(shell go env GOPATH)
 
 # gofmt
-UNFORMATTED_FILES=$(shell find . -not -path "./vendor/*" -name "*.go" | xargs gofmt -s -l)
+GOFMT_FILES?=find . -not -path './vendor/*' -name '*.go'
 
 # Get the git commit
 GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
@@ -60,18 +60,15 @@ dev: deps ## Build and install a development build
 	@cp $(GOPATH)/bin/packer pkg/$(GOOS)_$(GOARCH)
 
 fmt: ## Format Go code
-	@gofmt -w -s $(UNFORMATTED_FILES)
+	@$(GOFMT_FILES) | xargs gofmt -w -s
 
+fmt-check: UNFORMATTED_FILES=$(shell $(GOFMT_FILES) | xargs gofmt -s -l)
 fmt-check: ## Check go code formatting
-	@echo "==> Checking that code complies with gofmt requirements..."
-	@if [ ! -z "$(UNFORMATTED_FILES)" ]; then \
-		echo "gofmt needs to be run on the following files:"; \
-		echo "$(UNFORMATTED_FILES)" | xargs -n1; \
-		echo "You can use the command: \`make fmt\` to reformat code."; \
-		exit 1; \
-	else \
-		echo "Check passed."; \
-	fi
+	@echo -n "==> Checking that code complies with gofmt requirements... "
+	@[ -z "$(UNFORMATTED_FILES)" ] && echo "passed" || \
+		echo -e "failed\nRun \`make fmt\` to reformat the following files:"
+	@$(foreach item, $(UNFORMATTED_FILES), echo $(item); )
+	@[ -z "$(UNFORMATTED_FILES)" ] || exit 1
 
 fmt-docs:
 	@find ./website/source/docs -name "*.md" -exec pandoc --wrap auto --columns 79 --atx-headers -s -f "markdown_github+yaml_metadata_block" -t "markdown_github+yaml_metadata_block" {} -o {} \;


### PR DESCRIPTION
Shell environments have command-line limits and it's easy to construct a string (long list of files) that can overrun that limit. 

partially replaces #6230 
