### PR TITLE
small cleanups

### DIFF
--- a/packer/ui.go
+++ b/packer/ui.go
@@ -350,6 +350,7 @@ func (u *MachineReadableUi) Machine(category string, args ...string) {
 			panic(err)
 		}
 	}
+	log.Printf("%d,%s,%s,%s\n", now.Unix(), target, category, argsString)
 }
 
 // TimestampedUi is a UI that wraps another UI implementation and

--- a/provisioner/shell-local/provisioner.go
+++ b/provisioner/shell-local/provisioner.go
@@ -27,11 +27,8 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, _ packer.Communicator) error {
 	_, retErr := sl.Run(ctx, ui, &p.config)
-	if retErr != nil {
-		return retErr
-	}
 
-	return nil
+	return retErr
 }
 
 func (p *Provisioner) Cancel() {


### PR DESCRIPTION
While investigating a different issue, I found two minor single-line issues.

1) the shell-local provisoner was performing a check that it doesn't need to perform, since it's returning either an error or nil from the sl.Run() call anyway

2) the machine-readable UI wasn't logging UI calls to the logs.