### PR TITLE
fix docker tmp dir for mac

### DIFF
--- a/builder/docker/step_temp_dir.go
+++ b/builder/docker/step_temp_dir.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
-	"github.com/hashicorp/packer/packer/tmp"
 )
 
 // StepTempDir creates a temporary directory that we use in order to
@@ -16,12 +16,33 @@ type StepTempDir struct {
 	tempDir string
 }
 
+// ConfigTmpDir returns the configuration tmp directory for Docker
+func ConfigTmpDir() (string, error) {
+	if tmpdir := os.Getenv("PACKER_TMP_DIR"); tmpdir != "" {
+		return filepath.Abs(tmpdir)
+	}
+	configdir, err := packer.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	td := filepath.Join(configdir, "tmp")
+	_, err = os.Stat(td)
+	if os.IsNotExist(err) {
+		if err = os.MkdirAll(td, 0755); err != nil {
+			return "", err
+		}
+	} else if err != nil {
+		return "", err
+	}
+	return td, nil
+}
+
 func (s *StepTempDir) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Creating a temporary directory for sharing data...")
 
-	tempdir, err := tmp.Dir("packer-docker")
+	tempdir, err := ConfigTmpDir()
 	if err != nil {
 		err := fmt.Errorf("Error making temp dir: %s", err)
 		state.Put("error", err)

--- a/website/source/docs/builders/docker.html.md
+++ b/website/source/docs/builders/docker.html.md
@@ -380,9 +380,8 @@ portable provisioning scripts.
 
 ## Overriding the host directory
 
-By default, Packer creates a temporary folder under your system temporary
-directory, and uses that to stage files for uploading into the container. If
-you would like to change the path to this temporary folder, you can set
-environment variable `TMPDIR` (Unix) / `TMP` `TEMP` `USERPROFILE` (Windows) .
+By default, Packer creates a temporary folder under your home directory, and	
+uses that to stage files for uploading into the container. If you would like to	
+change the path to this temporary folder, you can set the `PACKER_TMP_DIR`.
 This can be useful, for example, if you have your home directory permissions
 set up to disallow access from the docker daemon.


### PR DESCRIPTION
this fixes #7208 that I brought in #7102.

I thought that for docker, a temporary directory could be in the system's temporary directory.
But it turns out it needs to be in the home dir on mac. Due this docker-desktop setting :

<img width="493" alt="screenshot 2019-01-18 at 16 46 06" src="https://user-images.githubusercontent.com/1024852/51397035-a022c180-1b40-11e9-8073-e8d3fc7ee66b.png">

And the fact that mac's tmp dir is under `/var/folders/...`.


___

Apparently this `/var/folder` tmp dir was introduced in mac os 10.5 as a security measure. ( years ago )

IMO it would be better to do a PR for docker to add `/var/folders` in possible temporary directories but there is no way it makes it fast enough 🙂 
___

Related: https://github.com/localstack/localstack/issues/480#issuecomment-346920862