### PR TITLE
ESXi: Fix failure to discover IP or export VM when 'displayName' differs from 'vm_name'

### DIFF
--- a/builder/vmware/common/step_configure_vmx_test.go
+++ b/builder/vmware/common/step_configure_vmx_test.go
@@ -201,3 +201,29 @@ func TestStepConfigureVMX_generatedAddresses(t *testing.T) {
 		}
 	}
 }
+
+// Should fail if the displayName key is not found in the VMX
+func TestStepConfigureVMX_displayNameMissing(t *testing.T) {
+	state := testState(t)
+	step := new(StepConfigureVMX)
+
+	// testVMXFile adds displayName key/value pair to the VMX
+	vmxPath := testVMXFile(t)
+	defer os.Remove(vmxPath)
+
+	// Bad: Delete displayName from the VMX/Create an empty VMX file
+	err := WriteVMX(vmxPath, map[string]string{})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state.Put("vmx_path", vmxPath)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionHalt {
+		t.Fatalf("bad action: %#v. Should halt when displayName key is missing from VMX", action)
+	}
+	if _, ok := state.GetOk("error"); !ok {
+		t.Fatal("should store error in state when displayName key is missing from VMX")
+	}
+}

--- a/builder/vmware/common/step_configure_vmx_test.go
+++ b/builder/vmware/common/step_configure_vmx_test.go
@@ -227,3 +227,28 @@ func TestStepConfigureVMX_displayNameMissing(t *testing.T) {
 		t.Fatal("should store error in state when displayName key is missing from VMX")
 	}
 }
+
+// Should store the value of displayName in the statebag
+func TestStepConfigureVMX_displayNameStore(t *testing.T) {
+	state := testState(t)
+	step := new(StepConfigureVMX)
+
+	// testVMXFile adds displayName key/value pair to the VMX
+	vmxPath := testVMXFile(t)
+	defer os.Remove(vmxPath)
+
+	state.Put("vmx_path", vmxPath)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	// The value of displayName must be stored in the statebag
+	if _, ok := state.GetOk("display_name"); !ok {
+		t.Fatalf("displayName should be stored in the statebag as 'display_name'")
+	}
+}

