### PR TITLE
Add feature to googlecompute-import post-processor to delete GCS files

### DIFF
--- a/website/source/docs/post-processors/googlecompute-import.html.md
+++ b/website/source/docs/post-processors/googlecompute-import.html.md
@@ -54,6 +54,8 @@ for details.
 
 -   `keep_input_artifact` (boolean) - if true, do not delete the compressed RAW disk image. Defaults to false.
 
+-   `skip_clean` (boolean) - Skip removing the TAR file uploaded to the GCS bucket after the import process has completed. "true" means that we should leave it in the GCS bucket, "false" means to clean it out. Defaults to `false`.
+
 
 ## Basic Example
 


### PR DESCRIPTION
New skip_clean config option added to control deleting import tar files from GCS bucket. Defaults to false meaning by default delete import tar files from the GCS bucket.