### PR TITLE
[WIP] Added warnings about writeable locations

### DIFF
--- a/website/source/docs/provisioners/file.html.md.erb
+++ b/website/source/docs/provisioners/file.html.md.erb
@@ -18,6 +18,11 @@ recommended usage of the file provisioner is to use it to upload files, and
 then use [shell provisioner](/docs/provisioners/shell.html) to move them to the
 proper place, set permissions, etc.
 
+Warning: You can only upload files to locations that the provisioning user 
+(generally not root) has permission to access. Creating files in /tmp and 
+using a shell provisioner to move them into the final location is the only
+way to upload files to root owned locations.
+
 The file provisioner can upload both single files and complete directories.
 
 ## Basic Example
@@ -44,7 +49,9 @@ The available configuration options are listed below.
 
 -   `destination` (string) - The path where the file will be uploaded to in the
     machine. This value must be a writable location and any parent directories
-    must already exist. If the source is a file, it's a good idea to make the
+    must already exist. If the provisioning user (generally not root) cannot 
+    write to this directory, you will receive a "Permission Denied" error.
+    If the source is a file, it's a good idea to make the
     destination a file as well, but if you set your destination as a directory,
     at least make sure that the destination ends in a trailing slash so that
     Packer knows to use the source's basename in the final upload path. Failure


### PR DESCRIPTION
This PR adds in some warning text regarding the behaviour of the file provisioner within Packer.
There is a closed issue from 2014  (#1551 ) which references the fact that the provisioner user may not be root, and so have limited write access to directories.
The closing comment states that it is defined in the docs, but as can be seen from the fact that multiple comments have been made on that issue since then (and indeed it was one of the first results for myself when searching for 'Packer file provisioner permission denied'), people still struggle to pick up on this from the current documentation.

I've added in the warning given by [tedivm](https://github.com/tedivm) in his comment, but obviously you may want to change the wording around (hence the [WIP] tag).

I can't see any open issues for this currently, would you like me to open a new one (or should 1551 be re-opened), or is this fine without one?

Thanks all,
Ben