### PR TITLE
Ensure amazon-private-ip fixes string values

### DIFF
--- a/fix/fixer_amazon_private_ip.go
+++ b/fix/fixer_amazon_private_ip.go
@@ -2,6 +2,7 @@ package fix
 
 import (
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -49,8 +50,12 @@ func (FixerAmazonPrivateIP) Fix(input map[string]interface{}) (map[string]interf
 		}
 		privateIP, ok := privateIPi.(bool)
 		if !ok {
-			log.Fatalf("Wrong type for ssh_private_ip")
-			continue
+			var err error
+			privateIP, err = strconv.ParseBool(privateIPi.(string))
+			if err != nil {
+				log.Fatalf("Wrong type for ssh_private_ip")
+				continue
+			}
 		}
 
 		delete(builder, "ssh_private_ip")

--- a/fix/fixer_amazon_private_ip_test.go
+++ b/fix/fixer_amazon_private_ip_test.go
@@ -39,6 +39,19 @@ func TestFixerAmazonPrivateIP(t *testing.T) {
 				"ssh_interface": "private_ip",
 			},
 		},
+
+		// ssh_private_ip specified as string
+		{
+			Input: map[string]interface{}{
+				"type":           "amazon-ebs",
+				"ssh_private_ip": "true",
+			},
+
+			Expected: map[string]interface{}{
+				"type":          "amazon-ebs",
+				"ssh_interface": "private_ip",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
The "ssh_private_ip" key works with either boolean values or string representations of booleans. The fixer errors when the value is defined as, for example, "true" (with quotation marks). This commit will attempt to convert the string into a bool when necessary to ensure this case is handled.

For example:

```
{
  "builders": [
    {
      "type": "amazon-ebs",
      "ssh_private_ip": "true"
    }
  ]
}
```

This JSON is valid and will behave as expected (including passing validation pre-deprecation). However, the associated fixer will not fix it as the value of `ssh_private_ip` is a string rather than a bool.