### PR TITLE
move region validation to run so that we don't break validation when no creds are set

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -162,13 +162,6 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 			fmt.Errorf("`access_key` and `secret_key` must both be either set or not set."))
 	}
 
-	if c.RawRegion != "" && !c.SkipValidation {
-		err := c.ValidateRegion(c.RawRegion)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error validating region: %s", err.Error()))
-		}
-	}
-
 	return errs
 }
 

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -96,14 +96,6 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 
 func (c *AMIConfig) prepareRegions(accessConfig *AccessConfig) (errs []error) {
 	if len(c.AMIRegions) > 0 {
-		if !c.AMISkipRegionValidation {
-			// Verify the regions are real
-			err := accessConfig.ValidateRegion(c.AMIRegions...)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("error validating regions: %v", err))
-			}
-		}
-
 		regionSet := make(map[string]struct{})
 		regions := make([]string, 0, len(c.AMIRegions))
 

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -25,7 +25,6 @@ func getFakeAccessConfig(region string) *AccessConfig {
 func TestAMIConfigPrepare_name(t *testing.T) {
 	c := testAMIConfig()
 	accessConf := testAccessConfig()
-	c.AMISkipRegionValidation = true
 	if err := c.Prepare(accessConf, nil); err != nil {
 		t.Fatalf("shouldn't have err: %s", err)
 	}
@@ -53,7 +52,6 @@ func (m *mockEC2Client) DescribeRegions(*ec2.DescribeRegionsInput) (*ec2.Describ
 func TestAMIConfigPrepare_regions(t *testing.T) {
 	c := testAMIConfig()
 	c.AMIRegions = nil
-	c.AMISkipRegionValidation = true
 
 	var errs []error
 	var err error
@@ -63,18 +61,12 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 		t.Fatalf("shouldn't have err: %#v", errs)
 	}
 
-	c.AMISkipRegionValidation = false
 	c.AMIRegions, err = listEC2Regions(mockConn)
 	if err != nil {
 		t.Fatalf("shouldn't have err: %s", err.Error())
 	}
 	if errs = c.prepareRegions(accessConf); len(errs) > 0 {
 		t.Fatalf("shouldn't have err: %#v", errs)
-	}
-
-	c.AMIRegions = []string{"foo"}
-	if errs = c.prepareRegions(accessConf); len(errs) == 0 {
-		t.Fatal("should have error")
 	}
 	errs = errs[:0]
 
@@ -89,11 +81,9 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 	}
 
 	c.AMIRegions = []string{"custom"}
-	c.AMISkipRegionValidation = true
 	if errs = c.prepareRegions(accessConf); len(errs) > 0 {
 		t.Fatal("shouldn't have error")
 	}
-	c.AMISkipRegionValidation = false
 
 	c.AMIRegions = []string{"us-east-1", "us-east-2", "us-west-1"}
 	c.AMIRegionKMSKeyIDs = map[string]string{
@@ -142,11 +132,9 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 		"us-west-1": "789-012-3456",
 	}
 
-	c.AMISkipRegionValidation = true
 	if err := c.Prepare(accessConf, nil); err == nil {
 		t.Fatal("should have error b/c theres a region in in ami_regions that isn't in the key map")
 	}
-	c.AMISkipRegionValidation = false
 
 	c.SnapshotUsers = []string{"foo", "bar"}
 	c.AMIKmsKeyId = "123-abc-456"
@@ -172,7 +160,6 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 
 func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {
 	c := testAMIConfig()
-	c.AMISkipRegionValidation = true
 	c.AMIUsers = []string{"testAccountID"}
 	c.AMIEncryptBootVolume = true
 
@@ -191,7 +178,6 @@ func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {
 
 func TestAMINameValidation(t *testing.T) {
 	c := testAMIConfig()
-	c.AMISkipRegionValidation = true
 
 	accessConf := testAccessConfig()
 

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -86,10 +86,16 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 }
 
 func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
-
 	session, err := b.config.Session()
 	if err != nil {
 		return nil, err
+	}
+	if !b.config.AMISkipRegionValidation {
+		regionsToValidate := append(b.config.AMIRegions, b.config.RawRegion)
+		err := b.config.AccessConfig.ValidateRegion(regionsToValidate...)
+		if err != nil {
+			return nil, fmt.Errorf("error validating regions: %v", err)
+		}
 	}
 	ec2conn := ec2.New(session)
 


### PR DESCRIPTION
`packer validate` shouldn't require credentials to run, so we shouldn't do this region test in validate. Instead, we can do it in the Run() call so that we can still make sure all the regions are good before the build, but not fail validation on missing credentials.

Closes #6888
