### PR TITLE
Support freeform tagging of OCI images

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
@@ -181,6 +182,30 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 	if c.BaseImageID == "" {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("'base_image_ocid' must be specified"))
+	}
+
+	// Validate tag lengths. TODO (hlowndes) maximum number of tags allowed.
+	if c.Tags != nil {
+		for k, v := range c.Tags {
+			k = strings.TrimSpace(k)
+			v = strings.TrimSpace(v)
+			if len(k) > 100 {
+				errs = packer.MultiErrorAppend(
+					errs, fmt.Errorf("Tag key length too long. Maximum 100 but found %d. Key: %s", len(k), k))
+			}
+			if len(k) == 0 {
+				errs = packer.MultiErrorAppend(
+					errs, errors.New("Tag key empty in config"))
+			}
+			if len(v) > 100 {
+				errs = packer.MultiErrorAppend(
+					errs, fmt.Errorf("Tag value length too long. Maximum 100 but found %d. Key: %s", len(v), k))
+			}
+			if len(v) == 0 {
+				errs = packer.MultiErrorAppend(
+					errs, errors.New("Tag value empty in config"))
+			}
+		}
 	}
 
 	if c.ImageName == "" {

--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -62,6 +62,9 @@ type Config struct {
 	// Networking
 	SubnetID string `mapstructure:"subnet_ocid"`
 
+	// Tagging
+	Tags map[string]string `mapstructure:"tags"`
+
 	ctx interpolate.Context
 }
 

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -80,6 +80,7 @@ func (d *driverOCI) CreateImage(ctx context.Context, id string) (core.Image, err
 		CompartmentId: &d.cfg.CompartmentID,
 		InstanceId:    &id,
 		DisplayName:   &d.cfg.ImageName,
+		FreeformTags:  d.cfg.Tags,
 	}})
 
 	if err != nil {

--- a/website/source/docs/builders/oracle-oci.html.md
+++ b/website/source/docs/builders/oracle-oci.html.md
@@ -138,6 +138,13 @@ launched instance.
    init. See [the Oracle docs](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/LaunchInstanceDetails) for more details. Example:
    `"user_data_file": "./boot_config/myscript.sh"`
 
+ - `tags` (map of strings) - Add one or more freeform tags to the resulting custom image. See [the Oracle docs](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/taggingoverview.htm) for more details. Example:
+
+``` {.yaml}
+"tags":
+  "tag1": "value1"
+  "tag2": "value2"
+```
 
 ## Basic Example
 


### PR DESCRIPTION
Resolves: #6313 

Adds support for OCI freeform tagging of custom images. Commit includes upgrading the official oci-go-sdk required for tag support.


