### PR TITLE
[azure] use deallocate instead of just power-off

### DIFF
--- a/builder/azure/arm/step_power_off_compute.go
+++ b/builder/azure/arm/step_power_off_compute.go
@@ -28,7 +28,7 @@ func NewStepPowerOffCompute(client *AzureClient, ui packer.Ui) *StepPowerOffComp
 }
 
 func (s *StepPowerOffCompute) powerOffCompute(ctx context.Context, resourceGroupName string, computeName string) error {
-	f, err := s.client.VirtualMachinesClient.PowerOff(ctx, resourceGroupName, computeName)
+	f, err := s.client.VirtualMachinesClient.Deallocate(ctx, resourceGroupName, computeName)
 	if err == nil {
 		err = f.WaitForCompletion(ctx, s.client.VirtualMachinesClient.Client)
 	}


### PR DESCRIPTION
1. allegedly prevents error where  fails because VM still appears running
2. prevents left-behind VM's after failures from accumulating charges

/CC @sumit-kalra @amydutta 