### PR TITLE
Fixes VMWare Builder issue regarding DHCP-less NAT networks.

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -358,7 +358,8 @@ func (d *VmwareDriver) GuestIP(state multistep.StateBag) (string, error) {
 		// open up the lease and read its contents
 		fh, err := os.Open(dhcpLeasesPath)
 		if err != nil {
-			return "", err
+			log.Printf("Unable to open lease path, skipping: %s", dhcpLeasesPath)
+			continue
 		}
 		defer fh.Close()
 

--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -358,7 +358,7 @@ func (d *VmwareDriver) GuestIP(state multistep.StateBag) (string, error) {
 		// open up the lease and read its contents
 		fh, err := os.Open(dhcpLeasesPath)
 		if err != nil {
-			log.Printf("Unable to open lease path, skipping: %s", dhcpLeasesPath)
+			log.Printf("Error while reading DHCP lease path file %s: %s", dhcpLeasesPath, err.Error())
 			continue
 		}
 		defer fh.Close()


### PR DESCRIPTION
Addresses Issue: https://github.com/hashicorp/packer/issues/6414

This PR skips any lease files that cannot be read. In some VMWare network setups
lease files are not produced. 

We could get more sophisticated in the checking but it is likely not worth it. In this case,
we elect to report and move on.