### PR TITLE
request to add packer.py to community tools

### DIFF
--- a/website/source/community-tools.html.md
+++ b/website/source/community-tools.html.md
@@ -49,6 +49,8 @@ power of Packer templates.
 
 - [packerlicious](https://github.com/mayn/packerlicious) - a python library for generating Packer templates
 
+- [packer.py](https://github.com/mayn/packer.py) - a python library for executing Packer CLI commands
+
 ## Other
 
 - [suitcase](https://github.com/tmclaugh/suitcase) - Packer based build system for CentOS OS images


### PR DESCRIPTION
packer.py(https://github.com/mayn/packer.py)  is a library that enables packer command execution via python.


example:
```
from packerpy import PackerExecutable

packer = PackerExecutable("/usr/local/bin/packer")
packer.build("/path/to/template.json")
```

At minimum please take a peek(project readme has more examples) and drop me some feedback.

(Not sure what the requirement are to get listed on the community tools page, understand if this doesn't make the cut.).

Thanks!