### PR TITLE
Fix misprints in steps names in Alicloud builder

### DIFF
--- a/builder/alicloud/ecs/builder.go
+++ b/builder/alicloud/ecs/builder.go
@@ -94,7 +94,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&stepCheckAlicloudSourceImage{
 			SourceECSImageId: b.config.AlicloudSourceImage,
 		},
-		&StepConfigAlicloudKeyPair{
+		&stepConfigAlicloudKeyPair{
 			Debug:                b.config.PackerDebug,
 			KeyPairName:          b.config.SSHKeyPairName,
 			PrivateKeyFile:       b.config.Comm.SSHPrivateKey,
@@ -136,7 +136,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ZoneId:                  b.config.ZoneId,
 		})
 	if b.chooseNetworkType() == VpcNet {
-		steps = append(steps, &setpConfigAlicloudEIP{
+		steps = append(steps, &stepConfigAlicloudEIP{
 			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
 			RegionId:                 b.config.AlicloudRegion,
 			InternetChargeType:       b.config.InternetChargeType,
@@ -147,7 +147,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		})
 	}
 	steps = append(steps,
-		&stepAttachKeyPar{},
+		&stepAttachKeyPair{},
 		&stepRunAlicloudInstance{},
 		&stepMountAlicloudDisk{},
 		&communicator.StepConnect{
@@ -170,12 +170,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AlicloudImageName:                 b.config.AlicloudImageName,
 		},
 		&stepCreateAlicloudImage{},
-		&setpRegionCopyAlicloudImage{
+		&stepRegionCopyAlicloudImage{
 			AlicloudImageDestinationRegions: b.config.AlicloudImageDestinationRegions,
 			AlicloudImageDestinationNames:   b.config.AlicloudImageDestinationNames,
 			RegionId:                        b.config.AlicloudRegion,
 		},
-		&setpShareAlicloudImage{
+		&stepShareAlicloudImage{
 			AlicloudImageShareAccounts:   b.config.AlicloudImageShareAccounts,
 			AlicloudImageUNShareAccounts: b.config.AlicloudImageUNShareAccounts,
 			RegionId:                     b.config.AlicloudRegion,

--- a/builder/alicloud/ecs/step_attach_keypair.go
+++ b/builder/alicloud/ecs/step_attach_keypair.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-type stepAttachKeyPar struct {
+type stepAttachKeyPair struct {
 }
 
-func (s *stepAttachKeyPar) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepAttachKeyPair) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	keyPairName := state.Get("keyPair").(string)
 	if keyPairName == "" {
 		return multistep.ActionContinue
@@ -50,7 +50,7 @@ func (s *stepAttachKeyPar) Run(_ context.Context, state multistep.StateBag) mult
 	return multistep.ActionContinue
 }
 
-func (s *stepAttachKeyPar) Cleanup(state multistep.StateBag) {
+func (s *stepAttachKeyPair) Cleanup(state multistep.StateBag) {
 	keyPairName := state.Get("keyPair").(string)
 	if keyPairName == "" {
 		return

--- a/builder/alicloud/ecs/step_config_eip.go
+++ b/builder/alicloud/ecs/step_config_eip.go
@@ -10,14 +10,14 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-type setpConfigAlicloudEIP struct {
+type stepConfigAlicloudEIP struct {
 	AssociatePublicIpAddress bool
 	RegionId                 string
 	InternetChargeType       string
 	allocatedId              string
 }
 
-func (s *setpConfigAlicloudEIP) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepConfigAlicloudEIP) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
@@ -55,7 +55,7 @@ func (s *setpConfigAlicloudEIP) Run(_ context.Context, state multistep.StateBag)
 	return multistep.ActionContinue
 }
 
-func (s *setpConfigAlicloudEIP) Cleanup(state multistep.StateBag) {
+func (s *stepConfigAlicloudEIP) Cleanup(state multistep.StateBag) {
 	if len(s.allocatedId) == 0 {
 		return
 	}

--- a/builder/alicloud/ecs/step_config_key_pair.go
+++ b/builder/alicloud/ecs/step_config_key_pair.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-type StepConfigAlicloudKeyPair struct {
+type stepConfigAlicloudKeyPair struct {
 	Debug                bool
 	SSHAgentAuth         bool
 	DebugKeyPath         string
@@ -25,7 +25,7 @@ type StepConfigAlicloudKeyPair struct {
 	keyName string
 }
 
-func (s *StepConfigAlicloudKeyPair) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepConfigAlicloudKeyPair) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	if s.PrivateKeyFile != "" {
@@ -108,7 +108,7 @@ func (s *StepConfigAlicloudKeyPair) Run(_ context.Context, state multistep.State
 	return multistep.ActionContinue
 }
 
-func (s *StepConfigAlicloudKeyPair) Cleanup(state multistep.StateBag) {
+func (s *stepConfigAlicloudKeyPair) Cleanup(state multistep.StateBag) {
 	// If no key name is set, then we never created it, so just return
 	// If we used an SSH private key file, do not go about deleting
 	// keypairs

--- a/builder/alicloud/ecs/step_region_copy_image.go
+++ b/builder/alicloud/ecs/step_region_copy_image.go
@@ -10,13 +10,13 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-type setpRegionCopyAlicloudImage struct {
+type stepRegionCopyAlicloudImage struct {
 	AlicloudImageDestinationRegions []string
 	AlicloudImageDestinationNames   []string
 	RegionId                        string
 }
 
-func (s *setpRegionCopyAlicloudImage) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepRegionCopyAlicloudImage) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	if len(s.AlicloudImageDestinationRegions) == 0 {
 		return multistep.ActionContinue
 	}
@@ -52,7 +52,7 @@ func (s *setpRegionCopyAlicloudImage) Run(_ context.Context, state multistep.Sta
 	return multistep.ActionContinue
 }
 
-func (s *setpRegionCopyAlicloudImage) Cleanup(state multistep.StateBag) {
+func (s *stepRegionCopyAlicloudImage) Cleanup(state multistep.StateBag) {
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)
 	if cancelled || halted {

--- a/builder/alicloud/ecs/step_share_image.go
+++ b/builder/alicloud/ecs/step_share_image.go
@@ -10,13 +10,13 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-type setpShareAlicloudImage struct {
+type stepShareAlicloudImage struct {
 	AlicloudImageShareAccounts   []string
 	AlicloudImageUNShareAccounts []string
 	RegionId                     string
 }
 
-func (s *setpShareAlicloudImage) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepShareAlicloudImage) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 	alicloudImages := state.Get("alicloudimages").(map[string]string)
@@ -37,7 +37,7 @@ func (s *setpShareAlicloudImage) Run(_ context.Context, state multistep.StateBag
 	return multistep.ActionContinue
 }
 
-func (s *setpShareAlicloudImage) Cleanup(state multistep.StateBag) {
+func (s *stepShareAlicloudImage) Cleanup(state multistep.StateBag) {
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)
 	if cancelled || halted {


### PR DESCRIPTION
Fixed misprints in step names.
Step names are visible when launching packer with --debug option.

StepConfigAlicloudKeyPair -> stepConfigAlicloudKeyPair (common naming convention for other steps)
setpConfigAlicloudEIP -> stepConfigAlicloudEIP
stepAttachKeyPar -> stepAttachKeyPair
setpRegionCopyAlicloudImage -> stepRegionCopyAlicloudImage
setpShareAlicloudImage -> stepShareAlicloudImage