### PR TITLE
revert changes to docker entrypoint; since this is a backwards-breaki…

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -73,7 +73,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	// Defaults
 	if len(c.RunCommand) == 0 {
-		c.RunCommand = []string{"-d", "-i", "-t", "--entrypoint=/bin/sh", "--", "{{.Image}}"}
+		c.RunCommand = []string{"-d", "-i", "-t", "{{.Image}}", "/bin/bash"}
 	}
 
 	// Default Pull if it wasn't set


### PR DESCRIPTION
Reverts #7069 since there's a chance it'll catch people who expect bash and get sh. I'll revert this revert in another PR for the 1.4.0 release.