### PR TITLE
Updated prlctl section with a non-cpu/mem example.

### DIFF
--- a/website/source/docs/builders/parallels-iso.html.md.erb
+++ b/website/source/docs/builders/parallels-iso.html.md.erb
@@ -290,24 +290,24 @@ In order to perform extra customization of the virtual machine, a template can
 define extra calls to `prlctl` to perform.
 [prlctl](http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Command%20Line%20Reference%20Guide.pdf)
 is the command-line interface to Parallels Desktop. It can be used to configure
-the virtual machine, such as set RAM, CPUs, etc.
+the advanced virtual machine options. 
 
-Extra `prlctl` commands are defined in the template in the `prlctl` section. An
-example is shown below that sets the memory and number of CPUs within the
-virtual machine:
+Extra `prlctl` commands are defined in the template in the `prlctl` section. In the
+example below `prlctl` is used to explicitly enable the adaptive hypervisor, and
+disable 3d acceleration:
 
 ``` json
 {
   "prlctl": [
-    ["set", "{{.Name}}", "--memsize", "1024"],
-    ["set", "{{.Name}}", "--cpus", "2"]
+    ["set", "{{.Name}}", "--3d-accelerate", "off"],
+    ["set", "{{.Name}}", "--adaptive-hypervisor", "on"]
   ]
 }
 ```
 
 The value of `prlctl` is an array of commands to execute. These commands are
-executed in the order defined. So in the above example, the memory will be set
-followed by the CPUs.
+executed in the order defined. So in the above example, 3d acceleration will be disabled
+first, followed by the command which enables the adaptive hypervisor.
 
 Each command itself is an array of strings, where each string is an argument to
 `prlctl`. Each argument is treated as a [template engine](/docs/templates/engine.html). The only available


### PR DESCRIPTION
I noticed that cpu/memory  keys have been added to the `paralells-iso` builder, yet the`prlctl` example in the docs still used these values to demonstrate the CLI interface... to avoid setting a bad example, I updated the `prlctl` section with an example showing how to set parameters which actually require the use of `prlctl`.

I looked into making the same update to the `parallels-pvm` page, but noticed that builder doesn't appear to support configuring the cpu/memory values via template keys. May the code gods decide whether that is an oversight in documentation, an oversight in implementation, or an intentional action. Because I assume code gods are incapable of mistakes, I went with intentional. Presuming it's intention, means the `prlctl` example, which modifies the modify cpu/memory values, is relevant, so I left it intact..