### PR TITLE
Fix ssh_host bug in hyper-v builders.

### DIFF
--- a/builder/hyperv/common/ssh.go
+++ b/builder/hyperv/common/ssh.go
@@ -1,32 +1,32 @@
 package common
 
 import (
-  "log"
+	"log"
 
 	"github.com/hashicorp/packer/helper/multistep"
 )
 
 func CommHost(host string) func(multistep.StateBag) (string, error) {
-  return func(state multistep.StateBag) (string, error) {
+	return func(state multistep.StateBag) (string, error) {
 
-    if host != "" {
-      log.Println("Using ssh_host value: %s", ipAddress)
-      return host, nil
-  	}
+		if host != "" {
+			log.Println("Using ssh_host value: %s", ipAddress)
+			return host, nil
+		}
 
-  	vmName := state.Get("vmName").(string)
-  	driver := state.Get("driver").(Driver)
+		vmName := state.Get("vmName").(string)
+		driver := state.Get("driver").(Driver)
 
-  	mac, err := driver.Mac(vmName)
-  	if err != nil {
-  		return "", err
-  	}
+		mac, err := driver.Mac(vmName)
+		if err != nil {
+			return "", err
+		}
 
-  	ip, err := driver.IpAddress(mac)
-  	if err != nil {
-  		return "", err
-  	}
+		ip, err := driver.IpAddress(mac)
+		if err != nil {
+			return "", err
+		}
 
-  	return ip, nil
-  }
+		return ip, nil
+	}
 }

--- a/builder/hyperv/common/ssh.go
+++ b/builder/hyperv/common/ssh.go
@@ -9,6 +9,7 @@ import (
 func CommHost(host string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 
+		// Skip IP auto detection if the configuration has an ssh host configured.
 		if host != "" {
 			log.Printf("Using ssh_host value: %s", host)
 			return host, nil

--- a/builder/hyperv/common/ssh.go
+++ b/builder/hyperv/common/ssh.go
@@ -10,7 +10,7 @@ func CommHost(host string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 
 		if host != "" {
-			log.Println("Using ssh_host value: %s", ipAddress)
+			log.Printf("Using ssh_host value: %s", host)
 			return host, nil
 		}
 

--- a/builder/hyperv/common/ssh.go
+++ b/builder/hyperv/common/ssh.go
@@ -1,22 +1,32 @@
 package common
 
 import (
+  "log"
+
 	"github.com/hashicorp/packer/helper/multistep"
 )
 
-func CommHost(state multistep.StateBag) (string, error) {
-	vmName := state.Get("vmName").(string)
-	driver := state.Get("driver").(Driver)
+func CommHost(host string) func(multistep.StateBag) (string, error) {
+  return func(state multistep.StateBag) (string, error) {
 
-	mac, err := driver.Mac(vmName)
-	if err != nil {
-		return "", err
-	}
+    if host != "" {
+      log.Println("Using ssh_host value: %s", ipAddress)
+      return host, nil
+  	}
 
-	ip, err := driver.IpAddress(mac)
-	if err != nil {
-		return "", err
-	}
+  	vmName := state.Get("vmName").(string)
+  	driver := state.Get("driver").(Driver)
 
-	return ip, nil
+  	mac, err := driver.Mac(vmName)
+  	if err != nil {
+  		return "", err
+  	}
+
+  	ip, err := driver.IpAddress(mac)
+  	if err != nil {
+  		return "", err
+  	}
+
+  	return ip, nil
+  }
 }

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -459,7 +459,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		// configure the communicator ssh, winrm
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,
-			Host:      hypervcommon.CommHost,
+			Host:      hypervcommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
 			SSHConfig: b.config.SSHConfig.Comm.SSHConfigFunc(),
 		},
 

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -482,7 +482,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		// configure the communicator ssh, winrm
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,
-			Host:      hypervcommon.CommHost,
+			Host:      hypervcommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
 			SSHConfig: b.config.SSHConfig.Comm.SSHConfigFunc(),
 		},
 


### PR DESCRIPTION
As reported [here](https://github.com/hashicorp/packer/issues/4825#issuecomment-450101972) the `hyperv-iso` builder ignores the value of `ssh_host` and thus fails to build boxes on Hyper-V when the IP auto detection is unavailable. This pull request fixes that issue and properly addresses/closes #4825. It also provides a possible workaround for #5049.

It's a somewhat crude patch, and would benefit from a regression test... but sadly, I've run out of play time, and need to get back to working on my own code/project.

Also, this was the first time I've had to resort to supplying an IP in my builder configuration, so I don't know which builders ignore the `ssh_host` value, but based on a cursory look, I suspect other builds may have this issue (`qemu` perhaps). Only the Parallels, VMWare and Virtualbox builders appear to supply SSH configuration unit tests, (Amazon too, but of a different form), and I don't know if those test cases look for this... but that is an issue for another day (and _hopefully_ person).