### PR TITLE
fix copypasta mistake switching ssh port mix/max for vnc port min/max

### DIFF
--- a/builder/qemu/step_forward_ssh.go
+++ b/builder/qemu/step_forward_ssh.go
@@ -28,8 +28,8 @@ func (s *stepForwardSSH) Run(ctx context.Context, state multistep.StateBag) mult
 	var err error
 	s.l, err = net.ListenRangeConfig{
 		Addr:    config.VNCBindAddress,
-		Min:     config.VNCPortMin,
-		Max:     config.VNCPortMax,
+		Min:     config.SSHHostPortMin,
+		Max:     config.SSHHostPortMax,
 		Network: "tcp",
 	}.Listen(ctx)
 	if err != nil {


### PR DESCRIPTION
We'd accidentally subbed vnc ports for ssh ports in the qemu ssh dialing code.
Closes #7607 