### PR TITLE
Fix typo in changelog for 1.3.3 bug fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 ### BUG FIXES:
 * builder/amazon: Better error handling of region/credential guessing from
     metadata [GH-6931]
-* builder.amazon: move region validation to run so that we don't break
+* builder/amazon: move region validation to run so that we don't break
     validation when no credentials are set [GH-7032]
 * builder/hyperv: Remove -Copy:$false when calling Hyper-V\Compare-VM
     compatability report [GH-7030]


### PR DESCRIPTION
Fix typo in changelog.  Change "builder.amazon" to "builder/amazon" under 1.3.3 bug fixes.