### PR TITLE
Work around bug in libvirt-vagrant plugin

### DIFF
--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -71,7 +71,7 @@ func (d *Vagrant_2_2_Driver) Destroy(id string) error {
 // Calls "vagrant package"
 func (d *Vagrant_2_2_Driver) Package(args []string) error {
 	// Ideally we'd pass vagrantCWD into the package command but
-	// we have to change directorie into the vagrant cwd instead in order to
+	// we have to change directory into the vagrant cwd instead in order to
 	// work around an upstream bug with the vagrant-libvirt plugin.
 	// We can stop doing this when
 	// https://github.com/vagrant-libvirt/vagrant-libvirt/issues/765

--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -71,7 +70,16 @@ func (d *Vagrant_2_2_Driver) Destroy(id string) error {
 
 // Calls "vagrant package"
 func (d *Vagrant_2_2_Driver) Package(args []string) error {
-	args = append(args, "--output", filepath.Join(d.VagrantCWD, "package.box"))
+	// Ideally we'd pass vagrantCWD into the package command but
+	// we have to change directorie into the vagrant cwd instead in order to
+	// work around an upstream bug with the vagrant-libvirt plugin.
+	// We can stop doing this when
+	// https://github.com/vagrant-libvirt/vagrant-libvirt/issues/765
+	// is fixed.
+	oldDir, _ := os.Getwd()
+	os.Chdir(d.VagrantCWD)
+	defer os.Chdir(oldDir)
+	args = append(args, "--output", "package.box")
 	_, _, err := d.vagrantCmd(append([]string{"package"}, args...)...)
 	return err
 }


### PR DESCRIPTION
Work around bug in libvirt-vagrant plugin by changing directories instead of supplying absolute path to output box.  This issue is really caused by an upstream bug but it's a popular enough plugin that it's working around, and this hack with changing directories means we don't need to reduce functionality for folks using that plugin.

Should always work the same as it did before; I tested with both the libvirt plugin and virtualbox and it works for both. 

Closes #7443
