### PR TITLE
NTLMv2 support docfix

### DIFF
--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -153,10 +153,12 @@ The WinRM communicator has the following options.
     become available. This defaults to `30m` since setting up a Windows
     machine generally takes a long time.
 
--   `winrm_use_ntlm` (boolean) - If `true`, NTLM authentication will be used for WinRM,
-    rather than default (basic authentication), removing the requirement for basic
-    authentication to be enabled within the target guest. Further reading for remote
-    connection authentication can be found [here](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx).
+-   `winrm_use_ntlm` (boolean) - If `true`, NTLMv2 authentication (with
+    session security) will be used for WinRM, rather than
+    default (basic authentication), removing the requirement for basic
+    authentication to be enabled within the target guest. Further reading
+    for remote connection authentication can be found
+    [here](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx).
 
 -   `winrm_use_ssl` (boolean) - If `true`, use HTTPS for WinRM.
 


### PR DESCRIPTION
Clarifies NTLMv2-only support in Packer. This must be communicated clearly to ensure user target machines have winrm configured properly before attempting to use the winrm communicator and PowerShell provisioner.

Related #6205
