### PR TITLE
WIP: add optional <reboot> during boot_command for sensitive guests

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -27,6 +27,9 @@ type Driver interface {
 	// Stop stops a VM specified by the name given.
 	Stop(string) error
 
+	// Reboot softly reboots a VM specified by the name given.
+	Reboot(string) error
+
 	// Verify checks to make sure that this driver should function
 	// properly. If there is any indication the driver can't function,
 	// this will return an error.

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -202,7 +202,7 @@ type DriverMock struct {
 
 	RebootVirtualMachine_Called bool
 	RebootVirtualMachine_VmName string
-	RebootVirtualMachine_Err error
+	RebootVirtualMachine_Err    error
 
 	RestartVirtualMachine_Called bool
 	RestartVirtualMachine_VmName string

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -200,6 +200,10 @@ type DriverMock struct {
 	CompactDisks_Result string
 	CompactDisks_Err    error
 
+	RebootVirtualMachine_Called bool
+	RebootVirtualMachine_VmName string
+	RebootVirtualMachine_Err error
+
 	RestartVirtualMachine_Called bool
 	RestartVirtualMachine_VmName string
 	RestartVirtualMachine_Err    error
@@ -514,6 +518,12 @@ func (d *DriverMock) CompactDisks(path string) (result string, err error) {
 	d.CompactDisks_Path = path
 	d.CompactDisks_Result = "Mock compact result msg: mockdisk.vhdx. Disk size reduced by 20%"
 	return d.CompactDisks_Result, d.CompactDisks_Err
+}
+
+func (d *DriverMock) RebootVirtualMachine(vmName string) error {
+	d.RebootVirtualMachine_Called = true
+	d.RebootVirtualMachine_VmName = vmName
+	return d.RebootVirtualMachine_Err
 }
 
 func (d *DriverMock) RestartVirtualMachine(vmName string) error {

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -55,6 +55,11 @@ func (d *HypervPS4Driver) Stop(vmName string) error {
 	return hyperv.StopVirtualMachine(vmName)
 }
 
+// Reboot softly reboots a VM specified by the name given.
+func (d *HypervPS4Driver) Reboot(vmName string) error {
+	return hyperv.RebootVirtualMachine(vmName)
+}
+
 func (d *HypervPS4Driver) Verify() error {
 
 	if err := d.verifyPSVersion(); err != nil {

--- a/builder/hyperv/common/step_type_boot_command.go
+++ b/builder/hyperv/common/step_type_boot_command.go
@@ -63,12 +63,14 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		vmName,
 	}
 
+	reboot := func() error {
+		return driver.Reboot(vmName)
+	}
 	sendCodes := func(codes []string) error {
 		scanCodesToSendString := strings.Join(codes, " ")
 		return driver.TypeScanCodes(vmName, scanCodesToSendString)
 	}
-	d := bootcommand.NewPCXTDriver(sendCodes, -1, s.GroupInterval)
-
+	d := bootcommand.NewPCXTDriver(reboot, sendCodes, -1, s.GroupInterval)
 	ui.Say("Typing the boot command...")
 	command, err := interpolate.Render(s.BootCommand, &s.Ctx)
 

--- a/builder/parallels/common/driver.go
+++ b/builder/parallels/common/driver.go
@@ -34,6 +34,9 @@ type Driver interface {
 	// Stop stops a running machine, forcefully.
 	Stop(string) error
 
+	// Reboot reboots a running machine, softly.
+	Reboot(string) error
+
 	// Prlctl executes the given Prlctl command
 	Prlctl(...string) error
 

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -232,6 +232,18 @@ func (d *Parallels9Driver) Stop(name string) error {
 	return nil
 }
 
+// Reboot softly reboots the VM.
+func (d *Parallels9Driver) Reboot(name string) error {
+	if err := d.Prlctl("restart", name); err != nil {
+		return err
+	}
+
+	// We sleep here for a little bit to let the session "unlock"
+	time.Sleep(2 * time.Second)
+
+	return nil
+}
+
 // Prlctl executes the specified "prlctl" command.
 func (d *Parallels9Driver) Prlctl(args ...string) error {
 	var stdout, stderr bytes.Buffer

--- a/builder/parallels/common/driver_mock.go
+++ b/builder/parallels/common/driver_mock.go
@@ -33,6 +33,9 @@ type DriverMock struct {
 	StopName string
 	StopErr  error
 
+	RebootName string
+	RebootErr error
+
 	PrlctlCalls [][]string
 	PrlctlErrs  []error
 
@@ -101,6 +104,11 @@ func (d *DriverMock) IsRunning(name string) (bool, error) {
 func (d *DriverMock) Stop(name string) error {
 	d.StopName = name
 	return d.StopErr
+}
+
+func (d *DriverMock) Reboot(name string) error {
+	d.RebootName = name
+	return d.RebootErr
 }
 
 func (d *DriverMock) Prlctl(args ...string) error {

--- a/builder/parallels/common/driver_mock.go
+++ b/builder/parallels/common/driver_mock.go
@@ -34,7 +34,7 @@ type DriverMock struct {
 	StopErr  error
 
 	RebootName string
-	RebootErr error
+	RebootErr  error
 
 	PrlctlCalls [][]string
 	PrlctlErrs  []error

--- a/builder/parallels/common/step_type_boot_command.go
+++ b/builder/parallels/common/step_type_boot_command.go
@@ -77,10 +77,14 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		s.VMName,
 	}
 
+	reboot := func() error {
+		return driver.Reboot(s.VMName)
+	}
 	sendCodes := func(codes []string) error {
 		return driver.SendKeyScanCodes(s.VMName, codes...)
 	}
-	d := bootcommand.NewPCXTDriver(sendCodes, -1, s.GroupInterval)
+
+	d := bootcommand.NewPCXTDriver(reboot, sendCodes, -1, s.GroupInterval)
 
 	ui.Say("Typing the boot command...")
 	command, err := interpolate.Render(s.BootCommand, &s.Ctx)

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -401,7 +401,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	steps = append(steps,
 		new(stepConfigureVNC),
 		steprun,
-		&stepTypeBootCommand{},
+		&stepTypeBootCommand{
+			Driver: driver,
+		},
 	)
 
 	if b.config.Comm.Type != "none" {
@@ -509,10 +511,16 @@ func (b *Builder) newDriver(qemuBinary string) (Driver, error) {
 		return nil, err
 	}
 
-	log.Printf("Qemu path: %s, Qemu Image page: %s", qemuPath, qemuImgPath)
+	virshPath, err := exec.LookPath("virsh")
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Qemu path: %s, Qemu Image page: %s, Virsh path: %s", qemuPath, qemuImgPath, virshPath)
 	driver := &QemuDriver{
 		QemuPath:    qemuPath,
 		QemuImgPath: qemuImgPath,
+		VirshPath: virshPath,
 	}
 
 	if err := driver.Verify(); err != nil {

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -520,7 +520,7 @@ func (b *Builder) newDriver(qemuBinary string) (Driver, error) {
 	driver := &QemuDriver{
 		QemuPath:    qemuPath,
 		QemuImgPath: qemuImgPath,
-		VirshPath: virshPath,
+		VirshPath:   virshPath,
 	}
 
 	if err := driver.Verify(); err != nil {

--- a/builder/qemu/driver.go
+++ b/builder/qemu/driver.go
@@ -50,7 +50,7 @@ type Driver interface {
 type QemuDriver struct {
 	QemuPath    string
 	QemuImgPath string
-	VirshPath string
+	VirshPath   string
 
 	vmCmd   *exec.Cmd
 	vmEndCh <-chan int

--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -33,7 +33,9 @@ type bootCommandTemplateData struct {
 //
 // Produces:
 //   <nothing>
-type stepTypeBootCommand struct{}
+type stepTypeBootCommand struct {
+	Driver Driver
+}
 
 func (s *stepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	config := state.Get("config").(*Config)
@@ -95,7 +97,10 @@ func (s *stepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		config.VMName,
 	}
 
-	d := bootcommand.NewVNCDriver(c, config.VNCConfig.BootKeyInterval)
+	reboot := func() error {
+		return s.Driver.Reboot()
+	}
+	d := bootcommand.NewVNCDriver(reboot, c, config.VNCConfig.BootKeyInterval)
 
 	ui.Say("Typing the boot command over VNC...")
 	command, err := interpolate.Render(config.VNCConfig.FlatBootCommand(), &configCtx)

--- a/builder/virtualbox/common/step_type_boot_command.go
+++ b/builder/virtualbox/common/step_type_boot_command.go
@@ -59,13 +59,19 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		s.VMName,
 	}
 
+	reboot := func() error {
+		args := []string{"controlvm", vmName, "reset"}
+
+		return driver.VBoxManage(args...)
+	}
 	sendCodes := func(codes []string) error {
 		args := []string{"controlvm", vmName, "keyboardputscancode"}
 		args = append(args, codes...)
 
 		return driver.VBoxManage(args...)
 	}
-	d := bootcommand.NewPCXTDriver(sendCodes, 25, s.GroupInterval)
+
+	d := bootcommand.NewPCXTDriver(reboot, sendCodes, 25, s.GroupInterval)
 
 	ui.Say("Typing the boot command...")
 	command, err := interpolate.Render(s.BootCommand, &s.Ctx)

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -40,6 +40,9 @@ type Driver interface {
 	// Stop stops a VM specified by the path to the VMX given.
 	Stop(string) error
 
+	// Reboot reboots a VM specified by the path to the VMX given.
+	Reboot(string) error
+
 	// SuppressMessages modifies the VMX or surrounding directory so that
 	// VMware doesn't show any annoying messages.
 	SuppressMessages(string) error

--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -149,6 +149,10 @@ func (d *ESX5Driver) Stop(vmxPathLocal string) error {
 	return d.sh("vim-cmd", "vmsvc/power.off", d.vmId)
 }
 
+func (d *ESX5Driver) Reboot(vmxPathLocal string) error {
+	return d.sh("vim-cmd", "vmsvc/power.reboot", d.vmId)
+}
+
 func (d *ESX5Driver) Register(vmxPathLocal string) error {
 	vmxPath := filepath.ToSlash(filepath.Join(d.outputDir, filepath.Base(vmxPathLocal)))
 	if err := d.upload(vmxPath, vmxPathLocal); err != nil {

--- a/builder/vmware/common/driver_fusion5.go
+++ b/builder/vmware/common/driver_fusion5.go
@@ -105,6 +105,12 @@ func (d *Fusion5Driver) Stop(vmxPath string) error {
 	return nil
 }
 
+func (d *Fusion5Driver) Reboot(vmxPath string) error {
+	cmd := exec.Command(d.vmrunPath(), "-T", "fusion", "reset", vmxPath, "soft")
+	_, _, err := runAndLog(cmd)
+	return err
+}
+
 func (d *Fusion5Driver) SuppressMessages(vmxPath string) error {
 	dir := filepath.Dir(vmxPath)
 	base := filepath.Base(vmxPath)

--- a/builder/vmware/common/driver_mock.go
+++ b/builder/vmware/common/driver_mock.go
@@ -92,6 +92,8 @@ type DriverMock struct {
 
 	VerifyCalled bool
 	VerifyErr    error
+
+	RebootCalled bool
 }
 
 type NetworkMapperMock struct {
@@ -209,6 +211,11 @@ func (d *DriverMock) Stop(path string) error {
 	d.StopCalled = true
 	d.StopPath = path
 	return d.StopErr
+}
+
+func (d *DriverMock) Reboot() error {
+	d.RebootCalled = true
+	return nil
 }
 
 func (d *DriverMock) SuppressMessages(path string) error {

--- a/builder/vmware/common/driver_player5.go
+++ b/builder/vmware/common/driver_player5.go
@@ -126,6 +126,12 @@ func (d *Player5Driver) Stop(vmxPath string) error {
 	return nil
 }
 
+func (d *Player5Driver) Reboot(vmxPath string) error {
+	cmd := exec.Command(d.VmrunPath, "-T", "player", "reset", vmxPath, "soft")
+	_, _, err := runAndLog(cmd)
+	return err
+}
+
 func (d *Player5Driver) SuppressMessages(vmxPath string) error {
 	return nil
 }

--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -99,6 +99,12 @@ func (d *Workstation9Driver) Stop(vmxPath string) error {
 	return nil
 }
 
+func (d *Workstation9Driver) Reboot(vmxPath string) error {
+	cmd := exec.Command(d.VmrunPath, "-T", "ws", "reset", vmxPath, "soft")
+	_, _, err := runAndLog(cmd)
+	return err
+}
+
 func (d *Workstation9Driver) SuppressMessages(vmxPath string) error {
 	return nil
 }

--- a/builder/vmware/common/remote_driver_mock.go
+++ b/builder/vmware/common/remote_driver_mock.go
@@ -26,7 +26,8 @@ type RemoteDriverMock struct {
 	UploadErr   error
 	DownloadErr error
 
-	ReloadVMErr error
+	RebootCalled bool
+	ReloadVMErr  error
 }
 
 func (d *RemoteDriverMock) UploadISO(path string, checksum string, checksumType string) (string, error) {
@@ -71,4 +72,9 @@ func (d *RemoteDriverMock) RemoveCache(localPath string) error {
 
 func (d *RemoteDriverMock) ReloadVM() error {
 	return d.ReloadVMErr
+}
+
+func (d *RemoteDriverMock) Reboot() error {
+	d.RebootCalled = true
+	return nil
 }

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -117,6 +117,9 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		s.VMName,
 	}
 
+	reboot := func() error {
+		return driver.Reboot(s.VMName)
+	}
 	d := bootcommand.NewVNCDriver(reboot, c, s.KeyInterval)
 
 	ui.Say("Typing the boot command over VNC...")

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -117,7 +117,7 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		s.VMName,
 	}
 
-	d := bootcommand.NewVNCDriver(c, s.KeyInterval)
+	d := bootcommand.NewVNCDriver(reboot, c, s.KeyInterval)
 
 	ui.Say("Typing the boot command over VNC...")
 	command, err := interpolate.Render(s.BootCommand, &s.Ctx)

--- a/common/bootcommand/boot_command.go
+++ b/common/bootcommand/boot_command.go
@@ -69,10 +69,14 @@ var g = &grammar{
 								},
 								&ruleRefExpr{
 									pos:  position{line: 10, col: 33, offset: 107},
+									name: "Reboot",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 10, col: 42, offset: 116},
 									name: "Special",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 10, col: 43, offset: 117},
+									pos:  position{line: 10, col: 52, offset: 126},
 									name: "Literal",
 								},
 							},
@@ -83,36 +87,36 @@ var g = &grammar{
 		},
 		{
 			name: "Wait",
-			pos:  position{line: 14, col: 1, offset: 150},
+			pos:  position{line: 14, col: 1, offset: 159},
 			expr: &actionExpr{
-				pos: position{line: 14, col: 8, offset: 157},
+				pos: position{line: 14, col: 8, offset: 166},
 				run: (*parser).callonWait1,
 				expr: &seqExpr{
-					pos: position{line: 14, col: 8, offset: 157},
+					pos: position{line: 14, col: 8, offset: 166},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 14, col: 8, offset: 157},
+							pos:  position{line: 14, col: 8, offset: 166},
 							name: "ExprStart",
 						},
 						&litMatcher{
-							pos:        position{line: 14, col: 18, offset: 167},
+							pos:        position{line: 14, col: 18, offset: 176},
 							val:        "wait",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 14, col: 25, offset: 174},
+							pos:   position{line: 14, col: 25, offset: 183},
 							label: "duration",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 14, col: 34, offset: 183},
+								pos: position{line: 14, col: 34, offset: 192},
 								expr: &choiceExpr{
-									pos: position{line: 14, col: 36, offset: 185},
+									pos: position{line: 14, col: 36, offset: 194},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 14, col: 36, offset: 185},
+											pos:  position{line: 14, col: 36, offset: 194},
 											name: "Duration",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 14, col: 47, offset: 196},
+											pos:  position{line: 14, col: 47, offset: 205},
 											name: "Integer",
 										},
 									},
@@ -120,7 +124,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 14, col: 58, offset: 207},
+							pos:  position{line: 14, col: 58, offset: 216},
 							name: "ExprEnd",
 						},
 					},
@@ -129,44 +133,73 @@ var g = &grammar{
 		},
 		{
 			name: "CharToggle",
-			pos:  position{line: 27, col: 1, offset: 453},
+			pos:  position{line: 27, col: 1, offset: 462},
 			expr: &actionExpr{
-				pos: position{line: 27, col: 14, offset: 466},
+				pos: position{line: 27, col: 14, offset: 475},
 				run: (*parser).callonCharToggle1,
 				expr: &seqExpr{
-					pos: position{line: 27, col: 14, offset: 466},
+					pos: position{line: 27, col: 14, offset: 475},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 27, col: 14, offset: 466},
+							pos:  position{line: 27, col: 14, offset: 475},
 							name: "ExprStart",
 						},
 						&labeledExpr{
-							pos:   position{line: 27, col: 24, offset: 476},
+							pos:   position{line: 27, col: 24, offset: 485},
 							label: "lit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 27, col: 29, offset: 481},
+								pos:  position{line: 27, col: 29, offset: 490},
 								name: "Literal",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 27, col: 38, offset: 490},
+							pos:   position{line: 27, col: 38, offset: 499},
 							label: "t",
 							expr: &choiceExpr{
-								pos: position{line: 27, col: 41, offset: 493},
+								pos: position{line: 27, col: 41, offset: 502},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 27, col: 41, offset: 493},
+										pos:  position{line: 27, col: 41, offset: 502},
 										name: "On",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 27, col: 46, offset: 498},
+										pos:  position{line: 27, col: 46, offset: 507},
 										name: "Off",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 27, col: 51, offset: 503},
+							pos:  position{line: 27, col: 51, offset: 512},
+							name: "ExprEnd",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Reboot",
+			pos:  position{line: 31, col: 1, offset: 583},
+			expr: &actionExpr{
+				pos: position{line: 31, col: 10, offset: 592},
+				run: (*parser).callonReboot1,
+				expr: &seqExpr{
+					pos: position{line: 31, col: 10, offset: 592},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 31, col: 10, offset: 592},
+							name: "ExprStart",
+						},
+						&labeledExpr{
+							pos:   position{line: 31, col: 20, offset: 602},
+							label: "s",
+							expr: &ruleRefExpr{
+								pos:  position{line: 31, col: 23, offset: 605},
+								name: "RebootKey",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 31, col: 34, offset: 616},
 							name: "ExprEnd",
 						},
 					},
@@ -175,39 +208,39 @@ var g = &grammar{
 		},
 		{
 			name: "Special",
-			pos:  position{line: 31, col: 1, offset: 574},
+			pos:  position{line: 35, col: 1, offset: 665},
 			expr: &actionExpr{
-				pos: position{line: 31, col: 11, offset: 584},
+				pos: position{line: 35, col: 11, offset: 675},
 				run: (*parser).callonSpecial1,
 				expr: &seqExpr{
-					pos: position{line: 31, col: 11, offset: 584},
+					pos: position{line: 35, col: 11, offset: 675},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 31, col: 11, offset: 584},
+							pos:  position{line: 35, col: 11, offset: 675},
 							name: "ExprStart",
 						},
 						&labeledExpr{
-							pos:   position{line: 31, col: 21, offset: 594},
+							pos:   position{line: 35, col: 21, offset: 685},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 31, col: 24, offset: 597},
+								pos:  position{line: 35, col: 24, offset: 688},
 								name: "SpecialKey",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 31, col: 36, offset: 609},
+							pos:   position{line: 35, col: 36, offset: 700},
 							label: "t",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 31, col: 38, offset: 611},
+								pos: position{line: 35, col: 38, offset: 702},
 								expr: &choiceExpr{
-									pos: position{line: 31, col: 39, offset: 612},
+									pos: position{line: 35, col: 39, offset: 703},
 									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 39, offset: 612},
+											pos:  position{line: 35, col: 39, offset: 703},
 											name: "On",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 31, col: 44, offset: 617},
+											pos:  position{line: 35, col: 44, offset: 708},
 											name: "Off",
 										},
 									},
@@ -215,7 +248,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 31, col: 50, offset: 623},
+							pos:  position{line: 35, col: 50, offset: 714},
 							name: "ExprEnd",
 						},
 					},
@@ -224,39 +257,39 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 39, col: 1, offset: 810},
+			pos:  position{line: 43, col: 1, offset: 901},
 			expr: &actionExpr{
-				pos: position{line: 39, col: 10, offset: 819},
+				pos: position{line: 43, col: 10, offset: 910},
 				run: (*parser).callonNumber1,
 				expr: &seqExpr{
-					pos: position{line: 39, col: 10, offset: 819},
+					pos: position{line: 43, col: 10, offset: 910},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 39, col: 10, offset: 819},
+							pos: position{line: 43, col: 10, offset: 910},
 							expr: &litMatcher{
-								pos:        position{line: 39, col: 10, offset: 819},
+								pos:        position{line: 43, col: 10, offset: 910},
 								val:        "-",
 								ignoreCase: false,
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 39, col: 15, offset: 824},
+							pos:  position{line: 43, col: 15, offset: 915},
 							name: "Integer",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 39, col: 23, offset: 832},
+							pos: position{line: 43, col: 23, offset: 923},
 							expr: &seqExpr{
-								pos: position{line: 39, col: 25, offset: 834},
+								pos: position{line: 43, col: 25, offset: 925},
 								exprs: []interface{}{
 									&litMatcher{
-										pos:        position{line: 39, col: 25, offset: 834},
+										pos:        position{line: 43, col: 25, offset: 925},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&oneOrMoreExpr{
-										pos: position{line: 39, col: 29, offset: 838},
+										pos: position{line: 43, col: 29, offset: 929},
 										expr: &ruleRefExpr{
-											pos:  position{line: 39, col: 29, offset: 838},
+											pos:  position{line: 43, col: 29, offset: 929},
 											name: "Digit",
 										},
 									},
@@ -269,29 +302,29 @@ var g = &grammar{
 		},
 		{
 			name: "Integer",
-			pos:  position{line: 43, col: 1, offset: 884},
+			pos:  position{line: 47, col: 1, offset: 975},
 			expr: &choiceExpr{
-				pos: position{line: 43, col: 11, offset: 894},
+				pos: position{line: 47, col: 11, offset: 985},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 43, col: 11, offset: 894},
+						pos:        position{line: 47, col: 11, offset: 985},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 43, col: 17, offset: 900},
+						pos: position{line: 47, col: 17, offset: 991},
 						run: (*parser).callonInteger3,
 						expr: &seqExpr{
-							pos: position{line: 43, col: 17, offset: 900},
+							pos: position{line: 47, col: 17, offset: 991},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 43, col: 17, offset: 900},
+									pos:  position{line: 47, col: 17, offset: 991},
 									name: "NonZeroDigit",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 43, col: 30, offset: 913},
+									pos: position{line: 47, col: 30, offset: 1004},
 									expr: &ruleRefExpr{
-										pos:  position{line: 43, col: 30, offset: 913},
+										pos:  position{line: 47, col: 30, offset: 1004},
 										name: "Digit",
 									},
 								},
@@ -303,21 +336,21 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 47, col: 1, offset: 977},
+			pos:  position{line: 51, col: 1, offset: 1068},
 			expr: &actionExpr{
-				pos: position{line: 47, col: 12, offset: 988},
+				pos: position{line: 51, col: 12, offset: 1079},
 				run: (*parser).callonDuration1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 47, col: 12, offset: 988},
+					pos: position{line: 51, col: 12, offset: 1079},
 					expr: &seqExpr{
-						pos: position{line: 47, col: 14, offset: 990},
+						pos: position{line: 51, col: 14, offset: 1081},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 47, col: 14, offset: 990},
+								pos:  position{line: 51, col: 14, offset: 1081},
 								name: "Number",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 47, col: 21, offset: 997},
+								pos:  position{line: 51, col: 21, offset: 1088},
 								name: "TimeUnit",
 							},
 						},
@@ -327,12 +360,12 @@ var g = &grammar{
 		},
 		{
 			name: "On",
-			pos:  position{line: 51, col: 1, offset: 1060},
+			pos:  position{line: 55, col: 1, offset: 1151},
 			expr: &actionExpr{
-				pos: position{line: 51, col: 6, offset: 1065},
+				pos: position{line: 55, col: 6, offset: 1156},
 				run: (*parser).callonOn1,
 				expr: &litMatcher{
-					pos:        position{line: 51, col: 6, offset: 1065},
+					pos:        position{line: 55, col: 6, offset: 1156},
 					val:        "on",
 					ignoreCase: true,
 				},
@@ -340,12 +373,12 @@ var g = &grammar{
 		},
 		{
 			name: "Off",
-			pos:  position{line: 55, col: 1, offset: 1098},
+			pos:  position{line: 59, col: 1, offset: 1189},
 			expr: &actionExpr{
-				pos: position{line: 55, col: 7, offset: 1104},
+				pos: position{line: 59, col: 7, offset: 1195},
 				run: (*parser).callonOff1,
 				expr: &litMatcher{
-					pos:        position{line: 55, col: 7, offset: 1104},
+					pos:        position{line: 59, col: 7, offset: 1195},
 					val:        "off",
 					ignoreCase: true,
 				},
@@ -353,216 +386,225 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 59, col: 1, offset: 1139},
+			pos:  position{line: 63, col: 1, offset: 1230},
 			expr: &actionExpr{
-				pos: position{line: 59, col: 11, offset: 1149},
+				pos: position{line: 63, col: 11, offset: 1240},
 				run: (*parser).callonLiteral1,
 				expr: &anyMatcher{
-					line: 59, col: 11, offset: 1149,
+					line: 63, col: 11, offset: 1240,
 				},
 			},
 		},
 		{
 			name: "ExprEnd",
-			pos:  position{line: 64, col: 1, offset: 1230},
+			pos:  position{line: 68, col: 1, offset: 1321},
 			expr: &litMatcher{
-				pos:        position{line: 64, col: 11, offset: 1240},
+				pos:        position{line: 68, col: 11, offset: 1331},
 				val:        ">",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "ExprStart",
-			pos:  position{line: 65, col: 1, offset: 1244},
+			pos:  position{line: 69, col: 1, offset: 1335},
 			expr: &litMatcher{
-				pos:        position{line: 65, col: 13, offset: 1256},
+				pos:        position{line: 69, col: 13, offset: 1347},
 				val:        "<",
 				ignoreCase: false,
 			},
 		},
 		{
+			name: "RebootKey",
+			pos:  position{line: 70, col: 1, offset: 1351},
+			expr: &litMatcher{
+				pos:        position{line: 70, col: 13, offset: 1363},
+				val:        "reboot",
+				ignoreCase: true,
+			},
+		},
+		{
 			name: "SpecialKey",
-			pos:  position{line: 66, col: 1, offset: 1260},
+			pos:  position{line: 71, col: 1, offset: 1373},
 			expr: &choiceExpr{
-				pos: position{line: 66, col: 14, offset: 1273},
+				pos: position{line: 71, col: 14, offset: 1386},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 66, col: 14, offset: 1273},
+						pos:        position{line: 71, col: 14, offset: 1386},
 						val:        "bs",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 66, col: 22, offset: 1281},
+						pos:        position{line: 71, col: 22, offset: 1394},
 						val:        "del",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 66, col: 31, offset: 1290},
+						pos:        position{line: 71, col: 31, offset: 1403},
 						val:        "enter",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 66, col: 42, offset: 1301},
+						pos:        position{line: 71, col: 42, offset: 1414},
 						val:        "esc",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 66, col: 51, offset: 1310},
+						pos:        position{line: 71, col: 51, offset: 1423},
 						val:        "f10",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 66, col: 60, offset: 1319},
