### PR TITLE
vmware-iso (esxi) Add check that "format" is not being set when remote_type is empty.

### DIFF
--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -171,6 +171,7 @@ func TestBuilderPrepare_RemoteType(t *testing.T) {
 
 	// Good
 	config["remote_type"] = ""
+	config["format"] = ""
 	config["remote_host"] = ""
 	config["remote_password"] = ""
 	config["remote_private_key_file"] = ""
@@ -245,6 +246,11 @@ func TestBuilderPrepare_Format(t *testing.T) {
 	for _, format := range goodFormats {
 		// Good
 		config["format"] = format
+		config["remote_type"] = "esx5"
+		config["remote_host"] = "hosty.hostface"
+		config["remote_password"] = "password"
+		config["skip_validate_credentials"] = true
+
 		b = Builder{}
 		warns, err = b.Prepare(config)
 		if len(warns) > 0 {

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -167,7 +167,12 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		}
 	}
 
-	if c.Format == "" {
+	if c.Format != "" {
+		if c.RemoteType != "esx5" {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("format is only valid when RemoteType=esx5"))
+		}
+	} else {
 		c.Format = "ovf"
 	}
 

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -98,7 +98,12 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		errs = packer.MultiErrorAppend(errs, err)
 	}
 
-	if c.Format == "" {
+	if c.Format != "" {
+		if c.RemoteType != "esx5" {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("format is only valid when RemoteType=esx5"))
+		}
+	} else {
 		c.Format = "ovf"
 	}
 


### PR DESCRIPTION
Add validation to make it clear that the "format" field is only used when exporting a vm from a remote build.

Closes #3329
