### PR TITLE
Encrypt the winrm password when it's saved in a temp file.

### DIFF
--- a/helper/common/shared_state.go
+++ b/helper/common/shared_state.go
@@ -1,7 +1,11 @@
 package common
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -15,14 +19,67 @@ func sharedStateFilename(suffix string, buildName string) string {
 }
 
 func SetSharedState(key string, value string, buildName string) error {
-	return ioutil.WriteFile(sharedStateFilename(key, buildName), []byte(value), 0600)
+	uuid := os.Getenv("PACKER_RUN_UUID")
+
+	// Encrypt the value using the run uuid. This is probably good enough as an
+	// encryption key because we only keep it in memory until after the point
+	// at which this storage file is wiped.
+	encryptionKey := []byte(uuid)[0:32]
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		return err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return err
+	}
+
+	encryptedVal, err := gcm.Seal(nonce, nonce, []byte(value), nil), nil
+
+	if err != nil {
+		return fmt.Errorf("Error encrypting sensitive variable: %s", err)
+	}
+
+	// Write encrypted value to the storage file.
+	err = ioutil.WriteFile(sharedStateFilename(key, buildName), encryptedVal, 0600)
+	return err
 }
 
 func RetrieveSharedState(key string, buildName string) (string, error) {
-	value, err := ioutil.ReadFile(sharedStateFilename(key, buildName))
+	uuid := os.Getenv("PACKER_RUN_UUID")
+
+	// Decrypt the stored item.
+	encryptionKey := []byte(uuid)[0:32]
+	encryptedValue, err := ioutil.ReadFile(sharedStateFilename(key, buildName))
+
+	block, err := aes.NewCipher([]byte(encryptionKey))
 	if err != nil {
 		return "", err
 	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(encryptedValue) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	// nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	nonce, encryptedValue := encryptedValue[:nonceSize], encryptedValue[nonceSize:]
+
+	value, err := gcm.Open(nil, nonce, encryptedValue, nil)
+	if err != nil {
+		return "", err
+	}
+
 	return string(value), nil
 }
 


### PR DESCRIPTION
WIP: don't merge. Have a few things left to do, like hashing the uuid that ends up in the filename. 

Peace of mind: I know that we set file perms on the winrm password to be pretty tight, and that it's a temporary file, but I feel better having it encrypted if it's gonna be written to disk.