### PR TITLE
add optional timestamps to build log

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -23,13 +23,14 @@ type BuildCommand struct {
 }
 
 func (c *BuildCommand) Run(args []string) int {
-	var cfgColor, cfgDebug, cfgForce, cfgParallel bool
+	var cfgColor, cfgDebug, cfgForce, cfgTimestamp, cfgParallel bool
 	var cfgOnError string
 	flags := c.Meta.FlagSet("build", FlagSetBuildFilter|FlagSetVars)
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	flags.BoolVar(&cfgColor, "color", true, "")
 	flags.BoolVar(&cfgDebug, "debug", false, "")
 	flags.BoolVar(&cfgForce, "force", false, "")
+	flags.BoolVar(&cfgTimestamp, "timestamp", false, "")
 	flagOnError := enumflag.New(&cfgOnError, "cleanup", "abort", "ask")
 	flags.Var(flagOnError, "on-error", "")
 	flags.BoolVar(&cfgParallel, "parallel", true, "")
@@ -100,6 +101,12 @@ func (c *BuildCommand) Run(args []string) int {
 				if i+1 == len(buildNames) {
 					// Add a newline between the color output and the actual output
 					c.Ui.Say("")
+				}
+				// Now add timestamps if requested
+				if cfgTimestamp {
+					ui = &packer.TimestampedUi{
+						Ui: ui,
+					}
 				}
 			}
 		}
@@ -302,6 +309,7 @@ Options:
   -machine-readable             Machine-readable output
   -on-error=[cleanup|abort|ask] If the build fails do: clean up (default), abort, or ask
   -parallel=false               Disable parallelization (on by default)
+  -timestamp=true               Enable timestamps in build log (off by default)
   -var 'key=value'              Variable for templates, can be used multiple times.
   -var-file=path                JSON file containing user variables.
 `
@@ -327,6 +335,7 @@ func (*BuildCommand) AutocompleteFlags() complete.Flags {
 		"-machine-readable": complete.PredictNothing,
 		"-on-error":         complete.PredictNothing,
 		"-parallel":         complete.PredictNothing,
+		"-timestamp":        complete.PredictNothing,
 		"-var":              complete.PredictNothing,
 		"-var-file":         complete.PredictNothing,
 	}

--- a/command/build.go
+++ b/command/build.go
@@ -309,7 +309,7 @@ Options:
   -machine-readable             Machine-readable output
   -on-error=[cleanup|abort|ask] If the build fails do: clean up (default), abort, or ask
   -parallel=false               Disable parallelization (on by default)
-  -timestamp=true               Enable timestamps in build log (off by default)
+  -timestamp-ui=true            Prefix each ui output with an RFC3339 timestamp (off by default).
   -var 'key=value'              Variable for templates, can be used multiple times.
   -var-file=path                JSON file containing user variables.
 `

--- a/packer/ui.go
+++ b/packer/ui.go
@@ -99,6 +99,14 @@ type MachineReadableUi struct {
 
 var _ Ui = new(MachineReadableUi)
 
+// TimestampedUi is a UI that wraps another UI implementation and prefixes
+// prefixes each message with an RFC3339 timestamp
+type TimestampedUi struct {
+	Ui Ui
+}
+
+var _ Ui = new(TimestampedUi)
+
 func (u *ColoredUi) Ask(query string) (string, error) {
 	return u.Ui.Ask(u.colorize(query, u.Color, true))
 }
@@ -341,4 +349,30 @@ func (u *MachineReadableUi) Machine(category string, args ...string) {
 
 func (u *MachineReadableUi) ProgressBar() ProgressBar {
 	return new(NoopProgressBar)
+}
+
+func (u *TimestampedUi) Ask(query string) (string, error) {
+	return u.Ui.Ask(query)
+}
+
+func (u *TimestampedUi) Say(message string) {
+	u.Ui.Say(u.timestampLine(message))
+}
+
+func (u *TimestampedUi) Message(message string) {
+	u.Ui.Message(u.timestampLine(message))
+}
+
+func (u *TimestampedUi) Error(message string) {
+	u.Ui.Error(u.timestampLine(message))
+}
+
+func (u *TimestampedUi) Machine(message string, args ...string) {
+	u.Ui.Machine(message, args...)
+}
+
+func (u *TimestampedUi) ProgressBar() ProgressBar { return u.Ui.ProgressBar() }
+
+func (u *TimestampedUi) timestampLine(string string) string {
+	return fmt.Sprintf("%v: %v", time.Now().Format(time.RFC3339), string)
 }

--- a/packer/ui.go
+++ b/packer/ui.go
@@ -99,14 +99,6 @@ type MachineReadableUi struct {
 
 var _ Ui = new(MachineReadableUi)
 
-// TimestampedUi is a UI that wraps another UI implementation and prefixes
-// prefixes each message with an RFC3339 timestamp
-type TimestampedUi struct {
-	Ui Ui
-}
-
-var _ Ui = new(TimestampedUi)
-
 func (u *ColoredUi) Ask(query string) (string, error) {
 	return u.Ui.Ask(u.colorize(query, u.Color, true))
 }
@@ -350,6 +342,14 @@ func (u *MachineReadableUi) Machine(category string, args ...string) {
 func (u *MachineReadableUi) ProgressBar() ProgressBar {
 	return new(NoopProgressBar)
 }
+
+// TimestampedUi is a UI that wraps another UI implementation and prefixes
+// prefixes each message with an RFC3339 timestamp
+type TimestampedUi struct {
+	Ui Ui
+}
+
+var _ Ui = new(TimestampedUi)
 
 func (u *TimestampedUi) Ask(query string) (string, error) {
 	return u.Ui.Ask(query)

--- a/website/source/docs/commands/build.html.md
+++ b/website/source/docs/commands/build.html.md
@@ -50,6 +50,9 @@ that are created will be outputted at the end of the build.
 -   `-parallel=false` - Disable parallelization of multiple builders (on by
     default).
 
+-   `-timestamp=true` - Enable timestamps for build logs without adding the extra
+    information included if PACKER_LOG is true.
+
 -   `-var` - Set a variable in your packer template. This option can be used
     multiple times. This is useful for setting version numbers for your build.
 

--- a/website/source/docs/commands/build.html.md
+++ b/website/source/docs/commands/build.html.md
@@ -50,8 +50,8 @@ that are created will be outputted at the end of the build.
 -   `-parallel=false` - Disable parallelization of multiple builders (on by
     default).
 
--   `-timestamp=true` - Enable timestamps for build logs without adding the extra
-    information included if PACKER_LOG is true.
+-   `-timestamp-ui=true` - Prefix each ui output with an RFC3339 timestamp (off
+    by default).
 
 -   `-var` - Set a variable in your packer template. This option can be used
     multiple times. This is useful for setting version numbers for your build.

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -119,5 +119,5 @@ For example, assume a tab is typed at the end of each prompt line:
 $ packer p
 plugin  build
 $ packer build -
--color             -debug             -except            -force             -machine-readable  -on-error          -only              -parallel          -var               -var-file
+-color             -debug             -except            -force             -machine-readable  -on-error          -only              -parallel          -timestamp          -var               -var-file
 ```


### PR DESCRIPTION
- Adds optional timestamps to the build log without adding any of the extra information added when PACKER_LOG is true. Particularly useful for us when running automated builds as we only get a copy of the build log after all is complete.
