### PR TITLE
use statebag instead of SetSharedState for winRM password

### DIFF
--- a/builder/amazon/common/step_get_password.go
+++ b/builder/amazon/common/step_get_password.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -95,15 +94,13 @@ WaitLoop:
 			"Password (since debug is enabled): %s", s.Comm.WinRMPassword))
 	}
 	// store so that we can access this later during provisioning
-
-	commonhelper.SetSharedState("winrm_password", s.Comm.WinRMPassword, s.BuildName)
+	state.Put("winrm_password", s.Comm.WinRMPassword)
 	packer.LogSecretFilter.Set(s.Comm.WinRMPassword)
 
 	return multistep.ActionContinue
 }
 
 func (s *StepGetPassword) Cleanup(multistep.StateBag) {
-	commonhelper.RemoveSharedStateFile("winrm_password", s.BuildName)
 }
 
 func (s *StepGetPassword) waitForPassword(state multistep.StateBag, cancel <-chan struct{}) (string, error) {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/packer/builder/azure/common/constants"
 	"github.com/hashicorp/packer/builder/azure/pkcs12"
 	"github.com/hashicorp/packer/common"
-	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
@@ -361,10 +360,7 @@ func setRuntimeValues(c *Config) {
 	var tempName = NewTempName()
 
 	c.tmpAdminPassword = tempName.AdminPassword
-	// store so that we can access this later during provisioning
-	commonhelper.SetSharedState("winrm_password", c.tmpAdminPassword, c.PackerConfig.PackerBuildName)
 	packer.LogSecretFilter.Set(c.tmpAdminPassword)
-
 	c.tmpCertificatePassword = tempName.CertificatePassword
 	if c.TempComputeName == "" {
 		c.tmpComputeName = tempName.ComputeName

--- a/builder/azure/arm/step_save_winrm_password.go
+++ b/builder/azure/arm/step_save_winrm_password.go
@@ -3,7 +3,6 @@ package arm
 import (
 	"context"
 
-	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -15,11 +14,10 @@ type StepSaveWinRMPassword struct {
 
 func (s *StepSaveWinRMPassword) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	// store so that we can access this later during provisioning
-	commonhelper.SetSharedState("winrm_password", s.Password, s.BuildName)
+	state.Put("winrm_password", s.Password)
 	packer.LogSecretFilter.Set(s.Password)
 	return multistep.ActionContinue
 }
 
 func (s *StepSaveWinRMPassword) Cleanup(multistep.StateBag) {
-	commonhelper.RemoveSharedStateFile("winrm_password", s.BuildName)
 }

--- a/builder/googlecompute/step_create_windows_password.go
+++ b/builder/googlecompute/step_create_windows_password.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"time"
 
-	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -114,7 +113,6 @@ func (s *StepCreateWindowsPassword) Run(_ context.Context, state multistep.State
 	}
 
 	state.Put("winrm_password", data.password)
-	commonhelper.SetSharedState("winrm_password", data.password, c.PackerConfig.PackerBuildName)
 	packer.LogSecretFilter.Set(data.password)
 
 	return multistep.ActionContinue

--- a/builder/oracle/oci/step_get_default_credentials.go
+++ b/builder/oracle/oci/step_get_default_credentials.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 
-	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -52,8 +51,9 @@ func (s *stepGetDefaultCredentials) Run(ctx context.Context, state multistep.Sta
 	}
 
 	// store so that we can access this later during provisioning
-	commonhelper.SetSharedState("winrm_password", s.Comm.WinRMPassword, s.BuildName)
+	state.Put("winrm_password", s.Comm.WinRMPassword)
 	packer.LogSecretFilter.Set(s.Comm.WinRMPassword)
+
 	return multistep.ActionContinue
 }
 

--- a/common/shell-local/config.go
+++ b/common/shell-local/config.go
@@ -53,6 +53,9 @@ type Config struct {
 	UseLinuxPathing bool `mapstructure:"use_linux_pathing"`
 
 	Ctx interpolate.Context
+
+	// internal use only; for the provisioner.
+	WinRMPassword string
 }
 
 func Decode(config *Config, raws ...interface{}) error {

--- a/packer/provisioner_mock.go
+++ b/packer/provisioner_mock.go
@@ -14,8 +14,10 @@ type MockProvisioner struct {
 }
 
 func (t *MockProvisioner) Prepare(configs ...interface{}) error {
-	t.PrepCalled = true
-	t.PrepConfigs = configs
+	if !t.PrepCalled {
+		t.PrepCalled = true
+		t.PrepConfigs = configs
+	}
 	return nil
 }
 

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -26,7 +26,6 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/hashicorp/packer/common"
-	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -58,6 +57,8 @@ type Config struct {
 	UseSFTP              bool     `mapstructure:"use_sftp"`
 	InventoryDirectory   string   `mapstructure:"inventory_directory"`
 	InventoryFile        string   `mapstructure:"inventory_file"`
+	// for internal use only; unsettable by user.
+	winrmpassword string
 }
 
 type Provisioner struct {
@@ -73,14 +74,35 @@ type PassthroughTemplate struct {
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
+	// This is a bit of a hack. For provisioners that need access to
+	// auto-generated WinRMPasswords, the mechanism of keeping provisioner data
+	// and build data totally segregated breaks down. We get around this by
+	// having the builder stash the WinRMPassword in the state bag, then
+	// grabbing it out of the statebag inside of StepProvision.  Then, when
+	// the time comes to provision for real, we run the prepare step one more
+	// time, now with WinRMPassword defined in the raws, and can store the
+	// password on the provisioner config without overwriting the rest of the
+	// work we've already done in the first prepare run.
+	if len(raws) == 1 {
+		for k, v := range raws[0].(map[interface{}]interface{}) {
+			if k.(string) == "WinRMPassword" {
+				p.config.winrmpassword = v.(string)
+
+				// Even if WinRMPassword is not gonna be used, we've stored the
+				// key and pointed it to an empty string. That means we'll
+				// always reach this on our second-run of Prepare()
+				return nil
+			}
+		}
+	}
+
 	p.done = make(chan struct{})
 
-	// Create passthrough for winrm password so we can fill it in once we know
-	// it
+	// don't interpolate winrmpassword yet; if we've made it to this line, then
+	// we have not obtained the winrm password yet.
 	p.config.ctx.Data = &PassthroughTemplate{
 		WinRMPassword: `{{.WinRMPassword}}`,
 	}
-
 	err := config.Decode(&p.config, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &p.config.ctx,
@@ -200,8 +222,9 @@ func (p *Provisioner) getVersion() error {
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	ui.Say("Provisioning with Ansible...")
 	// Interpolate env vars to check for .WinRMPassword
+	packer.LogSecretFilter.Set(p.config.winrmpassword)
 	p.config.ctx.Data = &PassthroughTemplate{
-		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
+		WinRMPassword: p.config.winrmpassword,
 	}
 	for i, envVar := range p.config.AnsibleEnvVars {
 		envVar, err := interpolate.Render(envVar, &p.config.ctx)
@@ -420,12 +443,7 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 
 	// remove winrm password from command, if it's been added
 	flattenedCmd := strings.Join(cmd.Args, " ")
-	sanitized := flattenedCmd
-	if len(getWinRMPassword(p.config.PackerBuildName)) > 0 {
-		sanitized = strings.Replace(sanitized,
-			getWinRMPassword(p.config.PackerBuildName), "*****", -1)
-	}
-	ui.Say(fmt.Sprintf("Executing Ansible: %s", sanitized))
+	ui.Say(fmt.Sprintf("Executing Ansible: %s", flattenedCmd))
 
 	if err := cmd.Start(); err != nil {
 		return err
@@ -551,12 +569,6 @@ func newSigner(privKeyFile string) (*signer, error) {
 	}
 
 	return signer, nil
-}
-
-func getWinRMPassword(buildName string) string {
-	winRMPass, _ := commonhelper.RetrieveSharedState("winrm_password", buildName)
-	packer.LogSecretFilter.Set(winRMPass)
-	return winRMPass
 }
 
 // Ui provides concurrency-safe access to packer.Ui.

--- a/provisioner/ansible/provisioner_test.go
+++ b/provisioner/ansible/provisioner_test.go
@@ -16,8 +16,8 @@ import (
 
 // Be sure to remove the Ansible stub file in each test with:
 //   defer os.Remove(config["command"].(string))
-func testConfig(t *testing.T) map[string]interface{} {
-	m := make(map[string]interface{})
+func testConfig(t *testing.T) map[interface{}]interface{} {
+	m := make((map[interface{}]interface{}))
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/common/uuid"
-	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -98,6 +97,9 @@ type Config struct {
 	// Changes will not be effective until the system is rebooted."
 	ValidExitCodes []int `mapstructure:"valid_exit_codes"`
 
+	// internal variable, to be written to at provisioner run time.
+	winrmpassword string
+
 	ctx interpolate.Context
 }
 
@@ -117,8 +119,28 @@ type EnvVarsTemplate struct {
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
-	// Create passthrough for winrm password so we can fill it in once we know
-	// it
+	// This is a bit of a hack. For provisioners that need access to
+	// auto-generated WinRMPasswords, the mechanism of keeping provisioner data
+	// and build data totally segregated breaks down. We get around this by
+	// having the builder stash the WinRMPassword in the state bag, then
+	// grabbing it out of the statebag inside of StepProvision.  Then, when
+	// the time comes to provision for real, we run the prepare step one more
+	// time, now with WinRMPassword defined in the raws, and can store the
+	// password on the provisioner config without overwriting the rest of the
+	// work we've already done in the first prepare run.
+	if len(raws) == 1 {
+		for k, v := range raws[0].(map[interface{}]interface{}) {
+			if k.(string) == "WinRMPassword" {
+				p.config.winrmpassword = v.(string)
+				// Even if WinRMPassword is not gonna be used, we've stored the
+				// key and pointed it to an empty string. That means we'll
+				// always reach this on our second-run of Prepare()
+				return nil
+			}
+		}
+	}
+
+	// Only get here if it's the first time the Provisioner's Prepare is run
 	p.config.ctx.Data = &EnvVarsTemplate{
 		WinRMPassword: `{{.WinRMPassword}}`,
 	}
@@ -135,7 +157,7 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}, raws...)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("Error decoding powershell provisioner template: %s", err)
 	}
 
 	if p.config.EnvVarFormat == "" {
@@ -261,7 +283,7 @@ func extractScript(p *Provisioner) (string, error) {
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	ui.Say(fmt.Sprintf("Provisioning with Powershell..."))
 	p.communicator = comm
-
+	packer.LogSecretFilter.Set(p.config.winrmpassword)
 	scripts := make([]string, len(p.config.Scripts))
 	copy(scripts, p.config.Scripts)
 
@@ -392,7 +414,7 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 
 	// interpolate environment variables
 	p.config.ctx.Data = &EnvVarsTemplate{
-		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
+		WinRMPassword: p.config.winrmpassword,
 	}
 	// Split vars into key/value components
 	for _, envVar := range p.config.Vars {
@@ -467,7 +489,7 @@ func (p *Provisioner) createCommandTextNonPrivileged() (command string, err erro
 	p.config.ctx.Data = &ExecuteCommandTemplate{
 		Path:          p.config.RemotePath,
 		Vars:          p.config.RemoteEnvVarPath,
-		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
+		WinRMPassword: p.config.winrmpassword,
 	}
 	command, err = interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 
@@ -477,12 +499,6 @@ func (p *Provisioner) createCommandTextNonPrivileged() (command string, err erro
 
 	// Return the interpolated command
 	return command, nil
-}
-
-func getWinRMPassword(buildName string) string {
-	winRMPass, _ := commonhelper.RetrieveSharedState("winrm_password", buildName)
-	packer.LogSecretFilter.Set(winRMPass)
-	return winRMPass
 }
 
 func (p *Provisioner) createCommandTextPrivileged() (command string, err error) {
@@ -496,7 +512,7 @@ func (p *Provisioner) createCommandTextPrivileged() (command string, err error) 
 	p.config.ctx.Data = &ExecuteCommandTemplate{
 		Path:          p.config.RemotePath,
 		Vars:          p.config.RemoteEnvVarPath,
-		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
+		WinRMPassword: p.config.winrmpassword,
 	}
 	command, err = interpolate.Render(p.config.ElevatedExecuteCommand, &p.config.ctx)
 	if err != nil {
@@ -555,7 +571,7 @@ func (p *Provisioner) generateElevatedRunner(command string) (uploadedPath strin
 	}
 	// Replace ElevatedPassword for winrm users who used this feature
 	p.config.ctx.Data = &EnvVarsTemplate{
-		WinRMPassword: getWinRMPassword(p.config.PackerBuildName),
+		WinRMPassword: p.config.winrmpassword,
 	}
 
 	p.config.ElevatedPassword, _ = interpolate.Render(p.config.ElevatedPassword, &p.config.ctx)

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-func testConfig() map[string]interface{} {
-	return map[string]interface{}{
+func testConfig() map[interface{}]interface{} {
+	return map[interface{}]interface{}{
 		"inline": []interface{}{"foo", "bar"},
 	}
 }

--- a/provisioner/shell-local/provisioner.go
+++ b/provisioner/shell-local/provisioner.go
@@ -10,6 +10,27 @@ type Provisioner struct {
 }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
+	// This is a bit of a hack. For provisioners that need access to
+	// auto-generated WinRMPasswords, the mechanism of keeping provisioner data
+	// and build data totally segregated breaks down. We get around this by
+	// having the builder stash the WinRMPassword in the state bag, then
+	// grabbing it out of the statebag inside of StepProvision.  Then, when
+	// the time comes to provision for real, we run the prepare step one more
+	// time, now with WinRMPassword defined in the raws, and can store the
+	// password on the provisioner config without overwriting the rest of the
+	// work we've already done in the first prepare run.
+	if len(raws) == 1 {
+		for k, v := range raws[0].(map[interface{}]interface{}) {
+			if k.(string) == "WinRMPassword" {
+				p.config.WinRMPassword = v.(string)
+				// Even if WinRMPassword is not gonna be used, we've stored the
+				// key and pointed it to an empty string. That means we'll
+				// always reach this on our second-run of Prepare()
+				return nil
+			}
+		}
+	}
+
 	err := sl.Decode(&p.config, raws...)
 	if err != nil {
 		return err

--- a/provisioner/shell-local/provisioner_test.go
+++ b/provisioner/shell-local/provisioner_test.go
@@ -48,8 +48,8 @@ func TestConfigPrepare(t *testing.T) {
 	}
 }
 
-func testConfig(t *testing.T) map[string]interface{} {
-	return map[string]interface{}{
+func testConfig(t *testing.T) map[interface{}]interface{} {
+	return map[interface{}]interface{}{
 		"command": "echo foo",
 	}
 }


### PR DESCRIPTION
This will be more secure on windows machines, where a tempfile may not have the same kind of protections that linux's restricted permissions give it. 

This also provides an example for how it's possible to share information between the builders and provisioners.

The old control flow called "Prepare" for the provisioners before the builders had a chance to obtain the winrm password. Now, we call "Prepare" a second time right before the provisioner runs, so that we can fill in the missing password value using data provided through the hooks.  Theoretically, we can share more information this way in the future, although this is something we definitely want to be cautious about overusing. In general, I prefer this method to using tempfiles as an arbitrary key/value store, because it keeps things in memory and, I think, more explicit in the code. 