### PR TITLE
ProxMox builder: Use ssh_host config as host for the communicator

### DIFF
--- a/builder/proxmox/builder.go
+++ b/builder/proxmox/builder.go
@@ -71,7 +71,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      commHost(b.config.Comm.SSHHost),
+			Host:      commHost(b.config.Comm.Host()),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},
@@ -98,11 +98,12 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	return artifact, nil
 }
 
-// Returns ssh_host config parameter when set, otherwise gets the host IP from running VM
-func commHost(sshHost string) func(state multistep.StateBag) (string, error) {
-	if sshHost != "" {
+// Returns ssh_host or winrm_host (see communicator.Config.Host) config
+// parameter when set, otherwise gets the host IP from running VM
+func commHost(host string) func(state multistep.StateBag) (string, error) {
+	if host != "" {
 		return func(state multistep.StateBag) (string, error) {
-			return sshHost, nil
+			return host, nil
 		}
 	}
 	return getVMIP

--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	NICs    []nicConfig  `mapstructure:"network_adapters"`
 	Disks   []diskConfig `mapstructure:"disks"`
 	ISOFile string       `mapstructure:"iso_file"`
+	Agent   string       `mapstructure:"qemu_agent"`
 
 	TemplateName        string `mapstructure:"template_name"`
 	TemplateDescription string `mapstructure:"template_description"`
@@ -148,6 +149,11 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 			log.Printf("Disk %d cache mode not set, using default 'none'", idx)
 			c.Disks[idx].CacheMode = "none"
 		}
+	}
+	// Valid values: 0 - no agent, 1 - with agent; default is 1
+	if c.Agent != "0" && c.Agent != "1" {
+		log.Printf("Agent '%s' is not valid, using default: 1", c.Agent)
+		c.Agent = "1"
 	}
 
 	errs = packer.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)

--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	NICs    []nicConfig  `mapstructure:"network_adapters"`
 	Disks   []diskConfig `mapstructure:"disks"`
 	ISOFile string       `mapstructure:"iso_file"`
-	Agent   string       `mapstructure:"qemu_agent"`
+	Agent   bool         `mapstructure:"qemu_agent"`
 
 	TemplateName        string `mapstructure:"template_name"`
 	TemplateDescription string `mapstructure:"template_description"`
@@ -69,6 +69,8 @@ type diskConfig struct {
 
 func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	c := new(Config)
+	// Agent defaults to true
+	c.Agent = true
 
 	var md mapstructure.Metadata
 	err := config.Decode(c, &config.DecodeOpts{
@@ -149,11 +151,6 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 			log.Printf("Disk %d cache mode not set, using default 'none'", idx)
 			c.Disks[idx].CacheMode = "none"
 		}
-	}
-	// Valid values: 0 - no agent, 1 - with agent; default is 1
-	if c.Agent != "0" && c.Agent != "1" {
-		log.Printf("Agent '%s' is not valid, using default: 1", c.Agent)
-		c.Agent = "1"
 	}
 
 	errs = packer.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)

