### PR TITLE
only fail on keep_registerd validation if the artifact isn't coming f…

### DIFF
--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -104,7 +104,9 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	s := artifact.State(vmwcommon.ArtifactConfSkipExport)
 
 	if f != "" && k != "true" && s == "false" {
-		return nil, false, errors.New("To use this post-processor with exporting behavior you need set keep_registered as true")
+		if artifact.BuilderId() == vmwcommon.BuilderIdESX {
+			return nil, false, errors.New("To use this post-processor with exporting behavior you need set keep_registered as true")
+		}
 	}
 
 	// In some occasions the VM state is powered on and if we immediately try to mark as template


### PR DESCRIPTION
Don't fail on keep_regsitered validation if user has just generated a vsphere template using a post processor.

closes #6790 