### PR TITLE
reset poll delay seconds default to 2 because it can actuall be used …

### DIFF
--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -289,7 +289,7 @@ func getOverride(varInfo envInfo) envInfo {
 func getEnvOverrides() overridableWaitVars {
 	// Load env vars from environment.
 	envValues := overridableWaitVars{
-		envInfo{"AWS_POLL_DELAY_SECONDS", 0, false},
+		envInfo{"AWS_POLL_DELAY_SECONDS", 2, false},
 		envInfo{"AWS_MAX_ATTEMPTS", 0, false},
 		envInfo{"AWS_TIMEOUT_SECONDS", 0, false},
 	}


### PR DESCRIPTION
Fix divide by zero error in the apply env overrides code.
Closes #6723 
