### PR TITLE
ADD: Ability to use empty image

### DIFF
--- a/website/source/docs/builders/scaleway.html.md
+++ b/website/source/docs/builders/scaleway.html.md
@@ -49,7 +49,8 @@ builder.
 -   `image` (string) - The UUID of the base image to use. This is the image
     that will be used to launch a new server and provision it. See
     <https://api-marketplace.scaleway.com/images> get the complete list of the
-    accepted image UUID.
+    accepted image UUID. You can also specify a size compatible with the
+    instance type which will then creae a blank base image.
 
 -   `region` (string) - The name of the region to launch the server in (`par1`
     or `ams1`). Consequently, this is the region where the snapshot will be
@@ -88,7 +89,7 @@ access tokens:
   "type": "scaleway",
   "api_access_key": "YOUR API ACCESS KEY",
   "api_token": "YOUR TOKEN",
-  "image": "UUID OF THE BASE IMAGE",
+  "image": "UUID OF THE BASE IMAGE OR SIZE FOR A BLANK IMAGE",
   "region": "par1",
   "commercial_type": "START1-S",
   "ssh_username": "root",


### PR DESCRIPTION
This PR goal is to add the ability to use a size an empty image for the builder if building from a `scratch`.

For example, specifying a size of `50GB` for the root volume of a `START1-S` will provision a newly created volume that contains no data. (or `25GB` for `START1-XS`)

This helps using the builder to, for example build a START1-XS image of ubuntu bionic that is based on nothing that currently exists.