### PR TITLE
managed_image_resource_group_name max length change

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -47,7 +47,7 @@ const (
 	//  -> ^[^_\W][\w-._]{0,79}(?<![-.])$
 	//
 	// This is not an exhaustive match, but it should be extremely close.
-	validResourceGroupNameRe = "^[^_\\W][\\w-._\\(\\)]{0,63}$"
+	validResourceGroupNameRe = "^[^_\\W][\\w-._\\(\\)]{0,89}$"
 	validManagedDiskName     = "^[^_\\W][\\w-._)]{0,79}$"
 )
 


### PR DESCRIPTION
The documentation linked in your source code (https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions) has updated the max length to 90 from 64. I'm not sure why the regex is one less, but it seems to be a convention so I followed it. There didn't seem to be a negative test for this so I did not add one. 

I've also validated you can create a 90 character RG but not a 91 character.