### PR TITLE
feat(provisioner/ansible): Provide extra SSH args

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -376,7 +376,7 @@ func (p *Provisioner) executeGalaxy(ui packer.Ui, comm packer.Communicator) erro
 func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator) error {
 	inventory := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.InventoryFile)))
 
-	extraArgs := fmt.Sprintf(" --extra-vars \"packer_build_name=%s packer_builder_type=%s packer_http_addr=%s\" ",
+	extraArgs := fmt.Sprintf(" --extra-vars \"packer_build_name=%s packer_builder_type=%s packer_http_addr=%s -o IdentitiesOnly=yes\" ",
 		p.config.PackerBuildName, p.config.PackerBuilderType, common.GetHTTPAddr())
 	if len(p.config.ExtraArguments) > 0 {
 		extraArgs = extraArgs + strings.Join(p.config.ExtraArguments, " ")

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -354,7 +354,7 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 
 	var envvars []string
 
-	args := []string{"--extra-vars", fmt.Sprintf("packer_build_name=%s packer_builder_type=%s",
+	args := []string{"--extra-vars", fmt.Sprintf("packer_build_name=%s packer_builder_type=%s -o IdentitiesOnly=yes",
 		p.config.PackerBuildName, p.config.PackerBuilderType),
 		"-i", inventory, playbook}
 	if len(privKeyFile) > 0 {


### PR DESCRIPTION
Adds `-o IdentitiesOnly=yes` as a default flag to extra vargs
in Ansible provisoner.

Closes https://github.com/hashicorp/packer/issues/5329
