### PR TITLE
create export directories for vmx and ovf file types, too.

### DIFF
--- a/builder/vmware/common/step_export.go
+++ b/builder/vmware/common/step_export.go
@@ -74,9 +74,7 @@ func (s *StepExport) Run(_ context.Context, state multistep.StateBag) multistep.
 		s.OutputDir = s.VMName + "." + s.Format
 	}
 
-	if s.Format == "ova" {
-		os.MkdirAll(s.OutputDir, 0755)
-	}
+	os.MkdirAll(s.OutputDir, 0755)
 
 	ui.Say("Exporting virtual machine...")
 	var displayName string


### PR DESCRIPTION
When step_export was originally created, we didn't verify that the output_dir existed for ovf and vmx files, just ova. Not sure why this was, but I think it creates unnecessary complexity.  

This PR removes the conditional approach, and always calls mkdirall on the output_dir regardless of the export format. 

Closes #6860
