### PR TITLE
Fix invalid character issue on Windows.

### DIFF
--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -120,7 +120,7 @@ func parseSSHConfig(lines []string, value string) string {
 			out = line[index+len(value):]
 		}
 	}
-	return out
+	return strings.Trim(out, "\r\n")
 }
 
 func yesno(yn string) bool {


### PR DESCRIPTION
Output from driver includes a `\r` character.  This change adds logic to
trim `\r` and `\n` values from parsed output.

#7414
