### PR TITLE
Vagrant was missing from Builders sidebar.

### DIFF
--- a/website/source/docs/builders/vagrant.html.md
+++ b/website/source/docs/builders/vagrant.html.md
@@ -1,3 +1,14 @@
+---
+description: |
+    The Vagrant builder is intended for building new boxes from already-existing
+    boxes.
+layout: docs
+page_title: 'Vagrant - Builders'
+sidebar_current: 'docs-builders-vagrant'
+---
+
+# Vagrant Builder
+
 The Vagrant builder is intended for building new boxes from already-existing
 boxes. Your source should be a URL or path to a .box file or a Vagrant Cloud
 box name such as `hashicorp/precise64`.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -171,6 +171,9 @@
           <li<%= sidebar_current("docs-builders-triton") %>>
             <a href="/docs/builders/triton.html">Triton</a>
           </li>
+          <li<%= sidebar_current("docs-builders-vagrant") %>>
+            <a href="/docs/builders/vagrant.html">Vagrant</a>
+          </li>
           <li<%= sidebar_current("docs-builders-virtualbox") %>>
             <a href="/docs/builders/virtualbox.html">VirtualBox</a>
             <ul class="nav">


### PR DESCRIPTION
I accidentally find out that Vagrant builder is supported in latest packer by finding out https://github.com/hashicorp/packer/pull/7221 from google. This PR fixes missing link to Vagrant builder.