### PR TITLE
Add configuration options to parallels builder to specify cpu count and memory size

### DIFF
--- a/builder/parallels/common/driver_10.go
+++ b/builder/parallels/common/driver_10.go
@@ -7,19 +7,17 @@ type Parallels10Driver struct {
 
 // SetDefaultConfiguration applies pre-defined default settings to the VM config.
 func (d *Parallels10Driver) SetDefaultConfiguration(vmName string) error {
-	commands := make([][]string, 12)
-	commands[0] = []string{"set", vmName, "--cpus", "1"}
-	commands[1] = []string{"set", vmName, "--memsize", "512"}
-	commands[2] = []string{"set", vmName, "--startup-view", "same"}
-	commands[3] = []string{"set", vmName, "--on-shutdown", "close"}
-	commands[4] = []string{"set", vmName, "--on-window-close", "keep-running"}
-	commands[5] = []string{"set", vmName, "--auto-share-camera", "off"}
-	commands[6] = []string{"set", vmName, "--smart-guard", "off"}
-	commands[7] = []string{"set", vmName, "--shared-cloud", "off"}
-	commands[8] = []string{"set", vmName, "--shared-profile", "off"}
-	commands[9] = []string{"set", vmName, "--smart-mount", "off"}
-	commands[10] = []string{"set", vmName, "--sh-app-guest-to-host", "off"}
-	commands[11] = []string{"set", vmName, "--sh-app-host-to-guest", "off"}
+	commands := make([][]string, 10)
+	commands[0] = []string{"set", vmName, "--startup-view", "same"}
+	commands[1] = []string{"set", vmName, "--on-shutdown", "close"}
+	commands[2] = []string{"set", vmName, "--on-window-close", "keep-running"}
+	commands[3] = []string{"set", vmName, "--auto-share-camera", "off"}
+	commands[4] = []string{"set", vmName, "--smart-guard", "off"}
+	commands[5] = []string{"set", vmName, "--shared-cloud", "off"}
+	commands[6] = []string{"set", vmName, "--shared-profile", "off"}
+	commands[7] = []string{"set", vmName, "--smart-mount", "off"}
+	commands[8] = []string{"set", vmName, "--sh-app-guest-to-host", "off"}
+	commands[9] = []string{"set", vmName, "--sh-app-host-to-guest", "off"}
 
 	for _, command := range commands {
 		err := d.Prlctl(command...)

--- a/builder/parallels/common/driver_11.go
+++ b/builder/parallels/common/driver_11.go
@@ -38,19 +38,17 @@ func (d *Parallels11Driver) Verify() error {
 
 // SetDefaultConfiguration applies pre-defined default settings to the VM config.
 func (d *Parallels11Driver) SetDefaultConfiguration(vmName string) error {
-	commands := make([][]string, 12)
-	commands[0] = []string{"set", vmName, "--cpus", "1"}
-	commands[1] = []string{"set", vmName, "--memsize", "512"}
-	commands[2] = []string{"set", vmName, "--startup-view", "headless"}
-	commands[3] = []string{"set", vmName, "--on-shutdown", "close"}
-	commands[4] = []string{"set", vmName, "--on-window-close", "keep-running"}
-	commands[5] = []string{"set", vmName, "--auto-share-camera", "off"}
-	commands[6] = []string{"set", vmName, "--smart-guard", "off"}
-	commands[7] = []string{"set", vmName, "--shared-cloud", "off"}
-	commands[8] = []string{"set", vmName, "--shared-profile", "off"}
-	commands[9] = []string{"set", vmName, "--smart-mount", "off"}
-	commands[10] = []string{"set", vmName, "--sh-app-guest-to-host", "off"}
-	commands[11] = []string{"set", vmName, "--sh-app-host-to-guest", "off"}
+	commands := make([][]string, 10)
+	commands[0] = []string{"set", vmName, "--startup-view", "headless"}
+	commands[1] = []string{"set", vmName, "--on-shutdown", "close"}
+	commands[2] = []string{"set", vmName, "--on-window-close", "keep-running"}
+	commands[3] = []string{"set", vmName, "--auto-share-camera", "off"}
+	commands[4] = []string{"set", vmName, "--smart-guard", "off"}
+	commands[5] = []string{"set", vmName, "--shared-cloud", "off"}
+	commands[6] = []string{"set", vmName, "--shared-profile", "off"}
+	commands[7] = []string{"set", vmName, "--smart-mount", "off"}
+	commands[8] = []string{"set", vmName, "--sh-app-guest-to-host", "off"}
+	commands[9] = []string{"set", vmName, "--sh-app-host-to-guest", "off"}
 
 	for _, command := range commands {
 		err := d.Prlctl(command...)

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -331,14 +331,12 @@ func prepend(head string, tail []string) []string {
 
 // SetDefaultConfiguration applies pre-defined default settings to the VM config.
 func (d *Parallels9Driver) SetDefaultConfiguration(vmName string) error {
-	commands := make([][]string, 7)
-	commands[0] = []string{"set", vmName, "--cpus", "1"}
-	commands[1] = []string{"set", vmName, "--memsize", "512"}
-	commands[2] = []string{"set", vmName, "--startup-view", "same"}
-	commands[3] = []string{"set", vmName, "--on-shutdown", "close"}
-	commands[4] = []string{"set", vmName, "--on-window-close", "keep-running"}
-	commands[5] = []string{"set", vmName, "--auto-share-camera", "off"}
-	commands[6] = []string{"set", vmName, "--smart-guard", "off"}
+	commands := make([][]string, 5)
+	commands[0] = []string{"set", vmName, "--startup-view", "same"}
+	commands[1] = []string{"set", vmName, "--on-shutdown", "close"}
+	commands[2] = []string{"set", vmName, "--on-window-close", "keep-running"}
+	commands[3] = []string{"set", vmName, "--auto-share-camera", "off"}
+	commands[4] = []string{"set", vmName, "--smart-guard", "off"}
 
 	for _, command := range commands {
 		err := d.Prlctl(command...)

--- a/builder/parallels/common/hw_config.go
+++ b/builder/parallels/common/hw_config.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/template/interpolate"
+)
+
+type HWConfig struct {
+
+	// cpu information
+	CpuCount   int `mapstructure:"cpu_count"`
+	MemorySize int `mapstructure:"memory_size"`
+
+	// device presence
+	Sound bool `mapstructure:"sound"`
+	USB   bool `mapstructure:"usb"`
+}
+
+func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
+	var errs []error
+
+	// Hardware and cpu options
+	if c.CpuCount < 0 {
+		errs = append(errs, fmt.Errorf("An invalid cpu_count was specified (cpu_count < 0): %d", c.CpuCount))
+		c.CpuCount = 0
+	}
+	if c.CpuCount == 0 {
+		c.CpuCount = 1
+	}
+
+	if c.MemorySize < 0 {
+		errs = append(errs, fmt.Errorf("An invalid memory_size was specified (memory_size < 0): %d", c.MemorySize))
+		c.MemorySize = 0
+	}
+	if c.MemorySize == 0 {
+		c.MemorySize = 512
+	}
+
+	// Peripherals
+	if !c.Sound {
+		c.Sound = false
+	}
+
+	if !c.USB {
+		c.USB = false
+	}
+
+	return nil
+}

--- a/builder/parallels/common/hw_config.go
+++ b/builder/parallels/common/hw_config.go
@@ -9,8 +9,8 @@ import (
 type HWConfig struct {
 
 	// cpu information
-	CpuCount   int `mapstructure:"cpu_count"`
-	MemorySize int `mapstructure:"memory_size"`
+	CpuCount   int `mapstructure:"cpus"`
+	MemorySize int `mapstructure:"memory"`
 
 	// device presence
 	Sound bool `mapstructure:"sound"`
@@ -22,7 +22,7 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 
 	// Hardware and cpu options
 	if c.CpuCount < 0 {
-		errs = append(errs, fmt.Errorf("An invalid cpu_count was specified (cpu_count < 0): %d", c.CpuCount))
+		errs = append(errs, fmt.Errorf("An invalid number of cpus was specified (cpus < 0): %d", c.CpuCount))
 		c.CpuCount = 0
 	}
 	if c.CpuCount == 0 {
@@ -30,7 +30,7 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 
 	if c.MemorySize < 0 {
-		errs = append(errs, fmt.Errorf("An invalid memory_size was specified (memory_size < 0): %d", c.MemorySize))
+		errs = append(errs, fmt.Errorf("An invalid memory size was specified (memory < 0): %d", c.MemorySize))
 		c.MemorySize = 0
 	}
 	if c.MemorySize == 0 {

--- a/builder/parallels/common/hw_config.go
+++ b/builder/parallels/common/hw_config.go
@@ -23,7 +23,6 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 	// Hardware and cpu options
 	if c.CpuCount < 0 {
 		errs = append(errs, fmt.Errorf("An invalid number of cpus was specified (cpus < 0): %d", c.CpuCount))
-		c.CpuCount = 0
 	}
 	if c.CpuCount == 0 {
 		c.CpuCount = 1
@@ -31,7 +30,6 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.MemorySize < 0 {
 		errs = append(errs, fmt.Errorf("An invalid memory size was specified (memory < 0): %d", c.MemorySize))
-		c.MemorySize = 0
 	}
 	if c.MemorySize == 0 {
 		c.MemorySize = 512
@@ -46,5 +44,5 @@ func (c *HWConfig) Prepare(ctx *interpolate.Context) []error {
 		c.USB = false
 	}
 
-	return nil
+	return errs
 }

--- a/builder/parallels/common/hw_config_test.go
+++ b/builder/parallels/common/hw_config_test.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestHWConfigPrepare(t *testing.T) {
+	c := new(HWConfig)
+	if errs := c.Prepare(testConfigTemplate(t)); len(errs) > 0 {
+		t.Fatalf("err: %#v", errs)
+	}
+
+	if c.CpuCount < 1 {
+		t.Errorf("bad cpu count: %d", c.CpuCount)
+	}
+
+	if c.MemorySize < 64 {
+		t.Errorf("bad memory size: %d", c.MemorySize)
+	}
+}

--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -29,6 +29,7 @@ type Config struct {
 	common.FloppyConfig                 `mapstructure:",squash"`
 	bootcommand.BootConfig              `mapstructure:",squash"`
 	parallelscommon.OutputConfig        `mapstructure:",squash"`
+	parallelscommon.HWConfig            `mapstructure:",squash"`
 	parallelscommon.PrlctlConfig        `mapstructure:",squash"`
 	parallelscommon.PrlctlPostConfig    `mapstructure:",squash"`
 	parallelscommon.PrlctlVersionConfig `mapstructure:",squash"`
@@ -76,6 +77,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, b.config.FloppyConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(
 		errs, b.config.OutputConfig.Prepare(&b.config.ctx, &b.config.PackerConfig)...)
+	errs = packer.MultiErrorAppend(errs, b.config.HWConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.PrlctlConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.PrlctlPostConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.PrlctlVersionConfig.Prepare(&b.config.ctx)...)

--- a/builder/parallels/iso/step_create_vm.go
+++ b/builder/parallels/iso/step_create_vm.go
@@ -3,6 +3,7 @@ package iso
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	parallelscommon "github.com/hashicorp/packer/builder/parallels/common"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -24,19 +25,46 @@ func (s *stepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 	ui := state.Get("ui").(packer.Ui)
 	name := config.VMName
 
-	command := []string{
+	commands := make([][]string, 3)
+
+	commands[0] = []string{
 		"create", name,
 		"--distribution", config.GuestOSType,
 		"--dst", config.OutputDir,
 		"--no-hdd",
 	}
+	commands[1] = []string{
+		"set", name,
+		"--cpus", strconv.Itoa(config.HWConfig.CpuCount),
+	}
+	commands[2] = []string{
+		"set", name,
+		"--memsize", strconv.Itoa(config.HWConfig.MemorySize),
+	}
+
+	if config.HWConfig.Sound {
+		commands = append(commands, []string{
+			"set", name,
+			"--device-add-sound",
+			"--connect",
+		})
+	}
+
+	if config.HWConfig.USB {
+		commands = append(commands, []string{
+			"set", name,
+			"--device-add-usb",
+		})
+	}
 
 	ui.Say("Creating virtual machine...")
-	if err := driver.Prlctl(command...); err != nil {
-		err := fmt.Errorf("Error creating VM: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
+	for _, command := range commands {
+		if err := driver.Prlctl(command...); err != nil {
+			err := fmt.Errorf("Error creating VM: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
 	}
 
 	ui.Say("Applying default settings...")

--- a/website/source/docs/builders/parallels-iso.html.md.erb
+++ b/website/source/docs/builders/parallels-iso.html.md.erb
@@ -103,7 +103,7 @@ builder.
     specified, the default is 10 seconds.
 
 -   `cpus` (number) - The number of cpus to use for building the VM.
-    Defaults to building with just one.
+    Defaults to `1`.
 
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40000 (about 40 GB).

--- a/website/source/docs/builders/parallels-iso.html.md.erb
+++ b/website/source/docs/builders/parallels-iso.html.md.erb
@@ -102,6 +102,9 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is 10 seconds.
 
+-   `cpu_count` (number) - The number of cpus to use for building the VM.
+    Defaults to building with just one.
+
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40000 (about 40 GB).
 
@@ -173,6 +176,9 @@ builder.
     URLs must point to the same file (same checksum). By default this is empty
     and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be specified.
 
+-   `memory_size` (number) - The amount of memory to use for building the VM in
+    megabytes. Defaults to `512` megabytes.
+
 -   `output_directory` (string) - This is the path to the directory where the
     resulting virtual machine will be created. This may be relative or absolute.
     If relative, the path is relative to the working directory when `packer`
@@ -220,6 +226,9 @@ builder.
     machine once all the provisioning is done. By default this is an empty
     string, which tells Packer to just forcefully shut down the machine.
 
+-   `sound` (boolean) - Specifies whether to enable the sound device when
+    building the VM. Defaults to `false`.
+
 -   `shutdown_timeout` (string) - The amount of time to wait after executing the
     `shutdown_command` for the virtual machine to actually shut down. If it
     doesn't shut down in this time, it is an error. By default, the timeout is
@@ -230,6 +239,9 @@ builder.
     `disk_type` is set to `plain`). In certain rare cases, this might corrupt
     the resulting disk image. If you find this to be the case, you can disable
     compaction using this configuration value.
+
+-   `usb` (boolean) - Specifies whether to enable the USB bus when building
+    the VM. Defaults to `false`.
 
 -   `vm_name` (string) - This is the name of the PVM directory for the new
     virtual machine, without the file extension. By default this is

--- a/website/source/docs/builders/parallels-iso.html.md.erb
+++ b/website/source/docs/builders/parallels-iso.html.md.erb
@@ -102,7 +102,7 @@ builder.
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is 10 seconds.
 
--   `cpu_count` (number) - The number of cpus to use for building the VM.
+-   `cpus` (number) - The number of cpus to use for building the VM.
     Defaults to building with just one.
 
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
@@ -176,7 +176,7 @@ builder.
     URLs must point to the same file (same checksum). By default this is empty
     and `iso_url` is used. Only one of `iso_url` or `iso_urls` can be specified.
 
--   `memory_size` (number) - The amount of memory to use for building the VM in
+-   `memory` (number) - The amount of memory to use for building the VM in
     megabytes. Defaults to `512` megabytes.
 
 -   `output_directory` (string) - This is the path to the directory where the


### PR DESCRIPTION
This exposes the cpu count and memory size to the user for the parallels-iso builder. This is a common configuration and people have been using `prlctl_whatever` to explicitly set this. In order to steer users away from using the `prlctl_whatever` hack, standardizing on some options to configure these things between all the builders should help. This is somewhat related to #7010.

Also I originally used `cpu_count` and `memory_size`, but shortened them to `cpus` and `memory` since this is probably a pretty common configuration. Lmk if you guys prefer the longer ones or something else and I'll revert.

Just a heads up, I don't have an instance of Parallels and so I'm unable to really test this.