### PR TITLE
fix flock build errors on solaris by shadowing the pkg

### DIFF
--- a/common/filelock/filelock.go
+++ b/common/filelock/filelock.go
@@ -1,0 +1,11 @@
+// +build !solaris
+
+package filelock
+
+import "github.com/gofrs/flock"
+
+type Flock = flock.Flock
+
+func New(path string) *Flock {
+	return flock.New(path)
+}

--- a/common/filelock/filelock_solaris.go
+++ b/common/filelock/filelock_solaris.go
@@ -1,0 +1,11 @@
+// build solaris
+
+package filelock
+
+// Flock is a noop on solaris for now.
+// TODO(azr): PR github.com/gofrs/flock for this.
+type Flock = Noop
+
+func New(string) *Flock {
+	return &Flock{}
+}

--- a/common/filelock/noop.go
+++ b/common/filelock/noop.go
@@ -1,0 +1,8 @@
+package filelock
+
+// this lock does nothing
+type Noop struct{}
+
+func (_ *Noop) Lock() (bool, error)    { return true, nil }
+func (_ *Noop) TryLock() (bool, error) { return true, nil }
+func (_ *Noop) Unlock() error          { return nil }

--- a/common/net/configure_port.go
+++ b/common/net/configure_port.go
@@ -81,8 +81,6 @@ func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
 			return ErrPortFileLocked(port)
 		}
 
