### PR TITLE
Add missing link to googlecompute-import post-processor docs

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -281,6 +281,9 @@
           <li<%= sidebar_current("docs-post-processors-googlecompute-export") %>>
             <a href="/docs/post-processors/googlecompute-export.html">Google Compute Export</a>
           </li>
+          <li<%= sidebar_current("docs-post-processors-googlecompute-import") %>>
+            <a href="/docs/post-processors/googlecompute-import.html">Google Compute Import</a>
+          </li>
           <li<%= sidebar_current("docs-post-processors-manifest") %>>
             <a href="/docs/post-processors/manifest.html">Manifest</a>
           </li>


### PR DESCRIPTION
This shoud have been done as part of pull request #6340, but
I missed it. So I'm fixing it now. This should have been in
release 1.2.5.