### PR TITLE
add new display_name template option

### DIFF
--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -20,9 +20,10 @@ import (
 // Produces:
 //   display_name string - Value of the displayName key set in the VMX file
 type StepConfigureVMX struct {
-	CustomData map[string]string
-	SkipFloppy bool
-	VMName     string
+	CustomData  map[string]string
+	DisplayName string
+	SkipFloppy  bool
+	VMName      string
 }
 
 func (s *StepConfigureVMX) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -73,6 +74,26 @@ func (s *StepConfigureVMX) Run(_ context.Context, state multistep.StateBag) mult
 		}
 	}
 
+	// If the build is taking place on a remote ESX server, the displayName
+	// will be needed for discovery of the VM's IP address and for export
+	// of the VM. The displayName key should always be set in the VMX file,
+	// so error if we don't find it and the user has not set it in the config.
+	if s.DisplayName != "" {
+		vmxData["displayname"] = s.DisplayName
+		state.Put("display_name", s.DisplayName)
+	} else {
+		displayName, ok := vmxData["displayname"]
+		if !ok { // Packer converts key names to lowercase!
+			err := fmt.Errorf("Error: Could not get value of displayName from VMX data")
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		} else {
+			state.Put("display_name", displayName)
+		}
+	}
+
+	log.Printf("%#v", vmxData)
 	err = WriteVMX(vmxPath, vmxData)
 
 	if err != nil {
@@ -80,19 +101,6 @@ func (s *StepConfigureVMX) Run(_ context.Context, state multistep.StateBag) mult
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
-	}
-
-	// If the build is taking place on a remote ESX server, the displayName
-	// will be needed for discovery of the VM's IP address and for export
-	// of the VM. The displayName key should always be set in the VMX file,
-	// so error if we don't find it
-	if displayName, ok := vmxData["displayname"]; !ok { // Packer converts key names to lowercase!
-		err := fmt.Errorf("Error: Could not get value of displayName from VMX data")
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	} else {
-		state.Put("display_name", displayName)
 	}
 
 	return multistep.ActionContinue

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -93,7 +93,6 @@ func (s *StepConfigureVMX) Run(_ context.Context, state multistep.StateBag) mult
 		}
 	}
 
-	log.Printf("%#v", vmxData)
 	err = WriteVMX(vmxPath, vmxData)
 
 	if err != nil {

--- a/builder/vmware/common/vmx_config.go
+++ b/builder/vmware/common/vmx_config.go
@@ -8,6 +8,7 @@ type VMXConfig struct {
 	VMXData           map[string]string `mapstructure:"vmx_data"`
 	VMXDataPost       map[string]string `mapstructure:"vmx_data_post"`
 	VMXRemoveEthernet bool              `mapstructure:"vmx_remove_ethernet_interfaces"`
+	VMXDisplayName    string            `mapstructure:"display_name"`
 }
 
 func (c *VMXConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -292,8 +292,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&stepCreateDisk{},
 		&stepCreateVMX{},
 		&vmwcommon.StepConfigureVMX{
-			CustomData: b.config.VMXData,
-			VMName:     b.config.VMName,
+			CustomData:  b.config.VMXData,
+			VMName:      b.config.VMName,
+			DisplayName: b.config.VMXDisplayName,
 		},
 		&vmwcommon.StepSuppressMessages{},
 		&common.StepHTTPServer{
@@ -349,9 +350,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Skip: b.config.SkipCompaction,
 		},
 		&vmwcommon.StepConfigureVMX{
-			CustomData: b.config.VMXDataPost,
-			SkipFloppy: true,
-			VMName:     b.config.VMName,
+			CustomData:  b.config.VMXDataPost,
+			SkipFloppy:  true,
+			VMName:      b.config.VMName,
+			DisplayName: b.config.VMXDisplayName,
 		},
 		&vmwcommon.StepCleanVMX{
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -88,8 +88,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Linked:    b.config.Linked,
 		},
 		&vmwcommon.StepConfigureVMX{
-			CustomData: b.config.VMXData,
-			VMName:     b.config.VMName,
+			CustomData:  b.config.VMXData,
+			VMName:      b.config.VMName,
+			DisplayName: b.config.VMXDisplayName,
 		},
 		&vmwcommon.StepSuppressMessages{},
 		&common.StepHTTPServer{
@@ -148,9 +149,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Skip: b.config.SkipCompaction,
 		},
 		&vmwcommon.StepConfigureVMX{
-			CustomData: b.config.VMXDataPost,
-			SkipFloppy: true,
-			VMName:     b.config.VMName,
+			CustomData:  b.config.VMXDataPost,
+			SkipFloppy:  true,
+			VMName:      b.config.VMName,
+			DisplayName: b.config.VMXDisplayName,
 		},
 		&vmwcommon.StepCleanVMX{
 			RemoveEthernetInterfaces: b.config.VMXConfig.VMXRemoveEthernet,

--- a/website/source/docs/builders/vmware-iso.html.md.erb
+++ b/website/source/docs/builders/vmware-iso.html.md.erb
@@ -154,6 +154,13 @@ builder.
     Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
     VMware clients. For ESXi, refer to the proper ESXi documentation.
 
+-   `display_name` (string) - The name that will appear in your vSphere client,
+    and will be used for the vmx basename. This will override the "displayname"
+    value in your vmx file. It will also override the "displayname" if you have
+    set it in the "vmx_data" Packer option. This option is useful if you are
+    chaining vmx builds and want to make sure that the display name of each step
+    in the chain is unique.
+
 -   `floppy_dirs` (array of strings) - A list of directories to place onto
     the floppy disk recursively. This is similar to the `floppy_files` option
     except that the directory structure is preserved. This is useful for when

--- a/website/source/docs/builders/vmware-vmx.html.md.erb
+++ b/website/source/docs/builders/vmware-vmx.html.md.erb
@@ -77,6 +77,13 @@ builder.
 -   `disable_vnc` (boolean) - Whether to create a VNC connection or not.
     A `boot_command` cannot be used when this is `false`. Defaults to `false`.
 
+-   `display_name` (string) - The name that will appear in your vSphere client,
+    and will be used for the vmx basename. This will override the "displayname"
+    value in your vmx file. It will also override the "displayname" if you have
+    set it in the "vmx_data" Packer option. This option is useful if you are
+    chaining vmx builds and want to make sure that the display name of each step
+    in the chain is unique.
+
 -   `floppy_dirs` (array of strings) - A list of directories to place onto
     the floppy disk recursively. This is similar to the `floppy_files` option
     except that the directory structure is preserved. This is useful for when


### PR DESCRIPTION
Add a new `"display_name"` option to the vmware templates.  This will overwrite the "displayname" in the vmx file.  Previously, users could achieve this same functionality using the "vmx_data" option, but I like the idea of making it an explicit and first-class option because it's something people regularly need to set for chained vmx builds.

Closes #6958 