### PR TITLE
googlecompute-export: set network project id to builder

### DIFF
--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -125,6 +125,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		MachineType:          p.config.MachineType,
 		Metadata:             exporterMetadata,
 		Network:              p.config.Network,
+		NetworkProjectId:     builderProjectId,
 		RawStateTimeout:      "5m",
 		SourceImageFamily:    "debian-9-worker",
 		SourceImageProjectId: "compute-image-tools",

--- a/website/source/docs/post-processors/googlecompute-export.html.md
+++ b/website/source/docs/post-processors/googlecompute-export.html.md
@@ -54,7 +54,7 @@ permissions to the GCS `paths`.
 -   `network` (string) - The Google Compute network id or URL to use for the
     export instance. Defaults to `"default"`. If the value is not a URL, it
     will be interpolated to
-    `projects/((network_project_id))/global/networks/((network))`. This value
+    `projects/((builder_project_id))/global/networks/((network))`. This value
     is not required if a `subnet` is specified.
 
 -   `subnetwork` (string) - The Google Compute subnetwork id or URL to use for
@@ -62,7 +62,7 @@ permissions to the GCS `paths`.
     custom subnetting. Note, the region of the subnetwork must match the
     `zone` in which the VM is launched. If the value is not a URL,
     it will be interpolated to
-    `projects/((network_project_id))/regions/((region))/subnetworks/((subnetwork))`
+    `projects/((builder_project_id))/regions/((region))/subnetworks/((subnetwork))`
 
 -   `zone` (string) - The zone in which to launch the export instance. Defaults
     to `googlecompute` builder zone. Example: `"us-central1-a"`


### PR DESCRIPTION
Hi,
I missed something during in my previous PR on the exporter, the internal config `NetworkProjectId` should default to builder project. An empty value will cause a bug in the interpolation step here: https://github.com/hashicorp/packer/blob/master/builder/googlecompute/networking.go#L31