### PR TITLE
HTTP CONNECT proxy and proxy+bastion support

### DIFF
--- a/communicator/ssh/connect.go
+++ b/communicator/ssh/connect.go
@@ -1,8 +1,13 @@
 package ssh
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -41,6 +46,57 @@ func ProxyConnectFunc(socksProxy string, socksAuth *proxy.Auth, network, addr st
 		c, err := dialer.Dial(network, addr)
 		if err != nil {
 			return nil, err
+		}
+
+		return c, nil
+	}
+}
+
+// ProxyConnectFunc is a convenience method for returning a function
+// that connects to a host using an HTTP CONNECT proxy
+//
+// Note: shamelessly copied from https://github.com/golang/build/blob/ce623a5/cmd/buildlet/reverse.go#L213
+func HTTPProxyConnectFunc(proxyURL *url.URL, addr string) func() (net.Conn, error) {
+	return func() (net.Conn, error) {
+		proxyAddr := proxyURL.Host
+		if proxyURL.Port() == "" {
+			proxyAddr = net.JoinHostPort(proxyAddr, "80")
+		}
+
+		c, err := net.Dial("tcp", proxyAddr)
+		if err != nil {
+			return nil, fmt.Errorf("dialing proxy %q failed: %v", proxyAddr, err)
+		}
+
+		req := bytes.NewBuffer(nil)
+		fmt.Fprintf(req, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n", addr, proxyURL.Hostname())
+		if proxyURL.User != nil {
+			auth := proxyURL.User.Username()
+			if p, ok := proxyURL.User.Password(); ok {
+				auth += ":" + p
+			}
+
+			fmt.Fprintf(req, "Proxy-Authorization: Basic %s\r\n", base64.StdEncoding.EncodeToString([]byte(auth)))
+		}
+		fmt.Fprintf(req, "\r\n")
+
+		req.WriteTo(c)
+
+		br := bufio.NewReader(c)
+		res, err := http.ReadResponse(br, nil)
+		if err != nil {
+			return nil, fmt.Errorf("reading HTTP response from CONNECT to %s via proxy %s failed: %v", addr, proxyAddr, err)
+		}
+		if res.StatusCode != 200 {
+			return nil, fmt.Errorf("proxy error from %s while dialing %s: %v", proxyAddr, addr, res.Status)
+		}
+
+		// It's safe to discard the bufio.Reader here and return the
+		// original TCP conn directly because we only use this for
+		// TLS, and in TLS the client speaks first, so we know there's
+		// no unbuffered data. But we can double-check.
+		if br.Buffered() > 0 {
+			return nil, fmt.Errorf("unexpected %d bytes of buffered data from CONNECT proxy %q", br.Buffered(), proxyAddr)
 		}
 
 		return c, nil

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	SSHProxyPort              int           `mapstructure:"ssh_proxy_port"`
 	SSHProxyUsername          string        `mapstructure:"ssh_proxy_username"`
 	SSHProxyPassword          string        `mapstructure:"ssh_proxy_password"`
+	SSHHTTPProxy              string        `mapstructure:"ssh_http_proxy"`
 	SSHKeepAliveInterval      time.Duration `mapstructure:"ssh_keep_alive_interval"`
 	SSHReadWriteTimeout       time.Duration `mapstructure:"ssh_read_write_timeout"`
 
@@ -188,6 +189,10 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 		errs = append(errs, fmt.Errorf(
 			"ssh_file_transfer_method ('%s') is invalid, valid methods: sftp, scp",
 			c.SSHFileTransferMethod))
+	}
+
+	if c.SSHProxyHost != "" && c.SSHHTTPProxy != "" {
+		errs = append(errs, errors.New("please specify either ssh_proxy_host or ssh_http_proxy, but not both"))
 	}
 
 	return errs

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -190,10 +190,6 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 			c.SSHFileTransferMethod))
 	}
 
-	if c.SSHBastionHost != "" && c.SSHProxyHost != "" {
-		errs = append(errs, errors.New("please specify either ssh_bastion_host or ssh_proxy_host, not both"))
-	}
-
 	return errs
 }
 

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -91,6 +91,9 @@ The SSH communicator has the following options:
 -   `ssh_host` (string) - The address to SSH to. This usually is automatically
     configured by the builder.
 
+-   `ssh_http_proxy` (string) - The URL of an HTTP CONNECT proxy to use for
+    SSH communication. Optional.
+
 *   `ssh_keep_alive_interval` (string) - How often to send "keep alive"
     messages to the server. Set to a negative value (`-1s`) to disable. Example
     value: `10s`. Defaults to `5s`.


### PR DESCRIPTION
This change set introduces two pieces of functionality:

1. support for using a proxy and a bastion host at the same time
2. support for http connect-style proxies

The intention is to allow connection via a bastion host from behind a
corporate firewall.

This does not have tests right now - I put these changes together
yesterday while trying to get a deployment off the ground, and I'm still
busy with that. I might not be able to come back around to write tests
for some time.