### PR TITLE
warn users to lock down winrm after provisioning

### DIFF
--- a/website/source/docs/builders/googlecompute.html.md
+++ b/website/source/docs/builders/googlecompute.html.md
@@ -166,6 +166,9 @@ setting a valid `account_file` and `project_id`:
 }
 ```
 
+-> **Warning:** Please note that if you're setting up WinRM for provisioning, you'll probably want to turn it off or restrict its permissions as part of a shutdown script at the end of Packer's provisioning process. For more details on the why/how, check out this useful blog post and the associated code:
+https://cloudywindows.io/post/winrm-for-provisioning---close-the-door-on-the-way-out-eh/
+
 This build can take up to 15 min.
 
 ### Nested Hypervisor Example

--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -876,6 +876,9 @@ Finish proxy after sysprep -->
 </unattend>
 ```
 
+-> **Warning:** Please note that if you're setting up WinRM for provisioning, you'll probably want to turn it off or restrict its permissions as part of a shutdown script at the end of Packer's provisioning process. For more details on the why/how, check out this useful blog post and the associated code:
+https://cloudywindows.io/post/winrm-for-provisioning---close-the-door-on-the-way-out-eh/
+
 ## Example For Ubuntu Vivid Generation 2
 
 If you are running Windows under virtualization, you may need to create a

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -893,6 +893,9 @@ Finish proxy after sysprep -->
 </unattend>
 ```
 
+-> **Warning:** Please note that if you're setting up WinRM for provisioning, you'll probably want to turn it off or restrict its permissions as part of a shutdown script at the end of Packer's provisioning process. For more details on the why/how, check out this useful blog post and the associated code:
+https://cloudywindows.io/post/winrm-for-provisioning---close-the-door-on-the-way-out-eh/
+
 ## Example For Ubuntu Vivid Generation 2
 
 If you are running Windows under virtualization, you may need to create a

--- a/website/source/docs/builders/ncloud.html.md
+++ b/website/source/docs/builders/ncloud.html.md
@@ -90,6 +90,9 @@ Here is a basic example for windows server.
       ]
     }
 
+-> **Warning:** Please note that if you're setting up WinRM for provisioning, you'll probably want to turn it off or restrict its permissions as part of a shutdown script at the end of Packer's provisioning process. For more details on the why/how, check out this useful blog post and the associated code:
+https://cloudywindows.io/post/winrm-for-provisioning---close-the-door-on-the-way-out-eh/
+
 Here is a basic example for linux server.
 
     {

--- a/website/source/docs/provisioners/ansible.html.md.erb
+++ b/website/source/docs/provisioners/ansible.html.md.erb
@@ -322,6 +322,9 @@ Platform:
 }
 ```
 
+-> **Warning:** Please note that if you're setting up WinRM for provisioning, you'll probably want to turn it off or restrict its permissions as part of a shutdown script at the end of Packer's provisioning process. For more details on the why/how, check out this useful blog post and the associated code:
+https://cloudywindows.io/post/winrm-for-provisioning---close-the-door-on-the-way-out-eh/
+
 ### Post i/o timeout errors
 
 If you see

--- a/website/source/intro/getting-started/build-image.html.md
+++ b/website/source/intro/getting-started/build-image.html.md
@@ -404,6 +404,9 @@ Start-Service -Name WinRM
 </powershell>
 ```
 
+-> **Warning:** Please note that if you're setting up WinRM for provisioning, you'll probably want to turn it off or restrict its permissions as part of a shutdown script at the end of Packer's provisioning process. For more details on the why/how, check out this useful blog post and the associated code:
+https://cloudywindows.io/post/winrm-for-provisioning---close-the-door-on-the-way-out-eh/
+
 Save the above code in a file named `bootstrap_win.txt`.
 
 -> **A quick aside/warning:**<br />


### PR DESCRIPTION
A while back we opened this issue for warning users that they shouldn't leave WinRM just up and running post-provisioning. 

Closes #6143