### PR TITLE
Revert "scripts/build.sh: allow to set build settings when building"

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,8 @@
 
 # This script builds the application from source for multiple platforms.
 # Determine the arch/os combos we're building for
-ALL_XC_ARCH=${ALL_XC_ARCH:-"386 amd64 arm arm64 ppc64le"}
-ALL_XC_OS=${ALL_XC_OS:-"linux darwin windows freebsd openbsd solaris"}
+ALL_XC_ARCH="386 amd64 arm arm64 ppc64le"
+ALL_XC_OS="linux darwin windows freebsd openbsd solaris"
 
 # Exit immediately if a command fails
 set -e


### PR DESCRIPTION
This reverts commit f6be550f1a6d10e5c2dd0b8285727ba0aed488cc of #7326

As @/mwhooker pointed out to me what I did is unnecessary since a little bit further down the file:

 https://github.com/hashicorp/packer/blob/413e242a148bc57ac06ee6a3e08610c97cfb7ee0/scripts/build.sh#L128-L136