### PR TITLE
[WIP] extra escape for windows backslashes in pathing vsphere post-processor

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -220,7 +220,7 @@ func (p *PostProcessor) BuildArgs(source, ovftool_uri string) ([]string, error) 
 		args = append(args, p.config.Options...)
 	}
 
-	args = append(args, fmt.Sprintf(`%s`, source))
+	args = append(args, fmt.Sprintf(`%s`, strings.Replace(source, `\`, `\\`, -1)))
 	args = append(args, fmt.Sprintf(`%s`, ovftool_uri))
 
 	return args, nil


### PR DESCRIPTION
This changes our call to ovftool to escape backslashes in the source-path.  This should fix errors for windows users.

Closes #7368 
