### PR TITLE
scaleway: add 'bootscript' configuration parameter

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	SnapshotName string `mapstructure:"snapshot_name"`
 	ImageName    string `mapstructure:"image_name"`
 	ServerName   string `mapstructure:"server_name"`
+	Bootscript   string `mapstructure:"bootscript"`
 
 	UserAgent string
 	ctx       interpolate.Context

--- a/builder/scaleway/step_create_server.go
+++ b/builder/scaleway/step_create_server.go
@@ -20,8 +20,13 @@ func (s *stepCreateServer) Run(_ context.Context, state multistep.StateBag) mult
 	c := state.Get("config").(Config)
 	sshPubKey := state.Get("ssh_pubkey").(string)
 	tags := []string{}
+	var bootscript *string
 
 	ui.Say("Creating server...")
+
+	if c.Bootscript != "" {
+		bootscript = &c.Bootscript
+	}
 
 	if sshPubKey != "" {
 		tags = []string{fmt.Sprintf("AUTHORIZED_KEY=%s", strings.TrimSpace(sshPubKey))}
@@ -33,6 +38,7 @@ func (s *stepCreateServer) Run(_ context.Context, state multistep.StateBag) mult
 		Organization:   c.Organization,
 		CommercialType: c.CommercialType,
 		Tags:           tags,
+		Bootscript:     bootscript,
 	})
 
 	if err != nil {

--- a/website/source/docs/builders/scaleway.html.md
+++ b/website/source/docs/builders/scaleway.html.md
@@ -74,6 +74,9 @@ builder.
 -   `snapshot_name` (string) - The name of the resulting snapshot that will
     appear in your account. Default `packer-TIMESTAMP`
 
+-   `bootscript` (string) - The id of an existing bootscript to use when booting
+    the server.
+
 ## Basic Example
 
 Here is a basic example. It is completely valid as soon as you enter your own


### PR DESCRIPTION
This PR adds a "bootscript" configuration parameter to the Scaleway builder, allowing the user to not use the default local bootscript when spawning a packer instance.

Not passing this new "bootscript" parameter should not break the previous builder behavior, as it defaults to the currently passed value (a nil string pointer).

Bootscripts (https://www.scaleway.com/docs/bootscript-and-how-to-use-it/) may be used to access the main block device of a single-disk instance from a provisionner (by using a rescue-mode bootscript), hence allowing to create an image from scratch on small "commercial types" (scaleway's instance types) -  at least, that's how i use them with packer. 

