### PR TITLE
Allow StepAttachIso in the VirtualBox builder to resolve symbolic links when processing the IsoPath.

### DIFF
--- a/builder/virtualbox/iso/step_attach_iso.go
+++ b/builder/virtualbox/iso/step_attach_iso.go
@@ -34,6 +34,16 @@ func (s *stepAttachISO) Run(_ context.Context, state multistep.StateBag) multist
 		device = "0"
 	}
 
+	// If it's a symlink, resolve it to it's target.
+	resolvedIsoPath, err := filepath.EvalSymlinks(isoPath)
+	if err != nil {
+		err := fmt.Errorf("Error resolving symlink for ISO: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+	isoPath = resolvedIsoPath
+	
 	// Attach the disk to the controller
 	command := []string{
 		"storageattach", vmName,

--- a/builder/virtualbox/iso/step_attach_iso.go
+++ b/builder/virtualbox/iso/step_attach_iso.go
@@ -43,7 +43,7 @@ func (s *stepAttachISO) Run(_ context.Context, state multistep.StateBag) multist
 		return multistep.ActionHalt
 	}
 	isoPath = resolvedIsoPath
-	
+
 	// Attach the disk to the controller
 	command := []string{
 		"storageattach", vmName,

--- a/builder/virtualbox/iso/step_attach_iso.go
+++ b/builder/virtualbox/iso/step_attach_iso.go
@@ -3,6 +3,7 @@ package iso
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	vboxcommon "github.com/hashicorp/packer/builder/virtualbox/common"
 	"github.com/hashicorp/packer/helper/multistep"


### PR DESCRIPTION
This just closes out a really old issue (#3437) by using `filepath.EvalSymLinks` to resolve the symbolic link that the user specifies for the IsoPath.

Closes #3437.