### PR TITLE
update docs explaining that you need local artifact for vagrant pp

### DIFF
--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -150,3 +150,9 @@ The following Docker input artifacts are supported:
 
 The `libvirt` provider supports QEMU artifacts built using any these
 accelerators: none, kvm, tcg, or hvf.
+
+### VMWare
+
+If you are using the Vagrant post-processor with the `vmware-esxi` builder, you
+must export the builder artifact locally; the Vagrant post-processor will
+not work on remote artifacts.


### PR DESCRIPTION
This just adds clarification to the docs that you need to have exported a vm if you want to use the vagrant pp on it. Closes #4056