### PR TITLE
Backport VNC log from vmware to qemu

### DIFF
--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -65,7 +65,8 @@ func (s *stepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 	}
 
 	// Connect to VNC
-	ui.Say("Connecting to VM via VNC")
+	ui.Say(fmt.Sprintf("Connecting to VM via VNC (%s:%d)", vncIP, vncPort))
+
 	nc, err := net.Dial("tcp", fmt.Sprintf("%s:%d", vncIP, vncPort))
 	if err != nil {
 		err := fmt.Errorf("Error connecting to VNC: %s", err)


### PR DESCRIPTION
Backport usefull log from vmware to qemu about vnc ip and port.

VNC host and port are now logged like this:

```
...
==> arm64: Connecting to VM via VNC (127.0.0.1:5975)
...
```