### PR TITLE
Remove `go get` from Quick Start as this isn't required just to use Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ from a single source configuration.
 Packer is lightweight, runs on every major operating system, and is highly
 performant, creating machine images for multiple platforms in parallel. Packer
 comes out of the box with support for many platforms, the full list of which can
-be found at https://www.packer.io/docs/builders/index.html. 
+be found at https://www.packer.io/docs/builders/index.html.
 
 Support for other platforms can be added via plugins.
 
@@ -32,10 +32,6 @@ The images that Packer creates can easily be turned into
 [Vagrant](http://www.vagrantup.com) boxes.
 
 ## Quick Start
-Download and install packages and dependencies
-```
-go get github.com/hashicorp/packer
-```
 
 **Note:** There is a great
 [introduction and getting started guide](https://www.packer.io/intro)


### PR DESCRIPTION
I'm not exactly sure what the intention was here. However, to me, the instructions at the beginning of the Quick Start section read as though you need to perform a `go get...` to use Packer...