+						pos:        position{line: 71, col: 60, offset: 1432},
 						val:        "f11",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 66, col: 69, offset: 1328},
+						pos:        position{line: 71, col: 69, offset: 1441},
 						val:        "f12",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 11, offset: 1345},
+						pos:        position{line: 72, col: 11, offset: 1458},
 						val:        "f1",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 19, offset: 1353},
+						pos:        position{line: 72, col: 19, offset: 1466},
 						val:        "f2",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 27, offset: 1361},
+						pos:        position{line: 72, col: 27, offset: 1474},
 						val:        "f3",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 35, offset: 1369},
+						pos:        position{line: 72, col: 35, offset: 1482},
 						val:        "f4",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 43, offset: 1377},
+						pos:        position{line: 72, col: 43, offset: 1490},
 						val:        "f5",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 51, offset: 1385},
+						pos:        position{line: 72, col: 51, offset: 1498},
 						val:        "f6",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 59, offset: 1393},
+						pos:        position{line: 72, col: 59, offset: 1506},
 						val:        "f7",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 67, offset: 1401},
+						pos:        position{line: 72, col: 67, offset: 1514},
 						val:        "f8",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 67, col: 75, offset: 1409},
+						pos:        position{line: 72, col: 75, offset: 1522},
 						val:        "f9",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 68, col: 12, offset: 1426},
