### PR TITLE
Remove the VC product line

### DIFF
--- a/builder/scaleway/builder_test.go
+++ b/builder/scaleway/builder_test.go
@@ -12,7 +12,7 @@ func testConfig() map[string]interface{} {
 		"api_access_key":  "foo",
 		"api_token":       "bar",
 		"region":          "ams1",
-		"commercial_type": "VC1S",
+		"commercial_type": "START1-S",
 		"ssh_username":    "root",
 		"image":           "image-uuid",
 	}
@@ -98,7 +98,7 @@ func TestBuilderPrepare_CommercialType(t *testing.T) {
 		t.Fatalf("should error")
 	}
 
-	expected := "VC1S"
+	expected := "START1-S"
 
 	config["commercial_type"] = expected
 	b = Builder{}

--- a/website/source/docs/builders/scaleway.html.md
+++ b/website/source/docs/builders/scaleway.html.md
@@ -58,7 +58,7 @@ builder.
 
 -   `commercial_type` (string) - The name of the server commercial type:
       `ARM64-128GB`,`ARM64-16GB`,`ARM64-2GB`,`ARM64-32GB`,`ARM64-4GB`, `ARM64-64GB`,
-      `ARM64-8GB`,`C1`,`C2L`,`C2M`,`C2S`,`VC1L`,`VC1M`,`VC1S`,
+      `ARM64-8GB`,`C1`,`C2L`,`C2M`,`C2S`,`START1-L`,`START1-M`,`START1-S`,`START1-XS`,
       `X64-120GB`,`X64-15GB`,`X64-30GB`,`X64-60GB`
 
 ### Optional:
@@ -84,7 +84,7 @@ access tokens:
   "api_token": "YOUR TOKEN",
   "image": "UUID OF THE BASE IMAGE",
   "region": "par1",
-  "commercial_type": "VC1S",
+  "commercial_type": "START1-S",
   "ssh_username": "root",
   "ssh_private_key_file": "~/.ssh/id_rsa"
 }


### PR DESCRIPTION
Scaleway VC product line is replaced with the START1 product line.