### PR TITLE
Update documentation for building on ESXi 6.5 and 6.7

### DIFF
--- a/website/source/docs/builders/vmware-iso.html.md.erb
+++ b/website/source/docs/builders/vmware-iso.html.md.erb
@@ -105,7 +105,7 @@ builder.
     this logic. This field can be specified as either `ide`, `sata`, or `scsi`.
 
 -   `disable_vnc` (boolean) - Whether to create a VNC connection or not.
-    A `boot_command` cannot be used when this is `false`. Defaults to `false`.
+    A `boot_command` cannot be used when this is `true`. Defaults to `false`.
 
 -   `disk_adapter_type` (string) - The adapter type of the VMware virtual disk
     to create. This option is for advanced usage, modify only if you know what

--- a/website/source/docs/builders/vmware-iso.html.md.erb
+++ b/website/source/docs/builders/vmware-iso.html.md.erb
@@ -412,7 +412,9 @@ builder.
     wish to bind to all interfaces use `0.0.0.0`.
 
 -   `vnc_disable_password` (boolean) - Don't auto-generate a VNC password that
-    is used to secure the VNC communication with the VM.
+    is used to secure the VNC communication with the VM. This must be set to 
+    `true` if building on ESXi 6.5 and 6.7 with VNC enabled. Defaults to
+    `false`.
 
 -   `vnc_port_min` and `vnc_port_max` (number) - The minimum and maximum port
     to use for VNC access to the virtual machine. The builder uses VNC to type
@@ -553,6 +555,8 @@ modify as well:
     Since ovftool is only capable of password based authentication
     `remote_password` must be set when exporting the VM.
 
+-   `vnc_disable_password` - This must be set to "true" when using VNC with
+    ESXi 6.5 or 6.7.
 
 ### VNC port discovery
 


### PR DESCRIPTION
This updates the documentation to clarify what settings are needed to use VNC in the vmware-iso builder with ESXi 6.5 and 6.7 per #5580.  It also fixes a slight logic error in the description of `disable_vnc`.