### PR TITLE
remove name argument for github_repository_webhook

### DIFF
--- a/website/deploy/main.tf
+++ b/website/deploy/main.tf
@@ -13,6 +13,8 @@ GitHub Resources
 
 provider "github" {
   organization = "${local.github_org}"
+
+  version = "~> 2.0.0"
 }
 
 // Configure the repository with the dynamically created Netlify key.
@@ -42,6 +44,10 @@ resource "github_repository_webhook" "main" {
 Netlify Resources
 -------------------------------------------------------------------
 */
+
+provider "netlify" {
+  version = "~> 0.1.0"
+}
 
 // A new, unique deploy key for this specific website
 resource "netlify_deploy_key" "key" {}

--- a/website/deploy/main.tf
+++ b/website/deploy/main.tf
@@ -31,6 +31,7 @@ resource "github_repository_webhook" "main" {
   configuration {
     content_type = "json"
     url          = "https://api.netlify.com/hooks/github"
+    insecure_ssl = false
   }
 
   depends_on = ["netlify_site.main"]
@@ -46,7 +47,8 @@ Netlify Resources
 resource "netlify_deploy_key" "key" {}
 
 resource "netlify_site" "main" {
-  name = "${var.name}"
+  name          = "${var.name}"
+  custom_domain = "${var.custom_site_domain}"
 
   repo {
     repo_branch   = "${var.github_branch}"

--- a/website/deploy/main.tf
+++ b/website/deploy/main.tf
@@ -26,7 +26,6 @@ resource "github_repository_deploy_key" "key" {
 // Create a webhook that triggers Netlify builds on push.
 resource "github_repository_webhook" "main" {
   repository = "${local.github_repo}"
-  name       = "web"
   events     = ["delete", "push", "pull_request"]
 
   configuration {

--- a/website/deploy/variables.tf
+++ b/website/deploy/variables.tf
@@ -12,3 +12,8 @@ variable "github_branch" {
   default = "stable-website"
   description = "GitHub branch which netlify will continuously deploy."
 }
+
+variable "custom_site_domain" {
+  default = "packer.io"
+  description = "The custom domain to use for the Netlify site."
+}


### PR DESCRIPTION
This PR should fix the Netlify website creation failures we are seeing. 

The `name` argument error we were seeing was due to the GitHub provider not being pinned and as a result, used the `2.0.0` provider version which removed the argument altogether (https://github.com/terraform-providers/terraform-provider-github/blob/master/CHANGELOG.md#200-may-02-2019). This has now been removed from the configuration and there is version pinning to prevent this from happening next time 😄.