### PR TITLE
VMX builder: Extend doc for new linked clones capability

### DIFF
--- a/website/source/docs/builders/vmware-vmx.html.md.erb
+++ b/website/source/docs/builders/vmware-vmx.html.md.erb
@@ -137,7 +137,18 @@ builder.
     doesn't shut down in this time, it is an error. By default, the timeout is
     `5m` or five minutes.
 
--   `linked` (boolean) - Virtual machine is created a linked clone. 
+-   `linked` (boolean) - By default Packer creates a 'full' clone of
+    the virtual machine specified in `source_path`. The resultant virtual
+    machine is fully independant from the parent it was cloned from.
+
+    Setting `linked` to `true` instead causes Packer to create the virtual
+    machine as a 'linked' clone. Linked clones use and require ongoing
+    access to the disks of the parent virtual machine. The benefit of a
+    linked clone is that the clones virtual disk is typically very much
+    smaller than would be the case for a full clone. Additionally, the
+    cloned virtual machine can also be created much faster. Creating a
+    linked clone will typically only be of benefit in some advanced build
+    scenarios. Most users will wish to create a full clone instead.
     Defaults to `false`.
 
 -   `skip_compaction` (boolean) - VMware-created disks are defragmented and


### PR DESCRIPTION
This PR tries to provide a bit of a better explanation of the new ability to create linked clones when building with the VMware VMX builder.

Comments and suggestions for improvements are welcome. 
