### PR TITLE
Fix typo and update ubuntu image version

### DIFF
--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -893,9 +893,9 @@ virtual switch with an `External` connection type.
     "cpus": "2",
     "memory": "1024",
     "disk_size": "21440",
-    "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.1-server-amd64.iso",
+    "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.6-server-amd64.iso",
     "iso_checksum_type": "sha1",
-    "iso_checksum": "DE5EE8665048F009577763EFBF4A6F0558833E59"
+    "iso_checksum": "056b7c15efc15bbbf40bf1a9ff1a3531fcbf70a2"
   },
   "builders": [
     {
@@ -927,7 +927,7 @@ virtual switch with an `External` connection type.
       ],
       "shutdown_command": "echo 'packer' | sudo -S -E shutdown -P now",
       "memory": "{{user `memory`}}",
-      "cpus": "{{user `cpu`}}",
+      "cpus": "{{user `cpus`}}",
       "generation": 2,
       "enable_secure_boot": false
     }


### PR DESCRIPTION
The old url is no longer available, user `cpu should be `cpus

**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer PR:

https://github.com/hashicorp/packer/blob/master/.github/CONTRIBUTING.md#opening-an-pull-request

Describe the change you are making here!

Please include tests. Check out these examples:

- https://github.com/hashicorp/packer/blob/master/builder/virtualbox/common/ssh_config_test.go#L19-L37
- https://github.com/hashicorp/packer/blob/master/post-processor/compress/post-processor_test.go#L153-L182

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx
