### PR TITLE
add support for ports to the OpenStack builder

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -92,6 +92,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			SourceImageName:  b.config.SourceImageName,
 			SecurityGroups:   b.config.SecurityGroups,
 			Networks:         b.config.Networks,
+			Ports:            b.config.Ports,
 			AvailabilityZone: b.config.AvailabilityZone,
 			UserData:         b.config.UserData,
 			UserDataFile:     b.config.UserDataFile,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -28,6 +28,7 @@ type RunConfig struct {
 	ReuseIps         bool              `mapstructure:"reuse_ips"`
 	SecurityGroups   []string          `mapstructure:"security_groups"`
 	Networks         []string          `mapstructure:"networks"`
+	Ports            []string          `mapstructure:"ports"`
 	UserData         string            `mapstructure:"user_data"`
 	UserDataFile     string            `mapstructure:"user_data_file"`
 	InstanceName     string            `mapstructure:"instance_name"`

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -40,7 +40,7 @@ func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) m
 		return multistep.ActionHalt
 	}
 
-	networks := make([]servers.Network, len(s.Networks) + len(s.Ports))
+	networks := make([]servers.Network, len(s.Networks)+len(s.Ports))
 	i := 0
 	if len(s.Ports) > 0 {
 		for i = 0; i < len(s.Ports); i++ {

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -18,6 +18,7 @@ type StepRunSourceServer struct {
 	SourceImageName  string
 	SecurityGroups   []string
 	Networks         []string
+	Ports            []string
 	AvailabilityZone string
 	UserData         string
 	UserDataFile     string
@@ -39,9 +40,17 @@ func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) m
 		return multistep.ActionHalt
 	}
 
-	networks := make([]servers.Network, len(s.Networks))
-	for i, networkUuid := range s.Networks {
-		networks[i].UUID = networkUuid
+	networks := make([]servers.Network, len(s.Networks) + len(s.Ports))
+	i := 0
+	if len(s.Ports) > 0 {
+		for i = 0; i < len(s.Ports); i++ {
+			networks[i].Port = s.Ports[i]
+		}
+	}
+	if len(s.Networks) > 0 {
+		for i = len(s.Ports); i < len(networks); i++ {
+			networks[i].UUID = s.Networks[i]
+		}
 	}
 
 	userData := []byte(s.UserData)

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -42,15 +42,11 @@ func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) m
 
 	networks := make([]servers.Network, len(s.Networks)+len(s.Ports))
 	i := 0
-	if len(s.Ports) > 0 {
-		for i = 0; i < len(s.Ports); i++ {
-			networks[i].Port = s.Ports[i]
-		}
+	for ; i < len(s.Ports); i++ {
+		networks[i].Port = s.Ports[i]
 	}
-	if len(s.Networks) > 0 {
-		for i = len(s.Ports); i < len(networks); i++ {
-			networks[i].UUID = s.Networks[i]
-		}
+	for ; i < len(networks); i++ {
+		networks[i].UUID = s.Networks[i]
 	}
 
 	userData := []byte(s.UserData)

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -139,6 +139,9 @@ builder.
 -   `networks` (array of strings) - A list of networks by UUID to attach to
     this instance.
 
+-   `ports` (array of strings) - A list of ports by UUID to attach to
+    this instance.
+
 -   `rackconnect_wait` (boolean) - For rackspace, whether or not to wait for
     Rackconnect to assign the machine an IP address before connecting via SSH.
     Defaults to false.


### PR DESCRIPTION
For networks that have multiple subnets, we may want to target a single
subnet.  OpenStack doesn't let you target a single subnet in a network
and so you need to make a port.
