### PR TITLE
Move logging about aws waiters to the access config prepare() so that…

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -110,6 +110,7 @@ func (c *AccessConfig) Session() (*session.Session, error) {
 	if c.DecodeAuthZMessages {
 		DecodeAuthZMessages(c.session)
 	}
+	LogEnvOverrideWarnings()
 
 	return c.session, nil
 }

--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -307,6 +308,36 @@ func getEnvOverrides() overridableWaitVars {
 	return envValues
 }
 
+func LogEnvOverrideWarnings() {
+	pollDelay := os.Getenv("AWS_POLL_DELAY_SECONDS")
+	timeoutSeconds := os.Getenv("AWS_TIMEOUT_SECONDS")
+	maxAttempts := os.Getenv("AWS_MAX_ATTEMPTS")
+
+	if maxAttempts != "" && timeoutSeconds != "" {
+		warning := fmt.Sprintf("[WARNING] (aws): AWS_MAX_ATTEMPTS and " +
+			"AWS_TIMEOUT_SECONDS are both set. Packer will use " +
+			"AWS_MAX_ATTEMPTS and discard AWS_TIMEOUT_SECONDS.")
+		if pollDelay == "" {
+			warning = fmt.Sprintf("%s  Since you have not set the poll delay, "+
+				"Packer will default to a 2-second delay.", warning)
+		}
+		log.Printf(warning)
+	} else if timeoutSeconds != "" {
+		log.Printf("[WARNING] (aws): env var AWS_TIMEOUT_SECONDS is " +
+			"deprecated in favor of AWS_MAX_ATTEMPTS. If you have not " +
+			"explicitly set AWS_POLL_DELAY_SECONDS, we are defaulting to a " +
+			"poll delay of 2 seconds, regardless of the AWS waiter's default.")
+	}
+	if maxAttempts == "" && timeoutSeconds == "" && pollDelay == "" {
+		log.Printf("[INFO] (aws): No AWS timeout and polling overrides have been set. " +
+			"Packer will default to waiter-specific delays and timeouts. If you would " +
+			"like to customize the length of time between retries and max " +
+			"number of retries you may do so by setting the environment " +
+			"variables AWS_POLL_DELAY_SECONDS and AWS_MAX_ATTEMPTS to your " +
+			"desired values.")
+	}
+}
+
 func applyEnvOverrides(envOverrides overridableWaitVars) []request.WaiterOption {
 	waitOpts := make([]request.WaiterOption, 0)
 	// If user has set poll delay seconds, overwrite it. If user has NOT,
@@ -320,18 +351,7 @@ func applyEnvOverrides(envOverrides overridableWaitVars) []request.WaiterOption 
 	// attempts, default to whatever the waiter has set as a default.
 	if envOverrides.awsMaxAttempts.overridden {
 		waitOpts = append(waitOpts, request.WithWaiterMaxAttempts(envOverrides.awsMaxAttempts.Val))
-	}
-
-	if envOverrides.awsMaxAttempts.overridden && envOverrides.awsTimeoutSeconds.overridden {
-		log.Printf("WARNING: AWS_MAX_ATTEMPTS and AWS_TIMEOUT_SECONDS are" +
-			" both set. Packer will be using AWS_MAX_ATTEMPTS and discarding " +
-			"AWS_TIMEOUT_SECONDS. If you have not set AWS_POLL_DELAY_SECONDS, " +
-			"Packer will default to a 2 second poll delay.")
 	} else if envOverrides.awsTimeoutSeconds.overridden {
-		log.Printf("DEPRECATION WARNING: env var AWS_TIMEOUT_SECONDS is " +
-			"deprecated in favor of AWS_MAX_ATTEMPTS. If you have not " +
-			"explicitly set AWS_POLL_DELAY_SECONDS, we are defaulting to a " +
-			"poll delay of 2 seconds, regardless of the AWS waiter's default.")
 		maxAttempts := envOverrides.awsTimeoutSeconds.Val / envOverrides.awsPollDelaySeconds.Val
 		// override the delay so we can get the timeout right
 		if !envOverrides.awsPollDelaySeconds.overridden {
@@ -339,14 +359,6 @@ func applyEnvOverrides(envOverrides overridableWaitVars) []request.WaiterOption 
 			waitOpts = append(waitOpts, request.WithWaiterDelay(delaySeconds))
 		}
 		waitOpts = append(waitOpts, request.WithWaiterMaxAttempts(maxAttempts))
-	}
-	if len(waitOpts) == 0 {
-		log.Printf("No AWS timeout and polling overrides have been set. " +
-			"Packer will default to waiter-specific delays and timeouts. If you would " +
-			"like to customize the length of time between retries and max " +
-			"number of retries you may do so by setting the environment " +
-			"variables AWS_POLL_DELAY_SECONDS and AWS_MAX_ATTEMPTS to your " +
-			"desired values.")
 	}
 
 	return waitOpts

--- a/post-processor/amazon-import/post-processor.go
+++ b/post-processor/amazon-import/post-processor.go
@@ -103,6 +103,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	if len(errs.Errors) > 0 {
 		return errs
 	}
+	awscommon.LogEnvOverrideWarnings()
 
 	packer.LogSecretFilter.Set(p.config.AccessKey, p.config.SecretKey, p.config.Token)
 	log.Println(p.config)


### PR DESCRIPTION
Clean up logging for aws waiters so that it only runs once per builder and once for the amazon-import post-processor. It was spammy before. 

Closes #6508