### PR TITLE
fix defaulting/lack thereof for cpu count and memory in vmware template

### DIFF
--- a/builder/vmware/common/artifact.go
+++ b/builder/vmware/common/artifact.go
@@ -49,7 +49,10 @@ func (a *artifact) State(name string) interface{} {
 }
 
 func (a *artifact) Destroy() error {
-	return a.dir.RemoveAll()
+	if a.dir != nil {
+		return a.dir.RemoveAll()
+	}
+	return nil
 }
 
 func NewArtifact(remoteType string, format string, exportOutputPath string, vmName string, skipExport bool, keepRegistered bool, state multistep.StateBag) (packer.Artifact, error) {

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -315,6 +315,18 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 		templateData.Serial_Host = ""
 		templateData.Serial_Auto = "FALSE"
 
+		// Set the number of cpus if it was specified
+		if config.HWConfig.CpuCount > 0 {
+			templateData.CpuCount = strconv.Itoa(config.HWConfig.CpuCount)
+		}
+
+		// Apply the memory size that was specified
+		if config.HWConfig.MemorySize > 0 {
+			templateData.MemorySize = strconv.Itoa(config.HWConfig.MemorySize)
+		} else {
+			templateData.MemorySize = "512"
+		}
+
 		switch serial.Union.(type) {
 		case *vmwcommon.SerialConfigPipe:
 			templateData.Serial_Type = "pipe"
@@ -412,15 +424,8 @@ func (s *stepCreateVMX) Run(_ context.Context, state multistep.StateBag) multist
 
 	/// Now to handle options that will modify the template
 	vmxData := vmwcommon.ParseVMX(vmxContents)
-
-	// Set the number of cpus if it was specified
-	if config.HWConfig.CpuCount > 0 {
-		vmxData["numvcpus"] = strconv.Itoa(config.HWConfig.CpuCount)
-	}
-
-	// Apply the memory size that was specified
-	if config.HWConfig.MemorySize > 0 {
-		vmxData["memsize"] = strconv.Itoa(config.HWConfig.MemorySize)
+	if vmxData["numvcpus"] == "" {
+		delete(vmxData, "numvcpus")
 	}
 
 	/// Write the vmxData to the vmxPath


### PR DESCRIPTION
PR #7019 had a great change but unfortunately I recommended a behavior that ended up causing the whole thing to break -- if we don't default CPU and memory size, but the template still defines them, we're left with empty strings and vmware doesn't know what to do. This PR returns the behavior when cpu and memory are unset to what they were before PR #7019; CPU is left to vmware to default and memsize is defaulted to 512.