### PR TITLE
Add feature to import user-data from a file

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	Subnetwork                   string                         `mapstructure:"subnetwork"`
 	Tags                         []string                       `mapstructure:"tags"`
 	UseInternalIP                bool                           `mapstructure:"use_internal_ip"`
-	UserdataFile                 string                         `mapstructure:"userdata_file"`
+	MetadataFiles                map[string]string              `mapstructure:"metadata_files"`
 	Zone                         string                         `mapstructure:"zone"`
 
 	Account            AccountFile

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	Subnetwork                   string                         `mapstructure:"subnetwork"`
 	Tags                         []string                       `mapstructure:"tags"`
 	UseInternalIP                bool                           `mapstructure:"use_internal_ip"`
+	UserdataFile                 string                         `mapstructure:"userdata_file"`
 	Zone                         string                         `mapstructure:"zone"`
 
 	Account            AccountFile

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -431,7 +431,8 @@ func testConfig(t *testing.T) (config map[string]interface{}, tempAccountFile st
 		"image_licenses": []string{
 			"test-license",
 		},
-		"zone": "us-east1-a",
+		"metadata_files": map[string]string{},
+		"zone":           "us-east1-a",
 	}
 
 	return config, tempAccountFile
@@ -478,6 +479,21 @@ func testAccountFile(t *testing.T) string {
 	defer tf.Close()
 
 	if _, err := tf.Write([]byte(testAccountContent)); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return tf.Name()
+}
+
+const testMetadataFileContent = `testMetadata`
+
+func testMetadataFile(t *testing.T) string {
+	tf, err := ioutil.TempFile("", "packer")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer tf.Close()
+	if _, err := tf.Write([]byte(testMetadataFileContent)); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -19,7 +19,6 @@ type StepCreateInstance struct {
 func (c *Config) createInstanceMetadata(sourceImage *Image, sshPublicKey string) (map[string]string, error) {
 	instanceMetadata := make(map[string]string)
 	var err error
-
 	// Copy metadata from config.
 	for k, v := range c.Metadata {
 		instanceMetadata[k] = v
@@ -45,6 +44,13 @@ func (c *Config) createInstanceMetadata(sourceImage *Image, sshPublicKey string)
 	} else if wrappedStartupScript, exists := instanceMetadata[StartupScriptKey]; exists {
 		instanceMetadata[StartupWrappedScriptKey] = wrappedStartupScript
 	}
+
+	if c.UserdataFile != "" {
+		var content []byte
+		content, err = ioutil.ReadFile(c.UserdataFile)
+		instanceMetadata["user-data"] = string(content)
+	}
+
 	if sourceImage.IsWindows() {
 		// Windows startup script support is not yet implemented.
 		// Mark the startup script as done.

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -45,10 +45,11 @@ func (c *Config) createInstanceMetadata(sourceImage *Image, sshPublicKey string)
 		instanceMetadata[StartupWrappedScriptKey] = wrappedStartupScript
 	}
 
-	if c.UserdataFile != "" {
+	// Read metadata from files specified with metadata_files
+	for key, value := range c.MetadataFiles {
 		var content []byte
-		content, err = ioutil.ReadFile(c.UserdataFile)
-		instanceMetadata["user-data"] = string(content)
+		content, err = ioutil.ReadFile(value)
+		instanceMetadata[key] = string(content)
 	}
 
 	if sourceImage.IsWindows() {

--- a/builder/googlecompute/step_create_instance_test.go
+++ b/builder/googlecompute/step_create_instance_test.go
@@ -303,7 +303,7 @@ func TestCreateInstanceMetadata(t *testing.T) {
 	key := "abcdefgh12345678"
 
 	// create our metadata
-	metadata, err := c.createInstanceMetadata(image, key, state)
+	metadata, err := c.createInstanceMetadata(image, key)
 
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 
@@ -318,7 +318,7 @@ func TestCreateInstanceMetadata_noPublicKey(t *testing.T) {
 	sshKeys := c.Metadata["sshKeys"]
 
 	// create our metadata
-	metadata, err := c.createInstanceMetadata(image, "", state)
+	metadata, err := c.createInstanceMetadata(image, "")
 
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 
@@ -335,7 +335,7 @@ func TestCreateInstanceMetadata_metadataFile(t *testing.T) {
 	c.MetadataFiles["user-data"] = fileName
 
 	// create our metadata
-	metadata, err := c.createInstanceMetadata(image, "", state)
+	metadata, err := c.createInstanceMetadata(image, "")
 
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 

--- a/builder/googlecompute/step_create_instance_test.go
+++ b/builder/googlecompute/step_create_instance_test.go
@@ -325,3 +325,20 @@ func TestCreateInstanceMetadata_noPublicKey(t *testing.T) {
 	// ensure the ssh metadata hasn't changed
 	assert.Equal(t, metadata["sshKeys"], sshKeys, "Instance metadata should not have been modified")
 }
+
+func TestCreateInstanceMetadata_metadataFile(t *testing.T) {
+	state := testState(t)
+	c := state.Get("config").(*Config)
+	image := StubImage("test-image", "test-project", []string{}, 100)
+	content := testMetadataFileContent
+	fileName := testMetadataFile(t)
+	c.MetadataFiles["user-data"] = fileName
+
+	// create our metadata
+	metadata, err := c.createInstanceMetadata(image, "", state)
+
+	assert.True(t, err == nil, "Metadata creation should have succeeded.")
+
+	// ensure the user-data key in metadata is updated with file content
+	assert.Equal(t, metadata["user-data"], content, "user-data field of the instance metadata should have been updated.")
+}

--- a/builder/googlecompute/step_create_instance_test.go
+++ b/builder/googlecompute/step_create_instance_test.go
@@ -303,7 +303,7 @@ func TestCreateInstanceMetadata(t *testing.T) {
 	key := "abcdefgh12345678"
 
 	// create our metadata
-	metadata, err := c.createInstanceMetadata(image, key)
+	metadata, err := c.createInstanceMetadata(image, key, state)
 
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 
@@ -318,7 +318,7 @@ func TestCreateInstanceMetadata_noPublicKey(t *testing.T) {
 	sshKeys := c.Metadata["sshKeys"]
 
 	// create our metadata
-	metadata, err := c.createInstanceMetadata(image, "")
+	metadata, err := c.createInstanceMetadata(image, "", state)
 
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 


### PR DESCRIPTION
Fixes #6617.
Adds one more field in the builder config for google compute named `userdata-file`. 

`TestListenRangeConfig_Listen` unit test in the `common/net` failed locally for me with error message `Port 1681 is file locked` and `Too many open files`.

Also, can any one guide me with how to run the acceptance tests for the google compute builder?

One more thing, if we want to keep the build config file in sync with the gcloud cli then maybe we can add a field `metadata_from_file` which could be a `map[string]string` and allow any field of metadata to be read from a file, instead of what I did right now.