### PR TITLE
show error message when -on-error=[ask|abort]

### DIFF
--- a/common/multistep_runner.go
+++ b/common/multistep_runner.go
@@ -73,7 +73,7 @@ func (s abortStep) Run(ctx context.Context, state multistep.StateBag) multistep.
 func (s abortStep) Cleanup(state multistep.StateBag) {
 	err, ok := state.GetOk("error")
 	if ok {
-		s.ui.Error(err.(error).Error())
+		s.ui.Error(fmt.Sprintf("%s", err))
 	}
 	if _, ok := state.GetOk(multistep.StateCancelled); ok {
 		s.ui.Error("Interrupted, aborting...")
@@ -105,7 +105,7 @@ func (s askStep) Run(ctx context.Context, state multistep.StateBag) (action mult
 
 		err, ok := state.GetOk("error")
 		if ok {
-			s.ui.Error(err.(error).Error())
+			s.ui.Error(fmt.Sprintf("%s", err))
 		}
 
 		switch ask(s.ui, typeName(s.step), state) {

--- a/common/multistep_runner.go
+++ b/common/multistep_runner.go
@@ -71,6 +71,10 @@ func (s abortStep) Run(ctx context.Context, state multistep.StateBag) multistep.
 }
 
 func (s abortStep) Cleanup(state multistep.StateBag) {
+	err, ok := state.GetOk("error")
+	if ok {
+		s.ui.Error(err.(error).Error())
+	}
 	if _, ok := state.GetOk(multistep.StateCancelled); ok {
 		s.ui.Error("Interrupted, aborting...")
 		os.Exit(1)
@@ -97,6 +101,11 @@ func (s askStep) Run(ctx context.Context, state multistep.StateBag) (action mult
 
 		if action != multistep.ActionHalt {
 			return
+		}
+
+		err, ok := state.GetOk("error")
+		if ok {
+			s.ui.Error(err.(error).Error())
 		}
 
 		switch ask(s.ui, typeName(s.step), state) {

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -335,7 +335,6 @@ func (c *comm) reconnect() (err error) {
 	}
 
 	if err != nil {
-		log.Printf("[ERROR] handshake error: %s", err)
 		return
 	}
 	log.Printf("[DEBUG] handshake complete!")


### PR DESCRIPTION
These alternate build behaviors tend to just `os.Exit(1)`. This patch tries to grab any saved errors and log them.

Closes #6252 