### PR TITLE
fix virtualbox 6.0 beta command options

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -25,7 +25,7 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string, portcoun
 	}
 
 	portCountArg := "--sataportcount"
-	if strings.HasPrefix(version, "4.3") || strings.HasPrefix(version, "5.") {
+	if strings.HasPrefix(version, "4.3") || strings.HasPrefix(version, "5.") || strings.HasPrefix(version, "6.") {
 		portCountArg = "--portcount"
 	}
 


### PR DESCRIPTION
need to change flag if version = 6.x too.  

We probably want to reverse the check at some point so it's checking for version <4.2 rather than >4.2

closes #7087 