### PR TITLE
remove default ssh_username from oracle classic builder, but add note…

### DIFF
--- a/builder/oracle/classic/config.go
+++ b/builder/oracle/classic/config.go
@@ -75,10 +75,6 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 	if c.SSHSourceList == "" {
 		c.SSHSourceList = "seciplist:/oracle/public/public-internet"
 	}
-	// Use default oracle username with sudo privileges
-	if c.Comm.SSHUsername == "" {
-		c.Comm.SSHUsername = "opc"
-	}
 
 	if c.SnapshotTimeout == 0 {
 		c.SnapshotTimeout = 20 * time.Minute

--- a/builder/oracle/classic/config_test.go
+++ b/builder/oracle/classic/config_test.go
@@ -42,6 +42,7 @@ func TestConfigValidationCatchesMissing(t *testing.T) {
 		"dest_image_list",
 		"source_image_list",
 		"shape",
+		"ssh_username",
 	}
 	for _, key := range required {
 		tc := testConfig()
@@ -50,15 +51,6 @@ func TestConfigValidationCatchesMissing(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Test should have failed when config lacked %s!", key)
 		}
-	}
-}
-
-func TestValidationsIgnoresOptional(t *testing.T) {
-	tc := testConfig()
-	delete(tc, "ssh_username")
-	_, err := NewConfig(tc)
-	if err != nil {
-		t.Fatalf("Shouldn't care if ssh_username is missing: err: %#v", err.Error())
 	}
 }
 

--- a/website/source/docs/builders/oracle-classic.html.md
+++ b/website/source/docs/builders/oracle-classic.html.md
@@ -87,9 +87,11 @@ builder. This builder currently only works with the SSH communicator.
     list. If you don't provide one, Packer will provide a generic description.
 
 -   `ssh_username` (string) - The username that Packer will use to SSH into the
-    instance; defaults to `opc`, the default oracle user, which has sudo
-    privileges. If you have already configured users on your machine, you may
-    prompt Packer to use one of those instead. For more detail, see the
+    instance; required if using SSH. The default oracle user with sudo
+    privileges is `opc`, so you may set `ssh_username` to `opc` if you have not
+    yet configured users on your machine. If you have already configured users
+    on your machine, you may prompt Packer to use one of those instead. For
+    more detail, see the
     [documentation](https://docs.oracle.com/en/cloud/iaas/compute-iaas-cloud/stcsg/accessing-oracle-linux-instance-using-ssh.html).
 
 -   `image_name` (string) - The name to assign to the resulting custom image.


### PR DESCRIPTION
Removes defaulting of SSH username to bring oracle classic builder in line with our other ones. The docs still mention this as the default SSH user, but we will no longer assume that's what people want.

Closes #6928 