### PR TITLE
Update CONTRIBUTING.md with version of go to download

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ can quickly merge or address your contributions.
 If you have never worked with Go before, you will have to install its
 runtime in order to build packer.
 
-1. The current version of go for this project is 1.12.x. [Install go](https://golang.org/doc/install#install)
+1. This project always releases from the latest version of golang. [Install go](https://golang.org/doc/install#install)
 
 ## Setting up Packer for dev
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ can quickly merge or address your contributions.
 If you have never worked with Go before, you will have to install its
 runtime in order to build packer.
 
-1. [Install go](https://golang.org/doc/install#install)
+1. The current version of go for this project is 1.12.x. [Install go](https://golang.org/doc/install#install)
 
 ## Setting up Packer for dev
 


### PR DESCRIPTION
The CONTIBUTING.md currently does not specify which version of go to use. Hence adding a message to update CONTRIBUTING.md with version of go to download. 

