### PR TITLE
Pass context into OCI client

### DIFF
--- a/builder/oracle/oci/artifact.go
+++ b/builder/oracle/oci/artifact.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/oracle/oci-go-sdk/core"
@@ -41,11 +42,12 @@ func (a *Artifact) String() string {
 	)
 }
 
+// State ...
 func (a *Artifact) State(name string) interface{} {
 	return nil
 }
 
 // Destroy deletes the custom image associated with the artifact.
 func (a *Artifact) Destroy() error {
-	return a.driver.DeleteImage(*a.Image.Id)
+	return a.driver.DeleteImage(context.TODO(), *a.Image.Id)
 }

--- a/builder/oracle/oci/driver.go
+++ b/builder/oracle/oci/driver.go
@@ -1,14 +1,18 @@
 package oci
 
-import "github.com/oracle/oci-go-sdk/core"
+import (
+	"context"
+
+	"github.com/oracle/oci-go-sdk/core"
+)
 
 // Driver interfaces between the builder steps and the OCI SDK.
 type Driver interface {
-	CreateInstance(publicKey string) (string, error)
-	CreateImage(id string) (core.Image, error)
-	DeleteImage(id string) error
-	GetInstanceIP(id string) (string, error)
-	TerminateInstance(id string) error
-	WaitForImageCreation(id string) error
-	WaitForInstanceState(id string, waitStates []string, terminalState string) error
+	CreateInstance(ctx context.Context, publicKey string) (string, error)
+	CreateImage(ctx context.Context, id string) (core.Image, error)
+	DeleteImage(ctx context.Context, id string) error
+	GetInstanceIP(ctx context.Context, id string) (string, error)
+	TerminateInstance(ctx context.Context, id string) error
+	WaitForImageCreation(ctx context.Context, id string) error
+	WaitForInstanceState(ctx context.Context, id string, waitStates []string, terminalState string) error
 }

--- a/builder/oracle/oci/driver_mock.go
+++ b/builder/oracle/oci/driver_mock.go
@@ -1,6 +1,10 @@
 package oci
 
-import "github.com/oracle/oci-go-sdk/core"
+import (
+	"context"
+
+	"github.com/oracle/oci-go-sdk/core"
+)
 
 // driverMock implements the Driver interface and communicates with Oracle
 // OCI.
@@ -27,7 +31,7 @@ type driverMock struct {
 }
 
 // CreateInstance creates a new compute instance.
