### PR TITLE
default wait time for amazon import to one hour.

### DIFF
--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -208,7 +208,7 @@ func WaitForVolumeToBeDetached(c *ec2.EC2, ctx aws.Context, input *ec2.DescribeV
 func WaitForImageToBeImported(c *ec2.EC2, ctx aws.Context, input *ec2.DescribeImportImageTasksInput, opts ...request.WaiterOption) error {
 	w := request.Waiter{
 		Name:        "DescribeImages",
-		MaxAttempts: 300,
+		MaxAttempts: 720,
 		Delay:       request.ConstantWaiterDelay(5 * time.Second),
 		Acceptors: []request.WaiterAcceptor{
 			{

--- a/website/source/docs/post-processors/amazon-import.html.md
+++ b/website/source/docs/post-processors/amazon-import.html.md
@@ -157,7 +157,9 @@ max retries or find yourself being rate limited, you can override the max
 retries and the delay in between retries by setting the environment variables
  `AWS_MAX_ATTEMPTS` and `AWS_POLL_DELAY_SECONDS` on the machine running the
  Packer build. By default, the waiter that waits for your image to be imported
- from s3 waits retries up to 300 times with a 5 second delay in between retries.
+ from s3 will retry for up to an hour: it retries up to 720 times with a 5
+ second delay in between retries.
+
  This is dramatically higher than many of our other waiters, to account for how
  long this process can take.
 


### PR DESCRIPTION
Bump wait default from 25 minutes to 1 hour, since amazon imports take a long time.

Closes #6732 
