### PR TITLE
Fix file copying for unprivileged LXC containers 

### DIFF
--- a/builder/lxc/communicator.go
+++ b/builder/lxc/communicator.go
@@ -59,7 +59,6 @@ func (c *LxcAttachCommunicator) Start(cmd *packer.RemoteCmd) error {
 }
 
 func (c *LxcAttachCommunicator) Upload(dst string, r io.Reader, fi *os.FileInfo) error {
-	dst = filepath.Join(c.RootFs, dst)
 	log.Printf("Uploading to rootfs: %s", dst)
 	tf, err := ioutil.TempFile("", "packer-lxc-attach")
 	if err != nil {
@@ -68,7 +67,11 @@ func (c *LxcAttachCommunicator) Upload(dst string, r io.Reader, fi *os.FileInfo)
 	defer os.Remove(tf.Name())
 	io.Copy(tf, r)
 
-	cpCmd, err := c.CmdWrapper(fmt.Sprintf("sudo cp %s %s", tf.Name(), dst))
+	attachCommand := []string{"cat", "%s", " | ", "lxc-attach"}
+	attachCommand = append(attachCommand, c.AttachOptions...)
+	attachCommand = append(attachCommand, []string{"--name", "%s", "--", "/bin/sh -c \"/bin/cat > %s\""}...)
+
+	cpCmd, err := c.CmdWrapper(fmt.Sprintf(strings.Join(attachCommand, " "), tf.Name(), c.ContainerName, dst))
 	if err != nil {
 		return err
 	}
@@ -78,14 +81,14 @@ func (c *LxcAttachCommunicator) Upload(dst string, r io.Reader, fi *os.FileInfo)
 		// rename tempfile to match original file name. This makes sure that if file is being
 		// moved into a directory, the filename is preserved instead of a temp name.
 		adjustedTempName := filepath.Join(tfDir, (*fi).Name())
-		mvCmd, err := c.CmdWrapper(fmt.Sprintf("sudo mv %s %s", tf.Name(), adjustedTempName))
+		mvCmd, err := c.CmdWrapper(fmt.Sprintf("mv %s %s", tf.Name(), adjustedTempName))
 		if err != nil {
 			return err
 		}
 		defer os.Remove(adjustedTempName)
 		ShellCommand(mvCmd).Run()
 		// change cpCmd to use new file name as source
-		cpCmd, err = c.CmdWrapper(fmt.Sprintf("sudo cp %s %s", adjustedTempName, dst))
+		cpCmd, err = c.CmdWrapper(fmt.Sprintf(strings.Join(attachCommand, " "), adjustedTempName, c.ContainerName, dst))
 		if err != nil {
 			return err
 		}
@@ -100,7 +103,7 @@ func (c *LxcAttachCommunicator) UploadDir(dst string, src string, exclude []stri
 	// TODO: remove any file copied if it appears in `exclude`
 	dest := filepath.Join(c.RootFs, dst)
 	log.Printf("Uploading directory '%s' to rootfs '%s'", src, dest)
-	cpCmd, err := c.CmdWrapper(fmt.Sprintf("sudo cp -R %s/. %s", src, dest))
+	cpCmd, err := c.CmdWrapper(fmt.Sprintf("cp -R %s/. %s", src, dest))
 	if err != nil {
 		return err
 	}
@@ -131,7 +134,7 @@ func (c *LxcAttachCommunicator) DownloadDir(src string, dst string, exclude []st
 func (c *LxcAttachCommunicator) Execute(commandString string) (*exec.Cmd, error) {
 	log.Printf("Executing with lxc-attach in container: %s %s %s", c.ContainerName, c.RootFs, commandString)
 
-	attachCommand := []string{"sudo", "lxc-attach"}
+	attachCommand := []string{"lxc-attach"}
 	attachCommand = append(attachCommand, c.AttachOptions...)
 	attachCommand = append(attachCommand, []string{"--name", "%s", "--", "/bin/sh -c \"%s\""}...)
 


### PR DESCRIPTION
Before #6244 files were copied using root permission.
When removing the sudo from the copy command you loose access to the file since it is still mapped to my original user.
I encountered this problem when I tried running a shell provisioner with an inline script.
Since now this is not the case, we need to be able to copy files into a container while preserving the file permissions according to the uid/guid mapping.
This PR does so for single files.
Uploading directories is still neither supported nor tested.