### PR TITLE
Fix typo in updated install doc command: enc -> env

### DIFF
--- a/website/source/intro/getting-started/install.html.md
+++ b/website/source/intro/getting-started/install.html.md
@@ -56,7 +56,7 @@ in your `PATH`.
 1.  Clone the Packer repository from GitHub into your `GOPATH`:
 
     ``` shell
-    $ mkdir -p $(go enc GOPATH)/src/github.com/hashicorp && cd $_
+    $ mkdir -p $(go env GOPATH)/src/github.com/hashicorp && cd $_
     $ git clone https://github.com/hashicorp/packer.git
     $ cd packer
     ```


### PR DESCRIPTION
Just a simple fix for a typo

Ping! @rickard-von-essen @SwampDragons 