-		log.Printf("Trying port: %d", port)
-
 		l, err := lc.ListenConfig.Listen(ctx, lc.Network, fmt.Sprintf("%s:%d", lc.Addr, port))
 		if err != nil {
 			if err := lock.Unlock(); err != nil {

--- a/common/net/configure_port.go
+++ b/common/net/configure_port.go
@@ -40,7 +40,7 @@ func (l *Listener) Close() error {
 // ListenRangeConfig contains options for listening to a free address [Min,Max)
 // range. ListenRangeConfig wraps a net.ListenConfig.
 type ListenRangeConfig struct {
-	// tcp", "udp"
+	// like "tcp" or "udp". defaults to "tcp".
 	Network  string
 	Addr     string
 	Min, Max int
@@ -51,6 +51,9 @@ type ListenRangeConfig struct {
 // until ctx is cancelled.
 // Listen uses net.ListenConfig.Listen internally.
 func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
+	if lc.Network == "" {
+		lc.Network = "tcp"
+	}
 	portRange := lc.Max - lc.Min
 	for {
 		if err := ctx.Err(); err != nil {

--- a/common/net/configure_port.go
+++ b/common/net/configure_port.go
@@ -65,8 +65,6 @@ func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
 			port += rand.Intn(portRange)
 		}
 
-		log.Printf("Trying port: %d", port)
-
 		lockFilePath, err := packer.CachePath("port", strconv.Itoa(port))
 		if err != nil {
 			return nil, err
@@ -80,6 +78,8 @@ func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
 		if !locked {
 			continue // this port seems to be locked by another packer goroutine
 		}
+
+		log.Printf("Trying port: %d", port)
 
 		l, err := lc.ListenConfig.Listen(ctx, lc.Network, fmt.Sprintf("%s:%d", lc.Addr, port))
 		if err != nil {

--- a/common/net/configure_port.go
+++ b/common/net/configure_port.go
@@ -8,8 +8,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/gofrs/flock"
-
+	"github.com/hashicorp/packer/common/filelock"
 	"github.com/hashicorp/packer/packer"
 )
 
@@ -26,7 +25,7 @@ type Listener struct {
 	net.Listener
 	Port    int
 	Address string
-	lock    *flock.Flock
+	lock    *filelock.Flock
 }
 
 func (l *Listener) Close() error {
@@ -70,7 +69,7 @@ func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
 			return nil, err
 		}
 
-		lock := flock.New(lockFilePath)
+		lock := filelock.New(lockFilePath)
 		locked, err := lock.TryLock()
 		if err != nil {
 			return nil, err

--- a/common/net/configure_port.go
+++ b/common/net/configure_port.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/packer/common/filelock"
 	"github.com/hashicorp/packer/packer"
@@ -97,5 +98,6 @@ func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
 			lock:     lock,
 		}, err
 
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/common/net/configure_port_test.go
+++ b/common/net/configure_port_test.go
@@ -1,0 +1,155 @@
+package net
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestListenRangeConfig_Listen(t *testing.T) {
+
+	topCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var err error
+	var lockedListener *Listener
+	{ // open a random port in range
+		ctx, cancel := context.WithTimeout(topCtx, time.Second*5)
+
+		lockedListener, err = ListenRangeConfig{
+			Min:  800,
+			Max:  10000,
+			Addr: "localhost",
+		}.Listen(ctx)
+		if err != nil {
+			t.Fatalf("could not open first port")
+		}
+		cancel()
+		defer lockedListener.Close() // in case
+	}
+
+	{ // open a second random port in range
+		ctx, cancel := context.WithTimeout(topCtx, time.Second*5)
+
+		listener, err := ListenRangeConfig{
+			Min:  800,
+			Max:  10000,
+			Addr: "localhost",
+		}.Listen(ctx)
+		if err != nil {
+			t.Fatalf("could not open first port")
+		}
+		cancel()
+		if err := listener.Close(); err != nil { // in case
+			t.Fatal("failed to close second random port")
+		}
+	}
+
+	{ // test that opened port cannot be openned using min/max
+		ctx, cancel := context.WithTimeout(topCtx, 250*time.Millisecond)
+
+		l, err := ListenRangeConfig{
+			Min: lockedListener.Port,
+			Max: lockedListener.Port,
+		}.Listen(ctx)
+		if err != context.DeadlineExceeded {
+			l.Close()
+			t.Fatalf("port should be taken, this should timeout: %v", err)
+		}
+		cancel()
+	}
+
+	{ // test that opened port cannot be openned using min only
+		ctx, cancel := context.WithTimeout(topCtx, 250*time.Millisecond)
+
+		l, err := ListenRangeConfig{
+			Min: lockedListener.Port,
+		}.Listen(ctx)
+		if err != context.DeadlineExceeded {
+			l.Close()
+			t.Fatalf("port should be taken, this should timeout: %v", err)
+		}
+		cancel()
+	}
+
+	err = lockedListener.Close() // close port and release lock file
+	if err != nil {
+		t.Fatalf("could not release lockfile or port: %v", err)
+	}
+
+	{ // test that closed port can be reopenned.
+		ctx, cancel := context.WithTimeout(topCtx, 250*time.Millisecond)
+
+		lockedListener, err = ListenRangeConfig{
+			Min: lockedListener.Port,
+		}.Listen(ctx)
+		if err != nil {
+			t.Fatalf("port should have been freed: %v", err)
+		}
+		cancel()
+		defer lockedListener.Close() // in case
+	}
+
+	err = lockedListener.Listener.Close() // close listener, keep lockfile only
+	if err != nil {
+		t.Fatalf("could not release lockfile or port: %v", err)
+	}
+
+	{ // test that file locked port cannot be opened
+		ctx, cancel := context.WithTimeout(topCtx, 250*time.Millisecond)
+
+		l, err := ListenRangeConfig{
+			Min: lockedListener.Port,
+		}.Listen(ctx)
+		if err != context.DeadlineExceeded {
+			l.Close()
+			t.Fatalf("port should be file locked, this should timeout: %v", err)
+		}
+		cancel()
+	}
+
+	var netListener net.Listener
+	{ // test that network port was closed. using net.Listen
+		netListener, err = net.Listen("tcp", lockedListener.Addr().String())
+		if err != nil {
+			t.Fatalf("listen on freed port failed: %v", err)
+		}
+
+	}
+
+	if err := lockedListener.lock.Unlock(); err != nil {
+		t.Fatalf("error closing port: %v", err)
+	}
+
+	{ // test that busy port cannot be opened
+		ctx, cancel := context.WithTimeout(topCtx, 250*time.Millisecond)
+
+		l, err := ListenRangeConfig{
+			Min: lockedListener.Port,
+		}.Listen(ctx)
+		if err != context.DeadlineExceeded {
+			l.Close()
+			t.Fatalf("port should be file locked, this should timeout: %v", err)
+		}
+		cancel()
+	}
+
+	if err := netListener.Close(); err != nil { // free port
+		t.Fatalf("close failed: %v", err)
+	}
+
+	{ // test that freed port can be opened
+		ctx, cancel := context.WithTimeout(topCtx, 250*time.Minute)
+
+		lockedListener, err = ListenRangeConfig{
+			Min: lockedListener.Port,
+		}.Listen(ctx)
+		if err != nil {
+			t.Fatalf("port should have been freed: %v", err)
+		}
+		cancel()
+		defer lockedListener.Close() // in case
+	}
+
+}

--- a/common/net/configure_port_test.go
+++ b/common/net/configure_port_test.go
@@ -53,8 +53,10 @@ func TestListenRangeConfig_Listen(t *testing.T) {
 			Min: lockedListener.Port,
 			Max: lockedListener.Port,
 		}.Listen(ctx)
-		if err != context.DeadlineExceeded {
+		if l != nil {
 			l.Close()
+		}
+		if err != context.DeadlineExceeded {
 			t.Fatalf("port should be taken, this should timeout: %v", err)
 		}
 		cancel()

--- a/common/step_download.go
+++ b/common/step_download.go
@@ -10,9 +10,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/gofrs/flock"
 	getter "github.com/hashicorp/go-getter"
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
+	"github.com/hashicorp/packer/common/filelock"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -146,7 +146,7 @@ func (s *StepDownload) download(ctx context.Context, ui packer.Ui, source string
 	lockFile := targetPath + ".lock"
 
 	log.Printf("Acquiring lock for: %s (%s)", u.String(), lockFile)
-	lock := flock.New(lockFile)
+	lock := filelock.New(lockFile)
 	lock.Lock()
 	defer lock.Unlock()
 


### PR DESCRIPTION
This PR makes of file locking is a no-op on solaris, so that packer builds and works at least.

Without this the following error occurs:

``` bash
$ GOOS=solaris go build .
# github.com/hashicorp/packer/vendor/github.com/gofrs/flock
vendor/github.com/gofrs/flock/flock_unix.go:28:22: undefined: syscall.LOCK_EX
vendor/github.com/gofrs/flock/flock_unix.go:39:22: undefined: syscall.LOCK_SH
vendor/github.com/gofrs/flock/flock_unix.go:56:12: undefined: syscall.Flock
vendor/github.com/gofrs/flock/flock_unix.go:66:12: undefined: syscall.Flock
vendor/github.com/gofrs/flock/flock_unix.go:96:12: undefined: syscall.Flock
vendor/github.com/gofrs/flock/flock_unix.go:96:42: undefined: syscall.LOCK_UN
vendor/github.com/gofrs/flock/flock_unix.go:118:21: undefined: syscall.LOCK_EX
vendor/github.com/gofrs/flock/flock_unix.go:130:21: undefined: syscall.LOCK_SH
vendor/github.com/gofrs/flock/flock_unix.go:149:9: undefined: syscall.Flock
vendor/github.com/gofrs/flock/flock_unix.go:149:44: undefined: syscall.LOCK_NB
vendor/github.com/gofrs/flock/flock_unix.go:149:44: too many errors
```

I also took the opportunity to add tests to `ListenRangeConfig.Listen` which uses the file lock internally.
The download step uses fslock too.