### PR TITLE
test for length of ami tags before tagging

### DIFF
--- a/builder/amazon/common/step_create_tags.go
+++ b/builder/amazon/common/step_create_tags.go
@@ -105,12 +105,16 @@ func (s *StepCreateTags) Run(ctx context.Context, state multistep.StateBag) mult
 			RetryDelay: (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30, Multiplier: 2}).Linear,
 		}.Run(ctx, func(ctx context.Context) error {
 			// Tag images and snapshots
-			_, err := regionConn.CreateTags(&ec2.CreateTagsInput{
-				Resources: resourceIds,
-				Tags:      amiTags,
-			})
-			if err != nil {
-				return err
+
+			var err error
+			if len(amiTags) > 0 {
+				_, err = regionConn.CreateTags(&ec2.CreateTagsInput{
+					Resources: resourceIds,
+					Tags:      amiTags,
+				})
+				if err != nil {
+					return err
+				}
 			}
 
 			// Override tags on snapshots


### PR DESCRIPTION
When spot_tags was set but ami_tags wasn't, we got an error because the length of ami tags was 0.
Closes #7699