### PR TITLE
scaleway: add boottype parameter in config

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ImageName    string `mapstructure:"image_name"`
 	ServerName   string `mapstructure:"server_name"`
 	Bootscript   string `mapstructure:"bootscript"`
+	BootType     string `mapstructure:"boottype"`
 
 	UserAgent string
 	ctx       interpolate.Context
@@ -84,6 +85,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	if c.ServerName == "" {
 		// Default to packer-[time-ordered-uuid]
 		c.ServerName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
+	}
+
+	if c.BootType == "" {
+		c.BootType = "bootscript"
 	}
 
 	var errs *packer.MultiError

--- a/builder/scaleway/step_create_server.go
+++ b/builder/scaleway/step_create_server.go
@@ -38,6 +38,7 @@ func (s *stepCreateServer) Run(_ context.Context, state multistep.StateBag) mult
 		CommercialType: c.CommercialType,
 		Tags:           tags,
 		Bootscript:     bootscript,
+		BootType:       c.BootType,
 	})
 
 	if err != nil {

--- a/website/source/docs/builders/scaleway.html.md
+++ b/website/source/docs/builders/scaleway.html.md
@@ -74,6 +74,9 @@ builder.
 -   `snapshot_name` (string) - The name of the resulting snapshot that will
     appear in your account. Default `packer-TIMESTAMP`
 
+-   `boottype` (string) - The type of boot, can be either `local` or `bootscript`,
+    Default `bootscript`
+
 -   `bootscript` (string) - The id of an existing bootscript to use when booting
     the server.
 


### PR DESCRIPTION
This commit adds the ability to specify the boottype at server creation.

This has always defaulted to `bootscript`, now we can specify `local` to boot the local kernel installed on the VM.

Closes #6770

@azr @dimtion @edouardb @mvaude @nicolai86 @sieben