### PR TITLE
Replaced unsafe method of determining a user's home directory with an implementation based on os/user.

### DIFF
--- a/packer/config_file_unix.go
+++ b/packer/config_file_unix.go
@@ -28,25 +28,21 @@ func configDir() (string, error) {
 }
 
 func homeDir() (string, error) {
-	var u *user.User
 
-	/// First prefer the HOME environmental variable
-	if home, ok := os.LookupEnv("HOME"); ok {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
 		log.Printf("Detected home directory from env var: %s", home)
 		return home, nil
 	}
 
-	/// Fall back to the passwd database if not found which follows
-	/// the same semantics as bourne shell
-	var err error
+	// Fall back to the passwd database if not found which follows
+	// the same semantics as bourne shell
+	u, err := user.Current()
 
-	// Check username specified in the environment first
-	if username, ok := os.LookupEnv("USER"); ok {
+	// Get homedir from specified username
+	// if it is set and different than what we have
+	if username := os.Getenv("USER"); username != "" && err == nil && u.Username != username {
 		u, err = user.Lookup(username)
-
-	} else {
-		// Otherwise we assume the current user
-		u, err = user.Current()
 	}
 
 	// Fail if we were unable to read the record

--- a/packer/config_file_unix.go
+++ b/packer/config_file_unix.go
@@ -2,53 +2,7 @@
 
 package packer
 
-import (
-	"log"
-	"os"
-	"os/user"
-	"path/filepath"
+const (
+	defaultConfigFile = ".packerconfig"
+	defaultConfigDir  = ".packer.d"
 )
-
-func configFile() (string, error) {
-	dir, err := homeDir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(dir, ".packerconfig"), nil
-}
-
-func configDir() (string, error) {
-	dir, err := homeDir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(dir, ".packer.d"), nil
-}
-
-func homeDir() (string, error) {
-
-	// First prefer the HOME environmental variable
-	if home := os.Getenv("HOME"); home != "" {
-		log.Printf("Detected home directory from env var: %s", home)
-		return home, nil
-	}
-
-	// Fall back to the passwd database if not found which follows
-	// the same semantics as bourne shell
-	u, err := user.Current()
-
-	// Get homedir from specified username
-	// if it is set and different than what we have
-	if username := os.Getenv("USER"); username != "" && err == nil && u.Username != username {
-		u, err = user.Lookup(username)
-	}
-
-	// Fail if we were unable to read the record
-	if err != nil {
-		return "", err
-	}
-
-	return u.HomeDir, nil
-}

--- a/packer/config_file_windows.go
+++ b/packer/config_file_windows.go
@@ -2,45 +2,7 @@
 
 package packer
 
-import (
-	"path/filepath"
-	"syscall"
-	"unsafe"
+const (
+	defaultConfigFile = "packer.config"
+	defaultConfigDir  = "packer.d"
 )
-
-var (
-	shell         = syscall.MustLoadDLL("Shell32.dll")
-	getFolderPath = shell.MustFindProc("SHGetFolderPathW")
-)
-
-const CSIDL_APPDATA = 26
-
-func configFile() (string, error) {
-	dir, err := homeDir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(dir, "packer.config"), nil
-}
-
-func configDir() (string, error) {
-	dir, err := homeDir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(dir, "packer.d"), nil
-}
-
-func homeDir() (string, error) {
-	b := make([]uint16, syscall.MAX_PATH)
-
-	// See: http://msdn.microsoft.com/en-us/library/windows/desktop/bb762181(v=vs.85).aspx
-	r, _, err := getFolderPath.Call(0, CSIDL_APPDATA, 0, 0, uintptr(unsafe.Pointer(&b[0])))
-	if uint32(r) != 0 {
-		return "", err
-	}
-
-	return syscall.UTF16ToString(b), nil
-}


### PR DESCRIPTION
packer/config_file_unix.go determines a user's home directory using a fork/exec to bourne shell. I guess this'd be fine if you're ok w/ that dep on bourne shell. The only issue is that it's using `eval echo` and it's not properly quoting the username which makes the whole function not work if there's a space in the username. Also, if someone wants to be a \_real\_ dick then they can inject a ';' and you can execute things despite this not really being how packer is intended to be used .

If the explicit call to bourne is desired, then it'd probably be better to get rid of `eval` and just somehow quote `~$USER` properly. The better way however is to not use it at all since bourne's semantics is to look it up in the passwd database.

This PR uses "os/user" to read from the passwd database the correct way whilst still honoring the "USER" environment variable to control it.