### PR TITLE
[proposal] merge vSphere builder from 'jetbrains-infra/packer-builder-vsphere'

### DIFF
--- a/builder/vsphere/builder.go
+++ b/builder/vsphere/builder.go
@@ -1,0 +1,1 @@
+package vsphere


### PR DESCRIPTION
Closes #4526 

Let's start a process of merging https://github.com/jetbrains-infra/packer-builder-vsphere into the Packer core.
This PR does not have the real code yet. I'll commit it after we settle a number of questions:

- *Backward compatibility*. Being an official builder, how strong should we keep compatibility of parameter naming schema? There are several features I'm going to significantly rewrite, and break current naming.
- *Parameter name review*. the current set of parameter names is quite inconsistent. Also, being non-native English speakers, we named some of them badly. I appreciate if you take a look at [the list](https://github.com/jetbrains-infra/packer-builder-vsphere/blob/master/README.md#parameter-reference) before the merging.
- *Contributor agreement*. We have commits from 14 people, 8 outside of JetBrains. Should all of them sign the new CLA?
- *Commit history*. Should I squash all the code into a single commit, or can import the whole history? `git blame` is super helpful in debugging.
- *Status of old plugins*. This builder overlaps with a remote mode of `vmware` builder, `vsphere` and `vsphere-template` post-processors. Technically they can coexist, but what kind of guidance are you going to give to your users? A product which performs a task by 3 different ways is a huge confusion for newcomers.
- *Acceptance tests*. The code is quite well covered by tests. Builds are run on our [public CI server](https://teamcity.jetbrains.com/viewType.html?buildTypeId=PackerVSphere_Build&guest=1), but use VPN to a vSphere lab hosted in our datacenter. I can manage this lab for a while, but cannot give any SLA for availability or recovery. Finally I'd like to migrate it to HashiCorp resources, maybe to the lab used by Terraform provider.

# Tasks

- [ ] Parameter name review
- [ ] Documentation
