### PR TITLE
Make the amazon-private-ip fixer errors more visible

### DIFF
--- a/fix/fixer_amazon_private_ip.go
+++ b/fix/fixer_amazon_private_ip.go
@@ -54,7 +54,6 @@ func (FixerAmazonPrivateIP) Fix(input map[string]interface{}) (map[string]interf
 			privateIP, err = strconv.ParseBool(privateIPi.(string))
 			if err != nil {
 				return nil, fmt.Errorf("ssh_private_ip is not a boolean")
-				continue
 			}
 		}
 

--- a/fix/fixer_amazon_private_ip.go
+++ b/fix/fixer_amazon_private_ip.go
@@ -53,7 +53,7 @@ func (FixerAmazonPrivateIP) Fix(input map[string]interface{}) (map[string]interf
 			var err error
 			privateIP, err = strconv.ParseBool(privateIPi.(string))
 			if err != nil {
-				return nil, fmt.Errorf("ssh_private_ip is not a boolean")
+				return nil, fmt.Errorf("ssh_private_ip is not a boolean, %s", err)
 			}
 		}
 

--- a/fix/fixer_amazon_private_ip.go
+++ b/fix/fixer_amazon_private_ip.go
@@ -1,7 +1,7 @@
 package fix
 
 import (
-	"log"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -53,7 +53,7 @@ func (FixerAmazonPrivateIP) Fix(input map[string]interface{}) (map[string]interf
 			var err error
 			privateIP, err = strconv.ParseBool(privateIPi.(string))
 			if err != nil {
-				log.Fatalf("Wrong type for ssh_private_ip")
+				return nil, fmt.Errorf("ssh_private_ip is not a boolean")
 				continue
 			}
 		}

--- a/fix/fixer_amazon_private_ip_test.go
+++ b/fix/fixer_amazon_private_ip_test.go
@@ -80,7 +80,7 @@ func TestFixerAmazonPrivateIPNonBoolean(t *testing.T) {
 	var f FixerAmazonPrivateIP
 
 	input := map[string]interface{}{
-		"builders": []map[string]interface{}{map[string]interface{}{
+		"builders": []map[string]interface{}{{
 			"type":           "amazon-ebs",
 			"ssh_private_ip": "not-a-boolean-value",
 		}},

--- a/fix/fixer_amazon_private_ip_test.go
+++ b/fix/fixer_amazon_private_ip_test.go
@@ -75,3 +75,19 @@ func TestFixerAmazonPrivateIP(t *testing.T) {
 		}
 	}
 }
+
+func TestFixerAmazonPrivateIPNonBoolean(t *testing.T) {
+	var f FixerAmazonPrivateIP
+
+	input := map[string]interface{}{
+		"builders": []map[string]interface{}{map[string]interface{}{
+			"type":           "amazon-ebs",
+			"ssh_private_ip": "not-a-boolean-value",
+		}},
+	}
+
+	_, err := f.Fix(input)
+	if err == nil {
+		t.Fatal("should have errored")
+	}
+}


### PR DESCRIPTION
At present, when using the `packer fix` command on a template that has `ssh_private_ip` set to anything but a boolean value, the fixer will fail, and appear to fail silently, simply returning a non-zero status code without any message.

To determine what happened, users have to know to set `PACKER_LOG=1` to make the log message visible.

So far as I can tell, this is the only instance of `log.Fatalf` being called, and based on the surrounding code the better solution would be to return an error, which will then be visible to users of `packer fix` without having to look in the logs.

This has come up because for our templates, we set `ssh_private_ip` to a user variable, which means that the value is a string and not a boolean. This problem kept occurring and it was not clear to me as a user what the issue was, and seemed to go against the fix documentation, which implies there should be an error message on failures.
