### PR TITLE
Devicelogin Support for Windows and not requiring object ID 

### DIFF
--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -122,7 +122,7 @@ func byConcatDecorators(decorators ...autorest.RespondDecorator) autorest.Respon
 }
 
 func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string,
-	cloud *azure.Environment, tenantID string, isDeviceLogin bool,
+	cloud *azure.Environment,
 	servicePrincipalToken, servicePrincipalTokenVault *adal.ServicePrincipalToken) (*AzureClient, error) {
 
 	var azureClient = &AzureClient{}

--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -122,7 +122,7 @@ func byConcatDecorators(decorators ...autorest.RespondDecorator) autorest.Respon
 }
 
 func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string,
-	cloud *azure.Environment,
+	cloud *azure.Environment, tenantID string, isDeviceLogin bool,
 	servicePrincipalToken, servicePrincipalTokenVault *adal.ServicePrincipalToken) (*AzureClient, error) {
 
 	var azureClient = &AzureClient{}

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -378,10 +378,12 @@ func (b *Builder) getServicePrincipalTokens(say func(string)) (*adal.ServicePrin
 	var err error
 
 	if b.config.useDeviceLogin {
+		say("Getting auth token for Service management endpoint")
 		servicePrincipalToken, err = packerAzureCommon.Authenticate(*b.config.cloudEnvironment, b.config.TenantID, say, b.config.cloudEnvironment.ServiceManagementEndpoint)
 		if err != nil {
 			return nil, nil, err
 		}
+		say("Getting token for Vault resource")
 		servicePrincipalTokenVault, err = packerAzureCommon.Authenticate(*b.config.cloudEnvironment, b.config.TenantID, say, strings.TrimRight(b.config.cloudEnvironment.KeyVaultEndpoint, "/"))
 		if err != nil {
 			return nil, nil, err

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -85,7 +85,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		b.config.cloudEnvironment,
 		spnCloud,
 		spnKeyVault)
-	
+
 	if err != nil {
 		return nil, err
 	}

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -92,7 +92,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, err
 	}
 	if b.config.ObjectID == "" {
-		b.config.ObjectID = getObjectIdFromToken(spnCloud)
+		b.config.ObjectID = getObjectIdFromToken(ui, spnCloud)
 	} else {
 		ui.Message("You have provided Object_ID which is no longer needed, azure packer builder determines this dynamically from the authentication token")
 	}
@@ -423,7 +423,7 @@ func (b *Builder) getServicePrincipalTokens(say func(string)) (*adal.ServicePrin
 	return servicePrincipalToken, servicePrincipalTokenVault, nil
 }
 
-func getObjectIdFromToken(token *adal.ServicePrincipalToken) string {
+func getObjectIdFromToken(ui packer.Ui, token *adal.ServicePrincipalToken) string {
 	claims := jwt.MapClaims{}
 	var p jwt.Parser
 
@@ -432,6 +432,7 @@ func getObjectIdFromToken(token *adal.ServicePrincipalToken) string {
 	_, _, err = p.ParseUnverified(token.OAuthToken(), claims)
 
 	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to parse the token,Error: %s", err.Error()))
 		return ""
 	}
 	return claims["oid"].(string)

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -91,11 +91,14 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if err := resolver.Resolve(b.config); err != nil {
 		return nil, err
 	}
-
-	b.config.ObjectID = getObjectIdFromToken(spnCloud)
+	if b.config.ObjectID == "" {
+		b.config.ObjectID = getObjectIdFromToken(spnCloud)
+	} else {
+		ui.Message("You have provided Object_ID which is no longer needed, azure packer builder determines this dynamically from the authentication token")
+	}
 
 	if b.config.ObjectID == "" && b.config.OSType != constants.Target_Linux {
-		return nil, fmt.Errorf("could not determined the ObjectID for the user, which is required for Windows builds")
+		return nil, fmt.Errorf("could not determine the ObjectID for the user, which is required for Windows builds")
 	}
 
 	if b.config.isManagedImage() {

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -85,6 +85,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		b.config.cloudEnvironment,
 		spnCloud,
 		spnKeyVault)
+	
 	if err != nil {
 		return nil, err
 	}

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -83,8 +83,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		b.config.ResourceGroupName,
 		b.config.StorageAccount,
 		b.config.cloudEnvironment,
-		b.config.TenantID,
-		b.config.useDeviceLogin,
 		spnCloud,
 		spnKeyVault)
 	if err != nil {

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -390,7 +390,7 @@ func (b *Builder) getServicePrincipalTokens(say func(string)) (*adal.ServicePrin
 		if err != nil {
 			return nil, nil, err
 		}
-		servicePrincipalTokenVault, err = packerAzureCommon.Authenticate(*b.config.cloudEnvironment, b.config.TenantID, say, b.config.cloudEnvironment.KeyVaultEndpoint)
+		servicePrincipalTokenVault, err = packerAzureCommon.Authenticate(*b.config.cloudEnvironment, b.config.TenantID, say, strings.TrimRight(b.config.cloudEnvironment.KeyVaultEndpoint, "/"))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -418,7 +418,7 @@ func (b *Builder) getServicePrincipalTokens(say func(string)) (*adal.ServicePrin
 	return servicePrincipalToken, servicePrincipalTokenVault, nil
 }
 
-func getObjectIdFromToken(token *adal.ServicePrincipalToken) (oid string) {
+func getObjectIdFromToken(token *adal.ServicePrincipalToken) string {
 	claims := jwt.MapClaims{}
 	var p jwt.Parser
 

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -12,7 +12,7 @@ package arm
 // The subscription in question should have a resource group
 // called "packer-acceptance-test" in "West US" region. The
 // storage account refered to in the above variable should
-// be inside this resource group and in "West US" as well.
+// be inside this resource group and in "South Central US" as well.
 //
 // In addition, the PACKER_ACC variable should also be set to
 // a non-empty value to enable Packer acceptance tests and the

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -10,7 +10,7 @@ package arm
 // * ARM_STORAGE_ACCOUNT
 //
 // The subscription in question should have a resource group
-// called "packer-acceptance-test" in "West US" region. The
+// called "packer-acceptance-test" in "South Central US" region. The
 // storage account refered to in the above variable should
 // be inside this resource group and in "South Central US" as well.
 //

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -24,7 +24,11 @@ import (
 	"testing"
 
 	builderT "github.com/hashicorp/packer/helper/builder/testing"
+	"os"
+	"fmt"
 )
+
+const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
 
 func TestBuilderAcc_ManagedDisk_Windows(t *testing.T) {
 	builderT.Test(t, builderT.TestCase{
@@ -35,6 +39,12 @@ func TestBuilderAcc_ManagedDisk_Windows(t *testing.T) {
 }
 
 func TestBuilderAcc_ManagedDisk_Windows_DeviceLogin(t *testing.T) {
+	if os.Getenv(DeviceLoginAcceptanceTest) == "" {
+		t.Skip(fmt.Sprintf(
+			"Device Login Acceptance tests skipped unless env '%s' set, as its requires manual step during execution",
+			DeviceLoginAcceptanceTest))
+		return
+	}
 	builderT.Test(t, builderT.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Builder:  &Builder{},
@@ -49,6 +59,21 @@ func TestBuilderAcc_ManagedDisk_Linux(t *testing.T) {
 		Template: testBuilderAccManagedDiskLinux,
 	})
 }
+
+func TestBuilderAcc_ManagedDisk_Linux_DeviceLogin(t *testing.T) {
+	if os.Getenv(DeviceLoginAcceptanceTest) == "" {
+		t.Skip(fmt.Sprintf(
+			"Device Login Acceptance tests skipped unless env '%s' set, as its requires manual step during execution",
+			DeviceLoginAcceptanceTest))
+		return
+	}
+	builderT.Test(t, builderT.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Builder:  &Builder{},
+		Template: testBuilderAccManagedDiskLinuxDeviceLogin,
+	})
+}
+
 
 func TestBuilderAcc_Blob_Windows(t *testing.T) {
 	builderT.Test(t, builderT.TestCase{
@@ -154,6 +179,30 @@ const testBuilderAccManagedDiskLinux = `
 	  "image_publisher": "Canonical",
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
+
+	  "location": "South Central US",
+	  "vm_size": "Standard_DS2_v2"
+	}]
+}
+`
+const testBuilderAccManagedDiskLinuxDeviceLogin = `
+{
+	"variables": {
+	  "subscription_id": "{{env ` + "`ARM_SUBSCRIPTION_ID`" + `}}"
+	},
+	"builders": [{
+	  "type": "test",
+
+	  "subscription_id": "{{user ` + "`subscription_id`" + `}}",
+
+	  "managed_image_resource_group_name": "packer-acceptance-test",
+	  "managed_image_name": "testBuilderAccManagedDiskLinuxDeviceLogin-{{timestamp}}",
+
+	  "os_type": "Linux",
+	  "image_publisher": "Canonical",
+	  "image_offer": "UbuntuServer",
+	  "image_sku": "16.04-LTS",
+      "async_resourcegroup_delete": "true",
 
 	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2"

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -119,7 +119,7 @@ const testBuilderAccManagedDiskWindows = `
 	  "winrm_insecure": "true",
 	  "winrm_timeout": "3m",
 	  "winrm_username": "packer",
-      "async_resourcegroup_delete": "true",
+	  "async_resourcegroup_delete": "true",
 
 	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2"
@@ -201,7 +201,7 @@ const testBuilderAccManagedDiskLinuxDeviceLogin = `
 	  "image_publisher": "Canonical",
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
-      "async_resourcegroup_delete": "true",
+	  "async_resourcegroup_delete": "true",
 
 	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2"

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -34,6 +34,14 @@ func TestBuilderAcc_ManagedDisk_Windows(t *testing.T) {
 	})
 }
 
+func TestBuilderAcc_ManagedDisk_Windows_DeviceLogin(t *testing.T) {
+	builderT.Test(t, builderT.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Builder:  &Builder{},
+		Template: testBuilderAccManagedDiskWindowsDeviceLogin,
+	})
+}
+
 func TestBuilderAcc_ManagedDisk_Linux(t *testing.T) {
 	builderT.Test(t, builderT.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -65,8 +73,7 @@ const testBuilderAccManagedDiskWindows = `
 	"variables": {
 	  "client_id": "{{env ` + "`ARM_CLIENT_ID`" + `}}",
 	  "client_secret": "{{env ` + "`ARM_CLIENT_SECRET`" + `}}",
-	  "subscription_id": "{{env ` + "`ARM_SUBSCRIPTION_ID`" + `}}",
-	  "object_id": "{{env ` + "`ARM_OBJECT_ID`" + `}}"
+	  "subscription_id": "{{env ` + "`ARM_SUBSCRIPTION_ID`" + `}}"
 	},
 	"builders": [{
 	  "type": "test",
@@ -74,7 +81,6 @@ const testBuilderAccManagedDiskWindows = `
 	  "client_id": "{{user ` + "`client_id`" + `}}",
 	  "client_secret": "{{user ` + "`client_secret`" + `}}",
 	  "subscription_id": "{{user ` + "`subscription_id`" + `}}",
-	  "object_id": "{{user ` + "`object_id`" + `}}",
 
 	  "managed_image_resource_group_name": "packer-acceptance-test",
 	  "managed_image_name": "testBuilderAccManagedDiskWindows-{{timestamp}}",
@@ -89,8 +95,39 @@ const testBuilderAccManagedDiskWindows = `
 	  "winrm_insecure": "true",
 	  "winrm_timeout": "3m",
 	  "winrm_username": "packer",
+      "async_resourcegroup_delete": "true",
 
-	  "location": "West US",
+	  "location": "South Central US",
+	  "vm_size": "Standard_DS2_v2"
+	}]
+}
+`
+
+const testBuilderAccManagedDiskWindowsDeviceLogin = `
+{
+	"variables": {
+	  "subscription_id": "{{env ` + "`ARM_SUBSCRIPTION_ID`" + `}}"
+	},
+	"builders": [{
+	  "type": "test",
+
+	  "subscription_id": "{{user ` + "`subscription_id`" + `}}",
+
+	  "managed_image_resource_group_name": "packer-acceptance-test",
+	  "managed_image_name": "testBuilderAccManagedDiskWindowsDeviceLogin-{{timestamp}}",
+
+	  "os_type": "Windows",
+	  "image_publisher": "MicrosoftWindowsServer",
+	  "image_offer": "WindowsServer",
+	  "image_sku": "2012-R2-Datacenter",
+
+	  "communicator": "winrm",
+	  "winrm_use_ssl": "true",
+	  "winrm_insecure": "true",
+	  "winrm_timeout": "3m",
+	  "winrm_username": "packer",
+
+	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2"
 	}]
 }
@@ -118,7 +155,7 @@ const testBuilderAccManagedDiskLinux = `
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
 
-	  "location": "West US",
+	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2"
 	}]
 }
@@ -157,7 +194,7 @@ const testBuilderAccBlobWindows = `
 	  "winrm_timeout": "3m",
 	  "winrm_username": "packer",
 
-	  "location": "West US",
+	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2"
 	}]
 }
@@ -188,7 +225,7 @@ const testBuilderAccBlobLinux = `
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
 
-	  "location": "West US",
+	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2"
 	}]
 }

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -23,9 +23,9 @@ package arm
 import (
 	"testing"
 
+	"fmt"
 	builderT "github.com/hashicorp/packer/helper/builder/testing"
 	"os"
-	"fmt"
 )
 
 const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
@@ -73,7 +73,6 @@ func TestBuilderAcc_ManagedDisk_Linux_DeviceLogin(t *testing.T) {
 		Template: testBuilderAccManagedDiskLinuxDeviceLogin,
 	})
 }
-
 
 func TestBuilderAcc_Blob_Windows(t *testing.T) {
 	builderT.Test(t, builderT.TestCase{

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -493,9 +493,6 @@ func assertRequiredParametersSet(c *Config, errs *packer.MultiError) {
 	// readable by the ObjectID of the App.  There may be another way to handle
 	// this case, but I am not currently aware of it - send feedback.
 	isUseDeviceLogin := func(c *Config) bool {
-		if c.OSType == constants.Target_Windows {
-			return false
-		}
 
 		return c.SubscriptionID != "" &&
 			c.ClientID == "" &&

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -2,13 +2,11 @@ package arm
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/hashicorp/packer/builder/azure/common/constants"
-	"github.com/hashicorp/packer/packer"
 )
 
 // List of configuration parameters that are required by the ARM builder.
@@ -445,39 +443,6 @@ func TestUserDeviceLoginIsEnabledForLinux(t *testing.T) {
 	_, _, err := newConfig(config, getPackerConfiguration())
 	if err != nil {
 		t.Fatalf("failed to use device login for Linux: %s", err)
-	}
-}
-
-func TestUseDeviceLoginIsDisabledForWindows(t *testing.T) {
-	config := map[string]string{
-		"capture_name_prefix":    "ignore",
-		"capture_container_name": "ignore",
-		"image_offer":            "ignore",
-		"image_publisher":        "ignore",
-		"image_sku":              "ignore",
-		"location":               "ignore",
-		"storage_account":        "ignore",
-		"resource_group_name":    "ignore",
-		"subscription_id":        "ignore",
-		"os_type":                constants.Target_Windows,
-		"communicator":           "none",
-	}
-
-	_, _, err := newConfig(config, getPackerConfiguration())
-	if err == nil {
-		t.Fatal("Expected test to fail, but it succeeded")
-	}
-
-	multiError, _ := err.(*packer.MultiError)
-	if len(multiError.Errors) != 2 {
-		t.Errorf("Expected to find 2 errors, but found %d errors", len(multiError.Errors))
-	}
-
-	if !strings.Contains(err.Error(), "client_id must be specified") {
-		t.Error("Expected to find error for 'client_id must be specified")
-	}
-	if !strings.Contains(err.Error(), "client_secret must be specified") {
-		t.Error("Expected to find error for 'client_secret must be specified")
 	}
 }
 

--- a/builder/azure/common/devicelogin.go
+++ b/builder/azure/common/devicelogin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2016-06-01/subscriptions"
 	"github.com/Azure/go-autorest/autorest"
@@ -40,8 +41,11 @@ var (
 
 // Authenticate fetches a token from the local file cache or initiates a consent
 // flow and waits for token to be obtained.
-func Authenticate(env azure.Environment, tenantID string, say func(string)) (*adal.ServicePrincipalToken, error) {
+func Authenticate(env azure.Environment, tenantID string, say func(string), apiScope string) (*adal.ServicePrincipalToken, error) {
 	clientID, ok := clientIDs[env.Name]
+	var resourceid string
+	var endpoint string
+
 	if !ok {
 		return nil, fmt.Errorf("packer-azure application not set up for Azure environment %q", env.Name)
 	}
@@ -53,9 +57,17 @@ func Authenticate(env azure.Environment, tenantID string, say func(string)) (*ad
 
 	// for AzurePublicCloud (https://management.core.windows.net/), this old
 	// Service Management scope covers both ASM and ARM.
-	apiScope := env.ServiceManagementEndpoint
+	//apiScope := env.ServiceManagementEndpoint
 
-	tokenPath := tokenCachePath(tenantID)
+	if strings.Contains(apiScope, "vault") {
+		resourceid = "vault"
+		endpoint = env.KeyVaultEndpoint
+	} else {
+		resourceid = "mgmt"
+		endpoint = env.ResourceManagerEndpoint
+	}
+
+	tokenPath := tokenCachePath(tenantID + resourceid)
 	saveToken := mkTokenCallback(tokenPath)
 	saveTokenCallback := func(t adal.Token) error {
 		say("Azure token expired. Saving the refreshed token...")
@@ -82,7 +94,7 @@ func Authenticate(env azure.Environment, tenantID string, say func(string)) (*ad
 		//      will go stale every 14 days and we will delete the token file,
 		//      re-initiate the device flow.
 		say("Validating the token.")
-		if err = validateToken(env, spt); err != nil {
+		if err = validateToken(endpoint, spt); err != nil {
 			say(fmt.Sprintf("Error: %v", err))
 			say("Stored Azure credentials expired. Please reauthenticate.")
 			say(fmt.Sprintf("Deleting %s", tokenPath))
@@ -187,12 +199,11 @@ func mkTokenCallback(path string) adal.TokenRefreshCallback {
 // sure if the access_token valid, if not it uses SDK’s functionality to
 // automatically refresh the token using refresh_token (which might have
 // expired). This check is essentially to make sure refresh_token is good.
-func validateToken(env azure.Environment, token *adal.ServicePrincipalToken) error {
-	c := subscriptions.NewClientWithBaseURI(env.ResourceManagerEndpoint)
-	c.Authorizer = autorest.NewBearerAuthorizer(token)
-	_, err := c.List(context.TODO())
+func validateToken(env string, token *adal.ServicePrincipalToken) error {
+	err := token.EnsureFresh()
+
 	if err != nil {
-		return fmt.Errorf("Token validity check failed: %v", err)
+		return fmt.Errorf("%s token validity check failed: %v", env,err)
 	}
 	return nil
 }

--- a/builder/azure/common/devicelogin.go
+++ b/builder/azure/common/devicelogin.go
@@ -41,10 +41,9 @@ var (
 
 // Authenticate fetches a token from the local file cache or initiates a consent
 // flow and waits for token to be obtained.
-func Authenticate(env azure.Environment, tenantID string, say func(string), apiScope string) (*adal.ServicePrincipalToken, error) {
+func Authenticate(env azure.Environment, tenantID string, say func(string), scope string) (*adal.ServicePrincipalToken, error) {
 	clientID, ok := clientIDs[env.Name]
 	var resourceid string
-	var endpoint string
 
 	if !ok {
 		return nil, fmt.Errorf("packer-azure application not set up for Azure environment %q", env.Name)
@@ -57,14 +56,11 @@ func Authenticate(env azure.Environment, tenantID string, say func(string), apiS
 
 	// for AzurePublicCloud (https://management.core.windows.net/), this old
 	// Service Management scope covers both ASM and ARM.
-	//apiScope := env.ServiceManagementEndpoint
 
-	if strings.Contains(apiScope, "vault") {
+	if strings.Contains(scope, "vault") {
 		resourceid = "vault"
-		endpoint = env.KeyVaultEndpoint
 	} else {
 		resourceid = "mgmt"
-		endpoint = env.ResourceManagerEndpoint
 	}
 
 	tokenPath := tokenCachePath(tenantID + resourceid)
@@ -75,41 +71,18 @@ func Authenticate(env azure.Environment, tenantID string, say func(string), apiS
 	}
 
 	// Lookup the token cache file for an existing token.
-	spt, err := tokenFromFile(say, *oauthCfg, tokenPath, clientID, apiScope, saveTokenCallback)
+	spt, err := tokenFromFile(say, *oauthCfg, tokenPath, clientID, scope, saveTokenCallback)
 	if err != nil {
 		return nil, err
 	}
 	if spt != nil {
 		say(fmt.Sprintf("Auth token found in file: %s", tokenPath))
-
-		// NOTE(ahmetalpbalkan): The token file we found may contain an
-		// expired access_token. In that case, the first call to Azure SDK will
-		// attempt to refresh the token using refresh_token, which might have
-		// expired[1], in that case we will get an error and we shall remove the
-		// token file and initiate token flow again so that the user would not
-		// need removing the token cache file manually.
-		//
-		// [1]: expiration date of refresh_token is not returned in AAD /token
-		//      response, we just know it is 14 days. Therefore user’s token
-		//      will go stale every 14 days and we will delete the token file,
-		//      re-initiate the device flow.
-		say("Validating the token.")
-		if err = validateToken(endpoint, spt); err != nil {
-			say(fmt.Sprintf("Error: %v", err))
-			say("Stored Azure credentials expired. Please reauthenticate.")
-			say(fmt.Sprintf("Deleting %s", tokenPath))
-			if err := os.RemoveAll(tokenPath); err != nil {
-				return nil, fmt.Errorf("Error deleting stale token file: %v", err)
-			}
-		} else {
-			say("Token works.")
-			return spt, nil
-		}
+		return spt, nil
 	}
 
 	// Start an OAuth 2.0 device flow
 	say(fmt.Sprintf("Initiating device flow: %s", tokenPath))
-	spt, err = tokenFromDeviceFlow(say, *oauthCfg, clientID, apiScope)
+	spt, err = tokenFromDeviceFlow(say, *oauthCfg, clientID, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -193,19 +166,6 @@ func mkTokenCallback(path string) adal.TokenRefreshCallback {
 		}
 		return nil
 	}
-}
-
-// validateToken makes a call to Azure SDK with given token, essentially making
-// sure if the access_token valid, if not it uses SDK’s functionality to
-// automatically refresh the token using refresh_token (which might have
-// expired). This check is essentially to make sure refresh_token is good.
-func validateToken(env string, token *adal.ServicePrincipalToken) error {
-	err := token.EnsureFresh()
-
-	if err != nil {
-		return fmt.Errorf("%s token validity check failed: %v", env, err)
-	}
-	return nil
 }
 
 // FindTenantID figures out the AAD tenant ID of the subscription by making an

--- a/builder/azure/common/devicelogin.go
+++ b/builder/azure/common/devicelogin.go
@@ -203,7 +203,7 @@ func validateToken(env string, token *adal.ServicePrincipalToken) error {
 	err := token.EnsureFresh()
 
 	if err != nil {
-		return fmt.Errorf("%s token validity check failed: %v", env,err)
+		return fmt.Errorf("%s token validity check failed: %v", env, err)
 	}
 	return nil
 }

--- a/examples/azure/windows_quickstart.json
+++ b/examples/azure/windows_quickstart.json
@@ -1,14 +1,10 @@
 {
   "variables": {
-    "client_id": "{{env `ARM_CLIENT_ID`}}",
-    "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
     "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
   },
   "builders": [{
     "type": "azure-arm",
 
-    "client_id": "{{user `client_id`}}",
-    "client_secret": "{{user `client_secret`}}",
     "subscription_id": "{{user `subscription_id`}}",
 
     "managed_image_resource_group_name": "packertest",

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
@@ -67,7 +67,7 @@ var (
 		ResourceManagerEndpoint:      "https://management.azure.com/",
 		ActiveDirectoryEndpoint:      "https://login.microsoftonline.com/",
 		GalleryEndpoint:              "https://gallery.azure.com/",
-		KeyVaultEndpoint:             "https://vault.azure.net/",
+		KeyVaultEndpoint:             "https://vault.azure.net",
 		GraphEndpoint:                "https://graph.windows.net/",
 		ServiceBusEndpoint:           "https://servicebus.windows.net/",
 		BatchManagementEndpoint:      "https://batch.core.windows.net/",

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
@@ -67,7 +67,7 @@ var (
 		ResourceManagerEndpoint:      "https://management.azure.com/",
 		ActiveDirectoryEndpoint:      "https://login.microsoftonline.com/",
 		GalleryEndpoint:              "https://gallery.azure.com/",
-		KeyVaultEndpoint:             "https://vault.azure.net",
+		KeyVaultEndpoint:             "https://vault.azure.net/",
 		GraphEndpoint:                "https://graph.windows.net/",
 		ServiceBusEndpoint:           "https://servicebus.windows.net/",
 		BatchManagementEndpoint:      "https://batch.core.windows.net/",

--- a/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
+++ b/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
@@ -56,8 +56,9 @@ This simple parsing example:
 is directly mapped to:
 
 ```go
-	if token, err := request.ParseFromRequest(tokenString, request.OAuth2Extractor, req, keyLookupFunc); err == nil {
-		fmt.Printf("Token for user %v expires %v", token.Claims["user"], token.Claims["exp"])
+	if token, err := request.ParseFromRequest(req, request.OAuth2Extractor, keyLookupFunc); err == nil {
+		claims := token.Claims.(jwt.MapClaims)
+		fmt.Printf("Token for user %v expires %v", claims["user"], claims["exp"])
 	}
 ```
 

--- a/vendor/github.com/dgrijalva/jwt-go/README.md
+++ b/vendor/github.com/dgrijalva/jwt-go/README.md
@@ -1,11 +1,15 @@
-A [go](http://www.golang.org) (or 'golang' for search engine friendliness) implementation of [JSON Web Tokens](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html)
+# jwt-go
 
 [![Build Status](https://travis-ci.org/dgrijalva/jwt-go.svg?branch=master)](https://travis-ci.org/dgrijalva/jwt-go)
+[![GoDoc](https://godoc.org/github.com/dgrijalva/jwt-go?status.svg)](https://godoc.org/github.com/dgrijalva/jwt-go)
 
-**BREAKING CHANGES:*** Version 3.0.0 is here. It includes _a lot_ of changes including a few that break the API.  We've tried to break as few things as possible, so there should just be a few type signature changes.  A full list of breaking changes is available in `VERSION_HISTORY.md`.  See `MIGRATION_GUIDE.md` for more information on updating your code.
+A [go](http://www.golang.org) (or 'golang' for search engine friendliness) implementation of [JSON Web Tokens](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html)
 
-**NOTICE:** A vulnerability in JWT was [recently published](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/).  As this library doesn't force users to validate the `alg` is what they expected, it's possible your usage is effected.  There will be an update soon to remedy this, and it will likey require backwards-incompatible changes to the API.  In the short term, please make sure your implementation verifies the `alg` is what you expect.
+**NEW VERSION COMING:** There have been a lot of improvements suggested since the version 3.0.0 released in 2016. I'm working now on cutting two different releases: 3.2.0 will contain any non-breaking changes or enhancements. 4.0.0 will follow shortly which will include breaking changes. See the 4.0.0 milestone to get an idea of what's coming. If you have other ideas, or would like to participate in 4.0.0, now's the time. If you depend on this library and don't want to be interrupted, I recommend you use your dependency mangement tool to pin to version 3. 
 
+**SECURITY NOTICE:** Some older versions of Go have a security issue in the cryotp/elliptic. Recommendation is to upgrade to at least 1.8.3. See issue #216 for more detail.
+
+**SECURITY NOTICE:** It's important that you [validate the `alg` presented is what you expect](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/). This library attempts to make it easy to do the right thing by requiring key types match the expected alg, but you should take the extra step to verify it in your usage.  See the examples provided.
 
 ## What the heck is a JWT?
 
@@ -25,8 +29,8 @@ This library supports the parsing and verification as well as the generation and
 
 See [the project documentation](https://godoc.org/github.com/dgrijalva/jwt-go) for examples of usage:
 
-* [Simple example of parsing and validating a token](https://godoc.org/github.com/dgrijalva/jwt-go#example_Parse_hmac)
-* [Simple example of building and signing a token](https://godoc.org/github.com/dgrijalva/jwt-go#example_New_hmac)
+* [Simple example of parsing and validating a token](https://godoc.org/github.com/dgrijalva/jwt-go#example-Parse--Hmac)
+* [Simple example of building and signing a token](https://godoc.org/github.com/dgrijalva/jwt-go#example-New--Hmac)
 * [Directory of Examples](https://godoc.org/github.com/dgrijalva/jwt-go#pkg-examples)
 
 ## Extensions
@@ -37,7 +41,7 @@ Here's an example of an extension that integrates with the Google App Engine sig
 
 ## Compliance
 
-This library was last reviewed to comply with [RTF 7519](http://www.rfc-editor.org/info/rfc7519) dated May 2015 with a few notable differences: 
+This library was last reviewed to comply with [RTF 7519](http://www.rfc-editor.org/info/rfc7519) dated May 2015 with a few notable differences:
 
 * In order to protect against accidental use of [Unsecured JWTs](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#UnsecuredJWT), tokens using `alg=none` will only be accepted if the constant `jwt.UnsafeAllowNoneSignatureType` is provided as the key.
 
@@ -47,7 +51,10 @@ This library is considered production ready.  Feedback and feature requests are 
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org).  Accepted pull requests will land on `master`.  Periodically, versions will be tagged from `master`.  You can find all the releases on [the project releases page](https://github.com/dgrijalva/jwt-go/releases).
 
-While we try to make it obvious when we make breaking changes, there isn't a great mechanism for pushing announcements out to users.  You may want to use this alternative package include: `gopkg.in/dgrijalva/jwt-go.v2`.  It will do the right thing WRT semantic versioning.
+While we try to make it obvious when we make breaking changes, there isn't a great mechanism for pushing announcements out to users.  You may want to use this alternative package include: `gopkg.in/dgrijalva/jwt-go.v3`.  It will do the right thing WRT semantic versioning.
+
+**BREAKING CHANGES:*** 
+* Version 3.0.0 includes _a lot_ of changes from the 2.x line, including a few that break the API.  We've tried to break as few things as possible, so there should just be a few type signature changes.  A full list of breaking changes is available in `VERSION_HISTORY.md`.  See `MIGRATION_GUIDE.md` for more information on updating your code.
 
 ## Usage Tips
 
@@ -68,18 +75,26 @@ Symmetric signing methods, such as HSA, use only a single secret. This is probab
 
 Asymmetric signing methods, such as RSA, use different keys for signing and verifying tokens. This makes it possible to produce tokens with a private key, and allow any consumer to access the public key for verification.
 
+### Signing Methods and Key Types
+
+Each signing method expects a different object type for its signing keys. See the package documentation for details. Here are the most common ones:
+
+* The [HMAC signing method](https://godoc.org/github.com/dgrijalva/jwt-go#SigningMethodHMAC) (`HS256`,`HS384`,`HS512`) expect `[]byte` values for signing and validation
+* The [RSA signing method](https://godoc.org/github.com/dgrijalva/jwt-go#SigningMethodRSA) (`RS256`,`RS384`,`RS512`) expect `*rsa.PrivateKey` for signing and `*rsa.PublicKey` for validation
+* The [ECDSA signing method](https://godoc.org/github.com/dgrijalva/jwt-go#SigningMethodECDSA) (`ES256`,`ES384`,`ES512`) expect `*ecdsa.PrivateKey` for signing and `*ecdsa.PublicKey` for validation
+
 ### JWT and OAuth
 
 It's worth mentioning that OAuth and JWT are not the same thing. A JWT token is simply a signed JSON object. It can be used anywhere such a thing is useful. There is some confusion, though, as JWT is the most common type of bearer token used in OAuth2 authentication.
 
 Without going too far down the rabbit hole, here's a description of the interaction of these technologies:
 
-* OAuth is a protocol for allowing an identity provider to be separate from the service a user is logging in to.  For example, whenever you use Facebook to log into a different service (Yelp, Spotify, etc), you are using OAuth.
+* OAuth is a protocol for allowing an identity provider to be separate from the service a user is logging in to. For example, whenever you use Facebook to log into a different service (Yelp, Spotify, etc), you are using OAuth.
 * OAuth defines several options for passing around authentication data. One popular method is called a "bearer token". A bearer token is simply a string that _should_ only be held by an authenticated user. Thus, simply presenting this token proves your identity. You can probably derive from here why a JWT might make a good bearer token.
 * Because bearer tokens are used for authentication, it's important they're kept secret. This is why transactions that use bearer tokens typically happen over SSL.
- 
+
 ## More
 
 Documentation can be found [on godoc.org](http://godoc.org/github.com/dgrijalva/jwt-go).
 
-The command line utility included in this project (cmd/jwt) provides a straightforward example of token creation and parsing as well as a useful tool for debugging your own integration.  You'll also find several implementation examples in to documentation.
+The command line utility included in this project (cmd/jwt) provides a straightforward example of token creation and parsing as well as a useful tool for debugging your own integration. You'll also find several implementation examples in the documentation.

--- a/vendor/github.com/dgrijalva/jwt-go/VERSION_HISTORY.md
+++ b/vendor/github.com/dgrijalva/jwt-go/VERSION_HISTORY.md
@@ -1,5 +1,18 @@
 ## `jwt-go` Version History
 
+#### 3.2.0
+
+* Added method `ParseUnverified` to allow users to split up the tasks of parsing and validation
+* HMAC signing method returns `ErrInvalidKeyType` instead of `ErrInvalidKey` where appropriate
+* Added options to `request.ParseFromRequest`, which allows for an arbitrary list of modifiers to parsing behavior. Initial set include `WithClaims` and `WithParser`. Existing usage of this function will continue to work as before.
+* Deprecated `ParseFromRequestWithClaims` to simplify API in the future.
+
+#### 3.1.0
+
+* Improvements to `jwt` command line tool
+* Added `SkipClaimsValidation` option to `Parser`
+* Documentation updates
+
 #### 3.0.0
 
 * **Compatibility Breaking Changes**: See MIGRATION_GUIDE.md for tips on updating your code

--- a/vendor/github.com/dgrijalva/jwt-go/ecdsa.go
+++ b/vendor/github.com/dgrijalva/jwt-go/ecdsa.go
@@ -14,6 +14,7 @@ var (
 )
 
 // Implements the ECDSA family of signing methods signing methods
+// Expects *ecdsa.PrivateKey for signing and *ecdsa.PublicKey for verification
 type SigningMethodECDSA struct {
 	Name      string
 	Hash      crypto.Hash

--- a/vendor/github.com/dgrijalva/jwt-go/errors.go
+++ b/vendor/github.com/dgrijalva/jwt-go/errors.go
@@ -51,13 +51,9 @@ func (e ValidationError) Error() string {
 	} else {
 		return "token is invalid"
 	}
-	return e.Inner.Error()
 }
 
 // No errors
 func (e *ValidationError) valid() bool {
-	if e.Errors > 0 {
-		return false
-	}
-	return true
+	return e.Errors == 0
 }

--- a/vendor/github.com/dgrijalva/jwt-go/hmac.go
+++ b/vendor/github.com/dgrijalva/jwt-go/hmac.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Implements the HMAC-SHA family of signing methods signing methods
+// Expects key type of []byte for both signing and validation
 type SigningMethodHMAC struct {
 	Name string
 	Hash crypto.Hash
@@ -90,5 +91,5 @@ func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) (string,
 		return EncodeSegment(hasher.Sum(nil)), nil
 	}
 
-	return "", ErrInvalidKey
+	return "", ErrInvalidKeyType
 }

--- a/vendor/github.com/dgrijalva/jwt-go/parser.go
+++ b/vendor/github.com/dgrijalva/jwt-go/parser.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Parser struct {
-	ValidMethods  []string // If populated, only these methods will be considered valid
-	UseJSONNumber bool     // Use JSON Number format in JSON decoder
+	ValidMethods         []string // If populated, only these methods will be considered valid
+	UseJSONNumber        bool     // Use JSON Number format in JSON decoder
+	SkipClaimsValidation bool     // Skip claims validation during token parsing
 }
 
 // Parse, validate, and return a token.
@@ -20,55 +21,9 @@ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 }
 
 func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
-	parts := strings.Split(tokenString, ".")
-	if len(parts) != 3 {
-		return nil, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
-	}
-
-	var err error
-	token := &Token{Raw: tokenString}
-
-	// parse Header
-	var headerBytes []byte
-	if headerBytes, err = DecodeSegment(parts[0]); err != nil {
-		if strings.HasPrefix(strings.ToLower(tokenString), "bearer ") {
-			return token, NewValidationError("tokenstring should not contain 'bearer '", ValidationErrorMalformed)
-		}
-		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
-	}
-	if err = json.Unmarshal(headerBytes, &token.Header); err != nil {
-		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
-	}
-
-	// parse Claims
-	var claimBytes []byte
-	token.Claims = claims
-
-	if claimBytes, err = DecodeSegment(parts[1]); err != nil {
-		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
-	}
-	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
-	if p.UseJSONNumber {
-		dec.UseNumber()
-	}
-	// JSON Decode.  Special case for map type to avoid weird pointer behavior
-	if c, ok := token.Claims.(MapClaims); ok {
-		err = dec.Decode(&c)
-	} else {
-		err = dec.Decode(&claims)
-	}
-	// Handle decode error
+	token, parts, err := p.ParseUnverified(tokenString, claims)
 	if err != nil {
-		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
-	}
-
-	// Lookup signature method
-	if method, ok := token.Header["alg"].(string); ok {
-		if token.Method = GetSigningMethod(method); token.Method == nil {
-			return token, NewValidationError("signing method (alg) is unavailable.", ValidationErrorUnverifiable)
-		}
-	} else {
-		return token, NewValidationError("signing method (alg) is unspecified.", ValidationErrorUnverifiable)
+		return token, err
 	}
 
 	// Verify signing method is in the required set
@@ -95,20 +50,25 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 	}
 	if key, err = keyFunc(token); err != nil {
 		// keyFunc returned an error
+		if ve, ok := err.(*ValidationError); ok {
+			return token, ve
+		}
 		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
 	}
 
 	vErr := &ValidationError{}
 
 	// Validate Claims
-	if err := token.Claims.Valid(); err != nil {
+	if !p.SkipClaimsValidation {
+		if err := token.Claims.Valid(); err != nil {
 
-		// If the Claims Valid returned an error, check if it is a validation error,
-		// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
-		if e, ok := err.(*ValidationError); !ok {
-			vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
-		} else {
-			vErr = e
+			// If the Claims Valid returned an error, check if it is a validation error,
+			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+			if e, ok := err.(*ValidationError); !ok {
+				vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
+			} else {
+				vErr = e
+			}
 		}
 	}
 
@@ -125,4 +85,64 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 	}
 
 	return token, vErr
+}
+
+// WARNING: Don't use this method unless you know what you're doing
+//
+// This method parses the token but doesn't validate the signature. It's only
+// ever useful in cases where you know the signature is valid (because it has
+// been checked previously in the stack) and you want to extract values from
+// it.
+func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Token, parts []string, err error) {
+	parts = strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return nil, parts, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
+	}
+
+	token = &Token{Raw: tokenString}
+
+	// parse Header
+	var headerBytes []byte
+	if headerBytes, err = DecodeSegment(parts[0]); err != nil {
+		if strings.HasPrefix(strings.ToLower(tokenString), "bearer ") {
+			return token, parts, NewValidationError("tokenstring should not contain 'bearer '", ValidationErrorMalformed)
+		}
+		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+	if err = json.Unmarshal(headerBytes, &token.Header); err != nil {
+		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+
+	// parse Claims
+	var claimBytes []byte
+	token.Claims = claims
+
+	if claimBytes, err = DecodeSegment(parts[1]); err != nil {
+		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
+	if p.UseJSONNumber {
+		dec.UseNumber()
+	}
+	// JSON Decode.  Special case for map type to avoid weird pointer behavior
+	if c, ok := token.Claims.(MapClaims); ok {
+		err = dec.Decode(&c)
+	} else {
+		err = dec.Decode(&claims)
+	}
+	// Handle decode error
+	if err != nil {
+		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+
+	// Lookup signature method
+	if method, ok := token.Header["alg"].(string); ok {
+		if token.Method = GetSigningMethod(method); token.Method == nil {
+			return token, parts, NewValidationError("signing method (alg) is unavailable.", ValidationErrorUnverifiable)
+		}
+	} else {
+		return token, parts, NewValidationError("signing method (alg) is unspecified.", ValidationErrorUnverifiable)
+	}
+
+	return token, parts, nil
 }

--- a/vendor/github.com/dgrijalva/jwt-go/rsa.go
+++ b/vendor/github.com/dgrijalva/jwt-go/rsa.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Implements the RSA family of signing methods signing methods
+// Expects *rsa.PrivateKey for signing and *rsa.PublicKey for validation
 type SigningMethodRSA struct {
 	Name string
 	Hash crypto.Hash
@@ -44,7 +45,7 @@ func (m *SigningMethodRSA) Alg() string {
 }
 
 // Implements the Verify method from SigningMethod
-// For this signing method, must be an rsa.PublicKey structure.
+// For this signing method, must be an *rsa.PublicKey structure.
 func (m *SigningMethodRSA) Verify(signingString, signature string, key interface{}) error {
 	var err error
 
@@ -73,7 +74,7 @@ func (m *SigningMethodRSA) Verify(signingString, signature string, key interface
 }
 
 // Implements the Sign method from SigningMethod
-// For this signing method, must be an rsa.PrivateKey structure.
+// For this signing method, must be an *rsa.PrivateKey structure.
 func (m *SigningMethodRSA) Sign(signingString string, key interface{}) (string, error) {
 	var rsaKey *rsa.PrivateKey
 	var ok bool

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -629,10 +629,11 @@
 			"revisionTime": "2017-11-27T16:20:29Z"
 		},
 		{
-			"checksumSHA1": "D37uI+U+FYvTJIdG2TTozXe7i7U=",
-			"comment": "v3.0.0",
+			"checksumSHA1": "4772zXrOaPVeDeSgdiV7Vp4KEjk=",
+			"comment": "v3.2.0",
 			"path": "github.com/dgrijalva/jwt-go",
-			"revision": "d2709f9f1f31ebcda9651b03077758c1f3a0018c"
+			"revision": "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e",
+			"revisionTime": "2018-03-08T23:13:08Z"
 		},
 		{
 			"checksumSHA1": "W1LGm0UNirwMDVCMFv5vZrOpUJI=",

--- a/website/source/docs/builders/azure-setup.html.md
+++ b/website/source/docs/builders/azure-setup.html.md
@@ -31,8 +31,7 @@ In order to get all of the items above, you will need a username and password fo
 
 Device login is an alternative way to authorize in Azure Packer. Device login only requires you to know your
 Subscription ID. (Device login is only supported for Linux based VMs.) Device login is intended for those who are first
-time users, and just want to ''kick the tires.'' We recommend the SPN approach if you intend to automate Packer, or for
-deploying Windows VMs.
+time users, and just want to ''kick the tires.'' We recommend the SPN approach if you intend to automate Packer.
 
 > Device login is for **interactive** builds, and SPN is **automated** builds.
 
@@ -44,7 +43,7 @@ There are three pieces of information you must provide to enable device login mo
 
 > Device login mode is enabled by not setting client\_id and client\_secret.
 
-> Device login mode is for the Public and US Gov clouds only, and Linux VMs only.
+> Device login mode is for the Public and US Gov clouds only.
 
 The device login flow asks that you open a web browser, navigate to <http://aka.ms/devicelogin>, and input the supplied
 code. This authorizes the Packer for Azure application to act on your behalf. An OAuth token will be created, and stored

--- a/website/source/docs/builders/azure-setup.html.md
+++ b/website/source/docs/builders/azure-setup.html.md
@@ -46,7 +46,8 @@ There are three pieces of information you must provide to enable device login mo
 The device login flow asks that you open a web browser, navigate to <http://aka.ms/devicelogin>, and input the supplied
 code. This authorizes the Packer for Azure application to act on your behalf. An OAuth token will be created, and stored
 in the user's home directory (~/.azure/packer/oauth-TenantID.json). This token is used if the token file exists, and it
-is refreshed as necessary. The token file prevents the need to continually execute the device login flow.
+is refreshed as necessary. The token file prevents the need to continually execute the device login flow. Packer will ask
+for two device login auth, one for service management endpoint and another for accessing temp keyvault secrets that it creates.
 
 ## Install the Azure CLI
 

--- a/website/source/docs/builders/azure-setup.html.md
+++ b/website/source/docs/builders/azure-setup.html.md
@@ -17,8 +17,6 @@ In order to build VMs in Azure Packer needs 6 configuration options to be specif
 
 -   `client_secret` - service principal secret / password
 
--   `object_id` - service principal object id (OSType = Windows Only)
-
 -   `resource_group_name` - name of the resource group where your VHD(s) will be stored
 
 -   `storage_account` - name of the storage account where your VHD(s) will be stored

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -140,11 +140,6 @@ Providing `temp_resource_group_name` or `location` in combination with `build_re
     account type for a managed image.  Valid values are Standard_LRS
     and Premium\_LRS.  The default is Standard\_LRS.
 
--   `object_id` (string) Specify an OAuth Object ID to protect WinRM certificates
-    created at runtime. This variable is required when creating images based on
-    Windows; this variable is not used by non-Windows builds. See `Windows`
-    behavior for `os_type`, below.
-
 -   `os_disk_size_gb` (number) Specify the size of the OS disk in GB (gigabytes).  Values of zero or less than zero are
     ignored.
 
@@ -412,8 +407,6 @@ A Windows build requires two templates and two deployments. Unfortunately, the K
 the same time hence the need for two templates and deployments. The time required to deploy a KeyVault template is
 minimal, so overall impact is small.
 
-> The KeyVault certificate is protected using the object\_id of the SPN. This is why Windows builds require object\_id,
-> and an SPN. The KeyVault is deleted when the resource group is deleted.
 
 See the [examples/azure](https://github.com/hashicorp/packer/tree/master/examples/azure) folder in the packer project
 for more examples.


### PR DESCRIPTION
This PR adds devicelogin support for windows build in Packer as well as removes the requirement for objectID to be present. Please note that you can still pass object_ID so current automation wont break. 

Added Acceptance tests specifically for device login and tested with that. 

Test covered

1. With Device Login ( Linux and Windows ) 
2. Without device login ( Linux and Windows ) 
3. Test in Public cloud

This PR also brings updated version of jwt-go as it needed a new method to parse JwT in an unverified fashion to get the token. The reason why verified function didnt make sense as there was a lot of additional logic to get the public key out which was not required for packer operation. All tokens are anyways verified by the Azure Management API .

Minor other updates

1. All acceptance tests were moved to use South Central US as West US typically is a very heavily loaded region 
2. Token validation is done via EnsureRefresh() method to provide consistent way for both spn and user token 

Outside verification pending
1. Verification in National clouds. 

closes #6284 