### PR TITLE
Prevent hang on export when using VMware ISO builder on remote ESXi host 

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -221,6 +221,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 			fmt.Errorf("format must be one of ova, ovf, or vmx"))
 	}
 
+	if b.config.RemoteType == "esx5" && b.config.SkipExport != true && b.config.RemotePassword == "" {
+		errs = packer.MultiErrorAppend(errs,
+			fmt.Errorf("exporting the vm (with ovftool) requires that you set a value for remote_password"))
+	}
+
 	// Warnings
 	if b.config.ShutdownCommand == "" {
 		warnings = append(warnings,

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -182,6 +182,34 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare_RemoteExport(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	config["remote_type"] = "esx5"
+	config["remote_host"] = "foobar.example.com"
+	// Bad
+	config["remote_password"] = ""
+	warns, err := b.Prepare(config)
+	if len(warns) != 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Good
+	config["remote_password"] = "supersecret"
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
 func TestBuilderPrepare_Format(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -145,6 +145,7 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 
 	config["format"] = "ovf"
 	config["remote_host"] = "foobar.example.com"
+	config["remote_password"] = "supersecret"
 	// Bad
 	config["remote_type"] = "foobar"
 	warns, err := b.Prepare(config)
@@ -155,9 +156,10 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 		t.Fatal("should have error")
 	}
 
-	config["remote_host"] = ""
-	config["remote_type"] = ""
+	config["remote_type"] = "esx5"
 	// Bad
+	config["remote_host"] = ""
+	b = Builder{}
 	warns, err = b.Prepare(config)
 	if len(warns) > 0 {
 		t.Fatalf("bad: %#v", warns)
@@ -169,6 +171,7 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 	// Good
 	config["remote_type"] = "esx5"
 	config["remote_host"] = "foobar.example.com"
+	config["remote_password"] = "supersecret"
 	b = Builder{}
 	warns, err = b.Prepare(config)
 	if len(warns) > 0 {

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -169,6 +169,20 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 	}
 
 	// Good
+	config["remote_type"] = ""
+	config["remote_host"] = ""
+	config["remote_password"] = ""
+	config["remote_private_key_file"] = ""
+	b = Builder{}
+	warns, err = b.Prepare(config)
+	if len(warns) > 0 {
+		t.Fatalf("bad: %#v", warns)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	// Good
 	config["remote_type"] = "esx5"
 	config["remote_host"] = "foobar.example.com"
 	config["remote_password"] = "supersecret"

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -177,18 +177,6 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not have error: %s", err)
 	}
-
-	// Good
-	config["remote_type"] = "esx5"
-	config["remote_host"] = "foobar.example.com"
-	b = Builder{}
-	warns, err = b.Prepare(config)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
 }
 
 func TestBuilderPrepare_Format(t *testing.T) {

--- a/website/source/docs/builders/vmware-iso.html.md.erb
+++ b/website/source/docs/builders/vmware-iso.html.md.erb
@@ -540,6 +540,9 @@ modify as well:
     format of the exported virtual machine. This defaults to "ovf".
     Before using this option, you need to install `ovftool`. This option
     works currently only with option remote_type set to "esx5".
+    Since ovftool is only capable of password based authentication
+    `remote_password` must be set when exporting the VM.
+
 
 ### VNC port discovery
 

--- a/website/source/docs/builders/vmware-iso.html.md.erb
+++ b/website/source/docs/builders/vmware-iso.html.md.erb
@@ -332,8 +332,13 @@ builder.
     using this configuration value. Defaults to `false`.
 
 -   `skip_export` (boolean) - Defaults to `false`. When enabled, Packer will
-    not export the VM. Useful if the build output is not the resultant image,
-    but created inside the VM.
+    not export the VM. Useful if the build output is not the resultant
+    image, but created inside the VM.
+    Currently, exporting the build VM is only supported when building on
+    ESXi e.g. when `remote_type` is set to `esx5`. See the [Building on a
+    Remote vSphere
+    Hypervisor](/docs/builders/vmware-iso.html#building-on-a-remote-vsphere-hypervisor)
+    section below for more info.
 
 -   `keep_registered` (boolean) - Set this to `true` if you would like to keep
     the VM registered with the remote ESXi server. This is convenient if you
@@ -345,6 +350,11 @@ builder.
     during export. Each item in the array is a new argument. The options
     `--noSSLVerify`, `--skipManifestCheck`, and `--targetType` are reserved,
     and should not be passed to this argument.
+    Currently, exporting the build VM (with ovftool) is only supported when
+    building on ESXi e.g. when `remote_type` is set to `esx5`. See the
+    [Building on a Remote vSphere
+    Hypervisor](/docs/builders/vmware-iso.html#building-on-a-remote-vsphere-hypervisor)
+    section below for more info.
 
 -   `sound` (boolean) - Enable VMware's virtual soundcard device for the VM.
 
@@ -539,7 +549,7 @@ modify as well:
 -   `format` (string) - Either "ovf", "ova" or "vmx", this specifies the output
     format of the exported virtual machine. This defaults to "ovf".
     Before using this option, you need to install `ovftool`. This option
-    works currently only with option remote_type set to "esx5".
+    currently only works when option remote_type is set to "esx5".
     Since ovftool is only capable of password based authentication
     `remote_password` must be set when exporting the VM.
 


### PR DESCRIPTION
Since `ovftool` only supports password based authentication a value for `remote_password` must be set in the build template for the export to succeed.

If `remote_password` is not set, Packer hangs when exporting the VM.

Clearly, if a user has set up key based authentication with `remote_private_key_file` then they may naturally assume that `remote_password` does not need to be set.

This PR ensures `remote_password` is set when required, failing the build template at validation if it is not.

This issue may affect users who had previously not encounter any errors due to #4538.