### PR TITLE
fix race condition causing hang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/mitchellh/go-fs v0.0.0-20180402234041-7b48fa161ea7
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
+	github.com/mitchellh/iochan v1.0.0
 	github.com/mitchellh/mapstructure v0.0.0-20180111000720-b4575eea38cc
 	github.com/mitchellh/panicwrap v0.0.0-20170106182340-fce601fe5557
 	github.com/mitchellh/prefixedio v0.0.0-20151214002211-6e6954073784

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,7 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed h1:FI2NIv6fpef6BQl2u3IZX/Cj20tfypRF4yd+uaHOMtI=
 github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed/go.mod h1:3rdaFaCv4AyBgu5ALFM0+tSuHrBh6v692nyQe3ikrq0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v0.0.0-20180111000720-b4575eea38cc h1:5T6hzGUO5OrL6MdYXYoLQtRWJDDgjdlOVBn9mIqGY1g=

--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -101,10 +101,13 @@ func (c *communicator) Start(ctx context.Context, cmd *packer.RemoteCmd) (err er
 
 	go func() {
 		conn, err := c.mux.Accept(responseStreamId)
+		log.Printf("Megan waiting...")
 		wg.Wait()
+		log.Printf("Megan done waiting...")
 		if err != nil {
 			log.Printf("[ERR] Error accepting response stream %d: %s",
 				responseStreamId, err)
+			log.Printf("Megan SetExited 1...")
 			cmd.SetExited(123)
 			return
 		}
@@ -115,15 +118,19 @@ func (c *communicator) Start(ctx context.Context, cmd *packer.RemoteCmd) (err er
 		if err := decoder.Decode(&finished); err != nil {
 			log.Printf("[ERR] Error decoding response stream %d: %s",
 				responseStreamId, err)
+			log.Printf("Megan SetExited 2...")
 			cmd.SetExited(123)
 			return
 		}
 
 		log.Printf("[INFO] RPC client: Communicator ended with: %d", finished.ExitStatus)
+		log.Printf("Megan SetExited 3...")
 		cmd.SetExited(finished.ExitStatus)
 	}()
 
+	log.Printf("Megan, calling communicator using c.client.call")
 	err = c.client.Call("Communicator.Start", &args, new(interface{}))
+	log.Printf("Megan, returned from communicator.Start c.client.call")
 	return
 }
 
@@ -202,6 +209,7 @@ func (c *communicator) Download(path string, w io.Writer) (err error) {
 }
 
 func (c *CommunicatorServer) Start(args *CommunicatorStartArgs, reply *interface{}) error {
+	log.Println("Megan inside communicatorServer")
 	ctx := context.TODO()
 
 	// Build the RemoteCmd on this side so that it all pipes over

--- a/packer/rpc/communicator.go
+++ b/packer/rpc/communicator.go
@@ -101,13 +101,10 @@ func (c *communicator) Start(ctx context.Context, cmd *packer.RemoteCmd) (err er
 
 	go func() {
 		conn, err := c.mux.Accept(responseStreamId)
-		log.Printf("Megan waiting...")
 		wg.Wait()
-		log.Printf("Megan done waiting...")
 		if err != nil {
 			log.Printf("[ERR] Error accepting response stream %d: %s",
 				responseStreamId, err)
-			log.Printf("Megan SetExited 1...")
 			cmd.SetExited(123)
 			return
 		}
@@ -118,19 +115,15 @@ func (c *communicator) Start(ctx context.Context, cmd *packer.RemoteCmd) (err er
 		if err := decoder.Decode(&finished); err != nil {
 			log.Printf("[ERR] Error decoding response stream %d: %s",
 				responseStreamId, err)
-			log.Printf("Megan SetExited 2...")
 			cmd.SetExited(123)
 			return
 		}
 
 		log.Printf("[INFO] RPC client: Communicator ended with: %d", finished.ExitStatus)
-		log.Printf("Megan SetExited 3...")
 		cmd.SetExited(finished.ExitStatus)
 	}()
 
-	log.Printf("Megan, calling communicator using c.client.call")
 	err = c.client.Call("Communicator.Start", &args, new(interface{}))
-	log.Printf("Megan, returned from communicator.Start c.client.call")
 	return
 }
 
@@ -209,7 +202,6 @@ func (c *communicator) Download(path string, w io.Writer) (err error) {
 }
 
 func (c *CommunicatorServer) Start(args *CommunicatorStartArgs, reply *interface{}) error {
-	log.Println("Megan inside communicatorServer")
 	ctx := context.TODO()
 
 	// Build the RemoteCmd on this side so that it all pipes over

--- a/vendor/github.com/mitchellh/iochan/LICENSE.md
+++ b/vendor/github.com/mitchellh/iochan/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/iochan/README.md
+++ b/vendor/github.com/mitchellh/iochan/README.md
@@ -1,0 +1,13 @@
+# iochan
+
+iochan is a Go library for treating `io` readers and writers like channels.
+This is useful when sometimes you wish to use `io.Reader` and such in `select`
+statements.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/iochan
+```

--- a/vendor/github.com/mitchellh/iochan/go.mod
+++ b/vendor/github.com/mitchellh/iochan/go.mod
@@ -1,0 +1,1 @@
+module github.com/mitchellh/iochan

--- a/vendor/github.com/mitchellh/iochan/iochan.go
+++ b/vendor/github.com/mitchellh/iochan/iochan.go
@@ -1,0 +1,41 @@
+package iochan
+
+import (
+	"bufio"
+	"io"
+)
+
+// DelimReader takes an io.Reader and produces the contents of the reader
+// on the returned channel. The contents on the channel will be returned
+// on boundaries specified by the delim parameter, and will include this
+// delimiter.
+//
+// If an error occurs while reading from the reader, the reading will end.
+//
+// In the case of an EOF or error, the channel will be closed.
+//
+// This must only be called once for any individual reader. The behavior is
+// unknown and will be unexpected if this is called multiple times with the
+// same reader.
+func DelimReader(r io.Reader, delim byte) <-chan string {
+	ch := make(chan string)
+
+	go func() {
+		buf := bufio.NewReader(r)
+
+		for {
+			line, err := buf.ReadString(delim)
+			if line != "" {
+				ch <- line
+			}
+
+			if err != nil {
+				break
+			}
+		}
+
+		close(ch)
+	}()
+
+	return ch
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -330,6 +330,8 @@ github.com/mitchellh/go-homedir
 github.com/mitchellh/go-testing-interface
 # github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
 github.com/mitchellh/go-vnc
+# github.com/mitchellh/iochan v1.0.0
+github.com/mitchellh/iochan
 # github.com/mitchellh/mapstructure v0.0.0-20180111000720-b4575eea38cc
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/panicwrap v0.0.0-20170106182340-fce601fe5557


### PR DESCRIPTION
Something about the iochan.LineReader was breaking the way we read whether a channel is closed. I reverted to our old way of piping and scrubbing stderr and stdout to end this race condition.

Closes #7525
Closes #7529