### PR TITLE
feat: ability to specify runtime OSs where shell-local should run

### DIFF
--- a/common/shell-local/config.go
+++ b/common/shell-local/config.go
@@ -175,7 +175,8 @@ func Validate(config *Config) error {
 				}
 			}
 			if supported_os != true {
-				return fmt.Errorf("Invalid OS specified in only_on: '%s'", provided_os)
+				return fmt.Errorf("Invalid OS specified in only_on: '%s'\n"+
+					"Supported OS names: %v", provided_os, supported_syslist)
 			}
 		}
 	}

--- a/common/shell-local/config.go
+++ b/common/shell-local/config.go
@@ -165,18 +165,17 @@ func Validate(config *Config) error {
 
 	// Check for properly formatted go os types
 	supported_syslist := []string{"darwin", "freebsd", "linux", "openbsd", "solaris", "windows"}
-	supported_os := false
 	if len(config.OnlyOn) > 0 {
 		for _, provided_os := range config.OnlyOn {
+			supported_os := false
 			for _, go_os := range supported_syslist {
 				if provided_os == go_os {
 					supported_os = true
 					break
 				}
-				if supported_os != true {
-					errs = packer.MultiErrorAppend(errs,
-						fmt.Errorf("Invalid OS specified in only_on: '%s'", provided_os))
-				}
+			}
+			if supported_os != true {
+				return fmt.Errorf("Invalid OS specified in only_on: '%s'", provided_os)
 			}
 		}
 	}

--- a/common/shell-local/config.go
+++ b/common/shell-local/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	InlineShebang string `mapstructure:"inline_shebang"`
 
 	// An array of multiple Runtime OSs to run on.
-	OnlyOn []string
+	OnlyOn []string `mapstructure:"only_on"`
 
 	// The file extension to use for the file generated from the inline commands
 	TempfileExtension string `mapstructure:"tempfile_extension"`
@@ -162,6 +162,25 @@ func Validate(config *Config) error {
 				fmt.Errorf("Bad script '%s': %s", path, err))
 		}
 	}
+
+	// Check for properly formatted go os types
+	supported_syslist := []string{"darwin", "freebsd", "linux", "openbsd", "solaris", "windows"}
+	supported_os := false
+	if len(config.OnlyOn) > 0 {
+		for _, provided_os := range config.OnlyOn {
+			for _, go_os := range supported_syslist {
+				if provided_os == go_os {
+					supported_os = true
+					break
+				}
+				if supported_os != true {
+					errs = packer.MultiErrorAppend(errs,
+						fmt.Errorf("Invalid OS specified in only_on: '%s'", provided_os))
+				}
+			}
+		}
+	}
+
 	if config.UseLinuxPathing {
 		for index, script := range config.Scripts {
 			scriptAbsPath, err := filepath.Abs(script)

--- a/common/shell-local/config.go
+++ b/common/shell-local/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	// The shebang value used when running inline scripts.
 	InlineShebang string `mapstructure:"inline_shebang"`
 
+	// An array of multiple Runtime OSs to run on.
+	OnlyOn []string
+
 	// The file extension to use for the file generated from the inline commands
 	TempfileExtension string `mapstructure:"tempfile_extension"`
 

--- a/common/shell-local/config.go
+++ b/common/shell-local/config.go
@@ -176,7 +176,7 @@ func Validate(config *Config) error {
 			}
 			if supported_os != true {
 				return fmt.Errorf("Invalid OS specified in only_on: '%s'\n"+
-					"Supported OS names: %v", provided_os, supported_syslist)
+					"Supported OS names: %s", provided_os, strings.Join(supported_syslist, ", "))
 			}
 		}
 	}

