### PR TITLE
bug-fix: syntax error in createApplication()

### DIFF
--- a/contrib/azure-setup.sh
+++ b/contrib/azure-setup.sh
@@ -156,7 +156,7 @@ createApplication() {
 
     if [ "$azure_client_id" != "" ]; then
         echo "==> application already exist, grab appId"
-        azure_client_id=$(az ad app list az ad app list --output json | jq -r '.[] | select(.displayName | contains("'$meta_name'")) .appId')
+        azure_client_id=$(az ad app list --output json | jq -r '.[] | select(.displayName | contains("'$meta_name'")) .appId')
     else
         echo "==> application does not exist"
         azure_client_id=$(az ad app create --display-name $meta_name --identifier-uris http://$meta_name --homepage http://$meta_name --password $azure_client_secret --output json | jq -r .appId)


### PR DESCRIPTION
setup throws an error: `az: error: unrecognized arguments: az ad app list` due to a syntax error in `createApplication()` method. This patch will fix the issue of the same.