### PR TITLE
[WIP] Split Hyper-V disk compaction process and vm export into separate steps

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -96,8 +96,6 @@ type Driver interface {
 
 	CompactDisks(string) error
 
-	CopyExportedVirtualMachine(string, string, string, string) error
-
 	RestartVirtualMachine(string) error
 
 	CreateDvdDrive(string, string, uint) (uint, uint, error)

--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -94,7 +94,7 @@ type Driver interface {
 
 	ExportVirtualMachine(string, string) error
 
-	CompactDisks(string, string) error
+	CompactDisks(string) error
 
 	CopyExportedVirtualMachine(string, string, string, string) error
 

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -190,13 +190,6 @@ type DriverMock struct {
 	CompactDisks_Path   string
 	CompactDisks_Err    error
 
-	CopyExportedVirtualMachine_Called     bool
-	CopyExportedVirtualMachine_ExpPath    string
-	CopyExportedVirtualMachine_OutputPath string
-	CopyExportedVirtualMachine_VhdDir     string
-	CopyExportedVirtualMachine_VmDir      string
-	CopyExportedVirtualMachine_Err        error
-
 	RestartVirtualMachine_Called bool
 	RestartVirtualMachine_VmName string
 	RestartVirtualMachine_Err    error
@@ -492,15 +485,6 @@ func (d *DriverMock) CompactDisks(Path string) error {
 	d.CompactDisks_Called = true
 	d.CompactDisks_Path = Path
 	return d.CompactDisks_Err
-}
-
-func (d *DriverMock) CopyExportedVirtualMachine(expPath string, outputPath string, vhdDir string, vmDir string) error {
-	d.CopyExportedVirtualMachine_Called = true
-	d.CopyExportedVirtualMachine_ExpPath = expPath
-	d.CopyExportedVirtualMachine_OutputPath = outputPath
-	d.CopyExportedVirtualMachine_VhdDir = vhdDir
-	d.CopyExportedVirtualMachine_VmDir = vmDir
-	return d.CopyExportedVirtualMachine_Err
 }
 
 func (d *DriverMock) RestartVirtualMachine(vmName string) error {

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -186,10 +186,9 @@ type DriverMock struct {
 	ExportVirtualMachine_Path   string
 	ExportVirtualMachine_Err    error
 
-	CompactDisks_Called  bool
-	CompactDisks_ExpPath string
-	CompactDisks_VhdDir  string
-	CompactDisks_Err     error
+	CompactDisks_Called bool
+	CompactDisks_Path   string
+	CompactDisks_Err    error
 
 	CopyExportedVirtualMachine_Called     bool
 	CopyExportedVirtualMachine_ExpPath    string
@@ -489,10 +488,9 @@ func (d *DriverMock) ExportVirtualMachine(vmName string, path string) error {
 	return d.ExportVirtualMachine_Err
 }
 
-func (d *DriverMock) CompactDisks(expPath string, vhdDir string) error {
+func (d *DriverMock) CompactDisks(Path string) error {
 	d.CompactDisks_Called = true
-	d.CompactDisks_ExpPath = expPath
-	d.CompactDisks_VhdDir = vhdDir
+	d.CompactDisks_Path = Path
 	return d.CompactDisks_Err
 }
 

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -219,8 +219,8 @@ func (d *HypervPS4Driver) ExportVirtualMachine(vmName string, path string) error
 	return hyperv.ExportVirtualMachine(vmName, path)
 }
 
-func (d *HypervPS4Driver) CompactDisks(expPath string, vhdDir string) error {
-	return hyperv.CompactDisks(expPath, vhdDir)
+func (d *HypervPS4Driver) CompactDisks(Path string) error {
+	return hyperv.CompactDisks(Path)
 }
 
 func (d *HypervPS4Driver) CopyExportedVirtualMachine(expPath string, outputPath string, vhdDir string, vmDir string) error {

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -223,10 +223,6 @@ func (d *HypervPS4Driver) CompactDisks(Path string) error {
 	return hyperv.CompactDisks(Path)
 }
 
-func (d *HypervPS4Driver) CopyExportedVirtualMachine(expPath string, outputPath string, vhdDir string, vmDir string) error {
-	return hyperv.CopyExportedVirtualMachine(expPath, outputPath, vhdDir, vmDir)
-}
-
 func (d *HypervPS4Driver) RestartVirtualMachine(vmName string) error {
 	return hyperv.RestartVirtualMachine(vmName)
 }

--- a/builder/hyperv/common/step_compact_disk.go
+++ b/builder/hyperv/common/step_compact_disk.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+type StepCompactDisk struct {
+	SkipCompaction bool
+}
+
+// Run runs a compaction/optimisation process on attached VHD/VHDX disks
+func (s *StepCompactDisk) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(Driver)
+	ui := state.Get("ui").(packer.Ui)
+
+	if s.SkipCompaction {
+		ui.Say("Skipping disk compaction...")
+		return multistep.ActionContinue
+	}
+
+	// Get the tmp dir used to store the VMs files during the build process
+	tmpPath := state.Get("packerTempDir").(string)
+
+	ui.Say("Compacting disks...")
+	// CompactDisks searches for all VHD/VHDX files under the supplied
+	// path and runs the compacting process on each of them
+	err := driver.CompactDisks(tmpPath)
+	if err != nil {
+		err := fmt.Errorf("Error compacting disks: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+// Cleanup does nothing
+func (s *StepCompactDisk) Cleanup(state multistep.StateBag) {}

--- a/builder/hyperv/common/step_compact_disk_test.go
+++ b/builder/hyperv/common/step_compact_disk_test.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer/helper/multistep"
+)
+
+func TestStepCompactDisk_impl(t *testing.T) {
+	var _ multistep.Step = new(StepCompactDisk)
+}
+
+func TestStepCompactDisk(t *testing.T) {
+	state := testState(t)
+	step := new(StepCompactDisk)
+
+	// Set up the path to the tmp directory used to store VM files
+	tmpPath := "foopath"
+	state.Put("packerTempDir", tmpPath)
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("Bad action: %v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("Should NOT have error")
+	}
+
+	// Test the driver
+	if !driver.CompactDisks_Called {
+		t.Fatal("Should have called CompactDisks")
+	}
+	if driver.CompactDisks_Path != tmpPath {
+		t.Fatalf("Should call with correct path. Got: %s Wanted: %s", driver.CompactDisks_Path, tmpPath)
+	}
+}
+
+func TestStepCompactDisk_skip(t *testing.T) {
+	state := testState(t)
+	step := new(StepCompactDisk)
+	step.SkipCompaction = true
+
+	// Set up the path to the tmp directory used to store VM files
+	state.Put("packerTempDir", "foopath")
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("Bad action: %v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatalf("Should NOT have error")
+	}
+
+	// Test the driver
+	if driver.CompactDisks_Called {
+		t.Fatal("Should not have called CompactDisks")
+	}
+}

--- a/builder/hyperv/common/step_export_vm.go
+++ b/builder/hyperv/common/step_export_vm.go
@@ -9,9 +9,8 @@ import (
 )
 
 type StepExportVm struct {
-	OutputDir      string
-	SkipCompaction bool
-	SkipExport     bool
+	OutputDir  string
+	SkipExport bool
 }
 
 func (s *StepExportVm) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -23,29 +22,11 @@ func (s *StepExportVm) Run(_ context.Context, state multistep.StateBag) multiste
 		return multistep.ActionContinue
 	}
 
-	// Get the VM name; Get the temp directory used to store the VMs files
-	// during the build process
-	vmName := state.Get("vmName").(string)
-	tmpPath := state.Get("packerTempDir").(string)
-
-	// Compact disks first so the export process has less to do
-	if s.SkipCompaction {
-		ui.Say("Skipping disk compaction...")
-	} else {
-		ui.Say("Compacting disks...")
-		err := driver.CompactDisks(tmpPath)
-		if err != nil {
-			err := fmt.Errorf("Error compacting disks: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-	}
-
 	ui.Say("Exporting virtual machine...")
 	// The export process exports the VM to a folder named 'vmName' under
 	// the output directory. This contains the usual 'Snapshots', 'Virtual
 	// Hard Disks' and 'Virtual Machines' directories.
+	vmName := state.Get("vmName").(string)
 	err := driver.ExportVirtualMachine(vmName, s.OutputDir)
 	if err != nil {
 		err = fmt.Errorf("Error exporting vm: %s", err)

--- a/builder/hyperv/common/step_export_vm.go
+++ b/builder/hyperv/common/step_export_vm.go
@@ -3,16 +3,9 @@ package common
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
 
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
-)
-
-const (
-	vhdDir string = "Virtual Hard Disks"
-	vmDir  string = "Virtual Machines"
 )
 
 type StepExportVm struct {
@@ -24,63 +17,43 @@ type StepExportVm struct {
 func (s *StepExportVm) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
-	var err error
-	var errorMsg string
 
+	if s.SkipExport {
+		ui.Say("Skipping export of virtual machine...")
+		return multistep.ActionContinue
+	}
+
+	// Get the VM name; Get the temp directory used to store the VMs files
+	// during the build process
 	vmName := state.Get("vmName").(string)
 	tmpPath := state.Get("packerTempDir").(string)
-	outputPath := s.OutputDir
-	expPath := s.OutputDir
 
-	// create temp path to export vm
-	errorMsg = "Error creating temp export path: %s"
-	vmExportPath, err := ioutil.TempDir(tmpPath, "export")
-	if err != nil {
-		err := fmt.Errorf(errorMsg, err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
-	if !s.SkipExport {
-		ui.Say("Exporting vm...")
-
-		err = driver.ExportVirtualMachine(vmName, vmExportPath)
-		if err != nil {
-			errorMsg = "Error exporting vm: %s"
-			err := fmt.Errorf(errorMsg, err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-		// copy to output dir
-		expPath = filepath.Join(vmExportPath, vmName)
-	}
-
+	// Compact disks first so the export process has less to do
 	if s.SkipCompaction {
 		ui.Say("Skipping disk compaction...")
 	} else {
 		ui.Say("Compacting disks...")
-		err = driver.CompactDisks(expPath, vhdDir)
+		err := driver.CompactDisks(tmpPath)
 		if err != nil {
-			errorMsg = "Error compacting disks: %s"
-			err := fmt.Errorf(errorMsg, err)
+			err := fmt.Errorf("Error compacting disks: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
 	}
 
-	if !s.SkipExport {
-		ui.Say("Copying to output dir...")
-		err = driver.CopyExportedVirtualMachine(expPath, outputPath, vhdDir, vmDir)
-		if err != nil {
-			errorMsg = "Error exporting vm: %s"
-			err := fmt.Errorf(errorMsg, err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
+	ui.Say("Exporting virtual machine...")
+	// The export process exports the VM to a folder named 'vmName' under
+	// the output directory. This contains the usual 'Snapshots', 'Virtual
+	// Hard Disks' and 'Virtual Machines' directories.
+	err := driver.ExportVirtualMachine(vmName, s.OutputDir)
+	if err != nil {
+		err = fmt.Errorf("Error exporting vm: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
 	}
+
 	return multistep.ActionContinue
 }
 

--- a/builder/hyperv/common/step_export_vm_test.go
+++ b/builder/hyperv/common/step_export_vm_test.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer/helper/multistep"
+)
+
+func TestStepExportVm_impl(t *testing.T) {
+	var _ multistep.Step = new(StepCompactDisk)
+}
+
+func TestStepExportVm(t *testing.T) {
+	state := testState(t)
+	step := new(StepExportVm)
+
+	// ExportVirtualMachine needs the VM name and a path to export to
+	vmName := "foo"
+	state.Put("vmName", vmName)
+	outputDir := "foopath"
+	step.OutputDir = outputDir
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("Bad action: %v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("Should NOT have error")
+	}
+
+	// Test the driver
+	if !driver.ExportVirtualMachine_Called {
+		t.Fatal("Should have called ExportVirtualMachine")
+	}
+	if driver.ExportVirtualMachine_Path != outputDir {
+		t.Fatalf("Should call with correct path. Got: %s Wanted: %s",
+			driver.ExportVirtualMachine_Path, outputDir)
+	}
+	if driver.ExportVirtualMachine_VmName != vmName {
+		t.Fatalf("Should call with correct vm name. Got: %s Wanted: %s",
+			driver.ExportVirtualMachine_VmName, vmName)
+	}
+}
+
+func TestStepExportVm_skip(t *testing.T) {
+	state := testState(t)
+	step := new(StepExportVm)
+	step.SkipExport = true
+
+	// ExportVirtualMachine needs the VM name and a path to export to
+	vmName := "foo"
+	state.Put("vmName", vmName)
+	outputDir := "foopath"
+	step.OutputDir = outputDir
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("Bad action: %v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatalf("Should NOT have error")
+	}
+
+	// Test the driver
+	if driver.ExportVirtualMachine_Called {
+		t.Fatal("Should not have called ExportVirtualMachine")
+	}
+}

--- a/builder/hyperv/common/step_test.go
+++ b/builder/hyperv/common/step_test.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+func testState(t *testing.T) multistep.StateBag {
+	state := new(multistep.BasicStateBag)
+	state.Put("driver", new(DriverMock))
+	state.Put("ui", &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	return state
+}

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -467,9 +467,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Generation: b.config.Generation,
 		},
 		&hypervcommon.StepExportVm{
-			OutputDir:      b.config.OutputDir,
-			SkipCompaction: b.config.SkipCompaction,
-			SkipExport:     b.config.SkipExport,
+			OutputDir:  b.config.OutputDir,
+			SkipExport: b.config.SkipExport,
 		},
 
 		// the clean up actions for each step will be executed reverse order

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -466,6 +466,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&hypervcommon.StepUnmountFloppyDrive{
 			Generation: b.config.Generation,
 		},
+		&hypervcommon.StepCompactDisk{
+			SkipCompaction: b.config.SkipCompaction,
+		},
 		&hypervcommon.StepExportVm{
 			OutputDir:  b.config.OutputDir,
 			SkipExport: b.config.SkipExport,

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -475,6 +475,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&hypervcommon.StepUnmountFloppyDrive{
 			Generation: b.config.Generation,
 		},
+		&hypervcommon.StepCompactDisk{
+			SkipCompaction: b.config.SkipCompaction,
+		},
 		&hypervcommon.StepExportVm{
 			OutputDir:  b.config.OutputDir,
 			SkipExport: b.config.SkipExport,

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -476,9 +476,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Generation: b.config.Generation,
 		},
 		&hypervcommon.StepExportVm{
-			OutputDir:      b.config.OutputDir,
-			SkipCompaction: b.config.SkipCompaction,
-			SkipExport:     b.config.SkipExport,
+			OutputDir:  b.config.OutputDir,
+			SkipExport: b.config.SkipExport,
 		},
 
 		// the clean up actions for each step will be executed reverse order

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -267,7 +267,7 @@ if ($harddrivePath){
 func DisableAutomaticCheckpoints(vmName string) error {
 	var script = `
 param([string]$vmName)
-if ((Get-Command Hyper-V\Set-Vm).Parameters["AutomaticCheckpointsEnabled"]) { 
+if ((Get-Command Hyper-V\Set-Vm).Parameters["AutomaticCheckpointsEnabled"]) {
 	Hyper-V\Set-Vm -Name $vmName -AutomaticCheckpointsEnabled $false }
 `
 	var ps powershell.PowerShellCmd
@@ -279,7 +279,7 @@ func ExportVmxcVirtualMachine(exportPath string, vmName string, snapshotName str
 	var script = `
 param([string]$exportPath, [string]$vmName, [string]$snapshotName, [string]$allSnapshotsString)
 
-$WorkingPath = Join-Path $exportPath $vmName 
+$WorkingPath = Join-Path $exportPath $vmName
 
 if (Test-Path $WorkingPath) {
 	throw "Export path working directory: $WorkingPath already exists!"
@@ -297,7 +297,7 @@ if ($snapshotName) {
     } else {
         $snapshot = $null
     }
-    
+
     if (!$snapshot) {
         #No snapshot clone
         Hyper-V\Export-VM -Name $vmName -Path $exportPath -ErrorAction Stop
@@ -328,7 +328,7 @@ param([string]$exportPath, [string]$cloneFromVmxcPath)
 if (!(Test-Path $cloneFromVmxcPath)){
 	throw "Clone from vmxc directory: $cloneFromVmxcPath does not exist!"
 }
-	
+
 if (!(Test-Path $exportPath)){
 	New-Item -ItemType Directory -Force -Path $exportPath
 }
@@ -390,12 +390,12 @@ if ($vhdPath){
 		$existingFirstHarddrive | Hyper-V\Set-VMHardDiskDrive -Path $vhdPath
 	} else {
 		Hyper-V\Add-VMHardDiskDrive -VM $compatibilityReport.VM -Path $vhdPath
-	}	
+	}
 }
 Hyper-V\Set-VMMemory -VM $compatibilityReport.VM -StartupBytes $memoryStartupBytes
 $networkAdaptor = $compatibilityReport.VM.NetworkAdapters | Select -First 1
 Hyper-V\Disconnect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor
-Hyper-V\Connect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor -SwitchName $switchName 
+Hyper-V\Connect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor -SwitchName $switchName
 $vm = Hyper-V\Import-VM -CompatibilityReport $compatibilityReport
 
 if ($vm) {
@@ -659,16 +659,16 @@ if (Test-Path -Path ([IO.Path]::Combine($path, $vmName, 'Virtual Machines', '*.V
 	return err
 }
 
-func CompactDisks(expPath string, vhdDir string) error {
+func CompactDisks(Path string) error {
 	var script = `
-param([string]$srcPath, [string]$vhdDirName)
-Get-ChildItem "$srcPath/$vhdDirName" -Filter *.vhd* | %{
+param([string]$srcPath)
+Get-ChildItem "$srcPath" -Filter *.vhd* | %{
     Optimize-VHD -Path $_.FullName -Mode Full
 }
 `
 
 	var ps powershell.PowerShellCmd
-	err := ps.Run(script, expPath, vhdDir)
+	err := ps.Run(script, Path)
 	return err
 }
 

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -672,20 +672,6 @@ Get-ChildItem "$srcPath" -Filter *.vhd* | %{
 	return err
 }
 
-func CopyExportedVirtualMachine(expPath string, outputPath string, vhdDir string, vmDir string) error {
-
-	var script = `
-param([string]$srcPath, [string]$dstPath, [string]$vhdDirName, [string]$vmDir)
-Move-Item -Path (Join-Path (Get-Item $srcPath).FullName "*.*") -Destination $dstPath
-Move-Item -Path (Join-Path (Get-Item $srcPath).FullName $vhdDirName) -Destination $dstPath
-Move-Item -Path (Join-Path (Get-Item $srcPath).FullName $vmDir) -Destination $dstPath
-`
-
-	var ps powershell.PowerShellCmd
-	err := ps.Run(script, expPath, outputPath, vhdDir, vmDir)
-	return err
-}
-
 func CreateVirtualSwitch(switchName string, switchType string) (bool, error) {
 
 	var script = `

--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -238,11 +238,11 @@ builder.
 -   `skip_compaction` (boolean) - If `true` skip compacting the hard disk for
     the virtual machine when exporting. This defaults to `false`.
 
--   `skip_export` (boolean) - If `true` Packer will skip the export of the
-    VM. If you are interested only in the VHD/VHDX files, you can enable
-    this option. This will create inline disks which improves the build
-    performance.  There will not be any copying of source VHDs to the temp
-    directory. This defaults to `false`.
+-   `skip_export` (boolean) - If `true` Packer will skip the export of the VM.
+    If you are interested only in the VHD/VHDX files, you can enable this
+    option. The resulting VHD/VHDX file will be output to
+    `<output_directory>/Virtual Hard Disks`. By default this option is `false`
+    and Packer will export the build VM to `<output_directory>/<vm_name>`.
 
 -   `switch_name` (string) - The name of the switch to connect the virtual
     machine to. By default, leaving this value unset will cause Packer to

--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -255,7 +255,11 @@ builder.
     the VLAN specified in by `vlan_id`.
 
 -   `temp_path` (string) - This is the temporary path in which Packer will
-    create the virtual machine. By default the value is the system `%temp%`.
+    create the virtual machine. By default a folder named
+    `packerhv[7-digit-number]` will be created under `%TEMP%` - where
+    7-digit-number is automatically generated to guarantee a unique folder
+    for the build. For most systems `%TEMP%` will evaluate to
+    `%USERPROFILE%/AppData/Local/Temp`.
 
 -   `use_fixed_vhd_format` (boolean) - If true, creates the boot disk on the
     virtual machine as a fixed VHD format disk. The default is `false`, which

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -239,11 +239,11 @@ builder.
 -   `skip_compaction` (boolean) - If `true` skip compacting the hard disk for
     the virtual machine when exporting. This defaults to `false`.
 
--   `skip_export` (boolean) - If `true` Packer will skip the export of the
-    VM. If you are interested only in the VHD/VHDX files, you can enable
-    this option. This will create inline disks which improves the build
-    performance.  There will not be any copying of source VHDs to the temp
-    directory. This defaults to `false`.
+-   `skip_export` (boolean) - If `true` Packer will skip the export of the VM.
+    If you are interested only in the VHD/VHDX files, you can enable this
+    option. The resulting VHD/VHDX file will be output to
+    `<output_directory>/Virtual Hard Disks`. By default this option is `false`
+    and Packer will export the build VM to `<output_directory>/<vm_name>`.
 
 -   `switch_name` (string) - The name of the switch to connect the virtual
     machine to. By default, leaving this value unset will cause Packer to


### PR DESCRIPTION
### ~~This PR is intended for review only.~~

Currently the code that performs disk compaction for Hyper-V is embedded within the step that exports the VM. This PR breaks out the disk compaction process into its own individual step, thereby allowing users who have set `skip_export: true` in their templates, the ability to compact their build disks.

This PR follows on from, *and includes* the commits in #6393. In other words this PR is a duplicate of #6393 with some additional bits bolted on!

There are some changes in behaviour that would be introduced by this PR *and the parent PR*. See #6393 and the comment [HERE](https://github.com/hashicorp/packer/issues/6392#issuecomment-397811836) for details.

I have tested the PR with a simplistic build template for the ISO builder only. Help with further testing (especially with the untested VMCX builder) would be greatly appreciated.

**Long and short, this PR needs plenty of testing, feedback from our Hyper-V experts and some further discussion before it should be considered fit for merging...**