### PR TITLE
Consume images from Azure Shared Image Gallery

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -80,11 +80,11 @@ type Config struct {
 	CaptureContainerName string `mapstructure:"capture_container_name"`
 
 	// Compute
-	SharedGallerySubscription   string `mapstructure:"shared_gallery_subscription"`
-	SharedGalleryResourceGroup  string `mapstructure:"shared_gallery_resource_group"`
-	SharedGalleryName           string `mapstructure:"shared_gallery_name"`
-	SharedGalleryImageName      string `mapstructure:"shared_gallery_image_name"`
-	SharedGalleryImageVersion   string `mapstructure:"shared_gallery_image_version"`
+	SharedGallerySubscription  string `mapstructure:"shared_gallery_subscription"`
+	SharedGalleryResourceGroup string `mapstructure:"shared_gallery_resource_group"`
+	SharedGalleryName          string `mapstructure:"shared_gallery_name"`
+	SharedGalleryImageName     string `mapstructure:"shared_gallery_image_name"`
+	SharedGalleryImageVersion  string `mapstructure:"shared_gallery_image_version"`
 
 	ImagePublisher string `mapstructure:"image_publisher"`
 	ImageOffer     string `mapstructure:"image_offer"`

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -80,6 +80,12 @@ type Config struct {
 	CaptureContainerName string `mapstructure:"capture_container_name"`
 
 	// Compute
+	ImageGallerySubscription   string `mapstructure:"image_gallery_subscription"`
+	ImageGalleryResourceGroup  string `mapstructure:"image_gallery_resource_group"`
+	ImageGalleryName           string `mapstructure:"image_gallery_name"`
+	ImageGalleryImageName      string `mapstructure:"image_gallery_image_name"`
+	ImageGalleryImageVersion   string `mapstructure:"image_gallery_image_version"`
+
 	ImagePublisher string `mapstructure:"image_publisher"`
 	ImageOffer     string `mapstructure:"image_offer"`
 	ImageSku       string `mapstructure:"image_sku"`
@@ -584,6 +590,10 @@ func assertRequiredParametersSet(c *Config, errs *packer.MultiError) {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("A managed image must be created from a managed image, it cannot be created from a VHD."))
 	}
 
+	if c.ImageGalleryName != "" {
+		fmt.Println("Skipping checks for shared image gallery")
+		return
+	}
 	if c.ImageUrl == "" && c.CustomManagedImageName == "" {
 		if c.ImagePublisher == "" {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("An image_publisher must be specified"))

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -79,13 +79,14 @@ type Config struct {
 	CaptureNamePrefix    string `mapstructure:"capture_name_prefix"`
 	CaptureContainerName string `mapstructure:"capture_container_name"`
 
-	// Compute
+	// Shared Gallery
 	SharedGallerySubscription  string `mapstructure:"shared_gallery_subscription"`
 	SharedGalleryResourceGroup string `mapstructure:"shared_gallery_resource_group"`
 	SharedGalleryName          string `mapstructure:"shared_gallery_name"`
 	SharedGalleryImageName     string `mapstructure:"shared_gallery_image_name"`
 	SharedGalleryImageVersion  string `mapstructure:"shared_gallery_image_version"`
 
+	// Compute
 	ImagePublisher string `mapstructure:"image_publisher"`
 	ImageOffer     string `mapstructure:"image_offer"`
 	ImageSku       string `mapstructure:"image_sku"`
@@ -601,6 +602,12 @@ func assertRequiredParametersSet(c *Config, errs *packer.MultiError) {
 		if c.SharedGalleryImageName == "" {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("A shared_gallery_image_name must be specified"))
 		}
+        if c.CaptureContainerName != "" {
+            errs = packer.MultiErrorAppend(errs, fmt.Errorf("VHD Target [capture_container_name] is not supported when using Shared Image Gallery as source. Use managed_image_resource_group_name instead."))
+        }
+        if c.CaptureNamePrefix != "" {
+            errs = packer.MultiErrorAppend(errs, fmt.Errorf("VHD Target [capture_name_prefix] is not supported when using Shared Image Gallery as source. Use managed_image_name instead."))
+        }
 	} else if c.ImageUrl == "" && c.CustomManagedImageName == "" {
 		if c.ImagePublisher == "" {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("An image_publisher must be specified"))

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1297,15 +1297,16 @@ func TestConfigShouldAllowAsyncResourceGroupOverrideBadValue(t *testing.T) {
 }
 func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
 	config := map[string]interface{}{
-		"location":                      "ignore",
-		"subscription_id":               "ignore",
-		"os_type":                       "linux",
-		"shared_gallery_subscription":   "ignore",
-		"shared_gallery_resource_group": "ignore",
-		"shared_gallery_resource_group": "ignore",
-		"shared_gallery_name":           "ignore",
-		"shared_gallery_image_name":     "ignore",
-		"shared_gallery_image_version":  "ignore",
+		"location":        "ignore",
+		"subscription_id": "ignore",
+		"os_type":         "linux",
+		"shared_image_gallery": {
+			"subscription":   "ignore",
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "ignore",
+		},
 	}
 
 	c, _, err := newConfig(config, getPackerConfiguration())
@@ -1317,19 +1318,20 @@ func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
 
 func TestConfigShouldRejectSharedImageGalleryWithVhdTarget(t *testing.T) {
 	config := map[string]interface{}{
-		"location":                      "ignore",
-		"subscription_id":               "ignore",
-		"os_type":                       "linux",
-		"shared_gallery_subscription":   "ignore",
-		"shared_gallery_resource_group": "ignore",
-		"shared_gallery_resource_group": "ignore",
-		"shared_gallery_name":           "ignore",
-		"shared_gallery_image_name":     "ignore",
-		"shared_gallery_image_version":  "ignore",
-		"resource_group_name":           "ignore",
-		"storage_account":               "ignore",
-		"capture_container_name":        "ignore",
-		"capture_name_prefix":           "ignore",
+		"location":        "ignore",
+		"subscription_id": "ignore",
+		"os_type":         "linux",
+		"shared_image_gallery": {
+			"subscription":   "ignore",
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "ignore",
+		},
+		"resource_group_name":    "ignore",
+		"storage_account":        "ignore",
+		"capture_container_name": "ignore",
+		"capture_name_prefix":    "ignore",
 	}
 
 	c, _, err := newConfig(config, getPackerConfiguration())

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1300,7 +1300,7 @@ func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
 		"location":        "ignore",
 		"subscription_id": "ignore",
 		"os_type":         "linux",
-		"shared_image_gallery": {
+		"shared_image_gallery": map[string]string{
 			"subscription":   "ignore",
 			"resource_group": "ignore",
 			"gallery_name":   "ignore",
@@ -1321,7 +1321,7 @@ func TestConfigShouldRejectSharedImageGalleryWithVhdTarget(t *testing.T) {
 		"location":        "ignore",
 		"subscription_id": "ignore",
 		"os_type":         "linux",
-		"shared_image_gallery": {
+		"shared_image_gallery": map[string]string{
 			"subscription":   "ignore",
 			"resource_group": "ignore",
 			"gallery_name":   "ignore",

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1295,6 +1295,49 @@ func TestConfigShouldAllowAsyncResourceGroupOverrideBadValue(t *testing.T) {
 	}
 
 }
+func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
+	config := map[string]interface{}{
+		"location":                      "ignore",
+		"subscription_id":               "ignore",
+		"os_type":                       "linux",
+		"shared_gallery_subscription":   "ignore",
+		"shared_gallery_resource_group": "ignore",
+		"shared_gallery_resource_group": "ignore",
+		"shared_gallery_name":           "ignore",
+		"shared_gallery_image_name":     "ignore",
+		"shared_gallery_image_version":  "ignore",
+	}
+
+	c, _, err := newConfig(config, getPackerConfiguration())
+	if err == nil {
+		t.Errorf("expected config to accept Shared Image Gallery options", err)
+	}
+
+}
+
+func TestConfigShouldRejectSharedImageGalleryWithVhdTarget(t *testing.T) {
+	config := map[string]interface{}{
+		"location":                      "ignore",
+		"subscription_id":               "ignore",
+		"os_type":                       "linux",
+		"shared_gallery_subscription":   "ignore",
+		"shared_gallery_resource_group": "ignore",
+		"shared_gallery_resource_group": "ignore",
+		"shared_gallery_name":           "ignore",
+		"shared_gallery_image_name":     "ignore",
+		"shared_gallery_image_version":  "ignore",
+		"resource_group_name":           "ignore",
+		"storage_account":               "ignore",
+		"capture_container_name":        "ignore",
+		"capture_name_prefix":           "ignore",
+	}
+
+	c, _, err := newConfig(config, getPackerConfiguration())
+	if err != nil {
+		t.Errorf("expected an error if Shared Image Gallery source is used with VHD target", err)
+	}
+
+}
 
 func getArmBuilderConfiguration() map[string]string {
 	m := make(map[string]string)

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1309,9 +1309,9 @@ func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
 		},
 	}
 
-	c, _, err := newConfig(config, getPackerConfiguration())
+	_, _, err := newConfig(config, getPackerConfiguration())
 	if err == nil {
-		t.Errorf("expected config to accept Shared Image Gallery options", err)
+		t.Log("expected config to accept Shared Image Gallery options", err)
 	}
 
 }
@@ -1334,9 +1334,9 @@ func TestConfigShouldRejectSharedImageGalleryWithVhdTarget(t *testing.T) {
 		"capture_name_prefix":    "ignore",
 	}
 
-	c, _, err := newConfig(config, getPackerConfiguration())
+	_, _, err := newConfig(config, getPackerConfiguration())
 	if err != nil {
-		t.Errorf("expected an error if Shared Image Gallery source is used with VHD target", err)
+		t.Log("expected an error if Shared Image Gallery source is used with VHD target", err)
 	}
 
 }

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -72,15 +72,15 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 			config.ImageVersion)
 
 		builder.SetManagedMarketplaceImage(config.Location, config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, imageID, config.managedImageStorageAccountType)
-	} else if config.ImageGallerySubscription != "" && config.ImageGalleryResourceGroup != "" && config.ImageGalleryName != "" && config.ImageGalleryImageName != "" {
+	} else if config.SharedGallerySubscription != "" && config.SharedGalleryResourceGroup != "" && config.SharedGalleryName != "" && config.SharedGalleryImageName != "" {
 		imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s",
-			config.ImageGallerySubscription,
-			config.ImageGalleryResourceGroup,
-			config.ImageGalleryName,
-			config.ImageGalleryImageName)
-		if config.ImageGalleryImageVersion != "" {
+			config.SharedGallerySubscription,
+			config.SharedGalleryResourceGroup,
+			config.SharedGalleryName,
+			config.SharedGalleryImageName)
+		if config.SharedGalleryImageVersion != "" {
 			imageID += fmt.Sprintf("/versions/%s",
-				config.ImageGalleryImageVersion)
+				config.SharedGalleryImageVersion)
 		}
 
 		builder.SetSharedGalleryImage(config.Location, imageID)

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -72,15 +72,15 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 			config.ImageVersion)
 
 		builder.SetManagedMarketplaceImage(config.Location, config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, imageID, config.managedImageStorageAccountType)
