### PR TITLE
Use Sprint() instead of Sprintf() in log dedupe

### DIFF
--- a/log.go
+++ b/log.go
@@ -35,7 +35,7 @@ func logOutput() (logOutput io.Writer, err error) {
 					if strings.Contains(scanner.Text(), "ui:") {
 						continue
 					}
-					os.Stderr.WriteString(fmt.Sprintf(scanner.Text() + "\n"))
+					os.Stderr.WriteString(fmt.Sprint(scanner.Text() + "\n"))
 				}
 			}(scanner)
 			logOutput = w


### PR DESCRIPTION
Uses `fmt.Sprint()` instead of `fmt.Sprintf()` for log deduplication.

Fixes: #6796
