### PR TITLE
Step download: always copy local files

### DIFF
--- a/common/step_download.go
+++ b/common/step_download.go
@@ -88,6 +88,19 @@ func (s *StepDownload) Run(ctx context.Context, state multistep.StateBag) multis
 	return multistep.ActionHalt
 }
 
+var (
+	getters = getter.Getters
+)
+
+func init() {
+	getters["file"] = &getter.FileGetter{
+		// always copy local files instead of symlinking to fix GH-7534. The
+		// longer term fix for this would be to change the go-getter so that it
+		// can leave the source file where it is & tell us where it is.
+		Copy: true,
+	}
+}
+
 func (s *StepDownload) download(ctx context.Context, ui packer.Ui, source string) (string, error) {
 	u, err := urlhelper.Parse(source)
 	if err != nil {
@@ -152,6 +165,7 @@ func (s *StepDownload) download(ctx context.Context, ui packer.Ui, source string
 		ProgressListener: ui,
 		Pwd:              wd,
 		Dir:              false,
+		Getters:          getters,
 	}
 
 	switch err := gc.Get(); err.(type) {

--- a/common/step_download.go
+++ b/common/step_download.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/gofrs/flock"
@@ -93,11 +94,13 @@ var (
 )
 
 func init() {
-	getters["file"] = &getter.FileGetter{
-		// always copy local files instead of symlinking to fix GH-7534. The
-		// longer term fix for this would be to change the go-getter so that it
-		// can leave the source file where it is & tell us where it is.
-		Copy: true,
+	if runtime.GOOS == "windows" {
+		getters["file"] = &getter.FileGetter{
+			// always copy local files instead of symlinking to fix GH-7534. The
+			// longer term fix for this would be to change the go-getter so that it
+			// can leave the source file where it is & tell us where it is.
+			Copy: true,
+		}
 	}
 }
 


### PR DESCRIPTION
instead of symlinking to fix #7534. The longer term fix for this would be to change the go-getter so that it can leave the source file where it is & tell us where it is.

We will do this when the right time comes.

fix #7534