### PR TITLE
Revert "Start building on Circle-CI"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
     working_directory: /go/src/github.com/hashicorp/packer
     steps:
       - checkout
+
       # specify any bash command here prefixed with `run: `
       - run: pwd
       - run: make ci


### PR DESCRIPTION
wasn't so simple after all. Reverts hashicorp/packer#7013