### PR TITLE
Replaced compute/v2/images with imageservice/v2/images.

### DIFF
--- a/builder/openstack/artifact.go
+++ b/builder/openstack/artifact.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 )
 
 // Artifact is an artifact implementation that contains built images.

--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -71,6 +71,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, fmt.Errorf("Error initializing compute client: %s", err)
 	}
 
+	imageClient, err := b.config.imageV2Client()
+	if err != nil {
+		return nil, fmt.Errorf("Error initializing image client: %s", err)
+	}
+
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
@@ -164,7 +169,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	artifact := &Artifact{
 		ImageId:        state.Get("image").(string),
 		BuilderIdValue: BuilderId,
-		Client:         computeClient,
+		Client:         imageClient,
 	}
 
 	return artifact, nil


### PR DESCRIPTION
Closes #6360 

Removed usage of a deprecated compute/v2/images API.
Standardized clientService naming to 'computeService'.

