### PR TITLE
6624

### DIFF
--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -441,6 +441,31 @@ func TestBuilderPrepare_VNCPort(t *testing.T) {
 	}
 }
 
+func TestBuilderCheckCollisions(t *testing.T) {
+	config := testConfig()
+	config["vmx_data"] = map[string]string{
+		"no.collision":    "awesomesauce",
+		"ide0:0.fileName": "is a collision",
+		"displayName":     "also a collision",
+	}
+	{
+		var b Builder
+		warns, _ := b.Prepare(config)
+		if len(warns) != 1 {
+			t.Fatalf("Should have warning about two collisions.")
+		}
+	}
+	{
+		config["vmx_template_path"] = "some/path.vmx"
+		var b Builder
+		warns, _ := b.Prepare(config)
+		if len(warns) != 0 {
+			t.Fatalf("Should not check for collisions with custom template.")
+		}
+	}
+
+}
+
 func TestBuilderPrepare_CommConfig(t *testing.T) {
 	// Test Winrm
 	{

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -28,10 +28,10 @@ type vmxTemplateData struct {
 	SATA_Present         string
 	NVME_Present         string
 
-	DiskName              string
-	DiskType              string
-	CDROMType             string
-	CDROMType_MasterSlave string
+	DiskName                   string
+	DiskType                   string
+	CDROMType                  string
+	CDROMType_PrimarySecondary string
 
 	Network_Type    string
 	Network_Device  string
@@ -383,10 +383,10 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 		SATA_Present:         "FALSE",
 		NVME_Present:         "FALSE",
 
-		DiskType:              "scsi",
-		HDD_BootOrder:         "scsi0:0",
-		CDROMType:             "ide",
-		CDROMType_MasterSlave: "0",
+		DiskType:                   "scsi",
+		HDD_BootOrder:              "scsi0:0",
+		CDROMType:                  "ide",
+		CDROMType_PrimarySecondary: "0",
 
 		Network_Adapter: "e1000",
 
@@ -406,20 +406,20 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 	case "ide":
 		templateData.DiskType = "ide"
 		templateData.CDROMType = "ide"
-		templateData.CDROMType_MasterSlave = "1"
+		templateData.CDROMType_PrimarySecondary = "1"
 		templateData.HDD_BootOrder = "ide0:0"
 	case "sata":
 		templateData.SATA_Present = "TRUE"
 		templateData.DiskType = "sata"
 		templateData.CDROMType = "sata"
-		templateData.CDROMType_MasterSlave = "1"
+		templateData.CDROMType_PrimarySecondary = "1"
 		templateData.HDD_BootOrder = "sata0:0"
 	case "nvme":
 		templateData.NVME_Present = "TRUE"
 		templateData.DiskType = "nvme"
 		templateData.SATA_Present = "TRUE"
 		templateData.CDROMType = "sata"
-		templateData.CDROMType_MasterSlave = "0"
+		templateData.CDROMType_PrimarySecondary = "0"
 		templateData.HDD_BootOrder = "nvme0:0"
 	case "scsi":
 		diskAdapterType = "lsilogic"
@@ -429,7 +429,7 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 		templateData.SCSI_diskAdapterType = diskAdapterType
 		templateData.DiskType = "scsi"
 		templateData.CDROMType = "ide"
-		templateData.CDROMType_MasterSlave = "0"
+		templateData.CDROMType_PrimarySecondary = "0"
 		templateData.HDD_BootOrder = "scsi0:0"
 	}
 
@@ -440,9 +440,9 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 	if cdromAdapterType == "" {
 		cdromAdapterType = templateData.CDROMType
 	} else if cdromAdapterType == diskAdapterType {
-		templateData.CDROMType_MasterSlave = "1"
+		templateData.CDROMType_PrimarySecondary = "1"
 	} else {
-		templateData.CDROMType_MasterSlave = "0"
+		templateData.CDROMType_PrimarySecondary = "0"
 	}
 
 	switch cdromAdapterType {
@@ -686,9 +686,9 @@ nvme0.present = "{{ .NVME_Present }}"
 {{ .DiskType }}0:0.present = "TRUE"
 {{ .DiskType }}0:0.fileName = "{{ .DiskName }}.vmdk"
 
-{{ .CDROMType }}0:{{ .CDROMType_MasterSlave }}.present = "TRUE"
-{{ .CDROMType }}0:{{ .CDROMType_MasterSlave }}.fileName = "{{ .ISOPath }}"
-{{ .CDROMType }}0:{{ .CDROMType_MasterSlave }}.deviceType = "cdrom-image"
+{{ .CDROMType }}0:{{ .CDROMType_PrimarySecondary }}.present = "TRUE"
+{{ .CDROMType }}0:{{ .CDROMType_PrimarySecondary }}.fileName = "{{ .ISOPath }}"
+{{ .CDROMType }}0:{{ .CDROMType_PrimarySecondary }}.deviceType = "cdrom-image"
 
 isolation.tools.hgfs.disable = "FALSE"
 memsize = "512"

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -435,7 +435,7 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 
 	/// Handle the cdrom adapter type. If the disk adapter type and the
 	//  cdrom adapter type are the same, then ensure that the cdrom is the
-	//  slave device on whatever bus the disk adapter is on.
+	//  secondary device on whatever bus the disk adapter is on.
 	cdromAdapterType := strings.ToLower(config.CdromAdapterType)
 	if cdromAdapterType == "" {
 		cdromAdapterType = templateData.CDROMType


### PR DESCRIPTION
Help users troubleshoot by warning them if their `vmx_data` overrides data that Packer uses the template engine to set in its default vmx template. 

Also changes "master/slave" disk labels in our variables to the more inclusive and less loaded "primary/secondary" because I didn't feel this naming change was complex enough to warrant its own pull request.

Closes #6624
