### PR TITLE
don't use default panic wrap key

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func main() {
 // realMain is executed from main and returns the exit status to exit with.
 func realMain() int {
 	var wrapConfig panicwrap.WrapConfig
+	wrapConfig.CookieKey = "PACKER_WRAP_COOKIE"
+	wrapConfig.CookieValue = "49C22B1A-3A93-4C98-97FA-E07D18C787B5"
 
 	if !panicwrap.Wrapped(&wrapConfig) {
 		// Generate a UUID for this packer run and pass it to the environment.

--- a/main.go
+++ b/main.go
@@ -37,6 +37,9 @@ func main() {
 // realMain is executed from main and returns the exit status to exit with.
 func realMain() int {
 	var wrapConfig panicwrap.WrapConfig
+	// When following env variable is set, packer
+	// wont panic wrap itself as it's already wrapped.
+	// i.e.: when terraform runs it.
 	wrapConfig.CookieKey = "PACKER_WRAP_COOKIE"
 	wrapConfig.CookieValue = "49C22B1A-3A93-4C98-97FA-E07D18C787B5"
 


### PR DESCRIPTION
This is a fun one. When packer is run from within another golang program that uses panicwrap, Packer never sets up logging correctly. Packer needs to use a unique CookieKey and CookieValue to prevent this.

Closes #6736