### PR TITLE
Validate 'none' communicator in the virtualbox builder

### DIFF
--- a/builder/virtualbox/common/guest_addition_modes.go
+++ b/builder/virtualbox/common/guest_addition_modes.go
@@ -1,9 +1,0 @@
-package common
-
-// These are the different valid mode values for "guest_additions_mode" which
-// determine how guest additions are delivered to the guest.
-const (
-	GuestAdditionsModeDisable string = "disable"
-	GuestAdditionsModeAttach         = "attach"
-	GuestAdditionsModeUpload         = "upload"
-)

--- a/builder/virtualbox/common/guest_additions_config.go
+++ b/builder/virtualbox/common/guest_additions_config.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/template/interpolate"
+)
+
+// These are the different valid mode values for "guest_additions_mode" which
+// determine how guest additions are delivered to the guest.
+const (
+	GuestAdditionsModeDisable string = "disable"
+	GuestAdditionsModeAttach         = "attach"
+	GuestAdditionsModeUpload         = "upload"
+)
+
+type GuestAdditionsConfig struct {
+	Communicator       string `mapstructure:"communicator"`
+	GuestAdditionsMode string `mapstructure:"guest_additions_mode"`
+}
+
+func (c *GuestAdditionsConfig) Prepare(ctx *interpolate.Context) []error {
+	var errs []error
+
+	if c.Communicator == "none" && c.GuestAdditionsMode != "disable" {
+		errs = append(errs, fmt.Errorf("guest_additions_mode has to be "+
+			"'disable' when communicator = 'none'."))
+	}
+
+	return errs
+}

--- a/builder/virtualbox/common/guest_additions_config_test.go
+++ b/builder/virtualbox/common/guest_additions_config_test.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestGuestAdditionsConfigPrepare(t *testing.T) {
+	c := new(GuestAdditionsConfig)
+	var errs []error
+
+	c.GuestAdditionsMode = "disable"
+	c.Communicator = "none"
+	errs = c.Prepare(testConfigTemplate(t))
+	if len(errs) > 0 {
+		t.Fatalf("should not have error: %s", errs)
+	}
+}

--- a/builder/virtualbox/common/vbox_version_config.go
+++ b/builder/virtualbox/common/vbox_version_config.go
@@ -1,18 +1,28 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/packer/template/interpolate"
 )
 
 type VBoxVersionConfig struct {
+	Communicator    string  `mapstructure:"communicator"`
 	VBoxVersionFile *string `mapstructure:"virtualbox_version_file"`
 }
 
 func (c *VBoxVersionConfig) Prepare(ctx *interpolate.Context) []error {
+	var errs []error
+
 	if c.VBoxVersionFile == nil {
 		default_file := ".vbox_version"
 		c.VBoxVersionFile = &default_file
 	}
 
-	return nil
+	if c.Communicator == "none" && *c.VBoxVersionFile != "" {
+		errs = append(errs, fmt.Errorf("virtualbox_version_file has to be an "+
+			"empty string when communicator = 'none'."))
+	}
+
+	return errs
 }

--- a/builder/virtualbox/common/vbox_version_config_test.go
+++ b/builder/virtualbox/common/vbox_version_config_test.go
@@ -62,3 +62,18 @@ func TestVBoxVersionConfigPrepare_empty(t *testing.T) {
 		t.Fatalf("bad value: %s", *c.VBoxVersionFile)
 	}
 }
+
+func TestVBoxVersionConfigPrepare_communicator(t *testing.T) {
+	var c *VBoxVersionConfig
+	var errs []error
+
+	// Test with 'none' communicator and non-empty virtualbox_version_file
+	c = new(VBoxVersionConfig)
+	filename := "test"
+	c.VBoxVersionFile = &filename
+	c.Communicator = "none"
+	errs = c.Prepare(testConfigTemplate(t))
+	if len(errs) == 0 {
+		t.Fatalf("should have an error")
+	}
+}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -40,6 +40,7 @@ type Config struct {
 	vboxcommon.VBoxManagePostConfig `mapstructure:",squash"`
 	vboxcommon.VBoxVersionConfig    `mapstructure:",squash"`
 	vboxcommon.VBoxBundleConfig     `mapstructure:",squash"`
+	vboxcommon.GuestAdditionsConfig `mapstructure:",squash"`
 
 	DiskSize                uint   `mapstructure:"disk_size"`
 	GuestAdditionsMode      string `mapstructure:"guest_additions_mode"`
@@ -101,6 +102,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxManagePostConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxVersionConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.BootConfig.Prepare(&b.config.ctx)...)
+	errs = packer.MultiErrorAppend(errs, b.config.GuestAdditionsConfig.Prepare(&b.config.ctx)...)
 
 	if b.config.DiskSize == 0 {
 		b.config.DiskSize = 40000

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	vboxcommon.VBoxManageConfig     `mapstructure:",squash"`
 	vboxcommon.VBoxManagePostConfig `mapstructure:",squash"`
 	vboxcommon.VBoxVersionConfig    `mapstructure:",squash"`
+	vboxcommon.GuestAdditionsConfig `mapstructure:",squash"`
 
 	Checksum                string   `mapstructure:"checksum"`
 	ChecksumType            string   `mapstructure:"checksum_type"`
@@ -97,6 +98,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	errs = packer.MultiErrorAppend(errs, c.VBoxManagePostConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.VBoxVersionConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.ctx)...)
+	errs = packer.MultiErrorAppend(errs, c.GuestAdditionsConfig.Prepare(&c.ctx)...)
 
 	c.ChecksumType = strings.ToLower(c.ChecksumType)
 	c.Checksum = strings.ToLower(c.Checksum)


### PR DESCRIPTION
Changes in PR check **none** `communicator` during validation time in the virtualbox builder, it fixes next errors during build:

1. `Build 'virtualbox-iso' errored: Error uploading VirtualBox version: Upload is not implemented when communicator = 'none'`- This error occurs when `communicator` is set to **none** and **virtualbox_version_file** has non-empty value:

2. `Build 'virtualbox-iso' errored: Error uploading guest additions: Upload is not implemented when communicator = 'none'` - This error occurs when `communicator` is set to **none** and `guest_additions_mode` is not  **disable**.

Closes #7246 
