### PR TITLE
Fix a link in the contributing doc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,7 +107,9 @@ From there, open your fork in your browser to open a new pull-request.
 will break if you `git clone` your fork instead of using `go get` on the main
 Packer project.
 
-**Note:** See [Working on forks](#Working on forks) for a better way to use `git push ...`.
+**Note:** See '[Working with
+forks](https://help.github.com/articles/working-with-forks/)' for a better way
+to use `git push ...`.
 
 ### Pull Request Lifecycle
 


### PR DESCRIPTION
Replaces a placeholder for GitHub's 'Working with forks' doc with the actual link
