### PR TITLE
Allow Powershell provisioner to use service accounts

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -190,11 +190,6 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			errors.New("Only one of script or scripts can be specified."))
 	}
 
-	if p.config.ElevatedUser != "" && p.config.ElevatedPassword == "" {
-		errs = packer.MultiErrorAppend(errs,
-			errors.New("Must supply an 'elevated_password' if 'elevated_user' provided"))
-	}
-
 	if p.config.ElevatedUser == "" && p.config.ElevatedPassword != "" {
 		errs = packer.MultiErrorAppend(errs,
 			errors.New("Must supply an 'elevated_user' if 'elevated_password' provided"))

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -148,8 +148,8 @@ func TestProvisionerPrepare_Elevated(t *testing.T) {
 	config["elevated_user"] = "vagrant"
 	err := p.Prepare(config)
 
-	if err == nil {
-		t.Fatal("should have error (only provided elevated_user)")
+	if err != nil {
+		t.Fatal("should not have error")
 	}
 
 	config["elevated_password"] = "vagrant"

--- a/website/source/docs/provisioners/powershell.html.md
+++ b/website/source/docs/provisioners/powershell.html.md
@@ -120,6 +120,14 @@ Optional parameters:
     "elevated_password": "{{.WinRMPassword}}",
     ```
 
+    If you specify an empty `elevated_password` value then the PowerShell
+    script is run as a service account. For example:
+
+    ``` json
+    "elevated_user": "SYSTEM",
+    "elevated_password": "",
+    ```
+
 -   `remote_path` (string) - The path where the PowerShell script will be
     uploaded to within the target build machine. This defaults to
     `C:/Windows/Temp/script-UUID.ps1` where UUID is replaced with a dynamically


### PR DESCRIPTION
This uses the logic defined in #6104 to allow running Powershell with a service account, i.e. setting `elevated_password` to an empty value.

Tested using a Powershell script that runs Puppet with `elevated_user` set to `SYSTEM`. Previously Puppet didn't have sufficient permissions within the WinRM connection to install all packages/apply changes whereas now it seems to work properly. Ultimately I'd like to extract some of this elevated functionality to fix #5478 (except with the `puppet-server` provisioner instead) however my familiarity with Windows internals is a tad lacking currently.

Fixes #6104