### PR TITLE
Ignore an already-scheduled reboot

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -96,7 +96,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		return err
 	}
 
-	if cmd.ExitStatus != 0 && cmd.ExitStatus != 1115 && cmd.ExitStatus != 1190 && cmd.ExitStatus != 1717 {
+	if cmd.ExitStatus != 0 && cmd.ExitStatus != 1115 && cmd.ExitStatus != 1190 {
 		return fmt.Errorf("Restart script exited with non-zero exit status: %d", cmd.ExitStatus)
 	}
 

--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -96,7 +96,7 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 		return err
 	}
 
-	if cmd.ExitStatus != 0 {
+	if cmd.ExitStatus != 0 && cmd.ExitStatus != 1115 && cmd.ExitStatus != 1190 && cmd.ExitStatus != 1717 {
 		return fmt.Errorf("Restart script exited with non-zero exit status: %d", cmd.ExitStatus)
 	}
 


### PR DESCRIPTION
We use Puppet (currently via the `powershell` provisioner) which also includes its own reboot resource type which _may_ be triggered on a run however it's not guaranteed. When this happens the `windows-restart` errors with the 1115 exit code and stops the build.

This PR excludes the "reboot already pending"-type exit codes from the non-zero check so only something non-zero that isn't also a pending reboot stops the build (Incidentally, I couldn't reliably find what exit code 1717 referred to however I included it as it's referred to in `waitForRestart()`).