### PR TITLE
Fix 7256

### DIFF
--- a/builder/virtualbox/common/step_attach_guest_additions.go
+++ b/builder/virtualbox/common/step_attach_guest_additions.go
@@ -21,8 +21,9 @@ import (
 //
 // Produces:
 type StepAttachGuestAdditions struct {
-	attachedPath       string
-	GuestAdditionsMode string
+	attachedPath            string
+	GuestAdditionsMode      string
+	GuestAdditionsInterface string
 }
 
 func (s *StepAttachGuestAdditions) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -40,12 +41,22 @@ func (s *StepAttachGuestAdditions) Run(_ context.Context, state multistep.StateB
 	guestAdditionsPath := state.Get("guest_additions_path").(string)
 
 	// Attach the guest additions to the computer
+
+	controllerName := "IDE Controller"
+	port := "1"
+	device := "0"
+	if s.GuestAdditionsInterface == "sata" {
+		controllerName = "SATA Controller"
+		port = "2"
+		device = "0"
+	}
+
 	log.Println("Attaching guest additions ISO onto IDE controller...")
 	command := []string{
 		"storageattach", vmName,
-		"--storagectl", "IDE Controller",
-		"--port", "1",
-		"--device", "0",
+		"--storagectl", controllerName,
+		"--port", port,
+		"--device", device,
 		"--type", "dvddrive",
 		"--medium", guestAdditionsPath,
 	}
@@ -71,11 +82,20 @@ func (s *StepAttachGuestAdditions) Cleanup(state multistep.StateBag) {
 	driver := state.Get("driver").(Driver)
 	vmName := state.Get("vmName").(string)
 
+	controllerName := "IDE Controller"
+	port := "1"
+	device := "0"
+	if s.GuestAdditionsInterface == "sata" {
+		controllerName = "SATA Controller"
+		port = "2"
+		device = "0"
+	}
+
 	command := []string{
 		"storageattach", vmName,
-		"--storagectl", "IDE Controller",
-		"--port", "1",
-		"--device", "0",
+		"--storagectl", controllerName,
+		"--port", port,
+		"--device", device,
 		"--medium", "none",
 	}
 

--- a/builder/virtualbox/common/step_remove_devices.go
+++ b/builder/virtualbox/common/step_remove_devices.go
@@ -20,7 +20,8 @@ import (
 //
 // Produces:
 type StepRemoveDevices struct {
-	Bundling VBoxBundleConfig
+	Bundling                VBoxBundleConfig
+	GuestAdditionsInterface string
 }
 
 func (s *StepRemoveDevices) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -100,11 +101,19 @@ func (s *StepRemoveDevices) Run(_ context.Context, state multistep.StateBag) mul
 
 	if _, ok := state.GetOk("guest_additions_attached"); ok {
 		ui.Message("Removing guest additions drive...")
+		controllerName := "IDE Controller"
+		port := "1"
+		device := "0"
+		if s.GuestAdditionsInterface == "sata" {
+			controllerName = "SATA Controller"
+			port = "2"
+			device = "0"
+		}
 		command := []string{
 			"storageattach", vmName,
-			"--storagectl", "IDE Controller",
-			"--port", "1",
-			"--device", "0",
+			"--storagectl", controllerName,
+			"--port", port,
+			"--device", device,
 			"--medium", "none",
 		}
 		if err := driver.VBoxManage(command...); err != nil {

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -41,20 +41,21 @@ type Config struct {
 	vboxcommon.VBoxVersionConfig    `mapstructure:",squash"`
 	vboxcommon.VBoxBundleConfig     `mapstructure:",squash"`
 
-	DiskSize               uint   `mapstructure:"disk_size"`
-	GuestAdditionsMode     string `mapstructure:"guest_additions_mode"`
-	GuestAdditionsPath     string `mapstructure:"guest_additions_path"`
-	GuestAdditionsSHA256   string `mapstructure:"guest_additions_sha256"`
-	GuestAdditionsURL      string `mapstructure:"guest_additions_url"`
-	GuestOSType            string `mapstructure:"guest_os_type"`
-	HardDriveDiscard       bool   `mapstructure:"hard_drive_discard"`
-	HardDriveInterface     string `mapstructure:"hard_drive_interface"`
-	SATAPortCount          int    `mapstructure:"sata_port_count"`
-	HardDriveNonrotational bool   `mapstructure:"hard_drive_nonrotational"`
-	ISOInterface           string `mapstructure:"iso_interface"`
-	KeepRegistered         bool   `mapstructure:"keep_registered"`
-	SkipExport             bool   `mapstructure:"skip_export"`
-	VMName                 string `mapstructure:"vm_name"`
+	DiskSize                uint   `mapstructure:"disk_size"`
+	GuestAdditionsMode      string `mapstructure:"guest_additions_mode"`
+	GuestAdditionsPath      string `mapstructure:"guest_additions_path"`
+	GuestAdditionsSHA256    string `mapstructure:"guest_additions_sha256"`
+	GuestAdditionsURL       string `mapstructure:"guest_additions_url"`
+	GuestAdditionsInterface string `mapstructure:"guest_additions_interface"`
+	GuestOSType             string `mapstructure:"guest_os_type"`
+	HardDriveDiscard        bool   `mapstructure:"hard_drive_discard"`
+	HardDriveInterface      string `mapstructure:"hard_drive_interface"`
+	SATAPortCount           int    `mapstructure:"sata_port_count"`
+	HardDriveNonrotational  bool   `mapstructure:"hard_drive_nonrotational"`
+	ISOInterface            string `mapstructure:"iso_interface"`
+	KeepRegistered          bool   `mapstructure:"keep_registered"`
+	SkipExport              bool   `mapstructure:"skip_export"`
+	VMName                  string `mapstructure:"vm_name"`
 
 	ctx interpolate.Context
 }
@@ -123,6 +124,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	if b.config.ISOInterface == "" {
 		b.config.ISOInterface = "ide"
+	}
+
+	if b.config.GuestAdditionsInterface == "" {
+		b.config.GuestAdditionsInterface = b.config.ISOInterface
 	}
 
 	if b.config.VMName == "" {
@@ -227,7 +232,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		new(stepCreateDisk),
 		new(stepAttachISO),
 		&vboxcommon.StepAttachGuestAdditions{
-			GuestAdditionsMode: b.config.GuestAdditionsMode,
+			GuestAdditionsMode:      b.config.GuestAdditionsMode,
+			GuestAdditionsInterface: b.config.GuestAdditionsInterface,
 		},
 		&vboxcommon.StepConfigureVRDP{
 			VRDPBindAddress: b.config.VRDPBindAddress,
@@ -280,7 +286,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Delay:   b.config.PostShutdownDelay,
 		},
 		&vboxcommon.StepRemoveDevices{
-			Bundling: b.config.VBoxBundleConfig,
+			Bundling:                b.config.VBoxBundleConfig,
+			GuestAdditionsInterface: b.config.GuestAdditionsInterface,
 		},
 		&vboxcommon.StepVBoxManage{
 			Commands: b.config.VBoxManagePost,

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -84,7 +84,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ImportFlags: b.config.ImportFlags,
 		},
 		&vboxcommon.StepAttachGuestAdditions{
-			GuestAdditionsMode: b.config.GuestAdditionsMode,
+			GuestAdditionsMode:      b.config.GuestAdditionsMode,
+			GuestAdditionsInterface: b.config.GuestAdditionsInterface,
 		},
 		&vboxcommon.StepConfigureVRDP{
 			VRDPBindAddress: b.config.VRDPBindAddress,
@@ -136,7 +137,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Timeout: b.config.ShutdownTimeout,
 			Delay:   b.config.PostShutdownDelay,
 		},
-		new(vboxcommon.StepRemoveDevices),
+		&vboxcommon.StepRemoveDevices{
+			GuestAdditionsInterface: b.config.GuestAdditionsInterface,
+		},
 		&vboxcommon.StepVBoxManage{
 			Commands: b.config.VBoxManagePost,
 			Ctx:      b.config.ctx,

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -1,4 +1,4 @@
-Gpackage ovf
+package ovf
 
 import (
 	"fmt"
@@ -73,8 +73,8 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	if c.GuestAdditionsPath == "" {
 		c.GuestAdditionsPath = "VBoxGuestAdditions.iso"
 	}
-	if b.config.GuestAdditionsInterface == "" {
-		b.config.GuestAdditionsInterface = "ide"
+	if c.GuestAdditionsInterface == "" {
+		c.GuestAdditionsInterface = "ide"
 	}
 
 	if c.VMName == "" {

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -1,4 +1,4 @@
-package ovf
+Gpackage ovf
 
 import (
 	"fmt"
@@ -28,19 +28,20 @@ type Config struct {
 	vboxcommon.VBoxManagePostConfig `mapstructure:",squash"`
 	vboxcommon.VBoxVersionConfig    `mapstructure:",squash"`
 
-	Checksum             string   `mapstructure:"checksum"`
-	ChecksumType         string   `mapstructure:"checksum_type"`
-	GuestAdditionsMode   string   `mapstructure:"guest_additions_mode"`
-	GuestAdditionsPath   string   `mapstructure:"guest_additions_path"`
-	GuestAdditionsSHA256 string   `mapstructure:"guest_additions_sha256"`
-	GuestAdditionsURL    string   `mapstructure:"guest_additions_url"`
-	ImportFlags          []string `mapstructure:"import_flags"`
-	ImportOpts           string   `mapstructure:"import_opts"`
-	SourcePath           string   `mapstructure:"source_path"`
-	TargetPath           string   `mapstructure:"target_path"`
-	VMName               string   `mapstructure:"vm_name"`
-	KeepRegistered       bool     `mapstructure:"keep_registered"`
-	SkipExport           bool     `mapstructure:"skip_export"`
+	Checksum                string   `mapstructure:"checksum"`
+	ChecksumType            string   `mapstructure:"checksum_type"`
+	GuestAdditionsMode      string   `mapstructure:"guest_additions_mode"`
+	GuestAdditionsPath      string   `mapstructure:"guest_additions_path"`
+	GuestAdditionsInterface string   `mapstructure:"guest_additions_interface"`
+	GuestAdditionsSHA256    string   `mapstructure:"guest_additions_sha256"`
+	GuestAdditionsURL       string   `mapstructure:"guest_additions_url"`
+	ImportFlags             []string `mapstructure:"import_flags"`
+	ImportOpts              string   `mapstructure:"import_opts"`
+	SourcePath              string   `mapstructure:"source_path"`
+	TargetPath              string   `mapstructure:"target_path"`
+	VMName                  string   `mapstructure:"vm_name"`
+	KeepRegistered          bool     `mapstructure:"keep_registered"`
+	SkipExport              bool     `mapstructure:"skip_export"`
 
 	ctx interpolate.Context
 }
@@ -71,6 +72,9 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	if c.GuestAdditionsPath == "" {
 		c.GuestAdditionsPath = "VBoxGuestAdditions.iso"
+	}
+	if b.config.GuestAdditionsInterface == "" {
+		b.config.GuestAdditionsInterface = "ide"
 	}
 
 	if c.VMName == "" {

--- a/website/source/docs/builders/virtualbox-iso.html.md.erb
+++ b/website/source/docs/builders/virtualbox-iso.html.md.erb
@@ -164,6 +164,12 @@ builder.
 -   `format` (string) - Either `ovf` or `ova`, this specifies the output format
     of the exported virtual machine. This defaults to `ovf`.
 
+-   `guest_additions_interface` (string) - The interface type to use to mount
+    guest additions when `guest_additions_mode` is set to `attach`. Will
+    default to the value set in `iso_interface`, if `iso_interface` is set.
+    Will default to "ide", if `iso_interface` is not set. Options are "ide" and
+    "sata".
+
 -   `guest_additions_mode` (string) - The method by which guest additions are
     made available to the guest for installation. Valid options are `upload`,
     `attach`, or `disable`. If the mode is `attach` the guest additions ISO will

--- a/website/source/docs/builders/virtualbox-ovf.html.md.erb
+++ b/website/source/docs/builders/virtualbox-ovf.html.md.erb
@@ -152,6 +152,10 @@ builder.
 -   `format` (string) - Either `ovf` or `ova`, this specifies the output format
     of the exported virtual machine. This defaults to `ovf`.
 
+-   `guest_additions_interface` (string) - The interface type to use to mount
+    guest additions when `guest_additions_mode` is set to `attach`. Will
+    default to "ide" if not set. Options are "ide" and "sata".
+
 -   `guest_additions_mode` (string) - The method by which guest additions are
     made available to the guest for installation. Valid options are `upload`,
     `attach`, or `disable`. If the mode is `attach` the guest additions ISO will


### PR DESCRIPTION
Adds new "guest_additions_interface" option to enable people who want to attach their guest additions with a SATA interface.

Closes #7256
Closes #7249
