### PR TITLE
unignore interrupt signals (ctrl + c) on windows

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -159,12 +159,12 @@ func (c *BuildCommand) Run(args []string) int {
 		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 		defer signal.Stop(sigCh)
 		go func(b packer.Build) {
-			<-sigCh
+			sig := <-sigCh
 			interruptWg.Add(1)
 			defer interruptWg.Done()
 			interrupted = true
 
-			log.Printf("Stopping build: %s", b.Name())
+			log.Printf("Stopping build: %s after receiving %s", b.Name(), sig)
 			b.Cancel()
 			//cancelCtx()
 			log.Printf("Build cancelled: %s", b.Name())

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/masterzen/azure-sdk-for-go v0.0.0-20161014135628-ee4f0065d00c // indirect
 	github.com/masterzen/simplexml v0.0.0-20140219194429-95ba30457eb1 // indirect
 	github.com/masterzen/winrm v0.0.0-20180224160350-7e40f93ae939
-	github.com/mattn/go-tty v0.0.0-20181127064339-e4f871175a2f
+	github.com/mattn/go-tty v0.0.0-20190322114730-5518497423d1
 	github.com/miekg/dns v1.1.1 // indirect
 	github.com/mitchellh/cli v0.0.0-20170908181043-65fcae5817c8
 	github.com/mitchellh/copystructure v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-tty v0.0.0-20181127064339-e4f871175a2f h1:4P7Ul+TAnk92vTeVkXs6VLjmf1EhrYtDRa03PCYY6VM=
-github.com/mattn/go-tty v0.0.0-20181127064339-e4f871175a2f/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
+github.com/mattn/go-tty v0.0.0-20190322114730-5518497423d1 h1:VRq8MIkqXRI9aytxCxOTDiQorwXRt8vlSOapwx8Ubys=
+github.com/mattn/go-tty v0.0.0-20190322114730-5518497423d1/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=

--- a/vendor/github.com/mattn/go-tty/tty_unix.go
+++ b/vendor/github.com/mattn/go-tty/tty_unix.go
@@ -105,6 +105,7 @@ func (tty *TTY) raw() (func() error, error) {
 	if err != nil {
 		return nil, err
 	}
+	backup := *termios
 
 	termios.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
 	termios.Oflag &^= unix.OPOST
@@ -118,7 +119,7 @@ func (tty *TTY) raw() (func() error, error) {
 	}
 
 	return func() error {
-		if err := unix.IoctlSetTermios(int(tty.in.Fd()), ioctlWriteTermios, termios); err != nil {
+		if err := unix.IoctlSetTermios(int(tty.in.Fd()), ioctlWriteTermios, &backup); err != nil {
 			return err
 		}
 		return nil

--- a/vendor/github.com/mattn/go-tty/tty_windows.go
+++ b/vendor/github.com/mattn/go-tty/tty_windows.go
@@ -178,7 +178,6 @@ func open() (*TTY, error) {
 	st &^= enableWindowInput
 	st &^= enableExtendedFlag
 	st &^= enableQuickEditMode
-	st &^= enableProcessedInput
 
 	// ignore error
 	procSetConsoleMode.Call(h, uintptr(st))


### PR DESCRIPTION
fix #7412 after https://github.com/mattn/go-tty/pull/12 got merged.

docs: https://docs.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals