### PR TITLE
Print VerifyChecksum log for the download as ui.Message output

### DIFF
--- a/common/download.go
+++ b/common/download.go
@@ -115,9 +115,9 @@ func (d *DownloadClient) Cancel() {
 	// TODO(mitchellh): Implement
 }
 
-func (d *DownloadClient) Get() (string, error) {
+func (d *DownloadClient) Get(ui packer.Ui) (string, error) {
 	// If we already have the file and it matches, then just return the target path.
-	if verify, _ := d.VerifyChecksum(d.config.TargetPath); verify {
+	if verify, _ := d.VerifyChecksum(ui, d.config.TargetPath); verify {
 		log.Println("[DEBUG] Initial checksum matched, no download needed.")
 		return d.config.TargetPath, nil
 	}
@@ -184,7 +184,7 @@ func (d *DownloadClient) Get() (string, error) {
 
 	if d.config.Hash != nil {
 		var verify bool
-		verify, err = d.VerifyChecksum(finalPath)
+		verify, err = d.VerifyChecksum(ui, finalPath)
 		if err == nil && !verify {
 			// Only delete the file if we made a copy or downloaded it
 			if d.config.CopyFile {
@@ -203,7 +203,7 @@ func (d *DownloadClient) Get() (string, error) {
 
 // VerifyChecksum tests that the path matches the checksum for the
 // download.
-func (d *DownloadClient) VerifyChecksum(path string) (bool, error) {
+func (d *DownloadClient) VerifyChecksum(ui packer.Ui, path string) (bool, error) {
 	if d.config.Checksum == nil || d.config.Hash == nil {
 		return false, errors.New("Checksum or Hash isn't set on download.")
 	}
@@ -214,7 +214,7 @@ func (d *DownloadClient) VerifyChecksum(path string) (bool, error) {
 	}
 	defer f.Close()
 
-	log.Printf("Verifying checksum of %s", path)
+	ui.Message(fmt.Sprintf("Verifying checksum of %s", path))
 	d.config.Hash.Reset()
 	io.Copy(d.config.Hash, f)
 	return bytes.Equal(d.config.Hash.Sum(nil), d.config.Checksum), nil

--- a/common/download_test.go
+++ b/common/download_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestDownloadClientVerifyChecksum(t *testing.T) {
+	ui := packer.TestUi(t)
 	tf, err := ioutil.TempFile("", "packer")
 	if err != nil {
 		t.Fatalf("tempfile error: %s", err)
@@ -40,7 +41,7 @@ func TestDownloadClientVerifyChecksum(t *testing.T) {
 	}
 
 	d := NewDownloadClient(config, new(packer.NoopUi))
-	result, err := d.VerifyChecksum(tf.Name())
+	result, err := d.VerifyChecksum(ui, tf.Name())
 	if err != nil {
 		t.Fatalf("Verify err: %s", err)
 	}
@@ -51,6 +52,7 @@ func TestDownloadClientVerifyChecksum(t *testing.T) {
 }
 
 func TestDownloadClient_basic(t *testing.T) {
+	ui := packer.TestUi(t)
 	tf, _ := ioutil.TempFile("", "packer")
 	tf.Close()
 	defer os.Remove(tf.Name())
@@ -64,7 +66,7 @@ func TestDownloadClient_basic(t *testing.T) {
 		CopyFile:   true,
 	}, new(packer.NoopUi))
 
-	path, err := client.Get()
+	path, err := client.Get(ui)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -80,6 +82,7 @@ func TestDownloadClient_basic(t *testing.T) {
 }
 
 func TestDownloadClient_checksumBad(t *testing.T) {
+	ui := packer.TestUi(t)
 	checksum, err := hex.DecodeString("b2946ac92492d2347c6235b4d2611184")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -100,12 +103,13 @@ func TestDownloadClient_checksumBad(t *testing.T) {
 		CopyFile:   true,
 	}, new(packer.NoopUi))
 
-	if _, err := client.Get(); err == nil {
+	if _, err := client.Get(ui); err == nil {
 		t.Fatal("should error")
 	}
 }
 
 func TestDownloadClient_checksumGood(t *testing.T) {
+	ui := packer.TestUi(t)
 	checksum, err := hex.DecodeString("b1946ac92492d2347c6235b4d2611184")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -126,7 +130,7 @@ func TestDownloadClient_checksumGood(t *testing.T) {
 		CopyFile:   true,
 	}, new(packer.NoopUi))
 
-	path, err := client.Get()
+	path, err := client.Get(ui)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -142,6 +146,7 @@ func TestDownloadClient_checksumGood(t *testing.T) {
 }
 
 func TestDownloadClient_checksumNoDownload(t *testing.T) {
+	ui := packer.TestUi(t)
 	checksum, err := hex.DecodeString("3740570a423feec44c2a759225a9fcf9")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -157,7 +162,7 @@ func TestDownloadClient_checksumNoDownload(t *testing.T) {
 		Checksum:   checksum,
 		CopyFile:   true,
 	}, new(packer.NoopUi))
-	path, err := client.Get()
+	path, err := client.Get(ui)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -176,6 +181,7 @@ func TestDownloadClient_checksumNoDownload(t *testing.T) {
 }
 
 func TestDownloadClient_notFound(t *testing.T) {
+	ui := packer.TestUi(t)
 	tf, _ := ioutil.TempFile("", "packer")
 	tf.Close()
 	defer os.Remove(tf.Name())
@@ -188,12 +194,13 @@ func TestDownloadClient_notFound(t *testing.T) {
 		TargetPath: tf.Name(),
 	}, new(packer.NoopUi))
 
-	if _, err := client.Get(); err == nil {
+	if _, err := client.Get(ui); err == nil {
 		t.Fatal("should error")
 	}
 }
 
 func TestDownloadClient_resume(t *testing.T) {
+	ui := packer.TestUi(t)
 	tf, _ := ioutil.TempFile("", "packer")
 	tf.Write([]byte("w"))
 	tf.Close()
@@ -216,7 +223,7 @@ func TestDownloadClient_resume(t *testing.T) {
 		CopyFile:   true,
 	}, new(packer.NoopUi))
 
-	path, err := client.Get()
+	path, err := client.Get(ui)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -232,6 +239,7 @@ func TestDownloadClient_resume(t *testing.T) {
 }
 
 func TestDownloadClient_usesDefaultUserAgent(t *testing.T) {
+	ui := packer.TestUi(t)
 	tf, err := ioutil.TempFile("", "packer")
 	if err != nil {
 		t.Fatalf("tempfile error: %s", err)
@@ -273,7 +281,7 @@ func TestDownloadClient_usesDefaultUserAgent(t *testing.T) {
 	}
 
 	client := NewDownloadClient(config, new(packer.NoopUi))
-	_, err = client.Get()
+	_, err = client.Get(ui)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,6 +292,7 @@ func TestDownloadClient_usesDefaultUserAgent(t *testing.T) {
 }
 
 func TestDownloadClient_setsUserAgent(t *testing.T) {
+	ui := packer.TestUi(t)
 	tf, err := ioutil.TempFile("", "packer")
 	if err != nil {
 		t.Fatalf("tempfile error: %s", err)
@@ -306,7 +315,7 @@ func TestDownloadClient_setsUserAgent(t *testing.T) {
 	}
 
 	client := NewDownloadClient(config, new(packer.NoopUi))
-	_, err = client.Get()
+	_, err = client.Get(ui)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,6 +388,7 @@ func TestHashForType(t *testing.T) {
 // delete the file if the checksum fails. Instead we'll just error and let the
 // user fix the checksum.
 func TestDownloadFileUrl(t *testing.T) {
+	ui := packer.TestUi(t)
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Unable to detect working directory: %s", err)
@@ -407,7 +417,7 @@ func TestDownloadFileUrl(t *testing.T) {
 	client := NewDownloadClient(config, new(packer.NoopUi))
 
 	// Verify that we fail to match the checksum
-	_, err = client.Get()
+	_, err = client.Get(ui)
 	if err.Error() != "checksums didn't match. expected 6e6f7065 and got 606f1945f81a022d0ed0bd99edfd4f99081c1cb1f97fae087291ee14e945e608" {
 		t.Fatalf("Unexpected failure; expected checksum not to match. Error was \"%v\"", err)
 	}
@@ -422,6 +432,7 @@ func TestDownloadFileUrl(t *testing.T) {
 // UNC path info, and then calling stat to ensure the correct file exists.
 //    (used by TestFileUriTransforms)
 func SimulateFileUriDownload(t *testing.T, uri string) (string, error) {
+	ui := packer.TestUi(t)
 	// source_path is a file path and source is a network path
 	source := fmt.Sprintf(uri)
 	t.Logf("Trying to download %s", source)
@@ -436,7 +447,7 @@ func SimulateFileUriDownload(t *testing.T, uri string) (string, error) {
 
 	// go go go
 	client := NewDownloadClient(config, new(packer.NoopUi))
-	path, err := client.Get()
+	path, err := client.Get(ui)
 
 	// ignore any non-important checksum errors if it's not a unc path
 	if !strings.HasPrefix(path, "\\\\") && err.Error() != "checksums didn't match. expected 6e6f7065 and got 606f1945f81a022d0ed0bd99edfd4f99081c1cb1f97fae087291ee14e945e608" {

--- a/common/step_download.go
+++ b/common/step_download.go
@@ -96,7 +96,7 @@ func (s *StepDownload) Run(_ context.Context, state multistep.StateBag) multiste
 		}
 		downloadConfigs[i] = config
 
-		if match, _ := NewDownloadClient(config, ui).VerifyChecksum(config.TargetPath); match {
+		if match, _ := NewDownloadClient(config, ui).VerifyChecksum(ui, config.TargetPath); match {
 			ui.Message(fmt.Sprintf("Found already downloaded, initial checksum matched, no download needed: %s", url))
 			finalPath = config.TargetPath
 			break
@@ -146,7 +146,7 @@ func (s *StepDownload) download(config *DownloadConfig, state multistep.StateBag
 	downloadCompleteCh := make(chan error, 1)
 	go func() {
 		var err error
-		path, err = download.Get()
+		path, err = download.Get(ui)
 		downloadCompleteCh <- err
 	}()
 


### PR DESCRIPTION
Print `Verifying checksum of <filepath>` of the downloaded file in the standard output with disabled logs (unset the PACKER_LOG environmental variable).

Closes #7247