### PR TITLE
[WIP] support oracle cloud infrastructure image export to oci object storage

### DIFF
--- a/command/plugin.go
+++ b/command/plugin.go
@@ -62,6 +62,7 @@ import (
 	googlecomputeexportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-export"
 	googlecomputeimportpostprocessor "github.com/hashicorp/packer/post-processor/googlecompute-import"
 	manifestpostprocessor "github.com/hashicorp/packer/post-processor/manifest"
+	oracleociexportpostprocessor "github.com/hashicorp/packer/post-processor/oracle/oci/export"
 	shelllocalpostprocessor "github.com/hashicorp/packer/post-processor/shell-local"
 	vagrantpostprocessor "github.com/hashicorp/packer/post-processor/vagrant"
 	vagrantcloudpostprocessor "github.com/hashicorp/packer/post-processor/vagrant-cloud"
@@ -166,6 +167,7 @@ var PostProcessors = map[string]packer.PostProcessor{
 	"vagrant-cloud":        new(vagrantcloudpostprocessor.PostProcessor),
 	"vsphere":              new(vspherepostprocessor.PostProcessor),
 	"vsphere-template":     new(vspheretemplatepostprocessor.PostProcessor),
+	"oracle-oci-export":    new(oracleociexportpostprocessor.PostProcessor),
 }
 
 var pluginRegexp = regexp.MustCompile("packer-(builder|post-processor|provisioner)-(.+)")

--- a/post-processor/oracle/oci/export/config.go
+++ b/post-processor/oracle/oci/export/config.go
@@ -1,0 +1,195 @@
+package export
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/config"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/template/interpolate"
+	ocicommon "github.com/oracle/oci-go-sdk/common"
+)
+
+type Config struct {
+	common.PackerConfig `mapstructure:",squash"`
+
+	ConfigProvider ocicommon.ConfigurationProvider
+
+	AccessCfgFile        string `mapstructure:"access_cfg_file"`
+	AccessCfgFileAccount string `mapstructure:"access_cfg_file_account"`
+
+	// Access config overrides
+	UserID      string `mapstructure:"user_ocid"`
+	TenancyID   string `mapstructure:"tenancy_ocid"`
+	Region      string `mapstructure:"region"`
+	Fingerprint string `mapstructure:"fingerprint"`
+	KeyFile     string `mapstructure:"key_file"`
+	PassPhrase  string `mapstructure:"pass_phrase"`
+
+	AvailabilityDomain string `mapstructure:"availability_domain"`
+	CompartmentID      string `mapstructure:"compartment_ocid"`
+
+	//Object Storage
+	BucketName string `mapstructure:"bucket_name"`
+	ImageName  string `mapstructure:"image_name"`
+
+	// Tagging
+	Tags map[string]string `mapstructure:"tags"`
+
+	ctx interpolate.Context
+}
+
+func NewConfig(raws ...interface{}) (*Config, error) {
+	c := &Config{}
+
+	// Decode from template
+	err := config.Decode(c, &config.DecodeOpts{
+		Interpolate:        true,
+		InterpolateContext: &c.ctx,
+	}, raws...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to mapstructure Config: %+v", err)
+	}
+
+	// Determine where the SDK config is located
+	if c.AccessCfgFile == "" {
+		c.AccessCfgFile, err = getDefaultOCISettingsPath()
+		if err != nil {
+			log.Println("Default OCI settings file not found")
+		}
+	}
+
+	if c.AccessCfgFileAccount == "" {
+		c.AccessCfgFileAccount = "DEFAULT"
+	}
+
+	var keyContent []byte
+	if c.KeyFile != "" {
+		path, err := packer.ExpandUser(c.KeyFile)
+		if err != nil {
+			return nil, err
+		}
+
+		// Read API signing key
+		keyContent, err = ioutil.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	fileProvider, _ := ocicommon.ConfigurationProviderFromFileWithProfile(c.AccessCfgFile, c.AccessCfgFileAccount, c.PassPhrase)
+	if c.Region == "" {
+		var region string
+		if fileProvider != nil {
+			region, _ = fileProvider.Region()
+		}
+		if region == "" {
+			c.Region = "us-phoenix-1"
+		}
+	}
+
+	providers := []ocicommon.ConfigurationProvider{
+		NewRawConfigurationProvider(c.TenancyID, c.UserID, c.Region, c.Fingerprint, string(keyContent), &c.PassPhrase),
+	}
+
+	if fileProvider != nil {
+		providers = append(providers, fileProvider)
+	}
+
+	// Load API access configuration from SDK
+	configProvider, err := ocicommon.ComposingConfigurationProvider(providers)
+	if err != nil {
+		return nil, err
+	}
+
+	var errs *packer.MultiError
+
+	if userOCID, _ := configProvider.UserOCID(); userOCID == "" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("'user_ocid' must be specified"))
+	}
+
+	tenancyOCID, _ := configProvider.TenancyOCID()
+	if tenancyOCID == "" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("'tenancy_ocid' must be specified"))
+	}
+
+	if fingerprint, _ := configProvider.KeyFingerprint(); fingerprint == "" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("'fingerprint' must be specified"))
+	}
+
+	if _, err := configProvider.PrivateRSAKey(); err != nil {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("'key_file' must be specified"))
+	}
+
+	c.ConfigProvider = configProvider
+
+	if c.AvailabilityDomain == "" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("'availability_domain' must be specified"))
+	}
+
+	if c.CompartmentID == "" && tenancyOCID != "" {
+		c.CompartmentID = tenancyOCID
+	}
+
+	// Validate tag lengths. TODO (hlowndes) maximum number of tags allowed.
+	if c.Tags != nil {
+		for k, v := range c.Tags {
+			k = strings.TrimSpace(k)
+			v = strings.TrimSpace(v)
+			if len(k) > 100 {
+				errs = packer.MultiErrorAppend(
+					errs, fmt.Errorf("Tag key length too long. Maximum 100 but found %d. Key: %s", len(k), k))
+			}
+			if len(k) == 0 {
+				errs = packer.MultiErrorAppend(
+					errs, errors.New("Tag key empty in config"))
+			}
+			if len(v) > 100 {
+				errs = packer.MultiErrorAppend(
+					errs, fmt.Errorf("Tag value length too long. Maximum 100 but found %d. Key: %s", len(v), k))
+			}
+			if len(v) == 0 {
+				errs = packer.MultiErrorAppend(
+					errs, errors.New("Tag value empty in config"))
+			}
+		}
+	}
+
+	if errs != nil && len(errs.Errors) > 0 {
+		return nil, errs
+	}
+
+	return c, nil
+}
+
+// getDefaultOCISettingsPath uses os/user to compute the default
+// config file location ($HOME/.oci/config).
+func getDefaultOCISettingsPath() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	if u.HomeDir == "" {
+		return "", fmt.Errorf("Unable to determine the home directory for the current user.")
+	}
+
+	path := filepath.Join(u.HomeDir, ".oci", "config")
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}

