### PR TITLE
WIP: Add service accounts to GCE-import post-processor

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -210,6 +210,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 			errs = packer.MultiErrorAppend(errs, err)
 		}
 	}
+	// If DisableDefaultServiceAccount is provided, don't allow a value for ServiceAccountEmail
+	if c.DisableDefaultServiceAccount && c.ServiceAccountEmail != "" {
+		errs = packer.MultiErrorAppend(fmt.Errorf("you may not specify a 'service_account_email' when 'disable_default_service_account' is true"))
+	}
 
 	if c.OmitExternalIP && c.Address != "" {
 		errs = packer.MultiErrorAppend(fmt.Errorf("you can not specify an external address when 'omit_external_ip' is true"))
@@ -225,11 +229,6 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	if c.AcceleratorCount > 0 && c.OnHostMaintenance != "TERMINATE" {
 		errs = packer.MultiErrorAppend(fmt.Errorf("'on_host_maintenance' must be set to 'TERMINATE' when 'accelerator_count' is more than 0"))
-	}
-
-	// If DisableDefaultServiceAccount is provided, don't allow a value for ServiceAccountEmail
-	if c.DisableDefaultServiceAccount && c.ServiceAccountEmail != "" {
-		errs = packer.MultiErrorAppend(fmt.Errorf("you may not specify a 'service_account_email' when 'disable_default_service_account' is true"))
 	}
 
 	if c.StartupScriptFile != "" {

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -83,7 +83,6 @@ func NewClientGCE(ui packer.Ui, p string, a *AccountFile, DriverScopes []string)
 		client = conf.Client(oauth2.NoContext)
 	} else {
 		log.Printf("[INFO] Requesting Google token via GCE API Default Client Token Source...")
-		client, err = google.DefaultClient(oauth2.NoContext, DriverScopes...)
 		// The DefaultClient uses the DefaultTokenSource of the google lib.
 		// The DefaultTokenSource uses the "Application Default Credentials"
 		// It looks for credentials in the following places, preferring the first location found:
@@ -96,11 +95,12 @@ func NewClientGCE(ui packer.Ui, p string, a *AccountFile, DriverScopes []string)
 		// 4. On Google Compute Engine and Google App Engine Managed VMs, it fetches
 		//    credentials from the metadata server.
 		//    (In this final case any provided scopes are ignored.)
+		client, err = google.DefaultClient(oauth2.NoContext, DriverScopes...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	return client, nil
 }
 


### PR DESCRIPTION
Extend auth for the GCE-import post-processor to look more like the GCE builder; This should probably be abstracted further, and added to the GCE-export post-processor before merging.

Closes #7006