### PR TITLE
feat: enabled timestamps in output

### DIFF
--- a/packer/ui.go
+++ b/packer/ui.go
@@ -195,7 +195,12 @@ func (u *TargetedUI) prefixLines(arrow bool, message string) string {
 	var result bytes.Buffer
 
 	for _, line := range strings.Split(message, "\n") {
-		result.WriteString(fmt.Sprintf("%s %s: %s\n", arrowText, u.Target, line))
+		if os.Getenv("PACKER_LOG_TIMESTAMPS") != "" {
+			currentTime := time.Now().Format(time.RFC850)
+			result.WriteString(fmt.Sprintf("%s %s %s: %s\n", arrowText, currentTime, u.Target, line))
+		} else {
+			result.WriteString(fmt.Sprintf("%s %s: %s\n", arrowText, u.Target, line))
+		}
 	}
 
 	return strings.TrimRightFunc(result.String(), unicode.IsSpace)

--- a/website/source/docs/other/environment-variables.html.md
+++ b/website/source/docs/other/environment-variables.html.md
@@ -23,6 +23,9 @@ each can be found below:
     set for any logging to occur. See the [debugging
     page](/docs/other/debugging.html).
 
+-   `PACKER_LOG_TIMESTAMPS` - Setting this to any value will enable timestamps
+    in the terminal for output.
+
 -   `PACKER_NO_COLOR` - Setting this to any value will disable color in
     the terminal.
 


### PR DESCRIPTION
Enabled environment variable (PACKER_LOG_TIMESTAMPS) to display timestamp in packer output. Format should be open for discussion, I just used a standard RFC. In addition, how to properly format as well should be up for interpretation. First pull request so apologies if I am not following a proper standard.

Potentially closes #6682
