### PR TITLE
Replace home-grown waiters with aws sdk's built in waiters

### DIFF
--- a/builder/amazon/chroot/step_create_volume.go
+++ b/builder/amazon/chroot/step_create_volume.go
@@ -22,7 +22,7 @@ type StepCreateVolume struct {
 	RootVolumeSize int64
 }
 
-func (s *StepCreateVolume) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepCreateVolume) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	instance := state.Get("instance").(*ec2.Instance)
@@ -84,7 +84,7 @@ func (s *StepCreateVolume) Run(_ context.Context, state multistep.StateBag) mult
 	log.Printf("Volume ID: %s", s.volumeId)
 
 	// Wait for the volume to become ready
-	err = awscommon.WaitUntilVolumeAvailable(ec2conn, s.volumeId)
+	err = awscommon.WaitUntilVolumeAvailable(ctx, ec2conn, s.volumeId)
 	if err != nil {
 		err := fmt.Errorf("Error waiting for volume: %s", err)
 		state.Put("error", err)

--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -102,15 +102,13 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 	amis[*ec2conn.Config.Region] = *registerResp.ImageId
 	state.Put("amis", amis)
 
-	// Wait for the image to become ready
-	if err := awscommon.WaitUntilAMIAvailable(ec2conn, *registerResp.ImageId); err != nil {
+	ui.Say("Waiting for AMI to become ready...")
+	if err := awscommon.WaitUntilAMIAvailable(ctx, ec2conn, *registerResp.ImageId); err != nil {
 		err := fmt.Errorf("Error waiting for AMI: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
-
-	ui.Say("Waiting for AMI to become ready...")
 
 	return multistep.ActionContinue
 }

--- a/builder/amazon/chroot/step_snapshot.go
+++ b/builder/amazon/chroot/step_snapshot.go
@@ -19,7 +19,7 @@ type StepSnapshot struct {
 	snapshotId string
 }
 
-func (s *StepSnapshot) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepSnapshot) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packer.Ui)
 	volumeId := state.Get("volume_id").(string)
@@ -43,7 +43,7 @@ func (s *StepSnapshot) Run(_ context.Context, state multistep.StateBag) multiste
 	ui.Message(fmt.Sprintf("Snapshot ID: %s", s.snapshotId))
 
 	// Wait for the snapshot to be ready
-	err = awscommon.WaitUntilSnapshotDone(ec2conn, s.snapshotId)
+	err = awscommon.WaitUntilSnapshotDone(ctx, ec2conn, s.snapshotId)
 	if err != nil {
 		err := fmt.Errorf("Error waiting for snapshot: %s", err)
 		state.Put("error", err)

--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -278,6 +278,14 @@ func getWaiterOptions() []request.WaiterOption {
 		}
 		waitOpts = append(waitOpts, request.WithWaiterMaxAttempts(maxAttempts))
 	}
+	if len(waitOpts) == 0 {
+		log.Printf("No AWS timeout and polling overrides have been set. " +
+			"Packer will defalt to waiter-specific delays and timeouts. If you would " +
+			"like to customize the length of time between retries and max " +
+			"number of retries you may do so by setting the environment " +
+			"variables AWS_POLL_DELAY_SECONDS and AWS_MAX_ATTEMPTS to your " +
+			"desired values.")
+	}
 
 	return waitOpts
 }

