### PR TITLE
Fix EBSsurrogate copy, encryption, and deletion of temporary unencrypted amis.

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -284,6 +284,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,
+			OriginalRegion:    *ec2conn.Config.Region,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,

--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer/helper/multistep"
 )
 
@@ -36,7 +37,7 @@ type StateChangeConf struct {
 // Following are wrapper functions that use Packer's environment-variables to
 // determing retry logic, then call the AWS SDK's built-in waiters.
 
-func WaitUntilAMIAvailable(ctx aws.Context, conn *ec2.EC2, imageId string) error {
+func WaitUntilAMIAvailable(ctx aws.Context, conn ec2iface.EC2API, imageId string) error {
 	imageInput := ec2.DescribeImagesInput{
 		ImageIds: []*string{&imageId},
 	}

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -51,9 +51,11 @@ func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) m
 
 	wg.Add(len(s.Regions))
 	for _, region := range s.Regions {
-		if region == *ec2conn.Config.Region && s.EncryptBootVolume == nil {
+		if region == *ec2conn.Config.Region &&
+			(s.EncryptBootVolume == nil || *s.EncryptBootVolume == false) {
 			ui.Message(fmt.Sprintf(
 				"Avoiding copying AMI to duplicate region %s", region))
+			wg.Done()
 			continue
 		}
 

--- a/builder/amazon/common/step_ami_region_copy_test.go
+++ b/builder/amazon/common/step_ami_region_copy_test.go
@@ -1,0 +1,164 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+func boolPointer(tf bool) *bool {
+	return &tf
+}
+
+// Define a mock struct to be used in unit tests for common aws steps.
+type mockEC2Conn struct {
+	ec2iface.EC2API
+	Config *aws.Config
+
+	// Counters to figure out what code path was taken
+	copyImageCount       int
+	describeImagesCount  int
+	deregisterImageCount int
+	deleteSnapshotCount  int
+	waitCount            int
+}
+
+func (m *mockEC2Conn) CopyImage(copyInput *ec2.CopyImageInput) (*ec2.CopyImageOutput, error) {
+	m.copyImageCount++
+	copiedImage := fmt.Sprintf("%s-copied-%d", *copyInput.SourceImageId, m.copyImageCount)
+	output := &ec2.CopyImageOutput{
+		ImageId: &copiedImage,
+	}
+	return output, nil
+}
+
+// functions we have to create mock responses for in order for test to run
+func (m *mockEC2Conn) DescribeImages(*ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+	m.describeImagesCount++
+	output := &ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{{}},
+	}
+	return output, nil
+}
+
+func (m *mockEC2Conn) DeregisterImage(*ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error) {
+	m.deregisterImageCount++
+	output := &ec2.DeregisterImageOutput{}
+	return output, nil
+}
+
+func (m *mockEC2Conn) DeleteSnapshot(*ec2.DeleteSnapshotInput) (*ec2.DeleteSnapshotOutput, error) {
+	m.deleteSnapshotCount++
+	output := &ec2.DeleteSnapshotOutput{}
+	return output, nil
+}
+
+func (m *mockEC2Conn) WaitUntilImageAvailableWithContext(aws.Context, *ec2.DescribeImagesInput, ...request.WaiterOption) error {
+	m.waitCount++
+	return nil
+}
+
+func getMockConn(config *AccessConfig, target string) (ec2iface.EC2API, error) {
+	mockConn := &mockEC2Conn{
+		Config: aws.NewConfig(),
+	}
+
+	return mockConn, nil
+}
+
+// Create statebag for running test
+func tState() multistep.StateBag {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	state.Put("amis", map[string]string{"us-east-1": "ami-12345"})
+	state.Put("snapshots", map[string][]string{"us-east-1": {"snap-0012345"}})
+	conn, _ := getMockConn(&AccessConfig{}, "us-east-2")
+	state.Put("ec2", conn)
+	return state
+}
+
+func TestStepAmiRegionCopy_nil_encryption(t *testing.T) {
+	// create step
+	stepAMIRegionCopy := StepAMIRegionCopy{
+		AccessConfig:      testAccessConfig(),
+		Regions:           make([]string, 0),
+		AMIKmsKeyId:       "",
+		RegionKeyIds:      make(map[string]string),
+		EncryptBootVolume: nil,
+		Name:              "fake-ami-name",
+		OriginalRegion:    "us-east-1",
+	}
+	// mock out the region connection code
+	stepAMIRegionCopy.getRegionConn = getMockConn
+
+	state := tState()
+	stepAMIRegionCopy.Run(context.Background(), state)
+
+	if stepAMIRegionCopy.toDelete != "" {
+		t.Fatalf("Shouldn't delete original AMI if not encrypted")
+	}
+	if len(stepAMIRegionCopy.Regions) > 0 {
+		t.Fatalf("Shouldn't have added original ami to original region")
+	}
+}
+
+func TestStepAmiRegionCopy_false_encryption(t *testing.T) {
+	// create step
+	stepAMIRegionCopy := StepAMIRegionCopy{
+		AccessConfig:      testAccessConfig(),
+		Regions:           make([]string, 0),
+		AMIKmsKeyId:       "",
+		RegionKeyIds:      make(map[string]string),
+		EncryptBootVolume: boolPointer(false),
+		Name:              "fake-ami-name",
+		OriginalRegion:    "us-east-1",
+	}
+	// mock out the region connection code
+	stepAMIRegionCopy.getRegionConn = getMockConn
+
+	state := tState()
+	stepAMIRegionCopy.Run(context.Background(), state)
+
+	if stepAMIRegionCopy.toDelete != "" {
+		t.Fatalf("Shouldn't delete original AMI if not encrypted")
+	}
+	if len(stepAMIRegionCopy.Regions) > 0 {
+		t.Fatalf("Shouldn't have added original ami to Regions")
+	}
+}
+
+func TestStepAmiRegionCopy_true_encryption(t *testing.T) {
+	// create step
+	stepAMIRegionCopy := StepAMIRegionCopy{
+		AccessConfig:      testAccessConfig(),
+		Regions:           make([]string, 0),
+		AMIKmsKeyId:       "",
+		RegionKeyIds:      make(map[string]string),
+		EncryptBootVolume: boolPointer(true),
+		Name:              "fake-ami-name",
+		OriginalRegion:    "us-east-1",
+	}
+	// mock out the region connection code
+	stepAMIRegionCopy.getRegionConn = getMockConn
+
+	state := tState()
+	stepAMIRegionCopy.Run(context.Background(), state)
+
+	if stepAMIRegionCopy.toDelete == "" {
+		t.Fatalf("Should delete original AMI if encrypted=true")
+	}
+	if len(stepAMIRegionCopy.Regions) == 0 {
+		t.Fatalf("Should have added original ami to Regions")
+	}
+}

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -227,6 +227,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,
+			OriginalRegion:    *ec2conn.Config.Region,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -95,12 +95,10 @@ func (s *stepCreateAMI) Cleanup(state multistep.StateBag) {
 	if s.image == nil {
 		return
 	}
-	config := state.Get("config").(*Config)
 
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)
-	encryptBootSet := config.AMIEncryptBootVolume != nil
-	if !cancelled && !halted && !encryptBootSet {
+	if !cancelled && !halted {
 		return
 	}
 
@@ -108,7 +106,7 @@ func (s *stepCreateAMI) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Deregistering the AMI and deleting associated snapshots because " +
-		"of cancellation, error or it was temporary (encrypt_boot was set)...")
+		"of cancellation, or error...")
 
 	resp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
 		ImageIds: []*string{s.image.ImageId},

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -252,6 +252,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,
+			OriginalRegion:    *ec2conn.Config.Region,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -303,6 +303,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
 			EncryptBootVolume: b.config.AMIEncryptBootVolume,
 			Name:              b.config.AMIName,
+			OriginalRegion:    *ec2conn.Config.Region,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,


### PR DESCRIPTION
- Fix logic error that still copied AMI within a single region when EncryptBoot was false.
- Fix wait group hang caused by skipping a region
- Delete unencrypted temporary ami and snapshots as part of copy step.

Closes #7595 