### PR TITLE
Fix usage of freebsd64 rescue image

### DIFF
--- a/builder/hcloud/step_create_server.go
+++ b/builder/hcloud/step_create_server.go
@@ -31,7 +31,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 			state.Put("error", fmt.Errorf("Problem reading user data file: %s", err))
 			return multistep.ActionHalt
 		}
-		
+
 		userData = string(contents)
 	}
 

--- a/builder/hcloud/step_create_snapshot.go
+++ b/builder/hcloud/step_create_snapshot.go
@@ -11,7 +11,7 @@ import (
 
 type stepCreateSnapshot struct{}
 
-func (s *stepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("hcloudClient").(*hcloud.Client)
 	ui := state.Get("ui").(packer.Ui)
 	c := state.Get("config").(*Config)
@@ -19,7 +19,7 @@ func (s *stepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) mu
 
 	ui.Say("Creating snapshot ...")
 	ui.Say("This can take some time")
-	result, _, err := client.Server.CreateImage(context.TODO(), &hcloud.Server{ID: serverID}, &hcloud.ServerCreateImageOpts{
+	result, _, err := client.Server.CreateImage(ctx, &hcloud.Server{ID: serverID}, &hcloud.ServerCreateImageOpts{
 		Type:        hcloud.ImageTypeSnapshot,
 		Labels:      c.SnapshotLabels,
 		Description: hcloud.String(c.SnapshotName),
@@ -32,7 +32,7 @@ func (s *stepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) mu
 	}
 	state.Put("snapshot_id", result.Image.ID)
 	state.Put("snapshot_name", c.SnapshotName)
-	_, errCh := client.Action.WatchProgress(context.TODO(), result.Action)
+	_, errCh := client.Action.WatchProgress(ctx, result.Action)
 	for {
 		select {
 		case err1 := <-errCh:

--- a/builder/hcloud/step_create_sshkey.go
+++ b/builder/hcloud/step_create_sshkey.go
@@ -25,7 +25,7 @@ type stepCreateSSHKey struct {
 	keyId int
 }
 
-func (s *stepCreateSSHKey) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepCreateSSHKey) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("hcloudClient").(*hcloud.Client)
 	ui := state.Get("ui").(packer.Ui)
 	c := state.Get("config").(*Config)
@@ -53,7 +53,7 @@ func (s *stepCreateSSHKey) Run(_ context.Context, state multistep.StateBag) mult
 	name := fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
 
 	// Create the key!
-	key, _, err := client.SSHKey.Create(context.TODO(), hcloud.SSHKeyCreateOpts{
+	key, _, err := client.SSHKey.Create(ctx, hcloud.SSHKeyCreateOpts{
 		Name:      name,
 		PublicKey: pubSSHFormat,
 	})

--- a/builder/hcloud/step_shutdown_server.go
+++ b/builder/hcloud/step_shutdown_server.go
@@ -11,14 +11,14 @@ import (
 
 type stepShutdownServer struct{}
 
-func (s *stepShutdownServer) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepShutdownServer) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("hcloudClient").(*hcloud.Client)
 	ui := state.Get("ui").(packer.Ui)
 	serverID := state.Get("server_id").(int)
 
 	ui.Say("Shutting down server...")
 
-	action, _, err := client.Server.Shutdown(context.TODO(), &hcloud.Server{ID: serverID})
+	action, _, err := client.Server.Shutdown(ctx, &hcloud.Server{ID: serverID})
 
 	if err != nil {
 		err := fmt.Errorf("Error stopping server: %s", err)
@@ -27,7 +27,7 @@ func (s *stepShutdownServer) Run(_ context.Context, state multistep.StateBag) mu
 		return multistep.ActionHalt
 	}
 
-	_, errCh := client.Action.WatchProgress(context.TODO(), action)
+	_, errCh := client.Action.WatchProgress(ctx, action)
 	for {
 		select {
 		case err1 := <-errCh:


### PR DESCRIPTION
Closes #7356 

This is a easy fix for the Hetzner Cloud Freebsd64 rescue image bug. 

We now ignore simply all ssh keys when the rescue image freebsd64 is set and use the Passwort which is returned from the API instead. 
