### PR TITLE
spot instance creation, only set blockDurationMinutes when > 0

### DIFF
--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -186,12 +186,15 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 	if s.Comm.SSHKeyPairName != "" {
 		runOpts.KeyName = &s.Comm.SSHKeyPairName
 	}
+	spotInstanceInput := &ec2.RequestSpotInstancesInput{
+		LaunchSpecification: runOpts,
+		SpotPrice:           &spotPrice,
+	}
+	if s.BlockDurationMinutes != 0 {
+		spotInstanceInput.BlockDurationMinutes = &s.BlockDurationMinutes
+	}
 
-	runSpotResp, err := ec2conn.RequestSpotInstances(&ec2.RequestSpotInstancesInput{
-		BlockDurationMinutes: &s.BlockDurationMinutes,
-		LaunchSpecification:  runOpts,
-		SpotPrice:            &spotPrice,
-	})
+	runSpotResp, err := ec2conn.RequestSpotInstances(spotInstanceInput)
 	if err != nil {
 		err := fmt.Errorf("Error launching source spot instance: %s", err)
 		state.Put("error", err)


### PR DESCRIPTION
this will fix #6696 

that was introduced by https://github.com/hashicorp/packer/pull/6638

I totally expected the golang marshalling to ignore zero values when I merged it