### PR TITLE
amazon-chroot: Allow users to specify custom block device mapping

### DIFF
--- a/builder/amazon/chroot/builder_test.go
+++ b/builder/amazon/chroot/builder_test.go
@@ -162,3 +162,49 @@ func TestBuilderPrepare_CopyFilesNoDefault(t *testing.T) {
 		t.Errorf("Was expecting no default value for copy_files.")
 	}
 }
+
+func TestBuilderPrepare_RootDeviceNameAndAMIMappings(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	config["root_device_name"] = "/dev/sda"
+	config["ami_block_device_mappings"] = []interface{}{map[string]string{}}
+	config["root_volume_size"] = 15
+	warnings, err := b.Prepare(config)
+	if len(warnings) == 0 {
+		t.Fatal("Missing warning, stating block device mappings will be overwritten")
+	} else if len(warnings) > 1 {
+		t.Fatalf("excessive warnings: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
+func TestBuilderPrepare_AMIMappingsNoRootDeviceName(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	config["ami_block_device_mappings"] = []interface{}{map[string]string{}}
+	warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatalf("should have error")
+	}
+}
+
+func TestBuilderPrepare_RootDeviceNameNoAMIMappings(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	config["root_device_name"] = "/dev/sda"
+	warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatalf("should have error")
+	}
+}

--- a/website/source/docs/builders/amazon-chroot.html.md
+++ b/website/source/docs/builders/amazon-chroot.html.md
@@ -173,8 +173,11 @@ each category, the available configuration keys are alphabetized.
     more [block device
     mappings](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html)
     to the AMI. These will be attached when booting a new instance from your
-    AMI. Your options here may vary depending on the type of VM you use. The
-    block device mappings allow for the following configuration:
+    AMI. If this field is populated, and you are building from an existing source image,
+    the block device mappings in the source image will be overwritten. This means you
+    must have a block device mapping entry for your root volume, `root_volume_size `,
+    and `root_device_name`. `Your options here may vary depending on the type of VM
+    you use. The block device mappings allow for the following configuration:
 
     -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
         deleted on instance termination. Default `false`. **NOTE**: If this


### PR DESCRIPTION
Previously, when you built from an existing image, you were unable
to reconfigure block device mappings, as it just took them and
copied them over. This allows users to specify new, custom
block device mappings, even when building from an existing
image.

It requires that the user completely rewrites the ami_block_device_mappings,
with one specified in their packer manifest.