### PR TITLE
Change GCP metadata url to FQDN

### DIFF
--- a/builder/googlecompute/startup.go
+++ b/builder/googlecompute/startup.go
@@ -15,7 +15,7 @@ const StartupScriptStatusNotDone string = "notdone"
 var StartupScriptLinux string = fmt.Sprintf(`#!/usr/bin/env bash
 echo "Packer startup script starting."
 RETVAL=0
-BASEMETADATAURL=http://metadata/computeMetadata/v1/instance/
+BASEMETADATAURL=http://metadata.google.internal/computeMetadata/v1/instance/
 
 GetMetadata () {
   echo "$(curl -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/${1} 2> /dev/null)"


### PR DESCRIPTION
If instance has a different DNS/search domain then "metadata" alone won't work. The FQDN of "metadata.google.internal" is included in hosts file, and will work regardless of DNS configuration. Alternatively the IP 169.254.169.254 can be used.
