### PR TITLE
Correct the Vagrant Cloud box URL in the example

### DIFF
--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -59,7 +59,8 @@ on Vagrant Cloud, as well as authentication and version information.
     if nothing is found, finally `ATLAS_TOKEN` will be used.
 
 -   `box_tag` (string) - The shorthand tag for your box that maps to Vagrant
-    Cloud, i.e `hashicorp/precise64` for `vagrantcloud.com/hashicorp/precise64`
+    Cloud, for example `hashicorp/precise64`, which is short for
+    `https://app.vagrantup.com/hashicorp/boxes/precise64`.
 
 -   `version` (string) - The version number, typically incrementing a
     previous version. The version string is validated based on [Semantic

--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -60,7 +60,7 @@ on Vagrant Cloud, as well as authentication and version information.
 
 -   `box_tag` (string) - The shorthand tag for your box that maps to Vagrant
     Cloud, for example `hashicorp/precise64`, which is short for
-    `https://app.vagrantup.com/hashicorp/boxes/precise64`.
+    `vagrantcloud.com/hashicorp/precise64`.
 
 -   `version` (string) - The version number, typically incrementing a
     previous version. The version string is validated based on [Semantic


### PR DESCRIPTION
I updated the URL, but I actually don't think that the URL adds much value to the documentation.
Perhaps it would be better to just remove the URL, so the item would read simply:

-   `box_tag` (string) - The shorthand tag for your box that maps to Vagrant
    Cloud, for example `hashicorp/precise64`.
