### PR TITLE
Highlight which user Ansible provisioner uses in docs

### DIFF
--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -14,9 +14,10 @@ Type: `ansible`
 The `ansible` Packer provisioner runs Ansible playbooks. It dynamically creates
 an Ansible inventory file configured to use SSH, runs an SSH server, executes
 `ansible-playbook`, and marshals Ansible plays through the SSH server to the
-machine being provisioned by Packer. Note, this means that any `remote_user`
-defined in tasks will be ignored. Packer will always connect with the user
-given in the json config.
+machine being provisioned by Packer. 
+
+-&gt; **Note:**: Any `remote_user` defined in tasks will be ignored. Packer will
+always connect with the user given in the json config for this provisioner.
 
 ## Basic Example
 


### PR DESCRIPTION
SSIA, but to divulge: after failing to read the documentation well enough, my expectations were not aligned with the documentation.

In that spirit, I thought I'd highlight the passage that came to my aid once I took a second (or fifth) look. :)