### PR TITLE
Fixes for Hyper-V ISO and VMCX docs

### DIFF
--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -13,19 +13,20 @@ sidebar_current: 'docs-builders-hyperv-iso'
 
 Type: `hyperv-iso`
 
-The Hyper-V Packer builder is able to create [Hyper-V](https://www.microsoft.com/en-us/server-cloud/solutions/virtualization.aspx)
+The Hyper-V Packer builder is able to create
+[Hyper-V](https://www.microsoft.com/en-us/server-cloud/solutions/virtualization.aspx)
 virtual machines and export them, starting from an ISO image.
 
-The builder builds a virtual machine by creating a new virtual machine
-from scratch, booting it, installing an OS, provisioning software within
-the OS, then shutting it down. The result of the Hyper-V builder is a directory
+The builder builds a virtual machine by creating a new virtual machine from
+scratch, booting it, installing an OS, provisioning software within the OS,
+then shutting it down. The result of the Hyper-V builder is a directory
 containing all the files necessary to run the virtual machine portably.
 
 ## Basic Example
 
-Here is a basic example. This example is not functional. It will start the
-OS installer but then fail because we don't provide the preseed file for
-Ubuntu to self-install. Still, the example serves to show the basic configuration:
+Here is a basic example. This example is not functional. It will start the OS
+installer but then fail because we don't provide the preseed file for Ubuntu
+to self-install. Still, the example serves to show the basic configuration:
 
 ``` json
 {
@@ -45,13 +46,13 @@ provisioner might not be saved.
 
 ## Configuration Reference
 
-There are many configuration options available for the Hyper-V builder.
-They are organized below into two categories: required and optional. Within
-each category, the available options are alphabetized and described.
+There are many configuration options available for the Hyper-V builder. They
+are organized below into two categories: required and optional. Within each
+category, the available options are alphabetized and described.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/communicator.html)
-can be configured for this builder.
+[communicator](/docs/templates/communicator.html) can be configured for this
+builder.
 
 ### Required:
 
@@ -64,85 +65,93 @@ can be configured for this builder.
 -   `iso_checksum_type` (string) - The type of the checksum specified in
     `iso_checksum`. Valid values are "none", "md5", "sha1", "sha256", or
     "sha512" currently. While "none" will skip checksumming, this is not
-    recommended since ISO files and virtual harddrive files are generally large
-    and corruption does happen from time to time.
+    recommended since ISO files and virtual harddrive files are generally
+    large and corruption does happen from time to time.
 
 -   `iso_url` (string) - A URL to the ISO containing the installation image or
-    virtual harddrive vhd or vhdx file to clone. This URL can be either an HTTP
-    URL or a file URL (or path to a file). If this is an HTTP URL, Packer will
-    download the file and cache it between runs.
+    virtual harddrive vhd or vhdx file to clone. This URL can be either an
+    HTTP URL or a file URL (or path to a file). If this is an HTTP URL, Packer
+    will download the file and cache it between runs.
 
 ### Optional:
 
 -   `boot_command` (array of strings) - This is an array of commands to type
-    when the virtual machine is first booted. The goal of these commands should
-    be to type just enough to initialize the operating system installer. Special
-    keys can be typed as well, and are covered in the section below on the boot
-    command. If this is not specified, it is assumed the installer will start
-    itself.
+    when the virtual machine is first booted. The goal of these commands
+    should be to type just enough to initialize the operating system
+    installer. Special keys can be typed as well, and are covered in the
+    section below on the boot command. If this is not specified, it is assumed
+    the installer will start itself.
 
 -   `boot_wait` (string) - The time to wait after booting the initial virtual
-    machine before typing the `boot_command`. The value of this should be
-    a duration. Examples are "5s" and "1m30s" which will cause Packer to wait
-    five seconds and one minute 30 seconds, respectively. If this isn't specified,
-    the default is 10 seconds.
+    machine before typing the `boot_command`. The value of this should be a
+    duration. Examples are "5s" and "1m30s" which will cause Packer to wait
+    five seconds and one minute 30 seconds, respectively. If this isn't
+    specified, the default is 10 seconds.
 
--   `cpu` (number) - The number of cpus the virtual machine should use. If this isn't specified,
-    the default is 1 cpu.
+-   `cpu` (number) - The number of cpus the virtual machine should use. If
+    this isn't specified, the default is 1 cpu.
 
 -   `disk_additional_size` (array of integers) - The size(s) of any additional
     hard disks for the VM in megabytes. If this is not specified then the VM
-    will only contain a primary hard disk. Additional drives will be attached to the SCSI
-    interface only.  The builder uses expandable, not fixed-size virtual hard disks,
-    so the actual file representing the disk will not use the full size unless it is full.
+    will only contain a primary hard disk. Additional drives will be attached
+    to the SCSI interface only.  The builder uses expandable, not fixed-size
+    virtual hard disks, so the actual file representing the disk will not use
+    the full size unless it is full.
 
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40 GB.
 
--   `differencing_disk` (boolean) - If true enables differencing disks. Only the changes will be written to the new disk. This is especially useful if your
-    source is a vhd/vhdx. This defaults to false.
+-   `differencing_disk` (boolean) - If true enables differencing disks. Only
+    the changes will be written to the new disk. This is especially useful if
+    your source is a vhd/vhdx. This defaults to false.
 
 -   `headless` (boolean) - Packer defaults to building Hyper-V virtual
-    machines by launching a GUI that shows the console of the machine
-    being built. When this value is set to true, the machine will start without
-    a console.
+    machines by launching a GUI that shows the console of the machine being
+    built. When this value is set to true, the machine will start without a
+    console.
 
--   `skip_export` (boolean) - If true skips VM export. If you are interested only in the vhd/vhdx files, you can enable this option. This will create
-    inline disks which improves the build performance. There will not be any copying of source vhds to temp directory. This defaults to false.
+-   `skip_export` (boolean) - If true skips VM export. If you are interested
+    only in the vhd/vhdx files, you can enable this option. This will create
+    inline disks which improves the build performance. There will not be any
+    copying of source vhds to temp directory. This defaults to false.
 
--   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for virtual machine.
-    This defaults to false.
+-   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for
+    virtual machine. This defaults to false.
 
--   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual machine.
-    This defaults to false.
+-   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual
+    machine. This defaults to false.
 
--   `enable_secure_boot` (boolean) - If true enable secure boot for virtual machine. This defaults to false.
+-   `enable_secure_boot` (boolean) - If true enable secure boot for virtual
+    machine. This defaults to false.
 
--    `secure_boot_template` (string) - The secure boot template to be configured. Valid values are "MicrosoftWindows" (Windows) or 
-     "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
+-   `secure_boot_template` (string) - The secure boot template to be
+    configured. Valid values are "MicrosoftWindows" (Windows) or
+    "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if
+    enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
 
 
--   `enable_virtualization_extensions` (boolean) - If true enable virtualization extensions for virtual machine.
-    This defaults to false. For nested virtualization you need to enable mac spoofing, disable dynamic memory
-    and have at least 4GB of RAM for virtual machine.
+-   `enable_virtualization_extensions` (boolean) - If true enable
+    virtualization extensions for virtual machine.  This defaults to false.
+    For nested virtualization you need to enable mac spoofing, disable dynamic
+    memory and have at least 4GB of RAM for virtual machine.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
-    disk that is attached when the VM is booted. This is most useful
-    for unattended Windows installs, which look for an `Autounattend.xml` file
-    on removable media. By default, no floppy will be attached. All files
-    listed in this setting get placed into the root directory of the floppy
-    and the floppy is attached as the first floppy device. Currently, no
-    support exists for creating sub-directories on the floppy. Wildcard
-    characters (`*`, `?`, and `[]`) are allowed. Directory names are also allowed,
-    which will add all the files found in the directory to the floppy.
+    disk that is attached when the VM is booted. This is most useful for
+    unattended Windows installs, which look for an `Autounattend.xml` file on
+    removable media. By default, no floppy will be attached. All files listed
+    in this setting get placed into the root directory of the floppy and the
+    floppy is attached as the first floppy device. Currently, no support
+    exists for creating sub-directories on the floppy. Wildcard characters
+    (`*`, `?`, and `[]`) are allowed. Directory names are also allowed, which
+    will add all the files found in the directory to the floppy.
 
 -   `floppy_dirs` (array of strings) - A list of directories to place onto
     the floppy disk recursively. This is similar to the `floppy_files` option
     except that the directory structure is preserved. This is useful for when
     your floppy disk includes drivers or if you just want to organize it's
-    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are allowed.
-    The maximum summary size of all files in the listed directories are the
-    same as in `floppy_files`.
+    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are
+    allowed.  The maximum summary size of all files in the listed directories
+    are the same as in `floppy_files`.
 
 -   `generation` (number) - The Hyper-V generation for the virtual machine. By
     default, this is 1. Generation 2 Hyper-V virtual machines do not support
@@ -150,10 +159,11 @@ can be configured for this builder.
     drives and dvd drives will also be scsi and not ide.
 
 -   `guest_additions_mode` (string) - How should guest additions be installed.
-    If value `attach` then attach iso image with by specified by `guest_additions_path`.
-    Otherwise guest additions is not installed.
+    If value `attach` then attach iso image with by specified by
+    `guest_additions_path`.  Otherwise guest additions is not installed.
 
--   `guest_additions_path` (string) - The path to the iso image for guest additions.
+-   `guest_additions_path` (string) - The path to the iso image for guest
+    additions.
 
 -   `http_directory` (string) - Path to a directory to serve using an HTTP
     server. The files in this directory will be available over HTTP that will
@@ -164,17 +174,19 @@ can be configured for this builder.
     below.
 
 -   `http_port_min` and `http_port_max` (number) - These are the minimum and
-    maximum port to use for the HTTP server started to serve the `http_directory`.
-    Because Packer often runs in parallel, Packer will choose a randomly available
-    port in this range to run the HTTP server. If you want to force the HTTP
-    server to be on one port, make this minimum and maximum port the same.
-    By default the values are 8000 and 9000, respectively.
+    maximum port to use for the HTTP server started to serve the
+    `http_directory`.  Because Packer often runs in parallel, Packer will
+    choose a randomly available port in this range to run the HTTP server. If
+    you want to force the HTTP server to be on one port, make this minimum and
+    maximum port the same.  By default the values are 8000 and 9000,
+    respectively.
 
 -   `iso_urls` (array of strings) - Multiple URLs for the ISO to download.
-    Packer will try these in order. If anything goes wrong attempting to download
-    or while downloading a single URL, it will move on to the next. All URLs
-    must point to the same file (same checksum). By default this is empty
-    and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be specified.
+    Packer will try these in order. If anything goes wrong attempting to
+    download or while downloading a single URL, it will move on to the next.
+    All URLs must point to the same file (same checksum). By default this is
+    empty and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be
+    specified.
 
 -   `iso_target_extension` (string) - The extension of the iso file after
     download. This defaults to "iso".
@@ -184,89 +196,96 @@ can be configured for this builder.
     original filename as its name.
 
 -   `output_directory` (string) - This is the path to the directory where the
-    resulting virtual machine will be created. This may be relative or absolute.
-    If relative, the path is relative to the working directory when `packer`
-    is executed. This directory must not exist or be empty prior to running the builder.
-    By default this is "output-BUILDNAME" where "BUILDNAME" is the name
-    of the build.
+    resulting virtual machine will be created. This may be relative or
+    absolute.  If relative, the path is relative to the working directory when
+    `packer` is executed. This directory must not exist or be empty prior to
+    running the builder.  By default this is "output-BUILDNAME" where
+    "BUILDNAME" is the name of the build.
 
--   `ram_size` (number) - The size, in megabytes, of the ram to create
-    for the VM. By default, this is 1 GB.
+-   `ram_size` (number) - The size, in megabytes, of the ram to create for the
+    VM. By default, this is 1 GB.
 
--   `secondary_iso_images` (array of strings) - A list of iso paths to attached to a
-    VM when it is booted. This is most useful for unattended Windows installs, which
-    look for an `Autounattend.xml` file on removable media. By default, no
-    secondary iso will be attached.
+-   `secondary_iso_images` (array of strings) - A list of iso paths to
+    attached to a VM when it is booted. This is most useful for unattended
+    Windows installs, which look for an `Autounattend.xml` file on removable
+    media. By default, no secondary iso will be attached.
 
--   `shutdown_command` (string) - The command to use to gracefully shut down the machine once all
-    the provisioning is done. By default this is an empty string, which tells Packer to just
-    forcefully shut down the machine unless a shutdown command takes place inside script so this may
-    safely be omitted. If one or more scripts require a reboot it is suggested to leave this blank
-    since reboots may fail and specify the final shutdown command in your last script.
+-   `shutdown_command` (string) - The command to use to gracefully shut down
+    the machine once all the provisioning is done. By default this is an empty
+    string, which tells Packer to just forcefully shut down the machine unless
+    a shutdown command takes place inside script so this may safely be
+    omitted. If one or more scripts require a reboot it is suggested to leave
+    this blank since reboots may fail and specify the final shutdown command
+    in your last script.
 
 -   `shutdown_timeout` (string) - The amount of time to wait after executing
-    the `shutdown_command` for the virtual machine to actually shut down.
-    If it doesn't shut down in this time, it is an error. By default, the timeout
+    the `shutdown_command` for the virtual machine to actually shut down.  If
+    it doesn't shut down in this time, it is an error. By default, the timeout
     is "5m", or five minutes.
 
--   `skip_compaction` (boolean) - If true skip compacting the hard disk for virtual machine when
-    exporting. This defaults to false.
+-   `skip_compaction` (boolean) - If true skip compacting the hard disk for
+    virtual machine when exporting. This defaults to false.
 
--   `switch_name` (string) - The name of the switch to connect the virtual machine to. Be defaulting
-    this to an empty string, Packer will try to determine the switch to use by looking for
-    external switch that is up and running.
+-   `switch_name` (string) - The name of the switch to connect the virtual
+    machine to. Be defaulting this to an empty string, Packer will try to
+    determine the switch to use by looking for external switch that is up and
+    running.
 
--   `switch_vlan_id` (string) - This is the vlan of the virtual switch's network card.
-    By default none is set. If none is set then a vlan is not set on the switch's network card.
-    If this value is set it should match the vlan specified in by `vlan_id`.
+-   `switch_vlan_id` (string) - This is the vlan of the virtual switch's
+    network card.  By default none is set. If none is set then a vlan is not
+    set on the switch's network card.  If this value is set it should match
+    the vlan specified in by `vlan_id`.
 
--   `use_fixed_vhd_format` (boolean) - If true, creates the boot disk on the virtual machine as
-    a fixed VHD format disk. The default is false, which creates a dynamic VHDX format disk. This
-    option requires setting `generation` to 1, `skip_compaction` to true, and `differencing_disk` to false.
-    Additionally, any value entered for `disk_block_size` will be ignored. The most likely use case for this
-    option is outputing a disk that is in the format required for upload to Azure.
+-   `use_fixed_vhd_format` (boolean) - If true, creates the boot disk on the
+    virtual machine as a fixed VHD format disk. The default is false, which
+    creates a dynamic VHDX format disk. This option requires setting
+    `generation` to 1, `skip_compaction` to true, and `differencing_disk` to
+    false.  Additionally, any value entered for `disk_block_size` will be
+    ignored. The most likely use case for this option is outputing a disk that
+    is in the format required for upload to Azure.
 
 -   `vhd_temp_path` (string) - A separate path to be used for storing the VM's
     disk image. The purpose is to enable reading and writing to take place on
     different physical disks (read from VHD temp path, write to regular temp
     path while exporting the VM) to eliminate a single-disk bottleneck.
 
--   `vlan_id` (string) - This is the vlan of the virtual machine's network card
-    for the new virtual machine. By default none is set. If none is set then
-    vlans are not set on the virtual machine's network card.
+-   `vlan_id` (string) - This is the vlan of the virtual machine's network
+    card for the new virtual machine. By default none is set. If none is set
+    then vlans are not set on the virtual machine's network card.
 
--   `mac_address` (string) - This allows a specific MAC address to be used on the
-    default virtual network card.  The MAC address must be a string with no
-    delimiters, for example "0000deadbeef".
+-   `mac_address` (string) - This allows a specific MAC address to be used on
+    the default virtual network card.  The MAC address must be a string with
+    no delimiters, for example "0000deadbeef".
 
--   `vm_name` (string) - This is the name of the virtual machine for the new virtual
-    machine, without the file extension. By default this is "packer-BUILDNAME",
-    where "BUILDNAME" is the name of the build.
+-   `vm_name` (string) - This is the name of the virtual machine for the new
+    virtual machine, without the file extension. By default this is
+    "packer-BUILDNAME", where "BUILDNAME" is the name of the build.
 
--   `temp_path` (string) - This is the temporary path in which Packer will create the virtual
-    machine. Default value is system `%temp%`
+-   `temp_path` (string) - This is the temporary path in which Packer will
+    create the virtual machine. Default value is system `%temp%`
 
--   `disk_block_size` (string) - The block size of the VHD to be created. 
-    Recommended disk block size for Linux hyper-v guests is 1 MiB. This defaults to "32 MiB".
+-   `disk_block_size` (string) - The block size of the VHD to be created.
+    Recommended disk block size for Linux hyper-v guests is 1 MiB. This
+    defaults to "32 MiB".
 
 ## Boot Command
 
-The `boot_command` configuration is very important: it specifies the keys
-to type when the virtual machine is first booted in order to start the
-OS installer. This command is typed after `boot_wait`, which gives the
-virtual machine some time to actually load the ISO.
+The `boot_command` configuration is very important: it specifies the keys to
+type when the virtual machine is first booted in order to start the OS
+installer. This command is typed after `boot_wait`, which gives the virtual
+machine some time to actually load the ISO.
 
-As documented above, the `boot_command` is an array of strings. The
-strings are all typed in sequence. It is an array only to improve readability
-within the template.
+As documented above, the `boot_command` is an array of strings. The strings
+are all typed in sequence. It is an array only to improve readability within
+the template.
 
 The boot command is "typed" character for character over the virtual keyboard
 to the machine, simulating a human actually typing the keyboard.
 
 <%= partial "partials/builders/boot-command" %>
 
-Example boot command. This is actually a working boot command used to start
-an Ubuntu 12.04 installer:
+Example boot command. This is actually a working boot command used to start an
+Ubuntu 12.04 installer:
 
 ``` json
 [
@@ -292,18 +311,22 @@ for the version of Hyper-V that is running.
 
 ## Generation 1 vs Generation 2
 
-Floppy drives are no longer supported by generation 2 machines. This requires you to
-take another approach when dealing with preseed or answer files. Two possible options
-are using virtual dvd drives or using the built in web server.
+Floppy drives are no longer supported by generation 2 machines. This requires
+you to take another approach when dealing with preseed or answer files. Two
+possible options are using virtual dvd drives or using the built in web
+server.
 
-When dealing with Windows you need to enable UEFI drives for generation 2 virtual machines.
+When dealing with Windows you need to enable UEFI drives for generation 2
+virtual machines.
 
 ## Creating iso from directory
 
-Programs like mkisofs can be used to create an iso from a directory.
-There is a [windows version of mkisofs](http://opensourcepack.blogspot.co.uk/p/cdrtools.html).
+Programs like mkisofs can be used to create an iso from a directory. There is
+a [windows version of
+mkisofs](http://opensourcepack.blogspot.co.uk/p/cdrtools.html).
 
-Example powershell script. This is an actually working powershell script used to create a Windows answer iso:
+Example powershell script. This is an actually working powershell script used
+to create a Windows answer iso:
 
 ``` powershell
 $isoFolder = "answer-iso"
@@ -866,8 +889,8 @@ Finish proxy after sysprep -->
 
 ## Example For Ubuntu Vivid Generation 2
 
-If you are running Windows under virtualization, you may need to create
-a virtual switch with an `External` connection type.
+If you are running Windows under virtualization, you may need to create a
+virtual switch with an `External` connection type.
 
 ### Packer config:
 

--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -18,9 +18,10 @@ The Hyper-V Packer builder is able to create
 virtual machines and export them, starting from an ISO image.
 
 The builder builds a virtual machine by creating a new virtual machine from
-scratch, booting it, installing an OS, provisioning software within the OS,
-then shutting it down. The result of the Hyper-V builder is a directory
-containing all the files necessary to run the virtual machine portably.
+scratch. Typically, the VM is booted, an OS is installed, and software is
+provisioned within the OS. Finally the VM is shut down. The result of the
+Hyper-V builder is a directory containing all the files necessary to run
+the virtual machine portably.
 
 ## Basic Example
 
@@ -40,9 +41,12 @@ to self-install. Still, the example serves to show the basic configuration:
 }
 ```
 
-It is important to add a `shutdown_command`. By default Packer halts the
-virtual machine and the file system may not be sync'd. Thus, changes made in a
-provisioner might not be saved.
+By default Packer will perform a hard power off of a virtual machine.
+However, when a machine is powered off this way, it is possible that
+changes made to the VMs file system may not be fully synced, possibly
+leading to corruption of files or lost changes. As such, it is important to
+add a `shutdown_command`. This tells Packer how to safely shutdown and
+power off the VM.
 
 ## Configuration Reference
 
@@ -56,20 +60,22 @@ builder.
 
 ### Required:
 
--   `iso_checksum` (string) - The checksum for the OS ISO file or virtual
-    harddrive file. Because these files are so large, this is required and
-    Packer will verify it prior to booting a virtual machine with the ISO or
-    virtual harddrive attached. The type of the checksum is specified with
-    `iso_checksum_type`, documented below.
+-   `iso_checksum` (string) - The checksum for the ISO file or virtual
+    hard drive file. The algorithm to use when computing the checksum is
+    specified with `iso_checksum_type`.
 
--   `iso_checksum_type` (string) - The type of the checksum specified in
-    `iso_checksum`. Valid values are "none", "md5", "sha1", "sha256", or
-    "sha512" currently. While "none" will skip checksumming, this is not
-    recommended since ISO files and virtual harddrive files are generally
-    large and corruption does happen from time to time.
+-   `iso_checksum_type` (string) - The algorithm to be used when computing
+    the checksum of the file specified in `iso_checksum`. Currently, valid
+    values are "none", "md5", "sha1", "sha256", or "sha512". Since the
+    validity of ISO and virtual disk files are typically crucial to a
+    successful build, Packer performs a check of any supplied media by
+    default. While setting "none" will cause Packer to skip this check,
+    corruption of large files such as ISOs and virtual hard drives can
+    occur from time to time. As such, skipping this check is not
+    recommended.
 
 -   `iso_url` (string) - A URL to the ISO containing the installation image or
-    virtual harddrive vhd or vhdx file to clone. This URL can be either an
+    virtual hard drive (VHD or VHDX) file to clone. This URL can be either an
     HTTP URL or a file URL (or path to a file). If this is an HTTP URL, Packer
     will download the file and cache it between runs.
 
@@ -83,57 +89,56 @@ builder.
     the installer will start itself.
 
 -   `boot_wait` (string) - The time to wait after booting the initial virtual
-    machine before typing the `boot_command`. The value of this should be a
-    duration. Examples are "5s" and "1m30s" which will cause Packer to wait
-    five seconds and one minute 30 seconds, respectively. If this isn't
-    specified, the default is 10 seconds.
+    machine before typing the `boot_command`. The value specified should be
+    a duration. For example, setting a duration of "1m30s" would cause
+    Packer to wait for 1 minute 30 seconds before typing the boot command.
+    The default duration is "10s" (10 seconds).
 
--   `cpu` (number) - The number of cpus the virtual machine should use. If
-    this isn't specified, the default is 1 cpu.
+-   `cpu` (number) - The number of CPUs the virtual machine should use. If
+    this isn't specified, the default is 1 CPU.
 
--   `disk_additional_size` (array of integers) - The size(s) of any additional
-    hard disks for the VM in megabytes. If this is not specified then the VM
-    will only contain a primary hard disk. Additional drives will be attached
-    to the SCSI interface only.  The builder uses expandable, not fixed-size
-    virtual hard disks, so the actual file representing the disk will not use
-    the full size unless it is full.
+-   `differencing_disk` (boolean) - If true enables differencing disks. Only
+    the changes will be written to the new disk. This is especially useful if
+    your source is a VHD/VHDX. This defaults to `false`.
+
+-   `disk_additional_size` (array of integers) - The size or sizes of any
+    additional hard disks for the VM in megabytes. If this is not specified
+    then the VM will only contain a primary hard disk. Additional drives
+    will be attached to the SCSI interface only. The builder uses
+    expandable rather than fixed-size virtual hard disks, so the actual
+    file representing the disk will not use the full size unless it is
+    full.
+
+-   `disk_block_size` (string) - The block size of the VHD to be created.
+    Recommended disk block size for Linux hyper-v guests is 1 MiB. This
+    defaults to "32 MiB".
 
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40 GB.
 
--   `differencing_disk` (boolean) - If true enables differencing disks. Only
-    the changes will be written to the new disk. This is especially useful if
-    your source is a vhd/vhdx. This defaults to false.
+-   `enable_dynamic_memory` (boolean) - If `true` enable dynamic memory for
+    the virtual machine. This defaults to `false`.
 
--   `headless` (boolean) - Packer defaults to building Hyper-V virtual
-    machines by launching a GUI that shows the console of the machine being
-    built. When this value is set to true, the machine will start without a
-    console.
+-   `enable_mac_spoofing` (boolean) - If `true` enable MAC address spoofing
+    for the virtual machine. This defaults to `false`.
 
--   `skip_export` (boolean) - If true skips VM export. If you are interested
-    only in the vhd/vhdx files, you can enable this option. This will create
-    inline disks which improves the build performance. There will not be any
-    copying of source vhds to temp directory. This defaults to false.
+-   `enable_secure_boot` (boolean) - If `true` enable secure boot for the
+    virtual machine. This defaults to `false`. See `secure_boot_template`
+    below for additional settings.
 
--   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for
-    virtual machine. This defaults to false.
+-   `enable_virtualization_extensions` (boolean) - If `true` enable
+    virtualization extensions for the virtual machine. This defaults to
+    `false`. For nested virtualization you need to enable MAC spoofing,
+    disable dynamic memory and have at least 4GB of RAM assigned to the
+    virtual machine.
 
--   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual
-    machine. This defaults to false.
-
--   `enable_secure_boot` (boolean) - If true enable secure boot for virtual
-    machine. This defaults to false.
-
--   `secure_boot_template` (string) - The secure boot template to be
-    configured. Valid values are "MicrosoftWindows" (Windows) or
-    "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if
-    enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
-
-
--   `enable_virtualization_extensions` (boolean) - If true enable
-    virtualization extensions for virtual machine.  This defaults to false.
-    For nested virtualization you need to enable mac spoofing, disable dynamic
-    memory and have at least 4GB of RAM for virtual machine.
+-   `floppy_dirs` (array of strings) - A list of directories to place onto
+    the floppy disk recursively. This is similar to the `floppy_files` option
+    except that the directory structure is preserved. This is useful for when
+    your floppy disk includes drivers or if you just want to organize it's
+    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are
+    allowed. The maximum summary size of all files in the listed directories
+    are the same as in `floppy_files`.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for
@@ -145,41 +150,45 @@ builder.
     (`*`, `?`, and `[]`) are allowed. Directory names are also allowed, which
     will add all the files found in the directory to the floppy.
 
--   `floppy_dirs` (array of strings) - A list of directories to place onto
-    the floppy disk recursively. This is similar to the `floppy_files` option
-    except that the directory structure is preserved. This is useful for when
-    your floppy disk includes drivers or if you just want to organize it's
-    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are
-    allowed.  The maximum summary size of all files in the listed directories
-    are the same as in `floppy_files`.
-
 -   `generation` (number) - The Hyper-V generation for the virtual machine. By
     default, this is 1. Generation 2 Hyper-V virtual machines do not support
     floppy drives. In this scenario use `secondary_iso_images` instead. Hard
-    drives and dvd drives will also be scsi and not ide.
+    drives and DVD drives will also be SCSI and not IDE.
 
--   `guest_additions_mode` (string) - How should guest additions be installed.
-    If value `attach` then attach iso image with by specified by
-    `guest_additions_path`.  Otherwise guest additions is not installed.
+-   `guest_additions_mode` (string) - If set to `attach` then attach and
+    mount the ISO image specified in `guest_additions_path`. If set to
+    `none` then guest additions are not attached and mounted; This is the
+    default.
 
--   `guest_additions_path` (string) - The path to the iso image for guest
+-   `guest_additions_path` (string) - The path to the ISO image for guest
     additions.
 
--   `http_directory` (string) - Path to a directory to serve using an HTTP
-    server. The files in this directory will be available over HTTP that will
-    be requestable from the virtual machine. This is useful for hosting
-    kickstart files and so on. By default this is "", which means no HTTP
-    server will be started. The address and port of the HTTP server will be
-    available as variables in `boot_command`. This is covered in more detail
-    below.
+-   `headless` (boolean) - Packer defaults to building Hyper-V virtual
+    machines by launching a GUI that shows the console of the machine being
+    built. When this value is set to true, the machine will start without a
+    console.
+
+-   `http_directory` (string) - Path to a directory to serve using Packers
+    inbuilt HTTP server. The files in this directory will be available
+    over HTTP to the virtual machine. This is useful for hosting kickstart
+    files and so on. By default this value is unset and the HTTP server is
+    not started. The address and port of the HTTP server will be available
+    as variables in `boot_command`. This is covered in more detail below.
 
 -   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
-    `http_directory`.  Because Packer often runs in parallel, Packer will
-    choose a randomly available port in this range to run the HTTP server. If
-    you want to force the HTTP server to be on one port, make this minimum and
-    maximum port the same.  By default the values are 8000 and 9000,
-    respectively.
+    `http_directory`. Since Packer often runs in parallel, a randomly
+    available port in this range will be repeatedly chosen until an
+    available port is found. To force the HTTP server to use a specific
+    port, set an identical value for `http_port_min` and `http_port_max`.
+    By default the values are 8000 and 9000, respectively.
+
+-   `iso_target_extension` (string) - The extension of the ISO file after
+    download. This defaults to "iso".
+
+-   `iso_target_path` (string) - The path where the ISO should be saved after
+    download. By default the ISO will be saved in the Packer cache
+    directory with a hash of the original filename as its name.
 
 -   `iso_urls` (array of strings) - Multiple URLs for the ISO to download.
     Packer will try these in order. If anything goes wrong attempting to
@@ -188,85 +197,87 @@ builder.
     empty and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be
     specified.
 
--   `iso_target_extension` (string) - The extension of the iso file after
-    download. This defaults to "iso".
-
--   `iso_target_path` (string) - The path where the iso should be saved after
-    download. By default will go in the packer cache, with a hash of the
-    original filename as its name.
+-   `mac_address` (string) - This allows a specific MAC address to be used on
+    the default virtual network card. The MAC address must be a string with
+    no delimiters, for example "0000deadbeef".
 
 -   `output_directory` (string) - This is the path to the directory where the
     resulting virtual machine will be created. This may be relative or
-    absolute.  If relative, the path is relative to the working directory when
+    absolute. If relative, the path is relative to the working directory when
     `packer` is executed. This directory must not exist or be empty prior to
-    running the builder.  By default this is "output-BUILDNAME" where
+    running the builder. By default this is "output-BUILDNAME" where
     "BUILDNAME" is the name of the build.
 
--   `ram_size` (number) - The size, in megabytes, of the ram to create for the
+-   `ram_size` (number) - The amount, in megabytes, of RAM to assign to the
     VM. By default, this is 1 GB.
 
--   `secondary_iso_images` (array of strings) - A list of iso paths to
-    attached to a VM when it is booted. This is most useful for unattended
+-   `secondary_iso_images` (array of strings) - A list of ISO paths to
+    attach to a VM when it is booted. This is most useful for unattended
     Windows installs, which look for an `Autounattend.xml` file on removable
-    media. By default, no secondary iso will be attached.
+    media. By default, no secondary ISO will be attached.
+
+-   `secure_boot_template` (string) - The secure boot template to be
+    configured. Valid values are "MicrosoftWindows" (Windows) or
+    "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if
+    `enable_secure_boot` is set to "true". This defaults to "MicrosoftWindows".
 
 -   `shutdown_command` (string) - The command to use to gracefully shut down
-    the machine once all the provisioning is done. By default this is an empty
-    string, which tells Packer to just forcefully shut down the machine unless
-    a shutdown command takes place inside script so this may safely be
-    omitted. If one or more scripts require a reboot it is suggested to leave
-    this blank since reboots may fail and specify the final shutdown command
-    in your last script.
+    the machine once all provisioning is complete. By default this is an
+    empty string, which tells Packer to just forcefully shut down the
+    machine. This setting can be safely omitted if for example, a shutdown
+    command to gracefully halt the machine is configured inside a
+    provisioning script. If one or more scripts require a reboot it is
+    suggested to leave this blank (since reboots may fail) and instead
+    specify the final shutdown command in your last script.
 
 -   `shutdown_timeout` (string) - The amount of time to wait after executing
-    the `shutdown_command` for the virtual machine to actually shut down.  If
-    it doesn't shut down in this time, it is an error. By default, the timeout
-    is "5m", or five minutes.
+    the `shutdown_command` for the virtual machine to actually shut down.
+    If the machine doesn't shut down in this time it is considered an
+    error. By default, the time out is "5m" (five minutes).
 
--   `skip_compaction` (boolean) - If true skip compacting the hard disk for
-    virtual machine when exporting. This defaults to false.
+-   `skip_compaction` (boolean) - If `true` skip compacting the hard disk for
+    the virtual machine when exporting. This defaults to `false`.
+
+-   `skip_export` (boolean) - If `true` Packer will skip the export of the
+    VM. If you are interested only in the VHD/VHDX files, you can enable
+    this option. This will create inline disks which improves the build
+    performance.  There will not be any copying of source VHDs to the temp
+    directory. This defaults to `false`.
 
 -   `switch_name` (string) - The name of the switch to connect the virtual
-    machine to. Be defaulting this to an empty string, Packer will try to
-    determine the switch to use by looking for external switch that is up and
-    running.
+    machine to. By default, leaving this value unset will cause Packer to
+    try and determine the switch to use by looking for an external switch
+    that is up and running.
 
--   `switch_vlan_id` (string) - This is the vlan of the virtual switch's
-    network card.  By default none is set. If none is set then a vlan is not
-    set on the switch's network card.  If this value is set it should match
-    the vlan specified in by `vlan_id`.
+-   `switch_vlan_id` (string) - This is the VLAN of the virtual switch's
+    network card. By default none is set. If none is set then a VLAN is not
+    set on the switch's network card. If this value is set it should match
+    the VLAN specified in by `vlan_id`.
+
+-   `temp_path` (string) - This is the temporary path in which Packer will
+    create the virtual machine. By default the value is the system `%temp%`.
 
 -   `use_fixed_vhd_format` (boolean) - If true, creates the boot disk on the
-    virtual machine as a fixed VHD format disk. The default is false, which
+    virtual machine as a fixed VHD format disk. The default is `false`, which
     creates a dynamic VHDX format disk. This option requires setting
-    `generation` to 1, `skip_compaction` to true, and `differencing_disk` to
-    false.  Additionally, any value entered for `disk_block_size` will be
-    ignored. The most likely use case for this option is outputing a disk that
-    is in the format required for upload to Azure.
+    `generation` to `1`, `skip_compaction` to `true`, and
+    `differencing_disk` to `false`. Additionally, any value entered for
+    `disk_block_size` will be ignored. The most likely use case for this
+    option is outputing a disk that is in the format required for upload to
+    Azure.
 
 -   `vhd_temp_path` (string) - A separate path to be used for storing the VM's
     disk image. The purpose is to enable reading and writing to take place on
     different physical disks (read from VHD temp path, write to regular temp
     path while exporting the VM) to eliminate a single-disk bottleneck.
 
--   `vlan_id` (string) - This is the vlan of the virtual machine's network
+-   `vlan_id` (string) - This is the VLAN of the virtual machine's network
     card for the new virtual machine. By default none is set. If none is set
-    then vlans are not set on the virtual machine's network card.
+    then VLANs are not set on the virtual machine's network card.
 
--   `mac_address` (string) - This allows a specific MAC address to be used on
-    the default virtual network card.  The MAC address must be a string with
-    no delimiters, for example "0000deadbeef".
-
--   `vm_name` (string) - This is the name of the virtual machine for the new
-    virtual machine, without the file extension. By default this is
-    "packer-BUILDNAME", where "BUILDNAME" is the name of the build.
-
--   `temp_path` (string) - This is the temporary path in which Packer will
-    create the virtual machine. Default value is system `%temp%`
-
--   `disk_block_size` (string) - The block size of the VHD to be created.
-    Recommended disk block size for Linux hyper-v guests is 1 MiB. This
-    defaults to "32 MiB".
+-   `vm_name` (string) - This is the name of the new virtual machine,
+    without the file extension. By default this is "packer-BUILDNAME",
+    where "BUILDNAME" is the name of the build.
 
 ## Boot Command
 
@@ -284,8 +295,8 @@ to the machine, simulating a human actually typing the keyboard.
 
 <%= partial "partials/builders/boot-command" %>
 
-Example boot command. This is actually a working boot command used to start an
-Ubuntu 12.04 installer:
+The example shown below is a working boot command used to start an Ubuntu
+12.04 installer:
 
 ``` json
 [
@@ -306,27 +317,27 @@ For more examples of various boot commands, see the sample projects from our
 
 ## Integration Services
 
-Packer will automatically attach the integration services iso as a dvd drive
+Packer will automatically attach the integration services ISO as a DVD drive
 for the version of Hyper-V that is running.
 
 ## Generation 1 vs Generation 2
 
 Floppy drives are no longer supported by generation 2 machines. This requires
 you to take another approach when dealing with preseed or answer files. Two
-possible options are using virtual dvd drives or using the built in web
+possible options are using virtual DVD drives or using Packers built in web
 server.
 
 When dealing with Windows you need to enable UEFI drives for generation 2
 virtual machines.
 
-## Creating iso from directory
+## Creating an ISO From a Directory
 
-Programs like mkisofs can be used to create an iso from a directory. There is
+Programs like mkisofs can be used to create an ISO from a directory. There is
 a [windows version of
-mkisofs](http://opensourcepack.blogspot.co.uk/p/cdrtools.html).
+mkisofs](http://opensourcepack.blogspot.co.uk/p/cdrtools.html) available.
 
-Example powershell script. This is an actually working powershell script used
-to create a Windows answer iso:
+Below is a working PowerShell script that can be used to create a Windows
+answer ISO:
 
 ``` powershell
 $isoFolder = "answer-iso"
@@ -825,7 +836,7 @@ Finish Setup cache proxy during installation -->
 
 sysprep-unattend.xml:
 
-``` text
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="generalize">
@@ -939,7 +950,7 @@ virtual switch with an `External` connection type.
       "generation": 2,
       "enable_secure_boot": false
     }
-]
+  ]
 }
 ```
 

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -78,11 +78,6 @@ builder.
 
 ### Optional:
 
--   `clone_from_snapshot_name` (string) - The name of the snapshot
-
--   `clone_all_snapshots` (boolean) - Should all snapshots be cloned when the
-    machine is cloned.
-
 -   `boot_command` (array of strings) - This is an array of commands to type
     when the virtual machine is first booted. The goal of these commands
     should be to type just enough to initialize the operating system
@@ -96,6 +91,10 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is 10 seconds.
 
+-   `clone_all_snapshots` (boolean) - Should all snapshots be cloned when the
+    machine is cloned.
+
+-   `clone_from_snapshot_name` (string) - The name of the snapshot
 -   `cpu` (number) - The number of cpus the virtual machine should use. If
     this isn't specified, the default is 1 cpu.
 
@@ -108,15 +107,18 @@ builder.
 -   `enable_secure_boot` (boolean) - If true enable secure boot for virtual
     machine. This defaults to false.
 
--   `secure_boot_template` (string) - The secure boot template to be
-    configured. Valid values are "MicrosoftWindows" (Windows) or
-    "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if
-    enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
-
 -   `enable_virtualization_extensions` (boolean) - If true enable
     virtualization extensions for virtual machine. This defaults to false. For
     nested virtualization you need to enable mac spoofing, disable dynamic
     memory and have at least 4GB of RAM for virtual machine.
+
+-   `floppy_dirs` (array of strings) - A list of directories to place onto the
+    floppy disk recursively. This is similar to the `floppy_files` option
+    except that the directory structure is preserved. This is useful for when
+    your floppy disk includes drivers or if you just want to organize it's
+    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are
+    allowed.  The maximum summary size of all files in the listed directories
+    are the same as in `floppy_files`.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for
@@ -127,14 +129,6 @@ builder.
     exists for creating sub-directories on the floppy. Wildcard characters (*,
     ?, and []) are allowed. Directory names are also allowed, which will add
     all the files found in the directory to the floppy.
-
--   `floppy_dirs` (array of strings) - A list of directories to place onto the
-    floppy disk recursively. This is similar to the `floppy_files` option
-    except that the directory structure is preserved. This is useful for when
-    your floppy disk includes drivers or if you just want to organize it's
-    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are
-    allowed.  The maximum summary size of all files in the listed directories
-    are the same as in `floppy_files`.
 
 -   `guest_additions_mode` (string) - How should guest additions be installed.
     If value `attach` then attach iso image with by specified by
@@ -164,16 +158,23 @@ builder.
     maximum port the same. By default the values are 8000 and 9000,
     respectively.
 
--   `iso_checksum` (string) - The checksum for the OS ISO file. Because ISO
-    files are so large, this is required and Packer will verify it prior to
-    booting a virtual machine with the ISO attached. The type of the checksum
-    is specified with `iso_checksum_type`, documented below.
-
 -   `iso_checksum_type` (string) - The type of the checksum specified in
     `iso_checksum`. Valid values are "none", "md5", "sha1", "sha256", or
     "sha512" currently. While "none" will skip checksumming, this is not
     recommended since ISO files are generally large and corruption does happen
     from time to time.
+
+-   `iso_checksum` (string) - The checksum for the OS ISO file. Because ISO
+    files are so large, this is required and Packer will verify it prior to
+    booting a virtual machine with the ISO attached. The type of the checksum
+    is specified with `iso_checksum_type`, documented below.
+
+-   `iso_target_extension` (string) - The extension of the iso file after
+    download. This defaults to "iso".
+
+-   `iso_target_path` (string) - The path where the iso should be saved after
+    download. By default will go in the packer cache, with a hash of the
+    original filename as its name.
 
 -   `iso_url` (string) - A URL to the ISO or VHD containing the installation
     image. This URL can be either an HTTP URL or a file URL (or path to a
@@ -187,12 +188,9 @@ builder.
     default this is empty and `iso_url` is used. Only one of `iso_url` or
     `iso_urls` can be specified.
 
--   `iso_target_extension` (string) - The extension of the iso file after
-    download. This defaults to "iso".
-
--   `iso_target_path` (string) - The path where the iso should be saved after
-    download. By default will go in the packer cache, with a hash of the
-    original filename as its name.
+-   `mac_address` (string) - This allows a specific MAC address to be used on
+    the default virtual network card.  The MAC address must be a string with
+    no delimiters, for example "0000deadbeef".
 
 -   `output_directory` (string) - This is the path to the directory where the
     resulting virtual machine will be created. This may be relative or
@@ -204,10 +202,15 @@ builder.
 -   `ram_size` (number) - The size, in megabytes, of the ram to create for the
     VM. By default, this is 1 GB.
 
-*   `secondary_iso_images` (array of strings) - A list of iso paths to
+-   `secondary_iso_images` (array of strings) - A list of iso paths to
     attached to a VM when it is booted. This is most useful for unattended
     Windows installs, which look for an `Autounattend.xml` file on removable
     media. By default, no secondary iso will be attached.
+
+-   `secure_boot_template` (string) - The secure boot template to be
+    configured. Valid values are "MicrosoftWindows" (Windows) or
+    "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if
+    enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
 
 -   `shutdown_command` (string) - The command to use to gracefully shut down
     the machine once all the provisioning is done. By default this is an empty
@@ -225,6 +228,12 @@ builder.
 -   `skip_compaction` (boolean) - If true skip compacting the hard disk for
     virtual machine when exporting. This defaults to false.
 
+-   `skip_export` (boolean) - If `true` Packer will skip the export of the
+    VM. If you are interested only in the VHD/VHDX files, you can enable
+    this option. This will create inline disks which improves the build
+    performance.  There will not be any copying of source VHDs to the temp
+    directory. This defaults to false.
+
 -   `switch_name` (string) - The name of the switch to connect the virtual
     machine to. Be defaulting this to an empty string, Packer will try to
     determine the switch to use by looking for external switch that is up and
@@ -238,10 +247,6 @@ builder.
 -   `vlan_id` (string) - This is the vlan of the virtual machine's network
     card for the new virtual machine. By default none is set. If none is set
     then vlans are not set on the virtual machine's network card.
-
--   `mac_address` (string) - This allows a specific MAC address to be used on
-    the default virtual network card.  The MAC address must be a string with
-    no delimiters, for example "0000deadbeef".
 
 -   `vm_name` (string) - This is the name of the virtual machine for the new
     virtual machine, without the file extension. By default this is

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -12,20 +12,21 @@ page_title: "Hyper-V Builder (from an vmcx)"
 
 Type: `hyperv-vmcx`
 
-The Hyper-V Packer builder is able to use exported virtual machines or clone existing
+The Hyper-V Packer builder is able to use exported virtual machines or clone
+existing
 [Hyper-V](https://www.microsoft.com/en-us/server-cloud/solutions/virtualization.aspx)
 virtual machines.
 
-The builder imports a virtual machine or clones an existing virtual machine boots it,
-and provisioning software within the OS, then shutting it down. The result of the
-Hyper-V builder is a directory containing all the files necessary to run the virtual
-machine portably.
+The builder imports a virtual machine or clones an existing virtual machine
+boots it, and provisioning software within the OS, then shutting it down. The
+result of the Hyper-V builder is a directory containing all the files
+necessary to run the virtual machine portably.
 
 ## Basic Example
 
-Here is a basic example. This example is not functional. It will start the
-OS installer but then fail because we don't provide the preseed file for
-Ubuntu to self-install. Still, the example serves to show the basic configuration:
+Here is a basic example. This example is not functional. It will start the OS
+installer but then fail because we don't provide the preseed file for Ubuntu
+to self-install. Still, the example serves to show the basic configuration:
 
 Import from folder:
 
@@ -57,13 +58,13 @@ provisioner might not be saved.
 
 ## Configuration Reference
 
-There are many configuration options available for the Hyper-V builder.
-They are organized below into two categories: required and optional. Within
-each category, the available options are alphabetized and described.
+There are many configuration options available for the Hyper-V builder.  They
+are organized below into two categories: required and optional. Within each
+category, the available options are alphabetized and described.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/communicator.html)
-can be configured for this builder.
+[communicator](/docs/templates/communicator.html) can be configured for this
+builder.
 
 ### Required for virtual machine import:
 
@@ -83,11 +84,11 @@ can be configured for this builder.
     machine is cloned.
 
 -   `boot_command` (array of strings) - This is an array of commands to type
-    when the virtual machine is first booted. The goal of these commands should
-    be to type just enough to initialize the operating system installer.
-    Special keys can be typed as well, and are covered in the section below on
-    the boot command. If this is not specified, it is assumed the installer
-    will start itself.
+    when the virtual machine is first booted. The goal of these commands
+    should be to type just enough to initialize the operating system
+    installer.  Special keys can be typed as well, and are covered in the
+    section below on the boot command. If this is not specified, it is assumed
+    the installer will start itself.
 
 -   `boot_wait` (string) - The time to wait after booting the initial virtual
     machine before typing the `boot_command`. The value of this should be
@@ -98,39 +99,42 @@ can be configured for this builder.
 -   `cpu` (number) - The number of cpus the virtual machine should use. If
     this isn't specified, the default is 1 cpu.
 
--   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for virtual
-    machine. This defaults to false.
+-   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for
+    virtual machine. This defaults to false.
 
 -   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual
     machine. This defaults to false.
 
--   `enable_secure_boot` (boolean) - If true enable secure boot for virtual machine. This defaults to false.
+-   `enable_secure_boot` (boolean) - If true enable secure boot for virtual
+    machine. This defaults to false.
 
--    `secure_boot_template` (string) - The secure boot template to be configured. Valid values are "MicrosoftWindows" (Windows) or 
-     "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
+-   `secure_boot_template` (string) - The secure boot template to be
+    configured. Valid values are "MicrosoftWindows" (Windows) or
+    "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if
+    enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
 
--   `enable_virtualization_extensions` (boolean) - If true enable virtualization
-    extensions for virtual machine. This defaults to false. For nested
-    virtualization you need to enable mac spoofing, disable dynamic memory and
-    have at least 4GB of RAM for virtual machine.
+-   `enable_virtualization_extensions` (boolean) - If true enable
+    virtualization extensions for virtual machine. This defaults to false. For
+    nested virtualization you need to enable mac spoofing, disable dynamic
+    memory and have at least 4GB of RAM for virtual machine.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
     disk that is attached when the VM is booted. This is most useful for
     unattended Windows installs, which look for an `Autounattend.xml` file on
     removable media. By default, no floppy will be attached. All files listed
     in this setting get placed into the root directory of the floppy and the
-    floppy is attached as the first floppy device. Currently, no support exists
-    for creating sub-directories on the floppy. Wildcard characters (*, ?, and
-    []) are allowed. Directory names are also allowed, which will add all the
-    files found in the directory to the floppy.
+    floppy is attached as the first floppy device. Currently, no support
+    exists for creating sub-directories on the floppy. Wildcard characters (*,
+    ?, and []) are allowed. Directory names are also allowed, which will add
+    all the files found in the directory to the floppy.
 
 -   `floppy_dirs` (array of strings) - A list of directories to place onto the
     floppy disk recursively. This is similar to the `floppy_files` option
     except that the directory structure is preserved. This is useful for when
     your floppy disk includes drivers or if you just want to organize it's
-    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are allowed.
-    The maximum summary size of all files in the listed directories are the
-    same as in `floppy_files`.
+    contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are
+    allowed.  The maximum summary size of all files in the listed directories
+    are the same as in `floppy_files`.
 
 -   `guest_additions_mode` (string) - How should guest additions be installed.
     If value `attach` then attach iso image with by specified by
@@ -140,9 +144,9 @@ can be configured for this builder.
     additions.
 
 -   `headless` (boolean) - Packer defaults to building Hyper-V virtual
-    machines by launching a GUI that shows the console of the machine
-    being built. When this value is set to true, the machine will start without
-    a console.
+    machines by launching a GUI that shows the console of the machine being
+    built. When this value is set to true, the machine will start without a
+    console.
 
 -   `http_directory` (string) - Path to a directory to serve using an HTTP
     server. The files in this directory will be available over HTTP that will
@@ -154,10 +158,11 @@ can be configured for this builder.
 
 -   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
-    `http_directory`. Because Packer often runs in parallel, Packer will choose
-    a randomly available port in this range to run the HTTP server. If you want
-    to force the HTTP server to be on one port, make this minimum and maximum
-    port the same. By default the values are 8000 and 9000, respectively.
+    `http_directory`. Because Packer often runs in parallel, Packer will
+    choose a randomly available port in this range to run the HTTP server. If
+    you want to force the HTTP server to be on one port, make this minimum and
+    maximum port the same. By default the values are 8000 and 9000,
+    respectively.
 
 -   `iso_checksum` (string) - The checksum for the OS ISO file. Because ISO
     files are so large, this is required and Packer will verify it prior to
@@ -171,16 +176,16 @@ can be configured for this builder.
     from time to time.
 
 -   `iso_url` (string) - A URL to the ISO or VHD containing the installation
-    image. This URL can be either an HTTP URL or a file URL (or path to
-    a file). If this is an HTTP URL, Packer will download iso and cache it
+    image. This URL can be either an HTTP URL or a file URL (or path to a
+    file). If this is an HTTP URL, Packer will download iso and cache it
     between runs.
 
 -   `iso_urls` (array of strings) - Multiple URLs for the ISO or VHD to
-    download. Packer will try these in order. If anything goes wrong attempting
-    to download or while downloading a single URL, it will move on to the next.
-    All URLs must point to the same file (same checksum). By default this is
-    empty and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be
-    specified.
+    download. Packer will try these in order. If anything goes wrong
+    attempting to download or while downloading a single URL, it will move on
+    to the next.  All URLs must point to the same file (same checksum). By
+    default this is empty and `iso_url` is used. Only one of `iso_url` or
+    `iso_urls` can be specified.
 
 -   `iso_target_extension` (string) - The extension of the iso file after
     download. This defaults to "iso".
@@ -199,23 +204,23 @@ can be configured for this builder.
 -   `ram_size` (number) - The size, in megabytes, of the ram to create for the
     VM. By default, this is 1 GB.
 
-*   `secondary_iso_images` (array of strings) - A list of iso paths to attached
-    to a VM when it is booted. This is most useful for unattended Windows
-    installs, which look for an `Autounattend.xml` file on removable media. By
-    default, no secondary iso will be attached.
+*   `secondary_iso_images` (array of strings) - A list of iso paths to
+    attached to a VM when it is booted. This is most useful for unattended
+    Windows installs, which look for an `Autounattend.xml` file on removable
+    media. By default, no secondary iso will be attached.
 
 -   `shutdown_command` (string) - The command to use to gracefully shut down
     the machine once all the provisioning is done. By default this is an empty
     string, which tells Packer to just forcefully shut down the machine unless
-    a shutdown command takes place inside script so this may safely be omitted.
-    If one or more scripts require a reboot it is suggested to leave this blank
-    since reboots may fail and specify the final shutdown command in your last
-    script.
+    a shutdown command takes place inside script so this may safely be
+    omitted.  If one or more scripts require a reboot it is suggested to leave
+    this blank since reboots may fail and specify the final shutdown command
+    in your last script.
 
 -   `shutdown_timeout` (string) - The amount of time to wait after executing
-    the `shutdown_command` for the virtual machine to actually shut down. If it
-    doesn't shut down in this time, it is an error. By default, the timeout is
-    "5m", or five minutes.
+    the `shutdown_command` for the virtual machine to actually shut down. If
+    it doesn't shut down in this time, it is an error. By default, the timeout
+    is "5m", or five minutes.
 
 -   `skip_compaction` (boolean) - If true skip compacting the hard disk for
     virtual machine when exporting. This defaults to false.
@@ -226,17 +231,17 @@ can be configured for this builder.
     running.
 
 -   `switch_vlan_id` (string) - This is the vlan of the virtual switch's
-    network card. By default none is set. If none is set then a vlan is not set
-    on the switch's network card. If this value is set it should match the vlan
-    specified in by `vlan_id`.
+    network card. By default none is set. If none is set then a vlan is not
+    set on the switch's network card. If this value is set it should match the
+    vlan specified in by `vlan_id`.
 
--   `vlan_id` (string) - This is the vlan of the virtual machine's network card
-    for the new virtual machine. By default none is set. If none is set then
-    vlans are not set on the virtual machine's network card.
+-   `vlan_id` (string) - This is the vlan of the virtual machine's network
+    card for the new virtual machine. By default none is set. If none is set
+    then vlans are not set on the virtual machine's network card.
 
--   `mac_address` (string) - This allows a specific MAC address to be used on the
-    default virtual network card.  The MAC address must be a string with no
-    delimiters, for example "0000deadbeef".
+-   `mac_address` (string) - This allows a specific MAC address to be used on
+    the default virtual network card.  The MAC address must be a string with
+    no delimiters, for example "0000deadbeef".
 
 -   `vm_name` (string) - This is the name of the virtual machine for the new
     virtual machine, without the file extension. By default this is
@@ -244,22 +249,22 @@ can be configured for this builder.
 
 ## Boot Command
 
-The `boot_command` configuration is very important: it specifies the keys
-to type when the virtual machine is first booted in order to start the
-OS installer. This command is typed after `boot_wait`, which gives the
-virtual machine some time to actually load the ISO.
+The `boot_command` configuration is very important: it specifies the keys to
+type when the virtual machine is first booted in order to start the OS
+installer. This command is typed after `boot_wait`, which gives the virtual
+machine some time to actually load the ISO.
 
-As documented above, the `boot_command` is an array of strings. The
-strings are all typed in sequence. It is an array only to improve readability
-within the template.
+As documented above, the `boot_command` is an array of strings. The strings
+are all typed in sequence. It is an array only to improve readability within
+the template.
 
 The boot command is "typed" character for character over the virtual keyboard
 to the machine, simulating a human actually typing the keyboard.
 
 <%= partial "partials/builders/boot-command" %>
 
-Example boot command. This is actually a working boot command used to start
-an Ubuntu 12.04 installer:
+Example boot command. This is actually a working boot command used to start an
+Ubuntu 12.04 installer:
 
 ```text
 [
@@ -282,18 +287,22 @@ for the version of Hyper-V that is running.
 
 ## Generation 1 vs Generation 2
 
-Floppy drives are no longer supported by generation 2 machines. This requires you to
-take another approach when dealing with preseed or answer files. Two possible options
-are using virtual dvd drives or using the built in web server.
+Floppy drives are no longer supported by generation 2 machines. This requires
+you to take another approach when dealing with preseed or answer files. Two
+possible options are using virtual dvd drives or using the built in web
+server.
 
-When dealing with Windows you need to enable UEFI drives for generation 2 virtual machines.
+When dealing with Windows you need to enable UEFI drives for generation 2
+virtual machines.
 
 ## Creating iso from directory
 
-Programs like mkisofs can be used to create an iso from a directory.
-There is a [windows version of mkisofs](http://opensourcepack.blogspot.co.uk/p/cdrtools.html).
+Programs like mkisofs can be used to create an iso from a directory. There is
+a [windows version of
+mkisofs](http://opensourcepack.blogspot.co.uk/p/cdrtools.html).
 
-Example powershell script. This is an actually working powershell script used to create a Windows answer iso:
+Example powershell script. This is an actually working powershell script used
+to create a Windows answer iso:
 
 ```text
 $isoFolder = "answer-iso"
@@ -855,8 +864,8 @@ Finish proxy after sysprep -->
 
 ## Example For Ubuntu Vivid Generation 2
 
-If you are running Windows under virtualization, you may need to create
-a virtual switch with an `External` connection type.
+If you are running Windows under virtualization, you may need to create a
+virtual switch with an `External` connection type.
 
 ### Packer config:
 

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -5,7 +5,7 @@ description: |-
   The Hyper-V Packer builder is able to clone an existing Hyper-V virtual machine and export them.
 layout: "docs"
 sidebar_current: 'docs-builders-hyperv-vmcx'
-page_title: "Hyper-V Builder (from an vmcx)"
+page_title: "Hyper-V Builder (from a vmcx)"
 ---
 
 # Hyper-V Builder (from a vmcx)
@@ -17,8 +17,8 @@ existing
 [Hyper-V](https://www.microsoft.com/en-us/server-cloud/solutions/virtualization.aspx)
 virtual machines.
 
-The builder imports a virtual machine or clones an existing virtual machine
-boots it, and provisioning software within the OS, then shutting it down. The
+Typically, the builder imports or clones an existing virtual machine,
+boots it, provisions software within the OS, and then shuts it down. The
 result of the Hyper-V builder is a directory containing all the files
 necessary to run the virtual machine portably.
 
@@ -30,7 +30,7 @@ to self-install. Still, the example serves to show the basic configuration:
 
 Import from folder:
 
-```json
+``` json
 {
   "type": "hyperv-vmcx",
   "clone_from_vmxc_path": "c:\\virtual machines\\ubuntu-12.04.5-server-amd64",
@@ -42,7 +42,7 @@ Import from folder:
 
 Clone from existing virtual machine:
 
-```json
+``` json
 {
     "clone_from_vm_name": "ubuntu-12.04.5-server-amd64",
     "shutdown_command": "echo 'packer' | sudo -S shutdown -P now",
@@ -52,13 +52,16 @@ Clone from existing virtual machine:
 }
 ```
 
-It is important to add a `shutdown_command`. By default Packer halts the
-virtual machine and the file system may not be sync'd. Thus, changes made in a
-provisioner might not be saved.
+By default Packer will perform a hard power off of a virtual machine.
+However, when a machine is powered off this way, it is possible that
+changes made to the VMs file system may not be fully synced, possibly
+leading to corruption of files or lost changes. As such, it is important to
+add a `shutdown_command`. This tells Packer how to safely shutdown and
+power off the VM.
 
 ## Configuration Reference
 
-There are many configuration options available for the Hyper-V builder.  They
+There are many configuration options available for the Hyper-V builder. They
 are organized below into two categories: required and optional. Within each
 category, the available options are alphabetized and described.
 
@@ -81,43 +84,47 @@ builder.
 -   `boot_command` (array of strings) - This is an array of commands to type
     when the virtual machine is first booted. The goal of these commands
     should be to type just enough to initialize the operating system
-    installer.  Special keys can be typed as well, and are covered in the
+    installer. Special keys can be typed as well, and are covered in the
     section below on the boot command. If this is not specified, it is assumed
     the installer will start itself.
 
 -   `boot_wait` (string) - The time to wait after booting the initial virtual
-    machine before typing the `boot_command`. The value of this should be
-    a duration. Examples are "5s" and "1m30s" which will cause Packer to wait
-    five seconds and one minute 30 seconds, respectively. If this isn't
-    specified, the default is 10 seconds.
+    machine before typing the `boot_command`. The value specified should be
+    a duration. For example, setting a duration of "1m30s" would cause
+    Packer to wait for 1 minute 30 seconds before typing the boot command.
+    The default duration is "10s" (10 seconds).
 
--   `clone_all_snapshots` (boolean) - Should all snapshots be cloned when the
-    machine is cloned.
+-   `clone_all_snapshots` (boolean) - If set to `true` all snapshots will be
+    cloned when the machine is cloned.
 
--   `clone_from_snapshot_name` (string) - The name of the snapshot
--   `cpu` (number) - The number of cpus the virtual machine should use. If
-    this isn't specified, the default is 1 cpu.
+-   `clone_from_snapshot_name` (string) - The name of the snapshot to clone
+    from.
 
--   `enable_dynamic_memory` (boolean) - If true enable dynamic memory for
-    virtual machine. This defaults to false.
+-   `cpu` (number) - The number of CPUs the virtual machine should use. If
+    this isn't specified, the default is 1 CPU.
 
--   `enable_mac_spoofing` (boolean) - If true enable mac spoofing for virtual
-    machine. This defaults to false.
+-   `enable_dynamic_memory` (boolean) - If `true` enable dynamic memory for
+    the virtual machine. This defaults to `false`.
 
--   `enable_secure_boot` (boolean) - If true enable secure boot for virtual
-    machine. This defaults to false.
+-   `enable_mac_spoofing` (boolean) - If `true` enable MAC address spoofing
+    for the virtual machine. This defaults to `false`.
 
--   `enable_virtualization_extensions` (boolean) - If true enable
-    virtualization extensions for virtual machine. This defaults to false. For
-    nested virtualization you need to enable mac spoofing, disable dynamic
-    memory and have at least 4GB of RAM for virtual machine.
+-   `enable_secure_boot` (boolean) - If `true` enable secure boot for the
+    virtual machine. This defaults to `false`. See `secure_boot_template`
+    below for additional settings.
 
--   `floppy_dirs` (array of strings) - A list of directories to place onto the
-    floppy disk recursively. This is similar to the `floppy_files` option
+-   `enable_virtualization_extensions` (boolean) - If `true` enable
+    virtualization extensions for the virtual machine. This defaults to
+    `false`. For nested virtualization you need to enable MAC spoofing,
+    disable dynamic memory and have at least 4GB of RAM assigned to the
+    virtual machine.
+
+-   `floppy_dirs` (array of strings) - A list of directories to place onto
+    the floppy disk recursively. This is similar to the `floppy_files` option
     except that the directory structure is preserved. This is useful for when
     your floppy disk includes drivers or if you just want to organize it's
     contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are
-    allowed.  The maximum summary size of all files in the listed directories
+    allowed. The maximum summary size of all files in the listed directories
     are the same as in `floppy_files`.
 
 -   `floppy_files` (array of strings) - A list of files to place onto a floppy
@@ -126,15 +133,16 @@ builder.
     removable media. By default, no floppy will be attached. All files listed
     in this setting get placed into the root directory of the floppy and the
     floppy is attached as the first floppy device. Currently, no support
-    exists for creating sub-directories on the floppy. Wildcard characters (*,
-    ?, and []) are allowed. Directory names are also allowed, which will add
-    all the files found in the directory to the floppy.
+    exists for creating sub-directories on the floppy. Wildcard characters
+    (`*`, `?`, and `[]`) are allowed. Directory names are also allowed, which
+    will add all the files found in the directory to the floppy.
 
--   `guest_additions_mode` (string) - How should guest additions be installed.
-    If value `attach` then attach iso image with by specified by
-    `guest_additions_path`. Otherwise guest additions is not installed.
+-   `guest_additions_mode` (string) - If set to `attach` then attach and
+    mount the ISO image specified in `guest_additions_path`. If set to
+    `none` then guest additions are not attached and mounted; This is the
+    default.
 
--   `guest_additions_path` (string) - The path to the iso image for guest
+-   `guest_additions_path` (string) - The path to the ISO image for guest
     additions.
 
 -   `headless` (boolean) - Packer defaults to building Hyper-V virtual
@@ -142,39 +150,41 @@ builder.
     built. When this value is set to true, the machine will start without a
     console.
 
--   `http_directory` (string) - Path to a directory to serve using an HTTP
-    server. The files in this directory will be available over HTTP that will
-    be requestable from the virtual machine. This is useful for hosting
-    kickstart files and so on. By default this is "", which means no HTTP
-    server will be started. The address and port of the HTTP server will be
-    available as variables in `boot_command`. This is covered in more detail
-    below.
+-   `http_directory` (string) - Path to a directory to serve using Packers
+    inbuilt HTTP server. The files in this directory will be available
+    over HTTP to the virtual machine. This is useful for hosting kickstart
+    files and so on. By default this value is unset and the HTTP server is
+    not started. The address and port of the HTTP server will be available
+    as variables in `boot_command`. This is covered in more detail below.
 
 -   `http_port_min` and `http_port_max` (number) - These are the minimum and
     maximum port to use for the HTTP server started to serve the
-    `http_directory`. Because Packer often runs in parallel, Packer will
-    choose a randomly available port in this range to run the HTTP server. If
-    you want to force the HTTP server to be on one port, make this minimum and
-    maximum port the same. By default the values are 8000 and 9000,
-    respectively.
+    `http_directory`. Since Packer often runs in parallel, a randomly
+    available port in this range will be repeatedly chosen until an
+    available port is found. To force the HTTP server to use a specific
+    port, set an identical value for `http_port_min` and `http_port_max`.
+    By default the values are 8000 and 9000, respectively.
 
--   `iso_checksum_type` (string) - The type of the checksum specified in
-    `iso_checksum`. Valid values are "none", "md5", "sha1", "sha256", or
-    "sha512" currently. While "none" will skip checksumming, this is not
-    recommended since ISO files are generally large and corruption does happen
-    from time to time.
+-   `iso_checksum_type` (string) - The algorithm to be used when computing
+    the checksum of the file specified in `iso_checksum`. Currently, valid
+    values are "none", "md5", "sha1", "sha256", or "sha512". Since the
+    validity of ISO and virtual disk files are typically crucial to a
+    successful build, Packer performs a check of any supplied media by
+    default. While setting "none" will cause Packer to skip this check,
+    corruption of large files such as ISOs and virtual hard drives can
+    occur from time to time. As such, skipping this check is not
+    recommended.
 
--   `iso_checksum` (string) - The checksum for the OS ISO file. Because ISO
-    files are so large, this is required and Packer will verify it prior to
-    booting a virtual machine with the ISO attached. The type of the checksum
-    is specified with `iso_checksum_type`, documented below.
+-   `iso_checksum` (string) - The checksum for the ISO file or virtual
+    hard drive file. The algorithm to use when computing the checksum is
+    specified with `iso_checksum_type`.
 
--   `iso_target_extension` (string) - The extension of the iso file after
+-   `iso_target_extension` (string) - The extension of the ISO file after
     download. This defaults to "iso".
 
--   `iso_target_path` (string) - The path where the iso should be saved after
-    download. By default will go in the packer cache, with a hash of the
-    original filename as its name.
+-   `iso_target_path` (string) - The path where the ISO should be saved after
+    download. By default the ISO will be saved in the Packer cache
+    directory with a hash of the original filename as its name.
 
 -   `iso_url` (string) - A URL to the ISO or VHD containing the installation
     image. This URL can be either an HTTP URL or a file URL (or path to a
@@ -189,7 +199,7 @@ builder.
     `iso_urls` can be specified.
 
 -   `mac_address` (string) - This allows a specific MAC address to be used on
-    the default virtual network card.  The MAC address must be a string with
+    the default virtual network card. The MAC address must be a string with
     no delimiters, for example "0000deadbeef".
 
 -   `output_directory` (string) - This is the path to the directory where the
@@ -199,58 +209,59 @@ builder.
     running the builder. By default this is "output-BUILDNAME" where
     "BUILDNAME" is the name of the build.
 
--   `ram_size` (number) - The size, in megabytes, of the ram to create for the
+-   `ram_size` (number) - The amount, in megabytes, of RAM to assign to the
     VM. By default, this is 1 GB.
 
--   `secondary_iso_images` (array of strings) - A list of iso paths to
-    attached to a VM when it is booted. This is most useful for unattended
+-   `secondary_iso_images` (array of strings) - A list of ISO paths to
+    attach to a VM when it is booted. This is most useful for unattended
     Windows installs, which look for an `Autounattend.xml` file on removable
-    media. By default, no secondary iso will be attached.
+    media. By default, no secondary ISO will be attached.
 
 -   `secure_boot_template` (string) - The secure boot template to be
     configured. Valid values are "MicrosoftWindows" (Windows) or
     "MicrosoftUEFICertificateAuthority" (Linux). This only takes effect if
-    enable_secure_boot is set to "true". This defaults to "MicrosoftWindows".
+    `enable_secure_boot` is set to "true". This defaults to "MicrosoftWindows".
 
 -   `shutdown_command` (string) - The command to use to gracefully shut down
-    the machine once all the provisioning is done. By default this is an empty
-    string, which tells Packer to just forcefully shut down the machine unless
-    a shutdown command takes place inside script so this may safely be
-    omitted.  If one or more scripts require a reboot it is suggested to leave
-    this blank since reboots may fail and specify the final shutdown command
-    in your last script.
+    the machine once all provisioning is complete. By default this is an
+    empty string, which tells Packer to just forcefully shut down the
+    machine. This setting can be safely omitted if for example, a shutdown
+    command to gracefully halt the machine is configured inside a
+    provisioning script. If one or more scripts require a reboot it is
+    suggested to leave this blank (since reboots may fail) and instead
+    specify the final shutdown command in your last script.
 
 -   `shutdown_timeout` (string) - The amount of time to wait after executing
-    the `shutdown_command` for the virtual machine to actually shut down. If
-    it doesn't shut down in this time, it is an error. By default, the timeout
-    is "5m", or five minutes.
+    the `shutdown_command` for the virtual machine to actually shut down.
+    If the machine doesn't shut down in this time it is considered an
+    error. By default, the time out is "5m" (five minutes).
 
--   `skip_compaction` (boolean) - If true skip compacting the hard disk for
-    virtual machine when exporting. This defaults to false.
+-   `skip_compaction` (boolean) - If `true` skip compacting the hard disk for
+    the virtual machine when exporting. This defaults to `false`.
 
 -   `skip_export` (boolean) - If `true` Packer will skip the export of the
     VM. If you are interested only in the VHD/VHDX files, you can enable
     this option. This will create inline disks which improves the build
     performance.  There will not be any copying of source VHDs to the temp
-    directory. This defaults to false.
+    directory. This defaults to `false`.
 
 -   `switch_name` (string) - The name of the switch to connect the virtual
-    machine to. Be defaulting this to an empty string, Packer will try to
-    determine the switch to use by looking for external switch that is up and
-    running.
+    machine to. By default, leaving this value unset will cause Packer to
+    try and determine the switch to use by looking for an external switch
+    that is up and running.
 
--   `switch_vlan_id` (string) - This is the vlan of the virtual switch's
-    network card. By default none is set. If none is set then a vlan is not
-    set on the switch's network card. If this value is set it should match the
-    vlan specified in by `vlan_id`.
+-   `switch_vlan_id` (string) - This is the VLAN of the virtual switch's
+    network card. By default none is set. If none is set then a VLAN is not
+    set on the switch's network card. If this value is set it should match
+    the VLAN specified in by `vlan_id`.
 
--   `vlan_id` (string) - This is the vlan of the virtual machine's network
+-   `vlan_id` (string) - This is the VLAN of the virtual machine's network
     card for the new virtual machine. By default none is set. If none is set
-    then vlans are not set on the virtual machine's network card.
+    then VLANs are not set on the virtual machine's network card.
 
--   `vm_name` (string) - This is the name of the virtual machine for the new
-    virtual machine, without the file extension. By default this is
-    "packer-BUILDNAME", where "BUILDNAME" is the name of the build.
+-   `vm_name` (string) - This is the name of the new virtual machine,
+    without the file extension. By default this is "packer-BUILDNAME",
+    where "BUILDNAME" is the name of the build.
 
 ## Boot Command
 
@@ -268,10 +279,10 @@ to the machine, simulating a human actually typing the keyboard.
 
 <%= partial "partials/builders/boot-command" %>
 
-Example boot command. This is actually a working boot command used to start an
-Ubuntu 12.04 installer:
+The example shown below is a working boot command used to start an Ubuntu
+12.04 installer:
 
-```text
+``` json
 [
   "<esc><esc><enter><wait>",
   "/install/vmlinuz noapic ",
@@ -285,31 +296,34 @@ Ubuntu 12.04 installer:
 ]
 ```
 
+For more examples of various boot commands, see the sample projects from our
+[community templates page](/community-tools.html#templates).
+
 ## Integration Services
 
-Packer will automatically attach the integration services iso as a dvd drive
+Packer will automatically attach the integration services ISO as a DVD drive
 for the version of Hyper-V that is running.
 
 ## Generation 1 vs Generation 2
 
 Floppy drives are no longer supported by generation 2 machines. This requires
 you to take another approach when dealing with preseed or answer files. Two
-possible options are using virtual dvd drives or using the built in web
+possible options are using virtual DVD drives or using Packers built in web
 server.
 
 When dealing with Windows you need to enable UEFI drives for generation 2
 virtual machines.
 
-## Creating iso from directory
+## Creating an ISO From a Directory
 
-Programs like mkisofs can be used to create an iso from a directory. There is
+Programs like mkisofs can be used to create an ISO from a directory. There is
 a [windows version of
-mkisofs](http://opensourcepack.blogspot.co.uk/p/cdrtools.html).
+mkisofs](http://opensourcepack.blogspot.co.uk/p/cdrtools.html) available.
 
-Example powershell script. This is an actually working powershell script used
-to create a Windows answer iso:
+Below is a working PowerShell script that can be used to create a Windows
+answer ISO:
 
-```text
+``` powershell
 $isoFolder = "answer-iso"
 if (test-path $isoFolder){
   remove-item $isoFolder -Force -Recurse
@@ -343,54 +357,56 @@ if (test-path $isoFolder){
 }
 ```
 
-
 ## Example For Windows Server 2012 R2 Generation 2
 
 Packer config:
 
-```javascript
+``` json
 {
   "builders": [
-  {
-    "vm_name":"windows2012r2",
-    "type": "hyperv-iso",
-    "disk_size": 61440,
-    "floppy_files": [],
-    "secondary_iso_images": [
-      "./windows/windows-2012R2-serverdatacenter-amd64/answer.iso"
-    ],
-    "http_directory": "./windows/common/http/",
-    "boot_wait": "0s",
-    "boot_command": [
-      "a<wait>a<wait>a"
-    ],
-    "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO",
-    "iso_checksum_type": "md5",
-    "iso_checksum": "458ff91f8abc21b75cb544744bf92e6a",
-    "communicator":"winrm",
-    "winrm_username": "vagrant",
-    "winrm_password": "vagrant",
-    "winrm_timeout" : "4h",
-    "shutdown_command": "f:\\run-sysprep.cmd",
-    "ram_size": 4096,
-    "cpu": 4,
-    "generation": 2,
-    "switch_name":"LAN",
-    "enable_secure_boot":true
-  }],
-  "provisioners": [{
-    "type": "powershell",
-    "elevated_user":"vagrant",
-    "elevated_password":"vagrant",
-    "scripts": [
-      "./windows/common/install-7zip.ps1",
-      "./windows/common/install-chef.ps1",
-      "./windows/common/compile-dotnet-assemblies.ps1",
-      "./windows/common/cleanup.ps1",
-      "./windows/common/ultradefrag.ps1",
-      "./windows/common/sdelete.ps1"
-    ]
-  }],
+    {
+      "vm_name":"windows2012r2",
+      "type": "hyperv-iso",
+      "disk_size": 61440,
+      "floppy_files": [],
+      "secondary_iso_images": [
+        "./windows/windows-2012R2-serverdatacenter-amd64/answer.iso"
+      ],
+      "http_directory": "./windows/common/http/",
+      "boot_wait": "0s",
+      "boot_command": [
+        "a<wait>a<wait>a"
+      ],
+      "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.16384.WINBLUE_RTM.130821-1623_X64FRE_SERVER_EVAL_EN-US-IRM_SSS_X64FREE_EN-US_DV5.ISO",
+      "iso_checksum_type": "md5",
+      "iso_checksum": "458ff91f8abc21b75cb544744bf92e6a",
+      "communicator":"winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout" : "4h",
+      "shutdown_command": "f:\\run-sysprep.cmd",
+      "ram_size": 4096,
+      "cpu": 4,
+      "generation": 2,
+      "switch_name":"LAN",
+      "enable_secure_boot":true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "elevated_user":"vagrant",
+      "elevated_password":"vagrant",
+      "scripts": [
+        "./windows/common/install-7zip.ps1",
+        "./windows/common/install-chef.ps1",
+        "./windows/common/compile-dotnet-assemblies.ps1",
+        "./windows/common/cleanup.ps1",
+        "./windows/common/ultradefrag.ps1",
+        "./windows/common/sdelete.ps1"
+      ]
+    }
+  ],
   "post-processors": [
     {
       "type": "vagrant",
@@ -403,7 +419,7 @@ Packer config:
 
 autounattend.xml:
 
-```xml
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
@@ -800,12 +816,11 @@ Finish Setup cache proxy during installation -->
     </settings>
     <cpi:offlineImage cpi:source="wim:c:/projects/baseboxes/9600.16384.winblue_rtm.130821-1623_x64fre_server_eval_en-us-irm_sss_x64free_en-us_dv5_slipstream/sources/install.wim#Windows Server 2012 R2 SERVERDATACENTER" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
 </unattend>
-
 ```
 
 sysprep-unattend.xml:
 
-```text
+``` xml
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="generalize">
@@ -874,7 +889,7 @@ virtual switch with an `External` connection type.
 
 ### Packer config:
 
-```javascript
+``` json
 {
   "variables": {
     "vm_name": "ubuntu-xenial",
@@ -886,45 +901,46 @@ virtual switch with an `External` connection type.
     "iso_checksum": "DE5EE8665048F009577763EFBF4A6F0558833E59"
   },
   "builders": [
-  {
-    "vm_name":"{{user `vm_name`}}",
-    "type": "hyperv-iso",
-    "disk_size": "{{user `disk_size`}}",
-    "guest_additions_mode": "disable",
-    "iso_url": "{{user `iso_url`}}",
-    "iso_checksum_type": "{{user `iso_checksum_type`}}",
-    "iso_checksum": "{{user `iso_checksum`}}",
-    "communicator":"ssh",
-    "ssh_username": "packer",
-    "ssh_password": "packer",
-    "ssh_timeout" : "4h",
-    "http_directory": "./",
-    "boot_wait": "5s",
-    "boot_command": [
-      "<esc><wait10><esc><esc><enter><wait>",
-      "set gfxpayload=1024x768<enter>",
-      "linux /install/vmlinuz ",
-      "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/hyperv-taliesins.cfg ",
-      "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
-      "hostname={{.Name}} ",
-      "fb=false debconf/frontend=noninteractive ",
-      "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
-      "keyboard-configuration/variant=USA console-setup/ask_detect=false <enter>",
-      "initrd /install/initrd.gz<enter>",
-      "boot<enter>"
-    ],
-    "shutdown_command": "echo 'packer' | sudo -S -E shutdown -P now",
-    "ram_size": "{{user `ram_size`}}",
-    "cpu": "{{user `cpu`}}",
-    "generation": 2,
-    "enable_secure_boot": false
-  }]
+    {
+      "vm_name":"{{user `vm_name`}}",
+      "type": "hyperv-iso",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_additions_mode": "disable",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "communicator":"ssh",
+      "ssh_username": "packer",
+      "ssh_password": "packer",
+      "ssh_timeout" : "4h",
+      "http_directory": "./",
+      "boot_wait": "5s",
+      "boot_command": [
+        "<esc><wait10><esc><esc><enter><wait>",
+        "set gfxpayload=1024x768<enter>",
+        "linux /install/vmlinuz ",
+        "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/hyperv-taliesins.cfg ",
+        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+        "hostname={{.Name}} ",
+        "fb=false debconf/frontend=noninteractive ",
+        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+        "keyboard-configuration/variant=USA console-setup/ask_detect=false <enter>",
+        "initrd /install/initrd.gz<enter>",
+        "boot<enter>"
+      ],
+      "shutdown_command": "echo 'packer' | sudo -S -E shutdown -P now",
+      "ram_size": "{{user `ram_size`}}",
+      "cpu": "{{user `cpu`}}",
+      "generation": 2,
+      "enable_secure_boot": false
+    }
+  ]
 }
 ```
 
 ### preseed.cfg:
 
-```text
+``` text
 ## Options to set on the command line
 d-i debian-installer/locale string en_US.utf8
 d-i console-setup/ask_detect boolean false


### PR DESCRIPTION
Fixes for the Hyper-V docs:

* Ensure configuration options are in alphabetical order
* Ensure ISO and VMCX doc are aligned where appropriate
* Add missing `skip_export` option into the VMCX doc
* Minor changes to wording
* Formatting fixes
* Fix long lines

I came across this by way of the comment/feature request [HERE](https://github.com/hashicorp/packer/issues/4131#issuecomment-397054173). Note that the export step for Hyper-V is common to both the ISO and VMCX builders - so if the skip option works for the ISO builder it should work for the VMCX builder as well.

As usual, feedback and suggestions for improvement are welcome.