### PR TITLE
Async delete Resource Group

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -344,6 +344,7 @@ func (b *Builder) configureStateBag(stateBag multistep.StateBag) {
 	stateBag.Put(constants.ArmIsManagedImage, b.config.isManagedImage())
 	stateBag.Put(constants.ArmManagedImageResourceGroupName, b.config.ManagedImageResourceGroupName)
 	stateBag.Put(constants.ArmManagedImageName, b.config.ManagedImageName)
+	stateBag.Put(constants.ArmAsyncRGDelete, b.config.AsyncRGDelete)
 }
 
 // Parameters that are only known at runtime after querying Azure.

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -344,7 +344,7 @@ func (b *Builder) configureStateBag(stateBag multistep.StateBag) {
 	stateBag.Put(constants.ArmIsManagedImage, b.config.isManagedImage())
 	stateBag.Put(constants.ArmManagedImageResourceGroupName, b.config.ManagedImageResourceGroupName)
 	stateBag.Put(constants.ArmManagedImageName, b.config.ManagedImageName)
-	stateBag.Put(constants.ArmAsyncRGDelete, b.config.AsyncRGDelete)
+	stateBag.Put(constants.ArmAsyncResourceGroupDelete, b.config.AsyncResourceGroupDelete)
 }
 
 // Parameters that are only known at runtime after querying Azure.

