### PR TITLE
Explicitly set ProxyFromEnvironment in httpclients when creating an aws session

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -9,9 +9,11 @@ import (
 	"log"
 	"runtime"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -190,7 +192,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if err != nil {
 		return nil, err
 	}
-	ec2conn := ec2.New(session)
+	ec2conn := ec2.New(session, &aws.Config{
+		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+	})
 
 	wrappedCommand := func(command string) (string, error) {
 		ctx := b.config.ctx

--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/go-cleanhttp"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/template/interpolate"
 )
 
@@ -170,5 +171,10 @@ func (c *AccessConfig) NewEC2Connection() (ec2iface.EC2API, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ec2.New(sess), nil
+
+	ec2conn := ec2.New(sess, &aws.Config{
+		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+	})
+
+	return ec2conn, nil
 }

--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/packer"
 )
 
@@ -70,7 +71,8 @@ func (a *Artifact) Destroy() error {
 		log.Printf("Deregistering image ID (%s) from region (%s)", imageId, region)
 
 		regionConn := ec2.New(a.Session, &aws.Config{
-			Region: aws.String(region),
+			Region:     aws.String(region),
+			HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
 		})
 
 		// Get image metadata

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -100,8 +100,9 @@ func amiRegionCopy(ctx context.Context, state multistep.StateBag, config *Access
 		isEncrypted = true
 	}
 	regionconn := ec2.New(session.Copy(&aws.Config{
-		Region: aws.String(target)},
-	))
+		Region:     aws.String(target),
+		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+	}))
 
 	resp, err := regionconn.CopyImage(&ec2.CopyImageInput{
 		SourceRegion:  &source,

--- a/builder/amazon/common/step_create_tags.go
+++ b/builder/amazon/common/step_create_tags.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	retry "github.com/hashicorp/packer/common"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -35,7 +36,8 @@ func (s *StepCreateTags) Run(_ context.Context, state multistep.StateBag) multis
 		ui.Say(fmt.Sprintf("Adding tags to AMI (%s)...", ami))
 
 		regionConn := ec2.New(session, &aws.Config{
-			Region: aws.String(region),
+			HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+			Region:     aws.String(region),
 		})
 
 		// Retrieve image list for given AMI

--- a/builder/amazon/common/step_deregister_ami.go
+++ b/builder/amazon/common/step_deregister_ami.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -37,8 +38,9 @@ func (s *StepDeregisterAMI) Run(_ context.Context, state multistep.StateBag) mul
 		}
 
 		regionconn := ec2.New(session.Copy(&aws.Config{
-			Region: aws.String(region)},
-		))
+			Region:     aws.String(region),
+			HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+		}))
 
 		resp, err := regionconn.DescribeImages(&ec2.DescribeImagesInput{
 			Owners: aws.StringSlice([]string{"self"}),

--- a/builder/amazon/common/step_modify_ami_attributes.go
+++ b/builder/amazon/common/step_modify_ami_attributes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -145,7 +146,8 @@ func (s *StepModifyAMIAttributes) Run(_ context.Context, state multistep.StateBa
 	for region, ami := range amis {
 		ui.Say(fmt.Sprintf("Modifying attributes on AMI (%s)...", ami))
 		regionConn := ec2.New(session, &aws.Config{
-			Region: aws.String(region),
+			Region:     aws.String(region),
+			HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
 		})
 		for name, input := range options {
 			ui.Message(fmt.Sprintf("Modifying: %s", name))
@@ -165,7 +167,8 @@ func (s *StepModifyAMIAttributes) Run(_ context.Context, state multistep.StateBa
 		for _, snapshot := range region_snapshots {
 			ui.Say(fmt.Sprintf("Modifying attributes on snapshot (%s)...", snapshot))
 			regionConn := ec2.New(session, &aws.Config{
-				Region: aws.String(region),
+				Region:     aws.String(region),
+				HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
 			})
 			for name, input := range snapshotOptions {
 				ui.Message(fmt.Sprintf("Modifying: %s", name))

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -97,7 +99,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			return nil, fmt.Errorf("error validating regions: %v", err)
 		}
 	}
-	ec2conn := ec2.New(session)
+	ec2conn := ec2.New(session, &aws.Config{
+		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+	})
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -105,7 +107,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if err != nil {
 		return nil, err
 	}
-	ec2conn := ec2.New(session)
+	ec2conn := ec2.New(session, &aws.Config{
+		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+	})
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -94,7 +96,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if err != nil {
 		return nil, err
 	}
-	ec2conn := ec2.New(session)
+	ec2conn := ec2.New(session, &aws.Config{
+		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+	})
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -175,7 +177,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if err != nil {
 		return nil, err
 	}
-	ec2conn := ec2.New(session)
+	ec2conn := ec2.New(session, &aws.Config{
+		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+	})
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)

--- a/builder/qemu/step_set_iso.go
+++ b/builder/qemu/step_set_iso.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -28,11 +29,7 @@ func (s *stepSetISO) Run(_ context.Context, state multistep.StateBag) multistep.
 
 		req.Header.Set("User-Agent", "Packer")
 
-		httpClient := &http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-			},
-		}
+		httpClient := commonhelper.HttpClientWithEnvironmentProxy()
 
 		res, err := httpClient.Do(req)
 		if err == nil && (res.StatusCode >= 200 && res.StatusCode < 300) {

--- a/common/download.go
+++ b/common/download.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strings"
 
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/packer"
 )
 
@@ -257,11 +258,7 @@ func (d *HTTPDownloader) Download(dst *os.File, src *url.URL) error {
 		req.Header.Set("User-Agent", d.userAgent)
 	}
 
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		},
-	}
+	httpClient := commonhelper.HttpClientWithEnvironmentProxy()
 
 	resp, err := httpClient.Do(req)
 	if err != nil || resp == nil {

--- a/common/download_test.go
+++ b/common/download_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/packer"
 )
 
@@ -258,11 +258,7 @@ func TestDownloadClient_usesDefaultUserAgent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-		},
-	}
+	httpClient := commonhelper.HttpClientWithEnvironmentProxy()
 
 	_, err = httpClient.Do(req)
 	if err != nil {

--- a/helper/common/default_client.go
+++ b/helper/common/default_client.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	"net/http"
+)
+
+func HttpClientWithEnvironmentProxy() *http.Client {
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
+	}
+	return httpClient
+}

