### PR TITLE
Add a new breakpoint provisioner

### DIFF
--- a/command/plugin.go
+++ b/command/plugin.go
@@ -65,6 +65,7 @@ import (
 	vspheretemplatepostprocessor "github.com/hashicorp/packer/post-processor/vsphere-template"
 	ansibleprovisioner "github.com/hashicorp/packer/provisioner/ansible"
 	ansiblelocalprovisioner "github.com/hashicorp/packer/provisioner/ansible-local"
+	breakpointprovisioner "github.com/hashicorp/packer/provisioner/breakpoint"
 	chefclientprovisioner "github.com/hashicorp/packer/provisioner/chef-client"
 	chefsoloprovisioner "github.com/hashicorp/packer/provisioner/chef-solo"
 	convergeprovisioner "github.com/hashicorp/packer/provisioner/converge"
@@ -122,6 +123,7 @@ var Builders = map[string]packer.Builder{
 var Provisioners = map[string]packer.Provisioner{
 	"ansible":           new(ansibleprovisioner.Provisioner),
 	"ansible-local":     new(ansiblelocalprovisioner.Provisioner),
+	"breakpoint":        new(breakpointprovisioner.Provisioner),
 	"chef-client":       new(chefclientprovisioner.Provisioner),
 	"chef-solo":         new(chefsoloprovisioner.Provisioner),
 	"converge":          new(convergeprovisioner.Provisioner),

--- a/provisioner/breakpoint/provisioner.go
+++ b/provisioner/breakpoint/provisioner.go
@@ -14,8 +14,8 @@ import (
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
-	// The local path of the file to upload.
-	Note string `mapstructure:"note"`
+	Note    string `mapstructure:"note"`
+	Disable bool   `mapstructure:"disable"`
 
 	ctx interpolate.Context
 }
@@ -40,6 +40,17 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 }
 
 func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
+	if p.config.Disable {
+		if p.config.Note != "" {
+			ui.Say(fmt.Sprintf(
+				"Breakpoint provisioner with note \"%s\" disabled; continuing...",
+				p.config.Note))
+		} else {
+			ui.Say("Breakpoint provisioner disabled; continuing...")
+		}
+
+		return nil
+	}
 	if p.config.Note != "" {
 		ui.Say(fmt.Sprintf("Pausing at breakpoint provisioner with note \"%s\".", p.config.Note))
 	} else {

--- a/provisioner/breakpoint/provisioner.go
+++ b/provisioner/breakpoint/provisioner.go
@@ -74,8 +74,6 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	case <-result:
 		return nil
 	}
-
-	return nil
 }
 
 func (p *Provisioner) Cancel() {

--- a/provisioner/breakpoint/provisioner.go
+++ b/provisioner/breakpoint/provisioner.go
@@ -1,0 +1,73 @@
+package breakpoint
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/config"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/template/interpolate"
+)
+
+type Config struct {
+	common.PackerConfig `mapstructure:",squash"`
+
+	// The local path of the file to upload.
+	Note string `mapstructure:"note"`
+
+	ctx interpolate.Context
+}
+
+type Provisioner struct {
+	config Config
+}
+
+func (p *Provisioner) Prepare(raws ...interface{}) error {
+	err := config.Decode(&p.config, &config.DecodeOpts{
+		Interpolate:        true,
+		InterpolateContext: &p.config.ctx,
+		InterpolateFilter: &interpolate.RenderFilter{
+			Exclude: []string{},
+		},
+	}, raws...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
+	if p.config.Note != "" {
+		ui.Say(fmt.Sprintf("Pausing at breakpoint provisioner with note \"%s\".", p.config.Note))
+	} else {
+		ui.Say("Pausing at breakpoint provisioner.")
+	}
+
+	message := fmt.Sprintf(
+		"Press enter to continue.")
+
+	result := make(chan string, 1)
+	go func() {
+		line, err := ui.Ask(message)
+		if err != nil {
+			log.Printf("Error asking for input: %s", err)
+		}
+
+		result <- line
+	}()
+
+	select {
+	case <-result:
+		return nil
+	}
+
+	return nil
+}
+
+func (p *Provisioner) Cancel() {
+	// Just hard quit.
+	os.Exit(0)
+}

--- a/website/source/docs/provisioners/breakpoint.html.md
+++ b/website/source/docs/provisioners/breakpoint.html.md
@@ -1,0 +1,37 @@
+---
+description: |
+    The breakpoint provisioner will pause until the user presses "enter" to
+    resume the build. This is intended for debugging purposes, and allows you
+    to halt at a particular part of the provisioning process.
+layout: docs
+page_title: 'breakpoint - Provisioners'
+sidebar_current: 'docs-provisioners-breakpoint'
+---
+
+# File Provisioner
+
+Type: `breakpoint`
+
+The breakpoint provisioner will pause until the user presses "enter" to
+resume the build. This is intended for debugging purposes, and allows you
+to halt at a particular part of the provisioning process, rather than using the
+`-debug` flag, which will instead halt at every step and between every
+provisioner.
+
+## Basic Example
+
+``` json
+{
+  "type": "breakpoint",
+  "note": "foo bar baz"
+}
+```
+
+## Configuration Reference
+
+### Optional
+
+-   `note` (string) - a string to include explaining the purpose or location of
+    the breakpoint. For example, you may find it useful to number your
+    breakpoints or label them with information about where in the build they
+    occur

--- a/website/source/docs/provisioners/breakpoint.html.md
+++ b/website/source/docs/provisioners/breakpoint.html.md
@@ -8,15 +8,16 @@ page_title: 'breakpoint - Provisioners'
 sidebar_current: 'docs-provisioners-breakpoint'
 ---
 
-# File Provisioner
+# Breakpoint Provisioner
 
 Type: `breakpoint`
 
 The breakpoint provisioner will pause until the user presses "enter" to
 resume the build. This is intended for debugging purposes, and allows you
-to halt at a particular part of the provisioning process, rather than using the
-`-debug` flag, which will instead halt at every step and between every
-provisioner.
+to halt at a particular part of the provisioning process.
+
+This is independent of the `-debug` flag, which will instead halt at every step
+and between every provisioner.
 
 ## Basic Example
 
@@ -31,7 +32,26 @@ provisioner.
 
 ### Optional
 
+-   `disable` (boolean) - If `true`, skip the breakpoint. Useful for when you
+    have set multiple breakpoints and want to toggle them off or on.
+    Default: `false`
+
 -   `note` (string) - a string to include explaining the purpose or location of
     the breakpoint. For example, you may find it useful to number your
     breakpoints or label them with information about where in the build they
     occur
+
+## Usage
+
+Insert this provisioner wherever you want the build to pause. You'll see ui
+output prompting you to press "enter" to continue the build when you are ready.
+
+For example:
+
+```
+==> docker: Pausing at breakpoint provisioner with note "foo bar baz".
+==> docker: Press enter to continue.
+```
+
+Once you press enter, the build will resume and run normally until it either
+completes or errors.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -201,6 +201,9 @@
           <li<%= sidebar_current("docs-provisioners-ansible-remote")%>>
             <a href="/docs/provisioners/ansible.html">Ansible Remote</a>
           </li>
+          <li<%= sidebar_current("docs-provisioners-breakpoint")%>>
+            <a href="/docs/provisioners/breakpoint.html">Breakpoint</a>
+          </li>
           <li<%= sidebar_current("docs-provisioners-chef-client")%>>
             <a href="/docs/provisioners/chef-client.html">Chef Client</a>
           </li>


### PR DESCRIPTION
This provisioner works independently of our debugger, and allows a user to set a breakpoint in between provisioners, with an optional note.  

Usage example:

```
  "provisioners": [
    {
      "type": "shell-local",
      "inline": "echo hi"
    },
    {
      "type": "breakpoint",
      "note": "this is a breakpoint 1"
    },
    {
      "type": "shell-local",
      "inline": "echo hi 2"
    }
  ]
```

Closes #6971
