### PR TITLE
extend decoder so that it can decode multiple times into the same con…

### DIFF
--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -42,10 +42,11 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 		if config.InterpolateContext == nil {
 			config.InterpolateContext = ctx
 		} else {
-			config.InterpolateContext.BuildName = ctx.BuildName
-			config.InterpolateContext.BuildType = ctx.BuildType
-			config.InterpolateContext.TemplatePath = ctx.TemplatePath
-			config.InterpolateContext.UserVariables = ctx.UserVariables
+			config.InterpolateContext.BuildName = updateString(config.InterpolateContext.BuildName, ctx.BuildName)
+			config.InterpolateContext.BuildType = updateString(config.InterpolateContext.BuildType, ctx.BuildType)
+			config.InterpolateContext.TemplatePath = updateString(config.InterpolateContext.TemplatePath, ctx.TemplatePath)
+			config.InterpolateContext.UserVariables = updateMap(config.InterpolateContext.UserVariables, ctx.UserVariables)
+			config.InterpolateContext.SensitiveVariables = append(config.InterpolateContext.SensitiveVariables, ctx.SensitiveVariables...)
 		}
 		ctx = config.InterpolateContext
 
@@ -144,4 +145,27 @@ func uint8ToStringHook(f reflect.Kind, t reflect.Kind, v interface{}) (interface
 	}
 
 	return v, nil
+}
+
+func updateString(oldString, newString string) string {
+	if oldString != "" {
+		if newString != "" {
+			return newString
+		}
+		return oldString
+	}
+	return newString
+}
+
+func updateMap(oldMap, newMap map[string]string) map[string]string {
+	if oldMap == nil {
+		oldMap = newMap
+	} else {
+		for newk, newv := range newMap {
+			if newk != "" {
+				oldMap[newk] = newv
+			}
+		}
+	}
+	return oldMap
 }

--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -148,23 +148,18 @@ func uint8ToStringHook(f reflect.Kind, t reflect.Kind, v interface{}) (interface
 }
 
 func updateString(oldString, newString string) string {
-	if oldString != "" {
-		if newString != "" {
-			return newString
-		}
-		return oldString
+	if newString != "" {
+		return newString
 	}
-	return newString
+	return oldString
 }
 
 func updateMap(oldMap, newMap map[string]string) map[string]string {
 	if oldMap == nil {
-		oldMap = newMap
+		return newMap
 	} else {
 		for newk, newv := range newMap {
-			if newk != "" {
-				oldMap[newk] = newv
-			}
+			oldMap[newk] = newv
 		}
 	}
 	return oldMap

--- a/helper/config/decode_test.go
+++ b/helper/config/decode_test.go
@@ -118,3 +118,47 @@ func TestDecode(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeAdditive(t *testing.T) {
+	type Target struct {
+		Name    string
+		Address string
+		Time    time.Duration
+	}
+
+	cases := map[string]struct {
+		Input  []interface{}
+		Output *Target
+		Opts   *DecodeOpts
+	}{
+		"build type": {
+			[]interface{}{
+				map[string]interface{}{
+					"name": "{{build_type}}",
+				},
+				map[string]interface{}{
+					"packer_builder_type": "foo",
+				},
+			},
+			&Target{
+				Name:    "foo",
+				Address: "keep",
+			},
+			nil,
+		},
+	}
+	for k, tc := range cases {
+		result := Target{
+			Name:    "overwrite",
+			Address: "keep",
+		}
+		err := Decode(&result, tc.Opts, tc.Input...)
+		if err != nil {
+			t.Fatalf("err: %s\n\n%s", k, err)
+		}
+
+		if !reflect.DeepEqual(&result, tc.Output) {
+			t.Fatalf("bad:\n\n%#v\n\n%#v", &result, tc.Output)
+		}
+	}
+}


### PR DESCRIPTION
Change decoder to be additive when run multiple times against the same target. 

Why:

The change I made so that we can pass WinRMPassword (and, potentially, other builder-generated items in the future) through to provisioners for interpolation at runtime had a fatal flaw: when Prepare was run a second time, the provisioner config's interpolation context was overwritten, without user variables, build-name, etc. 

The way the decoder is used in practice, there is no reason why it shouldn't be able to add new context to a target rather than blasting away context each time. This PR adds that functionality. 

closes https://github.com/hashicorp/packer/issues/6668