### PR TITLE
add snapshot_labels to hcloud builder

### DIFF
--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -30,10 +30,11 @@ type Config struct {
 	ServerType string `mapstructure:"server_type"`
 	Image      string `mapstructure:"image"`
 
-	SnapshotName string   `mapstructure:"snapshot_name"`
-	UserData     string   `mapstructure:"user_data"`
-	UserDataFile string   `mapstructure:"user_data_file"`
-	SSHKeys      []string `mapstructure:"ssh_keys"`
+	SnapshotName   string            `mapstructure:"snapshot_name"`
+	SnapshotLabels map[string]string `mapstructure:"snapshot_labels"`
+	UserData       string            `mapstructure:"user_data"`
+	UserDataFile   string            `mapstructure:"user_data_file"`
+	SSHKeys        []string          `mapstructure:"ssh_keys"`
 
 	RescueMode string `mapstructure:"rescue"`
 

--- a/builder/hcloud/step_create_snapshot.go
+++ b/builder/hcloud/step_create_snapshot.go
@@ -21,6 +21,7 @@ func (s *stepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) mu
 	ui.Say("This can take some time")
 	result, _, err := client.Server.CreateImage(context.TODO(), &hcloud.Server{ID: serverID}, &hcloud.ServerCreateImageOpts{
 		Type:        hcloud.ImageTypeSnapshot,
+		Labels:      c.SnapshotLabels,
 		Description: hcloud.String(c.SnapshotName),
 	})
 	if err != nil {

--- a/website/source/docs/builders/hetzner-cloud.html.md
+++ b/website/source/docs/builders/hetzner-cloud.html.md
@@ -58,7 +58,7 @@ builder.
     appear in your account. Defaults to "packer-{{timestamp}}" (see
     [configuration templates](/docs/templates/engine.html) for more info).
 
--   `snapshot_labels` (object of key/value strings) - Key/value pair labels to
+-   `snapshot_labels` (map of key/value strings) - Key/value pair labels to
     apply to the created image.
 
 -   `poll_interval` (string) - Configures the interval in which actions are

--- a/website/source/docs/builders/hetzner-cloud.html.md
+++ b/website/source/docs/builders/hetzner-cloud.html.md
@@ -58,6 +58,9 @@ builder.
     appear in your account. Defaults to "packer-{{timestamp}}" (see
     [configuration templates](/docs/templates/engine.html) for more info).
 
+-   `snapshot_labels` (object of key/value strings) - Key/value pair labels to
+    apply to the created image.
+
 -   `poll_interval` (string) - Configures the interval in which actions are
     polled by the client. Default `500ms`. Increase this interval if you run
     into rate limiting errors.


### PR DESCRIPTION
Currently difficult dynamically use packer-generated images with Terraform, as you cannot set name when generating a snapshot, nor can you select using the `description` attribute. This adds the ability to set labels, which allow you to dynamically specify the image such as:

```
data "hcloud_image" "myimage" {
  selector = "tf-image=myimage"
}
```