### PR TITLE
add DescribeInstanceStatus to minimum permissions

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -151,6 +151,7 @@ for Packer to work:
         "ec2:DescribeImageAttribute",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
         "ec2:DescribeRegions",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSnapshots",


### PR DESCRIPTION
Update documentation:
Packer needs DescribeInstanceStatus or else it ends up waiting forever for the instance to become ready.
