### PR TITLE
fix null file descriptor error

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -130,7 +130,11 @@ func (c *Communicator) Upload(path string, input io.Reader, fi *os.FileInfo) err
 	}
 	if strings.HasSuffix(path, `\`) {
 		// path is a directory
-		path += filepath.Base((*fi).Name())
+		if fi != nil {
+			path += filepath.Base((*fi).Name())
+		} else {
+			return fmt.Errorf("Was unable to infer file basename for upload.")
+		}
 	}
 	log.Printf("Uploading file to '%s'", path)
 	return wcp.Write(path, input)

--- a/communicator/winrm/communicator_test.go
+++ b/communicator/winrm/communicator_test.go
@@ -120,5 +120,25 @@ func TestUpload(t *testing.T) {
 	if downloadedPayload != PAYLOAD {
 		t.Fatalf("files are not equal: expected [%s] length: %v, got [%s] length %v", PAYLOAD, len(PAYLOAD), downloadedPayload, len(downloadedPayload))
 	}
+}
 
+func TestUpload_nilFileInfo(t *testing.T) {
+	wrm := newMockWinRMServer(t)
+	defer wrm.Close()
+
+	c, err := New(&Config{
+		Host:     wrm.Host,
+		Port:     wrm.Port,
+		Username: "user",
+		Password: "pass",
+		Timeout:  30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("error creating communicator: %s", err)
+	}
+	file := "C:\\Temp\\"
+	err = c.Upload(file, strings.NewReader(PAYLOAD), nil)
+	if err == nil {
+		t.Fatalf("Should have errored because of nil fileinfo")
+	}
 }


### PR DESCRIPTION
Make sure the powershell provisioner is giving a basename if the remote_path provided is a directory and not a file.

Closes #7687