### PR TITLE
Add registry key check for windows-restart provisioner

### DIFF
--- a/website/source/docs/provisioners/windows-restart.html.md
+++ b/website/source/docs/provisioners/windows-restart.html.md
@@ -38,6 +38,28 @@ The reference of available configuration options is listed below.
 
 Optional parameters:
 
+-   `check_registry` (bool) - if `true`, checks for several registry keys that
+    indicate that the system is going to reboot. This is useful if an
+    installation kicks off a reboot and you want the provisioner to wait for
+    that reboot to complete before reconnecting. Please note that this option is
+    a beta feature, and we generally recommend that you finish installs that
+    auto-reboot (like windows updates) during your autounattend phase before our
+    winrm provisioner connects.
+
+-   `registry_keys` (array of strings) - if `check-registry` is `true`,
+    windows-restart will not reconnect until after all of the listed keys are
+    no longer present in the registry.
+
+    default:
+
+    ```
+    var DefaultRegistryKeys = []string{
+      "HKLM:SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\RebootPending",
+      "HKLM:SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\PackagesPending",
+      "HKLM:Software\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\RebootInProgress",
+    }
+    ```
+
 -   `restart_command` (string) - The command to execute to initiate the
     restart. By default this is `shutdown /r /f /t 0 /c "packer restart"`.
 


### PR DESCRIPTION
The OP in #6799 had a good idea; we could add a check for any commonly used registry keys that indicate a reboot is pending.

If the reboot is pending, have the reboot check loop continue.

Still needs testing.

To test:

```
    {
      "type": "windows-restart",
      "check_registry": true
    },
```