### PR TITLE
make sure we filter the ui as well as the logs

### DIFF
--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -626,6 +626,9 @@ func TestSensitiveVars(t *testing.T) {
 		if filtered[0] != tc.Expected && len(filtered) != 1 {
 			t.Fatalf("not filtering sensitive vars; filtered is %#v", filtered)
 		}
+
+		// clear filter so it doesn't break other tests
+		LogSecretFilter.s = make(map[string]struct{})
 	}
 }
 

--- a/packer/ui.go
+++ b/packer/ui.go
@@ -247,6 +247,13 @@ func (rw *BasicUi) Message(message string) {
 	rw.l.Lock()
 	defer rw.l.Unlock()
 
+	// Use LogSecretFilter to scrub out sensitive variables
+	for s := range LogSecretFilter.s {
+		if s != "" {
+			message = strings.Replace(message, s, "<sensitive>", -1)
+		}
+	}
+
 	log.Printf("ui: %s", message)
 	_, err := fmt.Fprint(rw.Writer, message+"\n")
 	if err != nil {
@@ -261,6 +268,13 @@ func (rw *BasicUi) Error(message string) {
 	writer := rw.ErrorWriter
 	if writer == nil {
 		writer = rw.Writer
+	}
+
+	// Use LogSecretFilter to scrub out sensitive variables
+	for s := range LogSecretFilter.s {
+		if s != "" {
+			message = strings.Replace(message, s, "<sensitive>", -1)
+		}
 	}
 
 	log.Printf("ui error: %s", message)


### PR DESCRIPTION
Sensitive Vars was being filtered from calls to log, but not calls to our packer UI -- this meant that while log files were free of leaked variables, the UI stream could still accidentally reveal secrets.

This code filters the basic UI calls so that messages passing through them receive the same filtering as the logs. 

Closes #7448 