### PR TITLE
Fix the Hyper-V gen 1 guest boot order.

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -135,7 +135,7 @@ func SetBootDvdDrive(vmName string, controllerNumber uint, controllerLocation ui
 	if generation < 2 {
 		script := `
 param([string]$vmName)
-Hyper-V\Set-VMBios -VMName $vmName -StartupOrder @("CD", "IDE","LegacyNetworkAdapter","Floppy")
+Hyper-V\Set-VMBios -VMName $vmName -StartupOrder @("IDE","CD","LegacyNetworkAdapter","Floppy")
 `
 		var ps powershell.PowerShellCmd
 		err := ps.Run(script, vmName)


### PR DESCRIPTION
One of the major pain points with `packer` and `Hyper-V` has been that installers must eject the install media before rebooting, or builds will fail. This hurdle has caused major install issues with Alpine/Arch/Gentoo/FreeBSD/OpenBSD/HardenedBSD and more. I believe this explains some of the problems reported in #5049 (although it does not address the IP detection hurdle, which is a separate issue).

In short, the problem is thus... if an install script forces install media to eject while a system is booted, it will likely kernel panic before it can execute a normal reboot. The result is that installing distros which lack native support for automatic cdrom ejection, like those listed above, is extremely difficult.

I recently ran into this problem once again, because the RHEL 8 installer appears to have a bug, which causes it to ignore the eject directive. 

As a result of my most recent frustration, I dug into the code, and as a result, I submit the following patch. This tiny change alters the default boot order for generation 1 hyper-v guest machines. With this patch these machines will search the hard disk first, followed by the cdrom. I believe this is how all of the order builders work (qemu, vmware, parallels, virtualbox).

This changed fixed my installation issue with RHEL 8. Because I deployed it after 80% of my Hyper-V boxes were built (in this latest run), I've only tested it against 6 other distro configs, but so far it has caused no problems. That said, it's a pretty significant change, and needs more testing. If this change causes problems it may need to be tied to a config setting. 

I can, if necessary, remove the eject workarounds in packer configurations rebuild all of my Hyper-V but that takes several days... so I'd rather avoid it...

I also, explicitly did not change the boot order for generation 2 virtual machines. As a result generation 2 configs still place the cdrom ahead of the hard disk while booting. Since I don't use generation 2 virtual machines, I decided not to alter that logic, as I don't have any packer configurations to test it against.





