### PR TITLE
install doc : avoid name conflict

### DIFF
--- a/website/source/docs/install/index.html.md
+++ b/website/source/docs/install/index.html.md
@@ -30,7 +30,7 @@ inside is all that is necessary to run Packer (or `packer.exe` for Windows). Any
 additional files, if any, aren't required to run Packer.
 
 Copy the binary to anywhere on your system. If you intend to access it from the
-command-line, make sure to place it somewhere on your `PATH`.
+command-line, make sure to place it somewhere on your `PATH` before /usr/sbin.
 
 ## Compiling from Source
 


### PR DESCRIPTION
On CentOS /usr/sbin/packer (from cracklib-dicts RPM) is already present and is required by systemd.
This is a symlink to cracklib-packer.

To avoid trouble, two solutions are available :
- put packer in /usr/local/bin
- remove /usr/sbin in the PATH
