### PR TITLE
Proper fix to #6920 which ensures that entrypoint and arguments get passed to docker, not the image.

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -73,7 +73,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	// Defaults
 	if len(c.RunCommand) == 0 {
-		c.RunCommand = []string{"-d", "-i", "-t", "{{.Image}}", "--entrypoint=/bin/sh"}
+		c.RunCommand = []string{"-d", "-i", "-t", "--entrypoint=/bin/sh", "--", "{{.Image}}"}
 	}
 
 	// Default Pull if it wasn't set


### PR DESCRIPTION
Moved the entrypoint argument for the docker builder in front of the image so it's passed correctly as an argument.

@vrubiolo pointed out that entrypoint is being passed to the image and might not be passed to docker. This moves the "entrypoint" option in front of the image, and adds a double-hyphen to terminate argument parsing for docker.

This should fix #6920 properly. Sorry about that.