### PR TITLE
Fix support for aws-us-gov

### DIFF
--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -151,7 +151,7 @@ func (c *AMIConfig) prepareRegions(accessConfig *AccessConfig) (errs []error) {
 func validateKmsKey(kmsKey string) (valid bool) {
 	kmsKeyIdPattern := `[a-f0-9-]+$`
 	aliasPattern := `alias/[a-zA-Z0-9:/_-]+$`
-	kmsArnStartPattern := `^arn:aws:kms:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12}):`
+	kmsArnStartPattern := `^arn:aws(-us-gov)?:kms:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12}):`
 	if regexp.MustCompile(fmt.Sprintf("^%s", kmsKeyIdPattern)).MatchString(kmsKey) {
 		return true
 	}

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -187,6 +187,7 @@ func TestAMIConfigPrepare_ValidateKmsKey(t *testing.T) {
 		"alias/foo/bar",
 		"arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef",
 		"arn:aws:kms:us-east-1:012345678910:alias/foo/bar",
+		"arn:aws-us-gov:kms:us-gov-east-1:123456789012:key/12345678-1234-abcd-0000-123456789012",
 	}
 	for _, validCase := range validCases {
 		c.AMIKmsKeyId = validCase
@@ -201,6 +202,7 @@ func TestAMIConfigPrepare_ValidateKmsKey(t *testing.T) {
 		"ghij1234+e567_890f-a12b-a123b4cd56ef",
 		"foo/bar",
 		"arn:aws:kms:us-east-1:012345678910:foo/bar",
+		"arn:foo:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef",
 	}
 	for _, invalidCase := range invalidCases {
 		c.AMIKmsKeyId = invalidCase


### PR DESCRIPTION
While the `kmsArnStartPattern` regexp supports `us-gov` as a region, it does not take the AWS partition into consideration.

For more info see https://docs.aws.amazon.com/govcloud-us/latest/ug-east/using-govcloud-arns.html