### PR TITLE
fix 7403: Improve error message for conflicting images name

### DIFF
--- a/builder/alicloud/ecs/step_pre_validate.go
+++ b/builder/alicloud/ecs/step_pre_validate.go
@@ -37,7 +37,7 @@ func (s *stepPreValidate) Run(_ context.Context, state multistep.StateBag) multi
 	}
 
 	if len(images) > 0 {
-		err := fmt.Errorf("Error: name conflicts with an existing alicloud image: %s", images[0].ImageId)
+		err := fmt.Errorf("Error: Image Name: '%s' is used by an existing alicloud image: %s", images[0].ImageName, images[0].ImageId)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -90,7 +90,7 @@ func (s *StepPreValidate) Run(_ context.Context, state multistep.StateBag) multi
 	}
 
 	if len(resp.Images) > 0 {
-		err := fmt.Errorf("Error: name conflicts with an existing AMI: %s", *resp.Images[0].ImageId)
+		err := fmt.Errorf("Error: AMI Name: '%s' is used by an existing AMI: %s", *resp.Images[0].Name, *resp.Images[0].ImageId)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt


### PR DESCRIPTION
It improves it for AWS and Alibaba builders.
fix #7403