--- a/post-processor/oracle/oci/export/config_provider.go
+++ b/post-processor/oracle/oci/export/config_provider.go
@@ -1,0 +1,76 @@
+package export
+
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// rawConfigurationProvider allows a user to simply construct a configuration
+// provider from raw values. It errors on access when those values are empty.
+type rawConfigurationProvider struct {
+	tenancy              string
+	user                 string
+	region               string
+	fingerprint          string
+	privateKey           string
+	privateKeyPassphrase *string
+}
+
+// NewRawConfigurationProvider will create a rawConfigurationProvider.
+func NewRawConfigurationProvider(tenancy, user, region, fingerprint, privateKey string, privateKeyPassphrase *string) common.ConfigurationProvider {
+	return rawConfigurationProvider{tenancy, user, region, fingerprint, privateKey, privateKeyPassphrase}
+}
+
+func (p rawConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, err error) {
+	return common.PrivateKeyFromBytes([]byte(p.privateKey), p.privateKeyPassphrase)
+}
+
+func (p rawConfigurationProvider) KeyID() (keyID string, err error) {
+	tenancy, err := p.TenancyOCID()
+	if err != nil {
+		return
+	}
+
+	user, err := p.UserOCID()
+	if err != nil {
+		return
+	}
+
+	fingerprint, err := p.KeyFingerprint()
+	if err != nil {
+		return
+	}
+
+	return fmt.Sprintf("%s/%s/%s", tenancy, user, fingerprint), nil
+}
+
+func (p rawConfigurationProvider) TenancyOCID() (string, error) {
+	if p.tenancy == "" {
+		return "", errors.New("no tenancy provided")
+	}
+	return p.tenancy, nil
+}
+
+func (p rawConfigurationProvider) UserOCID() (string, error) {
+	if p.user == "" {
+		return "", errors.New("no user provided")
+	}
+	return p.user, nil
+}
+
+func (p rawConfigurationProvider) KeyFingerprint() (string, error) {
+	if p.fingerprint == "" {
+		return "", errors.New("no fingerprint provided")
+	}
+	return p.fingerprint, nil
+}
+
+func (p rawConfigurationProvider) Region() (string, error) {
+	if p.region == "" {
+		return "", errors.New("no region provided")
+	}
+	return p.region, nil
+}

