### PR TITLE
WIP: Add support for cloud-init on Scaleway builder

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	Bootscript   string `mapstructure:"bootscript"`
 	BootType     string `mapstructure:"boottype"`
 
+	CloudInit string `mapstructure:"cloud_init"`
+
 	UserAgent string
 	ctx       interpolate.Context
 }


### PR DESCRIPTION
This PR adds support for using cloud-init script when building the image with Packer.

Our goal is to offer to Packer users the possibility to configure their instance using a cloud-init script if they want to.

- https://cloudinit.readthedocs.io/en/latest/index.html
- https://blog.online.net/2018/07/05/introducing-scaleway-cloud-init-support/

This option will most likely have an option to configure whether if cloud-init file should be purged or not (Default should probably purge): `cloud-init clean ; rm -fr /var/log/cloud*`

You can check whether or not cloud-init finished running by seeing whether or not the following file is present: `/var/lib/cloud/instance/boot-finished` Checking for its existence is probably the simplest option.