--- a/builder/proxmox/config_test.go
+++ b/builder/proxmox/config_test.go
@@ -119,7 +119,7 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 }
 
 func TestAgentSetToFalse(t *testing.T) {
-	// pnly the mandatory attributes are specified
+	// only the mandatory attributes are specified
 	const config = `{
 		"builders": [
 			{

--- a/builder/proxmox/config_test.go
+++ b/builder/proxmox/config_test.go
@@ -93,6 +93,7 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	// OS not set, using default 'other'
 	// NIC 0 model not set, using default 'e1000'
 	// Disk 0 cache mode not set, using default 'none'
+	// Agent not set, default is 1
 
 	if b.config.Memory != 512 {
 		t.Errorf("Expected Memory to be 512, got %d", b.config.Memory)
@@ -111,5 +112,8 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	}
 	if b.config.Disks[0].CacheMode != "none" {
 		t.Errorf("Expected disk cache mode to be 'none', got %s", b.config.Disks[0].CacheMode)
+	}
+	if b.config.Agent != "1" {
+		t.Errorf("Expected Agent to be 1, got %s", b.config.Agent)
 	}
 }

--- a/builder/proxmox/config_test.go
+++ b/builder/proxmox/config_test.go
@@ -93,7 +93,7 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	// OS not set, using default 'other'
 	// NIC 0 model not set, using default 'e1000'
 	// Disk 0 cache mode not set, using default 'none'
-	// Agent not set, default is 1
+	// Agent not set, default is true
 
 	if b.config.Memory != 512 {
 		t.Errorf("Expected Memory to be 512, got %d", b.config.Memory)
@@ -113,7 +113,40 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	if b.config.Disks[0].CacheMode != "none" {
 		t.Errorf("Expected disk cache mode to be 'none', got %s", b.config.Disks[0].CacheMode)
 	}
-	if b.config.Agent != "1" {
-		t.Errorf("Expected Agent to be 1, got %s", b.config.Agent)
+	if b.config.Agent != true {
+		t.Errorf("Expected Agent to be true, got %t", b.config.Agent)
+	}
+}
+
+func TestAgentSetToFalse(t *testing.T) {
+	// pnly the mandatory attributes are specified
+	const config = `{
+		"builders": [
+			{
+				"type": "proxmox",
+				"proxmox_url": "https://my-proxmox.my-domain:8006/api2/json",
+				"username": "apiuser@pve",
+				"password": "supersecret",
+				"iso_file": "local:iso/Fedora-Server-dvd-x86_64-29-1.2.iso",
+				"ssh_username": "root",
+				"node": "my-proxmox",
+				"qemu_agent": false
+			}
+		]
+	}`
+
+	tpl, err := template.Parse(strings.NewReader(config))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := &Builder{}
+	warn, err := b.Prepare(tpl.Builders["proxmox"].Config)
+	if err != nil {
+		t.Fatal(err, warn)
+	}
+
+	if b.config.Agent != false {
+		t.Errorf("Expected Agent to be false, got %t", b.config.Agent)
 	}
 }

--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -21,10 +21,15 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 	client := state.Get("proxmoxClient").(*proxmox.Client)
 	c := state.Get("config").(*Config)
 
+	agent := "1"
+	if c.Agent == false {
+		agent = "0"
+	}
+
 	ui.Say("Creating VM")
 	config := proxmox.ConfigQemu{
 		Name:         c.VMName,
-		Agent:        c.Agent,
+		Agent:        agent,
 		Description:  "Packer ephemeral build VM",
 		Memory:       c.Memory,
 		QemuCores:    c.Cores,

--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -24,7 +24,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 	ui.Say("Creating VM")
 	config := proxmox.ConfigQemu{
 		Name:         c.VMName,
-		Agent:        "1",
+		Agent:        c.Agent,
 		Description:  "Packer ephemeral build VM",
 		Memory:       c.Memory,
 		QemuCores:    c.Cores,

--- a/website/source/docs/builders/proxmox.html.md
+++ b/website/source/docs/builders/proxmox.html.md
@@ -146,10 +146,9 @@ builder.
 -   `unmount_iso` (bool) - If true, remove the mounted ISO from the template
     after finishing. Defaults to `false`.
 
--   `qemu_agent` (string) - Enables (`1`) or disables (`0`) the QEMU Agent option 
-    for this VM. When disabled, then Packer can't determine the guest's IP, 
-    and `ssh_host` should be used. When enabled, then `qemu-guest-agent`
-    must be installed on the guest OS. Defaults to `1`.
+-   `qemu_agent` (boolean) - Disables QEMU Agent option for this VM. When enabled,
+    then `qemu-guest-agent` must be installed on the guest. When disabled, then 
+    `ssh_host` should be used. Defaults to `true`.
 
 ## Example: Fedora with kickstart
 

--- a/website/source/docs/builders/proxmox.html.md
+++ b/website/source/docs/builders/proxmox.html.md
@@ -146,6 +146,10 @@ builder.
 -   `unmount_iso` (bool) - If true, remove the mounted ISO from the template
     after finishing. Defaults to `false`.
 
+-   `qemu_agent` (string) - Enables (`1`) or disables (`0`) the QEMU Agent option 
+    for this VM. When disabled, then Packer can't determine the guest's IP, 
+    and `ssh_host` should be used. When enabled, then `qemu-guest-agent`
+    must be installed on the guest OS. Defaults to `1`.
 
 ## Example: Fedora with kickstart
 


### PR DESCRIPTION
When `ssh_host` config is present, then the builder gives this value to the communicator.

The original builder requires `qemu-guest-agent` package to be installed on the VM in order to determine it's IP address.

For environments with static addresses, the IP address of this VM is known in advance, and might already be configured in the template json, e.g. in boot command for Ubuntu.
