### PR TITLE
Document how to pass spaces in `puppet_bin_dir`

### DIFF
--- a/website/source/docs/provisioners/puppet-masterless.html.md
+++ b/website/source/docs/provisioners/puppet-masterless.html.md
@@ -101,7 +101,8 @@ manifests you should use `manifest_file` instead.
 -   `puppet_bin_dir` (string) - Path to the Puppet binary. Ideally the program
     should be on the system (unix: `$PATH`, windows: `%PATH%`), but some
     builders (eg. Docker) do not run profile-setup scripts and therefore PATH
-    might be empty or minimal.
+    might be empty or minimal. On Windows, spaces should be `^`-escaped, i.e.
+    `c:/program^ files/puppet^ labs/puppet/bin`.
 
 -   `staging_directory` (string) - Directory to where uploaded files will be
     placed (unix: "/tmp/packer-puppet-masterless", windows:

--- a/website/source/docs/provisioners/puppet-server.html.md
+++ b/website/source/docs/provisioners/puppet-server.html.md
@@ -81,7 +81,8 @@ listed below:
 -   `puppet_bin_dir` (string) - Path to the Puppet binary. Ideally the program
     should be on the system (unix: `$PATH`, windows: `%PATH%`), but some
     builders (eg. Docker) do not run profile-setup scripts and therefore PATH
-    might be empty or minimal.
+    might be empty or minimal. On Windows, spaces should be `^`-escaped, i.e.
+    `c:/program^ files/puppet^ labs/puppet/bin`.
 
 -   `puppet_node` (string) - The name of the node. If this isn't set, the fully
     qualified domain name will be used.


### PR DESCRIPTION
On Windows, I struggled how to pass the full path to the Puppet binary as it contains spaces, (it's normally `c:/program files/puppet labs/puppet/bin`. Backslashes, single/double quoting, nothing seemed to work until I discovered that you can use the `^` character to escape spaces, so passing `"puppet_bin_dir": "c:/program^ files/puppet^ labs/puppet/bin"` works. I wasted so much time trying to figure this out, I figured a small documentation update can spare the next person the same pain.