### PR TITLE
fix packer crash that occurs when image is nil

### DIFF
--- a/builder/oracle/oci/builder.go
+++ b/builder/oracle/oci/builder.go
@@ -89,9 +89,14 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, err
 	}
 
+	image, ok := state.GetOk("image")
+	if !ok {
+		return nil, err
+	}
+
 	// Build the artifact and return it
 	artifact := &Artifact{
-		Image:  state.Get("image").(core.Image),
+		Image:  image.(core.Image),
 		Region: region,
 		driver: driver,
 	}


### PR DESCRIPTION
I found a crash `panic: interface conversion: interface {} is nil, not core.Image` while I was trying to figure out winrm with oracle-oci. This code fixes it.

Closes #7125 