--- a/post-processor/oracle/oci/export/config_test.go
+++ b/post-processor/oracle/oci/export/config_test.go
@@ -1,0 +1,277 @@
+package export
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-ini/ini"
+)
+
+func testConfig(accessConfFile *os.File) map[string]interface{} {
+	return map[string]interface{}{
+		"availability_domain": "aaaa:PHX-AD-3",
+		"access_cfg_file":     accessConfFile.Name(),
+	}
+}
+
+func TestConfig(t *testing.T) {
+	// Shared set-up and deferred deletion
+
+	cfg, keyFile, err := baseTestConfigWithTmpKeyFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(keyFile.Name())
+
+	cfgFile, err := writeTestConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+
+	// Temporarily set $HOME to temp directory to bypass default
+	// access config loading.
+
+	tmpHome, err := ioutil.TempDir("", "packer_config_test")
+	if err != nil {
+		t.Fatalf("Unexpected error when creating temporary directory: %+v", err)
+	}
+	defer os.Remove(tmpHome)
+
+	home := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", home)
+
+	// Config tests
+	t.Run("BaseConfig", func(t *testing.T) {
+		raw := testConfig(cfgFile)
+		_, errs := NewConfig(raw)
+
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration %+v", errs)
+		}
+	})
+
+	t.Run("NoAccessConfig", func(t *testing.T) {
+		raw := testConfig(cfgFile)
+		delete(raw, "access_cfg_file")
+
+		_, errs := NewConfig(raw)
+
+		expectedErrors := []string{
+			"'user_ocid'", "'tenancy_ocid'", "'fingerprint'", "'key_file'",
+		}
+
+		s := errs.Error()
+		for _, expected := range expectedErrors {
+			if !strings.Contains(s, expected) {
+				t.Errorf("Expected %q to contain '%s'", s, expected)
+			}
+		}
+	})
+
+	t.Run("AccessConfigTemplateOnly", func(t *testing.T) {
+		raw := testConfig(cfgFile)
+		delete(raw, "access_cfg_file")
+		raw["user_ocid"] = "ocid1..."
+		raw["tenancy_ocid"] = "ocid1..."
+		raw["fingerprint"] = "00:00..."
+		raw["key_file"] = keyFile.Name()
+
+		_, errs := NewConfig(raw)
+
+		if errs != nil {
+			t.Fatalf("err: %+v", errs)
+		}
+
+	})
+
+	t.Run("TenancyReadFromAccessCfgFile", func(t *testing.T) {
+		raw := testConfig(cfgFile)
+		c, errs := NewConfig(raw)
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration %+v", errs)
+		}
+
+		tenancy, err := c.ConfigProvider.TenancyOCID()
+		if err != nil {
+			t.Fatalf("Unexpected error getting tenancy ocid: %v", err)
+		}
+
+		expected := "ocid1.tenancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		if tenancy != expected {
+			t.Errorf("Expected tenancy: %s, got %s.", expected, tenancy)
+		}
+
+	})
+
+	t.Run("RegionNotDefaultedToPHXWhenSetInOCISettings", func(t *testing.T) {
+		raw := testConfig(cfgFile)
+		c, errs := NewConfig(raw)
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration %+v", errs)
+		}
+
+		region, err := c.ConfigProvider.Region()
+		if err != nil {
+			t.Fatalf("Unexpected error getting region: %v", err)
+		}
+
+		expected := "us-ashburn-1"
+		if region != expected {
+			t.Errorf("Expected region: %s, got %s.", expected, region)
+		}
+
+	})
+
+	t.Run("ImageNameDefaultedIfEmpty", func(t *testing.T) {
+		raw := testConfig(cfgFile)
+
+		_, errs := NewConfig(raw)
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration %+v", errs)
+		}
+
+	})
+
+	t.Run("user_ocid_overridden", func(t *testing.T) {
+		expected := "override"
+		raw := testConfig(cfgFile)
+		raw["user_ocid"] = expected
+
+		c, errs := NewConfig(raw)
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration %+v", errs)
+		}
+
+		user, _ := c.ConfigProvider.UserOCID()
+		if user != expected {
+			t.Errorf("Expected ConfigProvider.UserOCID: %s, got %s", expected, user)
+		}
+	})
+
+	t.Run("tenancy_ocid_overidden", func(t *testing.T) {
+		expected := "override"
+		raw := testConfig(cfgFile)
+		raw["tenancy_ocid"] = expected
+
+		c, errs := NewConfig(raw)
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration %+v", errs)
+		}
+
+		tenancy, _ := c.ConfigProvider.TenancyOCID()
+		if tenancy != expected {
+			t.Errorf("Expected ConfigProvider.TenancyOCID: %s, got %s", expected, tenancy)
+		}
+	})
+
+	t.Run("region_overidden", func(t *testing.T) {
+		expected := "override"
+		raw := testConfig(cfgFile)
+		raw["region"] = expected
+
+		c, errs := NewConfig(raw)
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration %+v", errs)
+		}
+
+		region, _ := c.ConfigProvider.Region()
+		if region != expected {
+			t.Errorf("Expected ConfigProvider.Region: %s, got %s", expected, region)
+		}
+	})
+
+	t.Run("fingerprint_overidden", func(t *testing.T) {
+		expected := "override"
+		raw := testConfig(cfgFile)
+		raw["fingerprint"] = expected
+
+		c, errs := NewConfig(raw)
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration: %+v", errs)
+		}
+
+		fingerprint, _ := c.ConfigProvider.KeyFingerprint()
+		if fingerprint != expected {
+			t.Errorf("Expected ConfigProvider.KeyFingerprint: %s, got %s", expected, fingerprint)
+		}
+	})
+}
+
+// BaseTestConfig creates the base (DEFAULT) config including a temporary key
+// file.
+// NOTE: Caller is responsible for removing temporary key file.
+func baseTestConfigWithTmpKeyFile() (*ini.File, *os.File, error) {
+	keyFile, err := generateRSAKeyFile()
+	if err != nil {
+		return nil, keyFile, err
+	}
+	// Build ini
+	cfg := ini.Empty()
+	section, _ := cfg.NewSection("DEFAULT")
+	section.NewKey("region", "us-ashburn-1")
+	section.NewKey("tenancy", "ocid1.tenancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	section.NewKey("user", "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	section.NewKey("fingerprint", "70:04:5z:b3:19:ab:90:75:a4:1f:50:d4:c7:c3:33:20")
+	section.NewKey("key_file", keyFile.Name())
+
+	return cfg, keyFile, nil
+}
+
+// WriteTestConfig writes a ini.File to a temporary file for use in unit tests.
+// NOTE: Caller is responsible for removing temporary file.
+func writeTestConfig(cfg *ini.File) (*os.File, error) {
+	confFile, err := ioutil.TempFile("", "config_file")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := confFile.Write([]byte("[DEFAULT]\n")); err != nil {
+		os.Remove(confFile.Name())
+		return nil, err
+	}
+
+	if _, err := cfg.WriteTo(confFile); err != nil {
+		os.Remove(confFile.Name())
+		return nil, err
+	}
+	return confFile, nil
+}
+
+// generateRSAKeyFile generates an RSA key file for use in unit tests.
+// NOTE: The caller is responsible for deleting the temporary file.
+func generateRSAKeyFile() (*os.File, error) {
+	// Create temporary file for the key
+	f, err := ioutil.TempFile("", "key")
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate key
+	priv, err := rsa.GenerateKey(rand.Reader, 2014)
+	if err != nil {
+		return nil, err
+	}
+
+	// ASN.1 DER encoded form
+	privDer := x509.MarshalPKCS1PrivateKey(priv)
+	privBlk := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   privDer,
+	}
+
+	// Write the key out
+	if _, err := f.Write(pem.EncodeToMemory(&privBlk)); err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}

