### PR TITLE
Expose PACKER_HTTP_ADDR environment variable for shell-local

### DIFF
--- a/common/shell-local/run.go
+++ b/common/shell-local/run.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/packer/common"
 	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -164,6 +165,12 @@ func createFlattenedEnvVars(config *Config) (string, error) {
 	// Always available Packer provided env vars
 	envVars["PACKER_BUILD_NAME"] = fmt.Sprintf("%s", config.PackerBuildName)
 	envVars["PACKER_BUILDER_TYPE"] = fmt.Sprintf("%s", config.PackerBuilderType)
+
+	// expose PACKER_HTTP_ADDR
+	httpAddr := common.GetHTTPAddr()
+	if httpAddr != "" {
+		envVars["PACKER_HTTP_ADDR"] = fmt.Sprintf("%s", httpAddr)
+	}
 
 	// interpolate environment variables
 	config.Ctx.Data = &EnvVarsTemplate{

--- a/website/source/docs/provisioners/shell-local.html.md
+++ b/website/source/docs/provisioners/shell-local.html.md
@@ -184,6 +184,13 @@ commonly useful environmental variables:
     machine that the script is running on. This is useful if you want to run
     only certain parts of the script on systems built with certain builders.
 
+-   `PACKER_HTTP_ADDR` If using a builder that provides an http server for file
+    transfer (such as hyperv, parallels, qemu, virtualbox, and vmware), this
+    will be set to the address. You can use this address in your provisioner to
+    download large files over http. This may be useful if you're experiencing
+    slower speeds using the default file provisioner. A file provisioner using
+    the `winrm` communicator may experience these types of difficulties.
+
 ## Safely Writing A Script
 
 Whether you use the `inline` option, or pass it a direct `script` or `scripts`,


### PR DESCRIPTION
## Description
This PR exposes `PACKER_HTTP_ADDR` environment variable in the `shell-local` provisioner.

## Related issue
Issue: https://github.com/hashicorp/packer/issues/6452

## Test
https://github.com/Wenzel/bug_packer_ansible
(Don't mind the README, it was there for an old issue which has been solved now)

~~~
$ PACKER_LOG=1 $GOPATH/src/github.com/hashicorp/packer/bin/packer build windows_10_ansible_local.json
~~~

`template.json`
~~~JSON
    "provisioners": [
        {
            "type": "shell-local",
            "command": "ansible-playbook -vvvv -i '127.0.0.1,' -c winrm -T 300 -e \"ansible_user=vagrant ansible_password=vagrant ansible_port=2222 ansible_winrm_scheme=http\" ./ansible/site_lookup.yml"
        }
    ],
~~~

`ansible/site_lookup.yml`
~~~YAML
---
- hosts: all
  tasks:
    - name: ping
      win_ping:

    - name: display PACKER_BUILD_NAME
      debug:
        msg: "build {{ lookup('env', 'PACKER_BUILD_NAME') }}"

    - name: display PACKER_HTTP_ADDR
      debug:
        msg: "http://{{ lookup('env', 'PACKER_HTTP_ADDR') }}"
~~~

output:
~~~
    qemu: TASK [display PACKER_BUILD_NAME] ***********************************************
2018/07/17 19:19:50 ui:     qemu: TASK [display PACKER_BUILD_NAME] ***********************************************
2018/07/17 19:19:50 ui:     qemu: task path: /home/tarrma/tmp/bug_packer/ansible/site_lookup.yml:7
    qemu: task path: /home/tarrma/tmp/bug_packer/ansible/site_lookup.yml:7
    qemu: ok: [127.0.0.1] => {
2018/07/17 19:19:50 ui:     qemu: ok: [127.0.0.1] => {
    qemu:     "msg": "build qemu"
2018/07/17 19:19:50 ui:     qemu:     "msg": "build qemu"
    qemu: }
2018/07/17 19:19:50 ui:     qemu: }
    qemu:
2018/07/17 19:19:50 ui:     qemu:
    qemu: TASK [display PACKER_HTTP_ADDR] ************************************************
2018/07/17 19:19:50 ui:     qemu: TASK [display PACKER_HTTP_ADDR] ************************************************
    qemu: task path: /home/tarrma/tmp/bug_packer/ansible/site_lookup.yml:11
2018/07/17 19:19:50 ui:     qemu: task path: /home/tarrma/tmp/bug_packer/ansible/site_lookup.yml:11
    qemu: ok: [127.0.0.1] => {
2018/07/17 19:19:50 ui:     qemu: ok: [127.0.0.1] => {
    qemu:     "msg": "http://10.0.2.2:8556"
2018/07/17 19:19:50 ui:     qemu:     "msg": "http://10.0.2.2:8556"
    qemu: }
2018/07/17 19:19:50 ui:     qemu: }
    qemu: META: ran handlers
2018/07/17 19:19:50 ui:     qemu: META: ran handlers
    qemu: META: ran handlers
2018/07/17 19:19:50 ui:     qemu: META: ran handlers
    qemu:
2018/07/17 19:19:50 ui:     qemu:
    qemu: PLAY RECAP *********************************************************************
2018/07/17 19:19:50 ui:     qemu: PLAY RECAP *********************************************************************
    qemu: 127.0.0.1                  : ok=4    changed=0    unreachable=0    failed=0
2018/07/17 19:19:50 ui:     qemu: 127.0.0.1                  : ok=4    changed=0    unreachable=0    failed=0
    qemu:
2018/07/17 19:19:50 ui:     qemu:
~~~