### PR TITLE
Default keep input artifact

### DIFF
--- a/packer/build.go
+++ b/packer/build.go
@@ -275,11 +275,13 @@ PostProcessorRunSeqLoop:
 			}
 
 			keep := defaultKeep
-			// When nil, go for the default. If overridden by user, use that
-			// instead.
+			// When user has not set keep_input_artifuact
+			// corePP.keepInputArtifact is nil.
+			// In this case, use the keepDefault provided by the postprocessor.
+			// When user _has_ set keep_input_atifact, go with that instead.
 			// Exception: for postprocessors that will fail/become
-			// useless if keep isn't set, force an override that still uses
-			// post-processor preference instead of user preference.
+			// useless if keep isn't true, heed forceOverride and keep the
+			// input artifact regardless of user preference.
 			if corePP.keepInputArtifact != nil {
 				if defaultKeep && *corePP.keepInputArtifact == false && forceOverride {
 					log.Printf("The %s post-processor forces "+
@@ -287,7 +289,7 @@ PostProcessorRunSeqLoop:
 						"build chain. User-set keep_input_artifact=false will be"+
 						"ignored.", corePP.processorType)
 				} else {
-					// User overrides default
+					// User overrides default.
 					keep = *corePP.keepInputArtifact
 				}
 			}

--- a/packer/build.go
+++ b/packer/build.go
@@ -281,7 +281,7 @@ PostProcessorRunSeqLoop:
 			// useless if keep isn't set, force an override that still uses
 			// post-processor preference instead of user preference.
 			if corePP.keepInputArtifact != nil {
-				if *corePP.keepInputArtifact == false && forceOverride {
+				if defaultKeep && *corePP.keepInputArtifact == false && forceOverride {
 					log.Printf("The %s post-processor forces "+
 						"keep_input_artifact=true to preserve integrity of the"+
 						"build chain. User-set keep_input_artifact=false will be"+

--- a/packer/build.go
+++ b/packer/build.go
@@ -309,7 +309,8 @@ PostProcessorRunSeqLoop:
 				} else {
 					log.Printf("Deleting prior artifact from post-processor '%s'", corePP.processorType)
 					if err := priorArtifact.Destroy(); err != nil {
-						errors = append(errors, fmt.Errorf("Failed cleaning up prior artifact: %s", err))
+						log.Printf("Error is %#v", err)
+						errors = append(errors, fmt.Errorf("Failed cleaning up prior artifact: %s; pp is %s", err, corePP.processorType))
 					}
 				}
 			}

--- a/packer/build_test.go
+++ b/packer/build_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 )
 
+func boolPointer(tf bool) *bool {
+	return &tf
+}
+
 func testBuild() *coreBuild {
 	return &coreBuild{
 		name:          "test",
@@ -19,7 +23,7 @@ func testBuild() *coreBuild {
 		},
 		postProcessors: [][]coreBuildPostProcessor{
 			{
-				{&MockPostProcessor{ArtifactId: "pp"}, "testPP", make(map[string]interface{}), true},
+				{&MockPostProcessor{ArtifactId: "pp"}, "testPP", make(map[string]interface{}), boolPointer(true)},
 			},
 		},
 		variables: make(map[string]string),
@@ -245,7 +249,7 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build = testBuild()
 	build.postProcessors = [][]coreBuildPostProcessor{
 		{
-			{&MockPostProcessor{ArtifactId: "pp"}, "pp", make(map[string]interface{}), false},
+			{&MockPostProcessor{ArtifactId: "pp"}, "pp", make(map[string]interface{}), boolPointer(false)},
 		},
 	}
 
@@ -270,10 +274,10 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build = testBuild()
 	build.postProcessors = [][]coreBuildPostProcessor{
 		{
-			{&MockPostProcessor{ArtifactId: "pp1"}, "pp", make(map[string]interface{}), false},
+			{&MockPostProcessor{ArtifactId: "pp1"}, "pp", make(map[string]interface{}), boolPointer(false)},
 		},
 		{
-			{&MockPostProcessor{ArtifactId: "pp2"}, "pp", make(map[string]interface{}), true},
+			{&MockPostProcessor{ArtifactId: "pp2"}, "pp", make(map[string]interface{}), boolPointer(true)},
 		},
 	}
 
@@ -298,12 +302,12 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build = testBuild()
 	build.postProcessors = [][]coreBuildPostProcessor{
 		{
-			{&MockPostProcessor{ArtifactId: "pp1a"}, "pp", make(map[string]interface{}), false},
-			{&MockPostProcessor{ArtifactId: "pp1b"}, "pp", make(map[string]interface{}), true},
+			{&MockPostProcessor{ArtifactId: "pp1a"}, "pp", make(map[string]interface{}), boolPointer(false)},
+			{&MockPostProcessor{ArtifactId: "pp1b"}, "pp", make(map[string]interface{}), boolPointer(true)},
 		},
 		{
-			{&MockPostProcessor{ArtifactId: "pp2a"}, "pp", make(map[string]interface{}), false},
-			{&MockPostProcessor{ArtifactId: "pp2b"}, "pp", make(map[string]interface{}), false},
+			{&MockPostProcessor{ArtifactId: "pp2a"}, "pp", make(map[string]interface{}), boolPointer(false)},
+			{&MockPostProcessor{ArtifactId: "pp2b"}, "pp", make(map[string]interface{}), boolPointer(false)},
 		},
 	}
 
@@ -329,7 +333,61 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build.postProcessors = [][]coreBuildPostProcessor{
 		{
 			{
-				&MockPostProcessor{ArtifactId: "pp", Keep: true}, "pp", make(map[string]interface{}), false,
+				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: true}, "pp", make(map[string]interface{}), boolPointer(false),
+			},
+		},
+	}
+
+	build.Prepare()
+	artifacts, err = build.Run(ui)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expectedIds = []string{"b", "pp"}
+	artifactIds = make([]string, len(artifacts))
+	for i, artifact := range artifacts {
+		artifactIds[i] = artifact.Id()
+	}
+
+	if !reflect.DeepEqual(artifactIds, expectedIds) {
+		t.Fatalf("unexpected ids: %#v", artifactIds)
+	}
+
+	// Test case: Test that with a single post-processor that non-forcibly
+	// keeps inputs, that the artifacts are discarded if user overrides.
+	build = testBuild()
+	build.postProcessors = [][]coreBuildPostProcessor{
+		{
+			{
+				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: false}, "pp", make(map[string]interface{}), boolPointer(false),
+			},
+		},
+	}
+
+	build.Prepare()
+	artifacts, err = build.Run(ui)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expectedIds = []string{"pp"}
+	artifactIds = make([]string, len(artifacts))
+	for i, artifact := range artifacts {
+		artifactIds[i] = artifact.Id()
+	}
+
+	if !reflect.DeepEqual(artifactIds, expectedIds) {
+		t.Fatalf("unexpected ids: %#v", artifactIds)
+	}
+
+	// Test case: Test that with a single post-processor that non-forcibly
+	// keeps inputs, that the artifacts are kept if user does not have preference.
+	build = testBuild()
+	build.postProcessors = [][]coreBuildPostProcessor{
+		{
+			{
+				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: false}, "pp", make(map[string]interface{}), nil,
 			},
 		},
 	}

--- a/packer/plugin/post_processor.go
+++ b/packer/plugin/post_processor.go
@@ -20,7 +20,7 @@ func (c *cmdPostProcessor) Configure(config ...interface{}) error {
 	return c.p.Configure(config...)
 }
 
