### PR TITLE
Increase retries

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -43,6 +43,9 @@ func (c *AccessConfig) Session() (*session.Session, error) {
 		config.WithCredentials(staticCreds)
 	}
 
+	// default is 3, and when it was causing failures for users being throttled
+	config = config.WithMaxRetries(20)
+
 	if c.RawRegion != "" {
 		config = config.WithRegion(c.RawRegion)
 	} else if region := c.metadataRegion(); region != "" {


### PR DESCRIPTION
Increase the MaxRetries from the default to 20, to work around users who regularly reach their requestlimit and are being throttled.

Closes #6530
