### PR TITLE
Add disk_format option for OpenStack builder

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -52,6 +52,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, errs
 	}
 
+	if b.config.ImageConfig.ImageDiskFormat != "" && !b.config.RunConfig.UseBlockStorageVolume {
+		return nil, fmt.Errorf("use_blockstorage_volume must be true if image_disk_format is specified.")
+	}
+
 	// By default, instance name is same as image name
 	if b.config.InstanceName == "" {
 		b.config.InstanceName = b.config.ImageName

--- a/builder/openstack/image_config.go
+++ b/builder/openstack/image_config.go
@@ -14,6 +14,7 @@ type ImageConfig struct {
 	ImageMetadata   map[string]string            `mapstructure:"metadata"`
 	ImageVisibility imageservice.ImageVisibility `mapstructure:"image_visibility"`
 	ImageMembers    []string                     `mapstructure:"image_members"`
+	DiskFormat      string                       `mapstructure:"disk_format"`
 }
 
 func (c *ImageConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/openstack/image_config.go
+++ b/builder/openstack/image_config.go
@@ -14,7 +14,7 @@ type ImageConfig struct {
 	ImageMetadata   map[string]string            `mapstructure:"metadata"`
 	ImageVisibility imageservice.ImageVisibility `mapstructure:"image_visibility"`
 	ImageMembers    []string                     `mapstructure:"image_members"`
-	DiskFormat      string                       `mapstructure:"disk_format"`
+	ImageDiskFormat string                       `mapstructure:"image_disk_format"`
 }
 
 func (c *ImageConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -47,7 +47,7 @@ func (s *stepCreateImage) Run(_ context.Context, state multistep.StateBag) multi
 		}
 		volume := state.Get("volume_id").(string)
 		image, err := volumeactions.UploadImage(blockStorageClient, volume, volumeactions.UploadImageOpts{
-			DiskFormat: config.DiskFormat,
+			DiskFormat: config.ImageDiskFormat,
 			ImageName:  config.ImageName,
 		}).Extract()
 		if err != nil {

--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -47,7 +47,8 @@ func (s *stepCreateImage) Run(_ context.Context, state multistep.StateBag) multi
 		}
 		volume := state.Get("volume_id").(string)
 		image, err := volumeactions.UploadImage(blockStorageClient, volume, volumeactions.UploadImageOpts{
-			ImageName: config.ImageName,
+			DiskFormat: config.DiskFormat,
+			ImageName:  config.ImageName,
 		}).Extract()
 		if err != nil {
 			err := fmt.Errorf("Error creating image: %s", err)

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -275,6 +275,9 @@ builder.
     zones aren't specified, the default enforced by your OpenStack cluster will
     be used.
 
+-   `image_disk_format` (string) - Disk format of the resulting image.
+    This option works if `use_blockstorage_volume` is true.
+
 ## Basic Example: DevStack
 
 Here is a basic example. This is a example to build on DevStack running in a VM.


### PR DESCRIPTION
This PR adds an option to chose disk format of the built image to the OpenStack builder.

This option works if `use_blockstorage_volume` is true. (Related #6596)