### PR TITLE
Add note about using ssh_interface for WinRM

### DIFF
--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -170,6 +170,8 @@ And the following MACs:
 The WinRM communicator has the following options.
 
 -   `winrm_host` (string) - The address for WinRM to connect to.
+    
+    NOTE: If using an Amazon EBS builder, you can specify the interface WinRM connects to via [`ssh_interface`](https://www.packer.io/docs/builders/amazon-ebs.html#ssh_interface)
 
 -   `winrm_insecure` (boolean) - If `true`, do not check server certificate
     chain and host name.


### PR DESCRIPTION
Adds a note to the [WinRM](https://www.packer.io/docs/templates/communicator.html#winrm) communicator about using the `ssh_interface` property for communicating.

If you set `associate_public_ip_address` to `true` without defining the interface, WinRM by default attempts to connect over the public IP.