### PR TITLE
Hyper-V: Use Get-Command over Get-Help to check for SecureBootTemplate parameter

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -267,7 +267,7 @@ if ($harddrivePath){
 func DisableAutomaticCheckpoints(vmName string) error {
 	var script = `
 param([string]$vmName)
-if ((Get-Command Hyper-V\Set-Vm).Parameters["AutomaticCheckpointsEnabled"]) { 
+if ((Get-Command Hyper-V\Set-Vm).Parameters["AutomaticCheckpointsEnabled"]) {
 	Hyper-V\Set-Vm -Name $vmName -AutomaticCheckpointsEnabled $false }
 `
 	var ps powershell.PowerShellCmd
@@ -279,7 +279,7 @@ func ExportVmxcVirtualMachine(exportPath string, vmName string, snapshotName str
 	var script = `
 param([string]$exportPath, [string]$vmName, [string]$snapshotName, [string]$allSnapshotsString)
 
-$WorkingPath = Join-Path $exportPath $vmName 
+$WorkingPath = Join-Path $exportPath $vmName
 
 if (Test-Path $WorkingPath) {
 	throw "Export path working directory: $WorkingPath already exists!"
@@ -297,7 +297,7 @@ if ($snapshotName) {
     } else {
         $snapshot = $null
     }
-    
+
     if (!$snapshot) {
         #No snapshot clone
         Hyper-V\Export-VM -Name $vmName -Path $exportPath -ErrorAction Stop
@@ -328,7 +328,7 @@ param([string]$exportPath, [string]$cloneFromVmxcPath)
 if (!(Test-Path $cloneFromVmxcPath)){
 	throw "Clone from vmxc directory: $cloneFromVmxcPath does not exist!"
 }
-	
+
 if (!(Test-Path $exportPath)){
 	New-Item -ItemType Directory -Force -Path $exportPath
 }
@@ -390,12 +390,12 @@ if ($vhdPath){
 		$existingFirstHarddrive | Hyper-V\Set-VMHardDiskDrive -Path $vhdPath
 	} else {
 		Hyper-V\Add-VMHardDiskDrive -VM $compatibilityReport.VM -Path $vhdPath
-	}	
+	}
 }
 Hyper-V\Set-VMMemory -VM $compatibilityReport.VM -StartupBytes $memoryStartupBytes
 $networkAdaptor = $compatibilityReport.VM.NetworkAdapters | Select -First 1
 Hyper-V\Disconnect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor
-Hyper-V\Connect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor -SwitchName $switchName 
+Hyper-V\Connect-VMNetworkAdapter -VMNetworkAdapter $networkAdaptor -SwitchName $switchName
 $vm = Hyper-V\Import-VM -CompatibilityReport $compatibilityReport
 
 if ($vm) {
@@ -519,8 +519,9 @@ Hyper-V\Set-VMNetworkAdapter -VMName $vmName -MacAddressSpoofing $enableMacSpoof
 func SetVirtualMachineSecureBoot(vmName string, enableSecureBoot bool, templateName string) error {
 	var script = `
 param([string]$vmName, [string]$enableSecureBootString, [string]$templateName)
-$cmdletParameterExists = Get-Help SetVMFirmware -Parameter SecureBootTemplate -ErrorAction SilentlyContinue
-if ($cmdletParameterExists) {
+$cmdlet = Get-Command Hyper-V\Set-VMFirmware
+# The SecureBootTemplate parameter is only available in later versions
+if ($cmdlet.Parameters.SecureBootTemplate) {
 	Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBootString -SecureBootTemplate $templateName
 } else {
 	Hyper-V\Set-VMFirmware -VMName $vmName -EnableSecureBoot $enableSecureBootString


### PR DESCRIPTION
I was about to comment in #6419 when it got merged! 

While the overall logic and additional checks introduced in that PR look good, there was a small typo in the command that checked for the `SecureBootTemplate` parameter. 

Additionally, while checking for the existence of the `SecureBootTemplate` parameter is a neat addition, using `Get-Help` may not be the most reliable way to perform the check. This is because we can't guarantee the help files `Get-Help` relies upon have been installed - see [HERE](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/get-help?view=powershell-6#notes) for info.

This PR introduces a small change that replaces the command to check whether the SecureBootTemplate parameter exists.