### PR TITLE
Use config from state-bag as a pointer

### DIFF
--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -112,7 +112,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
-	state.Put("config", b.config)
+	state.Put("config", &b.config)
 	state.Put("ec2", ec2conn)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -17,7 +17,7 @@ type stepCreateAMI struct {
 }
 
 func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	instance := state.Get("instance").(*ec2.Instance)
 	ui := state.Get("ui").(packer.Ui)

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -111,7 +111,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
-	state.Put("config", b.config)
+	state.Put("config", &b.config)
 	state.Put("ec2", ec2conn)
 	state.Put("hook", hook)
 	state.Put("ui", ui)

--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -110,7 +110,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ConfigDrive:           b.config.ConfigDrive,
 			InstanceMetadata:      b.config.InstanceMetadata,
 			UseBlockStorageVolume: b.config.UseBlockStorageVolume,
-			Comm:                  &b.config.Comm,
 		},
 		&StepGetPassword{
 			Debug: b.config.PackerDebug,

--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -73,7 +73,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
-	state.Put("config", b.config)
+	state.Put("config", &b.config)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
 

--- a/builder/openstack/step_add_image_members.go
+++ b/builder/openstack/step_add_image_members.go
@@ -14,7 +14,7 @@ type stepAddImageMembers struct{}
 func (s *stepAddImageMembers) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	imageId := state.Get("image").(string)
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 
 	if len(config.ImageMembers) == 0 {
 		return multistep.ActionContinue

--- a/builder/openstack/step_allocate_ip.go
+++ b/builder/openstack/step_allocate_ip.go
@@ -18,7 +18,7 @@ type StepAllocateIp struct {
 
 func (s *StepAllocateIp) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	server := state.Get("server").(*servers.Server)
 
 	// We need the v2 compute client
@@ -138,7 +138,7 @@ func (s *StepAllocateIp) Run(_ context.Context, state multistep.StateBag) multis
 }
 
 func (s *StepAllocateIp) Cleanup(state multistep.StateBag) {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	instanceIP := state.Get("access_ip").(*floatingips.FloatingIP)
 

--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -20,7 +20,7 @@ type stepCreateImage struct {
 }
 
 func (s *stepCreateImage) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	server := state.Get("server").(*servers.Server)
 	ui := state.Get("ui").(packer.Ui)
 

--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -24,7 +24,7 @@ func (s *StepCreateVolume) Run(_ context.Context, state multistep.StateBag) mult
 		return multistep.ActionContinue
 	}
 
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	sourceImage := state.Get("source_image").(string)
 
@@ -92,7 +92,7 @@ func (s *StepCreateVolume) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
 	blockStorageClient, err := config.blockStorageV3Client()

--- a/builder/openstack/step_detach_volume.go
+++ b/builder/openstack/step_detach_volume.go
@@ -19,7 +19,7 @@ func (s *StepDetachVolume) Run(_ context.Context, state multistep.StateBag) mult
 		return multistep.ActionContinue
 	}
 
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
 	blockStorageClient, err := config.blockStorageV3Client()

--- a/builder/openstack/step_get_password.go
+++ b/builder/openstack/step_get_password.go
@@ -22,7 +22,7 @@ type StepGetPassword struct {
 }
 
 func (s *StepGetPassword) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
 	// Skip if we're not using winrm

--- a/builder/openstack/step_key_pair.go
+++ b/builder/openstack/step_key_pair.go
@@ -57,7 +57,7 @@ func (s *StepKeyPair) Run(_ context.Context, state multistep.StateBag) multistep
 		return multistep.ActionContinue
 	}
 
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 
 	// We need the v2 compute client
 	computeClient, err := config.computeV2Client()
@@ -169,7 +169,7 @@ func (s *StepKeyPair) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
 	// We need the v2 compute client

--- a/builder/openstack/step_load_flavor.go
+++ b/builder/openstack/step_load_flavor.go
@@ -18,7 +18,7 @@ type StepLoadFlavor struct {
 }
 
 func (s *StepLoadFlavor) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
 	// We need the v2 compute client

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -30,7 +30,7 @@ type StepRunSourceServer struct {
 }
 
 func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	flavor := state.Get("flavor_id").(string)
 	sourceImage := state.Get("source_image").(string)
 	ui := state.Get("ui").(packer.Ui)
@@ -148,7 +148,7 @@ func (s *StepRunSourceServer) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
 	// We need the v2 compute client

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
-	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -26,7 +25,6 @@ type StepRunSourceServer struct {
 	InstanceMetadata      map[string]string
 	UseBlockStorageVolume bool
 	server                *servers.Server
-	Comm                  *communicator.Config
 }
 
 func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -102,7 +100,7 @@ func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) m
 	}
 
 	// Add keypair to the server create options.
