### PR TITLE
Fix links broken by fmt-docs (Pandoc) due to newline

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -197,12 +197,12 @@ builder.
     networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
 
 -   `enable_t2_unlimited` (boolean) - Enabling T2 Unlimited allows the source
-    instance to burst additional CPU beyond its available \[CPU Credits\]
-    (<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html" class="uri">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html</a>)
+    instance to burst additional CPU beyond its available [CPU
+    Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
     for as long as the demand exists. This is in contrast to the standard
     configuration that only allows an instance to consume up to its available
-    CPU Credits. See the AWS documentation for \[T2 Unlimited\]
-    (<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html" class="uri">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html</a>)
+    CPU Credits. See the AWS documentation for [T2
+    Unlimited](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html)
     and the **T2 Unlimited Pricing** section of the [Amazon EC2 On-Demand
     Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for more
     information. By default this option is disabled and Packer will set up a
@@ -210,9 +210,9 @@ builder.
     Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-std.html)
     instance instead.
 
-    To use T2 Unlimited you must use a T2 instance type e.g. `t2.micro`.
+    To use T2 Unlimited you must use a T2 instance type, e.g. `t2.micro`.
     Additionally, T2 Unlimited cannot be used in conjunction with Spot
-    Instances, e.g., when the `spot_price` option has been configured.
+    Instances, e.g. when the `spot_price` option has been configured.
     Attempting to do so will cause an error.
 
     !&gt; **Warning!** Additional costs may be incurred by enabling T2

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -190,12 +190,12 @@ builder.
     networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
 
 -   `enable_t2_unlimited` (boolean) - Enabling T2 Unlimited allows the source
-    instance to burst additional CPU beyond its available \[CPU Credits\]
-    (<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html" class="uri">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html</a>)
+    instance to burst additional CPU beyond its available [CPU
+    Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
     for as long as the demand exists. This is in contrast to the standard
     configuration that only allows an instance to consume up to its available
-    CPU Credits. See the AWS documentation for \[T2 Unlimited\]
-    (<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html" class="uri">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html</a>)
+    CPU Credits. See the AWS documentation for [T2
+    Unlimited](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html)
     and the **T2 Unlimited Pricing** section of the [Amazon EC2 On-Demand
     Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for more
     information. By default this option is disabled and Packer will set up a
@@ -203,9 +203,9 @@ builder.
     Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-std.html)
     instance instead.
 
-    To use T2 Unlimited you must use a T2 instance type, e.g., `t2.micro`.
+    To use T2 Unlimited you must use a T2 instance type, e.g. `t2.micro`.
     Additionally, T2 Unlimited cannot be used in conjunction with Spot
-    Instances, e.g., when the `spot_price` option has been configured.
+    Instances, e.g. when the `spot_price` option has been configured.
     Attempting to do so will cause an error.
 
     !&gt; **Warning!** Additional costs may be incurred by enabling T2

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -163,23 +163,23 @@ builder.
     networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
 
 -   `enable_t2_unlimited` (boolean) - Enabling T2 Unlimited allows the source
-    instance to burst additional CPU beyond its available \[CPU Credits\]
-    (<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html" class="uri">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html</a>)
+    instance to burst additional CPU beyond its available [CPU
+    Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
     for as long as the demand exists. This is in contrast to the standard
     configuration that only allows an instance to consume up to its available
-    CPU Credits. See the AWS documentation for \[T2 Unlimited\]
-    (<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html" class="uri">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html</a>)
-    and the 'T2 Unlimited Pricing' section of the [Amazon EC2 On-Demand
+    CPU Credits. See the AWS documentation for [T2
+    Unlimited](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html)
+    and the **T2 Unlimited Pricing** section of the [Amazon EC2 On-Demand
     Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for more
     information. By default this option is disabled and Packer will set up a
     [T2
     Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-std.html)
     instance instead.
 
-    To use T2 Unlimited you must use a T2 instance type e.g. t2.micro.
+    To use T2 Unlimited you must use a T2 instance type, e.g. `t2.micro`.
     Additionally, T2 Unlimited cannot be used in conjunction with Spot
-    Instances e.g. when the `spot_price` option has been configured. Attempting
-    to do so will cause an error.
+    Instances, e.g. when the `spot_price` option has been configured.
+    Attempting to do so will cause an error.
 
     !&gt; **Warning!** Additional costs may be incurred by enabling T2
     Unlimited - even for instances that would usually qualify for the [AWS Free

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -213,23 +213,23 @@ builder.
     networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
 
 -   `enable_t2_unlimited` (boolean) - Enabling T2 Unlimited allows the source
-    instance to burst additional CPU beyond its available \[CPU Credits\]
-    (<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html" class="uri">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html</a>)
+    instance to burst additional CPU beyond its available [CPU
+    Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
     for as long as the demand exists. This is in contrast to the standard
     configuration that only allows an instance to consume up to its available
-    CPU Credits. See the AWS documentation for \[T2 Unlimited\]
-    (<a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html" class="uri">https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html</a>)
-    and the 'T2 Unlimited Pricing' section of the [Amazon EC2 On-Demand
+    CPU Credits. See the AWS documentation for [T2
+    Unlimited](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-unlimited.html)
+    and the **T2 Unlimited Pricing** section of the [Amazon EC2 On-Demand
     Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for more
     information. By default this option is disabled and Packer will set up a
     [T2
     Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-std.html)
     instance instead.
 
-    To use T2 Unlimited you must use a T2 instance type e.g. t2.micro.
+    To use T2 Unlimited you must use a T2 instance type, e.g. `t2.micro`.
     Additionally, T2 Unlimited cannot be used in conjunction with Spot
-    Instances e.g. when the `spot_price` option has been configured. Attempting
-    to do so will cause an error.
+    Instances, e.g. when the `spot_price` option has been configured.
+    Attempting to do so will cause an error.
 
     !&gt; **Warning!** Additional costs may be incurred by enabling T2
     Unlimited - even for instances that would usually qualify for the [AWS Free


### PR DESCRIPTION
Fixes links that were mistakenly changed and broken by Pandoc via `make fmt-docs` - see [HERE](https://www.packer.io/docs/builders/amazon-ebs.html#enable_t2_unlimited).

Pandoc made the changes because the Markdown originally had a newline between the `[Text]` and `(link)`. I've taken out the newline and corrected the changes it made.

Running `make fmt-docs` (albeit with a rather old version of Pandoc) now leaves the links intact.