### PR TITLE
Tiny fix to replace some duplicate code with usage of the already defined `halt` closure in the StepCloneVMX step for the vmware-vmx builder.

### DIFF
--- a/builder/vmware/vmx/step_clone_vmx.go
+++ b/builder/vmware/vmx/step_clone_vmx.go
@@ -39,9 +39,7 @@ func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multiste
 	log.Printf("Cloning to: %s", vmxPath)
 
 	if err := driver.Clone(vmxPath, s.Path, s.Linked); err != nil {
-		state.Put("error", err)
 		return halt(err)
-
 	}
 
 	// Read in the machine configuration from the cloned VMX file
@@ -102,8 +100,7 @@ func (s *StepCloneVMX) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	if len(diskFullPaths) == 0 {
-		state.Put("error", fmt.Errorf("Could not enumerate disk info from the vmx file"))
-		return multistep.ActionHalt
+		return halt(fmt.Errorf("Could not enumerate disk info from the vmx file"))
 	}
 
 	// Determine the network type by reading out of the .vmx


### PR DESCRIPTION
While going through the VMware builders I noticed that in the `StepCloneVMX` step there's a closure assigned, `halt()`, which pushes an error to the statebag, and returns `multistep.ActionHalt`. Probably done to duplication of a common construct.

In one place some code pushes an error to the statebag and then calls `halt()`. This code was replaced with just the call to `halt()` since the closure does both already.

In another place, the logic manually pushes the error into the statebag and returns `multistep.ActionHalt`. This was also replaced with the call to `halt()` for the prior described reason.