### PR TITLE
WIP googlecompute: Use "ssh-keys" metadata rather than deprecated "sshKeys"

### DIFF
--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -29,7 +29,7 @@ func (c *Config) createInstanceMetadata(sourceImage *Image, sshPublicKey string)
 	// supplied public key. This is possible if a private_key_file was
 	// specified.
 	if sshPublicKey != "" {
-		sshMetaKey := "sshKeys"
+		sshMetaKey := "ssh-keys"
 		sshKeys := fmt.Sprintf("%s:%s", c.Comm.SSHUsername, sshPublicKey)
 		if confSshKeys, exists := instanceMetadata[sshMetaKey]; exists {
 			sshKeys = fmt.Sprintf("%s\n%s", sshKeys, confSshKeys)

--- a/builder/googlecompute/step_create_instance_test.go
+++ b/builder/googlecompute/step_create_instance_test.go
@@ -308,14 +308,14 @@ func TestCreateInstanceMetadata(t *testing.T) {
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 
 	// ensure our key is listed
-	assert.True(t, strings.Contains(metadata["sshKeys"], key), "Instance metadata should contain provided key")
+	assert.True(t, strings.Contains(metadata["ssh-keys"], key), "Instance metadata should contain provided key")
 }
 
 func TestCreateInstanceMetadata_noPublicKey(t *testing.T) {
 	state := testState(t)
 	c := state.Get("config").(*Config)
 	image := StubImage("test-image", "test-project", []string{}, 100)
-	sshKeys := c.Metadata["sshKeys"]
+	sshKeys := c.Metadata["ssh-keys"]
 
 	// create our metadata
 	metadata, err := c.createInstanceMetadata(image, "")
@@ -323,5 +323,5 @@ func TestCreateInstanceMetadata_noPublicKey(t *testing.T) {
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 
 	// ensure the ssh metadata hasn't changed
-	assert.Equal(t, metadata["sshKeys"], sshKeys, "Instance metadata should not have been modified")
+	assert.Equal(t, metadata["ssh-keys"], sshKeys, "Instance metadata should not have been modified")
 }


### PR DESCRIPTION
As written in the official document, metadata key "sshKeys" is deprecated and replaced by "ssh-keys".

> **Note:** Setting the `sshKeys` metadata value on project metadata is deprecated. Use the `ssh-keys` metadata value instead. You might need to [update the guest environment](https://cloud.google.com/compute/docs/images/configuring-imported-images#install_guest_environment) in instances using older images.

https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys?hl=en#project-wide

With this modification, project-wide SSH keys are now allowed, and the already-closed issue #6201 is actually fixed.

> If (...snip...) or has a deprecated instance-only `sshKeys` value, the instance will ignore all project-wide SSH keys. To apply project-wide keys to an instance, make sure (...snip...) and, if present, remove the deprecated instance-only `sshKeys` value from [instance metadata](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys?hl=en#instance-only).