### PR TITLE
Add "version" option to hyperv calls

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -73,7 +73,7 @@ type Driver interface {
 
 	DeleteVirtualSwitch(string) error
 
-	CreateVirtualMachine(string, string, string, int64, int64, int64, string, uint, bool, bool) error
+	CreateVirtualMachine(string, string, string, int64, int64, int64, string, uint, bool, bool, string) error
 
 	AddVirtualMachineHardDrive(string, string, string, int64, int64, string) error
 

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -136,6 +136,7 @@ type DriverMock struct {
 	CreateVirtualMachine_Generation       uint
 	CreateVirtualMachine_DifferentialDisk bool
 	CreateVirtualMachine_FixedVHD         bool
+	CreateVirtualMachine_Version          string
 	CreateVirtualMachine_Err              error
 
 	CloneVirtualMachine_Called                bool
@@ -422,7 +423,7 @@ func (d *DriverMock) AddVirtualMachineHardDrive(vmName string, vhdFile string, v
 
 func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddrivePath string,
 	ram int64, diskSize int64, diskBlockSize int64, switchName string, generation uint,
-	diffDisks bool, fixedVHD bool) error {
+	diffDisks bool, fixedVHD bool, version string) error {
 	d.CreateVirtualMachine_Called = true
 	d.CreateVirtualMachine_VmName = vmName
 	d.CreateVirtualMachine_Path = path
@@ -433,6 +434,7 @@ func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddriveP
 	d.CreateVirtualMachine_SwitchName = switchName
 	d.CreateVirtualMachine_Generation = generation
 	d.CreateVirtualMachine_DifferentialDisk = diffDisks
+	d.CreateVirtualMachine_Version = version
 	return d.CreateVirtualMachine_Err
 }
 

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -188,9 +188,9 @@ func (d *HypervPS4Driver) AddVirtualMachineHardDrive(vmName string, vhdFile stri
 
 func (d *HypervPS4Driver) CreateVirtualMachine(vmName string, path string, harddrivePath string, ram int64,
 	diskSize int64, diskBlockSize int64, switchName string, generation uint, diffDisks bool,
-	fixedVHD bool) error {
+	fixedVHD bool, version string) error {
 	return hyperv.CreateVirtualMachine(vmName, path, harddrivePath, ram, diskSize, diskBlockSize, switchName,
-		generation, diffDisks, fixedVHD)
+		generation, diffDisks, fixedVHD, version)
 }
 
 func (d *HypervPS4Driver) CloneVirtualMachine(cloneFromVmcxPath string, cloneFromVmName string,

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -34,6 +34,7 @@ type StepCreateVM struct {
 	DifferencingDisk               bool
 	MacAddress                     string
 	FixedVHD                       bool
+	Version                        string
 }
 
 func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -65,7 +66,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 	diskBlockSize := int64(s.DiskBlockSize * 1024 * 1024)
 
 	err := driver.CreateVirtualMachine(s.VMName, path, harddrivePath, ramSize, diskSize, diskBlockSize,
-		s.SwitchName, s.Generation, s.DifferencingDisk, s.FixedVHD)
+		s.SwitchName, s.Generation, s.DifferencingDisk, s.FixedVHD, s.Version)
 	if err != nil {
 		err := fmt.Errorf("Error creating virtual machine: %s", err)
 		state.Put("error", err)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -96,6 +96,7 @@ type Config struct {
 	SecureBootTemplate             string `mapstructure:"secure_boot_template"`
 	EnableVirtualizationExtensions bool   `mapstructure:"enable_virtualization_extensions"`
 	TempPath                       string `mapstructure:"temp_path"`
+	Version                        string `mapstructure:"configuration_version"`
 
 	Communicator string `mapstructure:"communicator"`
 
@@ -418,6 +419,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DifferencingDisk:               b.config.DifferencingDisk,
 			MacAddress:                     b.config.MacAddress,
 			FixedVHD:                       b.config.FixedVHD,
+			Version:                        b.config.Version,
 		},
 		&hypervcommon.StepEnableIntegrationService{},
 

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -93,6 +93,7 @@ type Config struct {
 	SecureBootTemplate             string `mapstructure:"secure_boot_template"`
 	EnableVirtualizationExtensions bool   `mapstructure:"enable_virtualization_extensions"`
 	TempPath                       string `mapstructure:"temp_path"`
+	Version                        string `mapstructure:"configuration_version"`
 
 	Communicator string `mapstructure:"communicator"`
 

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -243,6 +243,7 @@ func getCreateVMScript(vmName string, path string, harddrivePath string, ram int
 		vhdx = vmName + ".vhd"
 	}
 
+	// Create VHD
 	templateString := `$vhdPath = Join-Path -Path {{ .Path }} -ChildPath {{ .VHDX }}` + "\n"
 	if harddrivePath != "" {
 		if diffDisks {
@@ -252,13 +253,15 @@ func getCreateVMScript(vmName string, path string, harddrivePath string, ram int
 		}
 	} else {
 		if fixedVHD {
-			// We only end up in here with generation 1 vms, because gen 2 doesn't support VHDs
 			templateString = templateString + `Hyper-V\New-VHD -Path $vhdPath -Fixed -SizeBytes {{ .NewVHDSizeBytes }}` + "\n"
 		} else {
 			templateString = templateString + `Hyper-V\New-VHD -Path $vhdPath -SizeBytes {{ .NewVHDSizeBytes }} -BlockSizeBytes {{ .VHDBlockSizeBytes }}` + "\n"
 		}
 	}
+
+	// Create new VM using the VHD you just made
 	templateString = templateString + `Hyper-V\New-VM -Name {{ .VMName }} -Path {{ .Path }} -MemoryStartupBytes {{ .MemoryStartupBytes }} -VHDPath $vhdPath -SwitchName {{ .SwitchName }}`
+	// Add optional tags to the end of the VM creation command
 	if generation == 2 {
 		templateString = templateString + ` -Generation {{ .Generation }}`
 	}

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -204,10 +204,9 @@ Hyper-V\Set-VMFloppyDiskDrive -VMName $vmName -Path $null
 	return err
 }
 
-func CreateVirtualMachine(vmName string, path string, harddrivePath string, ram int64,
+func getCreateVMScript(vmName string, path string, harddrivePath string, ram int64,
 	diskSize int64, diskBlockSize int64, switchName string, generation uint,
-	diffDisks bool, fixedVHD bool, version string) error {
-
+	diffDisks bool, fixedVHD bool, version string) string {
 	type scriptOptions struct {
 		VersionTag         string
 		VMName             string
@@ -287,7 +286,18 @@ else {
 		DiffDisks:          diffDisks,
 		FixedVHD:           fixedVHD,
 	})
-	script := scriptBuilder.String()
+
+	return scriptBuilder.String()
+}
+
+func CreateVirtualMachine(vmName string, path string, harddrivePath string, ram int64,
+	diskSize int64, diskBlockSize int64, switchName string, generation uint,
+	diffDisks bool, fixedVHD bool, version string) error {
+
+	script := getCreateVMScript(vmName, path, harddrivePath, ram,
+		diskSize, diskBlockSize, switchName, generation,
+		diffDisks, fixedVHD, version)
+
 	var ps powershell.PowerShellCmd
 	if err := ps.Run(script); err != nil {
 		return err

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -227,10 +227,8 @@ Hyper-V\Set-VMFloppyDiskDrive -VMName $vmName -Path $null
 // generate a conditional-free script which already sets all of the necessary
 // variables inline.
 //
-// $vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
-// New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
-// Hyper-V\New-VHD -Path $vhdPath -SizeBytes 8192 -BlockSizeBytes 10
-// Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch
+// For examples of what this template will generate, you can look at the
+// test cases in ./hyperv_test.go
 //
 func getCreateVMScript(opts *scriptOptions) (string, error) {
 

--- a/common/powershell/hyperv/hyperv_test.go
+++ b/common/powershell/hyperv/hyperv_test.go
@@ -6,22 +6,22 @@ import (
 )
 
 func Test_getCreateVMScript(t *testing.T) {
-	vmName := "myvm"
-	path := "C://mypath"
-	harddrivepath := "C://harddrivepath"
-	ram := int64(1024)
-	disksize := int64(8192)
-	diskBlockSize := int64(10)
-	switchName := "hyperv-vmx-switch"
-	generation := uint(1)
-	diffdisks := true
-	fixedVHD := true
-	version := "5.0"
+	opts := scriptOptions{
+		Version:            "5.0",
+		VMName:             "myvm",
+		Path:               "C://mypath",
+		HardDrivePath:      "C://harddrivepath",
+		MemoryStartupBytes: int64(1024),
+		NewVHDSizeBytes:    int64(8192),
+		VHDBlockSizeBytes:  int64(10),
+		SwitchName:         "hyperv-vmx-switch",
+		Generation:         uint(1),
+		DiffDisks:          true,
+		FixedVHD:           true,
+	}
 
 	// Check Fixed VHD conditional set
-	scriptString, err := getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	scriptString, err := getCreateVMScript(&opts)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
@@ -35,19 +35,15 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 
 	// We should never get here thanks to good template validation, but it's
 	// good to fail rather than trying to run the ps script and erroring.
-	generation = uint(2)
-	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	opts.Generation = uint(2)
+	scriptString, err = getCreateVMScript(&opts)
 	if err == nil {
 		t.Fatalf("Should have Error: %s", err.Error())
 	}
 
 	// Check VHDX conditional set
-	fixedVHD = false
-	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	opts.FixedVHD = false
+	scriptString, err = getCreateVMScript(&opts)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
@@ -60,11 +56,9 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 	}
 
 	// Check generation 1 no fixed VHD
-	fixedVHD = false
-	generation = uint(1)
-	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	opts.FixedVHD = false
+	opts.Generation = uint(1)
+	scriptString, err = getCreateVMScript(&opts)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
@@ -77,10 +71,8 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 	}
 
 	// Check that we use generation one template even if generation is unset
-	generation = uint(0)
-	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	opts.Generation = uint(0)
+	scriptString, err = getCreateVMScript(&opts)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
@@ -89,10 +81,8 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
 
-	version = ""
-	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	opts.Version = ""
+	scriptString, err = getCreateVMScript(&opts)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
@@ -103,10 +93,8 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
 
-	diffdisks = false
-	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	opts.DiffDisks = false
+	scriptString, err = getCreateVMScript(&opts)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
@@ -117,10 +105,8 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
 
-	harddrivepath = ""
-	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	opts.HardDrivePath = ""
+	scriptString, err = getCreateVMScript(&opts)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
@@ -131,10 +117,8 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
 
-	fixedVHD = true
-	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
-		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
-		version)
+	opts.FixedVHD = true
+	scriptString, err = getCreateVMScript(&opts)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}

--- a/common/powershell/hyperv/hyperv_test.go
+++ b/common/powershell/hyperv/hyperv_test.go
@@ -1,0 +1,147 @@
+package hyperv
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_getCreateVMScript(t *testing.T) {
+	vmName := "myvm"
+	path := "C://mypath"
+	harddrivepath := "C://harddrivepath"
+	ram := int64(1024)
+	disksize := int64(8192)
+	diskBlockSize := int64(10)
+	switchName := "hyperv-vmx-switch"
+	generation := uint(1)
+	diffdisks := true
+	fixedVHD := true
+	version := "5.0"
+
+	// Check Fixed VHD conditional set
+	scriptString, err := getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+
+	expected := `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhd
+Hyper-V\New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
+Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch -Version 5.0`
+	if ok := strings.Compare(scriptString, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
+	}
+
+	// We should never get here thanks to good template validation, but it's
+	// good to fail rather than trying to run the ps script and erroring.
+	generation = uint(2)
+	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err == nil {
+		t.Fatalf("Should have Error: %s", err.Error())
+	}
+
+	// Check VHDX conditional set
+	fixedVHD = false
+	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+
+	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
+Hyper-V\New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
+Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch -Generation 2 -Version 5.0`
+	if ok := strings.Compare(scriptString, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
+	}
+
+	// Check generation 1 no fixed VHD
+	fixedVHD = false
+	generation = uint(1)
+	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+
+	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
+Hyper-V\New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
+Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch -Version 5.0`
+	if ok := strings.Compare(scriptString, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
+	}
+
+	// Check that we use generation one template even if generation is unset
+	generation = uint(0)
+	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+	// same "expected" as above
+	if ok := strings.Compare(scriptString, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
+	}
+
+	version = ""
+	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
+Hyper-V\New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
+Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch`
+	if ok := strings.Compare(scriptString, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
+	}
+
+	diffdisks = false
+	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
+Copy-Item -Path C://harddrivepath -Destination $vhdPath
+Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch`
+	if ok := strings.Compare(scriptString, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
+	}
+
+	harddrivepath = ""
+	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
+Hyper-V\New-VHD -Path $vhdPath -SizeBytes 8192 -BlockSizeBytes 10
+Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch`
+	if ok := strings.Compare(scriptString, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
+	}
+
+	fixedVHD = true
+	scriptString, err = getCreateVMScript(vmName, path, harddrivepath, ram,
+		disksize, diskBlockSize, switchName, generation, diffdisks, fixedVHD,
+		version)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhd
+Hyper-V\New-VHD -Path $vhdPath -Fixed -SizeBytes 8192
+Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch`
+	if ok := strings.Compare(scriptString, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
+	}
+}


### PR DESCRIPTION
Adding a "version" flag was in response to #5984, but I realized as I was adding the tag that the powershell script for creating a VM was growing pretty complex for something stored entirely inside of a raw string. I broke it apart so that rather than maintaining two similar-but-different, divergent strings, we could easily update a set of template strings instead.  

The result is that all of the logic has been pulled from the CreateVirtualMachine powershell script and put into go code. And I wrote several tests to cover the majority of paths through that logic so that we can validate it works. Take a look at the test code to see examples of what is actually getting called to launch HyperV. 

I'd love to eventually refactor other the scripts in the hyperv driver in this manner, but this is intended as a POC/part of an incremental improvement.

Closes #5984
