### PR TITLE
Update list of required IAM permissions

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -184,7 +184,13 @@ Note that if you'd like to create a spot instance, you must also add:
 ec2:RequestSpotInstances,
 ec2:CancelSpotInstanceRequests,
 ec2:DescribeSpotInstanceRequests
-```  
+```
+
+If you have the `spot_price` parameter set to `auto`, you must also add:
+
+``` json
+ec2:DescribeSpotPriceHistory
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
Hey all, first time committer here with a simple doc update.

The `ec2:DescribeSpotPriceHistory` is required when the `spot_price` parameter is set to `auto`.