### PR TITLE
fixing infinite loop issue deleting existing resources if we have build_resource_group parameter

### DIFF
--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -38,6 +38,14 @@ func TestBuilderAcc_ManagedDisk_Windows(t *testing.T) {
 	})
 }
 
+func TestBuilderAcc_ManagedDisk_Windows_Build_Resource_Group(t *testing.T) {
+	builderT.Test(t, builderT.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Builder:  &Builder{},
+		Template: testBuilderAccManagedDiskWindowsBuildResourceGroup,
+	})
+}
+
 func TestBuilderAcc_ManagedDisk_Windows_DeviceLogin(t *testing.T) {
 	if os.Getenv(DeviceLoginAcceptanceTest) == "" {
 		t.Skip(fmt.Sprintf(
@@ -122,6 +130,40 @@ const testBuilderAccManagedDiskWindows = `
 	  "async_resourcegroup_delete": "true",
 
 	  "location": "South Central US",
+	  "vm_size": "Standard_DS2_v2"
+	}]
+}
+`
+const testBuilderAccManagedDiskWindowsBuildResourceGroup = `
+{
+	"variables": {
+	  "client_id": "{{env ` + "`ARM_CLIENT_ID`" + `}}",
+	  "client_secret": "{{env ` + "`ARM_CLIENT_SECRET`" + `}}",
+	  "subscription_id": "{{env ` + "`ARM_SUBSCRIPTION_ID`" + `}}"
+	},
+	"builders": [{
+	  "type": "test",
+
+	  "client_id": "{{user ` + "`client_id`" + `}}",
+	  "client_secret": "{{user ` + "`client_secret`" + `}}",
+	  "subscription_id": "{{user ` + "`subscription_id`" + `}}",
+
+	  "build_resource_group_name" : "packer-acceptance-test",
+	  "managed_image_resource_group_name": "packer-acceptance-test",
+	  "managed_image_name": "testBuilderAccManagedDiskWindows-{{timestamp}}",
+
+	  "os_type": "Windows",
+	  "image_publisher": "MicrosoftWindowsServer",
+	  "image_offer": "WindowsServer",
+	  "image_sku": "2012-R2-Datacenter",
+
+	  "communicator": "winrm",
+	  "winrm_use_ssl": "true",
+	  "winrm_insecure": "true",
+	  "winrm_timeout": "3m",
+	  "winrm_username": "packer",
+	  "async_resourcegroup_delete": "true",
+
 	  "vm_size": "Standard_DS2_v2"
 	}]
 }

--- a/builder/azure/arm/step_delete_resource_group.go
+++ b/builder/azure/arm/step_delete_resource_group.go
@@ -82,6 +82,7 @@ func (s *StepDeleteResourceGroup) deleteDeploymentResources(ctx context.Context,
 		deploymentOperation := deploymentOperations.Value()
 		// Sometimes an empty operation is added to the list by Azure
 		if deploymentOperation.Properties.TargetResource == nil {
+			deploymentOperations.Next()
 			continue
 		}
 

--- a/builder/azure/arm/step_deploy_template.go
+++ b/builder/azure/arm/step_deploy_template.go
@@ -185,6 +185,7 @@ func (s *StepDeployTemplate) Cleanup(state multistep.StateBag) {
 			deploymentOperation := deploymentOperations.Value()
 			// Sometimes an empty operation is added to the list by Azure
 			if deploymentOperation.Properties.TargetResource == nil {
+				deploymentOperations.Next()
 				continue
 			}
 			ui.Say(fmt.Sprintf(" -> %s : '%s'",


### PR DESCRIPTION
Discovered the issue while looking into https://github.com/hashicorp/packer/issues/5999 , while deleting resource while using build_resource_group we go into an infinite loop as we are not progressing the iterator if the deploymentoperations has an empty target resource entry ( We need to understand better why this is the case) .  Tested this with 1.2.4 and see it getting stuck after deletion of publicipaddress. and it fails with 

==> azure-arm:  -> ResourceGroupName : 'packer-acceptance-test'
==> azure-arm: 
==> azure-arm: The resource group was not created by Packer, only deleting individual resources ...
==> azure-arm:  -> Microsoft.Compute/virtualMachines : 'pkrvm95xn08g9m6'
==> azure-arm:  -> Microsoft.Network/networkInterfaces : 'pkrni95xn08g9m6'
==> azure-arm:  -> Microsoft.Network/virtualNetworks : 'pkrvn95xn08g9m6'
==> azure-arm:  -> Microsoft.Network/publicIPAddresses : 'pkrip95xn08g9m6'
Build 'azure-arm' errored: unexpected EOF

==> Some builds didn't complete successfully and had errors:
--> azure-arm: unexpected EOF

==> Builds finished but no artifacts were created.

So this fix, address Azure part of the issue reported by @owengr #5999

Added new acceptance test to cover the build_resource_group as well as tested this E2E. 

