### PR TITLE
Update example for -var-file

### DIFF
--- a/website/source/docs/templates/user-variables.html.md
+++ b/website/source/docs/templates/user-variables.html.md
@@ -176,7 +176,10 @@ variable values. Assuming this file is in `variables.json`, we can build our
 template using the following command:
 
 ``` text
+On Linux :
 $ packer build -var-file=variables.json template.json
+On Windows :
+packer build -var-file variables.json template.json
 ```
 
 The `-var-file` flag can be specified multiple times and variables from multiple


### PR DESCRIPTION
On Windows version v1.2.4, cannot use -var-file= syntax
invalid value "" for flag -var-file: open : The system cannot find the file specified.
Have to use -var-file .\file syntax
