### PR TITLE
also strip \r to work around windows file ending strangeness

### DIFF
--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -47,7 +47,7 @@ type ESX5Driver struct {
 
 func (d *ESX5Driver) Clone(dst, src string, linked bool) error {
 
-	linesToArray := func(lines string) []string { return strings.Split(strings.Trim(lines, "\n"), "\n") }
+	linesToArray := func(lines string) []string { return strings.Split(strings.Trim(lines, "\r\n"), "\n") }
 
 	d.SetOutputDir(path.Dir(filepath.ToSlash(dst)))
 	srcVmx := d.datastorePath(src)


### PR DESCRIPTION
Fixes a bug where we'd strip the \n from a \r\n line ending, but not the \r, causing issues referencing the filename.

Closes #7286
