### PR TITLE
Allow instance metadata to be specified in config

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -48,6 +48,9 @@ type Config struct {
 	// Instance
 	InstanceName string `mapstructure:"instance_name"`
 
+	// MetaData is optional but will be constructed to include UserData or UserDataFile under the "user_data" key
+	MetaData map[string]string `mapstructure:"metadata"`
+
 	// UserData and UserDataFile file are both optional and mutually exclusive.
 	UserData     string `mapstructure:"user_data"`
 	UserDataFile string `mapstructure:"user_data_file"`

--- a/builder/oracle/oci/config_test.go
+++ b/builder/oracle/oci/config_test.go
@@ -29,6 +29,9 @@ func testConfig(accessConfFile *os.File) map[string]interface{} {
 		// Comm
 		"ssh_username":   "opc",
 		"use_private_ip": false,
+		"metadata": map[string]string{
+			"key": "value",
+		},
 	}
 }
 
@@ -235,6 +238,7 @@ func TestConfig(t *testing.T) {
 			t.Errorf("Expected ConfigProvider.KeyFingerprint: %s, got %s", expected, fingerprint)
 		}
 	})
+
 }
 
 // BaseTestConfig creates the base (DEFAULT) config including a temporary key

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -42,6 +42,11 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 	metadata := map[string]string{
 		"ssh_authorized_keys": publicKey,
 	}
+	if d.cfg.MetaData != nil {
+		for key, value := range d.cfg.MetaData {
+			metadata[key] = value
+		}
+	}
 	if d.cfg.UserData != "" {
 		metadata["user_data"] = d.cfg.UserData
 	}

--- a/website/source/docs/builders/oracle-oci.html.md
+++ b/website/source/docs/builders/oracle-oci.html.md
@@ -125,6 +125,8 @@ builder.
 
  -  `use_private_ip` (boolean) - Use private ip addresses to connect to the instance via ssh.
 
+ - `metadata` (map of strings) - Metadata to be injected in the build instance.
+
  - `user_data` (string) - user_data to be used by cloud
    init. See [the Oracle docs](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/LaunchInstanceDetails) for more details. Generally speaking, it is easier to use the `user_data_file`,
    but you can use this option to put either the platintext data or the base64


### PR DESCRIPTION
This allows metadata to be specified in the config file which will then be applied to the instance used for building the image.