### PR TITLE
add qemu disk detect-zeroes= option

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -75,6 +75,12 @@ var diskDiscard = map[string]bool{
 	"ignore": true,
 }
 
+var diskDZeroes = map[string]bool{
+	"unmap":  true,
+	"on": true,
+	"off": true,
+}
+
 type Builder struct {
 	config Config
 	runner multistep.Runner
@@ -94,6 +100,7 @@ type Config struct {
 	DiskSize          uint       `mapstructure:"disk_size"`
 	DiskCache         string     `mapstructure:"disk_cache"`
 	DiskDiscard       string     `mapstructure:"disk_discard"`
+	DetectZeroes      string     `mapstructure:"disk_detect_zeroes"`
 	SkipCompaction    bool       `mapstructure:"skip_compaction"`
 	DiskCompression   bool       `mapstructure:"disk_compression"`
 	Format            string     `mapstructure:"format"`
@@ -155,6 +162,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if b.config.DiskDiscard == "" {
 		b.config.DiskDiscard = "ignore"
+	}
+
+	if b.config.DetectZeroes == "" {
+		b.config.DetectZeroes = "off"
 	}
 
 	if b.config.Accelerator == "" {
@@ -284,6 +295,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	if _, ok := diskDiscard[b.config.DiskDiscard]; !ok {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("unrecognized disk discard type"))
+	}
+
+	if _, ok := diskDZeroes[b.config.DetectZeroes]; !ok {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("unrecognized disk detect zeroes setting"))
 	}
 
 	if !b.config.PackerForce {

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -97,9 +97,9 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 	if qemuMajor >= 2 {
 		if config.DiskInterface == "virtio-scsi" {
 			deviceArgs = append(deviceArgs, "virtio-scsi-pci,id=scsi0", "scsi-hd,bus=scsi0.0,drive=drive0")
-			driveArgs = append(driveArgs, fmt.Sprintf("if=none,file=%s,id=drive0,cache=%s,discard=%s,format=%s", imgPath, config.DiskCache, config.DiskDiscard, config.Format))
+			driveArgs = append(driveArgs, fmt.Sprintf("if=none,file=%s,id=drive0,cache=%s,discard=%s,format=%s,detect-zeroes=%s", imgPath, config.DiskCache, config.DiskDiscard, config.Format, config.DetectZeroes))
 		} else {
-			driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s,format=%s", imgPath, config.DiskInterface, config.DiskCache, config.DiskDiscard, config.Format))
+			driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s,format=%s,detect-zeroes=%s", imgPath, config.DiskInterface, config.DiskCache, config.DiskDiscard, config.Format, config.DetectZeroes))
 		}
 	} else {
 		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=%s,cache=%s,format=%s", imgPath, config.DiskInterface, config.DiskCache, config.Format))


### PR DESCRIPTION
qemu builder. add detect-zeroes option to -drive switch. Setting disk_detect_zeroes and disk_discard qemu builder options to "unmap" prevent disk image grow to full size when cleanup by zeroing free space performed on qcow2 image.
add to qemu builder disk option doc:
disk_detect_zeroes (string) - The detect-zeroes mode to use for disk. Allowed values include any of unmap or on or off. By default, this is set to off.