### PR TITLE
VMware-ISO: Fix bug caused by 'nil' dir field in artifact struct when building locally

### DIFF
--- a/builder/vmware/common/artifact.go
+++ b/builder/vmware/common/artifact.go
@@ -62,10 +62,10 @@ func NewArtifact(remoteType string, format string, exportOutputPath string, vmNa
 	if remoteType != "" && !skipExport {
 		dir = new(LocalOutputDir)
 		dir.SetOutputDir(exportOutputPath)
-		files, err = dir.ListFiles()
 	} else {
-		files, err = state.Get("dir").(OutputDir).ListFiles()
+		dir = state.Get("dir").(OutputDir)
 	}
+	files, err = dir.ListFiles()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When building locally with the VMware ISO builder the 'dir' field in the artifact struct is undefined/nil. I think this was introduced by the refactor in fa12113eaf07483c8c3ae2640b60e8389e0ae536. This causes the following bug in the output at the end of the build:

```
Build 'vmware-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> vmware-iso: VM files in directory: %!s(<nil>)
```

This PR fixes the problem by setting the value for the dir field.

```
Build 'vmware-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> vmware-iso: VM files in directory: output-centos-76-x86_64-vmware-iso
```

I suspect not setting 'dir' was also the root cause of the crash 'fixed' by ec75913412f441386b4113b048bce3263bbdf055. This PR should negate the need for that fix. Obviously you can remove/leave in that change as you see fit.

I've tested the changes building locally with the VMware ISO builder (VMware Fusion). Currently, I don't have an ESXi instance set up to test against but I suspect the changes are OK.