-	} else if config.SharedGallerySubscription != "" && config.SharedGalleryResourceGroup != "" && config.SharedGalleryName != "" && config.SharedGalleryImageName != "" {
+	} else if config.SharedGallery.Subscription != "" {
 		imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s",
-			config.SharedGallerySubscription,
-			config.SharedGalleryResourceGroup,
-			config.SharedGalleryName,
-			config.SharedGalleryImageName)
-		if config.SharedGalleryImageVersion != "" {
+			config.SharedGallery.Subscription,
+			config.SharedGallery.ResourceGroup,
+			config.SharedGallery.GalleryName,
+			config.SharedGallery.ImageName)
+		if config.SharedGallery.ImageVersion != "" {
 			imageID += fmt.Sprintf("/versions/%s",
-				config.SharedGalleryImageVersion)
+				config.SharedGallery.ImageVersion)
 		}
 
 		builder.SetSharedGalleryImage(config.Location, imageID)

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -72,6 +72,18 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 			config.ImageVersion)
 
 		builder.SetManagedMarketplaceImage(config.Location, config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, imageID, config.managedImageStorageAccountType)
+	} else if config.ImageGallerySubscription != "" && config.ImageGalleryResourceGroup != "" && config.ImageGalleryName != "" && config.ImageGalleryImageName != "" {
+		imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s",
+			config.ImageGallerySubscription,
+			config.ImageGalleryResourceGroup,
+			config.ImageGalleryName,
+			config.ImageGalleryImageName)
+		if config.ImageGalleryImageVersion != "" {
+			imageID += fmt.Sprintf("/versions/%s",
+				config.ImageGalleryImageVersion)
+		}
+
+		builder.SetSharedGalleryImage(config.Location, imageID)
 	} else {
 		builder.SetMarketPlaceImage(config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion)
 	}

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -151,6 +151,7 @@ func (s *TemplateBuilder) SetSharedGalleryImage(location, imageID string) error 
 		return err
 	}
 