--- a/common/shell-local/run.go
+++ b/common/shell-local/run.go
@@ -29,21 +29,19 @@ type EnvVarsTemplate struct {
 
 func Run(ui packer.Ui, config *Config) (bool, error) {
 	// Check if shell-local can even execute against this runtime OS
-	runCommand := false
 	if len(config.OnlyOn) > 0 {
+		runCommand := false
 		for _, os := range config.OnlyOn {
 			if os == runtime.GOOS {
 				runCommand = true
 				break
 			}
 		}
-	} else {
-		runCommand = true
-	}
-	if !runCommand {
-		ui.Say(fmt.Sprintf("Skipping shell-local due to runtime OS"))
-		log.Printf("[INFO] (shell-local): skipping shell-local due to missing runtime OS")
-		return true, nil
+		if !runCommand {
+			ui.Say(fmt.Sprintf("Skipping shell-local due to runtime OS"))
+			log.Printf("[INFO] (shell-local): skipping shell-local due to missing runtime OS")
+			return true, nil
+		}
 	}
 
 	scripts := make([]string, len(config.Scripts))

--- a/website/source/docs/post-processors/shell-local.html.md
+++ b/website/source/docs/post-processors/shell-local.html.md
@@ -91,6 +91,12 @@ Optional parameters:
     **Important:** If you customize this, be sure to include something like the
     `-e` flag, otherwise individual steps failing won't fail the provisioner.
 
+-  `only_on` (array of strings) - This is an array of 
+    [runtime operating systems](https://golang.org/doc/install/source#environment)
+    where `shell-local` will execute. This allows you to execute `shell-local` 
+    *only* on specific operating systems. By default, shell-local will always run 
+    if `only_on` is not set."
+
 -  `use_linux_pathing` (bool) - This is only relevant to windows hosts. If you
    are running Packer in a Windows environment with the Windows Subsystem for
    Linux feature enabled, and would like to invoke a bash script rather than

--- a/website/source/docs/provisioners/shell-local.html.md
+++ b/website/source/docs/provisioners/shell-local.html.md
@@ -108,13 +108,11 @@ Optional parameters:
     **Important:** If you customize this, be sure to include something like the
     `-e` flag, otherwise individual steps failing won't fail the provisioner.
 
--  `onlyon` (array of strings) - This is an array of 
+-  `only_on` (array of strings) - This is an array of 
     [runtime operating systems](https://golang.org/doc/install/source#environment)
-    where `shell-local` will only run on. This allows you to run `shell-local` *only* 
-    on specific compatible operating systems. If specified, shell-local will only
-    execute if runtime operating system is in the list; otherwise it will skip the 
-    `shell-local` command. The default behavior is for `shell-local` to run if 
-    `onlyon` is not specified.
+    where `shell-local` will execute. This allows you to execute `shell-local` 
+    *only* on specific operating systems. By default, shell-local will always run 
+    if `only_on` is not set."
 
 -  `use_linux_pathing` (bool) - This is only relevant to windows hosts. If you
    are running Packer in a Windows environment with the Windows Subsystem for

--- a/website/source/docs/provisioners/shell-local.html.md
+++ b/website/source/docs/provisioners/shell-local.html.md
@@ -108,6 +108,14 @@ Optional parameters:
     **Important:** If you customize this, be sure to include something like the
     `-e` flag, otherwise individual steps failing won't fail the provisioner.
 
+-  `onlyon` (array of strings) - This is an array of 
+    [runtime operating systems](https://golang.org/doc/install/source#environment)
+    where `shell-local` will only run on. This allows you to run `shell-local` *only* 
+    on specific compatible operating systems. If specified, shell-local will only
+    execute if runtime operating system is in the list; otherwise it will skip the 
+    `shell-local` command. The default behavior is for `shell-local` to run if 
+    `onlyon` is not specified.
+
 -  `use_linux_pathing` (bool) - This is only relevant to windows hosts. If you
    are running Packer in a Windows environment with the Windows Subsystem for
    Linux feature enabled, and would like to invoke a bash script rather than


### PR DESCRIPTION
Enabling the ability to pass in a list of runtime operating systems where shell-local should run. If list is not provided, execute default behavior. If specified, but runtime not in list, skip over execution.

I was not sure to either fail earlier and raise an exception, or gracefully skip. I voted for skipping as it can potentially eliminate duplication allowing folks to do things like:
```
"provisioners": [
    {
      "type": "shell-local",
      "inline": "setup.sh",
      "onlyon": ["darwin", "linux"]
    },
    {
      "type": "shell-local",
      "inline": "setup.bat",
      "onlyon": ["windows"]
    }
```

Apologies as I am still new to GoLang, I think there is still tons of fixes and simplifications that can be done here and open for suggestions! 👍Also, I think this can be extended if needed to other provisioners; however starting small :). 

Potentially closes #6678 