### PR TITLE
Revert commits that enabled reporting of disk compaction results for VMware builders

### DIFF
--- a/builder/vmware/common/step_compact_disk.go
+++ b/builder/vmware/common/step_compact_disk.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math"
-	"os"
 
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -38,38 +36,9 @@ func (s StepCompactDisk) Run(_ context.Context, state multistep.StateBag) multis
 	ui.Say("Compacting all attached virtual disks...")
 	for i, diskFullPath := range diskFullPaths {
 		ui.Message(fmt.Sprintf("Compacting virtual disk %d", i+1))
-		// Get the file size of the virtual disk prior to compaction
-		fi, err := os.Stat(diskFullPath)
-		if err != nil {
-			state.Put("error", fmt.Errorf("Error getting virtual disk file info pre compaction: %s", err))
-			return multistep.ActionHalt
-		}
-		diskFileSizeStart := fi.Size()
-		// Defragment and compact the disk
 		if err := driver.CompactDisk(diskFullPath); err != nil {
 			state.Put("error", fmt.Errorf("Error compacting disk: %s", err))
 			return multistep.ActionHalt
-		}
-		// Get the file size of the virtual disk post compaction
-		fi, err = os.Stat(diskFullPath)
-		if err != nil {
-			state.Put("error", fmt.Errorf("Error getting virtual disk file info post compaction: %s", err))
-			return multistep.ActionHalt
-		}
-		diskFileSizeEnd := fi.Size()
-		// Report compaction results
-		log.Printf("Before compaction the disk file size was: %d", diskFileSizeStart)
-		log.Printf("After compaction the disk file size was: %d", diskFileSizeEnd)
-		if diskFileSizeStart > 0 {
-			percentChange := ((float64(diskFileSizeEnd) / float64(diskFileSizeStart)) * 100.0) - 100.0
-			switch {
-			case percentChange < 0:
-				ui.Message(fmt.Sprintf("Compacting reduced the disk file size by %.2f%%", math.Abs(percentChange)))
-			case percentChange == 0:
-				ui.Message(fmt.Sprintf("The compacting operation left the disk file size unchanged"))
-			case percentChange > 0:
-				ui.Message(fmt.Sprintf("WARNING: Compacting increased the disk file size by %.2f%%", percentChange))
-			}
 		}
 	}
 

--- a/builder/vmware/common/step_compact_disk_test.go
+++ b/builder/vmware/common/step_compact_disk_test.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -17,25 +15,8 @@ func TestStepCompactDisk(t *testing.T) {
 	state := testState(t)
 	step := new(StepCompactDisk)
 
-	// Create a fake vmdk file for disk file size operations
-	diskFile, err := ioutil.TempFile("", "disk.vmdk")
-	if err != nil {
-		t.Fatalf("Error creating fake vmdk file: %s", err)
-	}
-
-	diskFullPath := diskFile.Name()
-	defer os.Remove(diskFullPath)
-
-	content := []byte("I am the fake vmdk's contents")
-	if _, err := diskFile.Write(content); err != nil {
-		t.Fatalf("Error writing to fake vmdk file: %s", err)
-	}
-	if err := diskFile.Close(); err != nil {
-		t.Fatalf("Error closing fake vmdk file: %s", err)
-	}
-
-	// Set up required state
-	state.Put("disk_full_paths", []string{diskFullPath})
+	diskFullPaths := []string{"foo"}
+	state.Put("disk_full_paths", diskFullPaths)
 
 	driver := state.Get("driver").(*DriverMock)
 
@@ -51,7 +32,7 @@ func TestStepCompactDisk(t *testing.T) {
 	if !driver.CompactDiskCalled {
 		t.Fatal("should've called")
 	}
-	if driver.CompactDiskPath != diskFullPath {
+	if driver.CompactDiskPath != "foo" {
 		t.Fatal("should call with right path")
 	}
 }


### PR DESCRIPTION
Unfortunately 08f9d619a9299d81495d96cf10160f38cdb2476d broke the VMware ISO builder when used with remote ESXi hosts as it used os.Stat(...) to grab the file size. Clearly, os.Stat(...) isn't going to work for a remote file on a ESXi server. See #6272.

I'm hoping to fix this with a future PR but will need some time to do so. For the time being I think the best course of action is simply to revert these changes. 

This PR reverts 08f9d619a9299d81495d96cf10160f38cdb2476d and the related commit f342975ff31e5a59b4534b3fb216250365468b1f to fix. I've tested the changes using VMware Fusion with the ISO and VMX builders and things work as expected - we get compacted disks but no reporting of the actual changes/reduction in file size.

I have asked over in #6272 if the reporter can test with ESXi to ensure everything is fixed.

Depending on that test:
Closes #6272 