-func (c *cmdPostProcessor) PostProcess(ui packer.Ui, a packer.Artifact) (packer.Artifact, bool, error) {
+func (c *cmdPostProcessor) PostProcess(ui packer.Ui, a packer.Artifact) (packer.Artifact, bool, bool, error) {
 	defer func() {
 		r := recover()
 		c.checkExit(r, nil)

--- a/packer/plugin/post_processor_test.go
+++ b/packer/plugin/post_processor_test.go
@@ -13,8 +13,8 @@ func (helperPostProcessor) Configure(...interface{}) error {
 	return nil
 }
 
-func (helperPostProcessor) PostProcess(packer.Ui, packer.Artifact) (packer.Artifact, bool, error) {
-	return nil, false, nil
+func (helperPostProcessor) PostProcess(packer.Ui, packer.Artifact) (packer.Artifact, bool, bool, error) {
+	return nil, false, false, nil
 }
 
 func TestPostProcessor_NoExist(t *testing.T) {

--- a/packer/post_processor.go
+++ b/packer/post_processor.go
@@ -13,6 +13,10 @@ type PostProcessor interface {
 
 	// PostProcess takes a previously created Artifact and produces another
 	// Artifact. If an error occurs, it should return that error. If `keep`
-	// is to true, then the previous artifact is forcibly kept.
-	PostProcess(Ui, Artifact) (a Artifact, keep bool, err error)
+	// is true, then the previous artifact defaults to being kept if
+	// user has not given a value to keep_input_artifact. If forceOverride
+	// is true, then any user input for keep_input_artifact is ignored and
+	// the artifact is either kept or discarded according to the value set in
+	// `keep`.
+	PostProcess(Ui, Artifact) (a Artifact, keep bool, forceOverride bool, err error)
 }

--- a/packer/post_processor_mock.go
+++ b/packer/post_processor_mock.go
@@ -3,9 +3,10 @@ package packer
 // MockPostProcessor is an implementation of PostProcessor that can be
 // used for tests.
 type MockPostProcessor struct {
-	ArtifactId string
-	Keep       bool
-	Error      error
+	ArtifactId    string
+	Keep          bool
+	ForceOverride bool
+	Error         error
 
 	ConfigureCalled  bool
 	ConfigureConfigs []interface{}
@@ -22,12 +23,12 @@ func (t *MockPostProcessor) Configure(configs ...interface{}) error {
 	return t.ConfigureError
 }
 
-func (t *MockPostProcessor) PostProcess(ui Ui, a Artifact) (Artifact, bool, error) {
+func (t *MockPostProcessor) PostProcess(ui Ui, a Artifact) (Artifact, bool, bool, error) {
 	t.PostProcessCalled = true
 	t.PostProcessArtifact = a
 	t.PostProcessUi = ui
 
 	return &MockArtifact{
 		IdValue: t.ArtifactId,
-	}, t.Keep, t.Error
+	}, t.Keep, t.ForceOverride, t.Error
 }

--- a/packer/rpc/post_processor_test.go
+++ b/packer/rpc/post_processor_test.go
@@ -24,12 +24,12 @@ func (pp *TestPostProcessor) Configure(v ...interface{}) error {
 	return nil
 }
 
-func (pp *TestPostProcessor) PostProcess(ui packer.Ui, a packer.Artifact) (packer.Artifact, bool, error) {
+func (pp *TestPostProcessor) PostProcess(ui packer.Ui, a packer.Artifact) (packer.Artifact, bool, bool, error) {
 	pp.ppCalled = true
 	pp.ppArtifact = a
 	pp.ppArtifactId = a.Id()
 	pp.ppUi = ui
-	return testPostProcessorArtifact, false, nil
+	return testPostProcessorArtifact, false, false, nil
 }
 
 func TestPostProcessorRPC(t *testing.T) {
@@ -65,7 +65,7 @@ func TestPostProcessorRPC(t *testing.T) {
 		IdValue: "ppTestId",
 	}
 	ui := new(testUi)
-	artifact, _, err := ppClient.PostProcess(ui, a)
+	artifact, _, _, err := ppClient.PostProcess(ui, a)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/post-processor/alicloud-import/post-processor.go
+++ b/post-processor/alicloud-import/post-processor.go
@@ -118,13 +118,13 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	var err error
 
 	// Render this key since we didn't in the configure phase
 	p.config.OSSKey, err = interpolate.Render(p.config.OSSKey, &p.config.ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("Error rendering oss_key_name template: %s", err)
+		return nil, false, false, fmt.Errorf("Error rendering oss_key_name template: %s", err)
 	}
 	if p.config.OSSKey == "" {
 		p.config.OSSKey = "Packer_" + strconv.Itoa(time.Now().Nanosecond())
@@ -143,12 +143,12 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	// Hope we found something useful
 	if source == "" {
-		return nil, false, fmt.Errorf("No vhd or raw file found in artifact from builder")
+		return nil, false, false, fmt.Errorf("No vhd or raw file found in artifact from builder")
 	}
 
 	ecsClient, err := p.config.AlicloudAccessConfig.Client()
 	if err != nil {
-		return nil, false, fmt.Errorf("Failed to connect alicloud ecs  %s", err)
+		return nil, false, false, fmt.Errorf("Failed to connect alicloud ecs  %s", err)
 	}
 	ecsClient.SetBusinessInfo(BUSINESSINFO)
 
@@ -157,12 +157,12 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		ImageName: p.config.AlicloudImageName,
 	})
 	if err != nil {
-		return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+		return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 			getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 	}
 
 	if len(images) > 0 && !p.config.AlicloudImageForceDelete {
-		return nil, false, fmt.Errorf("Duplicated image exists, please delete the existing images " +
+		return nil, false, false, fmt.Errorf("Duplicated image exists, please delete the existing images " +
 			"or set the 'image_force_delete' value as true")
 	}
 
@@ -171,25 +171,25 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	client, err := oss.New(getEndPonit(p.config.AlicloudRegion), p.config.AlicloudAccessKey,
 		p.config.AlicloudSecretKey)
 	if err != nil {
-		return nil, false, fmt.Errorf("Creating oss connection failed: %s", err)
+		return nil, false, false, fmt.Errorf("Creating oss connection failed: %s", err)
 	}
 	bucket, err := queryOrCreateBucket(p.config.OSSBucket, client)
 	if err != nil {
-		return nil, false, fmt.Errorf("Failed to query or create bucket %s: %s", p.config.OSSBucket, err)
+		return nil, false, false, fmt.Errorf("Failed to query or create bucket %s: %s", p.config.OSSBucket, err)
 	}
 
 	if err != nil {
-		return nil, false, fmt.Errorf("Failed to open %s: %s", source, err)
+		return nil, false, false, fmt.Errorf("Failed to open %s: %s", source, err)
 	}
 
 	err = bucket.PutObjectFromFile(p.config.OSSKey, source)
 	if err != nil {
-		return nil, false, fmt.Errorf("Failed to upload image %s: %s", source, err)
+		return nil, false, false, fmt.Errorf("Failed to upload image %s: %s", source, err)
 	}
 	if len(images) > 0 && p.config.AlicloudImageForceDelete {
 		if err = ecsClient.DeleteImage(packercommon.Region(p.config.AlicloudRegion),
 			images[0].ImageId); err != nil {
-			return nil, false, fmt.Errorf("Delete duplicated image %s failed", images[0].ImageName)
+			return nil, false, false, fmt.Errorf("Delete duplicated image %s failed", images[0].ImageName)
 		}
 	}
 
@@ -221,7 +221,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 				RoleName: "AliyunECSImageImportDefaultRole",
 			})
 			if err != nil {
-				return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+				return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 					getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 			}
 			if roleResponse.Role.RoleId == "" {
@@ -229,7 +229,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 					RoleName:                 "AliyunECSImageImportDefaultRole",
 					AssumeRolePolicyDocument: AliyunECSImageImportDefaultRolePolicy,
 				}); err != nil {
-					return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+					return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 						getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 				}
 				if _, err := ramClient.AttachPolicyToRole(ram.AttachPolicyToRoleRequest{
@@ -239,7 +239,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 					},
 					RoleName: "AliyunECSImageImportDefaultRole",
 				}); err != nil {
-					return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+					return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 						getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 				}
 			} else {
@@ -247,7 +247,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 					RoleName: "AliyunECSImageImportDefaultRole",
 				})
 				if err != nil {
-					return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+					return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 						getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 				}
 				isAliyunECSImageImportRolePolicyNotExit := true
@@ -266,7 +266,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 						},
 						RoleName: "AliyunECSImageImportDefaultRole",
 					}); err != nil {
-						return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+						return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 							getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 					}
 				}