+						pos:        position{line: 73, col: 12, offset: 1539},
 						val:        "return",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 68, col: 24, offset: 1438},
+						pos:        position{line: 73, col: 24, offset: 1551},
 						val:        "tab",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 68, col: 33, offset: 1447},
+						pos:        position{line: 73, col: 33, offset: 1560},
 						val:        "up",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 68, col: 41, offset: 1455},
+						pos:        position{line: 73, col: 41, offset: 1568},
 						val:        "down",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 68, col: 51, offset: 1465},
+						pos:        position{line: 73, col: 51, offset: 1578},
 						val:        "spacebar",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 68, col: 65, offset: 1479},
+						pos:        position{line: 73, col: 65, offset: 1592},
 						val:        "insert",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 68, col: 77, offset: 1491},
+						pos:        position{line: 73, col: 77, offset: 1604},
 						val:        "home",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 69, col: 11, offset: 1509},
+						pos:        position{line: 74, col: 11, offset: 1622},
 						val:        "end",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 69, col: 20, offset: 1518},
+						pos:        position{line: 74, col: 20, offset: 1631},
 						val:        "pageup",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 69, col: 32, offset: 1530},
+						pos:        position{line: 74, col: 32, offset: 1643},
 						val:        "pagedown",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 69, col: 46, offset: 1544},
