### PR TITLE
fix describing snapshots issue when image_ignore_data_disks is provided

### DIFF
--- a/builder/alicloud/ecs/step_create_snapshot.go
+++ b/builder/alicloud/ecs/step_create_snapshot.go
@@ -3,9 +3,9 @@ package ecs
 import (
 	"context"
 	"fmt"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"time"
 
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -36,9 +36,6 @@ func (s *stepCreateAlicloudSnapshot) Run(ctx context.Context, state multistep.St
 		return halt(state, err, "Unable to find system disk of instance")
 	}
 
-	// Create the alicloud snapshot
-	ui.Say(fmt.Sprintf("Creating snapshot from system disk: %s", disks[0].DiskId))
-
 	createSnapshotRequest := ecs.CreateCreateSnapshotRequest()
 	createSnapshotRequest.DiskId = disks[0].DiskId
 	snapshot, err := client.CreateSnapshot(createSnapshotRequest)
@@ -46,44 +43,20 @@ func (s *stepCreateAlicloudSnapshot) Run(ctx context.Context, state multistep.St
 		return halt(state, err, "Error creating snapshot")
 	}
 
-	_, err = client.WaitForExpected(&WaitForExpectArgs{
-		RequestFunc: func() (responses.AcsResponse, error) {
-			request := ecs.CreateDescribeSnapshotsRequest()
-			request.RegionId = config.AlicloudRegion
-			request.SnapshotIds = snapshot.SnapshotId
-			return client.DescribeSnapshots(request)
-		},
-		EvalFunc: func(response responses.AcsResponse, err error) WaitForExpectEvalResult {
-			if err != nil {
-				return WaitForExpectToRetry
-			}
+	// Create the alicloud snapshot
+	ui.Say(fmt.Sprintf("Creating snapshot from system disk %s: %s", disks[0].DiskId, snapshot.SnapshotId))
 
-			snapshotsResponse := response.(*ecs.DescribeSnapshotsResponse)
-			snapshots := snapshotsResponse.Snapshots.Snapshot
-			for _, snapshot := range snapshots {
-				if snapshot.Status == SnapshotStatusAccomplished {
-					return WaitForExpectSuccess
-				}
-			}
-			return WaitForExpectToRetry
-		},
-		RetryTimeout: time.Duration(s.WaitSnapshotReadyTimeout) * time.Second,
-	})
-
+	snapshotsResponse, err := client.WaitForSnapshotStatus(config.AlicloudRegion, snapshot.SnapshotId, SnapshotStatusAccomplished, time.Duration(s.WaitSnapshotReadyTimeout)*time.Second)
 	if err != nil {
+		_, ok := err.(errors.Error)
+		if ok {
+			return halt(state, err, "Error querying created snapshot")
+		}
+
 		return halt(state, err, "Timeout waiting for snapshot to be created")
 	}
 
-	describeSnapshotsRequest := ecs.CreateDescribeSnapshotsRequest()
-	describeSnapshotsRequest.RegionId = config.AlicloudRegion
-	describeSnapshotsRequest.SnapshotIds = snapshot.SnapshotId
-
-	snapshotsResponse, err := client.DescribeSnapshots(describeSnapshotsRequest)
-	if err != nil {
-		return halt(state, err, "Error querying created snapshot")
-	}
-
-	snapshots := snapshotsResponse.Snapshots.Snapshot
+	snapshots := snapshotsResponse.(*ecs.DescribeSnapshotsResponse).Snapshots.Snapshot
 	if len(snapshots) == 0 {
 		return halt(state, err, "Unable to find created snapshot")
 	}


### PR DESCRIPTION
This PR is going to fix an issue when `image_ignore_data_disks=true` is provided:
If this option is provided, Packer will wait for snapshot ready until timeout, since parameters was set incorrectly.