### PR TITLE
Add support for whpx accelerator to qemu builder

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -28,6 +28,7 @@ var accels = map[string]struct{}{
 	"xen":  {},
 	"hax":  {},
 	"hvf":  {},
+	"whpx": {},
 }
 
 var netDevice = map[string]bool{
@@ -274,7 +275,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if _, ok := accels[b.config.Accelerator]; !ok {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("invalid accelerator, only 'kvm', 'tcg', 'xen', 'hax', 'hvf', or 'none' are allowed"))
+			errs, errors.New("invalid accelerator, only 'kvm', 'tcg', 'xen', 'hax', 'hvf', 'whpx', or 'none' are allowed"))
 	}
 
 	if _, ok := netDevice[b.config.NetDevice]; !ok {

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -107,7 +107,7 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
 ### Optional:
 
 -   `accelerator` (string) - The accelerator type to use when running the VM.
-    This may be `none`, `kvm`, `tcg`, `hax`, `hvf`, or `xen`. The appropriate
+    This may be `none`, `kvm`, `tcg`, `hax`, `hvf`, `whpx`, or `xen`. The appropriate
     software must have already been installed on your build machine to use the
     accelerator you specified. When no accelerator is specified, Packer will try
     to use `kvm` if it is available but will default to `tcg` otherwise.
@@ -116,11 +116,15 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     upstream issue which can be tracked
     [here](https://github.com/intel/haxm/issues/20).
 
-    -&gt; The `hvf` accelerator is new and experimental as of
+    -&gt; The `hvf` and `whpx` accelerator are new and experimental as of
     [QEMU 2.12.0](https://wiki.qemu.org/ChangeLog/2.12#Host_support).
-    You may encounter issues unrelated to Packer when using it.  You may need to
+    You may encounter issues unrelated to Packer when using these.  You may need to
     add [ "-global", "virtio-pci.disable-modern=on" ] to `qemuargs` depending on the
     guest operating system.
+
+    -&gt; For `whpx`, note that [Stefan Weil's QEMU for Windows distribution](https://qemu.weilnetz.de/w64/)
+    does not include WHPX support and users may need to compile or source a
+    build of QEMU for Windows themselves with WHPX support.
 
 -   `boot_command` (array of strings) - This is an array of commands to type
     when the virtual machine is first booted. The goal of these commands should


### PR DESCRIPTION
Windows Hypervisor Platform (WHPX) is the Windows counterpart to HVF and
 KVM. It's an operating system provided component that provides
 virtualization acceleration support.

This is kind of the missing counterpart to https://github.com/hashicorp/packer/pull/6193.
QEMU 2.12 also added support for WHPX.

There's no support for libvirt on Windows so nothing was added in those
areas.

The popular QEMU for Windows distribution does not have WHPX support
built-in for legal reasons as the maintainer does not wish to use or
obtain any part of Microsoft's SDK to compile the distribution.
Workarounds and alternatives are documented.