### PR TITLE
azure: configuration for disk caching

### DIFF
--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -59,9 +59,9 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 	}
 
 	if config.ImageUrl != "" {
-		builder.SetImageUrl(config.ImageUrl, osType)
+		builder.SetImageUrl(config.ImageUrl, osType, config.diskCachingType)
 	} else if config.CustomManagedImageName != "" {
-		builder.SetManagedDiskUrl(config.customManagedImageID, config.managedImageStorageAccountType)
+		builder.SetManagedDiskUrl(config.customManagedImageID, config.managedImageStorageAccountType, config.diskCachingType)
 	} else if config.ManagedImageName != "" && config.ImagePublisher != "" {
 		imageID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s/ArtifactTypes/vmimage/offers/%s/skus/%s/versions/%s",
 			config.SubscriptionID,
@@ -71,7 +71,7 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 			config.ImageSku,
 			config.ImageVersion)
 
-		builder.SetManagedMarketplaceImage(config.Location, config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, imageID, config.managedImageStorageAccountType)
+		builder.SetManagedMarketplaceImage(config.Location, config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, imageID, config.managedImageStorageAccountType, config.diskCachingType)
 	} else if config.SharedGallery.Subscription != "" {
 		imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s",
 			config.SharedGallery.Subscription,
@@ -83,9 +83,9 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 				config.SharedGallery.ImageVersion)
 		}
 
-		builder.SetSharedGalleryImage(config.Location, imageID)
+		builder.SetSharedGalleryImage(config.Location, imageID, config.diskCachingType)
 	} else {
-		builder.SetMarketPlaceImage(config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion)
+		builder.SetMarketPlaceImage(config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, config.diskCachingType)
 	}
 
 	if config.OSDiskSizeGB > 0 {
@@ -93,7 +93,8 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 	}
 
 	if len(config.AdditionalDiskSize) > 0 {
-		builder.SetAdditionalDisks(config.AdditionalDiskSize, config.CustomManagedImageName != "" || (config.ManagedImageName != "" && config.ImagePublisher != ""))
+		isManaged := config.CustomManagedImageName != "" || (config.ManagedImageName != "" && config.ImagePublisher != "")
+		builder.SetAdditionalDisks(config.AdditionalDiskSize, isManaged, config.diskCachingType)
 	}
 
 	if config.customData != "" {

--- a/builder/azure/common/template/template_builder_test.TestSharedImageGallery00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestSharedImageGallery00.approved.json
@@ -139,7 +139,7 @@
             "id": "/subscriptions/ignore/resourceGroups/ignore/providers/Microsoft.Compute/galleries/ignore/images/ignore"
           },
           "osDisk": {
-            "caching": "ReadWrite",
+            "caching": "ReadOnly",
             "createOption": "FromImage",
             "name": "[parameters('osDiskName')]",
             "osType": "Linux"

--- a/builder/azure/common/template/template_builder_test.go
+++ b/builder/azure/common/template/template_builder_test.go
@@ -20,7 +20,7 @@ func TestBuildLinux00(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.SetMarketPlaceImage("Canonical", "UbuntuServer", "16.04", "latest")
+	err = testSubject.SetMarketPlaceImage("Canonical", "UbuntuServer", "16.04", "latest", compute.CachingTypesReadWrite)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestBuildLinux01(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.SetImageUrl("http://azure/custom.vhd", compute.Linux)
+	err = testSubject.SetImageUrl("http://azure/custom.vhd", compute.Linux, compute.CachingTypesReadWrite)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestBuildLinux02(t *testing.T) {
 	}
 
 	testSubject.BuildLinux("--test-ssh-authorized-key--")
-	testSubject.SetImageUrl("http://azure/custom.vhd", compute.Linux)
+	testSubject.SetImageUrl("http://azure/custom.vhd", compute.Linux, compute.CachingTypesReadWrite)
 	testSubject.SetOSDiskSizeGB(100)
 
 	err = testSubject.SetVirtualNetwork("--virtual-network-resource-group--", "--virtual-network--", "--subnet-name--")
@@ -105,7 +105,7 @@ func TestBuildWindows00(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.SetMarketPlaceImage("MicrosoftWindowsServer", "WindowsServer", "2012-R2-Datacenter", "latest")
+	err = testSubject.SetMarketPlaceImage("MicrosoftWindowsServer", "WindowsServer", "2012-R2-Datacenter", "latest", compute.CachingTypesReadWrite)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,12 +133,12 @@ func TestBuildWindows01(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.SetManagedMarketplaceImage("MicrosoftWindowsServer", "WindowsServer", "2012-R2-Datacenter", "latest", "2015-1", "1", "Premium_LRS")
+	err = testSubject.SetManagedMarketplaceImage("MicrosoftWindowsServer", "WindowsServer", "2012-R2-Datacenter", "latest", "2015-1", "1", "Premium_LRS", compute.CachingTypesReadWrite)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = testSubject.SetAdditionalDisks([]int32{32, 64}, true)
+	err = testSubject.SetAdditionalDisks([]int32{32, 64}, true, compute.CachingTypesReadWrite)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestBuildWindows02(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.SetAdditionalDisks([]int32{32, 64}, false)
+	err = testSubject.SetAdditionalDisks([]int32{32, 64}, false, compute.CachingTypesReadWrite)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestSharedImageGallery00(t *testing.T) {
 	}
 
 	imageID := "/subscriptions/ignore/resourceGroups/ignore/providers/Microsoft.Compute/galleries/ignore/images/ignore"
-	err = testSubject.SetSharedGalleryImage("westcentralus", imageID)
+	err = testSubject.SetSharedGalleryImage("westcentralus", imageID, compute.CachingTypesReadOnly)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -190,6 +190,9 @@ Providing `temp_resource_group_name` or `location` in combination with
 -   `os_disk_size_gb` (number) Specify the size of the OS disk in GB
     (gigabytes). Values of zero or less than zero are ignored.
 
+-   `disk_caching_type` (string) Specify the disk caching type. Valid values are None, ReadOnly,
+     and ReadWrite. The default value is ReadWrite.
+
 -   `disk_additional_size` (array of integers) - The size(s) of any additional
     hard disks for the VM in gigabytes. If this is not specified then the VM
     will only contain an OS disk. The number of additional disks and maximum


### PR DESCRIPTION
Export a configuration knob to change the disk caching setting. The
default value remains ReadWrite.  This seems the most appropriate value
given Packer.  Certain disk sizes require that disk caching be disable,
and this knob allows the user to do just that.

Closes #6773 