### PR TITLE
quote variables in powershell script to account for spaces

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -242,13 +242,13 @@ func getCreateVMScript(opts *scriptOptions) (string, error) {
 	}
 
 	var tpl = template.Must(template.New("createVM").Parse(`
-$vhdPath = Join-Path -Path {{ .Path }} -ChildPath {{ .VHDX }}
+$vhdPath = Join-Path -Path "{{ .Path }}" -ChildPath "{{ .VHDX }}"
 
 {{ if ne .HardDrivePath "" -}}
     {{- if .DiffDisks -}}
-    Hyper-V\New-VHD -Path $vhdPath -ParentPath {{ .HardDrivePath }} -Differencing -BlockSizeBytes {{ .VHDBlockSizeBytes }}
+    Hyper-V\New-VHD -Path $vhdPath -ParentPath "{{ .HardDrivePath }}" -Differencing -BlockSizeBytes {{ .VHDBlockSizeBytes }}
     {{- else -}}
-    Copy-Item -Path {{ .HardDrivePath }} -Destination $vhdPath
+    Copy-Item -Path "{{ .HardDrivePath }}" -Destination $vhdPath
     {{- end -}}
 {{- else -}}
     {{- if .FixedVHD -}}
@@ -258,7 +258,7 @@ $vhdPath = Join-Path -Path {{ .Path }} -ChildPath {{ .VHDX }}
     {{- end -}}
 {{- end }}
 
-Hyper-V\New-VM -Name {{ .VMName }} -Path {{ .Path }} -MemoryStartupBytes {{ .MemoryStartupBytes }} -VHDPath $vhdPath -SwitchName {{ .SwitchName }}
+Hyper-V\New-VM -Name "{{ .VMName }}" -Path "{{ .Path }}" -MemoryStartupBytes {{ .MemoryStartupBytes }} -VHDPath $vhdPath -SwitchName "{{ .SwitchName }}"
 {{- if eq .Generation 2}} -Generation {{ .Generation }} {{- end -}}
 {{- if ne .Version ""}} -Version {{ .Version }} {{- end -}}
 `))

--- a/common/powershell/hyperv/hyperv_test.go
+++ b/common/powershell/hyperv/hyperv_test.go
@@ -26,9 +26,9 @@ func Test_getCreateVMScript(t *testing.T) {
 		t.Fatalf("Error: %s", err.Error())
 	}
 
-	expected := `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhd
-Hyper-V\New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
-Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch -Version 5.0`
+	expected := `$vhdPath = Join-Path -Path "C://mypath" -ChildPath "myvm.vhd"
+Hyper-V\New-VHD -Path $vhdPath -ParentPath "C://harddrivepath" -Differencing -BlockSizeBytes 10
+Hyper-V\New-VM -Name "myvm" -Path "C://mypath" -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName "hyperv-vmx-switch" -Version 5.0`
 	if ok := strings.Compare(scriptString, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
@@ -48,9 +48,9 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 		t.Fatalf("Error: %s", err.Error())
 	}
 
-	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
-Hyper-V\New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
-Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch -Generation 2 -Version 5.0`
+	expected = `$vhdPath = Join-Path -Path "C://mypath" -ChildPath "myvm.vhdx"
+Hyper-V\New-VHD -Path $vhdPath -ParentPath "C://harddrivepath" -Differencing -BlockSizeBytes 10
+Hyper-V\New-VM -Name "myvm" -Path "C://mypath" -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName "hyperv-vmx-switch" -Generation 2 -Version 5.0`
 	if ok := strings.Compare(scriptString, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
@@ -63,9 +63,9 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 		t.Fatalf("Error: %s", err.Error())
 	}
 
-	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
-Hyper-V\New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
-Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch -Version 5.0`
+	expected = `$vhdPath = Join-Path -Path "C://mypath" -ChildPath "myvm.vhdx"
+Hyper-V\New-VHD -Path $vhdPath -ParentPath "C://harddrivepath" -Differencing -BlockSizeBytes 10
+Hyper-V\New-VM -Name "myvm" -Path "C://mypath" -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName "hyperv-vmx-switch" -Version 5.0`
 	if ok := strings.Compare(scriptString, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
@@ -86,9 +86,9 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
-	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
-Hyper-V\New-VHD -Path $vhdPath -ParentPath C://harddrivepath -Differencing -BlockSizeBytes 10
-Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch`
+	expected = `$vhdPath = Join-Path -Path "C://mypath" -ChildPath "myvm.vhdx"
+Hyper-V\New-VHD -Path $vhdPath -ParentPath "C://harddrivepath" -Differencing -BlockSizeBytes 10
+Hyper-V\New-VM -Name "myvm" -Path "C://mypath" -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName "hyperv-vmx-switch"`
 	if ok := strings.Compare(scriptString, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
@@ -98,9 +98,9 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
-	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
-Copy-Item -Path C://harddrivepath -Destination $vhdPath
-Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch`
+	expected = `$vhdPath = Join-Path -Path "C://mypath" -ChildPath "myvm.vhdx"
+Copy-Item -Path "C://harddrivepath" -Destination $vhdPath
+Hyper-V\New-VM -Name "myvm" -Path "C://mypath" -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName "hyperv-vmx-switch"`
 	if ok := strings.Compare(scriptString, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
@@ -110,9 +110,9 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
-	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhdx
+	expected = `$vhdPath = Join-Path -Path "C://mypath" -ChildPath "myvm.vhdx"
 Hyper-V\New-VHD -Path $vhdPath -SizeBytes 8192 -BlockSizeBytes 10
-Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch`
+Hyper-V\New-VM -Name "myvm" -Path "C://mypath" -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName "hyperv-vmx-switch"`
 	if ok := strings.Compare(scriptString, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}
@@ -122,9 +122,9 @@ Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vh
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
-	expected = `$vhdPath = Join-Path -Path C://mypath -ChildPath myvm.vhd
+	expected = `$vhdPath = Join-Path -Path "C://mypath" -ChildPath "myvm.vhd"
 Hyper-V\New-VHD -Path $vhdPath -Fixed -SizeBytes 8192
-Hyper-V\New-VM -Name myvm -Path C://mypath -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName hyperv-vmx-switch`
+Hyper-V\New-VM -Name "myvm" -Path "C://mypath" -MemoryStartupBytes 1024 -VHDPath $vhdPath -SwitchName "hyperv-vmx-switch"`
 	if ok := strings.Compare(scriptString, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, scriptString)
 	}


### PR DESCRIPTION
My work to template the hyperv commands didn't take into account that I'd need to quote things that I am not setting as variables in PS.

Closes #7259 