### PR TITLE
docs/aws: Update documentation for AWS Spot Instances

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -168,10 +168,15 @@ for Packer to work:
       "Resource" : "*"
   }]
 }
-```
+``` 
 
-Note that if you'd like to create a spot instance, you must also add  
-`ec2:RequestSpotInstances` and `ec2:CancelSpotInstanceRequests`
+Note that if you'd like to create a spot instance, you must also add:
+
+``` json
+ec2:RequestSpotInstances,
+ec2:CancelSpotInstanceRequests,
+ec2:DescribeSpotInstanceRequests
+```  
 
 ## Troubleshooting
 


### PR DESCRIPTION
The docs didn't specify that `ec2:DescribeSpotInstanceRequests` was
required. This causes an error as follows:

```
Error waiting for spot request (sir-yg6866gj) to become ready:
UnauthorizedOperation: You are not authorized to perform this operation.
```

This is because the permission to describe instance state is not available
