### PR TITLE
update volume_type docs 

### DIFF
--- a/website/source/docs/builders/amazon-chroot.html.md.erb
+++ b/website/source/docs/builders/amazon-chroot.html.md.erb
@@ -177,47 +177,14 @@ each category, the available configuration keys are alphabetized.
     and `root_device_name`. `Your options here may vary depending on the type of VM
     you use. The block device mappings allow for the following configuration:
 
-    -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
-        deleted on instance termination. Default `false`. **NOTE**: If this
-        value is not explicitly set to `true` and volumes are not cleaned up by
-        an alternative method, additional volumes will accumulate after every
-        build.
-
-    -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required for every device in the block
-        device mapping.
-
-    -   `encrypted` (boolean) - Indicates whether or not to encrypt the volume.
-        By default, Packer will keep the encryption setting to what it was in
-        the source image. Setting `false` will result in an unencrypted device,
-        and `true` will result in an encrypted one.
+    <%= partial "partials/builders/aws-common-block-device-a-i" %>
 
     -   `kms_key_id` (string) - The ARN for the KMS encryption key. When
         specifying `kms_key_id`, `encrypted` needs to be set to `true`. For
         valid formats see *KmsKeyId* in the [AWS API docs -
         CopyImage](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html).
 
-    -   `iops` (number) - The number of I/O operations per second (IOPS) that
-        the volume supports. See the documentation on
-        [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
-        for more information.
-
-    -   `no_device` (boolean) - Suppresses the specified device included in the
-        block device mapping of the AMI.
-
-    -   `snapshot_id` (string) - The ID of the snapshot.
-
-    -   `virtual_name` (string) - The virtual device name. See the
-        documentation on [Block Device
-        Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
-        for more information.
-
-    -   `volume_size` (number) - The size of the volume, in GiB. Required if
-        not specifying a `snapshot_id`.
-
-    -   `volume_type` (string) - The volume type. `gp2` for General Purpose
-        (SSD) volumes, `io1` for Provisioned IOPS (SSD) volumes, and `standard`
-        for Magnetic volumes
+    <%= partial "partials/builders/aws-common-block-device-i-v" %>
 
 -   `region_kms_key_ids` (map of strings) - a map of regions to copy the ami
     to, along with the custom kms key id (alias or arn) to use for encryption

--- a/website/source/docs/builders/amazon-ebs.html.md.erb
+++ b/website/source/docs/builders/amazon-ebs.html.md.erb
@@ -81,42 +81,9 @@ builder.
     on the type of VM you use. The block device mappings allow for the
     following configuration:
 
-    -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
-        deleted on instance termination. Default `false`. **NOTE**: If this
-        value is not explicitly set to `true` and volumes are not cleaned up by
-        an alternative method, additional volumes will accumulate after every
-        build.
+    <%= partial "partials/builders/aws-common-block-device-a-i" %>
 
-    -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required for every device in the block
-        device mapping.
-
-    -   `encrypted` (boolean) - Indicates whether or not to encrypt the volume.
-        By default, Packer will keep the encryption setting to what it was in
-        the source image. Setting `false` will result in an unencrypted device,
-        and `true` will result in an encrypted one.
-
-    -   `iops` (number) - The number of I/O operations per second (IOPS) that
-        the volume supports. See the documentation on
-        [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
-        for more information
-
-    -   `no_device` (boolean) - Suppresses the specified device included in the
-        block device mapping of the AMI
-
-    -   `snapshot_id` (string) - The ID of the snapshot
-
-    -   `virtual_name` (string) - The virtual device name. See the
-        documentation on [Block Device
-        Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
-        for more information
-
-    -   `volume_size` (number) - The size of the volume, in GiB. Required if
-        not specifying a `snapshot_id`
-
-    -   `volume_type` (string) - The volume type. `gp2` for General Purpose
-        (SSD) volumes, `io1` for Provisioned IOPS (SSD) volumes, and `standard`
-        for Magnetic volumes
+    <%= partial "partials/builders/aws-common-block-device-i-v" %>
 
 -   `ami_description` (string) - The description to set for the resulting
     AMI(s). By default this description is empty. This is a [template

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
@@ -73,42 +73,9 @@ builder.
     on the type of VM you use. The block device mappings allow for the
     following configuration:
 
-    -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
-        deleted on instance termination. Default `false`. **NOTE**: If this
-        value is not explicitly set to `true` and volumes are not cleaned up by
-        an alternative method, additional volumes will accumulate after every
-        build.
+    <%= partial "partials/builders/aws-common-block-device-a-i" %>
 
-    -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required for every device in the block
-        device mapping.
-
-    -   `encrypted` (boolean) - Indicates whether or not to encrypt the volume.
-        By default, Packer will keep the encryption setting to what it was in
-        the source image. Setting `false` will result in an unencrypted device,
-        and `true` will result in an encrypted one.
-
-    -   `iops` (number) - The number of I/O operations per second (IOPS) that
-        the volume supports. See the documentation on
-        [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
-        for more information.
-
-    -   `no_device` (boolean) - Suppresses the specified device included in the
-        block device mapping of the AMI.
-
-    -   `snapshot_id` (string) - The ID of the snapshot.
-
-    -   `virtual_name` (string) - The virtual device name. See the
-        documentation on [Block Device
-        Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
-        for more information.
-
-    -   `volume_size` (number) - The size of the volume, in GiB. Required if
-        not specifying a `snapshot_id`.
-
-    -   `volume_type` (string) - The volume type. (`gp2` for General Purpose
-        (SSD) volumes, `io1` for Provisioned IOPS (SSD) volumes, and `standard`
-        for Magnetic volumes)
+    <%= partial "partials/builders/aws-common-block-device-i-v" %>
 
 -   `ami_description` (string) - The description to set for the resulting
     AMI(s). By default this description is empty. This is a [template

--- a/website/source/docs/builders/amazon-instance.html.md.erb
+++ b/website/source/docs/builders/amazon-instance.html.md.erb
@@ -100,42 +100,9 @@ builder.
     on the type of VM you use. The block device mappings allow for the
     following configuration:
 
-    -   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
-        deleted on instance termination. Default `false`. **NOTE**: If this
-        value is not explicitly set to `true` and volumes are not cleaned up by
-        an alternative method, additional volumes will accumulate after every
-        build.
+    <%= partial "partials/builders/aws-common-block-device-a-i" %>
 
-    -   `device_name` (string) - The device name exposed to the instance (for
-        example, `/dev/sdh` or `xvdh`). Required for every device in the block
-        device mapping.
-
-    -   `encrypted` (boolean) - Indicates whether or not to encrypt the volume.
-        By default, Packer will keep the encryption setting to what it was in
-        the source image. Setting `false` will result in an unencrypted device,
-        and `true` will result in an encrypted one.
-
-    -   `iops` (number) - The number of I/O operations per second (IOPS) that
-        the volume supports. See the documentation on
-        [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
-        for more information
-
-    -   `no_device` (boolean) - Suppresses the specified device included in the
-        block device mapping of the AMI
-
-    -   `snapshot_id` (string) - The ID of the snapshot
-
-    -   `virtual_name` (string) - The virtual device name. See the
-        documentation on [Block Device
-        Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
-        for more information
-
-    -   `volume_size` (number) - The size of the volume, in GiB. Required if
-        not specifying a `snapshot_id`
-
-    -   `volume_type` (string) - The volume type. `gp2` for General Purpose
-        (SSD) volumes, `io1` for Provisioned IOPS (SSD) volumes, and `standard`
-        for Magnetic volumes
+    <%= partial "partials/builders/aws-common-block-device-i-v" %>
 
 -   `ami_description` (string) - The description to set for the resulting
     AMI(s). By default this description is empty. This is a [template

--- a/website/source/partials/builders/_aws-common-block-device-a-i.html.md
+++ b/website/source/partials/builders/_aws-common-block-device-a-i.html.md
@@ -1,0 +1,19 @@
+-   `delete_on_termination` (boolean) - Indicates whether the EBS volume is
+    deleted on instance termination. Default `false`. **NOTE**: If this
+    value is not explicitly set to `true` and volumes are not cleaned up by
+    an alternative method, additional volumes will accumulate after every
+    build.
+
+-   `device_name` (string) - The device name exposed to the instance (for
+    example, `/dev/sdh` or `xvdh`). Required for every device in the block
+    device mapping.
+
+-   `encrypted` (boolean) - Indicates whether or not to encrypt the volume.
+    By default, Packer will keep the encryption setting to what it was in
+    the source image. Setting `false` will result in an unencrypted device,
+    and `true` will result in an encrypted one.
+
+-   `iops` (number) - The number of I/O operations per second (IOPS) that
+    the volume supports. See the documentation on
+    [IOPs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
+    for more information

--- a/website/source/partials/builders/_aws-common-block-device-i-v.html.md
+++ b/website/source/partials/builders/_aws-common-block-device-i-v.html.md
@@ -1,0 +1,17 @@
+-   `no_device` (boolean) - Suppresses the specified device included in the
+    block device mapping of the AMI.
+
+-   `snapshot_id` (string) - The ID of the snapshot.
+
+-   `virtual_name` (string) - The virtual device name. See the
+    documentation on [Block Device
+    Mapping](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
+    for more information.
+
+-   `volume_size` (number) - The size of the volume, in GiB. Required if
+    not specifying a `snapshot_id`.
+
+-   `volume_type` (string) - The volume type. `gp2` for General Purpose
+    (SSD) volumes, `io1` for Provisioned IOPS (SSD) volumes, `st1` for
+    Throughput Optimized HDD, `sc1` for Cold HDD, and `standard` for
+    Magnetic volumes.


### PR DESCRIPTION
Add full list of available volume types to the docs. 

Move ami_block_device_mappings into partials so that we don't have to keep it updated in four places. Two partials so that we can properly alphabetize the kms_key_id property only available in chroot

Closes #7650