### PR TITLE
Add a Optional Step for Creation of Snapshot to vSphere Template

### DIFF
--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -31,6 +31,11 @@ type Config struct {
 	Password            string `mapstructure:"password"`
 	Datacenter          string `mapstructure:"datacenter"`
 	Folder              string `mapstructure:"folder"`
+	SnapshotEnable      bool   `mapstructure:"snapshot_enable"`
+	SnapshotName        string `mapstructure:"snapshot_name"`
+	SnapshotDescription string `mapstructure:"snapshot_description"`
+	SnapshotMemory      bool   `mapstructure:"snapshot_memory"`
+	SnapshotQuiesce     bool   `mapstructure:"snapshot_quiesce"`
 
 	ctx interpolate.Context
 }
@@ -126,6 +131,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		&stepCreateFolder{
 			Folder: p.config.Folder,
 		},
+		NewStepCreateSnapshot(artifact, p),
 		NewStepMarkAsTemplate(artifact),
 	}
 	runner := common.NewRunnerWithPauseFn(steps, p.config.PackerConfig, ui, state)

--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -34,8 +34,6 @@ type Config struct {
 	SnapshotEnable      bool   `mapstructure:"snapshot_enable"`
 	SnapshotName        string `mapstructure:"snapshot_name"`
 	SnapshotDescription string `mapstructure:"snapshot_description"`
-	SnapshotMemory      bool   `mapstructure:"snapshot_memory"`
-	SnapshotQuiesce     bool   `mapstructure:"snapshot_quiesce"`
 
 	ctx interpolate.Context
 }

--- a/post-processor/vsphere-template/step_create_snapshot.go
+++ b/post-processor/vsphere-template/step_create_snapshot.go
@@ -1,0 +1,81 @@
+package vsphere_template
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/post-processor/vsphere"
+	"github.com/vmware/govmomi"
+)
+
+type stepCreateSnapshot struct {
+	VMName              string
+	RemoteFolder        string
+	SnapshotName        string
+	SnapshotDescription string
+	SnapshotMemory      bool
+	SnapshotQuiesce     bool
+	SnapshotEnable      bool
+}
+
+func NewStepCreateSnapshot(artifact packer.Artifact, p *PostProcessor) *stepCreateSnapshot {
+	remoteFolder := "Discovered virtual machine"
+	vmname := artifact.Id()
+
+	if artifact.BuilderId() == vsphere.BuilderId {
+		id := strings.Split(artifact.Id(), "::")
+		remoteFolder = id[1]
+		vmname = id[2]
+	}
+
+	return &stepCreateSnapshot{
+		VMName:              vmname,
+		RemoteFolder:        remoteFolder,
+		SnapshotEnable:      p.config.SnapshotEnable,
+		SnapshotName:        p.config.SnapshotName,
+		SnapshotDescription: p.config.SnapshotDescription,
+		SnapshotMemory:      p.config.SnapshotMemory,
+		SnapshotQuiesce:     p.config.SnapshotQuiesce,
+	}
+}
+
+func (s *stepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	cli := state.Get("client").(*govmomi.Client)
+	dcPath := state.Get("dcPath").(string)
+
+	if !s.SnapshotEnable {
+		ui.Message("Snapshot Not Enabled, Continue...")
+		return multistep.ActionContinue
+	}
+
+	ui.Message("Creating a Snapshot...")
+
+	vm, err := findRuntimeVM(cli, dcPath, s.VMName, s.RemoteFolder)
+
+	if err != nil {
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	task, err := vm.CreateSnapshot(context.Background(), s.SnapshotName, s.SnapshotDescription, s.SnapshotMemory, s.SnapshotQuiesce)
+
+	if err != nil {
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	if err = task.Wait(context.Background()); err != nil {
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepCreateSnapshot) Cleanup(multistep.StateBag) {}

--- a/post-processor/vsphere-template/step_create_snapshot.go
+++ b/post-processor/vsphere-template/step_create_snapshot.go
@@ -15,8 +15,6 @@ type stepCreateSnapshot struct {
 	RemoteFolder        string
 	SnapshotName        string
 	SnapshotDescription string
-	SnapshotMemory      bool
-	SnapshotQuiesce     bool
 	SnapshotEnable      bool
 }
 
@@ -36,8 +34,6 @@ func NewStepCreateSnapshot(artifact packer.Artifact, p *PostProcessor) *stepCrea
 		SnapshotEnable:      p.config.SnapshotEnable,
 		SnapshotName:        p.config.SnapshotName,
 		SnapshotDescription: p.config.SnapshotDescription,
-		SnapshotMemory:      p.config.SnapshotMemory,
-		SnapshotQuiesce:     p.config.SnapshotQuiesce,
 	}
 }
 
@@ -47,7 +43,6 @@ func (s *stepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) mu
 	dcPath := state.Get("dcPath").(string)
 
 	if !s.SnapshotEnable {
-		ui.Message("Snapshot Not Enabled, Continue...")
 		return multistep.ActionContinue
 	}
 
@@ -61,7 +56,7 @@ func (s *stepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) mu
 		return multistep.ActionHalt
 	}
 
