### PR TITLE
qemu: Add configuration options to specify cpu count and memory size

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -96,6 +96,7 @@ type Config struct {
 
 	ISOSkipCache      bool       `mapstructure:"iso_skip_cache"`
 	Accelerator       string     `mapstructure:"accelerator"`
+	CpuCount          int        `mapstructure:"cpus"`
 	DiskInterface     string     `mapstructure:"disk_interface"`
 	DiskSize          uint       `mapstructure:"disk_size"`
 	DiskCache         string     `mapstructure:"disk_cache"`
@@ -108,6 +109,7 @@ type Config struct {
 	DiskImage         bool       `mapstructure:"disk_image"`
 	UseBackingFile    bool       `mapstructure:"use_backing_file"`
 	MachineType       string     `mapstructure:"machine_type"`
+	MemorySize        int        `mapstructure:"memory"`
 	NetDevice         string     `mapstructure:"net_device"`
 	OutputDir         string     `mapstructure:"output_directory"`
 	QemuArgs          [][]string `mapstructure:"qemuargs"`
@@ -198,6 +200,16 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if b.config.QemuBinary == "" {
 		b.config.QemuBinary = "qemu-system-x86_64"
+	}
+
+	if b.config.MemorySize < 10 {
+		log.Printf("MemorySize %d is too small, using default: 512", b.config.MemorySize)
+		b.config.MemorySize = 512
+	}
+
+	if b.config.CpuCount < 1 {
+		log.Printf("CpuCount %d too small, using default: 1", b.config.CpuCount)
+		b.config.CpuCount = 1
 	}
 
 	if b.config.SSHHostPortMin == 0 {

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -150,7 +150,10 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 		defaultArgs["-cdrom"] = isoPath
 	}
 	defaultArgs["-boot"] = bootDrive
-	defaultArgs["-m"] = "512M"
+	defaultArgs["-m"] = fmt.Sprintf("%dM", config.MemorySize)
+	if config.CpuCount > 1 {
+		defaultArgs["-smp"] = fmt.Sprintf("cpus=%d,sockets=%d", config.CpuCount, config.CpuCount)
+	}
 	defaultArgs["-vnc"] = vnc
 
 	// Append the accelerator to the machine type if it is specified

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -136,6 +136,7 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     specified, the default is `10s` or 10 seconds.
 
 -   `cpus` (number) - The number of cpus to use when building the VM.
+     The default is `1` CPU.
 
 -   `disk_cache` (string) - The cache mode to use for disk. Allowed values
     include any of `writethrough`, `writeback`, `none`, `unsafe`

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -135,6 +135,8 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     five seconds and one minute 30 seconds, respectively. If this isn't
     specified, the default is `10s` or 10 seconds.
 
+-   `cpus` (number) - The number of cpus to use when building the VM.
+
 -   `disk_cache` (string) - The cache mode to use for disk. Allowed values
     include any of `writethrough`, `writeback`, `none`, `unsafe`
     or `directsync`. By default, this is set to `writeback`.
@@ -236,6 +238,9 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
 -   `machine_type` (string) - The type of machine emulation to use. Run your
     qemu binary with the flags `-machine help` to list available types for
     your system. This defaults to `pc`.
+
+-   `memory` (number) - The amount of memory to use when building the VM
+    in megabytes.
 
 -   `net_device` (string) - The driver to use for the network interface. Allowed
     values `ne2k_pci`, `i82551`, `i82557b`, `i82559er`, `rtl8139`, `e1000`,

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -240,7 +240,7 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     your system. This defaults to `pc`.
 
 -   `memory` (number) - The amount of memory to use when building the VM
-    in megabytes.
+    in megabytes. This defaults to `512` megabytes.
 
 -   `net_device` (string) - The driver to use for the network interface. Allowed
     values `ne2k_pci`, `i82551`, `i82557b`, `i82559er`, `rtl8139`, `e1000`,


### PR DESCRIPTION
provide memory and cpus like other builders does

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>

