### PR TITLE
move pause to after connection can be established.

### DIFF
--- a/helper/communicator/step_connect.go
+++ b/helper/communicator/step_connect.go
@@ -60,13 +60,6 @@ func (s *StepConnect) pause(pauseLen time.Duration, ctx context.Context) bool {
 func (s *StepConnect) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
-	if s.Config.PauseBeforeConnect > 0 {
-		cancelled := s.pause(s.Config.PauseBeforeConnect, ctx)
-		if cancelled {
-			return multistep.ActionHalt
-		}
-	}
-
 	typeMap := map[string]multistep.Step{
 		"none": nil,
 		"ssh": &StepConnectSSH{
@@ -114,7 +107,19 @@ func (s *StepConnect) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 
 	s.substep = step
-	return s.substep.Run(ctx, state)
+	action := s.substep.Run(ctx, state)
+	if action == multistep.ActionHalt {
+		return action
+	}
+
+	if s.Config.PauseBeforeConnect > 0 {
+		cancelled := s.pause(s.Config.PauseBeforeConnect, ctx)
+		if cancelled {
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
 }
 
 func (s *StepConnect) Cleanup(state multistep.StateBag) {


### PR DESCRIPTION
It's more intuitive to make this wait happen after SSH becomes available, not after boot.