### PR TITLE
[WIP] Add configuration options to virtualbox builder to specify cpu count and memory size

### DIFF
--- a/builder/virtualbox/common/hw_config.go
+++ b/builder/virtualbox/common/hw_config.go
@@ -9,8 +9,8 @@ import (
 type HWConfig struct {
 
 	// cpu information
-	CpuCount   int `mapstructure:"cpu_count"`
-	MemorySize int `mapstructure:"memory_size"`
+	CpuCount   int `mapstructure:"cpus"`
+	MemorySize int `mapstructure:"memory"`
 
 	// device presence
 	Sound string `mapstructure:"sound"`
@@ -22,7 +22,7 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 
 	// Hardware and cpu options
 	if c.CpuCount < 0 {
-		errs = append(errs, fmt.Errorf("An invalid cpu_count was specified (cpu_count < 0): %d", c.CpuCount))
+		errs = append(errs, fmt.Errorf("An invalid number of cpus was specified (cpus < 0): %d", c.CpuCount))
 		c.CpuCount = 0
 	}
 	if c.CpuCount == 0 {
@@ -30,7 +30,7 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 
 	if c.MemorySize < 0 {
-		errs = append(errs, fmt.Errorf("An invalid memory_size was specified (memory_size < 0): %d", c.MemorySize))
+		errs = append(errs, fmt.Errorf("An invalid memory size was specified (memory < 0): %d", c.MemorySize))
 		c.MemorySize = 0
 	}
 	if c.MemorySize == 0 {

--- a/builder/virtualbox/common/hw_config.go
+++ b/builder/virtualbox/common/hw_config.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/template/interpolate"
+)
+
+type HWConfig struct {
+
+	// cpu information
+	CpuCount   int `mapstructure:"cpu_count"`
+	MemorySize int `mapstructure:"memory_size"`
+
+	// device presence
+	Sound string `mapstructure:"sound"`
+	USB   bool   `mapstructure:"usb"`
+}
+
+func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
+	var errs []error
+
+	// Hardware and cpu options
+	if c.CpuCount < 0 {
+		errs = append(errs, fmt.Errorf("An invalid cpu_count was specified (cpu_count < 0): %d", c.CpuCount))
+		c.CpuCount = 0
+	}
+	if c.CpuCount == 0 {
+		c.CpuCount = 1
+	}
+
+	if c.MemorySize < 0 {
+		errs = append(errs, fmt.Errorf("An invalid memory_size was specified (memory_size < 0): %d", c.MemorySize))
+		c.MemorySize = 0
+	}
+	if c.MemorySize == 0 {
+		c.MemorySize = 512
+	}
+
+	// devices
+	if c.Sound == "" {
+		c.Sound = "none"
+	}
+
+	return nil
+}

--- a/builder/virtualbox/common/hw_config_test.go
+++ b/builder/virtualbox/common/hw_config_test.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestHWConfigPrepare(t *testing.T) {
+	c := new(HWConfig)
+	if errs := c.Prepare(testConfigTemplate(t)); len(errs) > 0 {
+		t.Fatalf("err: %#v", errs)
+	}
+
+	if c.CpuCount < 1 {
+		t.Errorf("bad cpu count: %d", c.CpuCount)
+	}
+
+	if c.MemorySize < 64 {
+		t.Errorf("bad memory size: %d", c.MemorySize)
+	}
+}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -35,6 +35,7 @@ type Config struct {
 	vboxcommon.RunConfig            `mapstructure:",squash"`
 	vboxcommon.ShutdownConfig       `mapstructure:",squash"`
 	vboxcommon.SSHConfig            `mapstructure:",squash"`
+	vboxcommon.HWConfig             `mapstructure:",squash"`
 	vboxcommon.VBoxManageConfig     `mapstructure:",squash"`
 	vboxcommon.VBoxManagePostConfig `mapstructure:",squash"`
 	vboxcommon.VBoxVersionConfig    `mapstructure:",squash"`
@@ -92,6 +93,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, b.config.RunConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.ShutdownConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.SSHConfig.Prepare(&b.config.ctx)...)
+	errs = packer.MultiErrorAppend(errs, b.config.HWConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxManageConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxManagePostConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxVersionConfig.Prepare(&b.config.ctx)...)

--- a/builder/virtualbox/iso/step_create_vm.go
+++ b/builder/virtualbox/iso/step_create_vm.go
@@ -3,6 +3,8 @@ package iso
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	vboxcommon "github.com/hashicorp/packer/builder/virtualbox/common"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -24,7 +26,7 @@ func (s *stepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 
 	name := config.VMName
 
-	commands := make([][]string, 4)
+	commands := make([][]string, 6)
 	commands[0] = []string{
 		"createvm", "--name", name,
 		"--ostype", config.GuestOSType, "--register",
@@ -33,8 +35,15 @@ func (s *stepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 		"modifyvm", name,
 		"--boot1", "disk", "--boot2", "dvd", "--boot3", "none", "--boot4", "none",
 	}
-	commands[2] = []string{"modifyvm", name, "--cpus", "1"}
-	commands[3] = []string{"modifyvm", name, "--memory", "512"}
+	commands[2] = []string{"modifyvm", name, "--cpus", strconv.Itoa(config.HWConfig.CpuCount)}
+	commands[3] = []string{"modifyvm", name, "--memory", strconv.Itoa(config.HWConfig.MemorySize)}
+	commands[4] = []string{"modifyvm", name, "--usb", map[bool]string{true: "on", false: "off"}[config.HWConfig.USB]}
+
+	if strings.ToLower(config.HWConfig.Sound) == "none" {
+		commands[5] = []string{"modifyvm", name, "--audio", config.HWConfig.Sound}
+	} else {
+		commands[5] = []string{"modifyvm", name, "--audio", config.HWConfig.Sound, "--audioin", "on", "--audioout", "on"}
+	}
 
 	ui.Say("Creating virtual machine...")
 	for _, command := range commands {

--- a/website/source/docs/builders/virtualbox-iso.html.md.erb
+++ b/website/source/docs/builders/virtualbox-iso.html.md.erb
@@ -94,7 +94,7 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is `10s` or 10 seconds.
 
--   `cpu_count` (number) - The number of cpus to use for building the VM.
+-   `cpus` (number) - The number of cpus to use for building the VM.
     Defaults to building with just one.
 
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
@@ -252,7 +252,7 @@ builder.
 -   `keep_registered` (boolean) - Set this to `true` if you would like to keep
     the VM registered with virtualbox. Defaults to `false`.
 
--   `memory_size` (number) - The amount of memory to use for building the VM
+-   `memory` (number) - The amount of memory to use for building the VM
     in megabytes. Defaults to `512` megabytes.
 
 -   `output_directory` (string) - This is the path to the directory where the

--- a/website/source/docs/builders/virtualbox-iso.html.md.erb
+++ b/website/source/docs/builders/virtualbox-iso.html.md.erb
@@ -94,6 +94,9 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is `10s` or 10 seconds.
 
+-   `cpu_count` (number) - The number of cpus to use for building the VM.
+    Defaults to building with just one.
+
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is `40000` (about 40 GB).
 
@@ -249,6 +252,9 @@ builder.
 -   `keep_registered` (boolean) - Set this to `true` if you would like to keep
     the VM registered with virtualbox. Defaults to `false`.
 
+-   `memory_size` (number) - The amount of memory to use for building the VM
+    in megabytes. Defaults to `512` megabytes.
+
 -   `output_directory` (string) - This is the path to the directory where the
     resulting virtual machine will be created. This may be relative or absolute.
     If relative, the path is relative to the working directory when `packer`
@@ -278,6 +284,10 @@ builder.
     not export the VM. Useful if the build output is not the resultant image,
     but created inside the VM.
 
+-  `sound` (string) - Defaults to `none`. The type of audio device to use for
+    sound when building the VM. Some of the options that are available are
+    `dsound`, `oss`, `alsa`, `pulse`, `coreaudio`, `null`.
+
 -   `ssh_host_port_min` and `ssh_host_port_max` (number) - The minimum and
     maximum port to use for the SSH port on the host machine which is forwarded
     to the SSH port on the guest machine. Because Packer often runs in parallel,
@@ -287,6 +297,9 @@ builder.
 -   `ssh_skip_nat_mapping` (boolean) - Defaults to `false`. When enabled, Packer
     does not setup forwarded port mapping for SSH requests and uses `ssh_port`
     on the host to communicate to the virtual machine.
+
+-   `usb` (boolean) - Specifies whether or not to enable the USB bus when
+    building the VM. Defaults to `false`.
 
 -   `vboxmanage` (array of array of strings) - Custom `VBoxManage` commands to
     execute in order to further customize the virtual machine being created. The


### PR DESCRIPTION
This exposes the cpu count and memory size to the user for the virtualbox-iso builder. This is a common configuration and people have been using `vboxmanage_whatever` to explicitly set this. In order to steer users away from using the `vboxmanage_whatever` hack, standardizing on some options to configure these things between all the builders should help. This is somewhat related to #7010.

Also I originally used `cpu_count` and `memory_size`, but shortened them to `cpus` and `memory` since this is probably a pretty common configuration. Lmk if you guys prefer the longer ones or something else and I'll revert.

Just a heads up, I don't have an instance of Virtualbox and so I'm unable to really test this.