### PR TITLE
Add vagrant-cloud post-processor support for the vagrant builder

### DIFF
--- a/builder/vagrant/artifact.go
+++ b/builder/vagrant/artifact.go
@@ -15,14 +15,16 @@ const BuilderId = "vagrant"
 type artifact struct {
 	OutputDir string
 	BoxName   string
+	Provider  string
 }
 
 // NewArtifact returns a vagrant artifact containing the .box file
-func NewArtifact(dir string) (packer.Artifact, error) {
+func NewArtifact(provider, dir string) packer.Artifact {
 	return &artifact{
 		OutputDir: dir,
 		BoxName:   "package.box",
-	}, nil
+		Provider:  provider,
+	}
 }
 
 func (*artifact) BuilderId() string {
@@ -30,15 +32,15 @@ func (*artifact) BuilderId() string {
 }
 
 func (a *artifact) Files() []string {
-	return []string{a.BoxName}
+	return []string{filepath.Join(a.OutputDir, a.BoxName)}
 }
 
 func (a *artifact) Id() string {
-	return filepath.Join(a.OutputDir, a.BoxName)
+	return a.Provider
 }
 
 func (a *artifact) String() string {
-	return fmt.Sprintf("Vagrant box is %s", a.Id())
+	return fmt.Sprintf("Vagrant box '%s' for '%s' provider", a.BoxName, a.Provider)
 }
 
 func (a *artifact) State(name string) interface{} {

--- a/builder/vagrant/artifact_test.go
+++ b/builder/vagrant/artifact_test.go
@@ -20,13 +20,11 @@ func TestArtifactId(t *testing.T) {
 	a := &artifact{
 		OutputDir: "/my/dir",
 		BoxName:   "package.box",
+		Provider:  "virtualbox",
 	}
 
-	expected := "/my/dir/package.box"
-	if runtime.GOOS == "windows" {
-		expected = strings.Replace(expected, "/", "\\", -1)
-	}
-	if strings.Compare(a.Id(), expected) != 0 {
+	expected := "virtualbox"
+	if a.Id() != expected {
 		t.Fatalf("artifact ID should match: expected: %s received: %s", expected, a.Id())
 	}
 }
@@ -35,8 +33,9 @@ func TestArtifactString(t *testing.T) {
 	a := &artifact{
 		OutputDir: "/my/dir",
 		BoxName:   "package.box",
+		Provider:  "virtualbox",
 	}
-	expected := "Vagrant box is /my/dir/package.box"
+	expected := "Vagrant box 'package.box' for 'virtualbox' provider"
 	if runtime.GOOS == "windows" {
 		expected = strings.Replace(expected, "/", "\\", -1)
 	}

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -264,7 +264,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		return nil, errors.New("Build was halted.")
 	}
 
-	return NewArtifact(b.config.OutputDir)
+	return NewArtifact(b.config.Provider, b.config.OutputDir), nil
 }
 
 // Cancel.

--- a/website/source/docs/builders/vagrant.html.md
+++ b/website/source/docs/builders/vagrant.html.md
@@ -61,6 +61,10 @@ one, by using `global_id` instead of `source_box`.
     to Vagrant, this is the name to give it. If left blank, will default to
     "packer_" plus your buildname.
 
+-   `provider` (string) - The vagrant [provider](docs/post-processors/vagrant.html).
+    This parameter is required to use vagrant builder with the `vagrant-cloud`
+    post-processor. Defaults to unset.
+
 -   `checksum` (string) - The checksum for the .box file. The type of the
     checksum is specified with `checksum_type`, documented below.
 

--- a/website/source/docs/builders/vagrant.html.md
+++ b/website/source/docs/builders/vagrant.html.md
@@ -27,7 +27,7 @@ You can change the behavior so that the builder doesn't destroy the box by
 setting the `teardown_method` option. You can change the behavior so the builder
 doesn't package it (not all provisioners support the `vagrant package` command)
 by setting the `skip package` option. You can also change the behavior so that
-rather than inititalizing a new Vagrant workspace, you use an already defined
+rather than initializing a new Vagrant workspace, you use an already defined
 one, by using `global_id` instead of `source_box`.
 
 ## Configuration Reference
@@ -76,8 +76,8 @@ one, by using `global_id` instead of `source_box`.
     {{ .SyncedFolder }}, which correspond to the Packer options `box_name` and
     `synced_folder`
 
--   `skip_add` (string) - Don't call "vagrant add" to add the box to your local
-    environment; this is necesasry if you want to launch a box that is already
+-   `skip_add` (bool) - Don't call "vagrant add" to add the box to your local
+    environment; this is necessary if you want to launch a box that is already
     added to your vagrant environment.
 
 -   `teardown_method` (string) - Whether to halt, suspend, or destroy the box when

--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -1,9 +1,9 @@
 ---
 description: |
     The Packer Vagrant Cloud post-processor receives a Vagrant box from the
-    `vagrant` post-processor and pushes it to Vagrant Cloud. Vagrant Cloud hosts
-    and serves boxes to Vagrant, allowing you to version and distribute boxes to an
-    organization in a simple way.
+    `vagrant` post-processor or vagrant builder and pushes it to Vagrant Cloud.
+    Vagrant Cloud hosts and serves boxes to Vagrant, allowing you to version and
+    distribute boxes to an organization in a simple way.
 layout: docs
 page_title: 'Vagrant Cloud - Post-Processors'
 sidebar_current: 'docs-post-processors-vagrant-cloud'
@@ -14,9 +14,9 @@ sidebar_current: 'docs-post-processors-vagrant-cloud'
 Type: `vagrant-cloud`
 
 The Packer Vagrant Cloud post-processor receives a Vagrant box from the
-`vagrant` post-processor and pushes it to Vagrant Cloud. [Vagrant
-Cloud](https://app.vagrantup.com/boxes/search) hosts and serves boxes to
-Vagrant, allowing you to version and distribute boxes to an organization in a
+`vagrant` post-processor or vagrant builder and pushes it to Vagrant Cloud.
+[Vagrant Cloud](https://app.vagrantup.com/boxes/search) hosts and serves boxes
+to Vagrant, allowing you to version and distribute boxes to an organization in a
 simple way.
 
 You'll need to be familiar with Vagrant Cloud, have an upgraded account to


### PR DESCRIPTION
These changes allow to use vagrant builder with vagrant-cloud post-processor.

Also includes fix typos in the vagrant builder documentation.

Closes #7321 
