### PR TITLE
Update github.com/masterzen/winrm & github.com/masterzen/winrm/soap to latest

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -988,16 +988,16 @@
 			"revision": "95ba30457eb1121fa27753627c774c7cd4e90083"
 		},
 		{
-			"checksumSHA1": "8z5kCCFRsBkhXic9jxxeIV3bBn8=",
+			"checksumSHA1": "dVQEUn5TxdIAXczK7rh6qUrq44Q=",
 			"path": "github.com/masterzen/winrm",
-			"revision": "a2df6b1315e6fd5885eb15c67ed259e85854125f",
-			"revisionTime": "2017-08-14T13:39:27Z"
+			"revision": "7e40f93ae939004a1ef3bd5ff5c88c756ee762bb",
+			"revisionTime": "2018-02-24T16:03:50Z"
 		},
 		{
 			"checksumSHA1": "XFSXma+KmkhkIPsh4dTd/eyja5s=",
 			"path": "github.com/masterzen/winrm/soap",
-			"revision": "a2df6b1315e6fd5885eb15c67ed259e85854125f",
-			"revisionTime": "2017-08-14T13:39:27Z"
+			"revision": "7e40f93ae939004a1ef3bd5ff5c88c756ee762bb",
+			"revisionTime": "2018-02-24T16:03:50Z"
 		},
 		{
 			"checksumSHA1": "NkbetqlpWBi3gP08JDneC+axTKw=",


### PR DESCRIPTION
In #6240 users reported problems that could be traced to the use of `RunWithString` in communicator/winrm/communicator.go [HERE](https://github.com/hashicorp/packer/blob/master/communicator/winrm/communicator.go#L135-L138).

[THIS PR](https://github.com/masterzen/winrm/pull/78) in the upstream WinRM package apparently fixed a race condition in `RunWithString` that only materialises with Go <= 1.10; This is possibly why we are only seeing this issue materialise with recent releases.

I ran the following commands to update:

$ govendor fetch -v github.com/masterzen/winrm
$ govendor fetch -v github.com/masterzen/winrm/soap

**NOTE: I was unable to reproduce the errors seen in #6240 so I have asked if the affected users there could test this PR to see if this fixes things for them**

That said I have tested using the three templates [HERE](https://github.com/DanHam/packer-testing/tree/master/aws/windows). All three built successfully with the updates to winrm and winrm/soap applied. Given that an issue has been found with the version of winrm we are currently using it may not be a bad idea to update to the latest anyway...