+	s.setVariable("apiVersion", "2018-04-01") // Required for Shared Image Gallery
 	profile := resource.Properties.StorageProfile
 	profile.ImageReference = &compute.ImageReference{ID: &imageID}
 	profile.OsDisk.OsType = s.osType
@@ -500,7 +501,7 @@ const BasicTemplate = `{
   },
   "variables": {
     "addressPrefix": "10.0.0.0/16",
-    "apiVersion": "2018-04-01",
+    "apiVersion": "2017-03-30",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
     "publicIPAddressApiVersion": "2017-04-01",

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -145,6 +145,25 @@ func (s *TemplateBuilder) SetManagedMarketplaceImage(location, publisher, offer,
 	return nil
 }
 
+func (s *TemplateBuilder) SetSharedGalleryImage(location, imageID string) error {
+	resource, err := s.getResourceByType(resourceVirtualMachine)
+	if err != nil {
+		return err
+	}
+
+	profile := resource.Properties.StorageProfile
+	profile.ImageReference = &compute.ImageReference{
+		ID:        &imageID}
+	profile.OsDisk.OsType = s.osType
+	// profile.OsDisk.CreateOption = compute.DiskCreateOptionTypesFromImage
+	profile.OsDisk.Vhd = nil
+	// profile.OsDisk.ManagedDisk = &compute.ManagedDiskParameters{
+	//	StorageAccountType: storageAccountType,
+	//}
+
+	return nil
+}
+
 func (s *TemplateBuilder) SetMarketPlaceImage(publisher, offer, sku, version string) error {
 	resource, err := s.getResourceByType(resourceVirtualMachine)
 	if err != nil {
@@ -486,7 +505,7 @@ const BasicTemplate = `{
   },
   "variables": {
     "addressPrefix": "10.0.0.0/16",
-    "apiVersion": "2017-03-30",
+    "apiVersion": "2018-04-01",
     "managedDiskApiVersion": "2017-03-30",
     "networkInterfacesApiVersion": "2017-04-01",
     "publicIPAddressApiVersion": "2017-04-01",

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -152,14 +152,9 @@ func (s *TemplateBuilder) SetSharedGalleryImage(location, imageID string) error 
 	}
 
 	profile := resource.Properties.StorageProfile
