### PR TITLE
reverts 406bf9c4aad7c925c3f5a837fe7f9c71169af098; this was incorrect …

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -351,9 +351,7 @@ func (p *Provisioner) Cancel() {
 func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, privKeyFile string) error {
 	playbook, _ := filepath.Abs(p.config.PlaybookFile)
 	inventory := p.config.InventoryFile
-	if len(p.config.InventoryDirectory) > 0 {
-		inventory = p.config.InventoryDirectory
-	}
+
 	var envvars []string
 
 	args := []string{"--extra-vars", fmt.Sprintf("packer_build_name=%s packer_builder_type=%s",


### PR DESCRIPTION
Don't set inventory to inventory_directory.  This changed the behavior of inventory_directory pretty dramatically and caused a lot of unintended consequences for users. 

Reverts #6065 
Closes #6405 