--- a/builder/vmware/common/step_configure_vmx_test.go
+++ b/builder/vmware/common/step_configure_vmx_test.go
@@ -14,6 +14,9 @@ func testVMXFile(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+
+	// displayName must always be set
+	err = WriteVMX(tf.Name(), map[string]string{"displayName": "PackerBuild"})
 	tf.Close()
 
 	return tf.Name()
@@ -132,12 +135,29 @@ func TestStepConfigureVMX_generatedAddresses(t *testing.T) {
 	vmxPath := testVMXFile(t)
 	defer os.Remove(vmxPath)
 
-	err := WriteVMX(vmxPath, map[string]string{
-		"foo": "bar",
-		"ethernet0.generatedAddress":       "foo",
-		"ethernet1.generatedAddress":       "foo",
-		"ethernet1.generatedAddressOffset": "foo",
-	})
+	additionalTestVmxData := []struct {
+		Key   string
+		Value string
+	}{
+		{"foo", "bar"},
+		{"ethernet0.generatedaddress", "foo"},
+		{"ethernet1.generatedaddress", "foo"},
+		{"ethernet1.generatedaddressoffset", "foo"},
+	}
+
+	// Get any existing VMX data from the VMX file
+	vmxData, err := ReadVMX(vmxPath)
+	if err != nil {
+		t.Fatalf("err %s", err)
+	}
+
+	// Add the additional key/value pairs we need for this test to the existing VMX data
+	for _, data := range additionalTestVmxData {
+		vmxData[data.Key] = data.Value
+	}
+
+	// Recreate the VMX file so it includes all the data needed for this test
+	err = WriteVMX(vmxPath, vmxData)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -157,7 +177,7 @@ func TestStepConfigureVMX_generatedAddresses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	vmxData := ParseVMX(string(vmxContents))
+	vmxData = ParseVMX(string(vmxContents))
 
 	cases := []struct {
 		Key   string
@@ -180,5 +200,4 @@ func TestStepConfigureVMX_generatedAddresses(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/builder/vmware/common/step_configure_vmx_test.go
+++ b/builder/vmware/common/step_configure_vmx_test.go
@@ -252,3 +252,19 @@ func TestStepConfigureVMX_displayNameStore(t *testing.T) {
 		t.Fatalf("displayName should be stored in the statebag as 'display_name'")
 	}
 }
+
+func TestStepConfigureVMX_vmxPathBad(t *testing.T) {
+	state := testState(t)
+	step := new(StepConfigureVMX)
+
+	state.Put("vmx_path", "some_bad_path")
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionHalt {
+		t.Fatalf("bad action: %#v. Should halt when vmxPath is bad", action)
+	}
+	if _, ok := state.GetOk("error"); !ok {
+		t.Fatal("should store error in state when vmxPath is bad")
+	}
+
+}

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -389,7 +389,13 @@ func (d *ESX5Driver) CommHost(state multistep.StateBag) (string, error) {
 		return "", err
 	}
 
-	record, err := r.find("Name", config.VMName)
+	// The value in the Name field returned by 'esxcli network vm list'
+	// corresponds directly to the value of displayName set in the VMX file
+	var displayName string
+	if v, ok := state.GetOk("display_name"); ok {
+		displayName = v.(string)
+	}
+	record, err := r.find("Name", displayName)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
For a VMware-ISO build against ESXi, when the value of `displayName` (set in the VMX file) differs from `vm_name` (set in the build template) Packer fails:

* To discover the build VMs IP address
* To discover and export the build VM

Example log output showing failure to discover the build VMs IP:

```
2018/07/02 16:21:10 ui: ==> vmware-iso-vsphere: Waiting for SSH to become available...
2018/07/02 16:21:10 packer: 2018/07/02 16:21:10 [DEBUG] Opening new ssh session
2018/07/02 16:21:10 packer: 2018/07/02 16:21:10 [DEBUG] starting remote command: esxcli --formatter csv network vm list
2018/07/02 16:21:11 packer: 2018/07/02 16:21:11 [DEBUG] Error getting SSH address: EOF
```

The message repeats until the ssh timeout is reached.

Example log output showing failure to discover and export the build VM:

```
2018/07/01 22:06:04 ui: ==> vmware-iso-vsphere: Exporting virtual machine...
2018/07/01 22:06:04 ui:     vmware-iso-vsphere: Executing: ovftool --noSSLVerify=true --skipManifestCheck -tt=ovf vi://root:****@esx67standalone.manage.localdomain/debian-94-x86_64-std-vmware-iso-vsphere output-debian-94-x86_64-std-vmware-iso-vsphere
2018/07/01 22:06:05 ui error: ==> vmware-iso-vsphere: Error exporting virtual machine: exit status 1
==> vmware-iso-vsphere: Opening VI source: vi://root@esx67standalone.manage.localdomain:443/debian-94-x86_64-std-vmware-iso-vsphere
==> vmware-iso-vsphere: Error: Locator does not refer to an object: vi://root@esx67standalone.manage.localdomain:443ha-datacenter/host/esx67standalone.manage.localdomain/Resources/debian-94-x86_64-std-vmware-iso-vsphere
==> vmware-iso-vsphere: Completed with errors
```


The failures occur because the value of `vm_name` has been used in commands, when `displayName` should have been used instead.

By default, Packer will configure and build a VMX file with `displayName` set to the same value as `vm_name` in the users build template. However, it is sometimes desirable to set `displayName` to some other custom value. This can be achieved through use of the `vmx_data` setting in the build template:

```
  ...
  "builders": [
    {
      "type": "vmware-iso",
      "vm_name": "Centos7",
      "vmx_data": {
        "displayName": "Packer-Centos7-Build",
      },
  ...
```

This PR fixes the failures seen with the above configuration by correctly using `displayName` rather than `vm_name` in the the arguments to the failing commands.

As usual, feedback and suggestions for improvement are welcome.