### PR TITLE
fix crash caused by invalid datacenter url

### DIFF
--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -76,6 +76,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	if err != nil {
 		errs = packer.MultiErrorAppend(
 			errs, fmt.Errorf("Error invalid vSphere sdk endpoint: %s", err))
+		return errs
 	}
 
 	sdk.User = url.UserPassword(p.config.Username, p.config.Password)


### PR DESCRIPTION
Return errors when url parsing does not work rather than try to access fields on a nil value. 

Closes #6527