### PR TITLE
Hyper-V: Fix integer overflows in 32-bit builds

### DIFF
--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -61,9 +61,9 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	// convert the MB to bytes
-	ramSize := int64(s.RamSize * 1024 * 1024)
-	diskSize := int64(s.DiskSize * 1024 * 1024)
-	diskBlockSize := int64(s.DiskBlockSize * 1024 * 1024)
+	ramSize := int64(s.RamSize) * 1024 * 1024
+	diskSize := int64(s.DiskSize) * 1024 * 1024
+	diskBlockSize := int64(s.DiskBlockSize) * 1024 * 1024
 
 	err := driver.CreateVirtualMachine(s.VMName, path, harddrivePath, ramSize, diskSize, diskBlockSize,
 		s.SwitchName, s.Generation, s.DifferencingDisk, s.FixedVHD, s.Version)


### PR DESCRIPTION
Fixes #7250.

I couldn't find any existing unit tests that cover this section of the codebase that I could basically use as a template, though there is a dummy driver that could be used as a mock/stub.

I'm new to Go so writing a test from scratch in an existing codebase is quite daunting.
