### PR TITLE
fix attaching keypair error due to missing keypair name

### DIFF
--- a/builder/alicloud/ecs/builder.go
+++ b/builder/alicloud/ecs/builder.go
@@ -146,7 +146,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		})
 	}
 	steps = append(steps,
-		&stepAttachKeyPair{},
+		&stepAttachKeyPair{
+			Comm: &b.config.Comm,
+		},
 		&stepRunAlicloudInstance{},
 		&stepMountAlicloudDisk{},
 		&communicator.StepConnect{

--- a/builder/alicloud/ecs/builder.go
+++ b/builder/alicloud/ecs/builder.go
@@ -79,7 +79,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, err
 	}
 	state := new(multistep.BasicStateBag)
-	state.Put("config", b.config)
+	state.Put("config", &b.config)
 	state.Put("client", client)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
@@ -146,9 +146,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		})
 	}
 	steps = append(steps,
-		&stepAttachKeyPair{
-			Comm: &b.config.Comm,
-		},
+		&stepAttachKeyPair{},
 		&stepRunAlicloudInstance{},
 		&stepMountAlicloudDisk{},
 		&communicator.StepConnect{

--- a/builder/alicloud/ecs/builder_acc_test.go
+++ b/builder/alicloud/ecs/builder_acc_test.go
@@ -236,8 +236,7 @@ const testBuilderAccBasic = `
 		"type": "test",
 		"region": "cn-beijing",
 		"instance_type": "ecs.n1.tiny",
-		"source_image":"ubuntu_16_0402_64_40G_base_20170222.vhd",
-		"ssh_username": "ubuntu",
+		"source_image":"ubuntu_16_0402_64_20G_alibase_20180409.vhd",
 		"io_optimized":"true",
 		"ssh_username":"root",
 		"image_name": "packer-test_{{timestamp}}"

--- a/builder/alicloud/ecs/step_attach_keypair.go
+++ b/builder/alicloud/ecs/step_attach_keypair.go
@@ -8,22 +8,20 @@ import (
 
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
-	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
 
 type stepAttachKeyPair struct {
-	Comm *communicator.Config
 }
 
 func (s *stepAttachKeyPair) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	client := state.Get("client").(*ecs.Client)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
 	timeoutPoint := time.Now().Add(120 * time.Second)
-	keyPairName := s.Comm.SSHKeyPairName
+	keyPairName := config.Comm.SSHKeyPairName
 	if keyPairName == "" {
 		return multistep.ActionContinue
 	}
@@ -54,7 +52,7 @@ func (s *stepAttachKeyPair) Run(_ context.Context, state multistep.StateBag) mul
 
 func (s *stepAttachKeyPair) Cleanup(state multistep.StateBag) {
 	client := state.Get("client").(*ecs.Client)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
 	keyPairName := config.Comm.SSHKeyPairName

--- a/builder/alicloud/ecs/step_attach_keypair.go
+++ b/builder/alicloud/ecs/step_attach_keypair.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
+	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
 
 type stepAttachKeyPair struct {
+	Comm *communicator.Config
 }
 
 func (s *stepAttachKeyPair) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -21,7 +23,7 @@ func (s *stepAttachKeyPair) Run(_ context.Context, state multistep.StateBag) mul
 	config := state.Get("config").(Config)
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
 	timeoutPoint := time.Now().Add(120 * time.Second)
-	keyPairName := config.Comm.SSHKeyPairName
+	keyPairName := s.Comm.SSHKeyPairName
 	if keyPairName == "" {
 		return multistep.ActionContinue
 	}

--- a/builder/alicloud/ecs/step_check_source_image.go
+++ b/builder/alicloud/ecs/step_check_source_image.go
@@ -16,7 +16,7 @@ type stepCheckAlicloudSourceImage struct {
 
 func (s *stepCheckAlicloudSourceImage) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	args := &ecs.DescribeImagesArgs{
 		RegionId: common.Region(config.AlicloudRegion),

--- a/builder/alicloud/ecs/step_config_vpc.go
+++ b/builder/alicloud/ecs/step_config_vpc.go
@@ -20,7 +20,7 @@ type stepConfigAlicloudVPC struct {
 }
 
 func (s *stepConfigAlicloudVPC) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 

--- a/builder/alicloud/ecs/step_config_vswitch.go
+++ b/builder/alicloud/ecs/step_config_vswitch.go
@@ -24,7 +24,7 @@ func (s *stepConfigAlicloudVSwitch) Run(_ context.Context, state multistep.State
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 	vpcId := state.Get("vpcid").(string)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 
 	if len(s.VSwitchId) != 0 {
 		vswitchs, _, err := client.DescribeVSwitches(&ecs.DescribeVSwitchesArgs{

--- a/builder/alicloud/ecs/step_create_image.go
+++ b/builder/alicloud/ecs/step_create_image.go
@@ -15,7 +15,7 @@ type stepCreateAlicloudImage struct {
 }
 
 func (s *stepCreateAlicloudImage) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 
@@ -85,7 +85,7 @@ func (s *stepCreateAlicloudImage) Cleanup(state multistep.StateBag) {
 
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 
 	ui.Say("Deleting the image because of cancellation or error...")
 	if err := client.DeleteImage(common.Region(config.AlicloudRegion), s.image.ImageId); err != nil {

--- a/builder/alicloud/ecs/step_create_instance.go
+++ b/builder/alicloud/ecs/step_create_instance.go
@@ -28,7 +28,7 @@ type stepCreateAlicloudInstance struct {
 
 func (s *stepCreateAlicloudInstance) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	source_image := state.Get("source_image").(*ecs.ImageType)
 	network_type := state.Get("networktype").(InstanceNetWork)

--- a/builder/alicloud/ecs/step_delete_images_snapshots.go
+++ b/builder/alicloud/ecs/step_delete_images_snapshots.go
@@ -20,7 +20,7 @@ type stepDeleteAlicloudImageSnapshots struct {
 func (s *stepDeleteAlicloudImageSnapshots) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui.Say("Deleting image snapshots.")
 	// Check for force delete
 	if s.AlicloudImageForceDelete {

--- a/builder/alicloud/ecs/step_mount_disk.go
+++ b/builder/alicloud/ecs/step_mount_disk.go
@@ -14,7 +14,7 @@ type stepMountAlicloudDisk struct {
 
 func (s *stepMountAlicloudDisk) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
 	alicloudDiskDevices := config.ECSImagesDiskMappings

--- a/builder/alicloud/ecs/step_pre_validate.go
+++ b/builder/alicloud/ecs/step_pre_validate.go
@@ -23,7 +23,7 @@ func (s *stepPreValidate) Run(_ context.Context, state multistep.StateBag) multi
 	}
 
 	client := state.Get("client").(*ecs.Client)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui.Say("Prevalidating image name...")
 	images, _, err := client.DescribeImages(&ecs.DescribeImagesArgs{
 		ImageName: s.AlicloudDestImageName,


### PR DESCRIPTION
KeyPair is created in `stepConfigAlicloudKeyPair` and stored in `Comm` field, but `stepAttachKeyPair` uses `config.Comm.SSHKeyPairName` which is found out to be an empty string. This causes `stepAttachKeyPair#Run` returns immediately without actually attaching the KeyPair.

This fix passes `Comm`  field to `stepAttachKeyPair` to make use of the KeyPair generated.