-	task, err := vm.CreateSnapshot(context.Background(), s.SnapshotName, s.SnapshotDescription, s.SnapshotMemory, s.SnapshotQuiesce)
+	task, err := vm.CreateSnapshot(context.Background(), s.SnapshotName, s.SnapshotDescription, false, false)
 
 	if err != nil {
 		state.Put("error", err)

--- a/website/source/docs/post-processors/vsphere-template.html.md
+++ b/website/source/docs/post-processors/vsphere-template.html.md
@@ -61,20 +61,14 @@ Optional:
 -   `insecure` (boolean) - If it's true skip verification of server
     certificate. Default is false
     
--   `snapshot_enable` (boolean) - Enable snapshot creation before marking as a 
+-   `snapshot_enable` (boolean) - Create a snapshot before marking as a 
     template. Default is false
     
 -   `snapshot_name` (string) - Name for the snapshot. 
-    Require when `snapshot_enable` is enabled
+    Required when `snapshot_enable` is `true`
     
 -   `snapshot_description` (string) - Description for the snapshot. 
-    Require when `snapshot_enable` is enabled
-    
--   `snapshot_memory` (boolean) - Enable memory option for the snapshot. 
-    Default is false
-    
--   `snapshot_quiesce` (boolean) - Enable quiesce option for the snapshot. 
-    Default is false
+    Required when `snapshot_enable` is `true`
     
 ## Using the vSphere Template with local builders
 

--- a/website/source/docs/post-processors/vsphere-template.html.md
+++ b/website/source/docs/post-processors/vsphere-template.html.md
@@ -60,7 +60,22 @@ Optional:
 
 -   `insecure` (boolean) - If it's true skip verification of server
     certificate. Default is false
-
+    
+-   `snapshot_enable` (boolean) - Enable snapshot creation before marking as a 
+    template. Default is false
+    
+-   `snapshot_name` (string) - Name for the snapshot. 
+    Require when `snapshot_enable` is enabled
+    
+-   `snapshot_description` (string) - Description for the snapshot. 
+    Require when `snapshot_enable` is enabled
+    
+-   `snapshot_memory` (boolean) - Enable memory option for the snapshot. 
+    Default is false
+    
+-   `snapshot_quiesce` (boolean) - Enable quiesce option for the snapshot. 
+    Default is false
+    
 ## Using the vSphere Template with local builders
 
 Once the [vSphere](/docs/post-processors/vsphere.html) takes an artifact from


### PR DESCRIPTION
# Description
A Proposal for having a optional step in vSphere-Template post-processor for creating snapshot before marking as a template

# Purpose & Use Case
This is useful in cases of connecting packer and terraform, in situation where a template by packer need to be ready to be consume by terraform, however the linked clone require a snapshot to exist beforehand

# Additional Changes made to the post-processor
Introduced parameters:

- snapshot_enable : boolean 
- snapshot_name : string
- snapshot_description : string
- snapshot_memory : bool
- snapshot_quiesce : bool