### PR TITLE
qemu: Add "hvf" as a libvirt driver

### DIFF
--- a/post-processor/vagrant/libvirt.go
+++ b/post-processor/vagrant/libvirt.go
@@ -39,7 +39,7 @@ func (p *LibVirtProvider) Process(ui packer.Ui, artifact packer.Artifact, dir st
 	// Convert domain type to libvirt driver
 	var driver string
 	switch domainType {
-	case "none", "tcg":
+	case "none", "tcg", "hvf":
 		driver = "qemu"
 	case "kvm":
 		driver = domainType

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -142,3 +142,8 @@ The following Docker input artifacts are supported:
 -   `docker-import`
 -   `docker-tag`
 -   `docker-push`
+
+### QEMU/libvirt
+
+The `libvirt` provider supports QEMU artifacts built using any these accelerators: none,
+kvm, tcg, or hvf.


### PR DESCRIPTION
To prevent post-processing from failing when running on macOS with the accelerator set to "hvf".

The hvf-accelerator was added app. a half year ago to QEMU builder (see #6193) but not yet included in the Vagrant post-processor. This is a very small "enhancement".
See issue #6954 for some background.

Steps taken:
- Re-compiled packer

```
$ packer version
Packer v1.4.0-dev (daf1f3993+CHANGES)
```

- Testing output add to this [gist](https://gist.github.com/hbokh/782e792644fa5fe40698182089c7925c).

(Note: My first PR for this project; I read the contributing guidelines.)