### PR TITLE
FIXES 6710 - support new ec2 instance family's device mappings

### DIFF
--- a/builder/amazon/chroot/device.go
+++ b/builder/amazon/chroot/device.go
@@ -42,7 +42,7 @@ func AvailableDevice() (string, error) {
 // devicePrefix returns the prefix ("sd" or "xvd" or so on) of the devices
 // on the system.
 func devicePrefix() (string, error) {
-	available := []string{"sd", "xvd"}
+	available := []string{"nvme", "sd", "xvd"}
 
 	f, err := os.Open("/sys/block")
 	if err != nil {


### PR DESCRIPTION
* add "nvme" to the devicePrefix list
* see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html for list of instance families using NVMe block devices

Closes #6710
