### PR TITLE
make sure that you encrypt using the provided kms key id and not the …

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -280,6 +280,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,
 			Regions:           b.config.AMIRegions,
+			AMIKmsKeyId:       b.config.AMIKmsKeyId,
 			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -14,6 +14,7 @@ import (
 type StepAMIRegionCopy struct {
 	AccessConfig      *AccessConfig
 	Regions           []string
+	AMIKmsKeyId       string
 	RegionKeyIds      map[string]string
 	EncryptBootVolume *bool // nil means preserve
 	Name              string
@@ -31,6 +32,7 @@ func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) m
 		// AMI with required encryption setting.
 		// temp image was created by stepCreateAMI.
 		s.Regions = append(s.Regions, *ec2conn.Config.Region)
+		s.RegionKeyIds[*ec2conn.Config.Region] = s.AMIKmsKeyId
 	}
 
 	if len(s.Regions) == 0 {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -223,6 +223,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,
 			Regions:           b.config.AMIRegions,
+			AMIKmsKeyId:       b.config.AMIKmsKeyId,
 			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -248,6 +248,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,
 			Regions:           b.config.AMIRegions,
+			AMIKmsKeyId:       b.config.AMIKmsKeyId,
 			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -299,6 +299,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,
 			Regions:           b.config.AMIRegions,
+			AMIKmsKeyId:       b.config.AMIKmsKeyId,
 			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,


### PR DESCRIPTION
When we changed the encryption we accidentally introduced a bug where we were using the default region kms key rather than a custom one for the build region.  This fixes it so we get the old, intended behavior.

Closes #7499 