### PR TITLE
Expose force_delete for openstack builder

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -115,6 +115,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			ConfigDrive:           b.config.ConfigDrive,
 			InstanceMetadata:      b.config.InstanceMetadata,
 			UseBlockStorageVolume: b.config.UseBlockStorageVolume,
+			ForceDelete:           b.config.ForceDelete,
 		},
 		&StepGetPassword{
 			Debug: b.config.PackerDebug,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -31,6 +31,7 @@ type RunConfig struct {
 	UserDataFile       string            `mapstructure:"user_data_file"`
 	InstanceName       string            `mapstructure:"instance_name"`
 	InstanceMetadata   map[string]string `mapstructure:"instance_metadata"`
+	ForceDelete        bool              `mapstructure:"force_delete"`
 
 	ConfigDrive bool `mapstructure:"config_drive"`
 

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -136,6 +136,10 @@ builder.
 -   `floating_ip_pool` (string) - *Deprecated* use `floating_ip_network`
     instead.
 
+-   `force_delete` (boolean) - Whether to force the OpenStack instance to be
+    forcefully deleted. This is useful for environments that have
+    reclaim / soft deletion enabled. By default this is false.
+
 -   `image_members` (array of strings) - List of members to add to the image
     after creation. An image member is usually a project (also called the
     "tenant") with whom the image is shared.


### PR DESCRIPTION
Very similar to how its exposed in terraform adds an optional force_delete config entry on the openstack builder.