### PR TITLE
Fix 6794

### DIFF
--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -47,11 +47,11 @@ func (d *ESX5Driver) Clone(dst, src string, linked bool) error {
 
 func (d *ESX5Driver) CompactDisk(diskPathLocal string) error {
 	diskPath := d.datastorePath(diskPathLocal)
-	return d.sh("vmkfstools", "--punchzero", diskPath)
+	return d.sh("vmkfstools", "--punchzero", fmt.Sprintf("\"%s\"", diskPath))
 }
 
 func (d *ESX5Driver) CreateDisk(diskPathLocal string, size string, adapter_type string, typeId string) error {
-	diskPath := fmt.Sprintf("'%s'", d.datastorePath(diskPathLocal))
+	diskPath := fmt.Sprintf("\"%s\"", d.datastorePath(diskPathLocal))
 	return d.sh("vmkfstools", "-c", size, "-d", typeId, "-a", adapter_type, diskPath)
 }
 
@@ -113,7 +113,7 @@ func (d *ESX5Driver) Destroy() error {
 }
 
 func (d *ESX5Driver) IsDestroyed() (bool, error) {
-	err := d.sh("test", "!", "-e", d.outputDir)
+	err := d.sh("test", "!", "-e", fmt.Sprintf("\"%s\"", d.outputDir))
 	if err != nil {
 		return false, err
 	}
@@ -142,7 +142,7 @@ func (d *ESX5Driver) UploadISO(localPath string, checksum string, checksumType s
 func (d *ESX5Driver) RemoveCache(localPath string) error {
 	finalPath := d.cachePath(localPath)
 	log.Printf("Removing remote cache path %s (local %s)", finalPath, localPath)
-	return d.sh("rm", "-f", finalPath)
+	return d.sh("rm", "-f", fmt.Sprintf("\"%s\"", finalPath))
 }
 
 func (d *ESX5Driver) ToolsIsoPath(string) string {
@@ -450,7 +450,7 @@ func (d *ESX5Driver) CommHost(state multistep.StateBag) (string, error) {
 //-------------------------------------------------------------------
 
 func (d *ESX5Driver) DirExists() (bool, error) {
-	err := d.sh("test", "-e", d.outputDir)
+	err := d.sh("test", "-e", fmt.Sprintf("\"%s\"", d.outputDir))
 	return err == nil, nil
 }
 
@@ -482,11 +482,11 @@ func (d *ESX5Driver) MkdirAll() error {
 }
 
 func (d *ESX5Driver) Remove(path string) error {
-	return d.sh("rm", path)
+	return d.sh("rm", fmt.Sprintf("\"%s\"", path))
 }
 
 func (d *ESX5Driver) RemoveAll() error {
-	return d.sh("rm", "-rf", d.outputDir)
+	return d.sh("rm", "-rf", fmt.Sprintf("\"%s\"", d.outputDir))
 }
 
 func (d *ESX5Driver) SetOutputDir(path string) {
@@ -579,7 +579,7 @@ func (d *ESX5Driver) checkGuestIPHackEnabled() error {
 }
 
 func (d *ESX5Driver) mkdir(path string) error {
-	return d.sh("mkdir", "-p", path)
+	return d.sh("mkdir", "-p", fmt.Sprintf("\"%s\"", path))
 }
 
 func (d *ESX5Driver) upload(dst, src string) error {
@@ -593,7 +593,7 @@ func (d *ESX5Driver) upload(dst, src string) error {
 
 func (d *ESX5Driver) verifyChecksum(ctype string, hash string, file string) bool {
 	if ctype == "none" {
-		if err := d.sh("stat", file); err != nil {
+		if err := d.sh("stat", fmt.Sprintf("\"%s\"", file)); err != nil {
 			return false
 		}
 	} else {

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -92,7 +92,7 @@ func (d *ESX5Driver) Register(vmxPathLocal string) error {
 	if err := d.upload(vmxPath, vmxPathLocal); err != nil {
 		return err
 	}
-	r, err := d.run(nil, "vim-cmd", "solo/registervm", vmxPath)
+	r, err := d.run(nil, "vim-cmd", "solo/registervm", fmt.Sprintf("\"%s\"", vmxPath))
 	if err != nil {
 		return err
 	}

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -51,8 +51,7 @@ func (d *ESX5Driver) CompactDisk(diskPathLocal string) error {
 }
 
 func (d *ESX5Driver) CreateDisk(diskPathLocal string, size string, adapter_type string, typeId string) error {
-	diskPath := d.datastorePath(diskPathLocal)
-	diskPath = strings.Replace(diskPath, " ", `\ `, -1)
+	diskPath := fmt.Sprintf("'%s'", d.datastorePath(diskPathLocal))
 	return d.sh("vmkfstools", "-c", size, "-d", typeId, "-a", adapter_type, diskPath)
 }
 

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -47,11 +48,11 @@ func (d *ESX5Driver) Clone(dst, src string, linked bool) error {
 
 func (d *ESX5Driver) CompactDisk(diskPathLocal string) error {
 	diskPath := d.datastorePath(diskPathLocal)
-	return d.sh("vmkfstools", "--punchzero", fmt.Sprintf("\"%s\"", diskPath))
+	return d.sh("vmkfstools", "--punchzero", strconv.Quote(diskPath))
 }
 
 func (d *ESX5Driver) CreateDisk(diskPathLocal string, size string, adapter_type string, typeId string) error {
-	diskPath := fmt.Sprintf("\"%s\"", d.datastorePath(diskPathLocal))
+	diskPath := strconv.Quote(d.datastorePath(diskPathLocal))
 	return d.sh("vmkfstools", "-c", size, "-d", typeId, "-a", adapter_type, diskPath)
 }
 
@@ -92,7 +93,7 @@ func (d *ESX5Driver) Register(vmxPathLocal string) error {
 	if err := d.upload(vmxPath, vmxPathLocal); err != nil {
 		return err
 	}
-	r, err := d.run(nil, "vim-cmd", "solo/registervm", fmt.Sprintf("\"%s\"", vmxPath))
+	r, err := d.run(nil, "vim-cmd", "solo/registervm", strconv.Quote(vmxPath))
 	if err != nil {
 		return err
 	}
@@ -113,7 +114,7 @@ func (d *ESX5Driver) Destroy() error {
 }
 
 func (d *ESX5Driver) IsDestroyed() (bool, error) {
-	err := d.sh("test", "!", "-e", fmt.Sprintf("\"%s\"", d.outputDir))
+	err := d.sh("test", "!", "-e", strconv.Quote(d.outputDir))
 	if err != nil {
 		return false, err
 	}
@@ -142,7 +143,7 @@ func (d *ESX5Driver) UploadISO(localPath string, checksum string, checksumType s
 func (d *ESX5Driver) RemoveCache(localPath string) error {
 	finalPath := d.cachePath(localPath)
 	log.Printf("Removing remote cache path %s (local %s)", finalPath, localPath)
-	return d.sh("rm", "-f", fmt.Sprintf("\"%s\"", finalPath))
+	return d.sh("rm", "-f", strconv.Quote(finalPath))
 }
 
 func (d *ESX5Driver) ToolsIsoPath(string) string {
@@ -450,7 +451,7 @@ func (d *ESX5Driver) CommHost(state multistep.StateBag) (string, error) {
 //-------------------------------------------------------------------
 
 func (d *ESX5Driver) DirExists() (bool, error) {
-	err := d.sh("test", "-e", fmt.Sprintf("\"%s\"", d.outputDir))
+	err := d.sh("test", "-e", strconv.Quote(d.outputDir))
 	return err == nil, nil
 }
 
@@ -482,11 +483,11 @@ func (d *ESX5Driver) MkdirAll() error {
 }
 
 func (d *ESX5Driver) Remove(path string) error {
-	return d.sh("rm", fmt.Sprintf("\"%s\"", path))
+	return d.sh("rm", strconv.Quote(path))
 }
 
 func (d *ESX5Driver) RemoveAll() error {
-	return d.sh("rm", "-rf", fmt.Sprintf("\"%s\"", d.outputDir))
+	return d.sh("rm", "-rf", strconv.Quote(d.outputDir))
 }
 
 func (d *ESX5Driver) SetOutputDir(path string) {
@@ -579,7 +580,7 @@ func (d *ESX5Driver) checkGuestIPHackEnabled() error {
 }
 
 func (d *ESX5Driver) mkdir(path string) error {
-	return d.sh("mkdir", "-p", fmt.Sprintf("\"%s\"", path))
+	return d.sh("mkdir", "-p", strconv.Quote(path))
 }
 
 func (d *ESX5Driver) upload(dst, src string) error {
@@ -593,7 +594,7 @@ func (d *ESX5Driver) upload(dst, src string) error {
 
 func (d *ESX5Driver) verifyChecksum(ctype string, hash string, file string) bool {
 	if ctype == "none" {
-		if err := d.sh("stat", fmt.Sprintf("\"%s\"", file)); err != nil {
+		if err := d.sh("stat", strconv.Quote(file)); err != nil {
 			return false
 		}
 	} else {

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -89,18 +89,13 @@ func (d *ESX5Driver) Stop(vmxPathLocal string) error {
 
 func (d *ESX5Driver) Register(vmxPathLocal string) error {
 	vmxPath := filepath.ToSlash(filepath.Join(d.outputDir, filepath.Base(vmxPathLocal)))
-	log.Printf("DEBUGGING 6794 (1): upload path is: %s", vmxPath)
 	if err := d.upload(vmxPath, vmxPathLocal); err != nil {
-		log.Printf("DEBUGGING 6794 (2): upload errored: %s", err.Error())
 		return err
 	}
-	log.Printf("DEBUGGING 6794 (3): Upload succeeded")
 	r, err := d.run(nil, "vim-cmd", "solo/registervm", fmt.Sprintf("\"%s\"", vmxPath))
 	if err != nil {
-		log.Printf("DEBUGGING 6794 (4): VM registration errorred: %s", err.Error())
 		return err
 	}
-	log.Printf("DEBUGGING 6794 (5): Registration succeeded")
 	d.vmId = strings.TrimRight(r, "\n")
 	return nil
 }
@@ -590,7 +585,6 @@ func (d *ESX5Driver) mkdir(path string) error {
 func (d *ESX5Driver) upload(dst, src string) error {
 	f, err := os.Open(src)
 	if err != nil {
-		log.Printf("DEBUGGING 6794 (6): unable to open src file for scp upload")
 		return err
 	}
 	defer f.Close()

--- a/builder/vmware/iso/driver_esx5.go
+++ b/builder/vmware/iso/driver_esx5.go
@@ -89,13 +89,18 @@ func (d *ESX5Driver) Stop(vmxPathLocal string) error {
 
 func (d *ESX5Driver) Register(vmxPathLocal string) error {
 	vmxPath := filepath.ToSlash(filepath.Join(d.outputDir, filepath.Base(vmxPathLocal)))
+	log.Printf("DEBUGGING 6794 (1): upload path is: %s", vmxPath)
 	if err := d.upload(vmxPath, vmxPathLocal); err != nil {
+		log.Printf("DEBUGGING 6794 (2): upload errored: %s", err.Error())
 		return err
 	}
+	log.Printf("DEBUGGING 6794 (3): Upload succeeded")
 	r, err := d.run(nil, "vim-cmd", "solo/registervm", fmt.Sprintf("\"%s\"", vmxPath))
 	if err != nil {
+		log.Printf("DEBUGGING 6794 (4): VM registration errorred: %s", err.Error())
 		return err
 	}
+	log.Printf("DEBUGGING 6794 (5): Registration succeeded")
 	d.vmId = strings.TrimRight(r, "\n")
 	return nil
 }
@@ -585,6 +590,7 @@ func (d *ESX5Driver) mkdir(path string) error {
 func (d *ESX5Driver) upload(dst, src string) error {
 	f, err := os.Open(src)
 	if err != nil {
+		log.Printf("DEBUGGING 6794 (6): unable to open src file for scp upload")
 		return err
 	}
 	defer f.Close()

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -563,6 +563,8 @@ func (c *comm) scpUploadSession(path string, input io.Reader, fi *os.FileInfo) e
 	// The target directory and file for talking the SCP protocol
 	target_dir := filepath.Dir(path)
 	target_file := filepath.Base(path)
+	log.Printf("DEBUGGING 6794 (7): target dir is %s", target_dir)
+	log.Printf("DEBUGGING 6794 (8): target file is %s", target_file)
 
 	// On windows, filepath.Dir uses backslash separators (ie. "\tmp").
 	// This does not work when the target host is unix.  Switch to forward slash

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -563,8 +563,8 @@ func (c *comm) scpUploadSession(path string, input io.Reader, fi *os.FileInfo) e
 	// The target directory and file for talking the SCP protocol
 	target_dir := filepath.Dir(path)
 	target_file := filepath.Base(path)
-	log.Printf("DEBUGGING 6794 (7): target dir is %s", target_dir)
-	log.Printf("DEBUGGING 6794 (8): target file is %s", target_file)
+	// Escape spaces in remote directory
+	target_dir = strings.Replace(target_dir, " ", "\\ ", -1)
 
 	// On windows, filepath.Dir uses backslash separators (ie. "\tmp").
 	// This does not work when the target host is unix.  Switch to forward slash

--- a/communicator/ssh/communicator.go
+++ b/communicator/ssh/communicator.go
@@ -563,13 +563,14 @@ func (c *comm) scpUploadSession(path string, input io.Reader, fi *os.FileInfo) e
 	// The target directory and file for talking the SCP protocol
 	target_dir := filepath.Dir(path)
 	target_file := filepath.Base(path)
-	// Escape spaces in remote directory
-	target_dir = strings.Replace(target_dir, " ", "\\ ", -1)
 
 	// On windows, filepath.Dir uses backslash separators (ie. "\tmp").
 	// This does not work when the target host is unix.  Switch to forward slash
 	// which works for unix and windows
 	target_dir = filepath.ToSlash(target_dir)
+
+	// Escape spaces in remote directory
+	target_dir = strings.Replace(target_dir, " ", "\\ ", -1)
 
 	scpFunc := func(w io.Writer, stdoutR *bufio.Reader) error {
 		return scpUploadFile(target_file, input, w, stdoutR, fi)


### PR DESCRIPTION
This PR consists of two sets of changes, both of which are necessary to allow a user to register a vm file to a remote esx server when the vmx path contains spaces.

First, it involves quoting a bunch of VMX paths in driver_esx5.go. 

Second, it involves escaping spaces in file paths inside of the ssh communicator's upload function itself. This has to happen here because the spaces need to be escaped _after_ ToSlash is called.

Before these changes, attempts to register a vm would fail if the vmx path contained spaces.

The ssh communicator change is necessary because without it, the upload would fail with an "ambiguous target" error

Closes #6794