### PR TITLE
Docs: fix typo in openstack builder

### DIFF
--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -317,7 +317,7 @@ VM.
 ``` json
 {
   "type": "openstack",
-  "identity_endpoint": "http://<destack-ip>:5000/v3",
+  "identity_endpoint": "http://<devstack-ip>:5000/v3",
   "tenant_name": "admin",
   "domain_name": "Default",
   "username": "admin",


### PR DESCRIPTION
This just fixes a small typo in the documentation for the OpenStack builder.
The placeholder in the DevStack example was missing a v.