### PR TITLE
Fix for #6804 - KVM/QEMU Network "has no peer"

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -217,6 +217,13 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 		}
 	}
 
+	// Check if we are missing the netDevice #6804
+	if x, ok := inArgs["-device"]; ok {
+		if !strings.Contains(strings.Join(x, ""), config.NetDevice) {
+			inArgs["-device"] = append(inArgs["-device"], fmt.Sprintf("%s,netdev=user.0", config.NetDevice))
+		}
+	}
+
 	// Flatten to array of strings
 	outArgs := make([]string, 0)
 	for key, values := range inArgs {


### PR DESCRIPTION
As per issue #6804, if the user uses a `-device` in the `qemuargs` it overrides the default network settings and results in no network. 

I picked up the issue because newer versions of QEMU have deprecated the use of `-usbdevice tablet` and replaced it with `-usb -device usb-tablet`.

I have tested locally with my Packer build and it resolves my original issue. The change does not break a QEMU build if `-device` is not present in the `qemuargs`.

Closes #6804 
