### PR TITLE
windows-restart-provisioner: change reboot pending registry keys to correct format

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -24,10 +24,10 @@ var TryCheckReboot = `shutdown /r /f /t 60 /c "packer restart test"`
 var AbortReboot = `shutdown /a`
 
 var KeyTestCommands = []string{
-	winrm.Powershell(`Test-Path "HKEY_LOCAL_MACHINE:SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending"`),
-	winrm.Powershell(`Test-Path "HKEY_LOCAL_MACHINE:SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\PackagePending"`),
-	winrm.Powershell(`Test-Path "HKEY_LOCAL_MACHINE:Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootInProgress"`),
-	winrm.Powershell(`Test-Path "HKEY_LOCAL_MACHINE:SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending"`),
+	winrm.Powershell(`Test-Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending"`),
+	winrm.Powershell(`Test-Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\PackagesPending"`),
+	winrm.Powershell(`Test-Path "HKLM:Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootInProgress"`),
+	winrm.Powershell(`Test-Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending"`),
 }
 
 type Config struct {


### PR DESCRIPTION
This PR is related to #6799 and #7056

<img width="847" alt="2018-12-07 3 57 20" src="https://user-images.githubusercontent.com/308623/49633090-6a67c480-fa3b-11e8-9b95-a93089ed8b1a.png">

After some testing it looks like `Test-Path` only takes abbreviated form of registry. 

(thought making a PR is much easier to merge into the branch)