### PR TITLE
scripts/build.sh: don't discard stderr when copying packer

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -145,7 +145,7 @@ IFS="${OLDIFS}"
 # Copy our OS/Arch to the bin/ directory
 echo "==> Copying binaries for this platform..."
 DEV_PLATFORM="./pkg/${XC_OS}_${XC_ARCH}"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f 2>/dev/null); do
+for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
     cp -v ${F} bin/
     cp -v ${F} "${MAIN_GOPATH}/bin/"
 done


### PR DESCRIPTION
to fix #7604
