### PR TITLE
Do 7150

### DIFF
--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -68,7 +68,7 @@ type Config struct {
 
 	// The size, in megabytes, of the computer memory in the VM.
 	// By default, this is 1024 (about 1 GB).
-	RamSize uint `mapstructure:"ram_size"`
+	RamSize uint `mapstructure:"memory"`
 
 	//
 	SecondaryDvdImages []string `mapstructure:"secondary_iso_images"`
@@ -87,7 +87,7 @@ type Config struct {
 	SwitchVlanId                   string `mapstructure:"switch_vlan_id"`
 	MacAddress                     string `mapstructure:"mac_address"`
 	VlanId                         string `mapstructure:"vlan_id"`
-	Cpu                            uint   `mapstructure:"cpu"`
+	Cpu                            uint   `mapstructure:"cpus"`
 	Generation                     uint   `mapstructure:"generation"`
 	EnableMacSpoofing              bool   `mapstructure:"enable_mac_spoofing"`
 	UseLegacyNetworkAdapter        bool   `mapstructure:"use_legacy_network_adapter"`
@@ -593,10 +593,10 @@ func (b *Builder) checkRamSize() error {
 	log.Println(fmt.Sprintf("%s: %v", "RamSize", b.config.RamSize))
 
 	if b.config.RamSize < MinRamSize {
-		return fmt.Errorf("ram_size: Virtual machine requires memory size >= %v MB, but defined: %v",
+		return fmt.Errorf("memory: Virtual machine requires memory size >= %v MB, but defined: %v",
 			MinRamSize, b.config.RamSize)
 	} else if b.config.RamSize > MaxRamSize {
-		return fmt.Errorf("ram_size: Virtual machine requires memory size <= %v MB, but defined: %v",
+		return fmt.Errorf("memory: Virtual machine requires memory size <= %v MB, but defined: %v",
 			MaxRamSize, b.config.RamSize)
 	}
 

--- a/builder/hyperv/iso/builder_test.go
+++ b/builder/hyperv/iso/builder_test.go
@@ -21,7 +21,7 @@ func testConfig() map[string]interface{} {
 		"iso_url":                 "http://www.packer.io",
 		"shutdown_command":        "yes",
 		"ssh_username":            "foo",
-		"ram_size":                64,
+		"memory":                  64,
 		"disk_size":               256,
 		"disk_block_size":         1,
 		"guest_additions_mode":    "none",

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -50,7 +50,7 @@ type Config struct {
 
 	// The size, in megabytes, of the computer memory in the VM.
 	// By default, this is 1024 (about 1 GB).
-	RamSize uint `mapstructure:"ram_size"`
+	RamSize uint `mapstructure:"memory"`
 
 	//
 	SecondaryDvdImages []string `mapstructure:"secondary_iso_images"`
@@ -85,7 +85,7 @@ type Config struct {
 	SwitchVlanId                   string `mapstructure:"switch_vlan_id"`
 	MacAddress                     string `mapstructure:"mac_address"`
 	VlanId                         string `mapstructure:"vlan_id"`
-	Cpu                            uint   `mapstructure:"cpu"`
+	Cpu                            uint   `mapstructure:"cpus"`
 	Generation                     uint   `mapstructure:"generation"`
 	EnableMacSpoofing              bool   `mapstructure:"enable_mac_spoofing"`
 	EnableDynamicMemory            bool   `mapstructure:"enable_dynamic_memory"`

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -576,10 +576,10 @@ func (b *Builder) checkRamSize() error {
 	log.Println(fmt.Sprintf("%s: %v", "RamSize", b.config.RamSize))
 
 	if b.config.RamSize < MinRamSize {
-		return fmt.Errorf("ram_size: Virtual machine requires memory size >= %v MB, but defined: %v",
+		return fmt.Errorf("memory: Virtual machine requires memory size >= %v MB, but defined: %v",
 			MinRamSize, b.config.RamSize)
 	} else if b.config.RamSize > MaxRamSize {
-		return fmt.Errorf("ram_size: Virtual machine requires memory size <= %v MB, but defined: %v",
+		return fmt.Errorf("memory: Virtual machine requires memory size <= %v MB, but defined: %v",
 			MaxRamSize, b.config.RamSize)
 	}
 

--- a/builder/hyperv/vmcx/builder_test.go
+++ b/builder/hyperv/vmcx/builder_test.go
@@ -22,7 +22,7 @@ func testConfig() map[string]interface{} {
 		"shutdown_command":        "yes",
 		"ssh_username":            "foo",
 		"switch_name":             "switch", // to avoid using builder.detectSwitchName which can lock down in travis-ci
-		"ram_size":                64,
+		"memory":                  64,
 		"guest_additions_mode":    "none",
 		"clone_from_vmcx_path":    "generated",
 		packer.BuildNameConfigKey: "foo",

--- a/fix/fixer.go
+++ b/fix/fixer.go
@@ -39,6 +39,7 @@ func init() {
 		"powershell-escapes":         new(FixerPowerShellEscapes),
 		"hyperv-deprecations":        new(FixerHypervDeprecations),
 		"hyperv-vmxc-typo":           new(FixerHypervVmxcTypo),
+		"hyperv-cpu-and-ram":         new(FizerHypervCPUandRAM),
 		"vmware-compaction":          new(FixerVMwareCompaction),
 	}
 
@@ -61,5 +62,6 @@ func init() {
 		"docker-email",
 		"powershell-escapes",
 		"vmware-compaction",
+		"hyperv-cpu-and-ram",
 	}
 }

--- a/fix/fixer_hyperv_cpu_and_ram_naming.go
+++ b/fix/fixer_hyperv_cpu_and_ram_naming.go
@@ -1,0 +1,58 @@
+package fix
+
+import (
+	"github.com/mitchellh/mapstructure"
+)
+
+// FizerHypervCPUandRAM fixes the typo in "clone_from_vmxc_path" replacing
+// it with "clone_from_vmcx_path" in Hyper-V VMCX builder templates
+type FizerHypervCPUandRAM struct{}
+
+func (FizerHypervCPUandRAM) Fix(input map[string]interface{}) (map[string]interface{}, error) {
+	// The type we'll decode into; we only care about builders
+	type template struct {
+		Builders []map[string]interface{}
+	}
+
+	// Decode the input into our structure, if we can
+	var tpl template
+	if err := mapstructure.Decode(input, &tpl); err != nil {
+		return nil, err
+	}
+
+	for _, builder := range tpl.Builders {
+		builderTypeRaw, ok := builder["type"]
+		if !ok {
+			continue
+		}
+
+		builderType, ok := builderTypeRaw.(string)
+		if !ok {
+			continue
+		}
+
+		if builderType != "hyperv-vmcx" && builderType != "hyperv-iso" {
+			continue
+		}
+
+		ncpus, ok := builder["cpu"]
+		if ok {
+			delete(builder, "cpu")
+			builder["cpus"] = ncpus
+		}
+
+		memory, ok := builder["ram_size"]
+		if ok {
+			delete(builder, "ram_size")
+			builder["memory"] = memory
+		}
+	}
+
+	input["builders"] = tpl.Builders
+	return input, nil
+}
+
+func (FizerHypervCPUandRAM) Synopsis() string {
+	return `Replaces "cpu" with "cpus" and "ram_size" with "memory"` +
+		`in Hyper-V VMCX builder templates`
+}

--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -78,7 +78,7 @@ builder.
 -   `configuration_version` (string) - This allows you to set the vm version when
      calling New-VM to generate the vm.
 
--   `cpu` (number) - The number of CPUs the virtual machine should use. If
+-   `cpus` (number) - The number of CPUs the virtual machine should use. If
     this isn't specified, the default is 1 CPU.
 
 -   `differencing_disk` (boolean) - If true enables differencing disks. Only
@@ -179,7 +179,7 @@ builder.
     created, must be empty prior to running the builder. By default this is
     "output-BUILDNAME" where "BUILDNAME" is the name of the build.
 
--   `ram_size` (number) - The amount, in megabytes, of RAM to assign to the
+-   `memory` (number) - The amount, in megabytes, of RAM to assign to the
     VM. By default, this is 1 GB.
 
 -   `secondary_iso_images` (array of strings) - A list of ISO paths to
@@ -379,8 +379,8 @@ Packer config:
       "winrm_password": "vagrant",
       "winrm_timeout" : "4h",
       "shutdown_command": "f:\\run-sysprep.cmd",
-      "ram_size": 4096,
-      "cpu": 4,
+      "memory": 4096,
+      "cpus": 4,
       "generation": 2,
       "switch_name":"LAN",
       "enable_secure_boot":true
@@ -887,8 +887,8 @@ virtual switch with an `External` connection type.
 {
   "variables": {
     "vm_name": "ubuntu-xenial",
-    "cpu": "2",
-    "ram_size": "1024",
+    "cpus": "2",
+    "memory": "1024",
     "disk_size": "21440",
     "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.1-server-amd64.iso",
     "iso_checksum_type": "sha1",
@@ -923,8 +923,8 @@ virtual switch with an `External` connection type.
         "boot<enter>"
       ],
       "shutdown_command": "echo 'packer' | sudo -S -E shutdown -P now",
-      "ram_size": "{{user `ram_size`}}",
-      "cpu": "{{user `cpu`}}",
+      "memory": "{{user `memory`}}",
+      "cpus": "{{user `cpu`}}",
       "generation": 2,
       "enable_secure_boot": false
     }

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -207,7 +207,7 @@ builder.
     created, must be empty prior to running the builder. By default this is
     "output-BUILDNAME" where "BUILDNAME" is the name of the build.
 
--   `ram_size` (number) - The amount, in megabytes, of RAM to assign to the
+-   `memory` (number) - The amount, in megabytes, of RAM to assign to the
     VM. By default, this is 1 GB.
 
 -   `secondary_iso_images` (array of strings) - A list of ISO paths to
@@ -393,7 +393,7 @@ Packer config:
       "winrm_password": "vagrant",
       "winrm_timeout" : "4h",
       "shutdown_command": "f:\\run-sysprep.cmd",
-      "ram_size": 4096,
+      "memory": 4096,
       "cpu": 4,
       "generation": 2,
       "switch_name":"LAN",
@@ -902,7 +902,7 @@ virtual switch with an `External` connection type.
   "variables": {
     "vm_name": "ubuntu-xenial",
     "cpu": "2",
-    "ram_size": "1024",
+    "memory": "1024",
     "disk_size": "21440",
     "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.1-server-amd64.iso",
     "iso_checksum_type": "sha1",
@@ -937,7 +937,7 @@ virtual switch with an `External` connection type.
         "boot<enter>"
       ],
       "shutdown_command": "echo 'packer' | sudo -S -E shutdown -P now",
-      "ram_size": "{{user `ram_size`}}",
+      "memory": "{{user `memory`}}",
       "cpu": "{{user `cpu`}}",
       "generation": 2,
       "enable_secure_boot": false


### PR DESCRIPTION
In our slow quest for conformity, replace "cpu" with "cpus" and "ram_size" with "memory" for the hyper-v builder in order to bring this builder's custom config in line with that of vmware/virtualbox/etc builders.

Backwards incompatible, but comes with a handy dandy fixer.

Closes #7150