@@ -275,7 +275,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 						RoleName:                    "AliyunECSImageImportDefaultRole",
 						NewAssumeRolePolicyDocument: AliyunECSImageImportDefaultRolePolicy,
 					}); err != nil {
-					return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+					return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 						getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 				}
 			}
@@ -290,7 +290,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 						e.Code == "InvalidImageName.Duplicated" {
 						break
 					}
-					return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+					return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 						getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 				}
 				break
@@ -298,7 +298,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 		} else {
 
-			return nil, false, fmt.Errorf("Failed to start import from %s/%s: %s",
+			return nil, false, false, fmt.Errorf("Failed to start import from %s/%s: %s",
 				getEndPonit(p.config.OSSBucket), p.config.OSSKey, err)
 		}
 	}
@@ -319,12 +319,12 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		ui.Message(fmt.Sprintf("Deleting import source %s/%s/%s",
 			getEndPonit(p.config.AlicloudRegion), p.config.OSSBucket, p.config.OSSKey))
 		if err = bucket.DeleteObject(p.config.OSSKey); err != nil {
-			return nil, false, fmt.Errorf("Failed to delete %s/%s/%s: %s",
+			return nil, false, false, fmt.Errorf("Failed to delete %s/%s/%s: %s",
 				getEndPonit(p.config.AlicloudRegion), p.config.OSSBucket, p.config.OSSKey, err)
 		}
 	}
 
-	return artifact, false, nil
+	return artifact, false, false, nil
 }
 
 func queryOrCreateBucket(bucketName string, client *oss.Client) (*oss.Bucket, error) {

--- a/post-processor/artifice/post-processor.go
+++ b/post-processor/artifice/post-processor.go
@@ -48,7 +48,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	if len(artifact.Files()) > 0 {
 		ui.Say(fmt.Sprintf("Discarding artifact files: %s", strings.Join(artifact.Files(), ", ")))
 	}
@@ -56,5 +56,5 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	artifact, err := NewArtifact(p.config.Files)
 	ui.Say(fmt.Sprintf("Using these artifact files: %s", strings.Join(artifact.Files(), ", ")))
 
-	return artifact, true, err
+	return artifact, true, false, err
 }

--- a/post-processor/checksum/post-processor.go
+++ b/post-processor/checksum/post-processor.go
@@ -95,7 +95,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	files := artifact.Files()
 	var h hash.Hash
 
@@ -113,29 +113,29 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		for _, art := range files {
 			checksumFile, err := interpolate.Render(p.config.OutputPath, &p.config.ctx)
 			if err != nil {
-				return nil, false, err
+				return nil, false, true, err
 			}
 
 			if _, err := os.Stat(checksumFile); err != nil {
 				newartifact.files = append(newartifact.files, checksumFile)
 			}
 			if err := os.MkdirAll(filepath.Dir(checksumFile), os.FileMode(0755)); err != nil {
-				return nil, false, fmt.Errorf("unable to create dir: %s", err.Error())
+				return nil, false, true, fmt.Errorf("unable to create dir: %s", err.Error())
 			}
 			fw, err := os.OpenFile(checksumFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.FileMode(0644))
 			if err != nil {
-				return nil, false, fmt.Errorf("unable to create file %s: %s", checksumFile, err.Error())
+				return nil, false, true, fmt.Errorf("unable to create file %s: %s", checksumFile, err.Error())
 			}
 			fr, err := os.Open(art)
 			if err != nil {
 				fw.Close()
-				return nil, false, fmt.Errorf("unable to open file %s: %s", art, err.Error())
+				return nil, false, true, fmt.Errorf("unable to open file %s: %s", art, err.Error())
 			}
 
 			if _, err = io.Copy(h, fr); err != nil {
 				fr.Close()
 				fw.Close()
-				return nil, false, fmt.Errorf("unable to compute %s hash for %s", ct, art)
+				return nil, false, true, fmt.Errorf("unable to compute %s hash for %s", ct, art)
 			}
 			fr.Close()
 			fw.WriteString(fmt.Sprintf("%x\t%s\n", h.Sum(nil), filepath.Base(art)))
@@ -144,5 +144,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		}
 	}
 
-	return newartifact, true, nil
+	// sets keep and forceOverride to true because we don't want to accidentally
+	// delete the very artifact we're checksumming.
+	return newartifact, true, true, nil
 }