+						pos:        position{line: 74, col: 46, offset: 1657},
 						val:        "leftalt",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 69, col: 59, offset: 1557},
+						pos:        position{line: 74, col: 59, offset: 1670},
 						val:        "leftctrl",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 69, col: 73, offset: 1571},
+						pos:        position{line: 74, col: 73, offset: 1684},
 						val:        "leftshift",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 70, col: 11, offset: 1594},
+						pos:        position{line: 75, col: 11, offset: 1707},
 						val:        "rightalt",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 70, col: 25, offset: 1608},
+						pos:        position{line: 75, col: 25, offset: 1721},
 						val:        "rightctrl",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 70, col: 40, offset: 1623},
+						pos:        position{line: 75, col: 40, offset: 1736},
 						val:        "rightshift",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 70, col: 56, offset: 1639},
+						pos:        position{line: 75, col: 56, offset: 1752},
 						val:        "leftsuper",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 70, col: 71, offset: 1654},
+						pos:        position{line: 75, col: 71, offset: 1767},
 						val:        "rightsuper",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 71, col: 11, offset: 1678},
+						pos:        position{line: 76, col: 11, offset: 1791},
 						val:        "left",
 						ignoreCase: true,
 					},
 					&litMatcher{
-						pos:        position{line: 71, col: 21, offset: 1688},
+						pos:        position{line: 76, col: 21, offset: 1801},
 						val:        "right",
 						ignoreCase: true,
 					},
