### PR TITLE
Allow both ports and networks in openstack builder

### DIFF
--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -48,7 +48,7 @@ func (s *StepRunSourceServer) Run(_ context.Context, state multistep.StateBag) m
 		networks[i].Port = s.Ports[i]
 	}
 	for ; i < len(networks); i++ {
-		networks[i].UUID = s.Networks[i]
+		networks[i].UUID = s.Networks[i-len(s.Ports)]
 	}
 
 	userData := []byte(s.UserData)


### PR DESCRIPTION
Current code would throw an index out of range exception when trying to access `s.Networks[len(s.Networks)]` when `len(s.Ports)>0` and would ignore the first `len(s.Ports)` entries of `s.Networks`, fix by shifting access to `s.Networks` back by `len(s.Ports)` so that the final read is `networks[len(s.Networks)+len(s.Ports)-1].UUID=s.Networks[len(s.Networks)+len(s.Ports)-1-len(s.Ports)]` which is necessarily the last member of `s.Networks`