### PR TITLE
Make Windows-Restart provisioner work even when using ssh communicator

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -17,11 +17,11 @@ import (
 	"github.com/masterzen/winrm"
 )
 
-var DefaultRestartCommand = "shutdown /r /f /t 0 /c \"packer restart\""
+var DefaultRestartCommand = `shutdown /r /f /t 0 /c "packer restart"`
 var DefaultRestartCheckCommand = winrm.Powershell(`echo "${env:COMPUTERNAME} restarted."`)
 var retryableSleep = 5 * time.Second
-var TryCheckReboot = "shutdown.exe -f -r -t 60"
-var AbortReboot = "shutdown.exe -a"
+var TryCheckReboot = `shutdown /r /f /t 60 /c "packer restart test"`
+var AbortReboot = `shutdown /a`
 
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
@@ -124,21 +124,29 @@ var waitForRestart = func(p *Provisioner, comm packer.Communicator) error {
 	for {
 		log.Printf("Check if machine is rebooting...")
 		cmd = &packer.RemoteCmd{Command: trycommand}
-		err = cmd.StartWithUi(comm, ui)
-		if err != nil {
+		if err := p.comm.Start(cmd); err != nil {
 			// Couldn't execute, we assume machine is rebooting already
 			break
 		}
-
-		if cmd.ExitStatus == 1115 || cmd.ExitStatus == 1190 {
+		cmd.Wait()
+		if cmd.ExitStatus == 1 {
+			// SSH provisioner, and we're already rebooting. SSH can reconnect
+			// without our help; exit this wait loop.
+			break
+		}
+		if cmd.ExitStatus == 1115 || cmd.ExitStatus == 1190 || cmd.ExitStatus == 1717 {
 			// Reboot already in progress but not completed
 			log.Printf("Reboot already in progress, waiting...")
 			time.Sleep(10 * time.Second)
+			break
 		}
 		if cmd.ExitStatus == 0 {
 			// Cancel reboot we created to test if machine was already rebooting
 			cmd = &packer.RemoteCmd{Command: abortcommand}
-			cmd.StartWithUi(comm, ui)
+			if err := p.comm.Start(cmd); err != nil {
+				return err
+			}
+			cmd.Wait()
 			break
 		}
 	}
@@ -175,7 +183,6 @@ WaitLoop:
 			return fmt.Errorf("Interrupt detected, quitting waiting for machine to restart")
 		}
 	}
-
 	return nil
 
 }


### PR DESCRIPTION
If someone calls the windows-restart provisioner while using an SSH communicator, it can get into a weird state where it a) spams the logs with the reboot help menu and b) can end up rebooting successfully, and then getting stuck in a reboot check loop. for ssh, this reboot check is unnecessary anyway because ssh can reconnect itself.  This PR fixes the spamminess by replacing StartWithUI with a simple Start() and Wait() for the command, so that we don't hook the ui pipes to the relatively useless stderr and stdout from this reboot command. It also fixes the possibility of getting stuck in an infinite loop by breaking out if the restart check command returns 1, which it will only do for the SSH communicator.

Tested on both SSH and WinRM and it works as expected. 

closes #6301
fixes #6055
