### PR TITLE
builder/digitalocean: pass config as a pointer so that ssh configuration is correctly set

### DIFF
--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -71,7 +71,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	// Set up the state
 	state := new(multistep.BasicStateBag)
-	state.Put("config", b.config)
+	state.Put("config", &b.config)
 	state.Put("client", client)
 	state.Put("hook", hook)
 	state.Put("ui", ui)

--- a/builder/digitalocean/step_create_droplet.go
+++ b/builder/digitalocean/step_create_droplet.go
@@ -18,7 +18,7 @@ type stepCreateDroplet struct {
 func (s *stepCreateDroplet) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*godo.Client)
 	ui := state.Get("ui").(packer.Ui)
-	c := state.Get("config").(Config)
+	c := state.Get("config").(*Config)
 	sshKeyId := state.Get("ssh_key_id").(int)
 
 	// Create the droplet based on configuration

--- a/builder/digitalocean/step_droplet_info.go
+++ b/builder/digitalocean/step_droplet_info.go
@@ -14,7 +14,7 @@ type stepDropletInfo struct{}
 func (s *stepDropletInfo) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*godo.Client)
 	ui := state.Get("ui").(packer.Ui)
-	c := state.Get("config").(Config)
+	c := state.Get("config").(*Config)
 	dropletID := state.Get("droplet_id").(int)
 
 	ui.Say("Waiting for droplet to become active...")

--- a/builder/digitalocean/step_power_off.go
+++ b/builder/digitalocean/step_power_off.go
@@ -14,7 +14,7 @@ type stepPowerOff struct{}
 
 func (s *stepPowerOff) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*godo.Client)
-	c := state.Get("config").(Config)
+	c := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	dropletId := state.Get("droplet_id").(int)
 

--- a/builder/digitalocean/step_shutdown.go
+++ b/builder/digitalocean/step_shutdown.go
@@ -15,7 +15,7 @@ type stepShutdown struct{}
 
 func (s *stepShutdown) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*godo.Client)
-	c := state.Get("config").(Config)
+	c := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	dropletId := state.Get("droplet_id").(int)
 

--- a/builder/digitalocean/step_snapshot.go
+++ b/builder/digitalocean/step_snapshot.go
@@ -17,7 +17,7 @@ type stepSnapshot struct{}
 func (s *stepSnapshot) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*godo.Client)
 	ui := state.Get("ui").(packer.Ui)
-	c := state.Get("config").(Config)
+	c := state.Get("config").(*Config)
 	dropletId := state.Get("droplet_id").(int)
 	var snapshotRegions []string
 


### PR DESCRIPTION
Hello 🙂 

this resolves #6715

Where call like the following one would panic:
https://github.com/hashicorp/packer/blob/b83c72fd5451ef78153f3c475e68efefd8b6e22e/builder/digitalocean/step_create_ssh_key.go#L31

Since a copy (not a pointer) of the configuration was stored in the statebag.

 issues/prs related:  #6712 #6720