### PR TITLE
Allow user variables to be interpreted within the variables section o…

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -303,7 +303,7 @@ func (c *Core) init() error {
 	// Go through the variables and interpolate the environment variables
 	ctx := c.Context()
 	ctx.EnableEnv = true
-	ctx.UserVariables = nil
+	ctx.UserVariables = make(map[string]string)
 	for k, v := range c.Template.Variables {
 		// Ignore variables that are required
 		if v.Required {
@@ -324,6 +324,7 @@ func (c *Core) init() error {
 		}
 
 		c.variables[k] = def
+		ctx.UserVariables = c.variables
 	}
 
 	for _, v := range c.Template.SensitiveVariables {

--- a/packer/core.go
+++ b/packer/core.go
@@ -359,11 +359,6 @@ func (c *Core) init() error {
 				tryCount++
 				failedInterpolation = fmt.Sprintf(`"%s": "%s"`, k, v.Default)
 				continue
-
-				return fmt.Errorf(
-					// unexpected interpolation error: abort the run
-					"error interpolating default value for '%s': %s",
-					k, err)
 			default:
 				return fmt.Errorf(
 					// unexpected interpolation error: abort the run

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -523,6 +523,58 @@ func TestCoreValidate(t *testing.T) {
 	}
 }
 
+func TestCore_InterpolateUserVars(t *testing.T) {
+	cases := []struct {
+		File     string
+		Expected map[string]string
+		Err      bool
+	}{
+		{
+			"variables.json",
+			map[string]string{
+				"foo":  "bar",
+				"bar":  "bar",
+				"baz":  "barbaz",
+				"bang": "bangbarbaz",
+			},
+			false,
+		},
+		{
+			"variables2.json",
+			map[string]string{},
+			true,
+		},
+	}
+	for _, tc := range cases {
+		f, err := os.Open(fixtureDir(tc.File))
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		tpl, err := template.Parse(f)
+		f.Close()
+		if err != nil {
+			t.Fatalf("err: %s\n\n%s", tc.File, err)
+		}
+
+		ccf, err := NewCore(&CoreConfig{
+			Template: tpl,
+			Version:  "1.0.0",
+		})
+
+		if (err != nil) != tc.Err {
+			t.Fatalf("err: %s\n\n%s", tc.File, err)
+		}
+		if !tc.Err {
+			for k, v := range ccf.variables {
+				if tc.Expected[k] != v {
+					t.Fatalf("Expected %s but got %s", tc.Expected[k], v)
+				}
+			}
+		}
+	}
+}
+
 func TestSensitiveVars(t *testing.T) {
 	cases := []struct {
 		File          string

--- a/packer/test-fixtures/variables.json
+++ b/packer/test-fixtures/variables.json
@@ -1,0 +1,11 @@
+{
+    "variables": {
+    	"foo":  "bar",
+		"bar":  "{{user `foo`}}",
+		"baz":  "{{user `bar`}}baz",
+		"bang": "bang{{user `baz`}}"
+	},
+	"builders": [
+        {"type": "foo"}
+    ]
+}

--- a/packer/test-fixtures/variables2.json
+++ b/packer/test-fixtures/variables2.json
@@ -1,0 +1,10 @@
+{
+    "variables": {
+		"bar":  "{{user `foo`}}",
+		"baz":  "{{user `bar`}}baz",
+		"bang": "bang{{user `baz`}}"
+	},
+	"builders": [
+        {"type": "foo"}
+    ]
+}

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -163,7 +163,15 @@ func funcGenUser(ctx *Context) interface{} {
 			return "", errors.New("test")
 		}
 
-		return ctx.UserVariables[k], nil
+		val, ok := ctx.UserVariables[k]
+		if ctx.EnableEnv {
+			// error and retry if we're interpolating UserVariables. But if
+			// we're elsewhere in the template, just return the empty string.
+			if !ok {
+				return "", errors.New(fmt.Sprintf("variable %s not set", k))
+			}
+		}
+		return val, nil
 	}
 }
 


### PR DESCRIPTION
…f the template.

This modifies the way we read uservariables from the template to add a loop with some skips so that we can assign variables from other variables within the variables section.

It shouldn't change backwards behavior at all.

However, it will throw an error if you try to define a variable in the variables section based on a variable that isn't set. This is different behavior than we see in the rest of the template, where a user variable that's unset will default to "" unless it is "Required"

Closes #4387 
