### PR TITLE
fix chroot communicator to properly escape quotes

### DIFF
--- a/builder/amazon/chroot/communicator.go
+++ b/builder/amazon/chroot/communicator.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -23,8 +24,10 @@ type Communicator struct {
 }
 
 func (c *Communicator) Start(cmd *packer.RemoteCmd) error {
+	// need extra escapes for the command since we're wrapping it in quotes
+	cmd.Command = strconv.Quote(cmd.Command)
 	command, err := c.CmdWrapper(
-		fmt.Sprintf("chroot %s /bin/sh -c \"%s\"", c.Chroot, cmd.Command))
+		fmt.Sprintf("chroot %s /bin/sh -c %s", c.Chroot, cmd.Command))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixed the bug that was the root of a few back and forth swings involving quoting extra vars with the Ansible-local provisioner. The Chroot communicator couldn't handle commands that contained quotes properly. Now we use strconv to fix up the command and make it executable even if there are nested quotes.

Closes #6493 