### PR TITLE
Add support for T2 Unlimited for Amazon builders

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -85,7 +85,7 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		c.SSHInterface != "public_dns" &&
 		c.SSHInterface != "private_dns" &&
 		c.SSHInterface != "" {
-		errs = append(errs, fmt.Errorf(fmt.Sprintf("Unknown interface type: %s", c.SSHInterface)))
+		errs = append(errs, fmt.Errorf("Unknown interface type: %s", c.SSHInterface))
 	}
 
 	if c.SSHKeyPairName != "" {

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -86,35 +85,35 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		c.SSHInterface != "public_dns" &&
 		c.SSHInterface != "private_dns" &&
 		c.SSHInterface != "" {
-		errs = append(errs, errors.New(fmt.Sprintf("Unknown interface type: %s", c.SSHInterface)))
+		errs = append(errs, fmt.Errorf(fmt.Sprintf("Unknown interface type: %s", c.SSHInterface)))
 	}
 
 	if c.SSHKeyPairName != "" {
 		if c.Comm.Type == "winrm" && c.Comm.WinRMPassword == "" && c.Comm.SSHPrivateKey == "" {
-			errs = append(errs, errors.New("ssh_private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name."))
+			errs = append(errs, fmt.Errorf("ssh_private_key_file must be provided to retrieve the winrm password when using ssh_keypair_name."))
 		} else if c.Comm.SSHPrivateKey == "" && !c.Comm.SSHAgentAuth {
-			errs = append(errs, errors.New("ssh_private_key_file must be provided or ssh_agent_auth enabled when ssh_keypair_name is specified."))
+			errs = append(errs, fmt.Errorf("ssh_private_key_file must be provided or ssh_agent_auth enabled when ssh_keypair_name is specified."))
 		}
 	}
 
 	if c.SourceAmi == "" && c.SourceAmiFilter.Empty() {
-		errs = append(errs, errors.New("A source_ami or source_ami_filter must be specified"))
+		errs = append(errs, fmt.Errorf("A source_ami or source_ami_filter must be specified"))
 	}
 
 	if c.InstanceType == "" {
-		errs = append(errs, errors.New("An instance_type must be specified"))
+		errs = append(errs, fmt.Errorf("An instance_type must be specified"))
 	}
 
 	if c.SpotPrice == "auto" {
 		if c.SpotPriceAutoProduct == "" {
-			errs = append(errs, errors.New(
+			errs = append(errs, fmt.Errorf(
 				"spot_price_auto_product must be specified when spot_price is auto"))
 		}
 	}
 
 	if c.SpotPriceAutoProduct != "" {
 		if c.SpotPrice != "auto" {
-			errs = append(errs, errors.New(
+			errs = append(errs, fmt.Errorf(
 				"spot_price should be set to auto when spot_price_auto_product is specified"))
 		}
 	}

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -112,6 +112,13 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		}
 	}
 
+	if c.SpotPriceAutoProduct != "" {
+		if c.SpotPrice != "auto" {
+			errs = append(errs, errors.New(
+				"spot_price should be set to auto when spot_price_auto_product is specified"))
+		}
+	}
+
 	if c.UserData != "" && c.UserDataFile != "" {
 		errs = append(errs, fmt.Errorf("Only one of user_data or user_data_file can be specified."))
 	} else if c.UserDataFile != "" {

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -32,6 +32,7 @@ type RunConfig struct {
 	AvailabilityZone                  string            `mapstructure:"availability_zone"`
 	DisableStopInstance               bool              `mapstructure:"disable_stop_instance"`
 	EbsOptimized                      bool              `mapstructure:"ebs_optimized"`
+	EnableT2Unlimited                 bool              `mapstructure:"enable_t2_unlimited"`
 	IamInstanceProfile                string            `mapstructure:"iam_instance_profile"`
 	InstanceInitiatedShutdownBehavior string            `mapstructure:"shutdown_behavior"`
 	InstanceType                      string            `mapstructure:"instance_type"`

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -30,25 +30,25 @@ func (d *AmiFilterOptions) Empty() bool {
 type RunConfig struct {
 	AssociatePublicIpAddress          bool              `mapstructure:"associate_public_ip_address"`
 	AvailabilityZone                  string            `mapstructure:"availability_zone"`
+	DisableStopInstance               bool              `mapstructure:"disable_stop_instance"`
 	EbsOptimized                      bool              `mapstructure:"ebs_optimized"`
 	IamInstanceProfile                string            `mapstructure:"iam_instance_profile"`
+	InstanceInitiatedShutdownBehavior string            `mapstructure:"shutdown_behavior"`
 	InstanceType                      string            `mapstructure:"instance_type"`
 	RunTags                           map[string]string `mapstructure:"run_tags"`
+	SecurityGroupId                   string            `mapstructure:"security_group_id"`
+	SecurityGroupIds                  []string          `mapstructure:"security_group_ids"`
 	SourceAmi                         string            `mapstructure:"source_ami"`
 	SourceAmiFilter                   AmiFilterOptions  `mapstructure:"source_ami_filter"`
 	SpotPrice                         string            `mapstructure:"spot_price"`
 	SpotPriceAutoProduct              string            `mapstructure:"spot_price_auto_product"`
-	DisableStopInstance               bool              `mapstructure:"disable_stop_instance"`
-	SecurityGroupId                   string            `mapstructure:"security_group_id"`
-	SecurityGroupIds                  []string          `mapstructure:"security_group_ids"`
-	TemporarySGSourceCidr             string            `mapstructure:"temporary_security_group_source_cidr"`
 	SubnetId                          string            `mapstructure:"subnet_id"`
 	TemporaryKeyPairName              string            `mapstructure:"temporary_key_pair_name"`
+	TemporarySGSourceCidr             string            `mapstructure:"temporary_security_group_source_cidr"`
 	UserData                          string            `mapstructure:"user_data"`
 	UserDataFile                      string            `mapstructure:"user_data_file"`
-	WindowsPasswordTimeout            time.Duration     `mapstructure:"windows_password_timeout"`
 	VpcId                             string            `mapstructure:"vpc_id"`
-	InstanceInitiatedShutdownBehavior string            `mapstructure:"shutdown_behavior"`
+	WindowsPasswordTimeout            time.Duration     `mapstructure:"windows_password_timeout"`
 
 	// Communicator settings
 	Comm           communicator.Config `mapstructure:",squash"`

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -79,6 +79,41 @@ func TestRunConfigPrepare_SourceAmiFilterGood(t *testing.T) {
 	}
 }
 
+func TestRunConfigPrepare_EnableT2UnlimitedGood(t *testing.T) {
+	c := testConfig()
+	// Must have a T2 instance type if T2 Unlimited is enabled
+	c.InstanceType = "t2.micro"
+	c.EnableT2Unlimited = true
+	err := c.Prepare(nil)
+	if len(err) > 0 {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestRunConfigPrepare_EnableT2UnlimitedBadInstanceType(t *testing.T) {
+	c := testConfig()
+	// T2 Unlimited cannot be used with instance types other than T2
+	c.InstanceType = "m5.large"
+	c.EnableT2Unlimited = true
+	err := c.Prepare(nil)
+	if len(err) != 1 {
+		t.Fatalf("T2 Unlimited should not work with non-T2 instance types")
+	}
+}
+
+func TestRunConfigPrepare_EnableT2UnlimitedBadWithSpotInstanceRequest(t *testing.T) {
+	c := testConfig()
+	// T2 Unlimited cannot be used with Spot Instances
+	c.InstanceType = "t2.micro"
+	c.EnableT2Unlimited = true
+	c.SpotPrice = "auto"
+	c.SpotPriceAutoProduct = "Linux/UNIX"
+	err := c.Prepare(nil)
+	if len(err) != 1 {
+		t.Fatalf("T2 Unlimited cannot be used in conjuntion with Spot Price requests")
+	}
+}
+
 func TestRunConfigPrepare_SpotAuto(t *testing.T) {
 	c := testConfig()
 	c.SpotPrice = "auto"

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -118,12 +118,18 @@ func TestRunConfigPrepare_SpotAuto(t *testing.T) {
 	c := testConfig()
 	c.SpotPrice = "auto"
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("spot_price_auto_product should be set when spot_price is set to auto")
 	}
 
+	// Good - SpotPrice and SpotPriceAutoProduct are correctly set
 	c.SpotPriceAutoProduct = "foo"
 	if err := c.Prepare(nil); len(err) != 0 {
 		t.Fatalf("err: %s", err)
+	}
+
+	c.SpotPrice = ""
+	if err := c.Prepare(nil); len(err) != 1 {
+		t.Fatalf("spot_price should be set to auto when spot_price_auto_product is set")
 	}
 }
 

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -48,7 +48,7 @@ func TestRunConfigPrepare_InstanceType(t *testing.T) {
 	c := testConfig()
 	c.InstanceType = ""
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("Should error if an instance_type is not specified")
 	}
 }
 
@@ -56,14 +56,14 @@ func TestRunConfigPrepare_SourceAmi(t *testing.T) {
 	c := testConfig()
 	c.SourceAmi = ""
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("Should error if a source_ami (or source_ami_filter) is not specified")
 	}
 }
 
 func TestRunConfigPrepare_SourceAmiFilterBlank(t *testing.T) {
 	c := testConfigFilter()
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("Should error if source_ami_filter is empty or not specified (and source_ami is not specified)")
 	}
 }
 
@@ -97,7 +97,7 @@ func TestRunConfigPrepare_EnableT2UnlimitedBadInstanceType(t *testing.T) {
 	c.EnableT2Unlimited = true
 	err := c.Prepare(nil)
 	if len(err) != 1 {
-		t.Fatalf("T2 Unlimited should not work with non-T2 instance types")
+		t.Fatalf("Should error if T2 Unlimited is enabled with non-T2 instance_type")
 	}
 }
 
@@ -110,7 +110,7 @@ func TestRunConfigPrepare_EnableT2UnlimitedBadWithSpotInstanceRequest(t *testing
 	c.SpotPriceAutoProduct = "Linux/UNIX"
 	err := c.Prepare(nil)
 	if len(err) != 1 {
-		t.Fatalf("T2 Unlimited cannot be used in conjuntion with Spot Price requests")
+		t.Fatalf("Should error if T2 Unlimited has been used in conjuntion with a Spot Price request")
 	}
 }
 
@@ -118,7 +118,7 @@ func TestRunConfigPrepare_SpotAuto(t *testing.T) {
 	c := testConfig()
 	c.SpotPrice = "auto"
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("spot_price_auto_product should be set when spot_price is set to auto")
+		t.Fatalf("Should error if spot_price_auto_product is not set and spot_price is set to auto")
 	}
 
 	// Good - SpotPrice and SpotPriceAutoProduct are correctly set
@@ -129,7 +129,7 @@ func TestRunConfigPrepare_SpotAuto(t *testing.T) {
 
 	c.SpotPrice = ""
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("spot_price should be set to auto when spot_price_auto_product is set")
+		t.Fatalf("Should error if spot_price is not set to auto and spot_price_auto_product is set")
 	}
 }
 
@@ -166,7 +166,7 @@ func TestRunConfigPrepare_UserData(t *testing.T) {
 	c.UserData = "foo"
 	c.UserDataFile = tf.Name()
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("Should error if user_data string and user_data_file have both been specified")
 	}
 }
 
@@ -178,7 +178,7 @@ func TestRunConfigPrepare_UserDataFile(t *testing.T) {
 
 	c.UserDataFile = "idontexistidontthink"
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("Should error if the file specified by user_data_file does not exist")
 	}
 
 	tf, err := ioutil.TempFile("", "packer")

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -24,6 +24,7 @@ type StepRunSourceInstance struct {
 	Ctx                               interpolate.Context
 	Debug                             bool
 	EbsOptimized                      bool
+	EnableT2Unlimited                 bool
 	ExpectedRootDevice                string
 	IamInstanceProfile                string
 	InstanceInitiatedShutdownBehavior string
@@ -114,6 +115,11 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		BlockDeviceMappings: s.BlockDevices.BuildLaunchDevices(),
 		Placement:           &ec2.Placement{AvailabilityZone: &s.AvailabilityZone},
 		EbsOptimized:        &s.EbsOptimized,
+	}
+
+	if s.EnableT2Unlimited {
+		creditOption := "unlimited"
+		runOpts.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: &creditOption}
 	}
 
 	// Collect tags for tagging on resource creation

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -148,6 +148,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
+			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
 			ExpectedRootDevice:                "ebs",
 			IamInstanceProfile:                b.config.IamInstanceProfile,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -162,6 +162,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
+			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
 			ExpectedRootDevice:                "ebs",
 			IamInstanceProfile:                b.config.IamInstanceProfile,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -145,6 +145,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
+			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
 			ExpectedRootDevice:                "ebs",
 			IamInstanceProfile:                b.config.IamInstanceProfile,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -230,6 +230,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Ctx:                      b.config.ctx,
 			Debug:                    b.config.PackerDebug,
 			EbsOptimized:             b.config.EbsOptimized,
+			EnableT2Unlimited:        b.config.EnableT2Unlimited,
 			IamInstanceProfile:       b.config.IamInstanceProfile,
 			InstanceType:             b.config.InstanceType,
 			IsRestricted:             b.config.IsChinaCloud() || b.config.IsGovCloud(),

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -169,6 +169,30 @@ builder.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
+-   `enable_t2_unlimited` (boolean) - Enabling T2 Unlimited allows the source
+    instance to burst additional CPU beyond its available [CPU Credits]
+    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
+    for as long as the demand exists.
+    This is in contrast to the standard configuration that only allows an
+    instance to consume up to its available CPU Credits.
+    See the AWS documentation for [T2 Unlimited]
+    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html)
+    and the 'T2 Unlimited Pricing' section of the [Amazon EC2 On-Demand
+    Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for more
+    information.
+    By default this option is disabled and Packer will set up a [T2
+    Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-std.html)
+    instance instead.
+
+    To use T2 Unlimited you must use a T2 instance type e.g. t2.micro.
+    Additionally, T2 Unlimited cannot be used in conjunction with Spot
+    Instances e.g. when the `spot_price` option has been configured.
+    Attempting to do so will cause an error.
+
+    !&gt; **Warning!** Additional costs may be incurred by enabling T2
+    Unlimited - even for instances that would usually qualify for the
+    [AWS Free Tier](https://aws.amazon.com/free/).
+
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
 

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -162,6 +162,30 @@ builder.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
+-   `enable_t2_unlimited` (boolean) - Enabling T2 Unlimited allows the source
+    instance to burst additional CPU beyond its available [CPU Credits]
+    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
+    for as long as the demand exists.
+    This is in contrast to the standard configuration that only allows an
+    instance to consume up to its available CPU Credits.
+    See the AWS documentation for [T2 Unlimited]
+    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html)
+    and the 'T2 Unlimited Pricing' section of the [Amazon EC2 On-Demand
+    Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for more
+    information.
+    By default this option is disabled and Packer will set up a [T2
+    Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-std.html)
+    instance instead.
+
+    To use T2 Unlimited you must use a T2 instance type e.g. t2.micro.
+    Additionally, T2 Unlimited cannot be used in conjunction with Spot
+    Instances e.g. when the `spot_price` option has been configured.
+    Attempting to do so will cause an error.
+
+    !&gt; **Warning!** Additional costs may be incurred by enabling T2
+    Unlimited - even for instances that would usually qualify for the
+    [AWS Free Tier](https://aws.amazon.com/free/).
+
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Default `false`.
 

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -120,6 +120,30 @@ builder.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
+-   `enable_t2_unlimited` (boolean) - Enabling T2 Unlimited allows the source
+    instance to burst additional CPU beyond its available [CPU Credits]
+    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
+    for as long as the demand exists.
+    This is in contrast to the standard configuration that only allows an
+    instance to consume up to its available CPU Credits.
+    See the AWS documentation for [T2 Unlimited]
+    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html)
+    and the 'T2 Unlimited Pricing' section of the [Amazon EC2 On-Demand
+    Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for more
+    information.
+    By default this option is disabled and Packer will set up a [T2
+    Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-std.html)
+    instance instead.
+
+    To use T2 Unlimited you must use a T2 instance type e.g. t2.micro.
+    Additionally, T2 Unlimited cannot be used in conjunction with Spot
+    Instances e.g. when the `spot_price` option has been configured.
+    Attempting to do so will cause an error.
+
+    !&gt; **Warning!** Additional costs may be incurred by enabling T2
+    Unlimited - even for instances that would usually qualify for the
+    [AWS Free Tier](https://aws.amazon.com/free/).
+
 -   `iam_instance_profile` (string) - The name of an [IAM instance
     profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
     to launch the EC2 instance with.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -193,6 +193,30 @@ builder.
     Note: you must make sure enhanced networking is enabled on your instance. See [Amazon's
     documentation on enabling enhanced networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking). Default `false`.
 
+-   `enable_t2_unlimited` (boolean) - Enabling T2 Unlimited allows the source
+    instance to burst additional CPU beyond its available [CPU Credits]
+    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
+    for as long as the demand exists.
+    This is in contrast to the standard configuration that only allows an
+    instance to consume up to its available CPU Credits.
+    See the AWS documentation for [T2 Unlimited]
+    (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html)
+    and the 'T2 Unlimited Pricing' section of the [Amazon EC2 On-Demand
+    Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for more
+    information.
+    By default this option is disabled and Packer will set up a [T2
+    Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-std.html)
+    instance instead.
+
+    To use T2 Unlimited you must use a T2 instance type e.g. t2.micro.
+    Additionally, T2 Unlimited cannot be used in conjunction with Spot
+    Instances e.g. when the `spot_price` option has been configured.
+    Attempting to do so will cause an error.
+
+    !&gt; **Warning!** Additional costs may be incurred by enabling T2
+    Unlimited - even for instances that would usually qualify for the
+    [AWS Free Tier](https://aws.amazon.com/free/).
+
 -   `force_deregister` (boolean) - Force Packer to first deregister an existing
     AMI if one with the same name already exists. Defaults to `false`.
 


### PR DESCRIPTION
This PR adds support for [T2 Unlimited](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html) for the following Amazon builders:

* amazon-ebs
* amazon-ebssurrogate
* amazon-ebsvolume
* amazon-instance

See #6260 for background info.

Note that T2 Unlimited support is not really required for `amazon-chroot` as the 'source instance' for this builder is already up and running and will likely already be configured as required.

I've tested with the `amazon-ebs` builder using the templates [HERE](https://github.com/DanHam/packer-testing/tree/master/aws/centos) and everything works as expected. The `source_ami_filter` should find the latest official CentOS 7 AMI for any configured region.
The templates should work (or error!) as expected without any modification. Clearly, you may wish to change the `region` to something more appropriate.

To determine whether T2 Unlimited is enabled/disabled see [Viewing the Credit Option for CPU Usage of a T2 Instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-how-to.html#describe-t2).

As usual, feedback and suggestions for improvement are welcome.

Closes #6260