### PR TITLE
Removed duplicate Azure, moved Docker entry.

### DIFF
--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -33,14 +33,13 @@ providers.
 -   AWS
 -   Azure
 -   DigitalOcean
--   Azure
+-   Docker
 -   Hyper-V
 -   LXC
 -   Parallels
 -   QEMU
 -   VirtualBox
 -   VMware
--   Docker
 
 -&gt; **Support for additional providers** is planned. If the Vagrant
 post-processor doesn't support creating boxes for a provider you care about,


### PR DESCRIPTION
Fix issues with the vagrant post processor documentation.

Specifically the list of support vagrant box types, as Azure was duplicated, which appears to have been a typo.

I also moved the Docker entry from last, to 4th, since it appears, and I presume, the list of vagrant box types is supposed to be alpha ordered.

Any idea what new types of vagrant boxes are in development/planned? 