### PR TITLE
scripts/build.sh: allow to set build settings when building

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,8 @@
 
 # This script builds the application from source for multiple platforms.
 # Determine the arch/os combos we're building for
-ALL_XC_ARCH="386 amd64 arm arm64 ppc64le"
-ALL_XC_OS="linux darwin windows freebsd openbsd solaris"
+ALL_XC_ARCH=${ALL_XC_ARCH:-"386 amd64 arm arm64 ppc64le"}
+ALL_XC_OS=${ALL_XC_OS:-"linux darwin windows freebsd openbsd solaris"}
 
 # Exit immediately if a command fails
 set -e


### PR DESCRIPTION
this will for example allow me to have the following alias:
```bash
alias buildmain='export T=$(mktemp -d) && ALL_XC_OS="linux darwin windows" ALL_XC_ARCH="amd64" GOLDFLAGS="-s -w" ./scripts/build.sh && cd pkg/ && for dir in *; do zip -r "$dir.zip" $dir & ; done ;  wait && mv *.zip $T/. && open $T'
```

that builds and zips only on 'main' platforms, so that I can share binaries easily.
