### PR TITLE
qemu builder: add the 'use_backing_file' setting for QCOW2 images

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -99,6 +99,7 @@ type Config struct {
 	Format            string     `mapstructure:"format"`
 	Headless          bool       `mapstructure:"headless"`
 	DiskImage         bool       `mapstructure:"disk_image"`
+	UseBackingFile    bool       `mapstructure:"use_backing_file"`
 	MachineType       string     `mapstructure:"machine_type"`
 	NetDevice         string     `mapstructure:"net_device"`
 	OutputDir         string     `mapstructure:"output_directory"`
@@ -253,6 +254,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	if b.config.Format != "qcow2" {
 		b.config.SkipCompaction = true
 		b.config.DiskCompression = false
+	}
+
+	if b.config.UseBackingFile && !(b.config.DiskImage && b.config.Format == "qcow2") {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("use_backing_file can only be enabled for QCOW2 images and when disk_image is true"))
 	}
 
 	if _, ok := accels[b.config.Accelerator]; !ok {

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -224,6 +224,49 @@ func TestBuilderPrepare_Format(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare_UseBackingFile(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	config["use_backing_file"] = true
+
+	// Bad: iso_url is not a disk_image
+	config["disk_image"] = false
+	config["format"] = "qcow2"
+	b = Builder{}
+	warns, err := b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Bad: format is not 'qcow2'
+	config["disk_image"] = true
+	config["format"] = "raw"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Good: iso_url is a disk image and format is 'qcow2'
+	config["disk_image"] = true
+	config["format"] = "qcow2"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
 func TestBuilderPrepare_FloppyFiles(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/builder/qemu/step_copy_disk.go
+++ b/builder/qemu/step_copy_disk.go
@@ -28,7 +28,7 @@ func (s *stepCopyDisk) Run(_ context.Context, state multistep.StateBag) multiste
 		path,
 	}
 
-	if config.DiskImage == false {
+	if !config.DiskImage || config.UseBackingFile {
 		return multistep.ActionContinue
 	}
 

--- a/builder/qemu/step_create_disk.go
+++ b/builder/qemu/step_create_disk.go
@@ -23,11 +23,19 @@ func (s *stepCreateDisk) Run(_ context.Context, state multistep.StateBag) multis
 	command := []string{
 		"create",
 		"-f", config.Format,
-		path,
-		fmt.Sprintf("%vM", config.DiskSize),
 	}
 
-	if config.DiskImage == true {
+	if config.UseBackingFile {
+		isoPath := state.Get("iso_path").(string)
+		command = append(command, "-b", isoPath)
+	}
+
+	command = append(command,
+		path,
+		fmt.Sprintf("%vM", config.DiskSize),
+	)
+
+	if config.DiskImage && !config.UseBackingFile {
 		return multistep.ActionContinue
 	}
 

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -152,8 +152,9 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
 
 -   `disk_image` (boolean) - Packer defaults to building from an ISO file, this
     parameter controls whether the ISO URL supplied is actually a bootable
-    QEMU image. When this value is set to true, the machine will clone the
-    source, resize it according to `disk_size` and boot the image.
+    QEMU image. When this value is set to `true`, the machine will either clone
+    the source or use it as a backing file (if `use_backing_file` is `true`);
+    then, it will resize the image according to `disk_size` and boot it.
 
 -   `disk_interface` (string) - The interface to use for the disk. Allowed
     values include any of `ide`, `scsi`, `virtio` or `virtio-scsi`^\*. Note
@@ -318,6 +319,12 @@ template that can be invoked by `make` in parallel:
 will bind to their own SSH port as determined by each process. This will also
 work with WinRM, just change the port forward in `qemuargs` to map to WinRM's
 default port of `5985` or whatever value you have the service set to listen on.
+
+-   `use_backing_file` (boolean) - Only applicable when `disk_image` is `true`
+    and `format` is `qcow2`, set this option to `true` to create a new QCOW2
+    file that uses the file located at `iso_url` as a backing file. The new file
+    will only contain blocks that have changed compared to the backing file, so
+    enabling this option can significantly reduce disk usage.
 
 -   `use_default_display` (boolean) - If true, do not pass a `-display` option
     to qemu, allowing it to choose the default. This may be needed when running


### PR DESCRIPTION
# Overview
This pull request introduces support for using backing files when creating QCOW2 images.

As described in the [QCOW2 specification](https://git.qemu.org/?p=qemu.git;a=blob;f=docs/interop/qcow2.txt), QCOW2 images can optionally utilize a backing file. When a backing file is used, the QCOW2 image will only contain changed blocks.

I build Windows images in four stages (with a separate Packer JSON configuration for each stage):
1. install
2. customize
3. Windows Update
4. cleanup & sysprep

Using backing files for stages 2 through 4 saves both disk space and time, since the images aren't complete copies of the stage 1 image.

# Comparison
_Note: the system I ran these builds on has striped SSDs, so the time savings aren't that impressive._

## Full copy (current behavior)
```
real    59m13.835s
user    45m34.192s
sys     8m59.754s

# find output -type f -exec ls -l {} +
-rw-r--r-- 1 root root  9945481216 May  1 20:25 output/1_install/win2016.qcow2
-rw-r--r-- 1 root root 10666246144 May  1 20:35 output/2_customize/win2016.qcow2
-rw-r--r-- 1 root root 19374604288 May  1 20:57 output/3_update/win2016.qcow2
-rw-r--r-- 1 root root 19905445888 May  1 21:18 output/4_sysprep/win2016.qcow2

# du -hs output/
56G     output/
```

## Using backing files
```
real    53m54.235s
user    44m34.496s
sys     7m50.458s

# find output -type f -exec ls -l {} +
-rw-r--r-- 1 root root 9942663168 May  1 21:28 output/1_install/win2016.qcow2
-rw-r--r-- 1 root root 4042326016 May  1 21:38 output/2_customize/win2016.qcow2
-rw-r--r-- 1 root root 9304866816 May  1 21:59 output/3_update/win2016.qcow2
-rw-r--r-- 1 root root 6048776192 May  1 22:17 output/4_sysprep/win2016.qcow2

# du -hs output/
28G     output/
```