### PR TITLE
Spotduration

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -114,7 +114,7 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		errs = append(errs, fmt.Errorf("An instance_type must be specified"))
 	}
 
-	if c.BlockDurationMinutes != nil && c.BlockDurationMinutes % 60 != 0 {
+	if c.BlockDurationMinutes % 60 != 0 {
 		errs = append(errs, fmt.Errorf(
 			"block_duration_minutes must be multiple of 60"))
 	}

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -34,6 +34,7 @@ func (d *AmiFilterOptions) NoOwner() bool {
 type RunConfig struct {
 	AssociatePublicIpAddress          bool              `mapstructure:"associate_public_ip_address"`
 	AvailabilityZone                  string            `mapstructure:"availability_zone"`
+	BlockDurationMinutes              int64             `mapstructure:"block_duration_minutes"`
 	DisableStopInstance               bool              `mapstructure:"disable_stop_instance"`
 	EbsOptimized                      bool              `mapstructure:"ebs_optimized"`
 	EnableT2Unlimited                 bool              `mapstructure:"enable_t2_unlimited"`
@@ -111,6 +112,11 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.InstanceType == "" {
 		errs = append(errs, fmt.Errorf("An instance_type must be specified"))
+	}
+
+	if c.BlockDurationMinutes != nil && c.BlockDurationMinutes % 60 != 0 {
+		errs = append(errs, fmt.Errorf(
+			"block_duration_minutes must be multiple of 60"))
 	}
 
 	if c.SpotPrice == "auto" {

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -114,7 +114,7 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		errs = append(errs, fmt.Errorf("An instance_type must be specified"))
 	}
 
-	if c.BlockDurationMinutes % 60 != 0 {
+	if c.BlockDurationMinutes%60 != 0 {
 		errs = append(errs, fmt.Errorf(
 			"block_duration_minutes must be multiple of 60"))
 	}

--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -23,6 +23,7 @@ type StepRunSpotInstance struct {
 	AssociatePublicIpAddress          bool
 	AvailabilityZone                  string
 	BlockDevices                      BlockDevices
+	BlockDurationMinutes              int64
 	Debug                             bool
 	EbsOptimized                      bool
 	ExpectedRootDevice                string
@@ -189,8 +190,9 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 	}
 
 	runSpotResp, err := ec2conn.RequestSpotInstances(&ec2.RequestSpotInstancesInput{
-		SpotPrice:           &spotPrice,
-		LaunchSpecification: runOpts,
+		BlockDurationMinutes: &s.BlockDurationMinutes,
+		LaunchSpecification:  runOpts,
+		SpotPrice:            &spotPrice,
 	})
 	if err != nil {
 		err := fmt.Errorf("Error launching source spot instance: %s", err)

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -126,6 +126,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
 			AvailabilityZone:                  b.config.AvailabilityZone,
 			BlockDevices:                      b.config.BlockDevices,
+			BlockDurationMinutes:              b.config.BlockDurationMinutes,
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -140,6 +140,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
 			AvailabilityZone:                  b.config.AvailabilityZone,
 			BlockDevices:                      b.config.BlockDevices,
+			BlockDurationMinutes:              b.config.BlockDurationMinutes,
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -124,6 +124,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
 			AvailabilityZone:                  b.config.AvailabilityZone,
 			BlockDevices:                      b.config.launchBlockDevices,
+			BlockDurationMinutes:              b.config.BlockDurationMinutes,
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -210,6 +210,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
 			AvailabilityZone:         b.config.AvailabilityZone,
 			BlockDevices:             b.config.BlockDevices,
+			BlockDurationMinutes:     b.config.BlockDurationMinutes,
 			Ctx:                      b.config.ctx,
 			Debug:                    b.config.PackerDebug,
 			EbsOptimized:             b.config.EbsOptimized,

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -145,6 +145,7 @@ builder.
 -   `block_duration_minutes` (int64) - Requires `spot_price` to
     be set. The required duration for the Spot Instances (also known as Spot blocks).
     This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+    You can't specify an Availability Zone group or a launch group if you specify a duration.
 
 -   `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
     provider whose API is compatible with aws EC2. Specify another endpoint

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -142,6 +142,10 @@ builder.
 -   `availability_zone` (string) - Destination availability zone to launch
     instance in. Leave this empty to allow Amazon to auto-assign.
 
+-   `block_duration_minutes` (int64) - Requires `spot_price` to
+    be set. The required duration for the Spot Instances (also known as Spot blocks).
+    This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+
 -   `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
     provider whose API is compatible with aws EC2. Specify another endpoint
     like this `https://ec2.custom.endpoint.com`.

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -135,6 +135,10 @@ builder.
 -   `availability_zone` (string) - Destination availability zone to launch
     instance in. Leave this empty to allow Amazon to auto-assign.
 
+-   `block_duration_minutes` (int64) - Requires `spot_price` to
+    be set. The required duration for the Spot Instances (also known as Spot blocks).
+    This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+
 -   `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
     provider whose API is compatible with aws EC2. Specify another endpoint
     like this `https://ec2.custom.endpoint.com`.

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -138,6 +138,7 @@ builder.
 -   `block_duration_minutes` (int64) - Requires `spot_price` to
     be set. The required duration for the Spot Instances (also known as Spot blocks).
     This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+    You can't specify an Availability Zone group or a launch group if you specify a duration.
 
 -   `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
     provider whose API is compatible with aws EC2. Specify another endpoint

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -107,6 +107,10 @@ builder.
 -   `availability_zone` (string) - Destination availability zone to launch
     instance in. Leave this empty to allow Amazon to auto-assign.
 
+-   `block_duration_minutes` (int64) - Requires `spot_price` to
+    be set. The required duration for the Spot Instances (also known as Spot blocks).
+    This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+
 -   `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
     provider whose API is compatible with aws EC2. Specify another endpoint
     like this `https://ec2.custom.endpoint.com`.

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -110,6 +110,7 @@ builder.
 -   `block_duration_minutes` (int64) - Requires `spot_price` to
     be set. The required duration for the Spot Instances (also known as Spot blocks).
     This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+    You can't specify an Availability Zone group or a launch group if you specify a duration.
 
 -   `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
     provider whose API is compatible with aws EC2. Specify another endpoint

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -164,6 +164,10 @@ builder.
 -   `availability_zone` (string) - Destination availability zone to launch
     instance in. Leave this empty to allow Amazon to auto-assign.
 
+-   `block_duration_minutes` (int64) - Requires `spot_price` to
+    be set. The required duration for the Spot Instances (also known as Spot blocks).
+    This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+
 -   `bundle_destination` (string) - The directory on the running instance where
     the bundled AMI will be saved prior to uploading. By default this is `/tmp`.
     This directory must exist and be writable.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -167,6 +167,7 @@ builder.
 -   `block_duration_minutes` (int64) - Requires `spot_price` to
     be set. The required duration for the Spot Instances (also known as Spot blocks).
     This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
+    You can't specify an Availability Zone group or a launch group if you specify a duration.
 
 -   `bundle_destination` (string) - The directory on the running instance where
     the bundled AMI will be saved prior to uploading. By default this is `/tmp`.


### PR DESCRIPTION
Allow to passe the spot instance duration.
This to prevent un-wanted build instance to remain alive long than expected.

This would also prevent build instance not being terminated (Situation we encountered in our company).