--- a/builder/azure/arm/builder_test.go
+++ b/builder/azure/arm/builder_test.go
@@ -25,6 +25,7 @@ func TestStateBagShouldBePopulatedExpectedValues(t *testing.T) {
 		constants.ArmStorageAccountName,
 		constants.ArmVirtualMachineCaptureParameters,
 		constants.ArmPublicIPAddressName,
+		constants.ArmAsyncResourceGroupDelete,
 	}
 
 	for _, v := range expectedStateBagKeys {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -153,7 +153,7 @@ type Config struct {
 	ctx  *interpolate.Context
 
 	//Cleanup
-	AsyncRGDelete bool `mapstructure:"async_resourcegroup_delete"`
+	AsyncResourceGroupDelete bool `mapstructure:"async_resourcegroup_delete"`
 }
 
 type keyVaultCertificate struct {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -151,6 +151,9 @@ type Config struct {
 
 	Comm communicator.Config `mapstructure:",squash"`
 	ctx  *interpolate.Context
+
+	//Cleanup
+	AsyncRGDelete bool `mapstructure:"async_resourcegroup_delete"`
 }
 
 type keyVaultCertificate struct {

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1264,6 +1264,73 @@ func TestConfigShouldAllowTempNameOverrides(t *testing.T) {
 	}
 }
 
+func TestConfigShouldAllowAsyncResourceGroupOverride(t *testing.T) {
+	config := map[string]interface{}{
+		"image_offer":                       "ignore",
+		"image_publisher":                   "ignore",
+		"image_sku":                         "ignore",
+		"location":                          "ignore",
+		"subscription_id":                   "ignore",
+		"communicator":                      "none",
+		"os_type":                           "linux",
+		"managed_image_name":                "ignore",
+		"managed_image_resource_group_name": "ignore",
+		"async_resourcegroup_delete":        "true",
+	}
+
+	c, _, err := newConfig(config, getPackerConfiguration())
+	if err != nil {
+		t.Errorf("newConfig failed with %q", err)
+	}
+
+	if c.AsyncResourceGroupDelete != true {
+		t.Errorf("expected async_resourcegroup_delete to be %q, but got %t", "async_resourcegroup_delete", c.AsyncResourceGroupDelete)
+	}
+}
+func TestConfigShouldAllowAsyncResourceGroupOverrideNoValue(t *testing.T) {
+	config := map[string]interface{}{
+		"image_offer":                       "ignore",
+		"image_publisher":                   "ignore",
+		"image_sku":                         "ignore",
+		"location":                          "ignore",
+		"subscription_id":                   "ignore",
+		"communicator":                      "none",
+		"os_type":                           "linux",
+		"managed_image_name":                "ignore",
+		"managed_image_resource_group_name": "ignore",
+	}
+
+	c, _, err := newConfig(config, getPackerConfiguration())
+	if err != nil {
+		t.Errorf("newConfig failed with %q", err)
+	}
+
+	if c.AsyncResourceGroupDelete != false {
+		t.Errorf("expected async_resourcegroup_delete to be %q, but got %t", "async_resourcegroup_delete", c.AsyncResourceGroupDelete)
+	}
+}
+func TestConfigShouldAllowAsyncResourceGroupOverrideBadValue(t *testing.T) {
+	config := map[string]interface{}{
+		"image_offer":                       "ignore",
+		"image_publisher":                   "ignore",
+		"image_sku":                         "ignore",
+		"location":                          "ignore",
+		"subscription_id":                   "ignore",
+		"communicator":                      "none",
+		"os_type":                           "linux",
+		"managed_image_name":                "ignore",
+		"managed_image_resource_group_name": "ignore",
+		"async_resourcegroup_delete":        "asdasda",
+	}
+
+	c, _, err := newConfig(config, getPackerConfiguration())
+	if err != nil && c == nil {
+		t.Log("newConfig failed  which is expected ", err)
+
+	}
+
+}
+
 func getArmBuilderConfiguration() map[string]string {
 	m := make(map[string]string)
 	for _, v := range requiredConfigValues {

--- a/builder/azure/arm/step_create_resource_group.go
+++ b/builder/azure/arm/step_create_resource_group.go
@@ -118,7 +118,7 @@ func (s *StepCreateResourceGroup) Cleanup(state multistep.StateBag) {
 		ctx := context.TODO()
 		f, err := s.client.GroupsClient.Delete(ctx, resourceGroupName)
 		if err == nil {
-			if state.Get(constants.ArmAsyncRGDelete).(bool) {
+			if state.Get(constants.ArmAsyncResourceGroupDelete).(bool) {
 				s.say(fmt.Sprintf("\n Not waiting for Resource Group delete as requested by user. Resource Group Name is %s", resourceGroupName))
 			} else {
 				err = f.WaitForCompletion(ctx, s.client.GroupsClient.Client)
@@ -130,7 +130,7 @@ func (s *StepCreateResourceGroup) Cleanup(state multistep.StateBag) {
 				"Error: %s", resourceGroupName, err))
 			return
 		}
-		if !state.Get(constants.ArmAsyncRGDelete).(bool) {
+		if !state.Get(constants.ArmAsyncResourceGroupDelete).(bool) {
 			ui.Say("Resource group has been deleted.")
 		}
 	}

--- a/builder/azure/arm/step_create_resource_group.go
+++ b/builder/azure/arm/step_create_resource_group.go
@@ -118,14 +118,20 @@ func (s *StepCreateResourceGroup) Cleanup(state multistep.StateBag) {
 		ctx := context.TODO()
 		f, err := s.client.GroupsClient.Delete(ctx, resourceGroupName)
 		if err == nil {
-			err = f.WaitForCompletion(ctx, s.client.GroupsClient.Client)
+			if state.Get(constants.ArmAsyncRGDelete).(bool) {
+				s.say(fmt.Sprintf("\n Not waiting for Resource Group delete as requested by user. Resource Group Name is %s", resourceGroupName))
+			} else {
+				err = f.WaitForCompletion(ctx, s.client.GroupsClient.Client)
+			}
 		}
 		if err != nil {
 			ui.Error(fmt.Sprintf("Error deleting resource group.  Please delete it manually.\n\n"+
 				"Name: %s\n"+
 				"Error: %s", resourceGroupName, err))
+			return
 		}
-
-		ui.Say("Resource group has been deleted.")
+		if !state.Get(constants.ArmAsyncRGDelete).(bool) {
+			ui.Say("Resource group has been deleted.")
+		}
 	}
 }

--- a/builder/azure/arm/step_delete_resource_group.go
+++ b/builder/azure/arm/step_delete_resource_group.go
@@ -53,7 +53,13 @@ func (s *StepDeleteResourceGroup) deleteResourceGroup(ctx context.Context, state
 		s.say("\nThe resource group was created by Packer, deleting ...")
 		f, err := s.client.GroupsClient.Delete(ctx, resourceGroupName)
 		if err == nil {
-			f.WaitForCompletion(ctx, s.client.GroupsClient.Client)
+			if state.Get(constants.ArmAsyncRGDelete).(bool) {
+				// No need to wait for the complition for delete if request is Accepted
+				s.say(fmt.Sprintf("\nResource Group is being deleted, not waiting for deletion due to config. Resource Group Name '%s'", resourceGroupName))
+			} else {
+				f.WaitForCompletion(ctx, s.client.GroupsClient.Client)
+			}
+
 		}
 
 		if err != nil {

--- a/builder/azure/arm/step_delete_resource_group.go
+++ b/builder/azure/arm/step_delete_resource_group.go
@@ -53,7 +53,7 @@ func (s *StepDeleteResourceGroup) deleteResourceGroup(ctx context.Context, state
 		s.say("\nThe resource group was created by Packer, deleting ...")
 		f, err := s.client.GroupsClient.Delete(ctx, resourceGroupName)
 		if err == nil {
-			if state.Get(constants.ArmAsyncRGDelete).(bool) {
+			if state.Get(constants.ArmAsyncResourceGroupDelete).(bool) {
 				// No need to wait for the complition for delete if request is Accepted
 				s.say(fmt.Sprintf("\nResource Group is being deleted, not waiting for deletion due to config. Resource Group Name '%s'", resourceGroupName))
 			} else {

--- a/builder/azure/common/constants/stateBag.go
+++ b/builder/azure/common/constants/stateBag.go
@@ -35,5 +35,5 @@ const (
 	ArmManagedImageResourceGroupName string = "arm.ManagedImageResourceGroupName"
 	ArmManagedImageLocation          string = "arm.ManagedImageLocation"
 	ArmManagedImageName              string = "arm.ManagedImageName"
-	ArmAsyncRGDelete                 string = "arm.AsyncRGDelete"
+	ArmAsyncResourceGroupDelete      string = "arm.AsyncResourceGroupDelete"
 )

--- a/builder/azure/common/constants/stateBag.go
+++ b/builder/azure/common/constants/stateBag.go
@@ -35,4 +35,5 @@ const (
 	ArmManagedImageResourceGroupName string = "arm.ManagedImageResourceGroupName"
 	ArmManagedImageLocation          string = "arm.ManagedImageLocation"
 	ArmManagedImageName              string = "arm.ManagedImageName"
+	ArmAsyncRGDelete                 string = "arm.AsyncRGDelete"
 )

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -221,6 +221,10 @@ Providing `temp_resource_group_name` or `location` in combination with `build_re
 
     CLI example `azure vm sizes -l westus`
 
+-   `async_resourcegroup_delete` (boolean) If you want packer to delete the temporary resource group asynchronously. Its a boolean value
+     and defaults to false. **Important** Setting this true would mean that your builds are faster however this is a very
+     small chance that the temporary resource group is not deleted by Azure.
+
 ## Basic Example
 
 Here is a basic example for Azure.

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -221,9 +221,8 @@ Providing `temp_resource_group_name` or `location` in combination with `build_re
 
     CLI example `azure vm sizes -l westus`
 
--   `async_resourcegroup_delete` (boolean) If you want packer to delete the temporary resource group asynchronously. Its a boolean value
-     and defaults to false. **Important** Setting this true would mean that your builds are faster however this is a very
-     small chance that the temporary resource group is not deleted by Azure.
+-   `async_resourcegroup_delete` (boolean) If you want packer to delete the temporary resource group asynchronously. It's a boolean value
+     and defaults to false. **Important** Setting this true means that your builds are faster, any failed deletes are not reported.
 
 ## Basic Example
 

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -221,8 +221,8 @@ Providing `temp_resource_group_name` or `location` in combination with `build_re
 
     CLI example `azure vm sizes -l westus`
 
--   `async_resourcegroup_delete` (boolean) If you want packer to delete the temporary resource group asynchronously. It's a boolean value
-     and defaults to false. **Important** Setting this true means that your builds are faster, any failed deletes are not reported.
+-   `async_resourcegroup_delete` (boolean) If you want packer to delete the temporary resource group asynchronously set this value. It's a boolean value
+     and defaults to false. **Important** Setting this true means that your builds are faster, however any failed deletes are not reported.
 
 ## Basic Example
 


### PR DESCRIPTION
Deleting Resource Group can take times as the resources gets cleaned up. Providing an option to users to do async delete Azure resource group as once the API gets Accepted Azure would delete the resource group. 

This will make the builds run faster as save average of 6-7 min. 

This change adds a new configuration option async_resourcegroup_delete that will default to False ( keeping existing synchronous delete behavior ) . If the value is set to true it will not wait for delete of the resource group as ARM has already returned Status Accepted for the operation. 

Tests 

1. Tested without the value set . Go defaults to false . Got the current behavior 
2. Tested without the value set and failed the deployment. Got the current behavior 
3. Set the value and tested and Got the new behavior with build not waiting for delete 
3. Set the value and failed the deployment and got the new behavior for not waiting for delete 

Not adding the new behavior to acceptance tests yet. 

closes #5293



