### PR TITLE
Issue 7140

### DIFF
--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -68,7 +68,7 @@ func (d *ESX5Driver) Clone(dst, src string, linked bool) error {
 		return fmt.Errorf("Failed to copy the vmx file %s: %s", srcVmx, err)
 	}
 
-	filesToClone, err := d.run(nil, "find", strconv.Quote(srcDir), "! -name '*.vmdk' ! -name '*.vmx' -type f ! -size 0")
+	filesToClone, err := d.run(nil, "find", strconv.Quote(srcDir), "! -name '*.vmdk' ! -name '*.vmx' ! -name '*.vmxf' -type f ! -size 0")
 	if err != nil {
 		return fmt.Errorf("Failed to get the file list to copy: %s", err)
 	}

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -103,15 +103,15 @@ func (s *StepConfigureVMX) Run(_ context.Context, state multistep.StateBag) mult
 	}
 
 	// Set the extendedConfigFile setting for the .vmxf filename to the VMName
-	// if displayName is not set. This is needed so that when VMWare creates 
+	// if displayName is not set. This is needed so that when VMWare creates
 	// the .vmxf file it matches the displayName if it is set. When just using
 	// the sisplayName if it was empty VMWare would make a file named ".vmxf".
 	// The ".vmxf" file would not get deleted when the VM got deleted.
-        if s.DisplayName != "" {
-                vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.DisplayName)
-        } else {
-                vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.VMName)
-        }
+	if s.DisplayName != "" {
+		vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.DisplayName)
+	} else {
+		vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.VMName)
+	}
 
 	err = WriteVMX(vmxPath, vmxData)
 

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -102,7 +102,16 @@ func (s *StepConfigureVMX) Run(_ context.Context, state multistep.StateBag) mult
 		}
 	}
 
-	vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.DisplayName)
+	// Set the extendedConfigFile setting for the .vmxf filename to the VMName
+	// if displayName is not set. This is needed so that when VMWare creates 
+	// the .vmxf file it matches the displayName if it is set. When just using
+	// the sisplayName if it was empty VMWare would make a file named ".vmxf".
+	// The ".vmxf" file would not get deleted when the VM got deleted.
+        if s.DisplayName != "" {
+                vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.DisplayName)
+        } else {
+                vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.VMName)
+        }
 
 	err = WriteVMX(vmxPath, vmxData)
 

--- a/builder/vmware/common/step_configure_vmx.go
+++ b/builder/vmware/common/step_configure_vmx.go
@@ -102,6 +102,8 @@ func (s *StepConfigureVMX) Run(_ context.Context, state multistep.StateBag) mult
 		}
 	}
 
+	vmxData["extendedconfigfile"] = fmt.Sprintf("%s.vmxf", s.DisplayName)
+
 	err = WriteVMX(vmxPath, vmxData)
 
 	if err != nil {


### PR DESCRIPTION
The vmx file has a property called extendedconfigfile that on initial setup sets the value of this property to <vmname>.vmxf. The cloning of the vmx file from one VM to another was not adjusting this name.

The other fix in this pull request is to not copy the .vmxf file from the source VM to the target VM as the name of the file does not match the new VM name and VMWare will not delete the file when the VM gets deleted. This causes the .vmxf and the folder that the target VM was deployed in to remain even after VMWare says the VM was destroyed. This will cause Packer to failed to rebuilding the same VM as the paths were not cleaned up properly. This will also cause Packer to hang if the build has a error and Packer tries to cleanup the VM. Packer will wait until the path of the VM on the datastore is empty which it will never become empty as VMware left the .vmxf and the folder behind.

Closes #7140 
