### PR TITLE
Add tags to DigitalOcean Droplets

### DIFF
--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	DropletName       string        `mapstructure:"droplet_name"`
 	UserData          string        `mapstructure:"user_data"`
 	UserDataFile      string        `mapstructure:"user_data_file"`
+	RunTags           []string      `mapstructure:"run_tags"`
 
 	ctx interpolate.Context
 }
@@ -119,6 +120,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 			errs = packer.MultiErrorAppend(
 				errs, errors.New(fmt.Sprintf("user_data_file not found: %s", c.UserDataFile)))
 		}
+	}
+
+	if c.RunTags == nil {
+		c.RunTags = make([]string, 0)
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	DropletName       string        `mapstructure:"droplet_name"`
 	UserData          string        `mapstructure:"user_data"`
 	UserDataFile      string        `mapstructure:"user_data_file"`
-	RunTags           []string      `mapstructure:"run_tags"`
+	Tags              []string      `mapstructure:"tags"`
 
 	ctx interpolate.Context
 }
@@ -122,8 +122,8 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		}
 	}
 
-	if c.RunTags == nil {
-		c.RunTags = make([]string, 0)
+	if c.Tags == nil {
+		c.Tags = make([]string, 0)
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/packer/common"
@@ -124,6 +125,13 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	if c.Tags == nil {
 		c.Tags = make([]string, 0)
+	}
+	tagRe := regexp.MustCompile("^[[:alnum:]:_-]{1,255}$")
+
+	for _, t := range c.Tags {
+		if !tagRe.MatchString(t) {
+			errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf("invalid tag: %s", t)))
+		}
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/builder/digitalocean/step_create_droplet.go
+++ b/builder/digitalocean/step_create_droplet.go
@@ -49,6 +49,7 @@ func (s *stepCreateDroplet) Run(_ context.Context, state multistep.StateBag) mul
 		Monitoring:        c.Monitoring,
 		IPv6:              c.IPv6,
 		UserData:          userData,
+		Tags:              c.RunTags,
 	})
 	if err != nil {
 		err := fmt.Errorf("Error creating droplet: %s", err)

--- a/builder/digitalocean/step_create_droplet.go
+++ b/builder/digitalocean/step_create_droplet.go
@@ -49,7 +49,7 @@ func (s *stepCreateDroplet) Run(_ context.Context, state multistep.StateBag) mul
 		Monitoring:        c.Monitoring,
 		IPv6:              c.IPv6,
 		UserData:          userData,
-		Tags:              c.RunTags,
+		Tags:              c.Tags,
 	})
 	if err != nil {
 		err := fmt.Errorf("Error creating droplet: %s", err)

--- a/website/source/docs/builders/digitalocean.html.md
+++ b/website/source/docs/builders/digitalocean.html.md
@@ -88,6 +88,8 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the Droplet.
 
+-   `tags` (list) - Tags to apply to the droplet when it is created
+
 ## Basic Example
 
 Here is a basic example. It is completely valid as soon as you enter your own


### PR DESCRIPTION
###  Description

Adds run time tags to DigitalOcean Droplets on build. This is useful when using ansible to build remotely and using the dynamic inventory. 

### Example

```
  "builders": [{
    "type": "digitalocean",
    "api_token": "....",
    "image": "ubuntu-16-04-x64",
    "region": "nyc3",
    "size": "s-1vcpu-2gb",
    "ssh_username": "root",
    "droplet_name": "packer-build",
    "private_networking": true,
    "snapshot_name": "nomad-{{timestamp}}",
    "tags": ["packer"]
  }],
```