--- a/post-processor/checksum/post-processor_test.go
+++ b/post-processor/checksum/post-processor_test.go
@@ -98,7 +98,7 @@ func testChecksum(t *testing.T, config string) packer.Artifact {
 	checksum.config.PackerBuildName = "vanilla"
 	checksum.config.PackerBuilderType = "file"
 
-	artifactOut, _, err := checksum.PostProcess(ui, artifact)
+	artifactOut, _, _, err := checksum.PostProcess(ui, artifact)
 	if err != nil {
 		t.Fatalf("Failed to checksum artifact: %s", err)
 	}

--- a/post-processor/compress/post-processor.go
+++ b/post-processor/compress/post-processor.go
@@ -100,7 +100,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 
 	// These are extra variables that will be made available for interpolation.
 	p.config.ctx.Data = map[string]string{
@@ -110,7 +110,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	target, err := interpolate.Render(p.config.OutputPath, &p.config.ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("Error interpolating output value: %s", err)
+		return nil, false, false, fmt.Errorf("Error interpolating output value: %s", err)
 	} else {
 		fmt.Println(target)
 	}
@@ -119,12 +119,12 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	newArtifact := &Artifact{Path: target}
 
 	if err = os.MkdirAll(filepath.Dir(target), os.FileMode(0755)); err != nil {
-		return nil, false, fmt.Errorf(
+		return nil, false, false, fmt.Errorf(
 			"Unable to create dir for archive %s: %s", target, err)
 	}
 	outputFile, err := os.Create(target)
 	if err != nil {
-		return nil, false, fmt.Errorf(
+		return nil, false, false, fmt.Errorf(
 			"Unable to create archive %s: %s", target, err)
 	}
 	defer outputFile.Close()
@@ -168,19 +168,19 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		ui.Say(fmt.Sprintf("Tarring %s with %s", target, compression))
 		err = createTarArchive(artifact.Files(), output)
 		if err != nil {
-			return nil, keep, fmt.Errorf("Error creating tar: %s", err)
+			return nil, keep, false, fmt.Errorf("Error creating tar: %s", err)
 		}
 	case "zip":
 		ui.Say(fmt.Sprintf("Zipping %s", target))
 		err = createZipArchive(artifact.Files(), output)
 		if err != nil {
-			return nil, keep, fmt.Errorf("Error creating zip: %s", err)
+			return nil, keep, false, fmt.Errorf("Error creating zip: %s", err)
 		}
 	default:
 		// Filename indicates no tarball (just compress) so we'll do an io.Copy
 		// into our compressor.
 		if len(artifact.Files()) != 1 {
-			return nil, keep, fmt.Errorf(
+			return nil, keep, false, fmt.Errorf(
 				"Can only have 1 input file when not using tar/zip. Found %d "+
 					"files: %v", len(artifact.Files()), artifact.Files())
 		}
@@ -189,21 +189,21 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 		source, err := os.Open(archiveFile)
 		if err != nil {
-			return nil, keep, fmt.Errorf(
+			return nil, keep, false, fmt.Errorf(
 				"Failed to open source file %s for reading: %s",
 				archiveFile, err)
 		}
 		defer source.Close()
 
 		if _, err = io.Copy(output, source); err != nil {
-			return nil, keep, fmt.Errorf("Failed to compress %s: %s",
+			return nil, keep, false, fmt.Errorf("Failed to compress %s: %s",
 				archiveFile, err)
 		}
 	}
 
 	ui.Say(fmt.Sprintf("Archive %s completed", target))
 
-	return newArtifact, keep, nil
+	return newArtifact, keep, false, nil
 }
 
 func (config *Config) detectFromFilename() {

--- a/post-processor/compress/post-processor_test.go
+++ b/post-processor/compress/post-processor_test.go
@@ -238,7 +238,7 @@ func testArchive(t *testing.T, config string) packer.Artifact {
 	compressor.config.PackerBuildName = "vanilla"
 	compressor.config.PackerBuilderType = "file"
 
-	artifactOut, _, err := compressor.PostProcess(ui, artifact)
+	artifactOut, _, _, err := compressor.PostProcess(ui, artifact)
 	if err != nil {
 		t.Fatalf("Failed to compress artifact: %s", err)
 	}

--- a/post-processor/digitalocean-import/post-processor.go
+++ b/post-processor/digitalocean-import/post-processor.go
@@ -136,12 +136,12 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	var err error
 
 	p.config.ObjectName, err = interpolate.Render(p.config.ObjectName, &p.config.ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("Error rendering space_object_name template: %s", err)
+		return nil, false, false, fmt.Errorf("Error rendering space_object_name template: %s", err)
 	}
 	log.Printf("Rendered space_object_name as %s", p.config.ObjectName)
 
@@ -166,7 +166,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 
 	if source == "" {
-		return nil, false, fmt.Errorf("Image file not found")
+		return nil, false, false, fmt.Errorf("Image file not found")
 	}
 
 	spacesCreds := credentials.NewStaticCredentials(p.config.SpacesKey, p.config.SpacesSecret, "")
@@ -185,7 +185,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	ui.Message(fmt.Sprintf("Uploading %s to spaces://%s/%s", source, p.config.SpaceName, p.config.ObjectName))
 	err = uploadImageToSpaces(source, p, sess)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 	ui.Message(fmt.Sprintf("Completed upload of %s to spaces://%s/%s", source, p.config.SpaceName, p.config.ObjectName))
 
@@ -196,13 +196,13 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	ui.Message(fmt.Sprintf("Started import of spaces://%s/%s", p.config.SpaceName, p.config.ObjectName))
 	image, err := importImageFromSpaces(p, client)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	ui.Message(fmt.Sprintf("Waiting for import of image %s to complete (may take a while)", p.config.Name))
 	err = waitUntilImageAvailable(client, image.ID, p.config.Timeout)
 	if err != nil {
-		return nil, false, fmt.Errorf("Import of image %s failed with error: %s", p.config.Name, err)
+		return nil, false, false, fmt.Errorf("Import of image %s failed with error: %s", p.config.Name, err)
 	}
 	ui.Message(fmt.Sprintf("Import of image %s complete", p.config.Name))
 
@@ -216,7 +216,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		ui.Message(fmt.Sprintf("Distributing image %s to additional regions: %v", p.config.Name, regions))
 		err = distributeImageToRegions(client, image.ID, regions, p.config.Timeout)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 	}
 
@@ -232,11 +232,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		ui.Message(fmt.Sprintf("Deleting import source spaces://%s/%s", p.config.SpaceName, p.config.ObjectName))
 		err = deleteImageFromSpaces(p, sess)
 		if err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 	}
 
-	return artifact, false, nil
+	return artifact, false, false, nil
 }
 
 func uploadImageToSpaces(source string, p *PostProcessor, s *session.Session) (err error) {

--- a/post-processor/docker-import/post-processor.go
+++ b/post-processor/docker-import/post-processor.go
@@ -43,7 +43,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	switch artifact.BuilderId() {
 	case docker.BuilderId, artifice.BuilderId:
 		break
@@ -51,7 +51,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		err := fmt.Errorf(
 			"Unknown artifact type: %s\nCan only import from Docker builder and Artifice post-processor artifacts.",
 			artifact.BuilderId())
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	importRepo := p.config.Repository
@@ -65,7 +65,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	ui.Message("Repository: " + importRepo)
 	id, err := driver.Import(artifact.Files()[0], p.config.Changes, importRepo)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	ui.Message("Imported ID: " + id)
@@ -77,5 +77,5 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		IdValue:        importRepo,
 	}
 
-	return artifact, false, nil
+	return artifact, false, false, nil
 }

--- a/post-processor/docker-push/post-processor_test.go
+++ b/post-processor/docker-push/post-processor_test.go
@@ -41,12 +41,15 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 		IdValue:        "foo/bar",
 	}
 
-	result, keep, err := p.PostProcess(testUi(), artifact)
+	result, keep, forceOverride, err := p.PostProcess(testUi(), artifact)
 	if _, ok := result.(packer.Artifact); !ok {
 		t.Fatal("should be instance of Artifact")
 	}
 	if !keep {
 		t.Fatal("should keep")
+	}
+	if forceOverride {
+		t.Fatal("Should default to keep, but not override user wishes")
 	}
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -71,12 +74,15 @@ func TestPostProcessor_PostProcess_portInName(t *testing.T) {
 		IdValue:        "localhost:5000/foo/bar",
 	}
 
-	result, keep, err := p.PostProcess(testUi(), artifact)
+	result, keep, forceOverride, err := p.PostProcess(testUi(), artifact)
 	if _, ok := result.(packer.Artifact); !ok {
 		t.Fatal("should be instance of Artifact")
 	}
 	if !keep {
 		t.Fatal("should keep")
+	}
+	if forceOverride {
+		t.Fatal("Should default to keep, but not override user wishes")
 	}
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -101,12 +107,15 @@ func TestPostProcessor_PostProcess_tags(t *testing.T) {
 		IdValue:        "hashicorp/ubuntu:precise",
 	}
 
-	result, keep, err := p.PostProcess(testUi(), artifact)
+	result, keep, forceOverride, err := p.PostProcess(testUi(), artifact)
 	if _, ok := result.(packer.Artifact); !ok {
 		t.Fatal("should be instance of Artifact")
 	}
 	if !keep {
 		t.Fatal("should keep")
+	}
+	if forceOverride {
+		t.Fatal("Should default to keep, but not override user wishes")
 	}
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/post-processor/docker-save/post-processor.go
+++ b/post-processor/docker-save/post-processor.go
@@ -45,13 +45,13 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	if artifact.BuilderId() != dockerimport.BuilderId &&
 		artifact.BuilderId() != dockertag.BuilderId {
 		err := fmt.Errorf(
 			"Unknown artifact type: %s\nCan only save Docker builder artifacts.",
 			artifact.BuilderId())
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	path := p.config.Path
@@ -60,7 +60,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	f, err := os.Create(path)
 	if err != nil {
 		err := fmt.Errorf("Error creating output file: %s", err)
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	driver := p.Driver
@@ -75,11 +75,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		f.Close()
 		os.Remove(f.Name())
 
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	f.Close()
 	ui.Message("Saved to: " + path)
 
-	return artifact, true, nil
+	return artifact, true, false, nil
 }

--- a/post-processor/docker-tag/post-processor.go
+++ b/post-processor/docker-tag/post-processor.go
@@ -45,13 +45,13 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	if artifact.BuilderId() != BuilderId &&
 		artifact.BuilderId() != dockerimport.BuilderId {
 		err := fmt.Errorf(
 			"Unknown artifact type: %s\nCan only tag from Docker builder artifacts.",
 			artifact.BuilderId())
-		return nil, false, err
+		return nil, false, true, err
 	}
 
 	driver := p.Driver
@@ -69,7 +69,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	ui.Message("Repository: " + importRepo)
 	err := driver.TagImage(artifact.Id(), importRepo, p.config.Force)
 	if err != nil {
-		return nil, false, err
+		return nil, false, true, err
 	}
 
 	// Build the artifact
@@ -79,5 +79,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		IdValue:        importRepo,
 	}
 
-	return artifact, true, nil
+	// If we tag an image and then delete it, there was no point in creating the
+	// tag. Override users to force us to always keep the input artifact.
+	return artifact, true, true, nil
 }

--- a/post-processor/docker-tag/post-processor_test.go
+++ b/post-processor/docker-tag/post-processor_test.go
@@ -48,12 +48,15 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 		IdValue:        "1234567890abcdef",
 	}
 
-	result, keep, err := p.PostProcess(testUi(), artifact)
+	result, keep, forceOverride, err := p.PostProcess(testUi(), artifact)
 	if _, ok := result.(packer.Artifact); !ok {
 		t.Fatal("should be instance of Artifact")
 	}
 	if !keep {
 		t.Fatal("should keep")
+	}
+	if !forceOverride {
+		t.Fatal("Should force keep no matter what user sets.")
 	}
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -87,12 +90,15 @@ func TestPostProcessor_PostProcess_Force(t *testing.T) {
 		IdValue:        "1234567890abcdef",
 	}
 
-	result, keep, err := p.PostProcess(testUi(), artifact)
+	result, keep, forceOverride, err := p.PostProcess(testUi(), artifact)
 	if _, ok := result.(packer.Artifact); !ok {
 		t.Fatal("should be instance of Artifact")
 	}
 	if !keep {
 		t.Fatal("should keep")
+	}
+	if !forceOverride {
+		t.Fatal("Should force keep no matter what user sets.")
 	}
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -75,12 +75,12 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	if artifact.BuilderId() != googlecompute.BuilderId {
 		err := fmt.Errorf(
 			"Unknown artifact type: %s\nCan only export from Google Compute Engine builder artifacts.",
 			artifact.BuilderId())
-		return nil, p.config.KeepOriginalImage, err
+		return nil, p.config.KeepOriginalImage, false, err
 	}
 
 	builderAccountFile := artifact.State("AccountFilePath").(string)
@@ -98,13 +98,13 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	if builderAccountFile != "" {
 		err := googlecompute.ProcessAccountFile(&p.config.Account, builderAccountFile)
 		if err != nil {
-			return nil, p.config.KeepOriginalImage, err
+			return nil, p.config.KeepOriginalImage, false, err
 		}
 	}
 	if p.config.AccountFile != "" {
 		err := googlecompute.ProcessAccountFile(&p.config.Account, p.config.AccountFile)
 		if err != nil {
-			return nil, p.config.KeepOriginalImage, err
+			return nil, p.config.KeepOriginalImage, false, err
 		}
 	}
 
@@ -141,7 +141,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	driver, err := googlecompute.NewDriverGCE(ui, builderProjectId, &p.config.Account)
 	if err != nil {
-		return nil, p.config.KeepOriginalImage, err
+		return nil, p.config.KeepOriginalImage, false, err
 	}
 
 	// Set up the state.
@@ -169,5 +169,5 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	result := &Artifact{paths: p.config.Paths}
 
-	return result, p.config.KeepOriginalImage, nil
+	return result, p.config.KeepOriginalImage, false, nil
 }

