### PR TITLE
Close opened TTY on packer exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,10 +189,11 @@ func wrappedMain() int {
 		var TTY packer.TTY
 		if !inPlugin {
 			var err error
-			TTY, err = tty.Open()
+			TTY, err := tty.Open()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "No tty available: %s\n", err)
 			}
+			defer TTY.Close()
 		}
 		ui = &packer.BasicUi{
 			Reader:      os.Stdin,


### PR DESCRIPTION
Fix changing terminal line settings including `icrnl` (translate carriage return to newline) after packer launch by closing opened **tty** in the `main.go` on exit.

Closes #7406 