### PR TITLE
[WIP] add 30 minute timeout for destroying a VM

### DIFF
--- a/builder/vmware/common/step_register.go
+++ b/builder/vmware/common/step_register.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -66,12 +67,19 @@ func (s *StepRegister) Cleanup(state multistep.StateBag) {
 				ui.Error(fmt.Sprintf("Error destroying VM: %s", err))
 			}
 			// Wait for the machine to actually destroy
+			start := time.Now()
 			for {
-				destroyed, _ := remoteDriver.IsDestroyed()
+				destroyed, err := remoteDriver.IsDestroyed()
 				if destroyed {
 					break
 				}
+				log.Printf("error destroying vm: %s", err)
 				time.Sleep(1 * time.Second)
+				if time.Since(start) >= time.Duration(30*time.Minute) {
+					ui.Error("Error unregistering VM; timed out. You may " +
+						"need to manually clean up your machine")
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When we're destroying a vm, if there's some kind of weirdness where the VM isn't being properly destroyed, we can get stuck in an infinite loop here. This creates a timeout of 30 minutes to protect against a build just running forever. 

I'm not adding context cancellation because it's in the cleanup phase and we specifically want to actually run through all the cleanup things.

I want to test it out on an actual remote instance before I remove the WIP tags; I'll spin something up on Packet later this week.

Closes #7404 