### PR TITLE
Vagrant post-processor for using a Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ package:
 	@sh -c "$(CURDIR)/scripts/dist.sh $(VERSION)"
 
 deps:
+	@go get golang.org/x/tools/cmd/goimports
 	@go get golang.org/x/tools/cmd/stringer
 	@go get -u github.com/mna/pigeon
 	@go get github.com/kardianos/govendor

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,10 @@ LINUX_BASE_BOX = "bento/ubuntu-16.04"
 FREEBSD_BASE_BOX = "jen20/FreeBSD-12.0-CURRENT"
 
 Vagrant.configure(2) do |config|
+        if Vagrant.has_plugin?("vagrant-cachier")
+                config.cache.scope = :box
+        end
+
 	# Compilation and development boxes
 	config.vm.define "linux", autostart: true, primary: true do |vmCfg|
 		vmCfg.vm.box = LINUX_BASE_BOX

--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/packer/template/interpolate"
 )
 
+const BuilderIdImport = "packer.post-processor.docker-import"
+
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
@@ -103,5 +105,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		return nil, false, err
 	}
 
-	return nil, false, nil
+	artifact = &docker.ImportArtifact{
+		BuilderIdValue: BuilderIdImport,
+		Driver:         driver,
+		IdValue:        name,
+	}
+
+	return artifact, true, nil
 }

--- a/post-processor/docker-push/post-processor_test.go
+++ b/post-processor/docker-push/post-processor_test.go
@@ -42,11 +42,11 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 	}
 
 	result, keep, err := p.PostProcess(testUi(), artifact)
-	if result != nil {
-		t.Fatal("should be nil")
+	if _, ok := result.(packer.Artifact); !ok {
+		t.Fatal("should be instance of Artifact")
 	}
-	if keep {
-		t.Fatal("should not keep")
+	if !keep {
+		t.Fatal("should keep")
 	}
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -57,6 +57,9 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 	}
 	if driver.PushName != "foo/bar" {
 		t.Fatal("bad name")
+	}
+	if result.Id() != "foo/bar" {
+		t.Fatal("bad image id")
 	}
 }
 
@@ -69,11 +72,11 @@ func TestPostProcessor_PostProcess_portInName(t *testing.T) {
 	}
 
 	result, keep, err := p.PostProcess(testUi(), artifact)
