### PR TITLE
Determine lxc root according to the running user

### DIFF
--- a/builder/lxc/step_export.go
+++ b/builder/lxc/step_export.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -19,7 +21,16 @@ func (s *stepExport) Run(_ context.Context, state multistep.StateBag) multistep.
 
 	name := config.ContainerName
 
-	containerDir := fmt.Sprintf("/var/lib/lxc/%s", name)
+	lxc_dir := "/var/lib/lxc"
+	user, err := user.Current()
+	if err != nil {
+		log.Print("Cannot find current user. Falling back to /var/lib/lxc...")
+	}
+	if user.Uid != "0" && user.HomeDir != "" {
+		lxc_dir = filepath.Join(user.HomeDir, ".local", "share", "lxc")
+	}
+
+	containerDir := filepath.Join(lxc_dir, name)
 	outputPath := filepath.Join(config.OutputDir, "rootfs.tar.gz")
 	configFilePath := filepath.Join(config.OutputDir, "lxc-config")
 

--- a/builder/lxc/step_lxc_create.go
+++ b/builder/lxc/step_lxc_create.go
@@ -3,6 +3,8 @@ package lxc
 import (
 	"context"
 	"fmt"
+	"log"
+	"os/user"
 	"path/filepath"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -19,6 +21,13 @@ func (s *stepLxcCreate) Run(_ context.Context, state multistep.StateBag) multist
 
 	// TODO: read from env
 	lxc_dir := "/var/lib/lxc"
+	user, err := user.Current()
+	if err != nil {
+		log.Print("Cannot find current user. Falling back to /var/lib/lxc...")
+	}
+	if user.Uid != "0" && user.HomeDir != "" {
+		lxc_dir = filepath.Join(user.HomeDir, ".local", "share", "lxc")
+	}
 	rootfs := filepath.Join(lxc_dir, name, "rootfs")
 
 	if config.PackerForce {


### PR DESCRIPTION
While #6244 resolved the issue of not being able to build unprivileged LXC containers, setting the LXC root path to `/var/lib/lxc` has some drawbacks if the system contains containers for different users. Usually `/var/lib/lxc` is owned by root and does not provide read access to other users. I temporarily chowned the directory to my user.

This PR correctly determines the LXC root path according to the user who run Packer.