### PR TITLE
add ssh_username

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -66,6 +66,8 @@ builder.
     created machine. `source_ami_filter` may be used instead to populate this
     automatically.
 
+-   `ssh_username` (string) - The username to connect to SSH with. Required if using SSH.
+
 ### Optional:
 
 -   `ami_block_device_mappings` (array of block device mappings) - Add one or


### PR DESCRIPTION
The amazon-ebs required parameters don't specify ssh_username.  I've added it to this PR.

https://www.packer.io/docs/builders/amazon-ebs.html

Here's the error I get when ssh_username isn't specified:

```
$ packer validate -var-file=variables.json example.json
Template validation failed. Errors are shown below.

Errors validating build 'amazon-ebs'. 1 error(s) occurred:

* An ssh_username must be specified
  Note: some builders used to default ssh_username to "root".
```
