### PR TITLE
Amazon-chroot: Fix building PV images and where mount_partition is set

### DIFF
--- a/builder/amazon/chroot/step_mount_device.go
+++ b/builder/amazon/chroot/step_mount_device.go
@@ -42,7 +42,7 @@ func (s *StepMountDevice) Run(_ context.Context, state multistep.StateBag) multi
 	wrappedCommand := state.Get("wrappedCommand").(CommandWrapper)
 
 	var virtualizationType string
-	if config.FromScratch {
+	if config.FromScratch || config.AMIVirtType != "" {
 		virtualizationType = config.AMIVirtType
 	} else {
 		image := state.Get("source_image").(*ec2.Image)


### PR DESCRIPTION
Right now, if we have a source image that's PV, and try to build an
image with mount_partition set to not 0, it does not get picked up.
This is because under PV we only had a filesystem, not partitions,
but you can convert a PV image to an HVM image during build time.