### PR TITLE
Update incorrect documentation on vagrant builder.

### DIFF
--- a/website/source/docs/builders/vagrant.html.md
+++ b/website/source/docs/builders/vagrant.html.md
@@ -74,7 +74,7 @@ one, by using `global_id` instead of `source_box`.
     not recommended since OVA files can be very large and corruption does happen
     from time to time.
 
--   `vagrantfile_template` (string) - a path to a golang template for a
+-   `template` (string) - a path to a golang template for a
     vagrantfile. Our default template can be found
     [here](https://github.com/hashicorp/packer/blob/a6d1d852bb0643e3593cc5d3dfe5ed80c4409b65/builder/vagrant/step_create_vagrantfile.go#L23-L30). So far the only template variables available to you are {{ .BoxName }} and
     {{ .SyncedFolder }}, which correspond to the Packer options `box_name` and


### PR DESCRIPTION
The packer option `vagrantfile_template` is not used.
This change corrects the documentation with the correct option name.

Closes #7414