### PR TITLE
Fix windows tests

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -17,6 +17,7 @@ func TestBuildOnlyFileCommaFlags(t *testing.T) {
 	}
 
 	args := []string{
+		"-parallel=false",
 		"-only=chocolate,vanilla",
 		filepath.Join(testFixture("build-only"), "template.json"),
 	}
@@ -58,7 +59,7 @@ func TestBuildStdin(t *testing.T) {
 	defer func() { os.Stdin = stdin }()
 
 	defer cleanup()
-	if code := c.Run([]string{"-"}); code != 0 {
+	if code := c.Run([]string{"-parallel=false", "-"}); code != 0 {
 		fatalCommand(t, c.Meta)
 	}
 
@@ -76,6 +77,7 @@ func TestBuildOnlyFileMultipleFlags(t *testing.T) {
 	}
 
 	args := []string{
+		"-parallel=false",
 		"-only=chocolate",
 		"-only=cherry",
 		"-only=apple", // ignored
@@ -109,6 +111,7 @@ func TestBuildEverything(t *testing.T) {
 	}
 
 	args := []string{
+		"-parallel=false",
 		`-except=`,
 		filepath.Join(testFixture("build-only"), "template.json"),
 	}
@@ -133,6 +136,7 @@ func TestBuildExceptFileCommaFlags(t *testing.T) {
 	}
 
 	args := []string{
+		"-parallel=false",
 		"-except=chocolate,vanilla",
 		filepath.Join(testFixture("build-only"), "template.json"),
 	}

--- a/command/test-fixtures/build-only/template.json
+++ b/command/test-fixtures/build-only/template.json
@@ -24,19 +24,19 @@
             {
                 "name": "apple",
                 "type": "shell-local",
-                "inline": [ "touch apple.txt" ]
+                "inline": [ "echo apple > apple.txt" ]
             },
             {
                 "name": "peach",
                 "type": "shell-local",
-                "inline": [ "touch peach.txt" ]
+                "inline": [ "echo peach > peach.txt" ]
             }
         ],
         [
             {
                 "name": "pear",
                 "type": "shell-local",
-                "inline": [ "touch pear.txt" ]
+                "inline": [ "echo pear > pear.txt" ]
             }
         ],
         [
@@ -46,7 +46,7 @@
                 ],
                 "name": "tomato",
                 "type": "shell-local",
-                "inline": [ "touch tomato.txt" ]
+                "inline": [ "echo tomato > tomato.txt" ]
             }
         ],
         [
@@ -55,7 +55,7 @@
                     "chocolate"
                 ],
                 "type": "shell-local",
-                "inline": [ "touch unnamed.txt" ]
+                "inline": [ "echo unnamed > unnamed.txt" ]
             }
         ]
     ]

--- a/common/shell-local/run.go
+++ b/common/shell-local/run.go
@@ -54,13 +54,15 @@ func Run(ui packer.Ui, config *Config) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		scripts = append(scripts, tempScriptFileName)
 
 		// figure out what extension the file should have, and rename it.
 		if config.TempfileExtension != "" {
 			os.Rename(tempScriptFileName, fmt.Sprintf("%s.%s", tempScriptFileName, config.TempfileExtension))
 			tempScriptFileName = fmt.Sprintf("%s.%s", tempScriptFileName, config.TempfileExtension)
 		}
+
+		scripts = append(scripts, tempScriptFileName)
+
 		defer os.Remove(tempScriptFileName)
 	}
 


### PR DESCRIPTION
this pull makes the test fixtures for build_test more generic so they can be run on both unix and windows.