### PR TITLE
aws: add validation for device_name parameter

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -88,6 +88,10 @@ func buildBlockDevices(b []BlockDevice) []*ec2.BlockDeviceMapping {
 }
 
 func (b *BlockDevice) Prepare(ctx *interpolate.Context) error {
+	if b.DeviceName == "" {
+		return fmt.Errorf("The `device_name` must be specified " +
+			"for every device in the block device mapping.")
+	}
 	// Warn that encrypted must be true when setting kms_key_id
 	if b.KmsKeyId != "" && b.Encrypted == false {
 		return fmt.Errorf("The device %v, must also have `encrypted: "+

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -169,7 +169,8 @@ each category, the available configuration keys are alphabetized.
         every build.
 
     -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required when specifying `volume_size`.
+        example, `/dev/sdh` or `xvdh`). Required for every device in the
+        block device mapping.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -195,8 +195,8 @@ each category, the available configuration keys are alphabetized.
     -   `volume_size` (number) - The size of the volume, in GiB. Required if not
         specifying a `snapshot_id`
 
-    -   `volume_type` (string) - The volume type. gp2 for General Purpose (SSD)
-        volumes, io1 for Provisioned IOPS (SSD) volumes, and standard for Magnetic
+    -   `volume_type` (string) - The volume type. `gp2` for General Purpose (SSD)
+        volumes, `io1` for Provisioned IOPS (SSD) volumes, and `standard` for Magnetic
         volumes
 
 -   `region_kms_key_ids` (map of strings) - a map of regions to copy the ami to,

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -83,7 +83,8 @@ builder.
         every build.
 
     -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required when specifying `volume_size`.
+        example, `/dev/sdh` or `xvdh`). Required for every device in the
+        block device mapping.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -76,7 +76,8 @@ builder.
         every build.
 
     -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required when specifying `volume_size`.
+        example, `/dev/sdh` or `xvdh`). Required for every device in the
+        block device mapping.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -63,7 +63,8 @@ builder.
     device mappings to the AMI. The block device mappings allow for keys:
 
     -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required when specifying `volume_size`.
+        example, `/dev/sdh` or `xvdh`). Required for every device in the
+        block device mapping.
 
     -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
         deleted on instance termination.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -105,7 +105,8 @@ builder.
         every build.
 
     -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required when specifying `volume_size`.
+        example, `/dev/sdh` or `xvdh`). Required for every device in the
+        block device mapping.
 
     -   `encrypted` (boolean) - Indicates whether to encrypt the volume or not
 


### PR DESCRIPTION
Changes:
* Added validation for required parameter `device_name` in block device mappings.
* Docs: proper description for `device_name` parameter and some cleanup for consistency.

Closes: #6138