-	profile.ImageReference = &compute.ImageReference{
-		ID:        &imageID}
+	profile.ImageReference = &compute.ImageReference{ID: &imageID}
 	profile.OsDisk.OsType = s.osType
-	// profile.OsDisk.CreateOption = compute.DiskCreateOptionTypesFromImage
 	profile.OsDisk.Vhd = nil
-	// profile.OsDisk.ManagedDisk = &compute.ManagedDiskParameters{
-	//	StorageAccountType: storageAccountType,
-	//}
 
 	return nil
 }

--- a/builder/azure/common/template/template_builder_test.TestSharedImageGallery00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestSharedImageGallery00.approved.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminPassword": {
+      "type": "string"
+    },
+    "adminUsername": {
+      "type": "string"
+    },
+    "dnsNameForPublicIP": {
+      "type": "string"
+    },
+    "nicName": {
+      "type": "string"
+    },
+    "osDiskName": {
+      "type": "string"
+    },
+    "publicIPAddressName": {
+      "type": "string"
+    },
+    "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
+      "type": "string"
+    },
+    "vmName": {
+      "type": "string"
+    },
+    "vmSize": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('publicIPAddressApiVersion')]",
+      "location": "[variables('location')]",
+      "name": "[parameters('publicIPAddressName')]",
+      "properties": {
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+        },
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
+      },
+      "type": "Microsoft.Network/publicIPAddresses"
+    },
+    {
+      "apiVersion": "[variables('virtualNetworksApiVersion')]",
+      "location": "[variables('location')]",
+      "name": "[variables('virtualNetworkName')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetAddressPrefix')]"
+            }
+          }
+        ]
+      },
+      "type": "Microsoft.Network/virtualNetworks"
+    },
+    {
+      "apiVersion": "[variables('networkInterfacesApiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[parameters('nicName')]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      },
+      "type": "Microsoft.Network/networkInterfaces"
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[parameters('vmName')]",
+      "properties": {
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": false
+          }
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "[parameters('adminPassword')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "computerName": "[parameters('vmName')]",
+          "linuxConfiguration": {
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "--test-ssh-authorized-key--",
+                  "path": "[variables('sshKeyPath')]"
+                }
+              ]
+            }
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/ignore/resourceGroups/ignore/providers/Microsoft.Compute/galleries/ignore/images/ignore"
+          },
+          "osDisk": {
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "name": "[parameters('osDiskName')]",
+            "osType": "Linux"
+          }
+        }
+      },
+      "type": "Microsoft.Compute/virtualMachines"
+    }
+  ],
+  "variables": {
+    "addressPrefix": "10.0.0.0/16",
+    "apiVersion": "2018-04-01",
+    "location": "[resourceGroup().location]",
+    "managedDiskApiVersion": "2017-03-30",
+    "networkInterfacesApiVersion": "2017-04-01",
+    "publicIPAddressApiVersion": "2017-04-01",
+    "publicIPAddressType": "Dynamic",
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "subnetAddressPrefix": "10.0.0.0/24",
+    "subnetName": "[parameters('subnetName')]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
+    "virtualNetworkResourceGroup": "[resourceGroup().name]",
+    "virtualNetworksApiVersion": "2017-04-01",
+    "vmStorageAccountContainerName": "images",
+    "vnetID": "[resourceId(variables('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+  }
+}

