### PR TITLE
add build for generating binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,21 @@ jobs:
     <<: *golang
     environment:
       GOOS: openbsd
+  generate_binaries:
+    <<: *golang
+    steps:
+      - checkout
+      - run:
+          name: Create windows, linux, and mac zipped binaries.
+          command: |
+            XC_ARCH=amd64 XC_OS="linux windows darwin" GOLDFLAGS="-s -w" ./scripts/build.sh;
+            mkdir ./pkg/zipped_packers
+            zip ./pkg/zipped_packers/packer_darwin.zip pkg/darwin_amd64/packer;
+            zip ./pkg/zipped_packers/packer_windows.zip pkg/windows_amd64/packer
+            zip ./pkg/zipped_packers/packer_linux.zip pkg/linux_amd64/packer
+      - store_artifacts:
+        path: ./pkg/zipped_packers
+
 workflows:
   version: 2
   build_and_check_vendor_vs_module:


### PR DESCRIPTION
this is a WIP for creating binaries that we save in circle ci's storage so that we can link them more easily on github issues.