### PR TITLE
Ansible 2.7 "use_tty" fix

### DIFF
--- a/website/source/docs/provisioners/ansible.html.md
+++ b/website/source/docs/provisioners/ansible.html.md
@@ -262,8 +262,7 @@ DOCUMENTATION = '''
     connection: packer
     short_description: ssh based connections for powershell via packer
     description:
-        - This connection plugin allows ansible to communicate to the target packer
-        machines via ssh based connections for powershell.
+        - This connection plugin allows ansible to communicate to the target packer machines via ssh based connections for powershell.
     author: Packer
     version_added: na
     options:


### PR DESCRIPTION
Per Issue #6453, Ansible@2.7 targetting Windows was throwing the following error when setup as the docs instruct:
"Requested option use_tty was not defined in configuration"

This is caused by something in Ansible silently discarding the whole `DOCUMENTATION` string configuration when it can't parse it. The changed line in this PR fixes that. :)

I tested Ansible 2.3.2, 2.4, 2.5, and 2.7.9 all work when using the ssh plugin doc string from Ansible 2.7. So I think the following are correct:

Closes: #4904
Closes: #6453 

It should probably also be documented that if you are using Ansible 2.3 you need to be on at least 2.3.2.