### PR TITLE
Remove json specifier from doc code block

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -180,7 +180,7 @@ for Packer to work:
 
 Note that if you'd like to create a spot instance, you must also add:
 
-``` json
+```
 ec2:RequestSpotInstances,
 ec2:CancelSpotInstanceRequests,
 ec2:DescribeSpotInstanceRequests
@@ -188,7 +188,7 @@ ec2:DescribeSpotInstanceRequests
 
 If you have the `spot_price` parameter set to `auto`, you must also add:
 
-``` json
+```
 ec2:DescribeSpotPriceHistory
 ```
 


### PR DESCRIPTION
This pull request removes the JSON formatting specifier from documentation code blocks that are not valid JSON. Left in, they are displayed as syntax errors on the packer.io website:

https://packer.io/docs/builders/amazon.html

![image](https://user-images.githubusercontent.com/3689108/47186619-c42ef680-d2f6-11e8-832d-59336846ffc7.png)

Also added a new line to the end of the file, which appears to be what most others have.
