### PR TITLE
fix region stuff

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -54,11 +54,11 @@ func (c *AccessConfig) Session() (*session.Session, error) {
 	// retries are exponentially backed off.
 	config = config.WithMaxRetries(8)
 
-	region, err := c.region()
-	if err != nil {
-		return nil, fmt.Errorf("Could not get region, "+
-			"probably because it's not set or we're not running on AWS. %s", err)
-	}
+	region, _ := c.region()
+	// if err != nil {
+	// 	return nil, fmt.Errorf("Could not get region, "+
+	// 		"probably because it's not set or we're not running on AWS. %s", err)
+	// }
 	config = config.WithRegion(region)
 
 	if c.CustomEndpointEc2 != "" {

--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -55,10 +55,6 @@ func (c *AccessConfig) Session() (*session.Session, error) {
 	config = config.WithMaxRetries(8)
 
 	region, _ := c.region()
-	// if err != nil {
-	// 	return nil, fmt.Errorf("Could not get region, "+
-	// 		"probably because it's not set or we're not running on AWS. %s", err)
-	// }
 	config = config.WithRegion(region)
 
 	if c.CustomEndpointEc2 != "" {

--- a/builder/amazon/common/regions.go
+++ b/builder/amazon/common/regions.go
@@ -34,6 +34,9 @@ func (c *AccessConfig) ValidateRegion(regions ...string) error {
 
 	var invalidRegions []string
 	for _, region := range regions {
+		if region == "" {
+			continue
+		}
 		found := false
 		for _, validRegion := range validRegions {
 			if region == validRegion {


### PR DESCRIPTION
If user sets region in env or config file rather than packer config, raw string can be "" which caused the validation code to fail.
Closes #7196 