--- a/post-processor/oracle/oci/export/export_driver.go
+++ b/post-processor/oracle/oci/export/export_driver.go
@@ -1,0 +1,128 @@
+package export
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	core "github.com/oracle/oci-go-sdk/core"
+	os "github.com/oracle/oci-go-sdk/objectstorage"
+)
+
+// driverOCI implements the Driver interface and communicates with Oracle
+// OCI.
+
+type ExportClient struct {
+	computeClient core.ComputeClient
+	osClient      os.ObjectStorageClient
+	cfg           *Config
+}
+
+// NewDriverOCI Creates a new driverOCI with a connected compute client and a connected vcn client.
+func NewExportClient(cfg *Config) (*ExportClient, error) {
+	coreClient, err := core.NewComputeClientWithConfigurationProvider(cfg.ConfigProvider)
+	if err != nil {
+		return nil, err
+	}
+	osclient, err := os.NewObjectStorageClientWithConfigurationProvider(cfg.ConfigProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ExportClient{
+		computeClient: coreClient,
+		osClient:      osclient,
+		cfg:           cfg,
+	}, nil
+}
+
+// CreateInstance creates a new compute instance.
+func (d *ExportClient) ExportImage(imageid string) (string, error) {
+	Namespace, err := d.getNamespace()
+	if err != nil {
+		return "", err
+	}
+	imageDetails := core.ExportImageViaObjectStorageTupleDetails{
+		BucketName:    &d.cfg.BucketName,
+		ObjectName:    &d.cfg.ImageName,
+		NamespaceName: &Namespace,
+	}
+
+	exportImageRequest := core.ExportImageRequest{
+		ImageId:            &imageid,
+		ExportImageDetails: imageDetails,
+	}
+
+	response, err := d.computeClient.ExportImage(context.TODO(), exportImageRequest)
+
+	if err != nil {
+		return "", err
+	}
+	err = d.WaitForImageExport(context.TODO(), imageid)
+	if err != nil {
+		return "", err
+	}
+
+	return response.Image.String(), nil
+}
+
+func (d *ExportClient) getNamespace() (string, error) {
+	request := os.GetNamespaceRequest{}
+	r, err := d.osClient.GetNamespace(context.TODO(), request)
+	if err != nil {
+		return "", err
+	}
+	fmt.Println("get namespace")
+	return *r.Value, nil
+}
+
+// WaitForImageCreation waits for a provisioning custom image to reach the
+// "AVAILABLE" state.
+func (d *ExportClient) WaitForImageExport(ctx context.Context, id string) error {
+	return waitForResourceToReachState(
+		func(string) (string, error) {
+			image, err := d.computeClient.GetImage(ctx, core.GetImageRequest{ImageId: &id})
+			if err != nil {
+				return "", err
+			}
+			return string(image.LifecycleState), nil
+		},
+		id,
+		[]string{"EXPORTING"},
+		"AVAILABLE",
+		0,             //Unlimited Retries
+		5*time.Second, //5 second wait between retries
+	)
+}
+
+// WaitForResourceToReachState checks the response of a request through a
+// polled get and waits until the desired state or until the max retried has
+// been reached.
+func waitForResourceToReachState(getResourceState func(string) (string, error), id string, waitStates []string, terminalState string, maxRetries int, waitDuration time.Duration) error {
+	for i := 0; maxRetries == 0 || i < maxRetries; i++ {
+		state, err := getResourceState(id)
+		if err != nil {
+			return err
+		}
+
+		if stringSliceContains(waitStates, state) {
+			time.Sleep(waitDuration)
+			continue
+		} else if state == terminalState {
+			return nil
+		}
+		return fmt.Errorf("Unexpected resource state %q, expecting a waiting state %s or terminal state  %q ", state, waitStates, terminalState)
+	}
+	return fmt.Errorf("Maximum number of retries (%d) exceeded; resource did not reach state %q", maxRetries, terminalState)
+}
+
+// stringSliceContains loops through a slice of strings returning a boolean
+// based on whether a given value is contained in the slice.
+func stringSliceContains(slice []string, value string) bool {
+	for _, elem := range slice {
+		if elem == value {
+			return true
+		}
+	}
+	return false
+}

--- a/post-processor/oracle/oci/export/post-processor.go
+++ b/post-processor/oracle/oci/export/post-processor.go
@@ -1,0 +1,38 @@
+package export
+
+import (
+	"github.com/hashicorp/packer/packer"
+)
+
+const BuilderId = "packer.post-processor.oracle-oci-export"
+
+// Configuration of this post processor
+
+type PostProcessor struct {
+	config *Config
+}
+
+// Entry point for configuration parsing when we've defined
+func (p *PostProcessor) Configure(raws ...interface{}) error {
+
+	config, err := NewConfig(raws...)
+	if err != nil {
+		return err
+	}
+	p.config = config
+	return nil
+}
+
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+	ui.Say(p.config.CompartmentID)
+	cli, err := NewExportClient(p.config)
+	if err != nil {
+		return artifact, false, err
+	}
+	_, err = cli.ExportImage(artifact.Id())
+	if err != nil {
+		return artifact, false, err
+	}
+	ui.Say("Image successfully exported to Object storage")
+	return artifact, true, nil
+}