--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -17,14 +17,13 @@ type Config struct {
 
 	AccountFile string `mapstructure:"account_file"`
 
-	DiskSizeGb        int64    `mapstructure:"disk_size"`
-	DiskType          string   `mapstructure:"disk_type"`
-	KeepOriginalImage bool     `mapstructure:"keep_input_artifact"`
-	MachineType       string   `mapstructure:"machine_type"`
-	Network           string   `mapstructure:"network"`
-	Paths             []string `mapstructure:"paths"`
-	Subnetwork        string   `mapstructure:"subnetwork"`
-	Zone              string   `mapstructure:"zone"`
+	DiskSizeGb  int64    `mapstructure:"disk_size"`
+	DiskType    string   `mapstructure:"disk_type"`
+	MachineType string   `mapstructure:"machine_type"`
+	Network     string   `mapstructure:"network"`
+	Paths       []string `mapstructure:"paths"`
+	Subnetwork  string   `mapstructure:"subnetwork"`
+	Zone        string   `mapstructure:"zone"`
 
 	Account googlecompute.AccountFile
 	ctx     interpolate.Context
@@ -80,7 +79,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		err := fmt.Errorf(
 			"Unknown artifact type: %s\nCan only export from Google Compute Engine builder artifacts.",
 			artifact.BuilderId())
-		return nil, p.config.KeepOriginalImage, false, err
+		return nil, false, false, err
 	}
 
 	builderAccountFile := artifact.State("AccountFilePath").(string)
@@ -98,13 +97,13 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	if builderAccountFile != "" {
 		err := googlecompute.ProcessAccountFile(&p.config.Account, builderAccountFile)
 		if err != nil {
-			return nil, p.config.KeepOriginalImage, false, err
+			return nil, false, false, err
 		}
 	}
 	if p.config.AccountFile != "" {
 		err := googlecompute.ProcessAccountFile(&p.config.Account, p.config.AccountFile)
 		if err != nil {
-			return nil, p.config.KeepOriginalImage, false, err
+			return nil, false, false, err
 		}
 	}
 
@@ -141,7 +140,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	driver, err := googlecompute.NewDriverGCE(ui, builderProjectId, &p.config.Account)
 	if err != nil {
-		return nil, p.config.KeepOriginalImage, false, err
+		return nil, false, false, err
 	}
 
 	// Set up the state.
@@ -169,5 +168,5 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	result := &Artifact{paths: p.config.Paths}
 
