### PR TITLE
Fix 6774

### DIFF
--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -133,7 +133,10 @@ func (*Artifact) Files() []string {
 }
 
 func (a *Artifact) Id() string {
-	return a.OSDiskUri
+	if a.OSDiskUri != "" {
+		return a.OSDiskUri
+	}
+	return a.ManagedImageId
 }
 
 func (a *Artifact) State(name string) interface{} {

--- a/log.go
+++ b/log.go
@@ -35,7 +35,7 @@ func logOutput() (logOutput io.Writer, err error) {
 					if strings.Contains(scanner.Text(), "ui:") {
 						continue
 					}
-					os.Stderr.WriteString(fmt.Sprintf(scanner.Text() + "\n"))
+					os.Stderr.WriteString(fmt.Sprint(scanner.Text() + "\n"))
 				}
 			}(scanner)
 			logOutput = w


### PR DESCRIPTION
Improve azure's artifact, so that the manifest post-processor works for managed images and doesn't provide an empty string in Id()
Closes #6774 
