### PR TITLE
Add "custom_data" key to packer manifest post-processor

### DIFF
--- a/post-processor/manifest/artifact.go
+++ b/post-processor/manifest/artifact.go
@@ -10,12 +10,13 @@ type ArtifactFile struct {
 }
 
 type Artifact struct {
-	BuildName     string         `json:"name"`
-	BuilderType   string         `json:"builder_type"`
-	BuildTime     int64          `json:"build_time"`
-	ArtifactFiles []ArtifactFile `json:"files"`
-	ArtifactId    string         `json:"artifact_id"`
-	PackerRunUUID string         `json:"packer_run_uuid"`
+	BuildName     string            `json:"name"`
+	BuilderType   string            `json:"builder_type"`
+	BuildTime     int64             `json:"build_time"`
+	ArtifactFiles []ArtifactFile    `json:"files"`
+	ArtifactId    string            `json:"artifact_id"`
+	PackerRunUUID string            `json:"packer_run_uuid"`
+	CustomData    map[string]string `json:"custom_data"`
 }
 
 func (a *Artifact) BuilderId() string {

--- a/post-processor/manifest/post-processor.go
+++ b/post-processor/manifest/post-processor.go
@@ -18,8 +18,9 @@ import (
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
-	OutputPath string `mapstructure:"output"`
-	StripPath  bool   `mapstructure:"strip_path"`
+	OutputPath string            `mapstructure:"output"`
+	StripPath  bool              `mapstructure:"strip_path"`
+	CustomData map[string]string `mapstructure:"custom_data"`
 	ctx        interpolate.Context
 }
 
@@ -75,6 +76,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, source packer.Artifact) (packe
 		artifact.ArtifactFiles = append(artifact.ArtifactFiles, af)
 	}
 	artifact.ArtifactId = source.Id()
+	artifact.CustomData = p.config.CustomData
 	artifact.BuilderType = p.config.PackerBuilderType
 	artifact.BuildName = p.config.PackerBuildName
 	artifact.BuildTime = time.Now().Unix()

--- a/website/source/docs/post-processors/manifest.html.md
+++ b/website/source/docs/post-processors/manifest.html.md
@@ -38,11 +38,12 @@ post-processors such as Docker and Artifice.
     to `packer-manifest.json`.
 -   `strip_path` (boolean) Write only filename without the path to the manifest
     file. This defaults to false.
+-   `custom_data` (map of strings) Arbitrary data to add to the manifest.
 
 ### Example Configuration
 
 You can simply add `{"type":"manifest"}` to your post-processor section. Below
-is a more verbose example:
+is a more complete example:
 
 ``` json
 {
@@ -50,7 +51,10 @@ is a more verbose example:
     {
       "type": "manifest",
       "output": "manifest.json",
-      "strip_path": true
+      "strip_path": true,
+      "custom_data": {
+        "my_custom_data": "example"
+      }
     }
   ]
 }
@@ -72,7 +76,10 @@ An example manifest file looks like:
         }
       ],
       "artifact_id": "Container",
-      "packer_run_uuid": "6d5d3185-fa95-44e1-8775-9e64fe2e2d8f"
+      "packer_run_uuid": "6d5d3185-fa95-44e1-8775-9e64fe2e2d8f",
+      "custom_data": {
+        "my_custom_data": "example"
+      }
     }
   ],
   "last_run_uuid": "6d5d3185-fa95-44e1-8775-9e64fe2e2d8f"
@@ -114,7 +121,10 @@ The above manifest was generated with this packer.json:
     {
       "type": "manifest",
       "output": "manifest.json",
-      "strip_path": true
+      "strip_path": true,
+      "custom_data": {
+        "my_custom_data": "example"
+      }
     }
   ]
 }


### PR DESCRIPTION
Hi,

This PR introduces a new `user_data` field in the manifest post-processor.

The purpose of this field is to output, as part of the manifest, user-supplied data in the form of key/value strings.

Use case:
We try to use the packer manifest as the single artefact generated from the POV of our CI. One issue we have is that the very limited information contained in the manifest is not sufficient anymore for our use case, and other features we use (like labels on generated gce images) are not a good fit for all kinds of metadata.

We could use the `shell-local` post-processor to generate another file, as I've seen people do elsewhere, but it feels a bit hackish to introduce other scripts to parse/calculate/retreive values when it is already done and the data available in the packer template. This can also introduce errors and not-immediately obvious issues (race conditions for example).

Further, I've seen other issues (#6198, #5413) where this feature could solve at least part of the points raised.

I'm sure other people will find their own uses for it.