### PR TITLE
building on go master is just wasting our time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ language: go
 
 go:
   - 1.12.x
-  - master
 
 before_install:
   - >
@@ -30,6 +29,5 @@ branches:
 
 matrix:
   allow_failures:
-    - go: master
     - os: windows
   fast_finish: true


### PR DESCRIPTION
Let's phase out some of these "acceptable failures" to decrease build time. Time to slowly wean off travis and scale up our circle ci builds anyway. No point in running the same tests in two different CI platforms.