### PR TITLE
fix datastore path that contains spaces

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -52,6 +52,7 @@ func (d *ESX5Driver) CompactDisk(diskPathLocal string) error {
 
 func (d *ESX5Driver) CreateDisk(diskPathLocal string, size string, adapter_type string, typeId string) error {
 	diskPath := d.datastorePath(diskPathLocal)
+	diskPath = strings.Replace(diskPath, " ", `\ `, -1)
 	return d.sh("vmkfstools", "-c", size, "-d", typeId, "-a", adapter_type, diskPath)
 }
 


### PR DESCRIPTION
Escape spaces in disk path name.
Closes #6794 
