### PR TITLE
Fixes SetVirtualMachineSecureBoot function

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -518,8 +518,13 @@ Hyper-V\Set-VMNetworkAdapter -VMName $vmName -MacAddressSpoofing $enableMacSpoof
 
 func SetVirtualMachineSecureBoot(vmName string, enableSecureBoot bool, templateName string) error {
 	var script = `
-param([string]$vmName, $enableSecureBoot)
-Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBoot
+param([string]$vmName, [string]$enableSecureBootString, [string]$templateName)
+$cmdletParameterExists = Get-Help SetVMFirmware -Parameter SecureBootTemplate -ErrorAction SilentlyContinue
+if ($cmdletParameterExists) {
+	Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBootString -SecureBootTemplate $templateName
+} else {
+	Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBootString
+}
 `
 
 	var ps powershell.PowerShellCmd


### PR DESCRIPTION
Hyperv-iso - Secure Boot Template doesn't change #6349

Fixed SecureBootTemplate not being passed through to PS cmdlet
Added check for SecureBootTemplate parameter for Server 2012 and below
Corrected enableSecureBootString usage

Closes #6349 - Hyperv-iso - Secure Boot Template doesn't change
