### PR TITLE
fix panic in StepConfigureVNC ( fix 7505 )

### DIFF
--- a/builder/vmware/common/step_configure_vnc.go
+++ b/builder/vmware/common/step_configure_vnc.go
@@ -106,7 +106,7 @@ func (s *StepConfigureVNC) Run(ctx context.Context, state multistep.StateBag) mu
 
 	vncPassword := VNCPassword(s.VNCDisablePassword)
 
-	log.Printf("Found available VNC port: %v", s.l)
+	log.Printf("Found available VNC port: %s:%d", vncBindAddress, vncPort)
 
 	vncFinder.UpdateVMX(vncBindAddress, vncPassword, vncPort, vmxData)
 
@@ -117,8 +117,8 @@ func (s *StepConfigureVNC) Run(ctx context.Context, state multistep.StateBag) mu
 		return multistep.ActionHalt
 	}
 
-	state.Put("vnc_port", s.l.Port)
-	state.Put("vnc_ip", s.l.Address)
+	state.Put("vnc_port", vncPort)
+	state.Put("vnc_ip", vncBindAddress)
 	state.Put("vnc_password", vncPassword)
 
 	return multistep.ActionContinue


### PR DESCRIPTION
When the driver is the esx5 driver s.l won't be set at all. Meaning this will crash.
In the esx5 driver we try to dial possible ports to see if it works so it doesn't make sense to use packer's `net.ListenRangeConfig`. It could make sense to have a net.DialRangeConfig but this sounds a bit too specific and not broad enough to do.

fix #7505
