### PR TITLE
Fixes "Host IP for the HyperV machine: False" if more than one VMNetworkAdapter is found

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -35,9 +35,11 @@ param([string]$switchName, [int]$addressIndex)
 
 $HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName
 if ($HostVMAdapter){
-    $HostNetAdapter = Get-NetAdapter | ?{ $_.DeviceID -eq $HostVMAdapter.DeviceId }
+    $HostNetAdapter = Get-NetAdapter | ?{ $HostVMAdapter.DeviceId.Contains($_.DeviceID) }
     if ($HostNetAdapter){
-        $HostNetAdapterConfiguration =  @(get-wmiobject win32_networkadapterconfiguration -filter "IPEnabled = 'TRUE' AND InterfaceIndex=$($HostNetAdapter.ifIndex)")
+        $HostNetAdapterIfIndex = @()
+        $HostNetAdapterIfIndex +=  $HostNetAdapter.ifIndex
+        $HostNetAdapterConfiguration =  @(get-wmiobject win32_networkadapterconfiguration -filter "IPEnabled = 'TRUE'") | Where-Object { $HostNetAdapterIfIndex.Contains($_.InterfaceIndex) }
         if ($HostNetAdapterConfiguration){
             return @($HostNetAdapterConfiguration.IpAddress)[$addressIndex]
         }


### PR DESCRIPTION
When using a Network Switch from docker (nat) where already container are attached to the network the call to Get-VMNetworkAdapter -ManagementOS -SwitchName "nat"

results in more than one adapter found, e.g. 
```
Name                                 IsManagementOs VMName SwitchName MacAddress   Status IPAddresses
----                                 -------------- ------ ---------- ----------   ------ -----------
Container NIC 7ddd4f35               True                  nat        00155DAE7F3D {Ok}
F010C062-134C-4B70-A306-DA49FB6F64B8 True                  nat        00155DAE7720 {Ok}
```

In order to handle the situation, the powershell code was improved to handle more than one result (lists)

my assumption is, this one fixes
Closes #5023 

although #4947 is marked as duplicate, it shows a different error information
==> hyperv-iso: Error getting host adapter ip address: PowerShell error: Get-VMNetworkAdapter : No network adapter is found with the given input.
therefore I am not sure if this also would fix #4947