### PR TITLE
support ssh with private ip address

### DIFF
--- a/builder/alicloud/ecs/builder.go
+++ b/builder/alicloud/ecs/builder.go
@@ -139,10 +139,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			RegionId:                 b.config.AlicloudRegion,
 			InternetChargeType:       b.config.InternetChargeType,
 			InternetMaxBandwidthOut:  b.config.InternetMaxBandwidthOut,
+			SSHPrivateIp:             b.config.SSHPrivateIp,
 		})
 	} else {
 		steps = append(steps, &stepConfigAlicloudPublicIP{
-			RegionId: b.config.AlicloudRegion,
+			RegionId:     b.config.AlicloudRegion,
+			SSHPrivateIp: b.config.SSHPrivateIp,
 		})
 	}
 	steps = append(steps,

--- a/builder/alicloud/ecs/run_config_test.go
+++ b/builder/alicloud/ecs/run_config_test.go
@@ -123,3 +123,27 @@ func TestRunConfigPrepare_TemporaryKeyPairName(t *testing.T) {
 		t.Fatal("keypair name does not match")
 	}
 }
+
+func TestRunConfigPrepare_SSHPrivateIp(t *testing.T) {
+	c := testConfig()
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+	if c.SSHPrivateIp != false {
+		t.Fatalf("invalid value, expected: %t, actul: %t", false, c.SSHPrivateIp)
+	}
+	c.SSHPrivateIp = true
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+	if c.SSHPrivateIp != true {
+		t.Fatalf("invalid value, expected: %t, actul: %t", true, c.SSHPrivateIp)
+	}
+	c.SSHPrivateIp = false
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+	if c.SSHPrivateIp != false {
+		t.Fatalf("invalid value, expected: %t, actul: %t", false, c.SSHPrivateIp)
+	}
+}

--- a/builder/alicloud/ecs/step_config_public_ip.go
+++ b/builder/alicloud/ecs/step_config_public_ip.go
@@ -12,12 +12,23 @@ import (
 type stepConfigAlicloudPublicIP struct {
 	publicIPAddress string
 	RegionId        string
+	SSHPrivateIp    bool
 }
 
 func (s *stepConfigAlicloudPublicIP) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
+
+	if s.SSHPrivateIp {
+		ipaddress := instance.InnerIpAddress.IpAddress
+		if len(ipaddress) == 0 {
+			ui.Say("Failed to get private ip of instance")
+			return multistep.ActionHalt
+		}
+		state.Put("ipaddress", ipaddress[0])
+		return multistep.ActionContinue
+	}
 
 	ipaddress, err := client.AllocatePublicIpAddress(instance.InstanceId)
 	if err != nil {

--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -190,6 +190,9 @@ builder.
 
 -   `zone_id` (string) - ID of the zone to which the disk belongs.
 
+-   `ssh_private_ip` (boolean) - If this value is true, packer will connect to the ECS created through private ip
+    instead of allocating a public ip or an EIP. The default value is false.
+
 ## Basic Example
 
 Here is a basic example for Alicloud.


### PR DESCRIPTION
If `ssh_private_ip="true"` is provided in alicloud.json, packer will connect to the ECS created through private ip instead of allocating a public ip or an EIP.