### PR TITLE
make reasonable tempfile default on windows

### DIFF
--- a/common/shell-local/config.go
+++ b/common/shell-local/config.go
@@ -91,6 +91,9 @@ func Validate(config *Config) error {
 				"{{.Script}}",
 			}
 		}
+		if len(config.TempfileExtension) == 0 {
+			config.TempfileExtension = ".cmd"
+		}
 	} else {
 		if config.InlineShebang == "" {
 			config.InlineShebang = "/bin/sh -e"


### PR DESCRIPTION
Use sensible defaulting for inline commands on windows. (append .cmd to tempfiles created for inline windows commands)

Closes #6620 