### PR TITLE
Make sure sshkey is not nil

### DIFF
--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -43,6 +43,10 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 			state.Put("error", fmt.Errorf("Error fetching SSH key: %s", err))
 			return multistep.ActionHalt
 		}
+		if sshKey == nil {
+			state.Put("error", fmt.Errorf("Could not find key: %s", k))
+			return multistep.ActionHalt
+		}
 		sshKeys = append(sshKeys, sshKey)
 	}
 


### PR DESCRIPTION
If the key name was not found, packer crashes. Just to save someone else 2 hours looking for the reason  why it is crashing :)

```
error: Build 'hcloud' errored: unexpected EOF

```