### PR TITLE
escape query as suggested in issue #7200

### DIFF
--- a/builder/vmware/common/driver_config.go
+++ b/builder/vmware/common/driver_config.go
@@ -69,9 +69,9 @@ func (c *DriverConfig) Validate(SkipExport bool) error {
 	// now, so that we don't fail for a simple mistake after a long
 	// build
 	ovftool := GetOVFTool()
-	ovfToolArgs := []string{"--verifyOnly", fmt.Sprintf("vi://" +
-		url.QueryEscape(c.RemoteUser) + ":" +
-		url.QueryEscape(c.RemotePassword) + "@" +
+	ovfToolArgs := []string{"--verifyOnly", fmt.Sprintf("vi://%s:%s@%s",
+		url.QueryEscape(c.RemoteUser),
+		url.QueryEscape(c.RemotePassword),
 		c.RemoteHost)}
 
 	var out bytes.Buffer


### PR DESCRIPTION
Fix bug in escaping by adding escaped queries via a format string rather than appending the string to the thing being formatted.

closes #7200