### PR TITLE
Change wording of build template variables

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -515,7 +515,8 @@ provisioning commands to install the os and bootloader.
 
 ## Build template data
 
-The available variables are:
+In configuration directives marked as a template engine above, the
+following variables are available:
 
 - `BuildRegion` - The region (for example `eu-central-1`) where Packer is building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build the AMI.

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -591,7 +591,8 @@ configuration of `launch_block_device_mappings` will expand the root volume
 
 ## Build template data
 
-The available variables are:
+In configuration directives marked as a template engine above, the
+following variables are available:
 
 - `BuildRegion` - The region (for example `eu-central-1`) where Packer is building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build the AMI.

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -559,7 +559,8 @@ You can use this information to access the instance as it is running.
 
 ## Build template data
 
-The available variables are:
+In configuration directives marked as a template engine above, the
+following variables are available:
 
 - `BuildRegion` - The region (for example `eu-central-1`) where Packer is building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build the AMI.

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -486,7 +486,8 @@ You can use this information to access the instance as it is running.
 
 ## Build template data
 
-The available variables are:
+In configuration directives marked as a template engine above, the
+following variables are available:
 
 - `BuildRegion` - The region (for example `eu-central-1`) where Packer is building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build the AMI.

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -548,7 +548,8 @@ You can use this information to access the instance as it is running.
 
 ## Build template data
 
-The available variables are:
+In configuration directives marked as a template engine above, the
+following variables are available:
 
 - `BuildRegion` - The region (for example `eu-central-1`) where Packer is building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build the AMI.


### PR DESCRIPTION
This changes the wording of the build templates variables section in
the AWS builders.

Closes #6791