-	keyName := s.Comm.SSHKeyPairName
+	keyName := config.Comm.SSHKeyPairName
 	if keyName != "" {
 		serverOptsExt = keypairs.CreateOptsExt{
 			CreateOptsBuilder: serverOptsExt,

--- a/builder/openstack/step_source_image_info.go
+++ b/builder/openstack/step_source_image_info.go
@@ -19,7 +19,7 @@ type StepSourceImageInfo struct {
 }
 
 func (s *StepSourceImageInfo) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
 	if s.SourceImage != "" {

--- a/builder/openstack/step_stop_server.go
+++ b/builder/openstack/step_stop_server.go
@@ -14,7 +14,7 @@ type StepStopServer struct{}
 
 func (s *StepStopServer) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	server := state.Get("server").(*servers.Server)
 
 	// We need the v2 compute client

--- a/builder/openstack/step_update_image_visibility.go
+++ b/builder/openstack/step_update_image_visibility.go
@@ -14,7 +14,7 @@ type stepUpdateImageVisibility struct{}
 func (s *stepUpdateImageVisibility) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	imageId := state.Get("image").(string)
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 
 	if config.ImageVisibility == "" {
 		return multistep.ActionContinue

--- a/builder/openstack/step_wait_for_rackconnect.go
+++ b/builder/openstack/step_wait_for_rackconnect.go
@@ -19,7 +19,7 @@ func (s *StepWaitForRackConnect) Run(_ context.Context, state multistep.StateBag
 		return multistep.ActionContinue
 	}
 
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	server := state.Get("server").(*servers.Server)
 	ui := state.Get("ui").(packer.Ui)
 

--- a/builder/triton/builder.go
+++ b/builder/triton/builder.go
@@ -54,7 +54,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	}
 
 	state := new(multistep.BasicStateBag)
-	state.Put("config", b.config)
+	state.Put("config", &b.config)
 	state.Put("debug", b.config.PackerDebug)
 	state.Put("driver", driver)
 	state.Put("hook", hook)

--- a/builder/triton/config_test.go
+++ b/builder/triton/config_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-func testConfig(t *testing.T) Config {
-	return Config{
+func testConfig(t *testing.T) *Config {
+	return &Config{
 		AccessConfig:        testAccessConfig(),
 		SourceMachineConfig: testSourceMachineConfig(t),
 		TargetImageConfig:   testTargetImageConfig(t),

--- a/builder/triton/step_create_image_from_machine.go
+++ b/builder/triton/step_create_image_from_machine.go
@@ -15,7 +15,7 @@ import (
 type StepCreateImageFromMachine struct{}
 
 func (s *StepCreateImageFromMachine) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 
@@ -23,7 +23,7 @@ func (s *StepCreateImageFromMachine) Run(_ context.Context, state multistep.Stat
 
 	ui.Say("Creating image from source machine...")
 
-	imageId, err := driver.CreateImageFromMachine(machineId, config)
+	imageId, err := driver.CreateImageFromMachine(machineId, *config)
 	if err != nil {
 		state.Put("error", fmt.Errorf("Problem creating image from machine: %s", err))
 		return multistep.ActionHalt

--- a/builder/triton/step_create_source_machine.go
+++ b/builder/triton/step_create_source_machine.go
@@ -14,13 +14,13 @@ import (
 type StepCreateSourceMachine struct{}
 
 func (s *StepCreateSourceMachine) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 
 	if !config.MachineImageFilters.Empty() {
 		ui.Say("Selecting an image based on search criteria")
-		imageId, err := driver.GetImage(config)
+		imageId, err := driver.GetImage(*config)
 		if err != nil {
 			state.Put("error", fmt.Errorf("Problem selecting an image based on an search criteria: %s", err))
 			return multistep.ActionHalt
@@ -29,7 +29,7 @@ func (s *StepCreateSourceMachine) Run(_ context.Context, state multistep.StateBa
 		config.MachineImage = imageId
 	}
 
-	machineId, err := driver.CreateMachine(config)
+	machineId, err := driver.CreateMachine(*config)
 	if err != nil {
 		state.Put("error", fmt.Errorf("Problem creating source machine: %s", err))
 		return multistep.ActionHalt


### PR DESCRIPTION
Hi 🙂,

This pr sanitises `config` usages by making them all pointers/references. So that we can fix issues before they happen 😄.

Affected builders are split per commit.
___

History:

pr #6621 refactored usages of the ssh configuration fields to put them in the `config` instance of the statebag.

Often times, a step creates a machine & generates ssh settings to set them in `config` of the statebag.
For some builders, `config` was stored as a copy, meaning the ssh configuration was not set into state; meaning we could not reach an instance.
All cases we tested had pointers so we didn't see it coming.

___
⚠️  Let's test this before anything ! ⚠️ 

digitalocean got fixed in #6729 
alicloud got fixed in #6720
this reverts #6701
closes #6712 #6757