### PR TITLE
Support instance display name configuration for OCI

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	BaseImageID string `mapstructure:"base_image_ocid"`
 	Shape       string `mapstructure:"shape"`
 	ImageName   string `mapstructure:"image_name"`
+
+	// Instance
+	InstanceName string `mapstructure:"instance_name"`
+
 	// UserData and UserDataFile file are both optional and mutually exclusive.
 	UserData     string `mapstructure:"user_data"`
 	UserDataFile string `mapstructure:"user_data_file"`

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -45,14 +45,21 @@ func (d *driverOCI) CreateInstance(publicKey string) (string, error) {
 		metadata["user_data"] = d.cfg.UserData
 	}
 
-	instance, err := d.computeClient.LaunchInstance(context.TODO(), core.LaunchInstanceRequest{LaunchInstanceDetails: core.LaunchInstanceDetails{
+	instanceDetails := core.LaunchInstanceDetails{
 		AvailabilityDomain: &d.cfg.AvailabilityDomain,
 		CompartmentId:      &d.cfg.CompartmentID,
 		ImageId:            &d.cfg.BaseImageID,
 		Shape:              &d.cfg.Shape,
 		SubnetId:           &d.cfg.SubnetID,
 		Metadata:           metadata,
-	}})
+	}
+
+	// When empty, the default display name is used.
+	if d.cfg.InstanceName != "" {
+		instanceDetails.DisplayName = &d.cfg.InstanceName
+	}
+
+	instance, err := d.computeClient.LaunchInstance(context.TODO(), core.LaunchInstanceRequest{LaunchInstanceDetails: instanceDetails})
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Adds support for customizing the instance display name in the builder config. Usage:

`"instance_name": "myInstanceName",`

Closes  #6287 
