### PR TITLE
Further simplify enumeration of attached disks for VMware VMX builder

### DIFF
--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -19,42 +19,6 @@ type StepCloneVMX struct {
 	VMName    string
 }
 
-type vmxAdapter struct {
-	diskPathKeyRe string
-}
-
-var (
-	// The VMX file stores the path to a configured disk, and information
-	// about that disks attachment to a virtual adapter/controller, as a
-	// key/value pair.
-	// For a virtual disk attached to bus ID 3 of the virtual machines
-	// first SCSI adapter the key/value pair would look something like:
-	// scsi0:3.fileName = "relative/path/to/scsiDisk.vmdk"
-	// The supported adapter types and configuration maximums for each type
-	// vary according to the VMware platform type and version, and the
-	// Virtual Machine Hardware version used. See the 'Virtual Machine
-	// Maximums' section within VMware's 'Configuration Maximums'
-	// documentation for each platform:
-	// https://kb.vmware.com/s/article/1003497
-	// Information about the supported Virtual Machine Hardware versions:
-	// https://kb.vmware.com/s/article/1003746
-	// The following regexp's are used to match all possible disk attachment
-	// points that may be found in the VMX file across all VMware
-	// platforms/versions and Virtual Machine Hardware versions
-	scsiAdapter = vmxAdapter{
-		diskPathKeyRe: `(?i)^scsi[[:digit:]]:[[:digit:]]{1,2}\.fileName`,
-	}
-	sataAdapter = vmxAdapter{
-		diskPathKeyRe: `(?i)^sata[[:digit:]]:[[:digit:]]{1,2}\.fileName`,
-	}
-	nvmeAdapter = vmxAdapter{
-		diskPathKeyRe: `(?i)^nvme[[:digit:]]:[[:digit:]]{1,2}\.fileName`,
-	}
-	ideAdapter = vmxAdapter{
-		diskPathKeyRe: `(?i)^ide[[:digit:]]:[[:digit:]]\.fileName`,
-	}
-)
-
 func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(vmwcommon.Driver)
 	ui := state.Get("ui").(packer.Ui)
@@ -81,16 +45,30 @@ func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multiste
 		return multistep.ActionHalt
 	}
 
-	// Search across all adapter types to get the filenames of attached disks
-	allDiskAdapters := []vmxAdapter{
-		scsiAdapter,
-		sataAdapter,
-		nvmeAdapter,
-		ideAdapter,
-	}
 	var diskFilenames []string
-	for _, adapter := range allDiskAdapters {
-		diskFilenames = append(diskFilenames, getAttachedDisks(adapter, vmxData)...)
+	// The VMX file stores the path to a configured disk, and information
+	// about that disks attachment to a virtual adapter/controller, as a
+	// key/value pair.
+	// For a virtual disk attached to bus ID 3 of the virtual machines
+	// first SCSI adapter the key/value pair would look something like:
+	// scsi0:3.fileName = "relative/path/to/scsiDisk.vmdk"
+	// The supported adapter types and configuration maximums for each type
+	// vary according to the VMware platform type and version, and the
+	// Virtual Machine Hardware version used. See the 'Virtual Machine
+	// Maximums' section within VMware's 'Configuration Maximums'
+	// documentation for each platform:
+	// https://kb.vmware.com/s/article/1003497
+	// Information about the supported Virtual Machine Hardware versions:
+	// https://kb.vmware.com/s/article/1003746
+	// The following regexp is used to match all possible disk attachment
+	// points that may be found in the VMX file across all VMware
+	// platforms/versions and Virtual Machine Hardware versions
+	diskPathKeyRe := regexp.MustCompile(`(?i)^(scsi|sata|ide|nvme)[[:digit:]]:[[:digit:]]{1,2}\.fileName`)
+	for k, v := range vmxData {
+		match := diskPathKeyRe.FindString(k)
+		if match != "" && filepath.Ext(v) == ".vmdk" {
+			diskFilenames = append(diskFilenames, v)
+		}
 	}
 
 	// Write out the relative, host filesystem paths to the disks
@@ -125,15 +103,4 @@ func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multiste
 }
 
 func (s *StepCloneVMX) Cleanup(state multistep.StateBag) {
-}
-
-func getAttachedDisks(a vmxAdapter, data map[string]string) (attachedDisks []string) {
-	pathKeyRe := regexp.MustCompile(a.diskPathKeyRe)
-	for k, v := range data {
-		match := pathKeyRe.FindString(k)
-		if match != "" && filepath.Ext(v) == ".vmdk" {
-			attachedDisks = append(attachedDisks, v)
-		}
-	}
-	return
 }


### PR DESCRIPTION
This PR:

* Collates separate regexp's into one for greater efficiency
* Inlines the internals of the `getAttachedDisk` function as we no longer need to call for separate adapter types
 * Removes the now defunct struct and variables

This should probably have gone in with #6229 so apologies for the repeat. However, I didn't really see it then for what ever reason. I've kept the rather lengthy comment in there to explain the regexp/background...

As usual, feedback and suggestions for improvement are welcome