### PR TITLE
alicloud: update windows examples

### DIFF
--- a/examples/alicloud/basic/alicloud_windows.json
+++ b/examples/alicloud/basic/alicloud_windows.json
@@ -17,10 +17,11 @@
     "communicator": "winrm",
     "winrm_port": 5985,
     "winrm_username": "Administrator",
-    "winrm_password": "Test1234"
+    "winrm_password": "Test1234",
+    "user_data_file": "examples/alicloud/basic/winrm_enable_userdata.ps1"
   }],
   "provisioners": [{
-      "type": "powershell",
-      "inline": ["dir c:\\"]
+    "type": "powershell",
+    "inline": ["dir c:\\"]
   }]
 }

--- a/examples/alicloud/basic/winrm_enable_userdata.ps1
+++ b/examples/alicloud/basic/winrm_enable_userdata.ps1
@@ -1,0 +1,26 @@
+#powershell
+write-output "Running User Data Script"
+write-host "(host) Running User Data Script"
+Set-ExecutionPolicy Unrestricted -Scope LocalMachine -Force -ErrorAction Ignore
+# Don't set this before Set-ExecutionPolicy as it throws an error
+$ErrorActionPreference = "stop"
+# Remove HTTP listener
+Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
+# WinRM
+write-output "Setting up WinRM"
+write-host "(host) setting up WinRM"
+cmd.exe /c winrm quickconfig -q
+cmd.exe /c winrm quickconfig '-transport:http'
+cmd.exe /c winrm set "winrm/config" '@{MaxTimeoutms="1800000"}'
+cmd.exe /c winrm set "winrm/config/winrs" '@{MaxMemoryPerShellMB="10240"}'
+cmd.exe /c winrm set "winrm/config/service" '@{AllowUnencrypted="true"}'
+cmd.exe /c winrm set "winrm/config/client" '@{AllowUnencrypted="true"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/client/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{CredSSP="true"}'
+cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" '@{Port="5985"}'
+cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
+cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985"
+cmd.exe /c net stop winrm
+cmd.exe /c sc config winrm start= auto
+cmd.exe /c net start winrm

--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -295,6 +295,11 @@ Here is a basic example for Alicloud.
 \~&gt; Note: Images can become deprecated after a while; run
 `aliyun ecs DescribeImages` to find one that exists.
 
+\~&gt; Note: Since WinRM is closed by default in the system image. If you are planning 
+to use Windows as the base image, you need enable it by userdata in order to connect to 
+the instance, check [alicloud_windows.json](https://github.com/hashicorp/packer/tree/master/examples/alicloud/basic/alicloud_windows.json) 
+and [winrm_enable_userdata.ps1](https://github.com/hashicorp/packer/tree/master/examples/alicloud/basic/winrm_enable_userdata.ps1) for details.
+
 See the
 [examples/alicloud](https://github.com/hashicorp/packer/tree/master/examples/alicloud)
 folder in the packer project for more examples.


### PR DESCRIPTION
Since WinRM is closed by default in the system image, WinRM should be enable first before provisioning. Update windows example and docs to make it clear.