### PR TITLE
prevent nil pointer dereference by defining IsUserAuthority. This occ…

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -241,6 +241,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 
 			return nil, nil
 		},
+		IsUserAuthority: func(k ssh.PublicKey) bool { return true },
 	}
 
 	config := &ssh.ServerConfig{

--- a/provisioner/inspec/provisioner.go
+++ b/provisioner/inspec/provisioner.go
@@ -234,6 +234,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 
 			return nil, nil
 		},
+		IsUserAuthority: func(k ssh.PublicKey) bool { return true },
 	}
 
 	config := &ssh.ServerConfig{


### PR DESCRIPTION
Sets IsUserAuthority to a dummy function that always returns true.

Between v1.3.5 and 1.4.0 we upgraded the crypto library when we switched to SSH modules. There was a change in the library since our previous upgrade: https://github.com/golang/crypto/commit/7e9105388ebff089b3f99f0ef676ea55a6da3a7e

Which changed the order of a check being done, forcing IsUserAuthority to be set; setting this to return true essentially replicates the prior behavior.  

Closes #7727 