### PR TITLE
Update Azure docs with Shared Image Gallery (for MDI only) as destination example

### DIFF
--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -122,6 +122,29 @@ When creating a managed image the following options are required.
     `managed_image_name` must also be set. See
     [documentation](https://docs.microsoft.com/en-us/azure/storage/storage-managed-disks-overview#images)
     to learn more about managed images.
+    
+    
+Managed images can optionally be published to [Shared Image Gallery](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
+as Shared Gallery Image version. Shared Image Gallery **only** works with Managed Images. **A VHD cannot be published to
+a Shared Image Gallery**. When publishing to a Shared Image Gallery the following options are required.
+    
+- `shared_image_gallery_destination` (object) The name of the Shared Image Gallery under which the managed image will 
+    be published as Shared Gallery Image version.
+    
+    Following is an example.
+     
+<!-- -->
+
+    "shared_image_gallery_destination": {
+        "subscription": "00000000-0000-0000-0000-00000000000",
+        "resource_group": "ResourceGroup",
+        "gallery_name": "GalleryName",
+        "image_name": "ImageName",
+        "image_version": "1.0.0",
+        "replication_regions": ["regionA", "regionB", "regionC"]
+    }
+    "managed_image_name": "TargetImageName",
+    "managed_image_resource_group_name": "TargetResourceGroup"
 
 #### Resource Group Usage
 

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -128,8 +128,7 @@ Managed images can optionally be published to [Shared Image Gallery](https://azu
 as Shared Gallery Image version. Shared Image Gallery **only** works with Managed Images. **A VHD cannot be published to
 a Shared Image Gallery**. When publishing to a Shared Image Gallery the following options are required.
     
-- `shared_image_gallery_destination` (object) The name of the Shared Image Gallery under which the managed image will 
-    be published as Shared Gallery Image version.
+- `shared_image_gallery_destination` (object) The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
     
     Following is an example.
      

--- a/website/source/docs/builders/azure.html.md
+++ b/website/source/docs/builders/azure.html.md
@@ -130,7 +130,7 @@ a Shared Image Gallery**. When publishing to a Shared Image Gallery the followin
     
 - `shared_image_gallery_destination` (object) The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
     
-    Following is an example.
+Following is an example.
      
 <!-- -->
 


### PR DESCRIPTION
Updated azure docs with example stating the required inputs for pushing MDI to Shared Image Gallery.