### PR TITLE
vagrantfile: add docker provider support; up go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y \
+    locales \
+    openssh-server \
+    sudo
+
+RUN locale-gen en_US.UTF-8
+
+RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash vagrant; fi \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && mkdir -p /etc/sudoers.d \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/vagrant \
+    && chmod 0440 /etc/sudoers.d/vagrant
+
+RUN mkdir -p /home/vagrant/.ssh \
+    && chmod 0700 /home/vagrant/.ssh \
+    && wget --no-check-certificate \
+      https://raw.github.com/hashicorp/vagrant/master/keys/vagrant.pub \
+      -O /home/vagrant/.ssh/authorized_keys \
+    && chmod 0600 /home/vagrant/.ssh/authorized_keys \
+    && chown -R vagrant /home/vagrant/.ssh
+
+RUN mkdir -p /run/sshd
+
+CMD /usr/sbin/sshd -D \
+    -o UseDNS=no \
+    -o PidFile=/tmp/sshd.pid

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,9 @@ LINUX_BASE_BOX = "bento/ubuntu-16.04"
 FREEBSD_BASE_BOX = "jen20/FreeBSD-12.0-CURRENT"
 
 Vagrant.configure(2) do |config|
-        if Vagrant.has_plugin?("vagrant-cachier")
-                config.cache.scope = :box
-        end
+	if Vagrant.has_plugin?("vagrant-cachier")
+		config.cache.scope = :box
+	end
 
 	# Compilation and development boxes
 	config.vm.define "linux", autostart: true, primary: true do |vmCfg|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,6 +73,12 @@ def configureProviders(vmCfg, cpus: "2", memory: "2048")
 		end
 	end
 
+	vmCfg.vm.provider "docker" do |d, override|
+		d.build_dir = "."
+		d.has_ssh = true
+		override.vm.box = nil
+	end
+
 	return vmCfg
 end
 

--- a/scripts/vagrant-linux-priv-config.sh
+++ b/scripts/vagrant-linux-priv-config.sh
@@ -8,6 +8,7 @@ apt-get install -y software-properties-common
 
 apt-get install -y bzr \
 	curl \
+	gcc \
 	git \
 	make \
 	mercurial \

--- a/scripts/vagrant-linux-priv-go.sh
+++ b/scripts/vagrant-linux-priv-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function install_go() {
-	local go_version=1.9.2
+	local go_version=1.11.1
 	local download=
 	
 	download="https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz"


### PR DESCRIPTION
Changes:
* Added Dockerfile based on official `ubuntu:16.04` image with minimal setup for running the vagrant shell provisioners.
* Added docker provider support to Vagrantfile and some cleanups.
* Updated go version in vagrant provision script due to failed `make` execution:
```bash
vagrant@linux:/opt/gopath/src/github.com/hashicorp/packer$ make -j4
==> Checking that code complies with gofmt requirements...
find: invalid mode '+111'
gofmt needs to be run on the following files:
find: invalid mode '+111'
./helper/communicator/step_connect_ssh.go
./fix/fixer_virtualbox_gaattach_test.go
./fix/fixer_parallels_deprecations_test.go
./builder/amazon/ebs/builder.go
./builder/amazon/ebssurrogate/builder.go
./builder/amazon/ebsvolume/builder.go
./builder/amazon/instance/builder.go
./builder/ncloud/step_terminate_server_instance_test.go
./builder/ncloud/config_test.go
./builder/ncloud/step_delete_block_storage_instance_test.go
./builder/ncloud/step_create_block_storage_instance_test.go
./builder/azure/common/template/template_parameters_test.go
./builder/azure/arm/resource_resolver.go
./builder/azure/arm/config_test.go
./builder/azure/arm/template_factory_test.go
You can use the command: `make fmt` to reformat code.
Makefile:69: recipe for target 'fmt-check' failed
make: *** [fmt-check] Error 1
make: *** Waiting for unfinished jobs....
make: *** wait: No child processes.  Stop.

vagrant@linux:/opt/gopath/src/github.com/hashicorp/packer$ make fmt
vagrant@linux:/opt/gopath/src/github.com/hashicorp/packer$ make -j4
==> Checking that code complies with gofmt requirements...
find: invalid mode '+111'
Check passed.
find: invalid mode '+111'
==> Checking that only certain files are executable...
Check passed.
go generate .
2018/10/12 12:49:44 Generated command/plugin.go
gofmt -w common/bootcommand/boot_command.go
goimports -w common/bootcommand/boot_command.go
gofmt -w command/plugin.go
# github.com/hashicorp/packer/command
command/fix_test.go:13:8: undefined: strings.Builder
...
ok  	github.com/hashicorp/packer/builder/vmware/vmx	0.017s
FAIL	github.com/hashicorp/packer/command [build failed]
...
```
* Added `gcc` package to the list of build packages in provision script.

Tested on docker `18.06.1-ce` and vagrant `2.1.1`