### PR TITLE
Update provisioner.go

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -138,7 +138,6 @@ var waitForRestart = func(p *Provisioner, comm packer.Communicator) error {
 			// Reboot already in progress but not completed
 			log.Printf("Reboot already in progress, waiting...")
 			time.Sleep(10 * time.Second)
-			break
 		}
 		if cmd.ExitStatus == 0 {
 			// Cancel reboot we created to test if machine was already rebooting


### PR DESCRIPTION
Remove extra break statement that made it's way into the "reboot pending" loop when some logic was rearranged in https://github.com/hashicorp/packer/commit/9fa47f5dad3a319d9987770853db9917853cf2f1#diff-8bb0a16231863cd1487dd9a3d3792565

New build successfully waits for restart to complete.

> azure-arm: Waiting for machine to restart...
> azure-arm: A system shutdown is in progress.(1115)
> azure-arm: A system shutdown is in progress.(1115)
> azure-arm: A system shutdown is in progress.(1115)
> azure-arm: A system shutdown is in progress.(1115)
> azure-arm: A system shutdown is in progress.(1115)
> azure-arm: restarted.

Closes #6733 