### PR TITLE
Cloudstack builder: adding public_ssh_port flag to use a fixed port in the forwarding rules

### DIFF
--- a/builder/cloudstack/config.go
+++ b/builder/cloudstack/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	Network                string   `mapstructure:"network"`
 	Project                string   `mapstructure:"project"`
 	PublicIPAddress        string   `mapstructure:"public_ip_address"`
-	PublicSSHPort          int      `mapstructure:"public_ssh_port"`
+	PublicPort             int      `mapstructure:"public_port"`
 	SecurityGroups         []string `mapstructure:"security_groups"`
 	ServiceOffering        string   `mapstructure:"service_offering"`
 	PreventFirewallChanges bool     `mapstructure:"prevent_firewall_changes"`

--- a/builder/cloudstack/config.go
+++ b/builder/cloudstack/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Network                string   `mapstructure:"network"`
 	Project                string   `mapstructure:"project"`
 	PublicIPAddress        string   `mapstructure:"public_ip_address"`
+	PublicSSHPort          int      `mapstructure:"public_ssh_port"`
 	SecurityGroups         []string `mapstructure:"security_groups"`
 	ServiceOffering        string   `mapstructure:"service_offering"`
 	PreventFirewallChanges bool     `mapstructure:"prevent_firewall_changes"`

--- a/builder/cloudstack/step_configure_networking.go
+++ b/builder/cloudstack/step_configure_networking.go
@@ -31,8 +31,8 @@ func (s *stepSetupNetworking) Run(_ context.Context, state multistep.StateBag) m
 		return multistep.ActionContinue
 	}
 
-	if config.PublicSSHPort != 0 {
-		s.publicPort = config.PublicSSHPort
+	if config.PublicPort != 0 {
+		s.publicPort = config.PublicPort
 	} else {
 		// Generate a random public port used to configure our port forward.
 		rand.Seed(time.Now().UnixNano())

--- a/builder/cloudstack/step_configure_networking.go
+++ b/builder/cloudstack/step_configure_networking.go
@@ -31,9 +31,13 @@ func (s *stepSetupNetworking) Run(_ context.Context, state multistep.StateBag) m
 		return multistep.ActionContinue
 	}
 
-	// Generate a random public port used to configure our port forward.
-	rand.Seed(time.Now().UnixNano())
-	s.publicPort = 50000 + rand.Intn(10000)
+	if config.PublicSSHPort != 0 {
+		s.publicPort = config.PublicSSHPort
+	} else {
+		// Generate a random public port used to configure our port forward.
+		rand.Seed(time.Now().UnixNano())
+		s.publicPort = 50000 + rand.Intn(10000)
+	}
 	state.Put("commPort", s.publicPort)
 
 	// Set the currently configured port to be the private port.

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -126,7 +126,7 @@ builder.
     connecting any provisioners to. If not provided, a temporary public IP
     address will be associated and released during the Packer run.
 
--   `public_ssh_port` (number) - The fixed port you want to configure in the port
+-   `public_port` (number) - The fixed port you want to configure in the port
     forwarding rule. Set this attribute if you do not want to use the a random
     public port.
 

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -126,6 +126,10 @@ builder.
     connecting any provisioners to. If not provided, a temporary public IP
     address will be associated and released during the Packer run.
 
+-   `public_ssh_port` (number) - The fixed port you want to configure in the port
+    forwarding rule. Set this attribute if you do not want to use the a random
+    public port.
+
 -   `security_groups` (array of strings) - A list of security group IDs or names
     to associate the instance with.
 


### PR DESCRIPTION
This PR aims to provide a new feature for the cloudstack builder.

Cloudstack builder geneates by default a random port from the range 50000-60000 to use as a public port in the port forwarding rules.

To be compliant with enterprise security requirements, it is undesirable to open 10000 ports if the instance that builds the images is out of cloudstack. For that I wanted to add an option to fix the public ssh port in the port forwarding rule so that now can be configured. If not passed, default behaviour remains as before.
