### PR TITLE
Fix some go vet issues in make test

### DIFF
--- a/builder/docker/communicator_test.go
+++ b/builder/docker/communicator_test.go
@@ -68,8 +68,8 @@ func TestUploadDownload(t *testing.T) {
 	hooks[packer.HookProvision] = []packer.Hook{
 		&packer.ProvisionHook{
 			Provisioners: []*packer.HookedProvisioner{
-				{upload, nil, ""},
-				{download, nil, ""},
+				{Provisioner: upload, Config: nil, TypeName: ""},
+				{Provisioner: download, Config: nil, TypeName: ""},
 			},
 		},
 	}
@@ -157,9 +157,9 @@ func TestLargeDownload(t *testing.T) {
 	hooks[packer.HookProvision] = []packer.Hook{
 		&packer.ProvisionHook{
 			Provisioners: []*packer.HookedProvisioner{
-				{shell, nil, ""},
-				{downloadCupcake, nil, ""},
-				{downloadBigcake, nil, ""},
+				{Provisioner: shell, Config: nil, TypeName: ""},
+				{Provisioner: downloadCupcake, Config: nil, TypeName: ""},
+				{Provisioner: downloadBigcake, Config: nil, TypeName: ""},
 			},
 		},
 	}
@@ -266,10 +266,10 @@ func TestFixUploadOwner(t *testing.T) {
 	hooks[packer.HookProvision] = []packer.Hook{
 		&packer.ProvisionHook{
 			Provisioners: []*packer.HookedProvisioner{
-				{fileProvisioner, nil, ""},
-				{dirProvisioner, nil, ""},
-				{shellProvisioner, nil, ""},
-				{verifyProvisioner, nil, ""},
+				{Provisioner: fileProvisioner, Config: nil, TypeName: ""},
+				{Provisioner: dirProvisioner, Config: nil, TypeName: ""},
+				{Provisioner: shellProvisioner, Config: nil, TypeName: ""},
+				{Provisioner: verifyProvisioner, Config: nil, TypeName: ""},
 			},
 		},
 	}

--- a/provisioner/ansible-local/provisioner_test.go
+++ b/provisioner/ansible-local/provisioner_test.go
@@ -367,8 +367,8 @@ func testProvisionerProvisionDockerWithPlaybookFiles(t *testing.T, templateStrin
 	hooks[packer.HookProvision] = []packer.Hook{
 		&packer.ProvisionHook{
 			Provisioners: []*packer.HookedProvisioner{
-				{ansible, nil, ""},
-				{download, nil, ""},
+				{Provisioner: ansible, Config: nil, TypeName: ""},
+				{Provisioner: download, Config: nil, TypeName: ""},
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixes some `composite literal uses unkeyed fields` errors I had when running `make test` on go 111