-func (d *driverMock) CreateInstance(publicKey string) (string, error) {
+func (d *driverMock) CreateInstance(ctx context.Context, publicKey string) (string, error) {
 	if d.CreateInstanceErr != nil {
 		return "", d.CreateInstanceErr
 	}
@@ -38,7 +42,7 @@ func (d *driverMock) CreateInstance(publicKey string) (string, error) {
 }
 
 // CreateImage creates a new custom image.
-func (d *driverMock) CreateImage(id string) (core.Image, error) {
+func (d *driverMock) CreateImage(ctx context.Context, id string) (core.Image, error) {
 	if d.CreateImageErr != nil {
 		return core.Image{}, d.CreateImageErr
 	}
@@ -47,7 +51,7 @@ func (d *driverMock) CreateImage(id string) (core.Image, error) {
 }
 
 // DeleteImage mocks deleting a custom image.
-func (d *driverMock) DeleteImage(id string) error {
+func (d *driverMock) DeleteImage(ctx context.Context, id string) error {
 	if d.DeleteImageErr != nil {
 		return d.DeleteImageErr
 	}
@@ -58,7 +62,7 @@ func (d *driverMock) DeleteImage(id string) error {
 }
 
 // GetInstanceIP returns the public or private IP corresponding to the given instance id.
-func (d *driverMock) GetInstanceIP(id string) (string, error) {
+func (d *driverMock) GetInstanceIP(ctx context.Context, id string) (string, error) {
 	if d.GetInstanceIPErr != nil {
 		return "", d.GetInstanceIPErr
 	}
@@ -69,7 +73,7 @@ func (d *driverMock) GetInstanceIP(id string) (string, error) {
 }
 
 // TerminateInstance terminates a compute instance.
-func (d *driverMock) TerminateInstance(id string) error {
+func (d *driverMock) TerminateInstance(ctx context.Context, id string) error {
 	if d.TerminateInstanceErr != nil {
 		return d.TerminateInstanceErr
 	}
@@ -81,12 +85,12 @@ func (d *driverMock) TerminateInstance(id string) error {
 
 // WaitForImageCreation waits for a provisioning custom image to reach the
 // "AVAILABLE" state.
-func (d *driverMock) WaitForImageCreation(id string) error {
+func (d *driverMock) WaitForImageCreation(ctx context.Context, id string) error {
 	return d.WaitForImageCreationErr
 }
 
 // WaitForInstanceState waits for an instance to reach the a given terminal
 // state.
-func (d *driverMock) WaitForInstanceState(id string, waitStates []string, terminalState string) error {
+func (d *driverMock) WaitForInstanceState(ctx context.Context, id string, waitStates []string, terminalState string) error {
 	return d.WaitForInstanceStateErr
 }

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -15,6 +15,7 @@ type driverOCI struct {
 	computeClient core.ComputeClient
 	vcnClient     core.VirtualNetworkClient
 	cfg           *Config
+	context       context.Context
 }
 
 // NewDriverOCI Creates a new driverOCI with a connected compute client and a connected vcn client.
@@ -37,7 +38,7 @@ func NewDriverOCI(cfg *Config) (Driver, error) {
 }
 
 // CreateInstance creates a new compute instance.
-func (d *driverOCI) CreateInstance(publicKey string) (string, error) {
+func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (string, error) {
 	metadata := map[string]string{
 		"ssh_authorized_keys": publicKey,
 	}
@@ -69,8 +70,8 @@ func (d *driverOCI) CreateInstance(publicKey string) (string, error) {
 }
 
 // CreateImage creates a new custom image.
-func (d *driverOCI) CreateImage(id string) (core.Image, error) {
-	res, err := d.computeClient.CreateImage(context.TODO(), core.CreateImageRequest{CreateImageDetails: core.CreateImageDetails{
+func (d *driverOCI) CreateImage(ctx context.Context, id string) (core.Image, error) {
+	res, err := d.computeClient.CreateImage(ctx, core.CreateImageRequest{CreateImageDetails: core.CreateImageDetails{
 		CompartmentId: &d.cfg.CompartmentID,
 		InstanceId:    &id,
 		DisplayName:   &d.cfg.ImageName,
@@ -84,14 +85,14 @@ func (d *driverOCI) CreateImage(id string) (core.Image, error) {
 }
 
 // DeleteImage deletes a custom image.
-func (d *driverOCI) DeleteImage(id string) error {
-	_, err := d.computeClient.DeleteImage(context.TODO(), core.DeleteImageRequest{ImageId: &id})
+func (d *driverOCI) DeleteImage(ctx context.Context, id string) error {
+	_, err := d.computeClient.DeleteImage(ctx, core.DeleteImageRequest{ImageId: &id})
 	return err
 }
 
 // GetInstanceIP returns the public or private IP corresponding to the given instance id.
-func (d *driverOCI) GetInstanceIP(id string) (string, error) {
-	vnics, err := d.computeClient.ListVnicAttachments(context.TODO(), core.ListVnicAttachmentsRequest{
+func (d *driverOCI) GetInstanceIP(ctx context.Context, id string) (string, error) {
+	vnics, err := d.computeClient.ListVnicAttachments(ctx, core.ListVnicAttachmentsRequest{
 		InstanceId:    &id,
 		CompartmentId: &d.cfg.CompartmentID,
 	})
@@ -103,7 +104,7 @@ func (d *driverOCI) GetInstanceIP(id string) (string, error) {
 		return "", errors.New("instance has zero VNICs")
 	}
 
-	vnic, err := d.vcnClient.GetVnic(context.TODO(), core.GetVnicRequest{VnicId: vnics.Items[0].VnicId})
+	vnic, err := d.vcnClient.GetVnic(ctx, core.GetVnicRequest{VnicId: vnics.Items[0].VnicId})
 	if err != nil {
 		return "", fmt.Errorf("Error getting VNIC details: %s", err)
 	}
@@ -119,8 +120,8 @@ func (d *driverOCI) GetInstanceIP(id string) (string, error) {
 	return *vnic.PublicIp, nil
 }
 
-func (d *driverOCI) GetInstanceInitialCredentials(id string) (string, string, error) {
-	credentials, err := d.computeClient.GetWindowsInstanceInitialCredentials(context.TODO(), core.GetWindowsInstanceInitialCredentialsRequest{
+func (d *driverOCI) GetInstanceInitialCredentials(ctx context.Context, id string) (string, string, error) {
+	credentials, err := d.computeClient.GetWindowsInstanceInitialCredentials(ctx, core.GetWindowsInstanceInitialCredentialsRequest{
 		InstanceId: &id,
 	})
 	if err != nil {
@@ -131,8 +132,8 @@ func (d *driverOCI) GetInstanceInitialCredentials(id string) (string, string, er
 }
 
 // TerminateInstance terminates a compute instance.
-func (d *driverOCI) TerminateInstance(id string) error {
-	_, err := d.computeClient.TerminateInstance(context.TODO(), core.TerminateInstanceRequest{
+func (d *driverOCI) TerminateInstance(ctx context.Context, id string) error {
+	_, err := d.computeClient.TerminateInstance(ctx, core.TerminateInstanceRequest{
 		InstanceId: &id,
 	})
 	return err
@@ -140,10 +141,10 @@ func (d *driverOCI) TerminateInstance(id string) error {
 
 // WaitForImageCreation waits for a provisioning custom image to reach the
 // "AVAILABLE" state.
-func (d *driverOCI) WaitForImageCreation(id string) error {
+func (d *driverOCI) WaitForImageCreation(ctx context.Context, id string) error {
 	return waitForResourceToReachState(
 		func(string) (string, error) {
-			image, err := d.computeClient.GetImage(context.TODO(), core.GetImageRequest{ImageId: &id})
+			image, err := d.computeClient.GetImage(ctx, core.GetImageRequest{ImageId: &id})
 			if err != nil {
 				return "", err
 			}
@@ -159,10 +160,10 @@ func (d *driverOCI) WaitForImageCreation(id string) error {
 
 // WaitForInstanceState waits for an instance to reach the a given terminal
 // state.
-func (d *driverOCI) WaitForInstanceState(id string, waitStates []string, terminalState string) error {
+func (d *driverOCI) WaitForInstanceState(ctx context.Context, id string, waitStates []string, terminalState string) error {
 	return waitForResourceToReachState(
 		func(string) (string, error) {
-			instance, err := d.computeClient.GetInstance(context.TODO(), core.GetInstanceRequest{InstanceId: &id})
+			instance, err := d.computeClient.GetInstance(ctx, core.GetInstanceRequest{InstanceId: &id})
 			if err != nil {
 				return "", err
 			}

--- a/builder/oracle/oci/step_create_instance.go
+++ b/builder/oracle/oci/step_create_instance.go
@@ -10,7 +10,7 @@ import (
 
 type stepCreateInstance struct{}
 
-func (s *stepCreateInstance) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepCreateInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	var (
 		driver    = state.Get("driver").(Driver)
 		ui        = state.Get("ui").(packer.Ui)
@@ -19,7 +19,7 @@ func (s *stepCreateInstance) Run(_ context.Context, state multistep.StateBag) mu
 
 	ui.Say("Creating instance...")
 
-	instanceID, err := driver.CreateInstance(publicKey)
+	instanceID, err := driver.CreateInstance(ctx, publicKey)
 	if err != nil {
 		err = fmt.Errorf("Problem creating instance: %s", err)
 		ui.Error(err.Error())
@@ -33,7 +33,7 @@ func (s *stepCreateInstance) Run(_ context.Context, state multistep.StateBag) mu
 
 	ui.Say("Waiting for instance to enter 'RUNNING' state...")
 
-	if err = driver.WaitForInstanceState(instanceID, []string{"STARTING", "PROVISIONING"}, "RUNNING"); err != nil {
+	if err = driver.WaitForInstanceState(ctx, instanceID, []string{"STARTING", "PROVISIONING"}, "RUNNING"); err != nil {
 		err = fmt.Errorf("Error waiting for instance to start: %s", err)
 		ui.Error(err.Error())
 		state.Put("error", err)
@@ -57,14 +57,14 @@ func (s *stepCreateInstance) Cleanup(state multistep.StateBag) {
 
 	ui.Say(fmt.Sprintf("Terminating instance (%s)...", id))
 
-	if err := driver.TerminateInstance(id); err != nil {
+	if err := driver.TerminateInstance(context.TODO(), id); err != nil {
 		err = fmt.Errorf("Error terminating instance. Please terminate manually: %s", err)
 		ui.Error(err.Error())
 		state.Put("error", err)
 		return
 	}
 
-	err := driver.WaitForInstanceState(id, []string{"TERMINATING"}, "TERMINATED")
+	err := driver.WaitForInstanceState(context.TODO(), id, []string{"TERMINATING"}, "TERMINATED")
 	if err != nil {
 		err = fmt.Errorf("Error terminating instance. Please terminate manually: %s", err)
 		ui.Error(err.Error())

--- a/builder/oracle/oci/step_get_default_credentials.go
+++ b/builder/oracle/oci/step_get_default_credentials.go
@@ -17,7 +17,7 @@ type stepGetDefaultCredentials struct {
 	BuildName string
 }
 
-func (s *stepGetDefaultCredentials) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepGetDefaultCredentials) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	var (
 		driver = state.Get("driver").(*driverOCI)
 		ui     = state.Get("ui").(packer.Ui)
@@ -36,7 +36,7 @@ func (s *stepGetDefaultCredentials) Run(_ context.Context, state multistep.State
 		return multistep.ActionContinue
 	}
 
-	username, password, err := driver.GetInstanceInitialCredentials(id)
+	username, password, err := driver.GetInstanceInitialCredentials(ctx, id)
 	if err != nil {
 		err = fmt.Errorf("Error getting instance's credentials: %s", err)
 		ui.Error(err.Error())

--- a/builder/oracle/oci/step_image.go
+++ b/builder/oracle/oci/step_image.go
@@ -10,7 +10,7 @@ import (
 
 type stepImage struct{}
 
-func (s *stepImage) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepImage) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	var (
 		driver     = state.Get("driver").(Driver)
 		ui         = state.Get("ui").(packer.Ui)
@@ -19,7 +19,7 @@ func (s *stepImage) Run(_ context.Context, state multistep.StateBag) multistep.S
 
 	ui.Say("Creating image from instance...")
 
-	image, err := driver.CreateImage(instanceID)
+	image, err := driver.CreateImage(ctx, instanceID)
 	if err != nil {
 		err = fmt.Errorf("Error creating image from instance: %s", err)
 		ui.Error(err.Error())
@@ -27,7 +27,7 @@ func (s *stepImage) Run(_ context.Context, state multistep.StateBag) multistep.S
 		return multistep.ActionHalt
 	}
 
-	err = driver.WaitForImageCreation(*image.Id)
+	err = driver.WaitForImageCreation(ctx, *image.Id)
 	if err != nil {
 		err = fmt.Errorf("Error waiting for image creation to finish: %s", err)
 		ui.Error(err.Error())

--- a/builder/oracle/oci/step_instance_info.go
+++ b/builder/oracle/oci/step_instance_info.go
@@ -10,14 +10,14 @@ import (
 
 type stepInstanceInfo struct{}
 
-func (s *stepInstanceInfo) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepInstanceInfo) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	var (
 		driver = state.Get("driver").(Driver)
 		ui     = state.Get("ui").(packer.Ui)
 		id     = state.Get("instance_id").(string)
 	)
 
-	ip, err := driver.GetInstanceIP(id)
+	ip, err := driver.GetInstanceIP(ctx, id)
 	if err != nil {
 		err = fmt.Errorf("Error getting instance's IP: %s", err)
 		ui.Error(err.Error())


### PR DESCRIPTION
Replaces the temporary `context.TODO()` placeholder and passes the context down through the client from `Run()`.

Closes #6323 