-	if result != nil {
-		t.Fatal("should be nil")
+	if _, ok := result.(packer.Artifact); !ok {
+		t.Fatal("should be instance of Artifact")
 	}
-	if keep {
-		t.Fatal("should not keep")
+	if !keep {
+		t.Fatal("should keep")
 	}
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -84,6 +87,9 @@ func TestPostProcessor_PostProcess_portInName(t *testing.T) {
 	}
 	if driver.PushName != "localhost:5000/foo/bar" {
 		t.Fatal("bad name")
+	}
+	if result.Id() != "localhost:5000/foo/bar" {
+		t.Fatal("bad image id")
 	}
 }
 
@@ -96,11 +102,11 @@ func TestPostProcessor_PostProcess_tags(t *testing.T) {
 	}
 
 	result, keep, err := p.PostProcess(testUi(), artifact)
-	if result != nil {
-		t.Fatal("should be nil")
+	if _, ok := result.(packer.Artifact); !ok {
+		t.Fatal("should be instance of Artifact")
 	}
-	if keep {
-		t.Fatal("should not keep")
+	if !keep {
+		t.Fatal("should keep")
 	}
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -111,5 +117,8 @@ func TestPostProcessor_PostProcess_tags(t *testing.T) {
 	}
 	if driver.PushName != "hashicorp/ubuntu:precise" {
 		t.Fatalf("bad name: %s", driver.PushName)
+	}
+	if result.Id() != "hashicorp/ubuntu:precise" {
+		t.Fatal("bad image id")
 	}
 }

--- a/post-processor/vagrant/docker.go
+++ b/post-processor/vagrant/docker.go
@@ -1,0 +1,26 @@
+package vagrant
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/packer"
+)
+
+type DockerProvider struct{}
+
+func (p *DockerProvider) KeepInputArtifact() bool {
+	return false
+}
+
+func (p *DockerProvider) Process(ui packer.Ui, artifact packer.Artifact, dir string) (vagrantfile string, metadata map[string]interface{}, err error) {
+	// Create the metadata
+	metadata = map[string]interface{}{"provider": "docker"}
+
+	vagrantfile = fmt.Sprintf(dockerVagrantfile)
+	return
+}
+
+var dockerVagrantfile = `
+Vagrant.configure("2") do |config|
+end
+`

--- a/post-processor/vagrant/docker.go
+++ b/post-processor/vagrant/docker.go
@@ -16,11 +16,14 @@ func (p *DockerProvider) Process(ui packer.Ui, artifact packer.Artifact, dir str
 	// Create the metadata
 	metadata = map[string]interface{}{"provider": "docker"}
 
-	vagrantfile = fmt.Sprintf(dockerVagrantfile)
+	vagrantfile = fmt.Sprintf(dockerVagrantfile, artifact.Id())
 	return
 }
 
 var dockerVagrantfile = `
 Vagrant.configure("2") do |config|
+	config.vm.provider :docker do |docker, override|
+		docker.image = "%s"
+	end
 end
 `

--- a/post-processor/vagrant/docker_test.go
+++ b/post-processor/vagrant/docker_test.go
@@ -1,0 +1,9 @@
+package vagrant
+
+import (
+	"testing"
+)
+
+func TestDockerProvider_impl(t *testing.T) {
+	var _ Provider = new(DockerProvider)
+}

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -31,7 +31,6 @@ var builtins = map[string]string{
 	"MSOpenTech.hyperv":                   "hyperv",
 	"transcend.qemu":                      "libvirt",
 	"ustream.lxc":                         "lxc",
-	"packer.docker":                       "docker",
 	"packer.post-processor.docker-import": "docker",
 	"packer.post-processor.docker-tag":    "docker",
 	"packer.post-processor.docker-push":   "docker",

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -31,6 +31,7 @@ var builtins = map[string]string{
 	"MSOpenTech.hyperv":                   "hyperv",
 	"transcend.qemu":                      "libvirt",
 	"ustream.lxc":                         "lxc",
+	"packer.docker":                       "docker",
 	"packer.post-processor.docker-import": "docker",
 	"packer.post-processor.docker-tag":    "docker",
 	"packer.post-processor.docker-push":   "docker",

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -32,6 +32,8 @@ var builtins = map[string]string{
 	"transcend.qemu":                      "libvirt",
 	"ustream.lxc":                         "lxc",
 	"packer.post-processor.docker-import": "docker",
+	"packer.post-processor.docker-tag":    "docker",
+	"packer.post-processor.docker-push":   "docker",
 }
 
 type Config struct {

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -19,18 +19,19 @@ import (
 )
 
 var builtins = map[string]string{
-	"mitchellh.amazonebs":       "aws",
-	"mitchellh.amazon.instance": "aws",
-	"mitchellh.virtualbox":      "virtualbox",
-	"mitchellh.vmware":          "vmware",
-	"mitchellh.vmware-esx":      "vmware",
-	"pearkes.digitalocean":      "digitalocean",
-	"packer.googlecompute":      "google",
-	"hashicorp.scaleway":        "scaleway",
-	"packer.parallels":          "parallels",
-	"MSOpenTech.hyperv":         "hyperv",
-	"transcend.qemu":            "libvirt",
-	"ustream.lxc":               "lxc",
+	"mitchellh.amazonebs":                 "aws",
+	"mitchellh.amazon.instance":           "aws",
+	"mitchellh.virtualbox":                "virtualbox",
+	"mitchellh.vmware":                    "vmware",
+	"mitchellh.vmware-esx":                "vmware",
+	"pearkes.digitalocean":                "digitalocean",
+	"packer.googlecompute":                "google",
+	"hashicorp.scaleway":                  "scaleway",
+	"packer.parallels":                    "parallels",
+	"MSOpenTech.hyperv":                   "hyperv",
+	"transcend.qemu":                      "libvirt",
+	"ustream.lxc":                         "lxc",
+	"packer.post-processor.docker-import": "docker",
 }
 
 type Config struct {
@@ -241,6 +242,8 @@ func providerForName(name string) Provider {
 		return new(GoogleProvider)
 	case "lxc":
 		return new(LXCProvider)
+	case "docker":
+		return new(DockerProvider)
 	default:
 		return nil
 	}

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -129,10 +129,13 @@ artifacts](/docs/templates/post-processors.html#toc_2) for more information.
 
 ### Docker
 
-Using the Docker builder or one of the Docker post processors as an input
-artifact will cause the `Vagrantfile` to include a reference to the image. For
-post processors allowing a tag to be specified, such as `docker-import` or
-`docker-tag`, the tag will be used. Otherwise, the sha256 hash will be used.
+Using a Docker input artifact will include a reference to the image in the
+`Vagrantfile`. If the image tag is not specified in the post-processor, the
+sha256 hash will be used.
 
-Note: Using the `docker` builder to save the image as a tar file cannot be used
-to produce a Vagrant box.
+The following Docker input artifacts are supported:
+
+ - `docker` builder with `commit: true`, always uses the sha256 hash
+ - `docker-import`
+ - `docker-tag`
+ - `docker-push`

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -39,6 +39,7 @@ providers.
 -   QEMU
 -   VirtualBox
 -   VMware
+-   Docker
 
 -&gt; **Support for additional providers** is planned. If the Vagrant
 post-processor doesn't support creating boxes for a provider you care about,
@@ -114,6 +115,7 @@ The available provider names are:
 - `scaleway`
 - `virtualbox`
 - `vmware`
+- `docker`
 
 ## Input Artifacts
 
@@ -124,3 +126,10 @@ it.
 
 Please see the [documentation on input
 artifacts](/docs/templates/post-processors.html#toc_2) for more information.
+
+### Docker
+
+Using the Docker builder or one of the Docker post processors as an input
+artifact will cause the `Vagrantfile` to include a reference to the image. For
+post processors allowing a tag to be specified, such as `docker-import` or
+`docker-tag`, the tag will be used. Otherwise, the sha256 hash will be used.

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -133,3 +133,6 @@ Using the Docker builder or one of the Docker post processors as an input
 artifact will cause the `Vagrantfile` to include a reference to the image. For
 post processors allowing a tag to be specified, such as `docker-import` or
 `docker-tag`, the tag will be used. Otherwise, the sha256 hash will be used.
+
+Note: Using the `docker` builder to save the image as a tar file cannot be used
+to produce a Vagrant box.


### PR DESCRIPTION
Adds support for packaging a Docker image as a vagrant box. This is useful when wanting to include settings such as ports, volumes, etc. in the Vagrantfile while still leveraging the benefits of Docker.