### PR TITLE
don't try to determine file or folder with winrm communicator; not al…

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -122,26 +122,11 @@ func runCommand(shell *winrm.Shell, cmd *winrm.Command, rc *packer.RemoteCmd) {
 }
 
 // Upload implementation of communicator.Communicator interface
-func (c *Communicator) Upload(path string, input io.Reader, fi *os.FileInfo) error {
+func (c *Communicator) Upload(path string, input io.Reader, _ *os.FileInfo) error {
 	wcp, err := c.newCopyClient()
-	if err != nil {
-		return err
-	}
-
 	if err != nil {
 		return fmt.Errorf("Was unable to create winrm client: %s", err)
 	}
-	client, err := c.newWinRMClient()
-	stdout, _, _, err := client.RunWithString(fmt.Sprintf("powershell -Command \"(Get-Item %s) -is [System.IO.DirectoryInfo]\"", path), "")
-	if err != nil {
-		return fmt.Errorf("Couldn't determine whether destination was a folder or file: %s", err)
-	}
-	if strings.Contains(stdout, "True") {
-		// The path exists and is a directory.
-		// Upload file into the directory instead of overwriting.
-		path = filepath.Join(path, filepath.Base((*fi).Name()))
-	}
-
 	log.Printf("Uploading file to '%s'", path)
 	return wcp.Write(path, input)
 }


### PR DESCRIPTION
We've already reverted this attempted helpfulness for the other communicators; we should have done it with the winrm communicator too. It should have been obvious to me when I was writing it that this would break things for systems that don't have Powershell.

closes #6476