--- a/post-processor/amazon-import/post-processor.go
+++ b/post-processor/amazon-import/post-processor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/common"
+	commonhelper "github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -169,7 +170,9 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	// Call EC2 image import process
 	log.Printf("Calling EC2 to import from s3://%s/%s", p.config.S3Bucket, p.config.S3Key)
 
-	ec2conn := ec2.New(session)
+	ec2conn := ec2.New(session, &aws.Config{
+		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
+	})
 	params := &ec2.ImportImageInput{
 		DiskContainers: []*ec2.ImageDiskContainer{
 			{

--- a/post-processor/vagrant-cloud/client.go
+++ b/post-processor/vagrant-cloud/client.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	commonhelper "github.com/hashicorp/packer/helper/common"
 )
 
 type VagrantCloudClient struct {
@@ -37,11 +39,7 @@ func (v VagrantCloudErrors) FormatErrors() string {
 
 func (v VagrantCloudClient) New(baseUrl string, token string) (*VagrantCloudClient, error) {
 	c := &VagrantCloudClient{
-		client: &http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-			},
-		},
+		client:      commonhelper.HttpClientWithEnvironmentProxy(),
 		BaseURL:     baseUrl,
 		AccessToken: token,
 	}


### PR DESCRIPTION
Here, I create a helper function that creates a very basic http client with ProxyFromEnvironment set, and then use it when instantiating aws sessions. This should fix the proxy issues we've been seeing in 6549.

Closes #6549