@@ -571,9 +613,9 @@ var g = &grammar{
 		},
 		{
 			name: "NonZeroDigit",
-			pos:  position{line: 73, col: 1, offset: 1698},
+			pos:  position{line: 78, col: 1, offset: 1811},
 			expr: &charClassMatcher{
-				pos:        position{line: 73, col: 16, offset: 1713},
+				pos:        position{line: 78, col: 16, offset: 1826},
 				val:        "[1-9]",
 				ranges:     []rune{'1', '9'},
 				ignoreCase: false,
@@ -582,9 +624,9 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 74, col: 1, offset: 1719},
+			pos:  position{line: 79, col: 1, offset: 1832},
 			expr: &charClassMatcher{
-				pos:        position{line: 74, col: 9, offset: 1727},
+				pos:        position{line: 79, col: 9, offset: 1840},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -593,42 +635,42 @@ var g = &grammar{
 		},
 		{
 			name: "TimeUnit",
-			pos:  position{line: 75, col: 1, offset: 1733},
+			pos:  position{line: 80, col: 1, offset: 1846},
 			expr: &choiceExpr{
-				pos: position{line: 75, col: 13, offset: 1745},
+				pos: position{line: 80, col: 13, offset: 1858},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 75, col: 13, offset: 1745},
+						pos:        position{line: 80, col: 13, offset: 1858},
 						val:        "ns",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 75, col: 20, offset: 1752},
+						pos:        position{line: 80, col: 20, offset: 1865},
 						val:        "us",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 75, col: 27, offset: 1759},
+						pos:        position{line: 80, col: 27, offset: 1872},
 						val:        "µs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 75, col: 34, offset: 1767},
+						pos:        position{line: 80, col: 34, offset: 1880},
 						val:        "ms",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 75, col: 41, offset: 1774},
