### PR TITLE
fix alicloud builder eip allocating issue

### DIFF
--- a/builder/alicloud/ecs/builder.go
+++ b/builder/alicloud/ecs/builder.go
@@ -140,6 +140,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
 			RegionId:                 b.config.AlicloudRegion,
 			InternetChargeType:       b.config.InternetChargeType,
+			InternetMaxBandwidthOut:  b.config.InternetMaxBandwidthOut,
 		})
 	} else {
 		steps = append(steps, &stepConfigAlicloudPublicIP{

--- a/builder/alicloud/ecs/step_config_eip.go
+++ b/builder/alicloud/ecs/step_config_eip.go
@@ -14,6 +14,7 @@ type stepConfigAlicloudEIP struct {
 	AssociatePublicIpAddress bool
 	RegionId                 string
 	InternetChargeType       string
+	InternetMaxBandwidthOut  int
 	allocatedId              string
 }
 
@@ -24,6 +25,7 @@ func (s *stepConfigAlicloudEIP) Run(_ context.Context, state multistep.StateBag)
 	ui.Say("Allocating eip")
 	ipaddress, allocateId, err := client.AllocateEipAddress(&ecs.AllocateEipAddressArgs{
 		RegionId: common.Region(s.RegionId), InternetChargeType: common.InternetChargeType(s.InternetChargeType),
+		Bandwidth: s.InternetMaxBandwidthOut,
 	})
 	if err != nil {
 		state.Put("error", err)


### PR DESCRIPTION
Fix alicloud plugin eip bandwidth allocating issue

alicloud builder does not pass the `internet_max_bandwidth_out` field when allocating eip, thus the bandwidth of the allocated eip will be the default value which is 5 Mbps.
