### PR TITLE
add noSSLVerify to ovftool args

### DIFF
--- a/builder/vmware/common/driver_config.go
+++ b/builder/vmware/common/driver_config.go
@@ -69,7 +69,7 @@ func (c *DriverConfig) Validate(SkipExport bool) error {
 	// now, so that we don't fail for a simple mistake after a long
 	// build
 	ovftool := GetOVFTool()
-	ovfToolArgs := []string{"--verifyOnly", fmt.Sprintf("vi://%s:%s@%s",
+	ovfToolArgs := []string{"--noSSLVerify", "--verifyOnly", fmt.Sprintf("vi://%s:%s@%s",
 		url.QueryEscape(c.RemoteUser),
 		url.QueryEscape(c.RemotePassword),
 		c.RemoteHost)}


### PR DESCRIPTION
Use flag --noSSLVerify (which is already used elsewhere in the code) when validating username and password. 

Closes #7234 
