### PR TITLE
digitalocean: artifact should include build region and fixed docs

### DIFF
--- a/builder/digitalocean/step_snapshot.go
+++ b/builder/digitalocean/step_snapshot.go
@@ -111,6 +111,7 @@ func (s *stepSnapshot) Run(_ context.Context, state multistep.StateBag) multiste
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
+	snapshotRegions = append(snapshotRegions, c.Region)
 
 	log.Printf("Snapshot image ID: %d", imageId)
 	state.Put("snapshot_image_id", imageId)

--- a/website/source/docs/builders/digitalocean.html.md
+++ b/website/source/docs/builders/digitalocean.html.md
@@ -73,9 +73,8 @@ builder.
     for the droplet being created. This defaults to `false`, or not enabled.
 
 -   `snapshot_name` (string) - The name of the resulting snapshot that will
-    appear in your account. This must be unique. To help make this unique, use a
-    function like `timestamp` (see [configuration
-    templates](/docs/templates/engine.html) for more info)
+    appear in your account. Defaults to "packer-{{timestamp}}" (see
+    [configuration templates](/docs/templates/engine.html) for more info).
 
 -   `snapshot_regions` (array of strings) - The regions of the resulting snapshot that will
     appear in your account.
@@ -98,7 +97,7 @@ access tokens:
 {
   "type": "digitalocean",
   "api_token": "YOUR API KEY",
-  "image": "ubuntu-14-04-x64",
+  "image": "ubuntu-16-04-x64",
   "region": "nyc3",
   "size": "512mb",
   "ssh_username": "root"


### PR DESCRIPTION
- Add the build region to the list of regions for the artefact
- Corrected docs: `snapshot_name` doesn't have to be unique.
- Updated example to use Ubuntu 16.04