### PR TITLE
Check if hyper-v addresses is an array before slicing it

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -1009,7 +1009,11 @@ param([string]$mac, [int]$addressIndex)
 try {
   $vm = Hyper-V\Get-VM | ?{$_.NetworkAdapters.MacAddress -eq $mac}
   if ($vm.NetworkAdapters.IpAddresses) {
-    $ip = $vm.NetworkAdapters.IpAddresses[$addressIndex]
+    $ipAddresses = $vm.NetworkAdapters.IPAddresses
+    if ($ipAddresses -isnot [array]) {
+      $ipAddresses = @($ipAddresses)
+    }
+    $ip = $ipAddresses[$addressIndex]
   } else {
     $vm_info = Get-CimInstance -ClassName Msvm_ComputerSystem -Namespace root\virtualization\v2 -Filter "ElementName='$($vm.Name)'"
     $ip_details = (Get-CimAssociatedInstance -InputObject $vm_info -ResultClassName Msvm_KvpExchangeComponent).GuestIntrinsicExchangeItems | %{ [xml]$_ } | ?{ $_.SelectSingleNode("/INSTANCE/PROPERTY[@NAME='Name']/VALUE[child::text()='NetworkAddressIPv4']") }


### PR DESCRIPTION
As discussed in https://github.com/hashicorp/packer/issues/6315, the PR https://github.com/hashicorp/packer/pull/6219 causes an issue when trying to get an IP Address on particular hosts. This change will first check if the address variable is an array before getting the address at the index specified.

* https://github.com/jborean93/github-misc/tree/master/packer/issue-6315

Closes https://github.com/hashicorp/packer/issues/6315