### PR TITLE
Add image filtering on properties.

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -97,6 +97,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			SourceImageName:  b.config.RunConfig.SourceImageName,
 			SourceImageOpts:  b.config.RunConfig.sourceImageOpts,
 			SourceMostRecent: b.config.SourceImageFilters.MostRecent,
+			SourceProperties: b.config.SourceImageFilters.Filters.Properties,
 		},
 		&StepCreateVolume{
 			UseBlockStorageVolume:  b.config.UseBlockStorageVolume,

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -48,7 +48,7 @@ type RunConfig struct {
 	OpenstackProvider string `mapstructure:"openstack_provider"`
 	UseFloatingIp     bool   `mapstructure:"use_floating_ip"`
 
-	sourceImageOpts images.ListOpts
+	sourceImageOpts images.ListOpts // derived from .SourceImageFilters.Filters ImageFilterOptions
 }
 
 type ImageFilter struct {
@@ -57,14 +57,15 @@ type ImageFilter struct {
 }
 
 type ImageFilterOptions struct {
-	Name       string   `mapstructure:"name"`
-	Owner      string   `mapstructure:"owner"`
-	Tags       []string `mapstructure:"tags"`
-	Visibility string   `mapstructure:"visibility"`
+	Name       string            `mapstructure:"name"`
+	Owner      string            `mapstructure:"owner"`
+	Tags       []string          `mapstructure:"tags"`
+	Visibility string            `mapstructure:"visibility"`
+	Properties map[string]string `mapstructure:"properties"`
 }
 
 func (f *ImageFilterOptions) Empty() bool {
-	return f.Name == "" && f.Owner == "" && len(f.Tags) == 0 && f.Visibility == ""
+	return f.Name == "" && f.Owner == "" && len(f.Tags) == 0 && f.Visibility == "" && len(f.Properties) == 0
 }
 
 func (f *ImageFilterOptions) Build() (*images.ListOpts, error) {

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -48,7 +48,7 @@ type RunConfig struct {
 	OpenstackProvider string `mapstructure:"openstack_provider"`
 	UseFloatingIp     bool   `mapstructure:"use_floating_ip"`
 
-	sourceImageOpts images.ListOpts // derived from .SourceImageFilters.Filters ImageFilterOptions
+	sourceImageOpts images.ListOpts
 }
 
 type ImageFilter struct {

--- a/builder/openstack/run_config_test.go
+++ b/builder/openstack/run_config_test.go
@@ -139,6 +139,7 @@ func TestBuildImageFilter(t *testing.T) {
 		Visibility: "public",
 		Owner:      "1234567890",
 		Tags:       []string{"prod", "ready"},
+		Properties: map[string]string{"os_distro": "ubuntu", "os_version": "16.04"},
 	}
 
 	listOpts, err := filters.Build()
@@ -198,6 +199,7 @@ func TestImageFiltersEmpty(t *testing.T) {
 		Visibility: "public",
 		Owner:      "1234567890",
 		Tags:       []string{"prod", "ready"},
+		Properties: map[string]string{"os_distro": "ubuntu", "os_version": "16.04"},
 	}
 
 	if filledFilters.Empty() {

--- a/builder/openstack/step_source_image_info.go
+++ b/builder/openstack/step_source_image_info.go
@@ -55,16 +55,10 @@ func (s *StepSourceImageInfo) Run(ctx context.Context, state multistep.StateBag)
 		if err != nil {
 			return false, err
 		}
-		ui.Message(fmt.Sprintf("Resulting images: %d", len(imgs)))
 
-		for index, img := range imgs {
-			ui.Message(fmt.Sprintf("index +%v, image %+v", index, img))
-			ui.Message(fmt.Sprintf("Metadata %+v", img.Metadata))
-			ui.Message(fmt.Sprintf("Properties %+v", img.Properties))
-
+		for _, img := range imgs {
 			// Check if all Properties are satisfied
 			if PropertiesSatisfied(&img, &s.SourceProperties) {
-				ui.Message(fmt.Sprintf("Matched properties %+v", s.SourceProperties))
 				count++
 				if count == 1 {
 					// Tentatively return this result.
@@ -74,12 +68,9 @@ func (s *StepSourceImageInfo) Run(ctx context.Context, state multistep.StateBag)
 				if count > 1 {
 					break
 				}
-			} else {
-				ui.Message(fmt.Sprintf("FAILED to match properties %+v", s.SourceProperties))
 			}
 		}
 
-		ui.Message(fmt.Sprintf("Count = %v", count))
 		switch count {
 		case 0: // Continue looking at next page.
 			return true, nil

--- a/website/source/docs/builders/openstack.html.md
+++ b/website/source/docs/builders/openstack.html.md
@@ -202,7 +202,10 @@ builder.
                 "name": "ubuntu-16.04",
                 "visibility": "protected",
                 "owner": "d1a588cf4b0743344508dc145649372d1",
-                "tags": ["prod", "ready"]
+                "tags": ["prod", "ready"],
+                "properties": {
+                    "os_distro": "ubuntu"
+                }
             },
             "most_recent": true
         }
@@ -228,6 +231,9 @@ builder.
         -   tags (array of strings)
 
         -   visibility (string)
+
+        -   properties (map of strings to strings) (fields that can be set
+            with `openstack image set --property key=value`)
 
     -   `most_recent` (boolean) - Selects the newest created image when true.
         This is most useful for selecting a daily distro build.


### PR DESCRIPTION
This change makes it possible with the openstack builder to filter source images based on image "properties". Example:

```
{
  "builders": [
    {
      "type": "openstack",
      "region": "foo",
      "image_name": "test-image",
      "ssh_username": "foo",
      "flavor": "m1.tiny",
      "source_image_filter": {
        "filters": {
          "visibility": "public",
          "properties": {
            "os_distro": "ubuntu",
            "os_type": "linux",
            "os_version": "18.04"
          }
        },
        "most_recent": false
      },
      "floating_ip_network": "foo"
    }
  ]
}
```
Since the openstack API doesn't allow filtering based on this, it is done in the builder.