### PR TITLE
Updated docker's default config to use regular bourne shell instead of bourne again.

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -73,7 +73,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	// Defaults
 	if len(c.RunCommand) == 0 {
-		c.RunCommand = []string{"-d", "-i", "-t", "{{.Image}}", "/bin/bash"}
+		c.RunCommand = []string{"-d", "-i", "-t", "{{.Image}}", "/bin/sh"}
 	}
 
 	// Default Pull if it wasn't set


### PR DESCRIPTION
Docker's default configuration is to use bourne again (bash) shell for `run_command`. Typically /bin/sh is symlinked from bash. However, on some containers bash doesn't exist (specifically containers based on busybox).

I looked around to see if there's any specific bashisms in the Docker builder that this might affect, but didn't spot any since this is just for the default option. So this should be a safe change, but if anybody else is more familiar with the Docker builder please check before merging this.

Closes #6920.