### PR TITLE
Make portcount default argument for storagectl

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -25,7 +25,9 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string, portcoun
 	}
 
 	portCountArg = "--portcount"
-	if strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") || strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1") || strings.HasPrefix(version, "4.2") {
+	if  strings.HasPrefix(version, "0.") || strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") ||
+			strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1") ||
+			strings.HasPrefix(version, "4.2") {
 		portCountArg := "--sataportcount"
 	}
 

--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -24,7 +24,7 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string, portcoun
 		return err
 	}
 
-	portCountArg = "--portcount"
+	portCountArg := "--portcount"
 	if strings.HasPrefix(version, "0.") || strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") ||
 		strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1") ||
 		strings.HasPrefix(version, "4.2") {

--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -24,9 +24,9 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string, portcoun
 		return err
 	}
 
-	portCountArg := "--sataportcount"
-	if strings.HasPrefix(version, "4.3") || strings.HasPrefix(version, "5.") || strings.HasPrefix(version, "6.") {
-		portCountArg = "--portcount"
+	portCountArg = "--portcount"
+	if strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") || strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1") || strings.HasPrefix(version, "4.2") {
+		portCountArg := "--sataportcount"
 	}
 
 	command := []string{

--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -28,7 +28,7 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string, portcoun
 	if strings.HasPrefix(version, "0.") || strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") ||
 		strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1") ||
 		strings.HasPrefix(version, "4.2") {
-		portCountArg := "--sataportcount"
+		portCountArg = "--sataportcount"
 	}
 
 	command := []string{

--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -25,9 +25,9 @@ func (d *VBox42Driver) CreateSATAController(vmName string, name string, portcoun
 	}
 
 	portCountArg = "--portcount"
-	if  strings.HasPrefix(version, "0.") || strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") ||
-			strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1") ||
-			strings.HasPrefix(version, "4.2") {
+	if strings.HasPrefix(version, "0.") || strings.HasPrefix(version, "1.") || strings.HasPrefix(version, "2.") ||
+		strings.HasPrefix(version, "3.") || strings.HasPrefix(version, "4.0") || strings.HasPrefix(version, "4.1") ||
+		strings.HasPrefix(version, "4.2") {
 		portCountArg := "--sataportcount"
 	}
 


### PR DESCRIPTION
As we know the exact versions that used the old `sataportcount` option, it's safe to assume we want to use the newer `portcount` option for everything else.

Reversed the option check and use the `portcount` option by default. Prevents needing to update this for future major versions of VirtualBox.

closes #7144