### PR TITLE
Qemu builder disk size as a string

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -146,8 +146,10 @@ type Config struct {
 	// one of the other listed interfaces. Using the `scsi` interface under
 	// these circumstances will cause the build to fail.
 	DiskInterface string `mapstructure:"disk_interface" required:"false"`
-	// The size, in megabytes, of the hard disk to create
-	// for the VM. By default, this is 40960 (40 GB).
+	// The size in bytes, suffixes of the first letter of common byte types
+	// like "k" or "K", "M" for megabytes, G for gigabytes, T for terabytes.
+	// Will create the of the hard disk of the VM. By default, this is
+	// `40960M` (40 GB).
 	DiskSize string `mapstructure:"disk_size" required:"false"`
 	// The cache mode to use for disk. Allowed values include any of
 	// `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -148,7 +148,7 @@ type Config struct {
 	DiskInterface string `mapstructure:"disk_interface" required:"false"`
 	// The size, in megabytes, of the hard disk to create
 	// for the VM. By default, this is 40960 (40 GB).
-	DiskSize uint `mapstructure:"disk_size" required:"false"`
+	DiskSize string `mapstructure:"disk_size" required:"false"`
 	// The cache mode to use for disk. Allowed values include any of
 	// `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By
 	// default, this is set to `writeback`.
@@ -316,7 +316,6 @@ type Config struct {
 	// "BUILDNAME" is the name of the build. Currently, no file extension will be
 	// used unless it is specified in this option.
 	VMName string `mapstructure:"vm_name" required:"false"`
-
 	// These are deprecated, but we keep them around for BC
 	// TODO(@mitchellh): remove
 	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout" required:"false"`
@@ -344,11 +343,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	var errs *packer.MultiError
 	warnings := make([]string, 0)
-
 	errs = packer.MultiErrorAppend(errs, b.config.ShutdownConfig.Prepare(&b.config.ctx)...)
 
-	if b.config.DiskSize == 0 {
-		b.config.DiskSize = 40960
+	if b.config.DiskSize == "" || b.config.DiskSize == "0" {
+		b.config.DiskSize = "40960M"
 	}
 
 	if b.config.DiskCache == "" {
@@ -700,7 +698,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		artifact.state["diskPaths"] = diskpaths
 	}
 	artifact.state["diskType"] = b.config.Format
-	artifact.state["diskSize"] = uint64(b.config.DiskSize)
+	artifact.state["diskSize"] = b.config.DiskSize
 	artifact.state["domainType"] = b.config.Accelerator
 
 	return artifact, nil

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -169,11 +169,11 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 		t.Fatalf("bad err: %s", err)
 	}
 
-	if b.config.DiskSize != 40960 {
-		t.Fatalf("bad size: %d", b.config.DiskSize)
+	if b.config.DiskSize != "40960M" {
+		t.Fatalf("bad size: %s", b.config.DiskSize)
 	}
 
-	config["disk_size"] = 60000
+	config["disk_size"] = "60000M"
 	b = Builder{}
 	warns, err = b.Prepare(config)
 	if len(warns) > 0 {
@@ -183,8 +183,8 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 
-	if b.config.DiskSize != 60000 {
-		t.Fatalf("bad size: %d", b.config.DiskSize)
+	if b.config.DiskSize != "60000M" {
+		t.Fatalf("bad size: %s", b.config.DiskSize)
 	}
 }
 

--- a/builder/qemu/step_create_disk.go
+++ b/builder/qemu/step_create_disk.go
@@ -29,7 +29,7 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	ui.Say("Creating required virtual machine disks")
 	// The 'main' or 'default' disk
 	diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, name))
-	diskSizes = append(diskSizes, fmt.Sprintf("%dM", uint64(config.DiskSize)))
+	diskSizes = append(diskSizes, fmt.Sprintf("%s", config.DiskSize))
 	// Additional disks
 	if len(config.AdditionalDiskSize) > 0 {
 		for i, diskSize := range config.AdditionalDiskSize {

--- a/builder/qemu/step_resize_disk.go
+++ b/builder/qemu/step_resize_disk.go
@@ -23,9 +23,8 @@ func (s *stepResizeDisk) Run(ctx context.Context, state multistep.StateBag) mult
 		"resize",
 		"-f", config.Format,
 		path,
-		fmt.Sprintf("%vM", config.DiskSize),
+		fmt.Sprintf("%s", config.DiskSize),
 	}
-
 	if config.DiskImage == false {
 		return multistep.ActionContinue
 	}

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -37,7 +37,7 @@ to files, URLS for ISOs and checksums.
       "iso_checksum_type": "md5",
       "output_directory": "output_centos_tdhtest",
       "shutdown_command": "echo 'packer' | sudo -S shutdown -P now",
-      "disk_size": 5000,
+      "disk_size": "5000M",
       "format": "qcow2",
       "accelerator": "kvm",
       "http_directory": "path/to/httpdir",

--- a/website/source/partials/builder/qemu/_Config-not-required.html.md
+++ b/website/source/partials/builder/qemu/_Config-not-required.html.md
@@ -47,8 +47,10 @@
     one of the other listed interfaces. Using the `scsi` interface under
     these circumstances will cause the build to fail.
     
--   `disk_size` (uint) - The size, in megabytes, of the hard disk to create
-    for the VM. By default, this is 40960 (40 GB).
+-   `disk_size` (string) - The size in bytes, suffixes of the first letter of common byte types
+    like "k" or "K", "M" for megabytes, G for gigabytes, T for terabytes.
+    Will create the of the hard disk of the VM. By default, this is
+    `40960M` (40 GB).
     
 -   `disk_cache` (string) - The cache mode to use for disk. Allowed values include any of
     `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By


### PR DESCRIPTION
Modified builder and steps to accept drive size string that `qemu-img` can use directly. Modification of tests was necessary for the tests to pass (since integers are no longer used). Website documentation also reflects the changes.

Closes #6092 

Personal note: this will definitely be a change where templates will need to be modified by users, and I felt that adding a catch to help prevent many builds from failing would be useful. I quickly wrote this to help convey my idea (forgive the brevity)
```
if _, err : =strconv.Atoi(artifact.state["diskSize"][len(artifact.state["diskSize"]-1:]) ); err == nil {
  artifact.stat["diskSize"] += "M"
}
```
But doing so would carry around code to handle legacy templates and I was not sure how long that should stick around. Additionally I would have needed to import another module.