+						pos:        position{line: 80, col: 41, offset: 1887},
 						val:        "s",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 75, col: 47, offset: 1780},
+						pos:        position{line: 80, col: 47, offset: 1893},
 						val:        "m",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 75, col: 53, offset: 1786},
+						pos:        position{line: 80, col: 53, offset: 1899},
 						val:        "h",
 						ignoreCase: false,
 					},
@@ -638,11 +680,11 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 77, col: 1, offset: 1792},
+			pos:         position{line: 82, col: 1, offset: 1905},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 77, col: 19, offset: 1810},
+				pos: position{line: 82, col: 19, offset: 1923},
 				expr: &charClassMatcher{
-					pos:        position{line: 77, col: 19, offset: 1810},
+					pos:        position{line: 82, col: 19, offset: 1923},
 					val:        "[ \\n\\t\\r]",
 					chars:      []rune{' ', '\n', '\t', '\r'},
 					ignoreCase: false,
@@ -652,11 +694,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 79, col: 1, offset: 1822},
+			pos:  position{line: 84, col: 1, offset: 1935},
 			expr: &notExpr{
-				pos: position{line: 79, col: 8, offset: 1829},
+				pos: position{line: 84, col: 8, offset: 1942},
 				expr: &anyMatcher{
-					line: 79, col: 9, offset: 1830,
+					line: 84, col: 9, offset: 1943,
 				},
 			},
 		},
