### PR TITLE
[WIP] Use go-rootcerts to support login-keychain in OSX

### DIFF
--- a/command/plugin.go
+++ b/command/plugin.go
@@ -14,22 +14,41 @@ import (
 	"github.com/hashicorp/packer/packer/plugin"
 
 	alicloudecsbuilder "github.com/hashicorp/packer/builder/alicloud/ecs"
+	alicloudimportpostprocessor "github.com/hashicorp/packer/post-processor/alicloud-import"
 	amazonchrootbuilder "github.com/hashicorp/packer/builder/amazon/chroot"
 	amazonebsbuilder "github.com/hashicorp/packer/builder/amazon/ebs"
 	amazonebssurrogatebuilder "github.com/hashicorp/packer/builder/amazon/ebssurrogate"
 	amazonebsvolumebuilder "github.com/hashicorp/packer/builder/amazon/ebsvolume"
+	amazonimportpostprocessor "github.com/hashicorp/packer/post-processor/amazon-import"
 	amazoninstancebuilder "github.com/hashicorp/packer/builder/amazon/instance"
+	ansiblelocalprovisioner "github.com/hashicorp/packer/provisioner/ansible-local"
+	ansibleprovisioner "github.com/hashicorp/packer/provisioner/ansible"
+	artificepostprocessor "github.com/hashicorp/packer/post-processor/artifice"
 	azurearmbuilder "github.com/hashicorp/packer/builder/azure/arm"
+	breakpointprovisioner "github.com/hashicorp/packer/provisioner/breakpoint"
+	checksumpostprocessor "github.com/hashicorp/packer/post-processor/checksum"
+	chefclientprovisioner "github.com/hashicorp/packer/provisioner/chef-client"
+	chefsoloprovisioner "github.com/hashicorp/packer/provisioner/chef-solo"
 	cloudstackbuilder "github.com/hashicorp/packer/builder/cloudstack"
+	compresspostprocessor "github.com/hashicorp/packer/post-processor/compress"
+	convergeprovisioner "github.com/hashicorp/packer/provisioner/converge"
 	digitaloceanbuilder "github.com/hashicorp/packer/builder/digitalocean"
 	dockerbuilder "github.com/hashicorp/packer/builder/docker"
+	dockerimportpostprocessor "github.com/hashicorp/packer/post-processor/docker-import"
+	dockerpushpostprocessor "github.com/hashicorp/packer/post-processor/docker-push"
+	dockersavepostprocessor "github.com/hashicorp/packer/post-processor/docker-save"
+	dockertagpostprocessor "github.com/hashicorp/packer/post-processor/docker-tag"
 	filebuilder "github.com/hashicorp/packer/builder/file"
+	fileprovisioner "github.com/hashicorp/packer/provisioner/file"
 	googlecomputebuilder "github.com/hashicorp/packer/builder/googlecompute"
+	googlecomputeexportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-export"
+	googlecomputeimportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-import"
 	hcloudbuilder "github.com/hashicorp/packer/builder/hcloud"
 	hypervisobuilder "github.com/hashicorp/packer/builder/hyperv/iso"
 	hypervvmcxbuilder "github.com/hashicorp/packer/builder/hyperv/vmcx"
 	lxcbuilder "github.com/hashicorp/packer/builder/lxc"
 	lxdbuilder "github.com/hashicorp/packer/builder/lxd"
+	manifestpostprocessor "github.com/hashicorp/packer/post-processor/manifest"
 	ncloudbuilder "github.com/hashicorp/packer/builder/ncloud"
 	nullbuilder "github.com/hashicorp/packer/builder/null"
 	oneandonebuilder "github.com/hashicorp/packer/builder/oneandone"
@@ -38,47 +57,29 @@ import (
 	oracleocibuilder "github.com/hashicorp/packer/builder/oracle/oci"
 	parallelsisobuilder "github.com/hashicorp/packer/builder/parallels/iso"
 	parallelspvmbuilder "github.com/hashicorp/packer/builder/parallels/pvm"
+	powershellprovisioner "github.com/hashicorp/packer/provisioner/powershell"
 	profitbricksbuilder "github.com/hashicorp/packer/builder/profitbricks"
+	puppetmasterlessprovisioner "github.com/hashicorp/packer/provisioner/puppet-masterless"
+	puppetserverprovisioner "github.com/hashicorp/packer/provisioner/puppet-server"
 	qemubuilder "github.com/hashicorp/packer/builder/qemu"
+	saltmasterlessprovisioner "github.com/hashicorp/packer/provisioner/salt-masterless"
 	scalewaybuilder "github.com/hashicorp/packer/builder/scaleway"
+	shelllocalpostprocessor "github.com/hashicorp/packer/post-processor/shell-local"
+	shelllocalprovisioner "github.com/hashicorp/packer/provisioner/shell-local"
+	shellprovisioner "github.com/hashicorp/packer/provisioner/shell"
 	tencentcloudcvmbuilder "github.com/hashicorp/packer/builder/tencentcloud/cvm"
 	tritonbuilder "github.com/hashicorp/packer/builder/triton"
+	vagrantcloudpostprocessor "github.com/hashicorp/packer/post-processor/vagrant-cloud"
+	vagrantpostprocessor "github.com/hashicorp/packer/post-processor/vagrant"
 	virtualboxisobuilder "github.com/hashicorp/packer/builder/virtualbox/iso"
 	virtualboxovfbuilder "github.com/hashicorp/packer/builder/virtualbox/ovf"
 	vmwareisobuilder "github.com/hashicorp/packer/builder/vmware/iso"
 	vmwarevmxbuilder "github.com/hashicorp/packer/builder/vmware/vmx"
-	alicloudimportpostprocessor "github.com/hashicorp/packer/post-processor/alicloud-import"
-	amazonimportpostprocessor "github.com/hashicorp/packer/post-processor/amazon-import"
-	artificepostprocessor "github.com/hashicorp/packer/post-processor/artifice"
-	checksumpostprocessor "github.com/hashicorp/packer/post-processor/checksum"
-	compresspostprocessor "github.com/hashicorp/packer/post-processor/compress"
-	dockerimportpostprocessor "github.com/hashicorp/packer/post-processor/docker-import"
-	dockerpushpostprocessor "github.com/hashicorp/packer/post-processor/docker-push"
-	dockersavepostprocessor "github.com/hashicorp/packer/post-processor/docker-save"
-	dockertagpostprocessor "github.com/hashicorp/packer/post-processor/docker-tag"
-	googlecomputeexportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-export"
-	googlecomputeimportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-import"
-	manifestpostprocessor "github.com/hashicorp/packer/post-processor/manifest"
-	shelllocalpostprocessor "github.com/hashicorp/packer/post-processor/shell-local"
-	vagrantpostprocessor "github.com/hashicorp/packer/post-processor/vagrant"
-	vagrantcloudpostprocessor "github.com/hashicorp/packer/post-processor/vagrant-cloud"
 	vspherepostprocessor "github.com/hashicorp/packer/post-processor/vsphere"
 	vspheretemplatepostprocessor "github.com/hashicorp/packer/post-processor/vsphere-template"
-	ansibleprovisioner "github.com/hashicorp/packer/provisioner/ansible"
-	ansiblelocalprovisioner "github.com/hashicorp/packer/provisioner/ansible-local"
-	breakpointprovisioner "github.com/hashicorp/packer/provisioner/breakpoint"
-	chefclientprovisioner "github.com/hashicorp/packer/provisioner/chef-client"
-	chefsoloprovisioner "github.com/hashicorp/packer/provisioner/chef-solo"
-	convergeprovisioner "github.com/hashicorp/packer/provisioner/converge"
-	fileprovisioner "github.com/hashicorp/packer/provisioner/file"
-	powershellprovisioner "github.com/hashicorp/packer/provisioner/powershell"
-	puppetmasterlessprovisioner "github.com/hashicorp/packer/provisioner/puppet-masterless"
-	puppetserverprovisioner "github.com/hashicorp/packer/provisioner/puppet-server"
-	saltmasterlessprovisioner "github.com/hashicorp/packer/provisioner/salt-masterless"
-	shellprovisioner "github.com/hashicorp/packer/provisioner/shell"
-	shelllocalprovisioner "github.com/hashicorp/packer/provisioner/shell-local"
 	windowsrestartprovisioner "github.com/hashicorp/packer/provisioner/windows-restart"
 	windowsshellprovisioner "github.com/hashicorp/packer/provisioner/windows-shell"
+
 )
 
 type PluginCommand struct {
@@ -86,79 +87,82 @@ type PluginCommand struct {
 }
 
 var Builders = map[string]packer.Builder{
-	"alicloud-ecs":        new(alicloudecsbuilder.Builder),
-	"amazon-chroot":       new(amazonchrootbuilder.Builder),
-	"amazon-ebs":          new(amazonebsbuilder.Builder),
-	"amazon-ebssurrogate": new(amazonebssurrogatebuilder.Builder),
-	"amazon-ebsvolume":    new(amazonebsvolumebuilder.Builder),
-	"amazon-instance":     new(amazoninstancebuilder.Builder),
-	"azure-arm":           new(azurearmbuilder.Builder),
-	"cloudstack":          new(cloudstackbuilder.Builder),
-	"digitalocean":        new(digitaloceanbuilder.Builder),
-	"docker":              new(dockerbuilder.Builder),
-	"file":                new(filebuilder.Builder),
-	"googlecompute":       new(googlecomputebuilder.Builder),
-	"hcloud":              new(hcloudbuilder.Builder),
-	"hyperv-iso":          new(hypervisobuilder.Builder),
-	"hyperv-vmcx":         new(hypervvmcxbuilder.Builder),
-	"lxc":                 new(lxcbuilder.Builder),
-	"lxd":                 new(lxdbuilder.Builder),
-	"ncloud":              new(ncloudbuilder.Builder),
-	"null":                new(nullbuilder.Builder),
-	"oneandone":           new(oneandonebuilder.Builder),
-	"openstack":           new(openstackbuilder.Builder),
-	"oracle-classic":      new(oracleclassicbuilder.Builder),
-	"oracle-oci":          new(oracleocibuilder.Builder),
-	"parallels-iso":       new(parallelsisobuilder.Builder),
-	"parallels-pvm":       new(parallelspvmbuilder.Builder),
-	"profitbricks":        new(profitbricksbuilder.Builder),
-	"qemu":                new(qemubuilder.Builder),
-	"scaleway":            new(scalewaybuilder.Builder),
-	"tencentcloud-cvm":    new(tencentcloudcvmbuilder.Builder),
-	"triton":              new(tritonbuilder.Builder),
-	"virtualbox-iso":      new(virtualboxisobuilder.Builder),
-	"virtualbox-ovf":      new(virtualboxovfbuilder.Builder),
-	"vmware-iso":          new(vmwareisobuilder.Builder),
-	"vmware-vmx":          new(vmwarevmxbuilder.Builder),
+	"alicloud-ecs":   new(alicloudecsbuilder.Builder),
+	"amazon-chroot":   new(amazonchrootbuilder.Builder),
+	"amazon-ebs":   new(amazonebsbuilder.Builder),
+	"amazon-ebssurrogate":   new(amazonebssurrogatebuilder.Builder),
+	"amazon-ebsvolume":   new(amazonebsvolumebuilder.Builder),
+	"amazon-instance":   new(amazoninstancebuilder.Builder),
+	"azure-arm":   new(azurearmbuilder.Builder),
+	"cloudstack":   new(cloudstackbuilder.Builder),
+	"digitalocean":   new(digitaloceanbuilder.Builder),
+	"docker":   new(dockerbuilder.Builder),
+	"file":   new(filebuilder.Builder),
+	"googlecompute":   new(googlecomputebuilder.Builder),
+	"hcloud":   new(hcloudbuilder.Builder),
+	"hyperv-iso":   new(hypervisobuilder.Builder),
+	"hyperv-vmcx":   new(hypervvmcxbuilder.Builder),
+	"lxc":   new(lxcbuilder.Builder),
+	"lxd":   new(lxdbuilder.Builder),
+	"ncloud":   new(ncloudbuilder.Builder),
+	"null":   new(nullbuilder.Builder),
+	"oneandone":   new(oneandonebuilder.Builder),
+	"openstack":   new(openstackbuilder.Builder),
+	"oracle-classic":   new(oracleclassicbuilder.Builder),
+	"oracle-oci":   new(oracleocibuilder.Builder),
+	"parallels-iso":   new(parallelsisobuilder.Builder),
+	"parallels-pvm":   new(parallelspvmbuilder.Builder),
+	"profitbricks":   new(profitbricksbuilder.Builder),
+	"qemu":   new(qemubuilder.Builder),
+	"scaleway":   new(scalewaybuilder.Builder),
+	"tencentcloud-cvm":   new(tencentcloudcvmbuilder.Builder),
+	"triton":   new(tritonbuilder.Builder),
+	"virtualbox-iso":   new(virtualboxisobuilder.Builder),
+	"virtualbox-ovf":   new(virtualboxovfbuilder.Builder),
+	"vmware-iso":   new(vmwareisobuilder.Builder),
+	"vmware-vmx":   new(vmwarevmxbuilder.Builder),
 }
+
 
 var Provisioners = map[string]packer.Provisioner{
-	"ansible":           new(ansibleprovisioner.Provisioner),
-	"ansible-local":     new(ansiblelocalprovisioner.Provisioner),
-	"breakpoint":        new(breakpointprovisioner.Provisioner),
-	"chef-client":       new(chefclientprovisioner.Provisioner),
-	"chef-solo":         new(chefsoloprovisioner.Provisioner),
-	"converge":          new(convergeprovisioner.Provisioner),
-	"file":              new(fileprovisioner.Provisioner),
-	"powershell":        new(powershellprovisioner.Provisioner),
-	"puppet-masterless": new(puppetmasterlessprovisioner.Provisioner),
-	"puppet-server":     new(puppetserverprovisioner.Provisioner),
+	"ansible":   new(ansibleprovisioner.Provisioner),
+	"ansible-local":   new(ansiblelocalprovisioner.Provisioner),
+	"breakpoint":   new(breakpointprovisioner.Provisioner),
+	"chef-client":   new(chefclientprovisioner.Provisioner),
+	"chef-solo":   new(chefsoloprovisioner.Provisioner),
+	"converge":   new(convergeprovisioner.Provisioner),
+	"file":   new(fileprovisioner.Provisioner),
+	"powershell":   new(powershellprovisioner.Provisioner),
+	"puppet-masterless":   new(puppetmasterlessprovisioner.Provisioner),
+	"puppet-server":   new(puppetserverprovisioner.Provisioner),
 	"salt-masterless":   new(saltmasterlessprovisioner.Provisioner),
-	"shell":             new(shellprovisioner.Provisioner),
-	"shell-local":       new(shelllocalprovisioner.Provisioner),
+	"shell":   new(shellprovisioner.Provisioner),
+	"shell-local":   new(shelllocalprovisioner.Provisioner),
 	"windows-restart":   new(windowsrestartprovisioner.Provisioner),
-	"windows-shell":     new(windowsshellprovisioner.Provisioner),
+	"windows-shell":   new(windowsshellprovisioner.Provisioner),
 }
 
+
 var PostProcessors = map[string]packer.PostProcessor{
-	"alicloud-import":      new(alicloudimportpostprocessor.PostProcessor),
-	"amazon-import":        new(amazonimportpostprocessor.PostProcessor),
-	"artifice":             new(artificepostprocessor.PostProcessor),
-	"checksum":             new(checksumpostprocessor.PostProcessor),
-	"compress":             new(compresspostprocessor.PostProcessor),
-	"docker-import":        new(dockerimportpostprocessor.PostProcessor),
-	"docker-push":          new(dockerpushpostprocessor.PostProcessor),
-	"docker-save":          new(dockersavepostprocessor.PostProcessor),
-	"docker-tag":           new(dockertagpostprocessor.PostProcessor),
-	"googlecompute-export": new(googlecomputeexportpostprocessor.PostProcessor),
-	"googlecompute-import": new(googlecomputeimportpostprocessor.PostProcessor),
-	"manifest":             new(manifestpostprocessor.PostProcessor),
-	"shell-local":          new(shelllocalpostprocessor.PostProcessor),
-	"vagrant":              new(vagrantpostprocessor.PostProcessor),
-	"vagrant-cloud":        new(vagrantcloudpostprocessor.PostProcessor),
-	"vsphere":              new(vspherepostprocessor.PostProcessor),
-	"vsphere-template":     new(vspheretemplatepostprocessor.PostProcessor),
+	"alicloud-import":   new(alicloudimportpostprocessor.PostProcessor),
+	"amazon-import":   new(amazonimportpostprocessor.PostProcessor),
+	"artifice":   new(artificepostprocessor.PostProcessor),
+	"checksum":   new(checksumpostprocessor.PostProcessor),
+	"compress":   new(compresspostprocessor.PostProcessor),
+	"docker-import":   new(dockerimportpostprocessor.PostProcessor),
+	"docker-push":   new(dockerpushpostprocessor.PostProcessor),
+	"docker-save":   new(dockersavepostprocessor.PostProcessor),
+	"docker-tag":   new(dockertagpostprocessor.PostProcessor),
+	"googlecompute-export":   new(googlecomputeexportpostprocessor.PostProcessor),
+	"googlecompute-import":   new(googlecomputeimportpostprocessor.PostProcessor),
+	"manifest":   new(manifestpostprocessor.PostProcessor),
+	"shell-local":   new(shelllocalpostprocessor.PostProcessor),
+	"vagrant":   new(vagrantpostprocessor.PostProcessor),
+	"vagrant-cloud":   new(vagrantcloudpostprocessor.PostProcessor),
+	"vsphere":   new(vspherepostprocessor.PostProcessor),
+	"vsphere-template":   new(vspheretemplatepostprocessor.PostProcessor),
 }
+
 
 var pluginRegexp = regexp.MustCompile("packer-(builder|post-processor|provisioner)-(.+)")
 

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -14,41 +14,22 @@ import (
 	"github.com/hashicorp/packer/packer/plugin"
 
 	alicloudecsbuilder "github.com/hashicorp/packer/builder/alicloud/ecs"
-	alicloudimportpostprocessor "github.com/hashicorp/packer/post-processor/alicloud-import"
 	amazonchrootbuilder "github.com/hashicorp/packer/builder/amazon/chroot"
 	amazonebsbuilder "github.com/hashicorp/packer/builder/amazon/ebs"
 	amazonebssurrogatebuilder "github.com/hashicorp/packer/builder/amazon/ebssurrogate"
 	amazonebsvolumebuilder "github.com/hashicorp/packer/builder/amazon/ebsvolume"
-	amazonimportpostprocessor "github.com/hashicorp/packer/post-processor/amazon-import"
 	amazoninstancebuilder "github.com/hashicorp/packer/builder/amazon/instance"
-	ansiblelocalprovisioner "github.com/hashicorp/packer/provisioner/ansible-local"
-	ansibleprovisioner "github.com/hashicorp/packer/provisioner/ansible"
-	artificepostprocessor "github.com/hashicorp/packer/post-processor/artifice"
 	azurearmbuilder "github.com/hashicorp/packer/builder/azure/arm"
-	breakpointprovisioner "github.com/hashicorp/packer/provisioner/breakpoint"
-	checksumpostprocessor "github.com/hashicorp/packer/post-processor/checksum"
-	chefclientprovisioner "github.com/hashicorp/packer/provisioner/chef-client"
-	chefsoloprovisioner "github.com/hashicorp/packer/provisioner/chef-solo"
 	cloudstackbuilder "github.com/hashicorp/packer/builder/cloudstack"
-	compresspostprocessor "github.com/hashicorp/packer/post-processor/compress"
-	convergeprovisioner "github.com/hashicorp/packer/provisioner/converge"
 	digitaloceanbuilder "github.com/hashicorp/packer/builder/digitalocean"
 	dockerbuilder "github.com/hashicorp/packer/builder/docker"
-	dockerimportpostprocessor "github.com/hashicorp/packer/post-processor/docker-import"
-	dockerpushpostprocessor "github.com/hashicorp/packer/post-processor/docker-push"
-	dockersavepostprocessor "github.com/hashicorp/packer/post-processor/docker-save"
-	dockertagpostprocessor "github.com/hashicorp/packer/post-processor/docker-tag"
 	filebuilder "github.com/hashicorp/packer/builder/file"
-	fileprovisioner "github.com/hashicorp/packer/provisioner/file"
 	googlecomputebuilder "github.com/hashicorp/packer/builder/googlecompute"
-	googlecomputeexportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-export"
-	googlecomputeimportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-import"
 	hcloudbuilder "github.com/hashicorp/packer/builder/hcloud"
 	hypervisobuilder "github.com/hashicorp/packer/builder/hyperv/iso"
 	hypervvmcxbuilder "github.com/hashicorp/packer/builder/hyperv/vmcx"
 	lxcbuilder "github.com/hashicorp/packer/builder/lxc"
 	lxdbuilder "github.com/hashicorp/packer/builder/lxd"
-	manifestpostprocessor "github.com/hashicorp/packer/post-processor/manifest"
 	ncloudbuilder "github.com/hashicorp/packer/builder/ncloud"
 	nullbuilder "github.com/hashicorp/packer/builder/null"
 	oneandonebuilder "github.com/hashicorp/packer/builder/oneandone"
@@ -57,29 +38,47 @@ import (
 	oracleocibuilder "github.com/hashicorp/packer/builder/oracle/oci"
 	parallelsisobuilder "github.com/hashicorp/packer/builder/parallels/iso"
 	parallelspvmbuilder "github.com/hashicorp/packer/builder/parallels/pvm"
-	powershellprovisioner "github.com/hashicorp/packer/provisioner/powershell"
 	profitbricksbuilder "github.com/hashicorp/packer/builder/profitbricks"
-	puppetmasterlessprovisioner "github.com/hashicorp/packer/provisioner/puppet-masterless"
-	puppetserverprovisioner "github.com/hashicorp/packer/provisioner/puppet-server"
 	qemubuilder "github.com/hashicorp/packer/builder/qemu"
-	saltmasterlessprovisioner "github.com/hashicorp/packer/provisioner/salt-masterless"
 	scalewaybuilder "github.com/hashicorp/packer/builder/scaleway"
-	shelllocalpostprocessor "github.com/hashicorp/packer/post-processor/shell-local"
-	shelllocalprovisioner "github.com/hashicorp/packer/provisioner/shell-local"
-	shellprovisioner "github.com/hashicorp/packer/provisioner/shell"
 	tencentcloudcvmbuilder "github.com/hashicorp/packer/builder/tencentcloud/cvm"
 	tritonbuilder "github.com/hashicorp/packer/builder/triton"
-	vagrantcloudpostprocessor "github.com/hashicorp/packer/post-processor/vagrant-cloud"
-	vagrantpostprocessor "github.com/hashicorp/packer/post-processor/vagrant"
 	virtualboxisobuilder "github.com/hashicorp/packer/builder/virtualbox/iso"
 	virtualboxovfbuilder "github.com/hashicorp/packer/builder/virtualbox/ovf"
 	vmwareisobuilder "github.com/hashicorp/packer/builder/vmware/iso"
 	vmwarevmxbuilder "github.com/hashicorp/packer/builder/vmware/vmx"
+	alicloudimportpostprocessor "github.com/hashicorp/packer/post-processor/alicloud-import"
+	amazonimportpostprocessor "github.com/hashicorp/packer/post-processor/amazon-import"
+	artificepostprocessor "github.com/hashicorp/packer/post-processor/artifice"
+	checksumpostprocessor "github.com/hashicorp/packer/post-processor/checksum"
+	compresspostprocessor "github.com/hashicorp/packer/post-processor/compress"
+	dockerimportpostprocessor "github.com/hashicorp/packer/post-processor/docker-import"
+	dockerpushpostprocessor "github.com/hashicorp/packer/post-processor/docker-push"
+	dockersavepostprocessor "github.com/hashicorp/packer/post-processor/docker-save"
+	dockertagpostprocessor "github.com/hashicorp/packer/post-processor/docker-tag"
+	googlecomputeexportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-export"
+	googlecomputeimportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-import"
+	manifestpostprocessor "github.com/hashicorp/packer/post-processor/manifest"
+	shelllocalpostprocessor "github.com/hashicorp/packer/post-processor/shell-local"
+	vagrantpostprocessor "github.com/hashicorp/packer/post-processor/vagrant"
+	vagrantcloudpostprocessor "github.com/hashicorp/packer/post-processor/vagrant-cloud"
 	vspherepostprocessor "github.com/hashicorp/packer/post-processor/vsphere"
 	vspheretemplatepostprocessor "github.com/hashicorp/packer/post-processor/vsphere-template"
+	ansibleprovisioner "github.com/hashicorp/packer/provisioner/ansible"
+	ansiblelocalprovisioner "github.com/hashicorp/packer/provisioner/ansible-local"
+	breakpointprovisioner "github.com/hashicorp/packer/provisioner/breakpoint"
+	chefclientprovisioner "github.com/hashicorp/packer/provisioner/chef-client"
+	chefsoloprovisioner "github.com/hashicorp/packer/provisioner/chef-solo"
+	convergeprovisioner "github.com/hashicorp/packer/provisioner/converge"
+	fileprovisioner "github.com/hashicorp/packer/provisioner/file"
+	powershellprovisioner "github.com/hashicorp/packer/provisioner/powershell"
+	puppetmasterlessprovisioner "github.com/hashicorp/packer/provisioner/puppet-masterless"
+	puppetserverprovisioner "github.com/hashicorp/packer/provisioner/puppet-server"
+	saltmasterlessprovisioner "github.com/hashicorp/packer/provisioner/salt-masterless"
+	shellprovisioner "github.com/hashicorp/packer/provisioner/shell"
+	shelllocalprovisioner "github.com/hashicorp/packer/provisioner/shell-local"
 	windowsrestartprovisioner "github.com/hashicorp/packer/provisioner/windows-restart"
 	windowsshellprovisioner "github.com/hashicorp/packer/provisioner/windows-shell"
-
 )
 
 type PluginCommand struct {
@@ -87,82 +86,79 @@ type PluginCommand struct {
 }
 
 var Builders = map[string]packer.Builder{
-	"alicloud-ecs":   new(alicloudecsbuilder.Builder),
-	"amazon-chroot":   new(amazonchrootbuilder.Builder),
-	"amazon-ebs":   new(amazonebsbuilder.Builder),
-	"amazon-ebssurrogate":   new(amazonebssurrogatebuilder.Builder),
-	"amazon-ebsvolume":   new(amazonebsvolumebuilder.Builder),
-	"amazon-instance":   new(amazoninstancebuilder.Builder),
-	"azure-arm":   new(azurearmbuilder.Builder),
-	"cloudstack":   new(cloudstackbuilder.Builder),
-	"digitalocean":   new(digitaloceanbuilder.Builder),
-	"docker":   new(dockerbuilder.Builder),
-	"file":   new(filebuilder.Builder),
-	"googlecompute":   new(googlecomputebuilder.Builder),
-	"hcloud":   new(hcloudbuilder.Builder),
-	"hyperv-iso":   new(hypervisobuilder.Builder),
-	"hyperv-vmcx":   new(hypervvmcxbuilder.Builder),
-	"lxc":   new(lxcbuilder.Builder),
-	"lxd":   new(lxdbuilder.Builder),
-	"ncloud":   new(ncloudbuilder.Builder),
-	"null":   new(nullbuilder.Builder),
-	"oneandone":   new(oneandonebuilder.Builder),
-	"openstack":   new(openstackbuilder.Builder),
-	"oracle-classic":   new(oracleclassicbuilder.Builder),
-	"oracle-oci":   new(oracleocibuilder.Builder),
-	"parallels-iso":   new(parallelsisobuilder.Builder),
-	"parallels-pvm":   new(parallelspvmbuilder.Builder),
-	"profitbricks":   new(profitbricksbuilder.Builder),
-	"qemu":   new(qemubuilder.Builder),
-	"scaleway":   new(scalewaybuilder.Builder),
-	"tencentcloud-cvm":   new(tencentcloudcvmbuilder.Builder),
-	"triton":   new(tritonbuilder.Builder),
-	"virtualbox-iso":   new(virtualboxisobuilder.Builder),
-	"virtualbox-ovf":   new(virtualboxovfbuilder.Builder),
-	"vmware-iso":   new(vmwareisobuilder.Builder),
-	"vmware-vmx":   new(vmwarevmxbuilder.Builder),
+	"alicloud-ecs":        new(alicloudecsbuilder.Builder),
+	"amazon-chroot":       new(amazonchrootbuilder.Builder),
+	"amazon-ebs":          new(amazonebsbuilder.Builder),
+	"amazon-ebssurrogate": new(amazonebssurrogatebuilder.Builder),
+	"amazon-ebsvolume":    new(amazonebsvolumebuilder.Builder),
+	"amazon-instance":     new(amazoninstancebuilder.Builder),
+	"azure-arm":           new(azurearmbuilder.Builder),
+	"cloudstack":          new(cloudstackbuilder.Builder),
+	"digitalocean":        new(digitaloceanbuilder.Builder),
+	"docker":              new(dockerbuilder.Builder),
+	"file":                new(filebuilder.Builder),
+	"googlecompute":       new(googlecomputebuilder.Builder),
+	"hcloud":              new(hcloudbuilder.Builder),
+	"hyperv-iso":          new(hypervisobuilder.Builder),
+	"hyperv-vmcx":         new(hypervvmcxbuilder.Builder),
+	"lxc":                 new(lxcbuilder.Builder),
+	"lxd":                 new(lxdbuilder.Builder),
+	"ncloud":              new(ncloudbuilder.Builder),
+	"null":                new(nullbuilder.Builder),
+	"oneandone":           new(oneandonebuilder.Builder),
+	"openstack":           new(openstackbuilder.Builder),
+	"oracle-classic":      new(oracleclassicbuilder.Builder),
+	"oracle-oci":          new(oracleocibuilder.Builder),
+	"parallels-iso":       new(parallelsisobuilder.Builder),
+	"parallels-pvm":       new(parallelspvmbuilder.Builder),
+	"profitbricks":        new(profitbricksbuilder.Builder),
+	"qemu":                new(qemubuilder.Builder),
+	"scaleway":            new(scalewaybuilder.Builder),
+	"tencentcloud-cvm":    new(tencentcloudcvmbuilder.Builder),
+	"triton":              new(tritonbuilder.Builder),
+	"virtualbox-iso":      new(virtualboxisobuilder.Builder),
+	"virtualbox-ovf":      new(virtualboxovfbuilder.Builder),
+	"vmware-iso":          new(vmwareisobuilder.Builder),
+	"vmware-vmx":          new(vmwarevmxbuilder.Builder),
 }
-
 
 var Provisioners = map[string]packer.Provisioner{
-	"ansible":   new(ansibleprovisioner.Provisioner),
-	"ansible-local":   new(ansiblelocalprovisioner.Provisioner),
-	"breakpoint":   new(breakpointprovisioner.Provisioner),
-	"chef-client":   new(chefclientprovisioner.Provisioner),
-	"chef-solo":   new(chefsoloprovisioner.Provisioner),
-	"converge":   new(convergeprovisioner.Provisioner),
-	"file":   new(fileprovisioner.Provisioner),
-	"powershell":   new(powershellprovisioner.Provisioner),
-	"puppet-masterless":   new(puppetmasterlessprovisioner.Provisioner),
-	"puppet-server":   new(puppetserverprovisioner.Provisioner),
+	"ansible":           new(ansibleprovisioner.Provisioner),
+	"ansible-local":     new(ansiblelocalprovisioner.Provisioner),
+	"breakpoint":        new(breakpointprovisioner.Provisioner),
+	"chef-client":       new(chefclientprovisioner.Provisioner),
+	"chef-solo":         new(chefsoloprovisioner.Provisioner),
+	"converge":          new(convergeprovisioner.Provisioner),
+	"file":              new(fileprovisioner.Provisioner),
+	"powershell":        new(powershellprovisioner.Provisioner),
+	"puppet-masterless": new(puppetmasterlessprovisioner.Provisioner),
+	"puppet-server":     new(puppetserverprovisioner.Provisioner),
 	"salt-masterless":   new(saltmasterlessprovisioner.Provisioner),
-	"shell":   new(shellprovisioner.Provisioner),
-	"shell-local":   new(shelllocalprovisioner.Provisioner),
+	"shell":             new(shellprovisioner.Provisioner),
+	"shell-local":       new(shelllocalprovisioner.Provisioner),
 	"windows-restart":   new(windowsrestartprovisioner.Provisioner),
-	"windows-shell":   new(windowsshellprovisioner.Provisioner),
+	"windows-shell":     new(windowsshellprovisioner.Provisioner),
 }
-
 
 var PostProcessors = map[string]packer.PostProcessor{
-	"alicloud-import":   new(alicloudimportpostprocessor.PostProcessor),
-	"amazon-import":   new(amazonimportpostprocessor.PostProcessor),
-	"artifice":   new(artificepostprocessor.PostProcessor),
-	"checksum":   new(checksumpostprocessor.PostProcessor),
-	"compress":   new(compresspostprocessor.PostProcessor),
-	"docker-import":   new(dockerimportpostprocessor.PostProcessor),
-	"docker-push":   new(dockerpushpostprocessor.PostProcessor),
-	"docker-save":   new(dockersavepostprocessor.PostProcessor),
-	"docker-tag":   new(dockertagpostprocessor.PostProcessor),
-	"googlecompute-export":   new(googlecomputeexportpostprocessor.PostProcessor),
-	"googlecompute-import":   new(googlecomputeimportpostprocessor.PostProcessor),
-	"manifest":   new(manifestpostprocessor.PostProcessor),
-	"shell-local":   new(shelllocalpostprocessor.PostProcessor),
-	"vagrant":   new(vagrantpostprocessor.PostProcessor),
-	"vagrant-cloud":   new(vagrantcloudpostprocessor.PostProcessor),
-	"vsphere":   new(vspherepostprocessor.PostProcessor),
-	"vsphere-template":   new(vspheretemplatepostprocessor.PostProcessor),
+	"alicloud-import":      new(alicloudimportpostprocessor.PostProcessor),
+	"amazon-import":        new(amazonimportpostprocessor.PostProcessor),
+	"artifice":             new(artificepostprocessor.PostProcessor),
+	"checksum":             new(checksumpostprocessor.PostProcessor),
+	"compress":             new(compresspostprocessor.PostProcessor),
+	"docker-import":        new(dockerimportpostprocessor.PostProcessor),
+	"docker-push":          new(dockerpushpostprocessor.PostProcessor),
+	"docker-save":          new(dockersavepostprocessor.PostProcessor),
+	"docker-tag":           new(dockertagpostprocessor.PostProcessor),
+	"googlecompute-export": new(googlecomputeexportpostprocessor.PostProcessor),
+	"googlecompute-import": new(googlecomputeimportpostprocessor.PostProcessor),
+	"manifest":             new(manifestpostprocessor.PostProcessor),
+	"shell-local":          new(shelllocalpostprocessor.PostProcessor),
+	"vagrant":              new(vagrantpostprocessor.PostProcessor),
+	"vagrant-cloud":        new(vagrantcloudpostprocessor.PostProcessor),
+	"vsphere":              new(vspherepostprocessor.PostProcessor),
+	"vsphere-template":     new(vspheretemplatepostprocessor.PostProcessor),
 }
-
 
 var pluginRegexp = regexp.MustCompile("packer-(builder|post-processor|provisioner)-(.+)")
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Azure/go-autorest v10.12.0+incompatible
 	github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4 // indirect
+	github.com/Bowery/prompt v0.0.0-20180817134258-8a1d5376df1c // indirect
 	github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290
 	github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895 // indirect
 	github.com/Jeffail/gabs v1.1.1 // indirect
@@ -34,6 +35,7 @@ require (
 	github.com/circonus-labs/circonusllhist v0.1.3 // indirect
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 // indirect
 	github.com/creack/goselect v0.0.0-20180210034346-528c74964609 // indirect
+	github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f // indirect
 	github.com/denverdino/aliyungo v0.0.0-20180417075537-ebad04655e03
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
@@ -78,7 +80,7 @@ require (
 	github.com/hashicorp/go-oracle-terraform v0.0.0-20181016190316-007121241b79
 	github.com/hashicorp/go-plugin v0.0.0-20181030172320-54b6ff97d818 // indirect
 	github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6 // indirect
-	github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90 // indirect
+	github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90
 	github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86 // indirect
 	github.com/hashicorp/go-uuid v0.0.0-20160329185618-73d19cdc2bf0
 	github.com/hashicorp/go-version v0.0.0-20160119211326-7e3c02b30806
@@ -93,6 +95,7 @@ require (
 	github.com/jefferai/jsonx v0.0.0-20160721235117-9cc31c3135ee // indirect
 	github.com/joyent/triton-go v0.0.0-20180116165742-545edbe0d564
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
+	github.com/kardianos/govendor v1.0.9 // indirect
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
 	github.com/keybase/go-crypto v0.0.0-20181127160227-255a5089e85a // indirect
 	github.com/klauspost/compress v0.0.0-20160131094358-f86d2e6d8a77 // indirect
@@ -122,6 +125,7 @@ require (
 	github.com/mitchellh/panicwrap v0.0.0-20170106182340-fce601fe5557
 	github.com/mitchellh/prefixedio v0.0.0-20151214002211-6e6954073784
 	github.com/mitchellh/reflectwalk v1.0.0
+	github.com/mna/pigeon v1.0.0 // indirect
 	github.com/moul/anonuuid v0.0.0-20160222162117-609b752a95ef // indirect
 	github.com/moul/gotty-client v0.0.0-20180327180212-b26a57ebc215 // indirect
 	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 // indirect
@@ -167,6 +171,7 @@ require (
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
 	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
+	golang.org/x/tools v0.0.0-20190206221403-44bcb96178d3 // indirect
 	google.golang.org/api v0.0.0-20180818000503-e21acd801f91
 	google.golang.org/grpc v1.17.0 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Azure/go-autorest v10.12.0+incompatible h1:6YphwUK+oXbzvCc1fd5VrnxCek
 github.com/Azure/go-autorest v10.12.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4 h1:pSm8mp0T2OH2CPmPDPtwHPr3VAQaOwVF/JbllOPP4xA=
 github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/Bowery/prompt v0.0.0-20180817134258-8a1d5376df1c h1:fAMg70P5ydy1uiIj6CdA69h6nmQKbv18VlVOXhKNrcM=
+github.com/Bowery/prompt v0.0.0-20180817134258-8a1d5376df1c/go.mod h1:4/6eNcqZ09BZ9wLK3tZOjBA1nDj+B0728nlX5YRlSmQ=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290 h1:K9I21XUHNbYD3GNMmJBN0UKJCpdP+glftwNZ7Bo8kqY=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170625215350-4fe035839290/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/DataDog/datadog-go v0.0.0-20180822151419-281ae9f2d895 h1:dmc/C8bpE5VkQn65PNbbyACDC8xw8Hpp/NEurdPmQDQ=
@@ -71,6 +73,8 @@ github.com/creack/goselect v0.0.0-20180210034346-528c74964609 h1:FSxXMd2wCHj6Gqg
 github.com/creack/goselect v0.0.0-20180210034346-528c74964609/go.mod h1:gHrIcH/9UZDn2qgeTUeW5K9eZsVYCH6/60J/FHysWyE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185 h1:3T8ZyTDp5QxTx3NU48JVb2u+75xc040fofcBaN+6jPA=
+github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185/go.mod h1:cFRxtTwTOJkz2x3rQUNCYKWC93yP1VKjR8NUhqFxZNU=
 github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f h1:WH0w/R4Yoey+04HhFxqZ6VX6I0d7RMyw5aXQ9UTvQPs=
 github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f/go.mod h1:xN/JuLBIz4bjkxNmByTiV1IbhfnYb6oo99phBn4Eqhc=
 github.com/denverdino/aliyungo v0.0.0-20180417075537-ebad04655e03 h1:NYqwUkb/ypX8OZmBDpPPbZ4npAPjlGFXZ4aSOyRzRL8=
@@ -204,6 +208,8 @@ github.com/joyent/triton-go v0.0.0-20180116165742-545edbe0d564 h1:+HMa2xWQOm+9eb
 github.com/joyent/triton-go v0.0.0-20180116165742-545edbe0d564/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kardianos/govendor v1.0.9 h1:WOH3FcVI9eOgnIZYg96iwUwrL4eOVx+aQ66oyX2R8Yc=
+github.com/kardianos/govendor v1.0.9/go.mod h1:yvmR6q9ZZ7nSF5Wvh40v0wfP+3TwwL8zYQp+itoZSVM=
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1 h1:PJPDf8OUfOK1bb/NeTKd4f1QXZItOX389VN3B6qC8ro=
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/keybase/go-crypto v0.0.0-20181127160227-255a5089e85a h1:X/UFlwD2/UV0RCy+8ITi4DmxJwk83YUH7bXwkJIHHMo=
@@ -269,6 +275,8 @@ github.com/mitchellh/prefixedio v0.0.0-20151214002211-6e6954073784 h1:+DAetXqxv/
 github.com/mitchellh/prefixedio v0.0.0-20151214002211-6e6954073784/go.mod h1:kB1naBgV9ORnkiTVeyJOI1DavaJkG4oNIq0Af6ZVKUo=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mna/pigeon v1.0.0 h1:n46IoStjdzjaXuyBH53j9HZ8CVqGWpC7P5/v8dP4qEY=
+github.com/mna/pigeon v1.0.0/go.mod h1:Iym28+kJVnC1hfQvv5MUtI6AiFFzvQjHcvI4RFTG/04=
 github.com/moul/anonuuid v0.0.0-20160222162117-609b752a95ef h1:E/seV1Rtsnr2juBw1Dfz4iDPT3/5s1H/BATx+ePmSyo=
 github.com/moul/anonuuid v0.0.0-20160222162117-609b752a95ef/go.mod h1:LgKrp0Iss/BVwquptq4eIe6HPr0s3t1WHT5x0qOh14U=
 github.com/moul/gotty-client v0.0.0-20180327180212-b26a57ebc215 h1:y6FZWUBBt1iPmJyGbGza3ncvVBMKzgd32oFChRZR7Do=
@@ -378,6 +386,8 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 h1:+DCIGbF/swA92ohVg0//6X2IVY3KZs6p9mix0ziNYJM=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190206221403-44bcb96178d3 h1:M9mD7d4inzK0+YbTneZEs9Y+q1B1zLv8YxJDJ6hFgnY=
+golang.org/x/tools v0.0.0-20190206221403-44bcb96178d3/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/api v0.0.0-20180818000503-e21acd801f91 h1:MgYYgjaWMS2qQiDwCznfbqNmEOdSULlvjCvSCvIe/Wo=
 google.golang.org/api v0.0.0-20180818000503-e21acd801f91/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=

--- a/helper/common/default_client.go
+++ b/helper/common/default_client.go
@@ -3,19 +3,18 @@ package common
 import (
 	"net/http"
 
-    "github.com/hashicorp/go-rootcerts"
+	"github.com/hashicorp/go-rootcerts"
 )
 
 func HttpClientWithEnvironmentProxy() *http.Client {
-    httpTransport := &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-    }
-    rootcerts.ConfigureTLS(httpTransport.TLSClientConfig, nil)
+	httpTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+	rootcerts.ConfigureTLS(httpTransport.TLSClientConfig, nil)
 
 	httpClient := &http.Client{
 		Transport: httpTransport,
 	}
-    
 
 	return httpClient
 }

--- a/helper/common/default_client.go
+++ b/helper/common/default_client.go
@@ -2,13 +2,20 @@ package common
 
 import (
 	"net/http"
+
+    "github.com/hashicorp/go-rootcerts"
 )
 
 func HttpClientWithEnvironmentProxy() *http.Client {
-	httpClient := &http.Client{
-		Transport: &http.Transport{
+    httpTransport := &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
-		},
+    }
+    rootcerts.ConfigureTLS(httpTransport.TLSClientConfig, nil)
+
+	httpClient := &http.Client{
+		Transport: httpTransport,
 	}
+    
+
 	return httpClient
 }


### PR DESCRIPTION
This change introduces go-rootcerts usage for the default http client, such requests made will be able to use the login-keychain in OSX. I haven't actually made this work locally, not quite sure why - inputs are very much welcome :-)

The change should be similar in functionality to what has already been done for the atlas provider #3494

I discovered this "error" when trying to use packer to upload a vagrant box to our internal repository, using a corporate internal certificate.

I'm not aware of any issues already opened.