### PR TITLE
[Hetzner Cloud] Add missing docs link

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -99,6 +99,9 @@
           <li<%= sidebar_current("docs-builders-googlecompute") %>>
             <a href="/docs/builders/googlecompute.html">Google Cloud</a>
           </li>
+          <li<%= sidebar_current("docs-builders-hetzner-cloud") %>>
+             <a href="/docs/builders/hetzner-cloud.html">Hetzner Cloud</a>
+          </li>
           <li<%= sidebar_current("docs-builders-hyperv") %>>
             <a href="/docs/builders/hyperv.html">Hyper-V</a>
             <ul class="nav">


### PR DESCRIPTION
Hello,

I have contributed the official Hetzner Cloud Packer Builder last month.

On the last PR I missed adding a link in the documentation sidebar. This PR fix this.