--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -35,58 +35,63 @@ type StateChangeConf struct {
 // Following are wrapper functions that use Packer's environment-variables to
 // determing retry logic, then call the AWS SDK's built-in waiters.
 
-func WaitUntilAMIAvailable(conn *ec2.EC2, imageId string) error {
+func WaitUntilAMIAvailable(ctx aws.Context, conn *ec2.EC2, imageId string) error {
 	imageInput := ec2.DescribeImagesInput{
 		ImageIds: []*string{&imageId},
 	}
 
-	err := conn.WaitUntilImageAvailableWithContext(aws.BackgroundContext(),
+	err := conn.WaitUntilImageAvailableWithContext(
+		ctx,
 		&imageInput,
 		getWaiterOptions()...)
 	return err
 }
 
-func WaitUntilInstanceTerminated(conn *ec2.EC2, instanceId string) error {
+func WaitUntilInstanceTerminated(ctx aws.Context, conn *ec2.EC2, instanceId string) error {
 
 	instanceInput := ec2.DescribeInstancesInput{
 		InstanceIds: []*string{&instanceId},
 	}
 
-	err := conn.WaitUntilInstanceTerminatedWithContext(aws.BackgroundContext(),
+	err := conn.WaitUntilInstanceTerminatedWithContext(
+		ctx,
 		&instanceInput,
 		getWaiterOptions()...)
 	return err
 }
 
 // This function works for both requesting and cancelling spot instances.
-func WaitUntilSpotRequestFulfilled(conn *ec2.EC2, spotRequestId string) error {
+func WaitUntilSpotRequestFulfilled(ctx aws.Context, conn *ec2.EC2, spotRequestId string) error {
 	spotRequestInput := ec2.DescribeSpotInstanceRequestsInput{
 		SpotInstanceRequestIds: []*string{&spotRequestId},
 	}
 
-	err := conn.WaitUntilSpotInstanceRequestFulfilledWithContext(aws.BackgroundContext(),
+	err := conn.WaitUntilSpotInstanceRequestFulfilledWithContext(
+		ctx,
 		&spotRequestInput,
 		getWaiterOptions()...)
 	return err
 }
 
-func WaitUntilVolumeAvailable(conn *ec2.EC2, volumeId string) error {
+func WaitUntilVolumeAvailable(ctx aws.Context, conn *ec2.EC2, volumeId string) error {
 	volumeInput := ec2.DescribeVolumesInput{
 		VolumeIds: []*string{&volumeId},
 	}
 
-	err := conn.WaitUntilVolumeAvailableWithContext(aws.BackgroundContext(),
+	err := conn.WaitUntilVolumeAvailableWithContext(
+		ctx,
 		&volumeInput,
 		getWaiterOptions()...)
 	return err
 }
 
-func WaitUntilSnapshotDone(conn *ec2.EC2, snapshotID string) error {
+func WaitUntilSnapshotDone(ctx aws.Context, conn *ec2.EC2, snapshotID string) error {
 	snapInput := ec2.DescribeSnapshotsInput{
 		SnapshotIds: []*string{&snapshotID},
 	}
 
-	err := conn.WaitUntilSnapshotCompletedWithContext(aws.BackgroundContext(),
+	err := conn.WaitUntilSnapshotCompletedWithContext(
+		ctx,
 		&snapInput,
 		getWaiterOptions()...)
 	return err
@@ -94,37 +99,37 @@ func WaitUntilSnapshotDone(conn *ec2.EC2, snapshotID string) error {
 
 // Wrappers for our custom AWS waiters
 
-func WaitUntilVolumeAttached(conn *ec2.EC2, volumeId string) error {
+func WaitUntilVolumeAttached(ctx aws.Context, conn *ec2.EC2, volumeId string) error {
 	volumeInput := ec2.DescribeVolumesInput{
 		VolumeIds: []*string{&volumeId},
 	}
 
 	err := WaitForVolumeToBeAttached(conn,
-		aws.BackgroundContext(),
+		ctx,
 		&volumeInput,
 		getWaiterOptions()...)
 	return err
 }
 
-func WaitUntilVolumeDetached(conn *ec2.EC2, volumeId string) error {
+func WaitUntilVolumeDetached(ctx aws.Context, conn *ec2.EC2, volumeId string) error {
 	volumeInput := ec2.DescribeVolumesInput{
 		VolumeIds: []*string{&volumeId},
 	}
 
-	err := WaitForVolumeToBeAttached(conn,
-		aws.BackgroundContext(),
+	err := WaitForVolumeToBeDetached(conn,
+		ctx,
 		&volumeInput,
 		getWaiterOptions()...)
 	return err
 }
 
-func WaitUntilImageImported(conn *ec2.EC2, taskID string) error {
+func WaitUntilImageImported(ctx aws.Context, conn *ec2.EC2, taskID string) error {
 	importInput := ec2.DescribeImportImageTasksInput{
 		ImportTaskIds: []*string{&taskID},
 	}
 
 	err := WaitForImageToBeImported(conn,
-		aws.BackgroundContext(),
+		ctx,
 		&importInput,
 		getWaiterOptions()...)
 	return err

--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -1,16 +1,13 @@
 package common
 
 import (
-	"errors"
-	"fmt"
 	"log"
-	"net"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/packer/helper/multistep"
 )
@@ -35,189 +32,220 @@ type StateChangeConf struct {
 	Target    string
 }
 
-// AMIStateRefreshFunc returns a StateRefreshFunc that is used to watch
-// an AMI for state changes.
-func AMIStateRefreshFunc(conn *ec2.EC2, imageId string) StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeImages(&ec2.DescribeImagesInput{
-			ImageIds: []*string{&imageId},
-		})
-		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidAMIID.NotFound" {
-				// Set this to nil as if we didn't find anything.
-				resp = nil
-			} else if isTransientNetworkError(err) {
-				// Transient network error, treat it as if we didn't find anything
-				resp = nil
-			} else {
-				log.Printf("Error on AMIStateRefresh: %s", err)
-				return nil, "", err
-			}
-		}
+// Following are wrapper functions that use Packer's environment-variables to
+// determing retry logic, then call the AWS SDK's built-in waiters.
 
-		if resp == nil || len(resp.Images) == 0 {
-			// Sometimes AWS has consistency issues and doesn't see the
-			// AMI. Return an empty state.
-			return nil, "", nil
-		}
-
-		i := resp.Images[0]
-		return i, *i.State, nil
+func WaitUntilAMIAvailable(conn *ec2.EC2, imageId string) error {
+	imageInput := ec2.DescribeImagesInput{
+		ImageIds: []*string{&imageId},
 	}
+
+	err := conn.WaitUntilImageAvailableWithContext(aws.BackgroundContext(),
+		&imageInput,
+		getWaiterOptions()...)
+	return err
 }
 
-// InstanceStateRefreshFunc returns a StateRefreshFunc that is used to watch
-// an EC2 instance.
-func InstanceStateRefreshFunc(conn *ec2.EC2, instanceId string) StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
-			InstanceIds: []*string{&instanceId},
-		})
-		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidInstanceID.NotFound" {
-				// Set this to nil as if we didn't find anything.
-				resp = nil
-			} else if isTransientNetworkError(err) {
-				// Transient network error, treat it as if we didn't find anything
-				resp = nil
-			} else {
-				log.Printf("Error on InstanceStateRefresh: %s", err)
-				return nil, "", err
-			}
-		}
+func WaitUntilInstanceTerminated(conn *ec2.EC2, instanceId string) error {
 
-		if resp == nil || len(resp.Reservations) == 0 || len(resp.Reservations[0].Instances) == 0 {
-			// Sometimes AWS just has consistency issues and doesn't see
-			// our instance yet. Return an empty state.
-			return nil, "", nil
-		}
-
-		i := resp.Reservations[0].Instances[0]
-		return i, *i.State.Name, nil
+	instanceInput := ec2.DescribeInstancesInput{
+		InstanceIds: []*string{&instanceId},
 	}
+
+	err := conn.WaitUntilInstanceTerminatedWithContext(aws.BackgroundContext(),
+		&instanceInput,
+		getWaiterOptions()...)
+	return err
 }
 
-// SpotRequestStateRefreshFunc returns a StateRefreshFunc that is used to watch
-// a spot request for state changes.
-func SpotRequestStateRefreshFunc(conn *ec2.EC2, spotRequestId string) StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
-			SpotInstanceRequestIds: []*string{&spotRequestId},
-		})
-
-		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidSpotInstanceRequestID.NotFound" {
-				// Set this to nil as if we didn't find anything.
-				resp = nil
-			} else if isTransientNetworkError(err) {
-				// Transient network error, treat it as if we didn't find anything
-				resp = nil
-			} else {
-				log.Printf("Error on SpotRequestStateRefresh: %s", err)
-				return nil, "", err
-			}
-		}
-
-		if resp == nil || len(resp.SpotInstanceRequests) == 0 {
-			// Sometimes AWS has consistency issues and doesn't see the
-			// SpotRequest. Return an empty state.
-			return nil, "", nil
-		}
-
-		i := resp.SpotInstanceRequests[0]
-		return i, *i.State, nil
+// This function works for both requesting and cancelling spot instances.
+func WaitUntilSpotRequestFulfilled(conn *ec2.EC2, spotRequestId string) error {
+	spotRequestInput := ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{&spotRequestId},
 	}
+
+	err := conn.WaitUntilSpotInstanceRequestFulfilledWithContext(aws.BackgroundContext(),
+		&spotRequestInput,
+		getWaiterOptions()...)
+	return err
 }
 
-func ImportImageRefreshFunc(conn *ec2.EC2, importTaskId string) StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeImportImageTasks(&ec2.DescribeImportImageTasksInput{
-			ImportTaskIds: []*string{
-				&importTaskId,
+func WaitUntilVolumeAvailable(conn *ec2.EC2, volumeId string) error {
+	volumeInput := ec2.DescribeVolumesInput{
+		VolumeIds: []*string{&volumeId},
+	}
+
+	err := conn.WaitUntilVolumeAvailableWithContext(aws.BackgroundContext(),
+		&volumeInput,
+		getWaiterOptions()...)
+	return err
+}
+
+func WaitUntilSnapshotDone(conn *ec2.EC2, snapshotID string) error {
+	snapInput := ec2.DescribeSnapshotsInput{
+		SnapshotIds: []*string{&snapshotID},
+	}
+
+	err := conn.WaitUntilSnapshotCompletedWithContext(aws.BackgroundContext(),
+		&snapInput,
+		getWaiterOptions()...)
+	return err
+}
+
+// Wrappers for our custom AWS waiters
+
+func WaitUntilVolumeAttached(conn *ec2.EC2, volumeId string) error {
+	volumeInput := ec2.DescribeVolumesInput{
+		VolumeIds: []*string{&volumeId},
+	}
+
+	err := WaitForVolumeToBeAttached(conn,
+		aws.BackgroundContext(),
+		&volumeInput,
+		getWaiterOptions()...)
+	return err
+}
+
+func WaitUntilVolumeDetached(conn *ec2.EC2, volumeId string) error {
+	volumeInput := ec2.DescribeVolumesInput{
+		VolumeIds: []*string{&volumeId},
+	}
+
+	err := WaitForVolumeToBeAttached(conn,
+		aws.BackgroundContext(),
+		&volumeInput,
+		getWaiterOptions()...)
+	return err
+}
+
+func WaitUntilImageImported(conn *ec2.EC2, taskID string) error {
+	importInput := ec2.DescribeImportImageTasksInput{
+		ImportTaskIds: []*string{&taskID},
+	}
+
+	err := WaitForImageToBeImported(conn,
+		aws.BackgroundContext(),
+		&importInput,
+		getWaiterOptions()...)
+	return err
+}
+
+// Custom waiters using AWS's request.Waiter
+
+func WaitForVolumeToBeAttached(c *ec2.EC2, ctx aws.Context, input *ec2.DescribeVolumesInput, opts ...request.WaiterOption) error {
+	w := request.Waiter{
+		Name:        "DescribeVolumes",
+		MaxAttempts: 40,
+		Delay:       request.ConstantWaiterDelay(5 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:    request.SuccessWaiterState,
+				Matcher:  request.PathAllWaiterMatch,
+				Argument: "Volumes[].State",
+				Expected: "attached",
+			},
+			{
+				State:    request.FailureWaiterState,
+				Matcher:  request.PathAnyWaiterMatch,
+				Argument: "Volumes[].State",
+				Expected: "deleted",
 			},
 		},
-		)
-		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && strings.HasPrefix(ec2err.Code(), "InvalidConversionTaskId") {
-				resp = nil
-			} else if isTransientNetworkError(err) {
-				resp = nil
-			} else {
-				log.Printf("Error on ImportImageRefresh: %s", err)
-				return nil, "", err
+		Logger: c.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+			var inCpy *ec2.DescribeVolumesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
 			}
-		}
-
-		if resp == nil || len(resp.ImportImageTasks) == 0 {
-			return nil, "", nil
-		}
-
-		i := resp.ImportImageTasks[0]
-		return i, *i.Status, nil
+			req, _ := c.DescribeVolumesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
 	}
+	return w.WaitWithContext(ctx)
 }
 
-// WaitForState watches an object and waits for it to achieve a certain
-// state.
-func WaitForState(conf *StateChangeConf) (i interface{}, err error) {
-	log.Printf("Waiting for state to become: %s", conf.Target)
-
-	sleepSeconds := SleepSeconds()
-	maxTicks := TimeoutSeconds()/sleepSeconds + 1
-	notfoundTick := 0
-
-	for {
-		var currentState string
-		i, currentState, err = conf.Refresh()
-		if err != nil {
-			return
-		}
-
-		if i == nil {
-			// If we didn't find the resource, check if we have been
-			// not finding it for awhile, and if so, report an error.
-			notfoundTick += 1
-			if notfoundTick > maxTicks {
-				return nil, errors.New("couldn't find resource")
+func WaitForVolumeToBeDetached(c *ec2.EC2, ctx aws.Context, input *ec2.DescribeVolumesInput, opts ...request.WaiterOption) error {
+	w := request.Waiter{
+		Name:        "DescribeVolumes",
+		MaxAttempts: 40,
+		Delay:       request.ConstantWaiterDelay(5 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:    request.SuccessWaiterState,
+				Matcher:  request.PathAllWaiterMatch,
+				Argument: "Volumes[].State",
+				Expected: "detached",
+			},
+		},
+		Logger: c.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+			var inCpy *ec2.DescribeVolumesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
 			}
-		} else {
-			// Reset the counter for when a resource isn't found
-			notfoundTick = 0
-
-			if currentState == conf.Target {
-				return
-			}
-
-			if conf.StepState != nil {
-				if _, ok := conf.StepState.GetOk(multistep.StateCancelled); ok {
-					return nil, errors.New("interrupted")
-				}
-			}
-
-			found := false
-			for _, allowed := range conf.Pending {
-				if currentState == allowed {
-					found = true
-					break
-				}
-			}
-
-			if !found {
-				err := fmt.Errorf("unexpected state '%s', wanted target '%s'", currentState, conf.Target)
-				return nil, err
-			}
-		}
-
-		time.Sleep(time.Duration(sleepSeconds) * time.Second)
+			req, _ := c.DescribeVolumesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
 	}
+	return w.WaitWithContext(ctx)
 }
 
-func isTransientNetworkError(err error) bool {
-	if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
-		return true
+func WaitForImageToBeImported(c *ec2.EC2, ctx aws.Context, input *ec2.DescribeImportImageTasksInput, opts ...request.WaiterOption) error {
+	w := request.Waiter{
+		Name:        "DescribeImages",
+		MaxAttempts: 40,
+		Delay:       request.ConstantWaiterDelay(5 * time.Second),
+		Acceptors: []request.WaiterAcceptor{
+			{
+				State:    request.SuccessWaiterState,
+				Matcher:  request.PathAllWaiterMatch,
+				Argument: "ImportImageTasks[].State",
+				Expected: "completed",
+			},
+			{
+				State:    request.RetryWaiterState,
+				Matcher:  request.ErrorWaiterMatch,
+				Expected: "InvalidConversionTaskId",
+			},
+		},
+		Logger: c.Config.Logger,
+		NewRequest: func(opts []request.Option) (*request.Request, error) {
+			var inCpy *ec2.DescribeImportImageTasksInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeImportImageTasksRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
 	}
+	return w.WaitWithContext(ctx)
+}
 
-	return false
+// This helper function uses the environment variables AWS_TIMEOUT_SECONDS and
+// AWS_POLL_DELAY_SECONDS to generate waiter options that can be passed into any
+// request.Waiter function. These options will control how many times the waiter
+// will retry the request, as well as how long to wait between the retries.
+func getWaiterOptions() []request.WaiterOption {
+	// use env vars to read in the wait delay and the max amount of time to wait
+	delay := SleepSeconds()
+	timeoutSeconds := TimeoutSeconds()
+	// AWS sdk uses max attempts instead of a timeout; convert timeout into
+	// max attempts
+	maxAttempts := timeoutSeconds / delay
+	delaySeconds := request.ConstantWaiterDelay(time.Duration(delay) * time.Second)
+
+	return []request.WaiterOption{
+		request.WithWaiterDelay(delaySeconds),
+		request.WithWaiterMaxAttempts(maxAttempts)}
 }
 
 // Returns 300 seconds (5 minutes) by default

--- a/builder/amazon/common/state_test.go
+++ b/builder/amazon/common/state_test.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func clearEnvVars() {
+	os.Unsetenv("AWS_POLL_DELAY_SECONDS")
+	os.Unsetenv("AWS_MAX_ATTEMPTS")
+	os.Unsetenv("AWS_TIMEOUT_SECONDS")
+}
+
+func testGetWaiterOptions(t *testing.T) {
+	clearEnvVars()
+
+	// no vars are set
+	options := getWaiterOptions()
+	if len(options) > 0 {
+		t.Fatalf("Did not expect any waiter options to be generated; actual: %#v", options)
+	}
+
+	// all vars are set
+	os.Setenv("AWS_MAX_ATTEMPTS", "800")
+	os.Setenv("AWS_TIMEOUT_SECONDS", "20")
+	os.Setenv("AWS_POLL_DELAY_SECONDS", "1")
+	options = getWaiterOptions()
+	expected := []request.WaiterOption{
+		request.WithWaiterDelay(request.ConstantWaiterDelay(time.Duration(1) * time.Second)),
+		request.WithWaiterMaxAttempts(800),
+	}
+	if !reflect.DeepEqual(options, expected) {
+		t.Fatalf("expected != actual!! Expected: %#v; Actual: %#v.", expected, options)
+	}
+	clearEnvVars()
+
+	// poll delay is not set
+	os.Setenv("AWS_MAX_ATTEMPTS", "800")
+	options = getWaiterOptions()
+	expected = []request.WaiterOption{
+		request.WithWaiterMaxAttempts(800),
+	}
+	if !reflect.DeepEqual(options, expected) {
+		t.Fatalf("expected != actual!! Expected: %#v; Actual: %#v.", expected, options)
+	}
+	clearEnvVars()
+
+	// poll delay is not set but timeout seconds is
+	os.Setenv("AWS_TIMEOUT_SECONDS", "20")
+	options = getWaiterOptions()
+	expected = []request.WaiterOption{
+		request.WithWaiterDelay(request.ConstantWaiterDelay(time.Duration(2) * time.Second)),
+		request.WithWaiterMaxAttempts(10),
+	}
+	if !reflect.DeepEqual(options, expected) {
+		t.Fatalf("expected != actual!! Expected: %#v; Actual: %#v.", expected, options)
+	}
+	clearEnvVars()
+}

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -116,14 +116,8 @@ func amiRegionCopy(state multistep.StateBag, config *AccessConfig, name string, 
 			imageId, target, err)
 	}
 
-	stateChange := StateChangeConf{
-		Pending:   []string{"pending"},
-		Target:    "available",
-		Refresh:   AMIStateRefreshFunc(regionconn, *resp.ImageId),
-		StepState: state,
-	}
-
-	if _, err := WaitForState(&stateChange); err != nil {
+	// Wait for the image to become ready
+	if err := WaitUntilAMIAvailable(regionconn, *resp.ImageId); err != nil {
 		return "", snapshotIds, fmt.Errorf("Error waiting for AMI (%s) in region (%s): %s",
 			*resp.ImageId, target, err)
 	}

--- a/builder/amazon/common/step_encrypted_ami.go
+++ b/builder/amazon/common/step_encrypted_ami.go
@@ -65,15 +65,8 @@ func (s *StepCreateEncryptedAMICopy) Run(_ context.Context, state multistep.Stat
 	}
 
 	// Wait for the copy to become ready
-	stateChange := StateChangeConf{
-		Pending:   []string{"pending"},
-		Target:    "available",
-		Refresh:   AMIStateRefreshFunc(ec2conn, *copyResp.ImageId),
-		StepState: state,
-	}
-
 	ui.Say("Waiting for AMI copy to become ready...")
-	if _, err := WaitForState(&stateChange); err != nil {
+	if err := WaitUntilAMIAvailable(ec2conn, *copyResp.ImageId); err != nil {
 		err := fmt.Errorf("Error waiting for AMI Copy: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/amazon/common/step_encrypted_ami.go
+++ b/builder/amazon/common/step_encrypted_ami.go
@@ -19,7 +19,7 @@ type StepCreateEncryptedAMICopy struct {
 	AMIMappings       []BlockDevice
 }
 
-func (s *StepCreateEncryptedAMICopy) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepCreateEncryptedAMICopy) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packer.Ui)
 	kmsKeyId := s.KeyID
@@ -66,7 +66,7 @@ func (s *StepCreateEncryptedAMICopy) Run(_ context.Context, state multistep.Stat
 
 	// Wait for the copy to become ready
 	ui.Say("Waiting for AMI copy to become ready...")
-	if err := WaitUntilAMIAvailable(ec2conn, *copyResp.ImageId); err != nil {
+	if err := WaitUntilAMIAvailable(ctx, ec2conn, *copyResp.ImageId); err != nil {
 		err := fmt.Errorf("Error waiting for AMI Copy: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -304,7 +304,7 @@ func (s *StepRunSourceInstance) Cleanup(state multistep.StateBag) {
 			return
 		}
 
-		if err := WaitUntilInstanceTerminated(ec2conn, s.instanceId); err != nil {
+		if err := WaitUntilInstanceTerminated(aws.BackgroundContext(), ec2conn, s.instanceId); err != nil {
 			ui.Error(err.Error())
 		}
 	}

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -303,14 +303,8 @@ func (s *StepRunSourceInstance) Cleanup(state multistep.StateBag) {
 			ui.Error(fmt.Sprintf("Error terminating instance, may still be around: %s", err))
 			return
 		}
-		stateChange := StateChangeConf{
-			Pending: []string{"pending", "running", "shutting-down", "stopped", "stopping"},
-			Refresh: InstanceStateRefreshFunc(ec2conn, s.instanceId),
-			Target:  "terminated",
-		}
 
-		_, err := WaitForState(&stateChange)
-		if err != nil {
+		if err := WaitUntilInstanceTerminated(ec2conn, s.instanceId); err != nil {
 			ui.Error(err.Error())
 		}
 	}

--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -202,7 +202,7 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 
 	spotRequestId := s.spotRequest.SpotInstanceRequestId
 	ui.Message(fmt.Sprintf("Waiting for spot request (%s) to become active...", *spotRequestId))
-	err = WaitUntilSpotRequestFulfilled(ec2conn, *spotRequestId)
+	err = WaitUntilSpotRequestFulfilled(ctx, ec2conn, *spotRequestId)
 	if err != nil {
 		err := fmt.Errorf("Error waiting for spot request (%s) to become ready: %s", *spotRequestId, err)
 		state.Put("error", err)
@@ -339,7 +339,7 @@ func (s *StepRunSpotInstance) Cleanup(state multistep.StateBag) {
 			return
 		}
 
-		err := WaitUntilSpotRequestFulfilled(ec2conn, *s.spotRequest.SpotInstanceRequestId)
+		err := WaitUntilSpotRequestFulfilled(aws.BackgroundContext(), ec2conn, *s.spotRequest.SpotInstanceRequestId)
 		if err != nil {
 			ui.Error(err.Error())
 		}
@@ -354,7 +354,7 @@ func (s *StepRunSpotInstance) Cleanup(state multistep.StateBag) {
 			return
 		}
 
-		if err := WaitUntilInstanceTerminated(ec2conn, s.instanceId); err != nil {
+		if err := WaitUntilInstanceTerminated(aws.BackgroundContext(), ec2conn, s.instanceId); err != nil {
 			ui.Error(err.Error())
 		}
 	}

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -44,15 +44,8 @@ func (s *stepCreateAMI) Run(_ context.Context, state multistep.StateBag) multist
 	state.Put("amis", amis)
 
 	// Wait for the image to become ready
-	stateChange := awscommon.StateChangeConf{
-		Pending:   []string{"pending"},
-		Target:    "available",
-		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *createResp.ImageId),
-		StepState: state,
-	}
-
 	ui.Say("Waiting for AMI to become ready...")
-	if _, err := awscommon.WaitForState(&stateChange); err != nil {
+	if err := awscommon.WaitUntilAMIAvailable(ec2conn, *createResp.ImageId); err != nil {
 		log.Printf("Error waiting for AMI: %s", err)
 		imagesResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
 		if err != nil {

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -15,7 +15,7 @@ type stepCreateAMI struct {
 	image *ec2.Image
 }
 
-func (s *stepCreateAMI) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(Config)
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	instance := state.Get("instance").(*ec2.Instance)
@@ -45,7 +45,7 @@ func (s *stepCreateAMI) Run(_ context.Context, state multistep.StateBag) multist
 
 	// Wait for the image to become ready
 	ui.Say("Waiting for AMI to become ready...")
-	if err := awscommon.WaitUntilAMIAvailable(ec2conn, *createResp.ImageId); err != nil {
+	if err := awscommon.WaitUntilAMIAvailable(ctx, ec2conn, *createResp.ImageId); err != nil {
 		log.Printf("Error waiting for AMI: %s", err)
 		imagesResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
 		if err != nil {

--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -21,7 +21,7 @@ type StepRegisterAMI struct {
 	image                    *ec2.Image
 }
 
-func (s *StepRegisterAMI) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	snapshotIds := state.Get("snapshot_ids").(map[string]string)
@@ -64,7 +64,7 @@ func (s *StepRegisterAMI) Run(_ context.Context, state multistep.StateBag) multi
 
 	// Wait for the image to become ready
 	ui.Say("Waiting for AMI to become ready...")
-	if err := awscommon.WaitUntilAMIAvailable(ec2conn, *registerResp.ImageId); err != nil {
+	if err := awscommon.WaitUntilAMIAvailable(ctx, ec2conn, *registerResp.ImageId); err != nil {
 		err := fmt.Errorf("Error waiting for AMI: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -63,15 +63,8 @@ func (s *StepRegisterAMI) Run(_ context.Context, state multistep.StateBag) multi
 	state.Put("amis", amis)
 
 	// Wait for the image to become ready
-	stateChange := awscommon.StateChangeConf{
-		Pending:   []string{"pending"},
-		Target:    "available",
-		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *registerResp.ImageId),
-		StepState: state,
-	}
-
 	ui.Say("Waiting for AMI to become ready...")
-	if _, err := awscommon.WaitForState(&stateChange); err != nil {
+	if err := awscommon.WaitUntilAMIAvailable(ec2conn, *registerResp.ImageId); err != nil {
 		err := fmt.Errorf("Error waiting for AMI: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -16,7 +16,7 @@ type StepRegisterAMI struct {
 	EnableAMISriovNetSupport bool
 }
 
-func (s *StepRegisterAMI) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	manifestPath := state.Get("remote_manifest_path").(string)
@@ -59,7 +59,7 @@ func (s *StepRegisterAMI) Run(_ context.Context, state multistep.StateBag) multi
 
 	// Wait for the image to become ready
 	ui.Say("Waiting for AMI to become ready...")
-	if err := awscommon.WaitUntilAMIAvailable(ec2conn, *registerResp.ImageId); err != nil {
+	if err := awscommon.WaitUntilAMIAvailable(ctx, ec2conn, *registerResp.ImageId); err != nil {
 		err := fmt.Errorf("Error waiting for AMI: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -58,15 +58,8 @@ func (s *StepRegisterAMI) Run(_ context.Context, state multistep.StateBag) multi
 	state.Put("amis", amis)
 
 	// Wait for the image to become ready
-	stateChange := awscommon.StateChangeConf{
-		Pending:   []string{"pending"},
-		Target:    "available",
-		Refresh:   awscommon.AMIStateRefreshFunc(ec2conn, *registerResp.ImageId),
-		StepState: state,
-	}
-
 	ui.Say("Waiting for AMI to become ready...")
-	if _, err := awscommon.WaitForState(&stateChange); err != nil {
+	if err := awscommon.WaitUntilAMIAvailable(ec2conn, *registerResp.ImageId); err != nil {
 		err := fmt.Errorf("Error waiting for AMI: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/post-processor/amazon-import/post-processor.go
+++ b/post-processor/amazon-import/post-processor.go
@@ -186,7 +186,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	// Wait for import process to complete, this takes a while
 	ui.Message(fmt.Sprintf("Waiting for task %s to complete (may take a while)", *import_start.ImportTaskId))
-	err = awscommon.WaitUntilImageImported(ec2conn, *import_start.ImportTaskId)
+	err = awscommon.WaitUntilImageImported(aws.BackgroundContext(), ec2conn, *import_start.ImportTaskId)
 
 	// Retrieve what the outcome was for the import task
 	import_result, err := ec2conn.DescribeImportImageTasks(&ec2.DescribeImportImageTasksInput{
@@ -226,7 +226,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 		ui.Message(fmt.Sprintf("Waiting for AMI rename to complete (may take a while)"))
 
-		if err := awscommon.WaitUntilAMIAvailable(ec2conn, *resp.ImageId); err != nil {
+		if err := awscommon.WaitUntilAMIAvailable(aws.BackgroundContext(), ec2conn, *resp.ImageId); err != nil {
 			return nil, false, fmt.Errorf("Error waiting for AMI (%s): %s", *resp.ImageId, err)
 		}
 

--- a/post-processor/amazon-import/post-processor.go
+++ b/post-processor/amazon-import/post-processor.go
@@ -203,7 +203,6 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 
 	// Check it was actually completed
-	log.Printf("MEGAN result was %s", *import_result.ImportImageTasks[0].Status)
 	if *import_result.ImportImageTasks[0].Status != "completed" {
 		// The most useful error message is from the job itself
 		return nil, false, fmt.Errorf("Import task %s failed: %s", *import_start.ImportTaskId, *import_result.ImportImageTasks[0].StatusMessage)

--- a/post-processor/amazon-import/post-processor.go
+++ b/post-processor/amazon-import/post-processor.go
@@ -187,6 +187,9 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	// Wait for import process to complete, this takes a while
 	ui.Message(fmt.Sprintf("Waiting for task %s to complete (may take a while)", *import_start.ImportTaskId))
 	err = awscommon.WaitUntilImageImported(aws.BackgroundContext(), ec2conn, *import_start.ImportTaskId)
+	if err != nil {
+		return nil, false, fmt.Errorf("Import task %s failed with error: %s", *import_start.ImportTaskId, err)
+	}
 
 	// Retrieve what the outcome was for the import task
 	import_result, err := ec2conn.DescribeImportImageTasks(&ec2.DescribeImportImageTasksInput{
@@ -200,6 +203,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 
 	// Check it was actually completed
+	log.Printf("MEGAN result was %s", *import_result.ImportImageTasks[0].Status)
 	if *import_result.ImportImageTasks[0].Status != "completed" {
 		// The most useful error message is from the job itself
 		return nil, false, fmt.Errorf("Import task %s failed: %s", *import_start.ImportTaskId, *import_result.ImportImageTasks[0].StatusMessage)

--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -176,7 +176,7 @@ for Packer to work:
       "Resource" : "*"
   }]
 }
-``` 
+```
 
 Note that if you'd like to create a spot instance, you must also add:
 
@@ -231,3 +231,20 @@ If you suspect your system's date is wrong, you can compare it against
 <http://www.time.gov/>. On Linux/OS X, you can run the `date` command to get the
 current time. If you're on Linux, you can try setting the time with ntp by
 running `sudo ntpd -q`.
+
+### `exceeded wait attempts` while waiting for tasks to complete
+We use the AWS SDK's built-in waiters to wait for longer-running tasks to
+complete. These waiters have default delays between queries and maximum number
+of queries that don't always work for our users.
+
+If you find that you are being rate-limited or have exceeded your max wait
+attempts, you can override the defaults by setting the following packer
+environment variables (note that these will apply to all aws tasks that we have
+to wait for):
+
+`AWS_MAX_ATTEMPTS` - This is how many times to re-send a status update request.
+Excepting tasks that we know can take an extremely long time, this defaults to
+40tries.
+
+`AWS_POLL_DELAY_SECONDS` - How many seconds to wait in between status update
+requests. Generally defaults to 2 or 5 seconds, depending on the task.

--- a/website/source/docs/post-processors/amazon-import.html.md
+++ b/website/source/docs/post-processors/amazon-import.html.md
@@ -125,30 +125,41 @@ This is an example that uses `vmware-iso` builder and exports the `.ova` file us
 ``` json
 "post-processors" : [
      [
-     {
-      "type": "shell-local",
-      "inline": [ "/usr/bin/ovftool <packer-output-directory>/<vmware-name>.vmx <packer-output-directory>/<vmware-name>.ova" ]
-     },
-     {
-         "files": [
-           "<packer-output-directory>/<vmware-name>.ova"
-         ],
-         "type": "artifice"
-     },
-     {
-      "type": "amazon-import",
-      "access_key": "YOUR KEY HERE",
-      "secret_key": "YOUR SECRET KEY HERE",
-      "region": "us-east-1",
-      "s3_bucket_name": "importbucket",
-      "license_type": "BYOL",
-      "tags": {
-        "Description": "packer amazon-import {{timestamp}}"
-      }
-     }
+        {
+          "type": "shell-local",
+          "inline": [ "/usr/bin/ovftool <packer-output-directory>/<vmware-name>.vmx <packer-output-directory>/<vmware-name>.ova" ]
+        },
+        {
+           "files": [
+             "<packer-output-directory>/<vmware-name>.ova"
+           ],
+           "type": "artifice"
+        },
+        {
+          "type": "amazon-import",
+          "access_key": "YOUR KEY HERE",
+          "secret_key": "YOUR SECRET KEY HERE",
+          "region": "us-east-1",
+          "s3_bucket_name": "importbucket",
+          "license_type": "BYOL",
+          "tags": {
+            "Description": "packer amazon-import {{timestamp}}"
+          }
+       }
     ]
   ]
 ```
+
+## Troubleshooting Timeouts
+The amazon-import feature can take a long time to upload and convert your OVAs
+into AMIs; if you find that your build is failing because you have exceeded your
+max retries or find yourself being rate limited, you can override the max
+retries and the delay in between retries by setting the environment variables
+ `AWS_MAX_ATTEMPTS` and `AWS_POLL_DELAY_SECONDS` on the machine running the
+ Packer build. By default, the waiter that waits for your image to be imported
+ from s3 waits retries up to 300 times with a 5 second delay in between retries.
+ This is dramatically higher than many of our other waiters, to account for how
+ long this process can take.
 
 -&gt; **Note:** Packer can also read the access key and secret access key from
 environmental variables. See the configuration reference in the section above


### PR DESCRIPTION
Replace our home-grown waiters with the AWS SDK's waiters. In situations where AWS hasn't already created a useful waiter, write our own using their waiter object.

Adds a new environment variable, AWS_MAX_RETRIES, which supersedes AWS_TIMEOUT_SECONDS if both are set. However, we do some math to still make AWS_TIMEOUT_SECONDS work, if set. 

The behavior of the timeouts should not change if the user has the AWS_POLL_DELAY and AWS_TIMEOUT_SECONDS set; however, the default has been changed from being a blanket 2 second delay / 300 second timeout to deferring to the delays set within the individual waiters.

closes #6177 
closes #6434