### PR TITLE
make packer inspect not print sensitive variables.

### DIFF
--- a/command/inspect.go
+++ b/command/inspect.go
@@ -50,6 +50,11 @@ func (c *InspectCommand) Run(args []string) int {
 	} else {
 		requiredHeader := false
 		for k, v := range tpl.Variables {
+			for _, sensitive := range tpl.SensitiveVariables {
+				if ok := strings.Compare(sensitive.Default, v.Default); ok == 0 {
+					v.Default = "<sensitive>"
+				}
+			}
 			if v.Required {
 				if !requiredHeader {
 					requiredHeader = true
@@ -81,6 +86,11 @@ func (c *InspectCommand) Run(args []string) int {
 			v := tpl.Variables[k]
 			if v.Required {
 				continue
+			}
+			for _, sensitive := range tpl.SensitiveVariables {
+				if ok := strings.Compare(sensitive.Default, v.Default); ok == 0 {
+					v.Default = "<sensitive>"
+				}
 			}
 
 			padding := strings.Repeat(" ", max-len(k))


### PR DESCRIPTION
Censor "sensitive-variables" in `packer inspect` output. This is a really simple/naive approach, but I don't really think anything more complex is called for, since `packer inspect` is such a straightforward command. 

Closes #7073