### PR TITLE
OpenStack: SSH keypair is not attached

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -110,6 +110,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ConfigDrive:           b.config.ConfigDrive,
 			InstanceMetadata:      b.config.InstanceMetadata,
 			UseBlockStorageVolume: b.config.UseBlockStorageVolume,
+			Comm:                  &b.config.Comm,
 		},
 		&StepGetPassword{
 			Debug: b.config.PackerDebug,

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -27,6 +28,7 @@ type StepRunSourceServer struct {
 	InstanceMetadata      map[string]string
 	UseBlockStorageVolume bool
 	server                *servers.Server
+	Comm                  *communicator.Config
 }
 
 func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -107,7 +109,7 @@ func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) m
 	}
 
 	// Add keypair to the server create options.
-	keyName := config.Comm.SSHKeyPairName
+	keyName := s.Comm.SSHKeyPairName
 	if keyName != "" {
 		serverOptsExt = keypairs.CreateOptsExt{
 			CreateOptsBuilder: serverOptsExt,


### PR DESCRIPTION
Using v1.3.0 with OpenStack builder, I noticed that a temporary SSH keypair is created normally, but that keypair is not attached to the instance.

[step_key_pair.go](https://github.com/hashicorp/packer/blob/4dbd11110b7b6048929e98d45e942880384d2883/builder/openstack/step_key_pair.go#L118-L119) and [step_run_source_server.go](https://github.com/hashicorp/packer/blob/4dbd11110b7b6048929e98d45e942880384d2883/builder/openstack/step_run_source_server.go#L110) are trying use keypair information in different ways. (It looks like this change was missed in https://github.com/hashicorp/packer/commit/d159c0900b0aeae4000e69f1a4f3acf5c40f0d3c)