-	return result, p.config.KeepOriginalImage, false, nil
+	return result, false, false, nil
 }

--- a/post-processor/manifest/post-processor.go
+++ b/post-processor/manifest/post-processor.go
@@ -56,7 +56,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, source packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, source packer.Artifact) (packer.Artifact, bool, bool, error) {
 	artifact := &Artifact{}
 
 	var err error
@@ -106,14 +106,14 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, source packer.Artifact) (packe
 	// Read the current manifest file from disk
 	contents := []byte{}
 	if contents, err = ioutil.ReadFile(p.config.OutputPath); err != nil && !os.IsNotExist(err) {
-		return source, true, fmt.Errorf("Unable to open %s for reading: %s", p.config.OutputPath, err)
+		return source, true, true, fmt.Errorf("Unable to open %s for reading: %s", p.config.OutputPath, err)
 	}
 
 	// Parse the manifest file JSON, if we have one
 	manifestFile := &ManifestFile{}
 	if len(contents) > 0 {
 		if err = json.Unmarshal(contents, manifestFile); err != nil {
-			return source, true, fmt.Errorf("Unable to parse content from %s: %s", p.config.OutputPath, err)
+			return source, true, true, fmt.Errorf("Unable to parse content from %s: %s", p.config.OutputPath, err)
 		}
 	}
 
@@ -130,11 +130,13 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, source packer.Artifact) (packe
 	// Write JSON to disk
 	if out, err := json.MarshalIndent(manifestFile, "", "  "); err == nil {
 		if err = ioutil.WriteFile(p.config.OutputPath, out, 0664); err != nil {
-			return source, true, fmt.Errorf("Unable to write %s: %s", p.config.OutputPath, err)
+			return source, true, true, fmt.Errorf("Unable to write %s: %s", p.config.OutputPath, err)
 		}
 	} else {
-		return source, true, fmt.Errorf("Unable to marshal JSON %s", err)
+		return source, true, true, fmt.Errorf("Unable to marshal JSON %s", err)
 	}
 
-	return source, true, nil
+	// The manifest should never delete the artifacts it is set to record, so it
+	// forcibly sets "keep" to true.
+	return source, true, true, nil
 }

--- a/post-processor/shell-local/post-processor.go
+++ b/post-processor/shell-local/post-processor.go
@@ -35,14 +35,14 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return sl.Validate(&p.config)
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	// this particular post-processor doesn't do anything with the artifact
 	// except to return it.
 
 	retBool, retErr := sl.Run(ui, &p.config)
 	if !retBool {
-		return nil, retBool, retErr
+		return nil, retBool, false, retErr
 	}
 
-	return artifact, retBool, retErr
+	return artifact, retBool, false, retErr
 }

--- a/post-processor/shell-local/post-processor.go
+++ b/post-processor/shell-local/post-processor.go
@@ -39,10 +39,14 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	// this particular post-processor doesn't do anything with the artifact
 	// except to return it.
 
-	retBool, retErr := sl.Run(ui, &p.config)
-	if !retBool {
-		return nil, retBool, false, retErr
+	success, retErr := sl.Run(ui, &p.config)
+	if !success {
+		return nil, false, false, retErr
 	}
 
-	return artifact, retBool, false, retErr
+	// Force shell-local pp to keep the input artifact, because otherwise we'll
+	// lose it instead of being able to pass it through. If oyu want to delete
+	// the input artifact for a shell local pp, use the artifice pp to create a
+	// new artifact
+	return artifact, true, true, retErr
 }

