### PR TITLE
Allow amazon builders to read credentials from Vault.

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -205,6 +205,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
+	state.Put("access_config", &b.config.AccessConfig)
+	state.Put("ami_config", &b.config.AMIConfig)
 	state.Put("ec2", ec2conn)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -44,11 +44,8 @@ func (s *StepPreValidate) Run(_ context.Context, state multistep.StateBag) multi
 						return false, nil
 					}
 					return true, err
-				} else {
-					return true, nil
 				}
-
-				return true, err
+				return true, nil
 			})
 
 			if err != nil {

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -43,6 +43,7 @@ func (s *StepPreValidate) Run(_ context.Context, state multistep.StateBag) multi
 							" to pass authentication... trying again.")
 						return false, nil
 					}
+					return true, err
 				} else {
 					return true, nil
 				}

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -3,9 +3,12 @@ package common
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	retry "github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -20,6 +23,53 @@ type StepPreValidate struct {
 
 func (s *StepPreValidate) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
+
+	if accessConfig, ok := state.GetOk("access_config"); ok {
+		accessconf := accessConfig.(*AccessConfig)
+		if !accessconf.VaultAWSEngine.Empty() {
+			// loop over the authentication a few times to give vault-created creds
+			// time to become eventually-consistent
+			ui.Say("You're using Vault-generated AWS credentials. It may take a " +
+				"few moments for them to become available on AWS. Waiting...")
+			err := retry.Retry(0.2, 30, 11, func(_ uint) (bool, error) {
+				ec2conn, err := accessconf.NewEC2Connection()
+				if err != nil {
+					return true, err
+				}
+				_, err = listEC2Regions(ec2conn)
+				if err != nil {
+					if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "AuthFailure" {
+						log.Printf("Waiting for Vault-generated AWS credentials" +
+							" to pass authentication... trying again.")
+						return false, nil
+					}
+				} else {
+					return true, nil
+				}
+
+				return true, err
+			})
+
+			if err != nil {
+				state.Put("error", fmt.Errorf("Was unable to Authenticate to AWS using Vault-"+
+					"Generated Credentials within the retry timeout."))
+				return multistep.ActionHalt
+			}
+		}
+
+		if amiConfig, ok := state.GetOk("ami_config"); ok {
+			amiconf := amiConfig.(*AMIConfig)
+			if !amiconf.AMISkipRegionValidation {
+				regionsToValidate := append(amiconf.AMIRegions, accessconf.RawRegion)
+				err := accessconf.ValidateRegion(regionsToValidate...)
+				if err != nil {
+					state.Put("error", fmt.Errorf("error validating regions: %v", err))
+					return multistep.ActionHalt
+				}
+			}
+		}
+	}
+
 	if s.ForceDeregister {
 		ui.Say("Force Deregister flag found, skipping prevalidating AMI Name")
 		return multistep.ActionContinue

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -92,13 +92,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	if err != nil {
 		return nil, err
 	}
-	if !b.config.AMISkipRegionValidation {
-		regionsToValidate := append(b.config.AMIRegions, b.config.RawRegion)
-		err := b.config.AccessConfig.ValidateRegion(regionsToValidate...)
-		if err != nil {
-			return nil, fmt.Errorf("error validating regions: %v", err)
-		}
-	}
+
 	ec2conn := ec2.New(session, &aws.Config{
 		HTTPClient: commonhelper.HttpClientWithEnvironmentProxy(),
 	})
@@ -106,6 +100,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
+	state.Put("access_config", &b.config.AccessConfig)
+	state.Put("ami_config", &b.config.AMIConfig)
 	state.Put("ec2", ec2conn)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -114,6 +114,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
+	state.Put("access_config", &b.config.AccessConfig)
+	state.Put("ami_config", &b.config.AMIConfig)
 	state.Put("ec2", ec2conn)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -103,6 +103,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
+	state.Put("access_config", &b.config.AccessConfig)
 	state.Put("ec2", ec2conn)
 	state.Put("hook", hook)
 	state.Put("ui", ui)

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -184,6 +184,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)
+	state.Put("access_config", &b.config.AccessConfig)
+	state.Put("ami_config", &b.config.AMIConfig)
 	state.Put("ec2", ec2conn)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -362,6 +362,43 @@ each category, the available configuration keys are alphabetized.
     [template engine](/docs/templates/engine.html), see [Build template
     data](#build-template-data) for more information.
 
+- `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
+  secrets engine. You must already have created a role to use. For more
+  information about generating credentials via the Vault engine, see the
+  [Vault docs.]
+  (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+  If you set this
+  flag, you must also set the below options:
+  -   `name` (string) - Required. Specifies the name of the role to generate
+      credentials against. This is part of the request URL.
+  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
+      docs, this is normally referred to as "aws", and Packer will default to
+      "aws" if `engine_name` is not set.
+  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
+      the Vault role is assumed_role. Must match one of the allowed role ARNs
+      in the Vault role. Optional if the Vault role only allows a single AWS
+      role ARN; required otherwise.
+  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
+      specified as a string with a duration suffix. Valid only when
+      credential_type is assumed_role or federation_token. When not specified,
+      the default_sts_ttl set for the role will be used. If that is also not
+      set, then the default value of 3600s will be used. AWS places limits on
+      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
+      parameter for AssumeRole (for assumed_role credential types) and
+      GetFederationToken (for federation_token credential types) for more
+      details.
+
+      Example:
+    ``` json
+    {
+        "vault_aws_engine": {
+            "name": "myrole",
+            "role_arn": "myarn",
+            "ttl": "3600s"
+        }
+    }
+    ```
+
 ## Basic Example
 
 Here is a basic example. It is completely valid except for the access keys:

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -24,7 +24,7 @@ builder is able to build an EBS-backed AMI without launching a new EC2
 instance. This can dramatically speed up AMI builds for organizations who need
 the extra fast build.
 
-~&gt; **This is an advanced builder** If you're just getting started with
+\~&gt; **This is an advanced builder** If you're just getting started with
 Packer, we recommend starting with the [amazon-ebs
 builder](/docs/builders/amazon-ebs.html), which is much easier to use.
 
@@ -154,8 +154,8 @@ each category, the available configuration keys are alphabetized.
     associated with AMIs, which have been deregistered by `force_deregister`.
     Default `false`.
 
--   `insecure_skip_tls_verify` (boolean) - This allows skipping TLS verification of
-    the AWS EC2 endpoint. The default is `false`.
+-   `insecure_skip_tls_verify` (boolean) - This allows skipping TLS
+    verification of the AWS EC2 endpoint. The default is `false`.
 
 -   `kms_key_id` (string) - ID, alias or ARN of the KMS key to use for boot
     volume encryption. This only applies to the main `region`, other regions
@@ -362,42 +362,33 @@ each category, the available configuration keys are alphabetized.
     [template engine](/docs/templates/engine.html), see [Build template
     data](#build-template-data) for more information.
 
-- `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
-  secrets engine. You must already have created a role to use. For more
-  information about generating credentials via the Vault engine, see the
-  [Vault docs.]
-  (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
-  If you set this
-  flag, you must also set the below options:
-  -   `name` (string) - Required. Specifies the name of the role to generate
-      credentials against. This is part of the request URL.
-  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
-      docs, this is normally referred to as "aws", and Packer will default to
-      "aws" if `engine_name` is not set.
-  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
-      the Vault role is assumed_role. Must match one of the allowed role ARNs
-      in the Vault role. Optional if the Vault role only allows a single AWS
-      role ARN; required otherwise.
-  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
-      specified as a string with a duration suffix. Valid only when
-      credential_type is assumed_role or federation_token. When not specified,
-      the default_sts_ttl set for the role will be used. If that is also not
-      set, then the default value of 3600s will be used. AWS places limits on
-      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
-      parameter for AssumeRole (for assumed_role credential types) and
-      GetFederationToken (for federation_token credential types) for more
-      details.
+-   `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
+    secrets engine. You must already have created a role to use. For more
+    information about generating credentials via the Vault engine, see the
+    [Vault
+    docs.](https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+    If you set this flag, you must also set the below options:
+    -   `name` (string) - Required. Specifies the name of the role to generate
+        credentials against. This is part of the request URL.
+    -   `engine_name` (string) - The name of the aws secrets engine. In the
+        Vault docs, this is normally referred to as "aws", and Packer will
+        default to "aws" if `engine_name` is not set.
+    -   `role_arn` (string)- The ARN of the role to assume if credential\_type
+        on the Vault role is assumed\_role. Must match one of the allowed role
+        ARNs in the Vault role. Optional if the Vault role only allows a single
+        AWS role ARN; required otherwise.
+    -   `ttl` (string) - Specifies the TTL for the use of the STS token. This
+        is specified as a string with a duration suffix. Valid only when
+        credential\_type is assumed\_role or federation\_token. When not
+        specified, the default\_sts\_ttl set for the role will be used. If that
+        is also not set, then the default value of 3600s will be used. AWS
+        places limits on the maximum TTL allowed. See the AWS documentation on
+        the DurationSeconds parameter for AssumeRole (for assumed\_role
+        credential types) and GetFederationToken (for federation\_token
+        credential types) for more details.
 
-      Example:
-    ``` json
-    {
-        "vault_aws_engine": {
-            "name": "myrole",
-            "role_arn": "myarn",
-            "ttl": "3600s"
-        }
-    }
-    ```
+        Example:
+        `json   {   "vault_aws_engine": {       "name": "myrole",       "role_arn": "myarn",       "ttl": "3600s"   }   }`
 
 ## Basic Example
 
@@ -494,8 +485,8 @@ services:
 
 ### Ansible provisioner
 
-Running ansible against `amazon-chroot` requires changing the Ansible connection
-to chroot and running Ansible as root/sudo.
+Running ansible against `amazon-chroot` requires changing the Ansible
+connection to chroot and running Ansible as root/sudo.
 
 ### Using Instances with NVMe block devices.
 

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -47,7 +47,8 @@ builder.
 
 -   `access_key` (string) - The access key used to communicate with AWS. [Learn
     how to set this](amazon.html#specifying-amazon-credentials). This is not
-    required if you are using `use_vault_aws_engine` for authentication instead.
+    required if you are using `use_vault_aws_engine` for authentication
+    instead.
 
 -   `ami_name` (string) - The name of the resulting AMI that will appear when
     managing AMIs in the AWS console or via APIs. This must be unique. To help
@@ -62,7 +63,8 @@ builder.
 
 -   `secret_key` (string) - The secret key used to communicate with AWS. [Learn
     how to set this](amazon.html#specifying-amazon-credentials). This is not
-    required if you are using `use_vault_aws_engine` for authentication instead.
+    required if you are using `use_vault_aws_engine` for authentication
+    instead.
 
 -   `source_ami` (string) - The initial AMI used as a base for the newly
     created machine. `source_ami_filter` may be used instead to populate this
@@ -507,31 +509,30 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the instance.
 
-- `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
-  secrets engine. You must already have created a role to use. For more
-  information about generating credentials via the Vault engine, see the
-  [Vault docs.]
-  (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
-  If you set this
-  flag, you must also set the below options:
-  -   `name` (string) - Required. Specifies the name of the role to generate
-      credentials against. This is part of the request URL.
-  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
-      docs, this is normally referred to as "aws", and Packer will default to
-      "aws" if `engine_name` is not set.
-  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
-      the Vault role is assumed_role. Must match one of the allowed role ARNs
-      in the Vault role. Optional if the Vault role only allows a single AWS
-      role ARN; required otherwise.
-  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
-      specified as a string with a duration suffix. Valid only when
-      credential_type is assumed_role or federation_token. When not specified,
-      the default_sts_ttl set for the role will be used. If that is also not
-      set, then the default value of 3600s will be used. AWS places limits on
-      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
-      parameter for AssumeRole (for assumed_role credential types) and
-      GetFederationToken (for federation_token credential types) for more
-      details.
+-   `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
+    secrets engine. You must already have created a role to use. For more
+    information about generating credentials via the Vault engine, see the
+    [Vault
+    docs.](https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+    If you set this flag, you must also set the below options:
+    -   `name` (string) - Required. Specifies the name of the role to generate
+        credentials against. This is part of the request URL.
+    -   `engine_name` (string) - The name of the aws secrets engine. In the
+        Vault docs, this is normally referred to as "aws", and Packer will
+        default to "aws" if `engine_name` is not set.
+    -   `role_arn` (string)- The ARN of the role to assume if credential\_type
+        on the Vault role is assumed\_role. Must match one of the allowed role
+        ARNs in the Vault role. Optional if the Vault role only allows a single
+        AWS role ARN; required otherwise.
+    -   `ttl` (string) - Specifies the TTL for the use of the STS token. This
+        is specified as a string with a duration suffix. Valid only when
+        credential\_type is assumed\_role or federation\_token. When not
+        specified, the default\_sts\_ttl set for the role will be used. If that
+        is also not set, then the default value of 3600s will be used. AWS
+        places limits on the maximum TTL allowed. See the AWS documentation on
+        the DurationSeconds parameter for AssumeRole (for assumed\_role
+        credential types) and GetFederationToken (for federation\_token
+        credential types) for more details.
 
     ``` json
     {

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -507,7 +507,7 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the instance.
 
-- `use_vault_aws_engine` (bool) - Get credentials from Hashicorp Vault's aws
+- `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
   secrets engine. You must already have created a role to use. For more
   information about generating credentials via the Vault engine, see the
   [Vault docs.]
@@ -533,6 +533,16 @@ builder.
       Please note that because credentials that are not supported by an STS
       token are eventually consistent, Packer will pause for ten seconds after
       retrieving the credentials before continuing with the build.
+
+    ``` json
+    {
+        "vault_aws_engine": {
+            "name": "myrole"
+            "role_arn": "myarn"
+            "ttl": "3600s"
+        }
+    }
+    ```
 
 -   `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
     in order to create a temporary security group within the VPC. Requires

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -46,7 +46,8 @@ builder.
 ### Required:
 
 -   `access_key` (string) - The access key used to communicate with AWS. [Learn
-    how to set this](amazon.html#specifying-amazon-credentials)
+    how to set this](amazon.html#specifying-amazon-credentials). This is not
+    required if you are using `use_vault_aws_engine` for authentication instead.
 
 -   `ami_name` (string) - The name of the resulting AMI that will appear when
     managing AMIs in the AWS console or via APIs. This must be unique. To help
@@ -60,7 +61,8 @@ builder.
     to launch the EC2 instance to create the AMI.
 
 -   `secret_key` (string) - The secret key used to communicate with AWS. [Learn
-    how to set this](amazon.html#specifying-amazon-credentials)
+    how to set this](amazon.html#specifying-amazon-credentials). This is not
+    required if you are using `use_vault_aws_engine` for authentication instead.
 
 -   `source_ami` (string) - The initial AMI used as a base for the newly
     created machine. `source_ami_filter` may be used instead to populate this
@@ -504,6 +506,33 @@ builder.
 
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the instance.
+
+- `use_vault_aws_engine` (bool) - Get credentials from Hashicorp Vault's aws
+  secrets engine. You must already have created a role to use. For more
+  information about generating credentials via the Vault engine, see the
+  [Vault docs.]
+  (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+  If you set this
+  flag, you must also set the below options:
+  -   `name` (string) - Required. Specifies the name of the role to generate
+      credentials against. This is part of the request URL.
+  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
+      the Vault role is assumed_role. Must match one of the allowed role ARNs
+      in the Vault role. Optional if the Vault role only allows a single AWS
+      role ARN; required otherwise.
+  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
+      specified as a string with a duration suffix. Valid only when
+      credential_type is assumed_role or federation_token. When not specified,
+      the default_sts_ttl set for the role will be used. If that is also not
+      set, then the default value of 3600s will be used. AWS places limits on
+      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
+      parameter for AssumeRole (for assumed_role credential types) and
+      GetFederationToken (for federation_token credential types) for more
+      details.
+
+      Please note that because credentials that are not supported by an STS
+      token are eventually consistent, Packer will pause for ten seconds after
+      retrieving the credentials before continuing with the build.
 
 -   `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
     in order to create a temporary security group within the VPC. Requires

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -516,6 +516,9 @@ builder.
   flag, you must also set the below options:
   -   `name` (string) - Required. Specifies the name of the role to generate
       credentials against. This is part of the request URL.
+  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
+      docs, this is normally referred to as "aws", and Packer will default to
+      "aws" if `engine_name` is not set.
   -   `role_arn` (string)- The ARN of the role to assume if credential_type on
       the Vault role is assumed_role. Must match one of the allowed role ARNs
       in the Vault role. Optional if the Vault role only allows a single AWS

--- a/website/source/docs/builders/amazon-ebs.html.md
+++ b/website/source/docs/builders/amazon-ebs.html.md
@@ -533,15 +533,11 @@ builder.
       GetFederationToken (for federation_token credential types) for more
       details.
 
-      Please note that because credentials that are not supported by an STS
-      token are eventually consistent, Packer will pause for ten seconds after
-      retrieving the credentials before continuing with the build.
-
     ``` json
     {
         "vault_aws_engine": {
-            "name": "myrole"
-            "role_arn": "myarn"
+            "name": "myrole",
+            "role_arn": "myarn",
             "ttl": "3600s"
         }
     }

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -497,42 +497,33 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the instance.
 
-
 -   `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
     secrets engine. You must already have created a role to use. For more
     information about generating credentials via the Vault engine, see the
-    [Vault docs.]
-    (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+    [Vault
+    docs.](https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
     If you set this flag, you must also set the below options:
-  -   `name` (string) - Required. Specifies the name of the role to generate
-      credentials against. This is part of the request URL.
-  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
-      docs, this is normally referred to as "aws", and Packer will default to
-      "aws" if `engine_name` is not set.
-  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
-      the Vault role is assumed_role. Must match one of the allowed role ARNs
-      in the Vault role. Optional if the Vault role only allows a single AWS
-      role ARN; required otherwise.
-  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
-      specified as a string with a duration suffix. Valid only when
-      credential_type is assumed_role or federation_token. When not specified,
-      the default_sts_ttl set for the role will be used. If that is also not
-      set, then the default value of 3600s will be used. AWS places limits on
-      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
-      parameter for AssumeRole (for assumed_role credential types) and
-      GetFederationToken (for federation_token credential types) for more
-      details.
+-   `name` (string) - Required. Specifies the name of the role to generate
+    credentials against. This is part of the request URL.
+-   `engine_name` (string) - The name of the aws secrets engine. In the Vault
+    docs, this is normally referred to as "aws", and Packer will default to
+    "aws" if `engine_name` is not set.
+-   `role_arn` (string)- The ARN of the role to assume if credential\_type on
+    the Vault role is assumed\_role. Must match one of the allowed role ARNs in
+    the Vault role. Optional if the Vault role only allows a single AWS role
+    ARN; required otherwise.
+-   `ttl` (string) - Specifies the TTL for the use of the STS token. This is
+    specified as a string with a duration suffix. Valid only when
+    credential\_type is assumed\_role or federation\_token. When not specified,
+    the default\_sts\_ttl set for the role will be used. If that is also not
+    set, then the default value of 3600s will be used. AWS places limits on the
+    maximum TTL allowed. See the AWS documentation on the DurationSeconds
+    parameter for AssumeRole (for assumed\_role credential types) and
+    GetFederationToken (for federation\_token credential types) for more
+    details.
 
-      Example:
-    ``` json
-    {
-        "vault_aws_engine": {
-            "name": "myrole",
-            "role_arn": "myarn",
-            "ttl": "3600s"
-        }
-    }
-    ```
+    Example:
+    `json     {   "vault_aws_engine": {       "name": "myrole",       "role_arn": "myarn",       "ttl": "3600s"   }     }`
 -   `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
     in order to create a temporary security group within the VPC. Requires
     `subnet_id` to be set. If this field is left blank, Packer will try to get

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md
@@ -497,6 +497,42 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the instance.
 
+
+-   `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
+    secrets engine. You must already have created a role to use. For more
+    information about generating credentials via the Vault engine, see the
+    [Vault docs.]
+    (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+    If you set this flag, you must also set the below options:
+  -   `name` (string) - Required. Specifies the name of the role to generate
+      credentials against. This is part of the request URL.
+  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
+      docs, this is normally referred to as "aws", and Packer will default to
+      "aws" if `engine_name` is not set.
+  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
+      the Vault role is assumed_role. Must match one of the allowed role ARNs
+      in the Vault role. Optional if the Vault role only allows a single AWS
+      role ARN; required otherwise.
+  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
+      specified as a string with a duration suffix. Valid only when
+      credential_type is assumed_role or federation_token. When not specified,
+      the default_sts_ttl set for the role will be used. If that is also not
+      set, then the default value of 3600s will be used. AWS places limits on
+      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
+      parameter for AssumeRole (for assumed_role credential types) and
+      GetFederationToken (for federation_token credential types) for more
+      details.
+
+      Example:
+    ``` json
+    {
+        "vault_aws_engine": {
+            "name": "myrole",
+            "role_arn": "myarn",
+            "ttl": "3600s"
+        }
+    }
+    ```
 -   `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
     in order to create a temporary security group within the VPC. Requires
     `subnet_id` to be set. If this field is left blank, Packer will try to get

--- a/website/source/docs/builders/amazon-ebsvolume.html.md
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md
@@ -407,6 +407,43 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the instance.
 
+-   `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
+    secrets engine. You must already have created a role to use. For more
+    information about generating credentials via the Vault engine, see the
+    [Vault docs.]
+    (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+    If you set this
+    flag, you must also set the below options:
+  -   `name` (string) - Required. Specifies the name of the role to generate
+      credentials against. This is part of the request URL.
+  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
+      docs, this is normally referred to as "aws", and Packer will default to
+      "aws" if `engine_name` is not set.
+  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
+      the Vault role is assumed_role. Must match one of the allowed role ARNs
+      in the Vault role. Optional if the Vault role only allows a single AWS
+      role ARN; required otherwise.
+  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
+      specified as a string with a duration suffix. Valid only when
+      credential_type is assumed_role or federation_token. When not specified,
+      the default_sts_ttl set for the role will be used. If that is also not
+      set, then the default value of 3600s will be used. AWS places limits on
+      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
+      parameter for AssumeRole (for assumed_role credential types) and
+      GetFederationToken (for federation_token credential types) for more
+      details.
+
+      Example:
+    ``` json
+    {
+        "vault_aws_engine": {
+            "name": "myrole",
+            "role_arn": "myarn",
+            "ttl": "3600s"
+        }
+    }
+    ```
+
 -   `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
     in order to create a temporary security group within the VPC. Requires
     `subnet_id` to be set. If this field is left blank, Packer will try to get

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -489,6 +489,44 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the instance.
 
+
+- `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
+  secrets engine. You must already have created a role to use. For more
+  information about generating credentials via the Vault engine, see the
+  [Vault docs.]
+  (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+  If you set this
+  flag, you must also set the below options:
+  -   `name` (string) - Required. Specifies the name of the role to generate
+      credentials against. This is part of the request URL.
+  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
+      docs, this is normally referred to as "aws", and Packer will default to
+      "aws" if `engine_name` is not set.
+  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
+      the Vault role is assumed_role. Must match one of the allowed role ARNs
+      in the Vault role. Optional if the Vault role only allows a single AWS
+      role ARN; required otherwise.
+  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
+      specified as a string with a duration suffix. Valid only when
+      credential_type is assumed_role or federation_token. When not specified,
+      the default_sts_ttl set for the role will be used. If that is also not
+      set, then the default value of 3600s will be used. AWS places limits on
+      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
+      parameter for AssumeRole (for assumed_role credential types) and
+      GetFederationToken (for federation_token credential types) for more
+      details.
+
+      Example:
+    ``` json
+    {
+        "vault_aws_engine": {
+            "name": "myrole",
+            "role_arn": "myarn",
+            "ttl": "3600s"
+        }
+    }
+    ```
+
 -   `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
     in order to create a temporary security group within the VPC. Requires
     `subnet_id` to be set. If this field is left blank, Packer will try to get

--- a/website/source/docs/builders/amazon-instance.html.md
+++ b/website/source/docs/builders/amazon-instance.html.md
@@ -489,43 +489,33 @@ builder.
 -   `user_data_file` (string) - Path to a file that will be used for the user
     data when launching the instance.
 
+-   `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
+    secrets engine. You must already have created a role to use. For more
+    information about generating credentials via the Vault engine, see the
+    [Vault
+    docs.](https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
+    If you set this flag, you must also set the below options:
+    -   `name` (string) - Required. Specifies the name of the role to generate
+        credentials against. This is part of the request URL.
+    -   `engine_name` (string) - The name of the aws secrets engine. In the
+        Vault docs, this is normally referred to as "aws", and Packer will
+        default to "aws" if `engine_name` is not set.
+    -   `role_arn` (string)- The ARN of the role to assume if credential\_type
+        on the Vault role is assumed\_role. Must match one of the allowed role
+        ARNs in the Vault role. Optional if the Vault role only allows a single
+        AWS role ARN; required otherwise.
+    -   `ttl` (string) - Specifies the TTL for the use of the STS token. This
+        is specified as a string with a duration suffix. Valid only when
+        credential\_type is assumed\_role or federation\_token. When not
+        specified, the default\_sts\_ttl set for the role will be used. If that
+        is also not set, then the default value of 3600s will be used. AWS
+        places limits on the maximum TTL allowed. See the AWS documentation on
+        the DurationSeconds parameter for AssumeRole (for assumed\_role
+        credential types) and GetFederationToken (for federation\_token
+        credential types) for more details.
 
-- `vault_aws_engine` (object) - Get credentials from Hashicorp Vault's aws
-  secrets engine. You must already have created a role to use. For more
-  information about generating credentials via the Vault engine, see the
-  [Vault docs.]
-  (https://www.vaultproject.io/api/secret/aws/index.html#generate-credentials)
-  If you set this
-  flag, you must also set the below options:
-  -   `name` (string) - Required. Specifies the name of the role to generate
-      credentials against. This is part of the request URL.
-  -   `engine_name` (string) - The name of the aws secrets engine. In the Vault
-      docs, this is normally referred to as "aws", and Packer will default to
-      "aws" if `engine_name` is not set.
-  -   `role_arn` (string)- The ARN of the role to assume if credential_type on
-      the Vault role is assumed_role. Must match one of the allowed role ARNs
-      in the Vault role. Optional if the Vault role only allows a single AWS
-      role ARN; required otherwise.
-  -   `ttl` (string) -  Specifies the TTL for the use of the STS token. This is
-      specified as a string with a duration suffix. Valid only when
-      credential_type is assumed_role or federation_token. When not specified,
-      the default_sts_ttl set for the role will be used. If that is also not
-      set, then the default value of 3600s will be used. AWS places limits on
-      the maximum TTL allowed. See the AWS documentation on the DurationSeconds
-      parameter for AssumeRole (for assumed_role credential types) and
-      GetFederationToken (for federation_token credential types) for more
-      details.
-
-      Example:
-    ``` json
-    {
-        "vault_aws_engine": {
-            "name": "myrole",
-            "role_arn": "myarn",
-            "ttl": "3600s"
-        }
-    }
-    ```
+        Example:
+        `json   {   "vault_aws_engine": {       "name": "myrole",       "role_arn": "myarn",       "ttl": "3600s"   }   }`
 
 -   `vpc_id` (string) - If launching into a VPC subnet, Packer needs the VPC ID
     in order to create a temporary security group within the VPC. Requires


### PR DESCRIPTION
This PR allows users to read AWS credentials from the HashiCorp Vault aws secrets engine.

To use, replace your access_key and secret_key in your Packer config with 
```
            "vault_aws_engine": {
              "name": "my-role"
            },
```
replacing "my-role" with the name of the role you want to use in the Vault engine.

See the [Vault docs](https://github.com/hashicorp/vault/blob/756fdc4587350daf1c65b93647b2cc31a6f119cd/website/source/docs/secrets/aws/index.html.md) for getting an aws engine set up to generate new credentials. 

The implementation of the Vault read itself was fairly trivial, but I also had to add a retry loop to wait for the credentials created by Vault to become usable.  This caused enough extra code that I didn't want to have to copy/paste it for each Amazon builder, so I added it to step_pre_validate; this meant I also had to move region validation into step_pre_validate, and honestly it probably should have been there some time ago.

The refactor moving the region validation into step pre-validate also fixes an issue I had introduced in fbb3d526e333434e5865d323ed3178cc2afff8d4 where we were no longer validating regions in any builder but the ebs builder; this happened because I needed to move region validation into the "run" phase of the build and only did it for the ebs builder. No one has raised this as a github issue, but it was definitely a mistake and it's nice that this fixes it and prevents similar goofs from happening in the future.

Closes #6994
