### PR TITLE
 Check error returned from retry.Config.Run() in powershell provisioner

### DIFF
--- a/packer/communicator_mock.go
+++ b/packer/communicator_mock.go
@@ -3,6 +3,7 @@ package packer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -111,4 +112,20 @@ func (c *MockCommunicator) DownloadDir(src string, dst string, excl []string) er
 	c.DownloadDirExclude = excl
 
 	return nil
+}
+
+// ScriptUploadErrorMockCommunicator returns an error from it's Upload() method
+// when a script is uploaded to test the case where this upload fails.
+type ScriptUploadErrorMockCommunicator struct {
+	MockCommunicator
+}
+
+var ScriptUploadErrorMockCommunicatorError = errors.New("ScriptUploadErrorMockCommunicator Upload error")
+
+func (c *ScriptUploadErrorMockCommunicator) Upload(path string, r io.Reader, fi *os.FileInfo) error {
+	// only fail on script uploads, not on environment variable uploads
+	if !strings.Contains(path, "packer-ps-env-vars") {
+		return ScriptUploadErrorMockCommunicatorError
+	}
+	return c.MockCommunicator.Upload(path, r, fi)
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -254,7 +254,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		// that the upload succeeded, a restart is initiated, and then the
 		// command is executed but the file doesn't exist any longer.
 		var cmd *packer.RemoteCmd
-		retry.Config{StartTimeout: p.config.StartRetryTimeout}.Run(ctx, func(ctx context.Context) error {
+		err = retry.Config{StartTimeout: p.config.StartRetryTimeout}.Run(ctx, func(ctx context.Context) error {
 			if _, err := f.Seek(0, 0); err != nil {
 				return err
 			}

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/packer/packer"
 )
@@ -500,6 +501,22 @@ func TestProvisionerProvision_UISlurp(t *testing.T) {
 	// UI should be called n times
 
 	// UI should receive following messages / output
+}
+
+func TestProvisionerProvision_UploadFails(t *testing.T) {
+	config := testConfig()
+	ui := testUi()
+
+	p := new(Provisioner)
+	comm := new(packer.ScriptUploadErrorMockCommunicator)
+	p.Prepare(config)
+	p.config.StartRetryTimeout = time.Second
+	err := p.Provision(context.Background(), ui, comm)
+	if !strings.Contains(err.Error(), packer.ScriptUploadErrorMockCommunicatorError.Error()) {
+		t.Fatalf("expected Provision() error %q to contain %q",
+			err.Error(),
+			packer.ScriptUploadErrorMockCommunicatorError.Error())
+	}
 }
 
 func TestProvisioner_createFlattenedElevatedEnvVars_windows(t *testing.T) {


### PR DESCRIPTION
Fixes #7655 

The error returned from the retried `Run()` method was not captured and the error check right after would always succeed.
This could result in the code continuing with `cmd` remaining nil, which would result in a nil dereference later in the code.