### PR TITLE
Expose ansible packer_http_addr extra var

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -336,6 +336,13 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 		// args = append(args, "--private-key", privKeyFile)
 		args = append(args, "-e", fmt.Sprintf("ansible_ssh_private_key_file=%s", privKeyFile))
 	}
+
+	// expose packer_http_addr extra variable
+	httpAddr := common.GetHTTPAddr()
+	if httpAddr != "" {
+		args = append(args, "--extra-vars", fmt.Sprintf("packer_http_addr=%s", httpAddr))
+	}
+
 	args = append(args, p.config.ExtraArguments...)
 	if len(p.config.AnsibleEnvVars) > 0 {
 		envvars = append(envvars, p.config.AnsibleEnvVars...)

--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -142,6 +142,13 @@ commonly useful Ansible variables:
     machine that the script is running on. This is useful if you want to run
     only certain parts of the playbook on systems built with certain builders.
 
+-   `packer_http_addr` If using a builder that provides an http server for file
+    transfer (such as hyperv, parallels, qemu, virtualbox, and vmware), this
+    will be set to the address. You can use this address in your provisioner to
+    download large files over http. This may be useful if you're experiencing
+    slower speeds using the default file provisioner. A file provisioner using
+    the `winrm` communicator may experience these types of difficulties.
+
 ## Debugging
 
 To debug underlying issues with Ansible, add `"-vvvv"` to `"extra_arguments"` to enable verbose logging.


### PR DESCRIPTION
## Description
This PR exposes `packer_http_addr` extra variable in the `Ansible provisioner`.

The goal was to use Packer's HTTP server in Ansible since WinRM is unable to handle huge file uploads.

## Related issue
Issue: https://github.com/hashicorp/packer/issues/6447

## Test
https://github.com/Wenzel/bug_packer_ansible
(Don't mind the README, it was there for an old issue which has been solved now)

`ansible/site.yml`
~~~
---
- hosts: all
  tasks:
    - name: ping
      win_ping:

    - name: display packer_build_name
      debug:
        msg: "build name {{ packer_build_name }}"

    - name: display packer_http_addr
      debug:
        msg: "http://{{ packer_http_addr }}"
~~~

output:
~~~
    qemu: ok: [default] => {"changed": false, "ping": "pong"}
    qemu:
2018/07/17 17:40:11 ui:     qemu:
2018/07/17 17:40:11 ui:     qemu: TASK [display packer_build_name] ***********************************************
    qemu: TASK [display packer_build_name] ***********************************************
2018/07/17 17:40:11 ui:     qemu: ok: [default] => {
    qemu: ok: [default] => {
2018/07/17 17:40:11 ui:     qemu:     "msg": "build name qemu"
    qemu:     "msg": "build name qemu"
    qemu: }
2018/07/17 17:40:11 ui:     qemu: }
    qemu:
2018/07/17 17:40:11 ui:     qemu:
    qemu: TASK [display packer_http_addr] ************************************************
2018/07/17 17:40:11 ui:     qemu: TASK [display packer_http_addr] ************************************************
2018/07/17 17:40:11 ui:     qemu: ok: [default] => {
    qemu: ok: [default] => {
    qemu:     "msg": "http://10.0.2.2:8162"
2018/07/17 17:40:11 ui:     qemu:     "msg": "http://10.0.2.2:8162"
    qemu: }
2018/07/17 17:40:11 ui:     qemu: }
    qemu:
2018/07/17 17:40:11 ui:     qemu:
    qemu: PLAY RECAP *********************************************************************
2018/07/17 17:40:11 ui:     qemu: PLAY RECAP *********************************************************************
    qemu: default                    : ok=4    changed=0    unreachable=0    failed=0
2018/07/17 17:40:11 ui:     qemu: default                    : ok=4    changed=0    unreachable=0    failed=0
    qemu:
2018/07/17 17:40:11 ui:     qemu:

~~~