### PR TITLE
found a config validation bug where packer crashes instead of throwin…

### DIFF
--- a/common/shell-local/config.go
+++ b/common/shell-local/config.go
@@ -215,6 +215,13 @@ func ConvertToLinuxPath(winAbsPath string) (string, error) {
 	// get absolute path of script, and morph it into the bash path
 	winAbsPath = strings.Replace(winAbsPath, "\\", "/", -1)
 	splitPath := strings.SplitN(winAbsPath, ":/", 2)
-	winBashPath := fmt.Sprintf("/mnt/%s/%s", strings.ToLower(splitPath[0]), splitPath[1])
-	return winBashPath, nil
+	if len(splitPath) == 2 {
+		winBashPath := fmt.Sprintf("/mnt/%s/%s", strings.ToLower(splitPath[0]), splitPath[1])
+		return winBashPath, nil
+	} else {
+		err := fmt.Errorf("There was an error splitting your absolute path; expected "+
+			"to find a drive following the format ':/' but did not: absolute "+
+			"path: %s", winAbsPath)
+		return "", err
+	}
 }


### PR DESCRIPTION
if you are on linux when you end up in this code, Packer crashes. Throw a validation error instead.