### PR TITLE
Increase waiter timeout for AWS WaitUntilImageAvailable command

### DIFF
--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -42,9 +42,9 @@ func WaitUntilAMIAvailable(ctx aws.Context, conn *ec2.EC2, imageId string) error
 
 	waitOpts := getWaiterOptions()
 	if len(waitOpts) == 0 {
-		// Bump this default to 25 minutes because the aws default
+		// Bump this default to 30 minutes because the aws default
 		// of ten minutes doesn't work for some of our long-running copies.
-		waitOpts = append(waitOpts, request.WithWaiterMaxAttempts(100))
+		waitOpts = append(waitOpts, request.WithWaiterMaxAttempts(120))
 	}
 	err := conn.WaitUntilImageAvailableWithContext(
 		ctx,

--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -40,10 +40,16 @@ func WaitUntilAMIAvailable(ctx aws.Context, conn *ec2.EC2, imageId string) error
 		ImageIds: []*string{&imageId},
 	}
 
+	waitOpts := getWaiterOptions()
+	if len(waitOpts) == 0 {
+		// Bump this default to 25 minutes because the aws default
+		// of ten minutes doesn't work for some of our long-running copies.
+		waitOpts = append(waitOpts, request.WithWaiterMaxAttempts(100))
+	}
 	err := conn.WaitUntilImageAvailableWithContext(
 		ctx,
 		&imageInput,
-		getWaiterOptions()...)
+		waitOpts...)
 	return err
 }
 


### PR DESCRIPTION
Bump the timeout from 10 (aws default) to 30 minutes, if user has not manually configured a timeout.

Root cause: our old home-grown waiter theoretically had a timeout at 300 seconds (5 minutes) but it didn't actually start counting queries towards that timeout until a resource existed. In situations of long-running copies, that meant that we didn't really have any timeout at all. 

Closes #6536 
Closes #6526