### PR TITLE
allow building packer on solaris by removing progress bar and tty imports on solaris

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,4 +57,4 @@ workflows:
       - build_windows
       - build_freebsd
       - build_openbsd
-      
+      - build_solaris

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/packer/packer/plugin"
 	"github.com/hashicorp/packer/packer/tmp"
 	"github.com/hashicorp/packer/version"
-	"github.com/mattn/go-tty"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/panicwrap"
 	"github.com/mitchellh/prefixedio"
@@ -193,7 +192,7 @@ func wrappedMain() int {
 		}
 		ui = basicUi
 		if !inPlugin {
-			if TTY, err := tty.Open(); err != nil {
+			if TTY, err := openTTY(); err != nil {
 				fmt.Fprintf(os.Stderr, "No tty available: %s\n", err)
 			} else {
 				basicUi.TTY = TTY

--- a/packer/progressbar.go
+++ b/packer/progressbar.go
@@ -1,3 +1,5 @@
+// +build !solaris
+
 package packer
 
 import (
@@ -78,12 +80,3 @@ type readCloser struct {
 }
 
 func (c *readCloser) Close() error { return c.close() }
-
-// NoopProgressTracker is a progress tracker
-// that displays nothing.
-type NoopProgressTracker struct{}
-
-// TrackProgress returns stream
-func (*NoopProgressTracker) TrackProgress(_ string, _, _ int64, stream io.ReadCloser) io.ReadCloser {
-	return stream
-}

--- a/packer/progressbar_noop.go
+++ b/packer/progressbar_noop.go
@@ -1,0 +1,12 @@
+package packer
+
+import "io"
+
+// NoopProgressTracker is a progress tracker
+// that displays nothing.
+type NoopProgressTracker struct{}
+
+// TrackProgress returns stream
+func (*NoopProgressTracker) TrackProgress(_ string, _, _ int64, stream io.ReadCloser) io.ReadCloser {
+	return stream
+}

--- a/packer/progressbar_solaris.go
+++ b/packer/progressbar_solaris.go
@@ -1,0 +1,3 @@
+package packer
+
+type uiProgressBar = NoopProgressTracker

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@
 # This script builds the application from source for multiple platforms.
 # Determine the arch/os combos we're building for
 ALL_XC_ARCH="386 amd64 arm arm64 ppc64le mips mips64 mipsle mipsle64 s390x"
-ALL_XC_OS="linux darwin windows freebsd openbsd"
+ALL_XC_OS="linux darwin windows freebsd openbsd solaris"
 
 # Exit immediately if a command fails
 set -e

--- a/tty.go
+++ b/tty.go
@@ -1,0 +1,9 @@
+// +build !solaris
+
+package main
+
+import (
+	"github.com/mattn/go-tty"
+)
+
+var openTTY = tty.Open

--- a/tty_solaris.go
+++ b/tty_solaris.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/packer"
+)
+
+func openTTY() (packer.TTY, error) {
+	return nil, fmt.Errorf("no TTY available on solaris")
+}


### PR DESCRIPTION
This removes the progress bar and tty features for solaris only & until we find a suitable solution.

This will at least ensure a basic version of packer compiles for Solaris.

fix #7586
