### PR TITLE
Don't run StepCleanupTempKeys when communicator is set to none

### DIFF
--- a/common/step_cleanup_temp_keys.go
+++ b/common/step_cleanup_temp_keys.go
@@ -19,6 +19,10 @@ func (s *StepCleanupTempKeys) Run(_ context.Context, state multistep.StateBag) m
 	// so there's no realistic situation where these keys can cause issues.
 	// However, it's nice to clean up after yourself.
 
+	if s.Comm.Type == "none" {
+		return multistep.ActionContinue
+	}
+
 	comm := state.Get("communicator").(packer.Communicator)
 	ui := state.Get("ui").(packer.Ui)
 


### PR DESCRIPTION

the step to cleanup ssh keys is run even when communicator is set to none, this causes a crash
- Packer version : .3.4-dev (32f226e+CHANGES)
- Host platform : linux/amd64
- Debug log output from `PACKER_LOG=1 packer build template.json`.
   https://gist.github.com/anish/adfa2873d5ca3964892304ec4c3d6aed
- example template included in gist above

This was added in https://github.com/hashicorp/packer/pull/6713/files
Even with `ssh_clear_authorized_keys` set to false, this https://github.com/hashicorp/packer/blob/38cc525ec75161455c29e2fd23b2ad98c5c0b84d/common/step_cleanup_temp_keys.go#L22 is always evaluated which causes a crash.

I chose to go with this approach, I can also break up that step to look for `SSHClearAuthorizedKeys` first, or move this check to the builders when this step is added every time
