### PR TITLE
add force to powershell move command

### DIFF
--- a/provisioner/guest_commands.go
+++ b/provisioner/guest_commands.go
@@ -30,7 +30,7 @@ var guestOSTypeCommands = map[string]guestOSTypeCommand{
 		mkdir:     "powershell.exe -Command \"New-Item -ItemType directory -Force -ErrorAction SilentlyContinue -Path %s\"",
 		removeDir: "powershell.exe -Command \"rm %s -recurse -force\"",
 		statPath:  "powershell.exe -Command { if (test-path %s) { exit 0 } else { exit 1 } }",
-		mv:        "powershell.exe -Command \"mv %s %s\"",
+		mv:        "powershell.exe -Command \"mv %s %s -force\"",
 	},
 }
 

--- a/provisioner/guest_commands_test.go
+++ b/provisioner/guest_commands_test.go
@@ -183,7 +183,7 @@ func TestMovePath(t *testing.T) {
 		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
 	}
 	cmd = guestCmd.MovePath("C:\\Temp\\SomeDir", "C:\\Temp\\NewDir")
-	if cmd != "powershell.exe -Command \"mv C:\\Temp\\SomeDir C:\\Temp\\NewDir\"" {
+	if cmd != "powershell.exe -Command \"mv C:\\Temp\\SomeDir C:\\Temp\\NewDir\ -force"" {
 		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
 	}
 

--- a/provisioner/guest_commands_test.go
+++ b/provisioner/guest_commands_test.go
@@ -183,7 +183,7 @@ func TestMovePath(t *testing.T) {
 		t.Fatalf("Failed to create new GuestCommands for OS: %s", WindowsOSType)
 	}
 	cmd = guestCmd.MovePath("C:\\Temp\\SomeDir", "C:\\Temp\\NewDir")
-	if cmd != "powershell.exe -Command \"mv C:\\Temp\\SomeDir C:\\Temp\\NewDir\ -force"" {
+	if cmd != "powershell.exe -Command \"mv C:\\Temp\\SomeDir C:\\Temp\\NewDir -force\"" {
 		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
 	}
 

--- a/provisioner/guest_commands_test.go
+++ b/provisioner/guest_commands_test.go
@@ -189,7 +189,7 @@ func TestMovePath(t *testing.T) {
 
 	// Windows OS w/ space in path
 	cmd = guestCmd.MovePath("C:\\Temp\\Some Dir", "C:\\Temp\\New Dir")
-	if cmd != "powershell.exe -Command \"mv C:\\Temp\\Some` Dir C:\\Temp\\New` Dir\"" {
+	if cmd != "powershell.exe -Command \"mv C:\\Temp\\Some` Dir C:\\Temp\\New` Dir -force\"" {
 		t.Fatalf("Unexpected Windows remove dir cmd: %s", cmd)
 	}
 }


### PR DESCRIPTION
This will add the -Force flag into powershell guest commands used in provisioners.

This fix situations were the file is not replaced because it already exists.

Closes #7280 
Closes #6591 (requires testing)