--- a/website/source/docs/post-processors/oracle-oci-export.html.md
+++ b/website/source/docs/post-processors/oracle-oci-export.html.md
@@ -1,0 +1,116 @@
+---
+description: |
+    The Oracle Cloud infrastructure Image Exporter post-processor exports an image from a Packer oracle-oci builder run and uploads it to oracle cloud object storage. The exported
+    images can be easily shared and uploaded to other oracle Cloud Projects.
+layout: docs
+page_title: 'Oracle cloud Image Exporter - Post-Processors'
+sidebar_current: 'docs-post-processors-oralce-oci-export'
+---
+
+# Oracle Cloud Infrastructure Image Exporter Post-Processor
+
+Type: `oracle-oci-export`
+
+The Oracle Cloud infrastructure Image Exporter  post-processor exports the resultant image
+from a oracle-oci build to a object storage bucket.
+
+The exporter uses the same credentials as oracle-oci builder.
+
+
+
+## Configuration
+
+### Required
+
+-   `availability_domain` (string) - The name of the [Availability
+    Domain](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/regions.htm)
+    within which a new instance is launched and provisioned. The names of the
+    Availability Domains have a prefix that is specific to your
+    [tenancy](https://docs.us-phoenix-1.oraclecloud.com/Content/GSG/Concepts/concepts.htm#two).
+
+    To get a list of the Availability Domains, use the
+    [ListAvailabilityDomains](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/identity/latest/AvailabilityDomain/ListAvailabilityDomains)
+    operation, which is available in the IAM Service API.
+
+-   `compartment_ocid` (string) - The OCID of the
+    [compartment](https://docs.us-phoenix-1.oraclecloud.com/Content/GSG/Tasks/choosingcompartments.htm)
+
+-   `fingerprint` (string) - Fingerprint for the OCI API signing key. Overrides
+    value provided by the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present.
+
+### Optional
+
+-   `access_cfg_file` (string) - The path to the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm).
+    Defaults to `$HOME/.oci/config`.
+
+-   `access_cfg_file_account` (string) - The specific account in the [OCI
+    config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    to use. Defaults to `DEFAULT`.
+
+-   `bucket_name` (string) - Bucket name where the image is stored in objectstorage.
+
+-   `image_name` (string) - Name of the image.
+
+-   `key_file` (string) - Full path and filename of the OCI API signing key.
+    Overrides value provided by the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present.
+
+-   `pass_phrase` (string) - Pass phrase used to decrypt the OCI API signing
+    key. Overrides value provided by the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present.
+
+-   `region` (string) - An Oracle Cloud Infrastructure region. Overrides value
+    provided by the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present.
+
+-   `tenancy_ocid` (string) - The OCID of your tenancy. Overrides value
+    provided by the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present.
+
+-   `user_ocid` (string) - The OCID of the user calling the OCI API. Overrides
+    value provided by the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present.
+
+-   `tags` (map of strings) - Add one or more freeform tags to the resulting
+    custom image. See [the Oracle
+    docs](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/taggingoverview.htm)
+    for more details. Example:
+
+## Basic Example
+
+The following example builds a Oracle cloud infrastructre image and exports the image to a specified bucked in oracle cloud objectstorage.
+
+``` json
+{
+  "builders": [
+    {
+        "availability_domain": "aaaa:PHX-AD-1",
+        "base_image_ocid": "ocid1.image.oc1.phx.aaaaaaaa5yu6pw3riqtuhxzov7fdngi4tsteganmao54nq3pyxu3hxcuzmoa",
+        "compartment_ocid": "ocid1.compartment.oc1..aaa",
+        "image_name": "ExampleImage",
+        "shape": "VM.Standard1.1",
+        "ssh_username": "opc",
+        "subnet_ocid": "ocid1.subnet.oc1..aaa",
+        "type": "oracle-oci"
+    }
+  ],
+  "post-processors": [
+    {
+          "type": "oracle-oci-export",
+          "availability_domain": "aaaa:PHX-AD-1",
+          "compartment_ocid": "ocid1.compartment.oc1..aaa",
+          "image_name": "customOracle_V1.2",
+          "bucket_name":"ocitest"
+   }
+  ]
+}
+```


### PR DESCRIPTION
Support exporting Oracle cloud infrastructure images. Once the image is build using oracle-oci builder type, the post-processor type oracle-oci-export expects similar configuration as builder and exports image to the respective bucket in object storage. The exported images can be shared publicly.  

Test results 
https://gist.github.com/smothiki/4c2f3a3c2a75ddd57bd0f2efef12544b