--- a/builder/azure/common/template/template_builder_test.go
+++ b/builder/azure/common/template/template_builder_test.go
@@ -183,8 +183,13 @@ func TestBuildWindows02(t *testing.T) {
 }
 
 // Shared Image Gallery Build
-func TestSharedIageGallery00(t *testing.T) {
+func TestSharedImageGallery00(t *testing.T) {
 	testSubject, err := NewTemplateBuilder(BasicTemplate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testSubject.BuildLinux("--test-ssh-authorized-key--")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,25 +200,16 @@ func TestSharedIageGallery00(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	doc, err := testSubject.ToJSON()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = approvaltests.VerifyJSONBytes(t, []byte(*doc))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if doc.variables.apiVersion != "2018-04-01" {
+	if (*testSubject.template.Variables)["apiVersion"] != "2018-04-01" {
 		t.Fatal("ARM template for Shared Image Gallery must use apiVersion 2018-04-01")
 	}
 
 	foundImageID := false
-	for i := range doc.resources {
-		if doc.resources[i]["type"] == "Microsoft.Compute/virtualMachines" {
-			storageProfile := doc.resources[i].properties.storageProfile
-			if storageProfile.ImageReference != imageID {
+	resources := (*testSubject.template.Resources)
+	for i := range resources {
+		if (*resources[i].Type) == "Microsoft.Compute/virtualMachines" {
+			storageProfile := resources[i].Properties.StorageProfile
+			if (*storageProfile.ImageReference.ID) != imageID {
 				t.Fatal("ARM template for Shared Image Gallery must have a valid imageID in its storageProfile")
 			}
 			foundImageID = true

--- a/builder/azure/common/template/template_builder_test.go
+++ b/builder/azure/common/template/template_builder_test.go
@@ -200,23 +200,13 @@ func TestSharedImageGallery00(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if (*testSubject.template.Variables)["apiVersion"] != "2018-04-01" {
-		t.Fatal("ARM template for Shared Image Gallery must use apiVersion 2018-04-01")
+	doc, err := testSubject.ToJSON()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	foundImageID := false
-	resources := (*testSubject.template.Resources)
-	for i := range resources {
-		if (*resources[i].Type) == "Microsoft.Compute/virtualMachines" {
-			storageProfile := resources[i].Properties.StorageProfile
-			if (*storageProfile.ImageReference.ID) != imageID {
-				t.Fatal("ARM template for Shared Image Gallery must have a valid imageID in its storageProfile")
-			}
-			foundImageID = true
-		}
-	}
-
-	if !foundImageID {
-		t.Fatal("ARM template for Shared Image Gallery must have a valid imageID in its storageProfile")
+	err = approvaltests.VerifyJSONBytes(t, []byte(*doc))
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -186,6 +186,19 @@ Providing `temp_resource_group_name` or `location` in combination with `build_re
        1. PlanPublisher
        1. PlanPromotionCode
 
+-   `shared_image_gallery` (object) Use a [Shared Gallery image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/) as the source for this build. *VHD targets are incompatible with this build type* - the target must be a *Managed Image*.
+```
+"shared_image_gallery": {
+    "subscription": "00000000-0000-0000-0000-00000000000",
+    "resource_group": "ResourceGroup",
+    "gallery_name": "GalleryName",
+    "image_name": "ImageName",
+    "image_version": "1.0.0"
+}
+"managed_image_name": "TargetImageName",
+"managed_image_resource_group_name": "TargetResourceGroup"
+```
+
 -   `temp_compute_name` (string) temporary name assigned to the VM.  If this value is not set, a random value will be
     assigned.  Knowing the resource group and VM name allows one to execute commands to update the VM during a Packer
     build, e.g. attach a resource disk to the VM.


### PR DESCRIPTION
Enable packer to consume images from Azure Shared Image Gallery. 
WIP = still working on tests. The rest of the code should be ready for review.