### PR TITLE
Openstack add volume size option

### DIFF
--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -40,6 +40,7 @@ type RunConfig struct {
 	UseBlockStorageVolume  bool   `mapstructure:"use_blockstorage_volume"`
 	VolumeName             string `mapstructure:"volume_name"`
 	VolumeType             string `mapstructure:"volume_type"`
+	VolumeSize             int    `mapstructure:"volume_size"`
 	VolumeAvailabilityZone string `mapstructure:"volume_availability_zone"`
 
 	// Not really used, but here for BC

--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -35,20 +35,25 @@ func (s *StepCreateVolume) Run(_ context.Context, state multistep.StateBag) mult
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
-	imageClient, err := config.imageV2Client()
-	if err != nil {
-		err = fmt.Errorf("Error initializing image client: %s", err)
-		state.Put("error", err)
-		return multistep.ActionHalt
-	}
+
+	volumeSize := config.VolumeSize
 
 	// Get needed volume size from the source image.
-	volumeSize, err := GetVolumeSize(imageClient, sourceImage)
-	if err != nil {
-		err := fmt.Errorf("Error creating volume: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
+	if volumeSize == 0 {
+		imageClient, err := config.imageV2Client()
+		if err != nil {
+			err = fmt.Errorf("Error initializing image client: %s", err)
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
+
+		volumeSize, err = GetVolumeSize(imageClient, sourceImage)
+		if err != nil {
+			err := fmt.Errorf("Error creating volume: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
 	}
 
 	ui.Say("Creating volume...")

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -275,6 +275,11 @@ builder.
     isn't specified, the default enforced by your OpenStack cluster will be
     used.
 
+-   `volume_size` (int) - Size of the Block Storage service volume in GB. If this
+    isn't specified, it is set to source image min disk value (if set) or
+    calculated from the source image bytes size. Note that in some cases this
+    needs to be specified, if `use_blockstorage_volume` is true.
+
 -   `volume_availability_zone` (string) - Availability zone of the Block
     Storage service volume. If omitted, Compute instance availability zone will
     be used. If both of Compute instance and Block Storage volume availability


### PR DESCRIPTION
Adds an option to OpenStack, `volume_size` (int), which is the size of the Block Storage service volume in GB. Use openstack volume_size option on creation if present. Otherwise fallback to to source image min disk value (if set) or calculated from the source image bytes size.
    
Note that in some cases this needs to be specified, if `use_blockstorage_volume` is true.

Relates to #6957
Closes #6956