### PR TITLE
Make storagectl --portcount the default and override with the

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -26,7 +26,7 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string, portcoun
 
 	portCountArg := "--portcount"
 	if strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") || strings.HasPrefix(version, "3.") ||
-	   strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1.") || strings.HasPrefix(version, "4.2.") {
+		strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1.") || strings.HasPrefix(version, "4.2.") {
 		portCountArg = "--sataportcount"
 	}
 

--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -24,9 +24,10 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string, portcoun
 		return err
 	}
 
-	portCountArg := "--sataportcount"
-	if strings.HasPrefix(version, "4.3") || strings.HasPrefix(version, "5.") || strings.HasPrefix(version, "6.") {
-		portCountArg = "--portcount"
+	portCountArg := "--portcount"
+	if strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") || strings.HasPrefix(version, "3.") ||
+	   strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1.") || strings.HasPrefix(version, "4.2.") {
+		portCountArg = "--sataportcount"
 	}
 
 	command := []string{


### PR DESCRIPTION
As of VirtualBox 4.3, VBoxManage storagectl renamed the --sataportcount option to --portcount.

This patch makes the contemporary behavior the default and overrides it for VirtualBox versions up to and including 4.2.