### PR TITLE
add keep_registered option to hyperv

### DIFF
--- a/builder/hyperv/common/step_clone_vm.go
+++ b/builder/hyperv/common/step_clone_vm.go
@@ -31,6 +31,7 @@ type StepCloneVM struct {
 	SecureBootTemplate             string
 	EnableVirtualizationExtensions bool
 	MacAddress                     string
+	KeepRegistered                 bool
 }
 
 func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -147,6 +148,12 @@ func (s *StepCloneVM) Cleanup(state multistep.StateBag) {
 
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
+
+	if s.KeepRegistered {
+		ui.Say("keep_registered set. Skipping unregister/deletion of VM.")
+		return
+	}
+
 	ui.Say("Unregistering and deleting virtual machine...")
 
 	err := driver.DeleteVirtualMachine(s.VMName)

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -35,6 +35,7 @@ type StepCreateVM struct {
 	MacAddress                     string
 	FixedVHD                       bool
 	Version                        string
+	KeepRegistered                 bool
 }
 
 func (s *StepCreateVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -168,6 +169,12 @@ func (s *StepCreateVM) Cleanup(state multistep.StateBag) {
 
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
+
+	if s.KeepRegistered {
+		ui.Say("keep_registered set. Skipping unregister/deletion of VM.")
+		return
+	}
+
 	ui.Say("Unregistering and deleting virtual machine...")
 
 	err := driver.DeleteVirtualMachine(s.VMName)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -98,6 +98,7 @@ type Config struct {
 	EnableVirtualizationExtensions bool   `mapstructure:"enable_virtualization_extensions"`
 	TempPath                       string `mapstructure:"temp_path"`
 	Version                        string `mapstructure:"configuration_version"`
+	KeepRegistered                 bool   `mapstructure:"keep_registered"`
 
 	Communicator string `mapstructure:"communicator"`
 
@@ -420,6 +421,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			MacAddress:                     b.config.MacAddress,
 			FixedVHD:                       b.config.FixedVHD,
 			Version:                        b.config.Version,
+			KeepRegistered:                 b.config.KeepRegistered,
 		},
 		&hypervcommon.StepEnableIntegrationService{},
 

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -95,6 +95,7 @@ type Config struct {
 	EnableVirtualizationExtensions bool   `mapstructure:"enable_virtualization_extensions"`
 	TempPath                       string `mapstructure:"temp_path"`
 	Version                        string `mapstructure:"configuration_version"`
+	KeepRegistered                 bool   `mapstructure:"keep_registered"`
 
 	Communicator string `mapstructure:"communicator"`
 
@@ -441,6 +442,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			SecureBootTemplate:             b.config.SecureBootTemplate,
 			EnableVirtualizationExtensions: b.config.EnableVirtualizationExtensions,
 			MacAddress:                     b.config.MacAddress,
+			KeepRegistered:                 b.config.KeepRegistered,
 		},
 
 		&hypervcommon.StepEnableIntegrationService{},

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -195,6 +195,9 @@ builder.
     port, set an identical value for `http_port_min` and `http_port_max`.
     By default the values are 8000 and 9000, respectively.
 
+-   `keep_registered` (bool) - If "true", Packer will not delete the VM from
+    The Hyper-V manager.
+
 -   `mac_address` (string) - This allows a specific MAC address to be used on
     the default virtual network card. The MAC address must be a string with
     no delimiters, for example "0000deadbeef".


### PR DESCRIPTION
This allows you to skip deleting the VM so it stays in hyperv and can be relaunched from the GUI later.

Closes #7465 