### PR TITLE
Added support for source image_list_entry field

### DIFF
--- a/builder/oracle/classic/config.go
+++ b/builder/oracle/classic/config.go
@@ -29,11 +29,12 @@ type Config struct {
 	apiEndpointURL *url.URL
 
 	// Image
-	ImageName       string        `mapstructure:"image_name"`
-	Shape           string        `mapstructure:"shape"`
-	SourceImageList string        `mapstructure:"source_image_list"`
-	SnapshotTimeout time.Duration `mapstructure:"snapshot_timeout"`
-	DestImageList   string        `mapstructure:"dest_image_list"`
+	ImageName            string        `mapstructure:"image_name"`
+	Shape                string        `mapstructure:"shape"`
+	SourceImageList      string        `mapstructure:"source_image_list"`
+	SourceImageListEntry string        `mapstructure:"source_image_list_entry"`
+	SnapshotTimeout      time.Duration `mapstructure:"snapshot_timeout"`
+	DestImageList        string        `mapstructure:"dest_image_list"`
 	// Attributes and Attributes file are both optional and mutually exclusive.
 	Attributes     string `mapstructure:"attributes"`
 	AttributesFile string `mapstructure:"attributes_file"`

--- a/builder/oracle/classic/step_create_instance.go
+++ b/builder/oracle/classic/step_create_instance.go
@@ -34,6 +34,7 @@ func (s *stepCreateInstance) Run(_ context.Context, state multistep.StateBag) mu
 		Name:       config.ImageName,
 		Shape:      config.Shape,
 		ImageList:  config.SourceImageList,
+		Entry:      config.SourceImageListEntry,
 		Networking: map[string]compute.NetworkingInfo{"eth0": netInfo},
 		Attributes: config.attribs,
 	}

--- a/website/source/docs/builders/oracle-classic.html.md
+++ b/website/source/docs/builders/oracle-classic.html.md
@@ -63,14 +63,14 @@ This builder currently only works with the SSH communicator.
 
 ### Optional
 
- -  `attributes` (string) - (string) - Attributes to apply when launching the 
-    instance. Note that you need to be careful about escaping characters due to 
-    the templates being JSON. It is often more convenient to use 
-    `attributes_file`, instead. You may only define either `attributes`  or 
+ -  `attributes` (string) - (string) - Attributes to apply when launching the
+    instance. Note that you need to be careful about escaping characters due to
+    the templates being JSON. It is often more convenient to use
+    `attributes_file`, instead. You may only define either `attributes`  or
     `attributes_file`, not both.
 
- -  `attributes_file` (string) - Path to a json file that will be used for the 
-    attributes when launching the instance. You may only define either 
+ -  `attributes_file` (string) - Path to a json file that will be used for the
+    attributes when launching the instance. You may only define either
     `attributes` or `attributes_file`, not both.
 
  -  `image_description` (string) - a description for your destination
@@ -83,6 +83,9 @@ This builder currently only works with the SSH communicator.
     [documentation](https://docs.oracle.com/en/cloud/iaas/compute-iaas-cloud/stcsg/accessing-oracle-linux-instance-using-ssh.html).
 
  -  `image_name` (string) - The name to assign to the resulting custom image.
+
+ -  `source_image_list_entry` (string) -  The source image version number of
+    the image in the image list. The default value is to use the latest version.
 
  - `snapshot_timeout` (string) - How long to wait for a snapshot to be
     created. Expects a positive golang Time.Duration string, which is
@@ -128,10 +131,10 @@ obfuscated; you will need to add a working `username`, `password`,
 Attributes file is optional for connecting via ssh, but required for winrm.
 
 The following file contains the bare minimum necessary to get winRM working;
-you have to give it the password to give to the "Administrator" user, which 
+you have to give it the password to give to the "Administrator" user, which
 will be the one winrm connects to. You must also whitelist your computer
 to connect via winRM -- the empty braces below whitelist any computer to access
-winRM but you can make it more secure by only allowing your build machine 
+winRM but you can make it more secure by only allowing your build machine
 access. See the [docs](https://docs.oracle.com/en/cloud/iaas/compute-iaas-cloud/stcsg/automating-instance-initialization-using-opc-init.html#GUID-A0A107D6-3B38-47F4-8FC8-96D50D99379B)
 for more details on how to define a trusted host.
 


### PR DESCRIPTION
Added Source Image List Entry attribute, to select a specific image version from an image list as the base image.

Still having the issue of 
```
* unknown configuration key: "source_image_list_entry"
```

when it runs though

Closes #6833

