### PR TITLE
Ignores SSL verification when on premise vagrant cloud

### DIFF
--- a/post-processor/vagrant-cloud/client.go
+++ b/post-processor/vagrant-cloud/client.go
@@ -2,6 +2,7 @@ package vagrantcloud
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,11 +38,18 @@ func (v VagrantCloudErrors) FormatErrors() string {
 	return strings.Join(errs, ". ")
 }
 
-func (v VagrantCloudClient) New(baseUrl string, token string) (*VagrantCloudClient, error) {
+func (v VagrantCloudClient) New(baseUrl string, token string, InsecureSkipTLSVerify bool) (*VagrantCloudClient, error) {
 	c := &VagrantCloudClient{
 		client:      commonhelper.HttpClientWithEnvironmentProxy(),
 		BaseURL:     baseUrl,
 		AccessToken: token,
+	}
+
+	if InsecureSkipTLSVerify {
+		transport := c.client.Transport.(*http.Transport)
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
 	}
 
 	return c, c.ValidateAuthentication()

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -63,7 +63,7 @@ func TestPostProcessor_Insecure_Ssl(t *testing.T) {
 	config["vagrant_cloud_url"] = server.URL
 	config["insecure_skip_tls_verify"] = true
 	if err := p.Configure(config); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("Expected TLS to skip certificate validation: %s", err)
 	}
 }
 

--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -78,6 +78,10 @@ on Vagrant Cloud, as well as authentication and version information.
     This is useful if you're using Vagrant Private Cloud in your own network.
     Defaults to `https://vagrantcloud.com/api/v1`
 
+-   `insecure_skip_tls_verify` (boolean) - If set to true *and* `vagrant_cloud_url`
+    is set to something different than its default, it will set TLS InsecureSkipVerify
+    to true. In other words, this will disable security checks of SSL.
+
 -   `version_description` (string) - Optionally markdown text used as a
     full-length and in-depth description of the version, typically for denoting
     changes introduced

--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -80,7 +80,9 @@ on Vagrant Cloud, as well as authentication and version information.
 
 -   `insecure_skip_tls_verify` (boolean) - If set to true *and* `vagrant_cloud_url`
     is set to something different than its default, it will set TLS InsecureSkipVerify
-    to true. In other words, this will disable security checks of SSL.
+    to true. In other words, this will disable security checks of SSL. You may need
+    to set this option to true if your host at vagrant_cloud_url is using a
+    self-signed certificate.
 
 -   `version_description` (string) - Optionally markdown text used as a
     full-length and in-depth description of the version, typically for denoting


### PR DESCRIPTION

When using an on premise server, you may want to ignore SSL errors.
So, I made it so that if the `config.VagrantCloudUrl` is *different* from VAGRANT_CLOUD_URL (official one) *and* there is a flag to ignore SSL verification, then the TLS InsecureSkipVerify will be set to true.

I'm pretty newbie when it comes to Go, so I don't really know how to test this.