@@ -710,6 +752,16 @@ func (p *parser) callonCharToggle1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCharToggle1(stack["lit"], stack["t"])
+}
+
+func (c *current) onReboot1(s interface{}) (interface{}, error) {
+	return &rebootExpression{}, nil
+}
+
+func (p *parser) callonReboot1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onReboot1(stack["s"])
 }
 
 func (c *current) onSpecial1(s, t interface{}) (interface{}, error) {

--- a/common/bootcommand/boot_command.pigeon
+++ b/common/bootcommand/boot_command.pigeon
@@ -7,7 +7,7 @@ Input <- expr:Expr EOF {
     return expr, nil
 }
 
-Expr <- l:( Wait / CharToggle / Special / Literal)+ {
+Expr <- l:( Wait / CharToggle / Reboot / Special / Literal)+ {
     return l, nil
 }
 
@@ -26,6 +26,10 @@ Wait = ExprStart "wait" duration:( Duration / Integer )? ExprEnd {
 
 CharToggle = ExprStart lit:(Literal) t:(On / Off) ExprEnd {
     return &literal{lit.(*literal).s, t.(KeyAction)}, nil
+}
+
+Reboot = ExprStart s:(RebootKey) ExprEnd {
+    return &rebootExpression{}, nil
 }
 
 Special = ExprStart s:(SpecialKey) t:(On / Off)? ExprEnd {
@@ -63,6 +67,7 @@ Literal = . {
 
 ExprEnd = ">"
 ExprStart = "<"
+RebootKey = "reboot"i
 SpecialKey = "bs"i / "del"i / "enter"i / "esc"i / "f10"i / "f11"i / "f12"i
         / "f1"i / "f2"i / "f3"i / "f4"i / "f5"i / "f6"i / "f7"i / "f8"i / "f9"i
         /  "return"i / "tab"i / "up"i / "down"i / "spacebar"i / "insert"i / "home"i

--- a/common/bootcommand/boot_command_ast.go
+++ b/common/bootcommand/boot_command_ast.go
@@ -118,6 +118,18 @@ func (w *waitExpression) String() string {
 	return fmt.Sprintf("Wait<%s>", w.d)
 }
 
+type rebootExpression struct {}
+
+func (r *rebootExpression) Do(ctx context.Context, driver BCDriver) error {
+	log.Print("[INFO] Rebooting")
+	return driver.Reboot()
+}
+
+// Validate always passes
+func (r *rebootExpression) Validate() error {
+	return nil
+}
+
 type specialExpression struct {
 	s      string
 	action KeyAction

--- a/common/bootcommand/boot_command_ast.go
+++ b/common/bootcommand/boot_command_ast.go
@@ -118,7 +118,7 @@ func (w *waitExpression) String() string {
 	return fmt.Sprintf("Wait<%s>", w.d)
 }
 
-type rebootExpression struct {}
+type rebootExpression struct{}
 
 func (r *rebootExpression) Do(ctx context.Context, driver BCDriver) error {
 	log.Print("[INFO] Rebooting")

--- a/common/bootcommand/driver.go
+++ b/common/bootcommand/driver.go
@@ -2,6 +2,13 @@ package bootcommand
 
 const shiftedChars = "~!@#$%^&*()_+{}|:\"<>?"
 
+// RebootFunc will be called to reboot the VM
+type RebootFunc func() error
+
+func noopReboot() error {
+	return nil
+}
+
 // BCDriver is our access to the VM we want to type boot commands to
 type BCDriver interface {
 	Reboot() error

--- a/common/bootcommand/driver.go
+++ b/common/bootcommand/driver.go
@@ -4,6 +4,7 @@ const shiftedChars = "~!@#$%^&*()_+{}|:\"<>?"
 
 // BCDriver is our access to the VM we want to type boot commands to
 type BCDriver interface {
+	Reboot() error
 	SendKey(key rune, action KeyAction) error
 	SendSpecial(special string, action KeyAction) error
 	// Flush will be called when we want to send scancodes to the VM.

--- a/common/bootcommand/pc_xt_driver.go
+++ b/common/bootcommand/pc_xt_driver.go
@@ -12,12 +12,13 @@ import (
 	"github.com/hashicorp/packer/common"
 )
 
-// RebootFunc will be called to reboot the VM
-type RebootFunc func() error
-
 // SendCodeFunc will be called to send codes to the VM
 type SendCodeFunc func([]string) error
 type scMap map[string]*scancode
+
+func noopPCXTSendCode([]string) error {
+	return nil
+}
 
 type pcXTDriver struct {
 	interval    time.Duration

--- a/common/bootcommand/pc_xt_driver_test.go
+++ b/common/bootcommand/pc_xt_driver_test.go
@@ -105,7 +105,7 @@ func Test_pcxtSpecial(t *testing.T) {
 }
 
 func Test_flushes(t *testing.T) {
-	in := "abc123<wait>098"
+	in := "abc123<wait>098<reboot>"
 	expected := [][]string{
 		{"1e", "9e", "30", "b0", "2e", "ae", "02", "82", "03", "83", "04", "84"},
 		{"0b", "8b", "0a", "8a", "09", "89"},
@@ -115,12 +115,17 @@ func Test_flushes(t *testing.T) {
 		actual = append(actual, c)
 		return nil
 	}
-	d := NewPCXTDriver(sendCodes, -1, time.Duration(0))
+
+	boots := make(map[string]int)
+
+	d := NewPCXTDriver(func() { boots["reboot"] = 1; return nil }, sendCodes,
+		-1, time.Duration(0))
 	seq, err := GenerateExpressionSequence(in)
 	assert.NoError(t, err)
 	err = seq.Do(context.Background(), d)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
+	assert.Equal(boots["reboot"], 1)
 }
 
 func Test_KeyIntervalNotGiven(t *testing.T) {

--- a/common/bootcommand/pc_xt_driver_test.go
+++ b/common/bootcommand/pc_xt_driver_test.go
@@ -105,7 +105,7 @@ func Test_pcxtSpecial(t *testing.T) {
 }
 
 func Test_flushes(t *testing.T) {
-	in := "abc123<wait>098<reboot>"
+	in := "abc123<wait>098"
 	expected := [][]string{
 		{"1e", "9e", "30", "b0", "2e", "ae", "02", "82", "03", "83", "04", "84"},
 		{"0b", "8b", "0a", "8a", "09", "89"},
@@ -120,12 +120,12 @@ func Test_flushes(t *testing.T) {
 
 	d := NewPCXTDriver(func() { boots["reboot"] = 1; return nil }, sendCodes,
 		-1, time.Duration(0))
+
 	seq, err := GenerateExpressionSequence(in)
 	assert.NoError(t, err)
 	err = seq.Do(context.Background(), d)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
-	assert.Equal(boots["reboot"], 1)
 }
 
 func Test_KeyIntervalNotGiven(t *testing.T) {

--- a/common/bootcommand/pc_xt_driver_test.go
+++ b/common/bootcommand/pc_xt_driver_test.go
@@ -130,7 +130,6 @@ func Test_flushes(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-
 func Test_KeyIntervalNotGiven(t *testing.T) {
 	d := NewPCXTDriver(noopReboot, nil, -1, time.Duration(0))
 	assert.Equal(t, d.interval, time.Duration(100)*time.Millisecond)
@@ -139,6 +138,7 @@ func Test_KeyIntervalNotGiven(t *testing.T) {
 func Test_KeyIntervalGiven(t *testing.T) {
 	d := NewPCXTDriver(noopReboot, nil, -1, time.Duration(5000)*time.Millisecond)
 	assert.Equal(t, d.interval, time.Duration(5000)*time.Millisecond)
+}
 
 func Test_pcxtReboot(t *testing.T) {
 	in := "abc123<wait>098<reboot>"

--- a/common/bootcommand/vnc_driver.go
+++ b/common/bootcommand/vnc_driver.go
@@ -26,7 +26,7 @@ type vncDriver struct {
 	err error
 }
 
-func NewVNCDriver(reboot func() error, c VNCKeyEvent, interval time.Duration) *vncDriver {
+func NewVNCDriver(reboot RebootFunc, c VNCKeyEvent, interval time.Duration) *vncDriver {
 	// We delay (default 100ms) between each key event to allow for CPU or
 	// network latency. See PackerKeyEnv for tuning.
 	keyInterval := common.PackerKeyDefault

--- a/common/bootcommand/vnc_driver.go
+++ b/common/bootcommand/vnc_driver.go
@@ -18,6 +18,7 @@ type VNCKeyEvent interface {
 }
 
 type vncDriver struct {
+	reboot     func() error
 	c          VNCKeyEvent
 	interval   time.Duration
 	specialMap map[string]uint32
@@ -25,7 +26,7 @@ type vncDriver struct {
 	err error
 }
 
-func NewVNCDriver(c VNCKeyEvent, interval time.Duration) *vncDriver {
+func NewVNCDriver(reboot func() error, c VNCKeyEvent, interval time.Duration) *vncDriver {
 	// We delay (default 100ms) between each key event to allow for CPU or
 	// network latency. See PackerKeyEnv for tuning.
 	keyInterval := common.PackerKeyDefault
@@ -78,6 +79,7 @@ func NewVNCDriver(c VNCKeyEvent, interval time.Duration) *vncDriver {
 	sMap["up"] = 0xFF52
 
 	return &vncDriver{
+		reboot:     reboot,
 		c:          c,
 		interval:   keyInterval,
 		specialMap: sMap,
@@ -99,6 +101,10 @@ func (d *vncDriver) keyEvent(k uint32, down bool) error {
 // Flush does nothing here
 func (d *vncDriver) Flush() error {
 	return nil
+}
+
+func (d *vncDriver) Reboot() error {
+	return d.reboot()
 }
 
 func (d *vncDriver) SendKey(key rune, action KeyAction) error {

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -872,14 +872,14 @@ if ($vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Off) {
 
 func RebootVirtualMachine(vmName string) error {
 
-		var script = `
+	var script = `
 	param([string]$vmName)
 	Hyper-V\Restart-VM $vmName -Confirm:$false
 	`
 
-		var ps powershell.PowerShellCmd
-		err := ps.Run(script, vmName)
-		return err
+	var ps powershell.PowerShellCmd
+	err := ps.Run(script, vmName)
+	return err
 }
 
 func RestartVirtualMachine(vmName string) error {

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -870,6 +870,18 @@ if ($vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Off) {
 	return err
 }
 
+func RebootVirtualMachine(vmName string) error {
+
+		var script = `
+	param([string]$vmName)
+	Hyper-V\Restart-VM $vmName -Confirm:$false
+	`
+
+		var ps powershell.PowerShellCmd
+		err := ps.Run(script, vmName)
+		return err
+}
+
 func RestartVirtualMachine(vmName string) error {
 
 	var script = `


### PR DESCRIPTION
Allow `boot_command`s to signal a reboot during packing, so that some guests such as Plan 9 are able to complete installation.

VirtualBox driver tested with `<reboot>`; would be good for fellow contributors to test the other providers as well.