### PR TITLE
common/net: Cleanup cache of used port after closing

### DIFF
--- a/common/net/configure_port_test.go
+++ b/common/net/configure_port_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestListenRangeConfig_Listen(t *testing.T) {
-
 	topCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
I noticed after cloning a fresh copy of this repository and running tests via `make test` there was an untracked directory `common/net/packer_cache/` with cached port numbers.

I originally thought I would just introduce a new entry to `.gitignore`, but then I thought why not clean up the cache for users too? I'm not that familiar with Packer internals though - so I'm willing to listen why this may be a bad idea and I'm totally willing to go back to the original idea of just adding `.gitignore` entry and I'm also open to any alternative solutions. 😉 
