### PR TITLE
openstack: `image_tags` - Adds support for tagging new images.

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -142,6 +142,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&stepCreateImage{
 			UseBlockStorageVolume: b.config.UseBlockStorageVolume,
 		},
+		&stepUpdateImageTags{},
 		&stepUpdateImageVisibility{},
 		&stepAddImageMembers{},
 	}

--- a/builder/openstack/image_config.go
+++ b/builder/openstack/image_config.go
@@ -15,6 +15,7 @@ type ImageConfig struct {
 	ImageVisibility imageservice.ImageVisibility `mapstructure:"image_visibility"`
 	ImageMembers    []string                     `mapstructure:"image_members"`
 	ImageDiskFormat string                       `mapstructure:"image_disk_format"`
+	ImageTags       []string                     `mapstructure:"image_tags"`
 }
 
 func (c *ImageConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/openstack/step_update_image_tags.go
+++ b/builder/openstack/step_update_image_tags.go
@@ -1,0 +1,52 @@
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	imageservice "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+type stepUpdateImageTags struct{}
+
+func (s *stepUpdateImageTags) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	imageId := state.Get("image").(string)
+	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("config").(*Config)
+
+	if len(config.ImageTags) == 0 {
+		return multistep.ActionContinue
+	}
+	imageClient, err := config.imageV2Client()
+	if err != nil {
+		err = fmt.Errorf("Error initializing image service client: %s", err)
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	ui.Say(fmt.Sprintf("Updating image tags to %s", strings.Join(config.ImageTags, ", ")))
+	r := imageservice.Update(
+		imageClient,
+		imageId,
+		imageservice.UpdateOpts{
+			imageservice.ReplaceImageTags{
+				NewTags: config.ImageTags,
+			},
+		},
+	)
+
+	if _, err = r.Extract(); err != nil {
+		err = fmt.Errorf("Error updating image tags: %s", err)
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepUpdateImageTags) Cleanup(multistep.StateBag) {
+	// No cleanup...
+}

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -127,6 +127,9 @@ builder.
     after creation. An image member is usually a project (also called the
     "tenant") with whom the image is shared.
 
+-   `image_tags` (array of strings) - List of tags to add to the image after
+    creation.
+
 -   `image_visibility` (string) - One of "public", "private", "shared", or
     "community".
 


### PR DESCRIPTION
Introduces new OpenStack builder configuration option, `image_tags`. Support for tagging newly created images with zero or more tags. The OpenStack builder already supported looking up source images by tag, but did not allow for tagging newly created images. 

OpenStack supporting documentation:
See: https://developer.openstack.org/api-ref/image/v2/#image-tags
