### PR TITLE
windows plugin: prioritize AppData over default user directory ( UserProfile )

### DIFF
--- a/packer/config_file.go
+++ b/packer/config_file.go
@@ -44,8 +44,13 @@ func ConfigTmpDir() (string, error) {
 
 func homeDir() (string, error) {
 
-	// First prefer the HOME environmental variable
+	// Prefer $HOME over user.Current due to glibc bug: golang.org/issue/13470
 	if home := os.Getenv("HOME"); home != "" {
+		log.Printf("Detected home directory from env var: %s", home)
+		return home, nil
+	}
+
+	if home := os.Getenv("APPDATA"); home != "" {
 		log.Printf("Detected home directory from env var: %s", home)
 		return home, nil
 	}

--- a/website/source/docs/extending/plugins.html.md
+++ b/website/source/docs/extending/plugins.html.md
@@ -52,10 +52,13 @@ later, it will take precedence over one found earlier.
 
 1.  The directory where `packer` is, or the executable directory.
 
-2.  `~/.packer.d/plugins` on Unix systems or `%APPDATA%/packer.d/plugins` on
-    Windows.
+2.  The `$HOME/packer.d/plugins` directory, if `$HOME` is defined (unix)
 
-3.  The current working directory.
+3.  The `%APPDATA%/packer.d/plugins` if `%APPDATA%` is defined (windows)
+
+4.  The `%USERPROFILE%/packer.d/plugins` if `%USERPROFILE%` is defined (windows)
+
+4.  The current working directory.
 
 The valid types for plugins are:
 


### PR DESCRIPTION
This fixes regression brought by #7036 and explained in #7160
It is standard for a binary to use files from the AppData directory. ex: https://github.com/golang/oauth2/blob/c453e0c757598fd055e170a3a359263c91e13153/google/default.go#L104

More on home: https://en.wikipedia.org/wiki/Home_directory

This fixes #7160 