### PR TITLE
allow the basic example to pass packer validate

### DIFF
--- a/website/source/docs/builders/hetzner-cloud.html.md
+++ b/website/source/docs/builders/hetzner-cloud.html.md
@@ -84,11 +84,13 @@ access tokens:
 
 ``` json
 {
-  "type": "hcloud",
-  "token": "YOUR API KEY",
-  "image": "ubuntu-18.04",
-  "location": "nbg1",
-  "server_type": "cx11",
-  "ssh_username": "root"
+  "builders": [{
+    "type": "hcloud",
+    "token": "YOUR API KEY",
+    "image": "ubuntu-18.04",
+    "location": "nbg1",
+    "server_type": "cx11",
+    "ssh_username": "root"
+   }]
 }
 ```


### PR DESCRIPTION
tested with Packer v1.3.4.  Without the builders section is complains for " Unknown root level key in template:  " for every key in the JSON.

