### PR TITLE
add omit_from_artifact option for ebssurragote launch_block_devices

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -21,6 +21,8 @@ type BlockDevice struct {
 	VolumeType          string `mapstructure:"volume_type"`
 	VolumeSize          int64  `mapstructure:"volume_size"`
 	KmsKeyId            string `mapstructure:"kms_key_id"`
+	// ebssurrogate only
+	OmitFromArtifact bool `mapstructure:"omit_from_artifact"`
 }
 
 type BlockDevices struct {
@@ -96,6 +98,7 @@ func (b *BlockDevice) Prepare(ctx *interpolate.Context) error {
 		return fmt.Errorf("The device %v, must also have `encrypted: "+
 			"true` when setting a kms_key_id.", b.DeviceName)
 	}
+
 	return nil
 }
 
@@ -119,4 +122,14 @@ func (b *AMIBlockDevices) BuildAMIDevices() []*ec2.BlockDeviceMapping {
 
 func (b *LaunchBlockDevices) BuildLaunchDevices() []*ec2.BlockDeviceMapping {
 	return buildBlockDevices(b.LaunchMappings)
+}
+
+func (b *LaunchBlockDevices) GetOmissions() map[string]bool {
+	omitMap := make(map[string]bool)
+
+	for _, blockDevice := range b.LaunchMappings {
+		omitMap[blockDevice.DeviceName] = blockDevice.OmitFromArtifact
+	}
+
+	return omitMap
 }

--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -20,6 +20,7 @@ type StepRegisterAMI struct {
 	EnableAMISriovNetSupport bool
 	Architecture             string
 	image                    *ec2.Image
+	LaunchOmitMap            map[string]bool
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -126,6 +127,11 @@ func (s *StepRegisterAMI) combineDevices(snapshotIds map[string]string) []*ec2.B
 	// the same name in ami_block_device_mappings, except for the
 	// one designated as the root device in ami_root_device
 	for _, device := range s.LaunchDevices {
+		// Skip devices we've flagged for omission
+		omit, ok := s.LaunchOmitMap[*device.DeviceName]
+		if ok && omit {
+			continue
+		}
 		snapshotId, ok := snapshotIds[*device.DeviceName]
 		if ok {
 			device.Ebs.SnapshotId = aws.String(snapshotId)

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
@@ -254,7 +254,7 @@ builder.
 
     In addition to the fields available in ami_block_device_mappings, you may
     optionally use the following field:
-        - "omit_from_artifact" (boolean) - If true, this block device will not
+    -   `omit_from_artifact` (boolean) - If true, this block device will not
         be snapshotted and the created AMI will not contain block device mapping
         information for this volume. If false, the block device will be mapped
         into the final created AMI. Set this option to true if you need a block

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
@@ -252,6 +252,14 @@ builder.
     new AMI, the instance automatically launches with these additional volumes,
     and will restore them from snapshots taken from the source instance.
 
+    In addition to the fields available in ami_block_device_mappings, you may
+    optionally use the following field:
+        - "omit_from_artifact" (boolean) - If true, this block device will not
+        be snapshotted and the created AMI will not contain block device mapping
+        information for this volume. If false, the block device will be mapped
+        into the final created AMI. Set this option to true if you need a block
+        device mounted in the surrogate AMI but not in the final created AMI.
+
 -   `mfa_code` (string) - The MFA
     [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
     code. This should probably be a user variable since it changes all the


### PR DESCRIPTION
Add "omit_from_artifact" option to allow amazon ebs surrogate users to have control over which launch block devices make it into the created AMI.

Closes #6897 