### PR TITLE
Fix Azure interactive authentication

### DIFF
--- a/builder/azure/arm/authenticate_devicewflow.go
+++ b/builder/azure/arm/authenticate_devicewflow.go
@@ -10,7 +10,11 @@ import (
 )
 
 func NewDeviceFlowOAuthTokenProvider(env azure.Environment, say func(string), tenantID string) oAuthTokenProvider {
-	return &deviceflowOauthTokenProvider{}
+	return &deviceflowOauthTokenProvider{
+		env:      env,
+		say:      say,
+		tenantID: tenantID,
+	}
 }
 
 type deviceflowOauthTokenProvider struct {

--- a/builder/azure/arm/clientconfig.go
+++ b/builder/azure/arm/clientconfig.go
@@ -155,8 +155,7 @@ func (c ClientConfig) useDeviceLogin() bool {
 		c.ClientID == "" &&
 		c.ClientSecret == "" &&
 		c.ClientJWT == "" &&
-		c.ClientCertPath == "" &&
-		c.TenantID == ""
+		c.ClientCertPath == ""
 }
 
 func (c ClientConfig) useMSI() bool {

--- a/builder/azure/arm/clientconfig_test.go
+++ b/builder/azure/arm/clientconfig_test.go
@@ -268,11 +268,18 @@ func getCloud() *azure.Environment {
 // tests for assertRequiredParametersSet
 
 func Test_ClientConfig_CanUseDeviceCode(t *testing.T) {
-	cfg := emptyClientConfig()
-	cfg.SubscriptionID = "12345"
-	// TenantID is optional
-
-	assertValid(t, cfg)
+	// TenantID is optional, but Builder will look up tenant ID before requesting
+	t.Run("without TenantID", func(t *testing.T) {
+		cfg := emptyClientConfig()
+		cfg.SubscriptionID = "12345"
+		assertValid(t, cfg)
+	})
+	t.Run("with TenantID", func(t *testing.T) {
+		cfg := emptyClientConfig()
+		cfg.SubscriptionID = "12345"
+		cfg.TenantID = "12345"
+		assertValid(t, cfg)
+	})
 }
 
 func assertValid(t *testing.T, cfg ClientConfig) {


### PR DESCRIPTION
Builder looks up tenant ID before asking for token. Client config did
not allow that. Also found that token provider was not properly
initialized.

Closes #7267