### PR TITLE
builder/googlecompute: validate startup_script_file exists

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -3,6 +3,7 @@ package googlecompute
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"time"
 
@@ -229,6 +230,13 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	// If DisableDefaultServiceAccount is provided, don't allow a value for ServiceAccountEmail
 	if c.DisableDefaultServiceAccount && c.ServiceAccountEmail != "" {
 		errs = packer.MultiErrorAppend(fmt.Errorf("you may not specify a 'service_account_email' when 'disable_default_service_account' is true"))
+	}
+
+	if c.StartupScriptFile != "" {
+		if _, err := os.Stat(c.StartupScriptFile); err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, fmt.Errorf("startup_script_file: %v", err))
+		}
 	}
 
 	// Check for any errors.

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -329,6 +329,22 @@ func TestConfigPrepareServiceAccount(t *testing.T) {
 	}
 }
 
+func TestConfigPrepareStartupScriptFile(t *testing.T) {
+	config := map[string]interface{}{
+		"project_id":          "project",
+		"source_image":        "foo",
+		"ssh_username":        "packer",
+		"startup_script_file": "no-such-file",
+		"zone":                "us-central1-a",
+	}
+
+	_, _, errs := NewConfig(config)
+
+	if errs == nil || !strings.Contains(errs.Error(), "startup_script_file") {
+		t.Fatalf("should error: startup_script_file")
+	}
+}
+
 func TestConfigDefaults(t *testing.T) {
 	cases := []struct {
 		Read  func(c *Config) interface{}


### PR DESCRIPTION

This change causes builder/googlecompute to return an error if startup_script_file is specified, but file does not exists.
```
$ go build -o bin/packer
$ bin/packer validate issue6831.template 
Template validation failed. Errors are shown below.

Errors validating build 'googlecompute'. 1 error(s) occurred:

* startup_script_file not found: no-such-file
$
$ touch no-such-file
$ bin/packer validate issue6831.template 
Template validated successfully.
$
$ cat  issue6831.template
{
  "builders": [
    {
      "type": "googlecompute",
      "project_id": "project",
      "source_image": "ubuntu-minimal-1804-lts",
      "ssh_username": "packer",
      "startup_script_file": "no-such-file",
      "zone": "us-central1-a"
    }
  ]
}
$
```



Closes #6831