--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -117,15 +117,15 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	if _, ok := builtins[artifact.BuilderId()]; !ok {
-		return nil, false, fmt.Errorf(
+		return nil, false, false, fmt.Errorf(
 			"Unknown artifact type, requires box from vagrant post-processor or vagrant builder: %s", artifact.BuilderId())
 	}
 
 	// We assume that there is only one .box file to upload
 	if !strings.HasSuffix(artifact.Files()[0], ".box") {
-		return nil, false, fmt.Errorf(
+		return nil, false, false, fmt.Errorf(
 			"Unknown files in artifact, vagrant box is required: %s", artifact.Files())
 	}
 
@@ -142,7 +142,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 	boxDownloadUrl, err := interpolate.Render(p.config.BoxDownloadUrl, &p.config.ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("Error processing box_download_url: %s", err)
+		return nil, false, false, fmt.Errorf("Error processing box_download_url: %s", err)
 	}
 
 	// Set up the state
@@ -181,10 +181,10 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	// If there was an error, return that
 	if rawErr, ok := state.GetOk("error"); ok {
-		return nil, false, rawErr.(error)
+		return nil, false, false, rawErr.(error)
 	}
 
-	return NewArtifact(providerName, p.config.Tag), true, nil
+	return NewArtifact(providerName, p.config.Tag), true, false, nil
 }
 
 // Runs a cleanup if the post processor fails to upload

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -158,11 +158,11 @@ func (p *PostProcessor) PostProcessProvider(name string, provider Provider, ui p
 	return NewArtifact(name, outputPath), provider.KeepInputArtifact(), nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 
 	name, ok := builtins[artifact.BuilderId()]
 	if !ok {
-		return nil, false, fmt.Errorf(
+		return nil, false, false, fmt.Errorf(
 			"Unknown artifact type, can't build box: %s", artifact.BuilderId())
 	}
 
@@ -172,7 +172,14 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		panic(fmt.Sprintf("bad provider name: %s", name))
 	}
 
-	return p.PostProcessProvider(name, provider, ui, artifact)
+	artifact, keep, err := p.PostProcessProvider(name, provider, ui, artifact)
+
+	// In some cases, (e.g. AMI), deleting the input artifact would render the
+	// resulting vagrant box useless. Because of these cases, we want to
+	// forcibly set keep_input_artifact.
+
+	// TODO: rework all provisioners to only forcibly keep those where it matters
+	return artifact, keep, true, err
 }
 
 func (p *PostProcessor) configureSingle(c *Config, raws ...interface{}) error {

--- a/post-processor/vagrant/post-processor_test.go
+++ b/post-processor/vagrant/post-processor_test.go
@@ -151,7 +151,7 @@ func TestPostProcessorPostProcess_badId(t *testing.T) {
 		BuilderIdValue: "invalid.packer",
 	}
 
-	_, _, err := testPP(t).PostProcess(testUi(), artifact)
+	_, _, _, err := testPP(t).PostProcess(testUi(), artifact)
 	if !strings.Contains(err.Error(), "artifact type") {
 		t.Fatalf("err: %s", err)
 	}
@@ -181,7 +181,7 @@ func TestPostProcessorPostProcess_vagrantfileUserVariable(t *testing.T) {
 	a := &packer.MockArtifact{
 		BuilderIdValue: "packer.parallels",
 	}
-	a2, _, err := p.PostProcess(testUi(), a)
+	a2, _, _, err := p.PostProcess(testUi(), a)
 	if a2 != nil {
 		for _, fn := range a2.Files() {
 			defer os.Remove(fn)

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -114,9 +114,9 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	return nil
 }
 
-func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
+func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
 	if _, ok := builtins[artifact.BuilderId()]; !ok {
-		return nil, false, fmt.Errorf("Unknown artifact type, can't build box: %s", artifact.BuilderId())
+		return nil, false, false, fmt.Errorf("Unknown artifact type, can't build box: %s", artifact.BuilderId())
 	}
 
 	source := ""
@@ -128,7 +128,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 
 	if source == "" {
-		return nil, false, fmt.Errorf("VMX, OVF or OVA file not found")
+		return nil, false, false, fmt.Errorf("VMX, OVF or OVA file not found")
 	}
 
 	password := escapeWithSpaces(p.config.Password)
@@ -174,14 +174,14 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	if err := cmd.Run(); err != nil {
 		err := fmt.Errorf("Error uploading virtual machine: %s\n%s\n", err, p.filterLog(errOut.String()))
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	ui.Message(p.filterLog(errOut.String()))
 
 	artifact = NewArtifact(p.config.Datastore, p.config.VMFolder, p.config.VMName, artifact.Files())
 
-	return artifact, false, nil
+	return artifact, false, false, nil
 }
 
 func (p *PostProcessor) filterLog(s string) string {

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func boolPointer(tf bool) *bool {
+	return &tf
+}
+
 func TestParse(t *testing.T) {
 	cases := []struct {
 		File   string
@@ -205,7 +209,7 @@ func TestParse(t *testing.T) {
 						{
 							Name:              "foo",
 							Type:              "foo",
-							KeepInputArtifact: true,
+							KeepInputArtifact: boolPointer(true),
 						},
 					},
 				},

--- a/template/template.go
+++ b/template/template.go
@@ -111,7 +111,7 @@ type PostProcessor struct {
 
 	Name              string                 `json:"name,omitempty"`
 	Type              string                 `json:"type"`
-	KeepInputArtifact bool                   `mapstructure:"keep_input_artifact" json:"keep_input_artifact,omitempty"`
+	KeepInputArtifact *bool                  `mapstructure:"keep_input_artifact" json:"keep_input_artifact,omitempty"`
 	Config            map[string]interface{} `json:"config,omitempty"`
 }
 
@@ -119,7 +119,7 @@ type PostProcessor struct {
 // to provide valid Packer template JSON
 func (p *PostProcessor) MarshalJSON() ([]byte, error) {
 	// Early exit for simple definitions
-	if len(p.Config) == 0 && len(p.OnlyExcept.Only) == 0 && len(p.OnlyExcept.Except) == 0 && !p.KeepInputArtifact {
+	if len(p.Config) == 0 && len(p.OnlyExcept.Only) == 0 && len(p.OnlyExcept.Except) == 0 && p.KeepInputArtifact == nil {
 		return json.Marshal(p.Type)
 	}
 

--- a/website/source/docs/post-processors/alicloud-import.html.md
+++ b/website/source/docs/post-processors/alicloud-import.html.md
@@ -60,6 +60,9 @@ are two categories: required and optional parameters.
 
 ### Optional:
 
+-   `keep_input_artifact` (boolean) - if true, do not delete the RAW or VHD
+    disk image after importing it to the cloud. Defaults to false.
+
 -   `oss_key_name` (string) - The name of the object key in `oss_bucket_name`
     where the RAW or VHD file will be copied to for import.
 

--- a/website/source/docs/post-processors/amazon-import.html.md
+++ b/website/source/docs/post-processors/amazon-import.html.md
@@ -101,6 +101,9 @@ Optional:
 -   `insecure_skip_tls_verify` (boolean) - This allows skipping TLS
     verification of the AWS EC2 endpoint. The default is `false`.
 
+-   `keep_input_artifact` (boolean) - if true, do not delete the source virtual
+    machine image after importing it to the cloud. Defaults to false.
+
 -   `license_type` (string) - The license type to be used for the Amazon
     Machine Image (AMI) after importing. Valid values: `AWS` or `BYOL`
     (default). For more details regarding licensing, see

--- a/website/source/docs/post-processors/artifice.html.md
+++ b/website/source/docs/post-processors/artifice.html.md
@@ -59,6 +59,11 @@ The configuration allows you to specify which files comprise your artifact.
     packer is complete. These will replace any of the builder's original
     artifacts (such as a VM snapshot).
 
+### Optional:
+
+-   `keep_input_artifact` (boolean) - if true, do not delete the original
+    artifact files after creating your new artifact. Defaults to true.
+
 ### Example Configuration
 
 This minimal example:

--- a/website/source/docs/post-processors/checksum.html.md
+++ b/website/source/docs/post-processors/checksum.html.md
@@ -43,6 +43,11 @@ Optional parameters:
 
 -   `checksum_types` (array of strings) - An array of strings of checksum types
     to compute. Allowed values are md5, sha1, sha224, sha256, sha384, sha512.
+
+-   `keep_input_artifact` (boolean) - Unlike most post-processors, setting
+    `keep_input_artifact` will have no effect; the checksum post-processor
+    always saves the artifact that it is calculating the checksum for.
+
 -   `output` (string) - Specify filename to store checksums. This defaults to
     `packer_{{.BuildName}}_{{.BuilderType}}_{{.ChecksumType}}.checksum`. For
     example, if you had a builder named `database`, you might see the file

--- a/website/source/docs/post-processors/compress.html.md
+++ b/website/source/docs/post-processors/compress.html.md
@@ -38,7 +38,9 @@ you will need to specify the `output` option.
     algorithms that support it, from 1 through 9 inclusive. Typically higher
     compression levels take longer but produce smaller files. Defaults to `6`
 
--   `keep_input_artifact` (boolean) - Keep source files; defaults to `false`
+-   `keep_input_artifact` (boolean) - if `true`, keep both the source files and
+    the compressed file; if `false`, discard the source files. Defaults to
+    `false`
 
 ### Supported Formats
 

--- a/website/source/docs/post-processors/digitalocean-import.html.md
+++ b/website/source/docs/post-processors/digitalocean-import.html.md
@@ -67,6 +67,9 @@ Optional:
 -   `image_tags` (array of strings) - A list of tags to apply to the resulting
     imported image.
 
+-   `keep_input_artifact` (boolean) - if true, do not delete the source virtual
+    machine image after importing it to the cloud. Defaults to false.
+
 -   `skip_clean` (boolean) - Whether we should skip removing the image file
     uploaded to Spaces after the import process has completed. "true" means
     that we should leave it in the Space, "false" means to clean it out.

--- a/website/source/docs/post-processors/docker-import.html.md
+++ b/website/source/docs/post-processors/docker-import.html.md
@@ -38,6 +38,9 @@ is optional.
     commit. Example of instructions are `CMD`, `ENTRYPOINT`, `ENV`, and
     `EXPOSE`. Example: `[ "USER ubuntu", "WORKDIR /app", "EXPOSE 8080" ]`
 
+-   `keep_input_artifact` (boolean) - if true, do not delete the source tar
+    after importing it to docker. Defaults to false.
+
 ## Example
 
 An example is shown below, showing only the post-processor configuration:

--- a/website/source/docs/post-processors/docker-push.html.md
+++ b/website/source/docs/post-processors/docker-push.html.md
@@ -42,6 +42,10 @@ This post-processor has only optional configuration:
     the duration of the push. If true `login_server` is required and `login`,
     `login_username`, and `login_password` will be ignored.
 
+-   `keep_input_artifact` (boolean) - if true, do not delete the docker image
+    after pushing it to the cloud. Defaults to true, but can be set to false if
+    you do not need to save your local copy of the docker container.
+
 -   `login` (boolean) - Defaults to false. If true, the post-processor will
     login prior to pushing. For log into ECR see `ecr_login`.
 

--- a/website/source/docs/post-processors/docker-save.html.md
+++ b/website/source/docs/post-processors/docker-save.html.md
@@ -24,9 +24,16 @@ familiar with this and vice versa.
 
 ## Configuration
 
+### Required
+
 The configuration for this post-processor only requires one option.
 
 -   `path` (string) - The path to save the image.
+
+### Optional
+
+-   `keep_input_artifact` (boolean) - if true, do not delete the docker
+	container, and only save the .tar created by docker save. Defaults to true.
 
 ## Example
 

--- a/website/source/docs/post-processors/docker-tag.html.md
+++ b/website/source/docs/post-processors/docker-tag.html.md
@@ -38,6 +38,13 @@ settings are optional.
     after 1.12.0.
     [reference](https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag)
 
+-   `keep_input_artifact` (boolean) - Unlike most other post-processors, the
+    keep_input_artifact option will have no effect for the docker-tag
+    post-processor. We will always retain the input artifact for docker-tag,
+    since deleting the image we just tagged is not a behavior anyone should ever
+    expect. `keep_input_artifact will` therefore always be evaluated as true,
+    regardless of the value you enter into this field.
+
 ## Example
 
 An example is shown below, showing only the post-processor configuration:

--- a/website/source/docs/post-processors/googlecompute-export.html.md
+++ b/website/source/docs/post-processors/googlecompute-export.html.md
@@ -45,8 +45,8 @@ permissions to the GCS `paths`.
 -   `disk_type` (string) - Type of disk used to back export instance, like
     `pd-ssd` or `pd-standard`. Defaults to `pd-ssd`.
 
--   `keep_input_artifact` (boolean) - If true, do not delete the Google Compute
-    Engine (GCE) image being exported.
+-   `keep_input_artifact` (boolean) - If `true`, do not delete the Google Compute
+    Engine (GCE) image being exported. defaults to `false`.
 
 -   `machine_type` (string) - The export instance machine type. Defaults
     to `"n1-highcpu-4"`.

--- a/website/source/docs/post-processors/manifest.html.md
+++ b/website/source/docs/post-processors/manifest.html.md
@@ -40,6 +40,13 @@ post-processors such as Docker and Artifice.
     file. This defaults to false.
 -   `custom_data` (map of strings) Arbitrary data to add to the manifest.
 
+-   `keep_input_artifact` (boolean) - Unlike most other post-processors, the
+    keep_input_artifact option will have no effect for the manifest
+    post-processor. We will always retain the input artifact for manifest,
+    since deleting the files we just recorded is not a behavior anyone should
+    ever expect. `keep_input_artifact will` therefore always be evaluated as
+    true, regardless of the value you enter into this field.
+
 ### Example Configuration
 
 You can simply add `{"type":"manifest"}` to your post-processor section. Below

--- a/website/source/docs/post-processors/shell-local.html.md
+++ b/website/source/docs/post-processors/shell-local.html.md
@@ -101,6 +101,15 @@ Optional parameters:
     like the `-e` flag, otherwise individual steps failing won't fail the
     provisioner.
 
+-   `keep_input_artifact` (boolean) - Unlike most other post-processors, the
+    keep_input_artifact option will have no effect for the shell-local
+    post-processor. Packer will always retain the input artifact for
+    shell-local, since the shell-local post-processor merely passes forward the
+    artifact it receives. If your shell-local post-processor produces a file or
+    files which you would like to have replace the input artifact, you may
+    overwrite the input artifact using the [artifice](./artifice.html)
+    post-processor after your shell-local processor has run.
+
 -   `only_on` (array of strings) - This is an array of [runtime operating
     systems](https://golang.org/doc/install/source#environment) where
     `shell-local` will execute. This allows you to execute `shell-local` *only*

--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -84,6 +84,9 @@ on Vagrant Cloud, as well as authentication and version information.
     to set this option to true if your host at vagrant_cloud_url is using a
     self-signed certificate.
 
+-   `keep_input_artifact` (boolean) - When true, preserve the local box
+    after uploading to Vagrant cloud. Defaults to `true`.
+
 -   `version_description` (string) - Optionally markdown text used as a
     full-length and in-depth description of the version, typically for denoting
     changes introduced

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -65,8 +65,12 @@ more details about certain options in following sections.
     Vagrant box (regardless of their paths). They can then be used from the
     Vagrantfile.
 
--   `keep_input_artifact` (boolean) - If set to true, do not delete the
-    `output_directory` on a successful build. Defaults to false.
+-   `keep_input_artifact` (boolean) - When true, preserve the artifact we use to
+    create the vagrant box. Defaults to `false`, except when you set a cloud
+    provider (e.g. aws, azure, google, digitalocean). In these cases deleting
+    the input artifact would render the vagrant box useless, so we always keep
+    these artifacts -- even if you specifically set
+    `"keep_input_artifact":false`
 
 -   `output` (string) - The full path to the box file that will be created by
     this post-processor. This is a [configuration

--- a/website/source/docs/post-processors/vsphere-template.html.md
+++ b/website/source/docs/post-processors/vsphere-template.html.md
@@ -61,6 +61,12 @@ Optional:
 -   `insecure` (boolean) - If it's true skip verification of server
     certificate. Default is false
 
+-   `keep_input_artifact` (boolean) - Unlike most post-processors, this option
+    has no effect for vsphere-template. This is because in order for a template
+    to work, you can't delete the vm that you generate the template from. The
+    vsphere template post-processor will therefore always preserve the original
+    vm.
+
 -   `snapshot_enable` (boolean) - Create a snapshot before marking as a
     template. Default is false
 

--- a/website/source/docs/post-processors/vsphere.html.md
+++ b/website/source/docs/post-processors/vsphere.html.md
@@ -54,6 +54,9 @@ Optional:
 -   `insecure` (boolean) - Whether or not the connection to vSphere can be done
     over an insecure connection. By default this is false.
 
+-   `keep_input_artifact` (boolean) - When `true`, preserve the local VM files,
+    even after importing them to vsphere. Defaults to `false`.
+
 -   `resource_pool` (string) - The resource pool to upload the VM to.
 
 -   `vm_folder` (string) - The folder within the datastore to store the VM.


### PR DESCRIPTION
This PR changes the way we handle keeping input artifacts. 

Previously, users could either set keep_input_artifact to true or false, with it defaulting to false. Certain post-processors could override these preferences though, forcing a "keep" regardless of what the user wanted.  This prevented users from accidentally deleting artifacts they probably didn't intend to delete, but did mean that there were cases where users ended up with artifacts they didn't want or need, and had to do manual cleanup.

This change understands the difference between a user setting true/false and a user not setting anything, by changing the bool into a *bool and doing a nil value test. It changes the "keep" flag returned from post-processors to a default value, and adds a new flag forceOverride, to determine whether to actually ignore user desires or not.

This means that we're able to set a default to "keep" for certain post processors where a user _probably_ but doesn't _definitely_ need to keep the input artifacts, and we're able to set a hard override to "keep" for post processors where the resulting artifact will be clearly useless if it's deleted (for example, no one running the checksum post-processor wants to then turn around and delete the files they just checksummed)

This PR changes the function signature for the post-processors, so it touches a lot of core code and will break third party plugins. I do not expect it to break many if any user builds, because the defaults remain the same and the only case that gets changed is that the user has more control over what is kept and what is discarded.

I also added documentation for each post processor about what exactly to expect from the default behavior of keep_input_artifact, and which post-processors ignore it altogether and force you to keep your input artifact.

Closes #6294