### PR TITLE
Fix 6862

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -149,7 +149,10 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.RawRegion != "" && !c.SkipValidation {
 		ec2conn := getValidationSession()
-		if valid := ValidateRegion(c.RawRegion, ec2conn); !valid {
+		valid, err := ValidateRegion(c.RawRegion, ec2conn)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error validating region: %s", err.Error()))
+		} else if !valid {
 			errs = append(errs, fmt.Errorf("Unknown region: %s", c.RawRegion))
 		}
 	}

--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -149,11 +149,9 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.RawRegion != "" && !c.SkipValidation {
 		ec2conn := getValidationSession()
-		valid, err := ValidateRegion(c.RawRegion, ec2conn)
+		err := ValidateRegion(c.RawRegion, ec2conn)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error validating region: %s", err.Error()))
-		} else if !valid {
-			errs = append(errs, fmt.Errorf("Unknown region: %s", c.RawRegion))
 		}
 	}
 

--- a/builder/amazon/common/access_config_test.go
+++ b/builder/amazon/common/access_config_test.go
@@ -17,20 +17,20 @@ func TestAccessConfigPrepare_Region(t *testing.T) {
 	mockConn := &mockEC2Client{}
 
 	c.RawRegion = "us-east-12"
-	valid, _ := ValidateRegion(c.RawRegion, mockConn)
-	if valid {
+	err := ValidateRegion(c.RawRegion, mockConn)
+	if err == nil {
 		t.Fatalf("should have region validation err: %s", c.RawRegion)
 	}
 
 	c.RawRegion = "us-east-1"
-	valid, _ = ValidateRegion(c.RawRegion, mockConn)
-	if !valid {
+	err = ValidateRegion(c.RawRegion, mockConn)
+	if err != nil {
 		t.Fatalf("shouldn't have region validation err: %s", c.RawRegion)
 	}
 
 	c.RawRegion = "custom"
-	valid, _ = ValidateRegion(c.RawRegion, mockConn)
-	if valid {
+	err = ValidateRegion(c.RawRegion, mockConn)
+	if err == nil {
 		t.Fatalf("should have region validation err: %s", c.RawRegion)
 	}
 

--- a/builder/amazon/common/access_config_test.go
+++ b/builder/amazon/common/access_config_test.go
@@ -17,19 +17,19 @@ func TestAccessConfigPrepare_Region(t *testing.T) {
 	mockConn := &mockEC2Client{}
 
 	c.RawRegion = "us-east-12"
-	valid := ValidateRegion(c.RawRegion, mockConn)
+	valid, _ := ValidateRegion(c.RawRegion, mockConn)
 	if valid {
 		t.Fatalf("should have region validation err: %s", c.RawRegion)
 	}
 
 	c.RawRegion = "us-east-1"
-	valid = ValidateRegion(c.RawRegion, mockConn)
+	valid, _ = ValidateRegion(c.RawRegion, mockConn)
 	if !valid {
 		t.Fatalf("shouldn't have region validation err: %s", c.RawRegion)
 	}
 
 	c.RawRegion = "custom"
-	valid = ValidateRegion(c.RawRegion, mockConn)
+	valid, _ = ValidateRegion(c.RawRegion, mockConn)
 	if valid {
 		t.Fatalf("should have region validation err: %s", c.RawRegion)
 	}

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -112,7 +112,11 @@ func (c *AMIConfig) prepareRegions(ec2conn ec2iface.EC2API, accessConfig *Access
 
 			if !c.AMISkipRegionValidation {
 				// Verify the region is real
-				if valid := ValidateRegion(region, ec2conn); !valid {
+				ec2conn := getValidationSession()
+				valid, err := ValidateRegion(region, ec2conn)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("error validating region: %s", err.Error()))
+				} else if !valid {
 					errs = append(errs, fmt.Errorf("Unknown region: %s", region))
 				}
 			}

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -112,11 +112,9 @@ func (c *AMIConfig) prepareRegions(ec2conn ec2iface.EC2API, accessConfig *Access
 
 			if !c.AMISkipRegionValidation {
 				// Verify the region is real
-				valid, err := ValidateRegion(region, ec2conn)
+				err := ValidateRegion(region, ec2conn)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("error validating region: %s", err.Error()))
-				} else if !valid {
-					errs = append(errs, fmt.Errorf("Unknown region: %s", region))
 				}
 			}
 

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -112,7 +112,6 @@ func (c *AMIConfig) prepareRegions(ec2conn ec2iface.EC2API, accessConfig *Access
 
 			if !c.AMISkipRegionValidation {
 				// Verify the region is real
-				ec2conn := getValidationSession()
 				valid, err := ValidateRegion(region, ec2conn)
 				if err != nil {
 					errs = append(errs, fmt.Errorf("error validating region: %s", err.Error()))

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -55,13 +55,17 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	c.AMISkipRegionValidation = true
 
 	var errs []error
+	var err error
 	mockConn := &mockEC2Client{}
 	if errs = c.prepareRegions(mockConn, nil, errs); len(errs) > 0 {
 		t.Fatalf("shouldn't have err: %#v", errs)
 	}
 
 	c.AMISkipRegionValidation = false
-	c.AMIRegions = listEC2Regions(mockConn)
+	c.AMIRegions, err = listEC2Regions(mockConn)
+	if err != nil {
+		t.Fatalf("shouldn't have err: %s", err.Error())
+	}
 	if errs = c.prepareRegions(mockConn, nil, errs); len(errs) > 0 {
 		t.Fatalf("shouldn't have err: %#v", errs)
 	}

--- a/builder/amazon/common/regions.go
+++ b/builder/amazon/common/regions.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -30,16 +31,17 @@ func listEC2Regions(ec2conn ec2iface.EC2API) ([]string, error) {
 
 // ValidateRegion returns true if the supplied region is a valid AWS
 // region and false if it's not.
-func ValidateRegion(region string, ec2conn ec2iface.EC2API) (bool, error) {
+func ValidateRegion(region string, ec2conn ec2iface.EC2API) error {
 	regions, err := listEC2Regions(ec2conn)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	for _, valid := range regions {
 		if region == valid {
-			return true, nil
+			return nil
 		}
 	}
-	return false, nil
+
+	return fmt.Errorf("Invalid region: %s", region)
 }

--- a/builder/amazon/common/regions.go
+++ b/builder/amazon/common/regions.go
@@ -15,23 +15,31 @@ func getValidationSession() *ec2.EC2 {
 	return ec2conn
 }
 
-func listEC2Regions(ec2conn ec2iface.EC2API) []string {
+func listEC2Regions(ec2conn ec2iface.EC2API) ([]string, error) {
 	var regions []string
-	resultRegions, _ := ec2conn.DescribeRegions(nil)
+	resultRegions, err := ec2conn.DescribeRegions(nil)
+	if err != nil {
+		return []string{}, err
+	}
 	for _, region := range resultRegions.Regions {
 		regions = append(regions, *region.RegionName)
 	}
 
-	return regions
+	return regions, nil
 }
 
 // ValidateRegion returns true if the supplied region is a valid AWS
 // region and false if it's not.
-func ValidateRegion(region string, ec2conn ec2iface.EC2API) bool {
-	for _, valid := range listEC2Regions(ec2conn) {
+func ValidateRegion(region string, ec2conn ec2iface.EC2API) (bool, error) {
+	regions, err := listEC2Regions(ec2conn)
+	if err != nil {
+		return false, err
+	}
+
+	for _, valid := range regions {
 		if region == valid {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }


### PR DESCRIPTION
Make sure we expose errors with amazon credentials rather than burying those underneath a region validation error. 

Closes #6862

TODO update tests