### PR TITLE
don't set DetectZeroes if it's off, because some versions of QEMU don…

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -97,9 +97,18 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 	if qemuMajor >= 2 {
 		if config.DiskInterface == "virtio-scsi" {
 			deviceArgs = append(deviceArgs, "virtio-scsi-pci,id=scsi0", "scsi-hd,bus=scsi0.0,drive=drive0")
-			driveArgs = append(driveArgs, fmt.Sprintf("if=none,file=%s,id=drive0,cache=%s,discard=%s,format=%s,detect-zeroes=%s", imgPath, config.DiskCache, config.DiskDiscard, config.Format, config.DetectZeroes))
+			driveArgumentString := fmt.Sprintf("if=none,file=%s,id=drive0,cache=%s,discard=%s,format=%s", imgPath, config.DiskCache, config.DiskDiscard, config.Format)
+			if config.DetectZeroes != "off" {
+				driveArgumentString = fmt.Sprintf("%s,detect-zeroes=%s", driveArgumentString, config.DetectZeroes)
+			}
+			driveArgs = append(driveArgs, driveArgumentString)
 		} else {
-			driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s,format=%s,detect-zeroes=%s", imgPath, config.DiskInterface, config.DiskCache, config.DiskDiscard, config.Format, config.DetectZeroes))
+			driveArgumentString := fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s,format=%s", imgPath, config.DiskInterface, config.DiskCache, config.DiskDiscard, config.Format)
+			if config.DetectZeroes != "off" {
+				driveArgumentString = fmt.Sprintf("%s,detect-zeroes=%s", driveArgumentString, config.DetectZeroes)
+			}
+			driveArgs = append(driveArgs, driveArgumentString)
+
 		}
 	} else {
 		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=%s,cache=%s,format=%s", imgPath, config.DiskInterface, config.DiskCache, config.Format))

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -145,8 +145,10 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
 -   `disk_discard` (string) - The discard mode to use for disk. Allowed values
     include any of `unmap` or `ignore`. By default, this is set to `ignore`.
 
--   `disk_detect_zeroes` (string) - The detect-zeroes mode to use for disk. 
+-   `disk_detect_zeroes` (string) - The detect-zeroes mode to use for disk.
     Allowed values include any of `unmap`, `on` or `off`. Defaults to `off`.
+    When the value is "off" we don't set the flag in the qemu command, so that
+    Packer still works with old versions of QEMU that don't have this option.
 
 -   `disk_image` (boolean) - Packer defaults to building from an ISO file, this
     parameter controls whether the ISO URL supplied is actually a bootable


### PR DESCRIPTION
Don't set the DetectZeroes option if it's "off" because older versions of qemu don't actually have this option and adding it broke builds.

Closes #7004