### PR TITLE
Add env vars "PACKER_HTTP_IP" and "PACKER_HTTP_PORT" to our various shell provisioners 

### DIFF
--- a/common/shell-local/run.go
+++ b/common/shell-local/run.go
@@ -178,10 +178,18 @@ func createFlattenedEnvVars(config *Config) (string, error) {
 	envVars["PACKER_BUILD_NAME"] = fmt.Sprintf("%s", config.PackerBuildName)
 	envVars["PACKER_BUILDER_TYPE"] = fmt.Sprintf("%s", config.PackerBuilderType)
 
-	// expose PACKER_HTTP_ADDR
+	// expose ip address variables
 	httpAddr := common.GetHTTPAddr()
 	if httpAddr != "" {
-		envVars["PACKER_HTTP_ADDR"] = fmt.Sprintf("%s", httpAddr)
+		envVars["PACKER_HTTP_ADDR"] = httpAddr
+	}
+	httpIP := common.GetHTTPIP()
+	if httpIP != "" {
+		envVars["PACKER_HTTP_IP"] = httpIP
+	}
+	httpPort := common.GetHTTPPort()
+	if httpPort != "" {
+		envVars["PACKER_HTTP_PORT"] = httpPort
 	}
 
 	// interpolate environment variables

--- a/common/step_http_server.go
+++ b/common/step_http_server.go
@@ -96,6 +96,22 @@ func GetHTTPAddr() string {
 	return fmt.Sprintf("%s:%s", ip, port)
 }
 
+func GetHTTPPort() string {
+	port, err := common.RetrieveSharedState("port", "")
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%s", port)
+}
+
+func GetHTTPIP() string {
+	ip, err := common.RetrieveSharedState("ip", "")
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%s", ip)
+}
+
 func (s *StepHTTPServer) Cleanup(multistep.StateBag) {
 	if s.l != nil {
 		// Close the listener so that the HTTP server stops

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -380,9 +380,18 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 	envVars["PACKER_BUILD_NAME"] = p.config.PackerBuildName
 	envVars["PACKER_BUILDER_TYPE"] = p.config.PackerBuilderType
 
+	// expose ip address variables
 	httpAddr := common.GetHTTPAddr()
 	if httpAddr != "" {
 		envVars["PACKER_HTTP_ADDR"] = httpAddr
+	}
+	httpIP := common.GetHTTPIP()
+	if httpIP != "" {
+		envVars["PACKER_HTTP_IP"] = httpIP
+	}
+	httpPort := common.GetHTTPPort()
+	if httpPort != "" {
+		envVars["PACKER_HTTP_PORT"] = httpPort
 	}
 
 	// interpolate environment variables

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -463,9 +463,19 @@ func (p *Provisioner) escapeEnvVars() ([]string, map[string]string) {
 	// Always available Packer provided env vars
 	envVars["PACKER_BUILD_NAME"] = fmt.Sprintf("%s", p.config.PackerBuildName)
 	envVars["PACKER_BUILDER_TYPE"] = fmt.Sprintf("%s", p.config.PackerBuilderType)
+
+	// expose ip address variables
 	httpAddr := common.GetHTTPAddr()
 	if httpAddr != "" {
-		envVars["PACKER_HTTP_ADDR"] = fmt.Sprintf("%s", httpAddr)
+		envVars["PACKER_HTTP_ADDR"] = httpAddr
+	}
+	httpIP := common.GetHTTPIP()
+	if httpIP != "" {
+		envVars["PACKER_HTTP_IP"] = httpIP
+	}
+	httpPort := common.GetHTTPPort()
+	if httpPort != "" {
+		envVars["PACKER_HTTP_PORT"] = httpPort
 	}
 
 	// Split vars into key/value components

--- a/provisioner/windows-shell/provisioner.go
+++ b/provisioner/windows-shell/provisioner.go
@@ -289,9 +289,19 @@ func (p *Provisioner) createFlattenedEnvVars() (flattened string) {
 	// Always available Packer provided env vars
 	envVars["PACKER_BUILD_NAME"] = p.config.PackerBuildName
 	envVars["PACKER_BUILDER_TYPE"] = p.config.PackerBuilderType
+
+	// expose ip address variables
 	httpAddr := common.GetHTTPAddr()
 	if httpAddr != "" {
 		envVars["PACKER_HTTP_ADDR"] = httpAddr
+	}
+	httpIP := common.GetHTTPIP()
+	if httpIP != "" {
+		envVars["PACKER_HTTP_IP"] = httpIP
+	}
+	httpPort := common.GetHTTPPort()
+	if httpPort != "" {
+		envVars["PACKER_HTTP_PORT"] = httpPort
 	}
 
 	// Split vars into key/value components


### PR DESCRIPTION
A simple nice-to-have to save users some bash scripting by exposing IP and port separately as well as together

Closes #4844
