### PR TITLE
Abort hyperv build if there's a name collision

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -73,6 +73,8 @@ type Driver interface {
 
 	DeleteVirtualSwitch(string) error
 
+	CheckVMName(string) error
+
 	CreateVirtualMachine(string, string, string, int64, int64, int64, string, uint, bool, bool, string) error
 
 	AddVirtualMachineHardDrive(string, string, string, int64, int64, string) error

--- a/builder/hyperv/common/driver_mock.go
+++ b/builder/hyperv/common/driver_mock.go
@@ -110,6 +110,9 @@ type DriverMock struct {
 	DeleteVirtualSwitch_SwitchName string
 	DeleteVirtualSwitch_Err        error
 
+	CheckVMName_Called bool
+	CheckVMName_Err    error
+
 	CreateVirtualSwitch_Called     bool
 	CreateVirtualSwitch_SwitchName string
 	CreateVirtualSwitch_SwitchType string
@@ -419,6 +422,11 @@ func (d *DriverMock) AddVirtualMachineHardDrive(vmName string, vhdFile string, v
 	d.AddVirtualMachineHardDrive_VhdSizeBytes = vhdDiskBlockSize
 	d.AddVirtualMachineHardDrive_ControllerType = controllerType
 	return d.AddVirtualMachineHardDrive_Err
+}
+
+func (d *DriverMock) CheckVMName(vmName string) error {
+	d.CheckVMName_Called = true
+	return d.CheckVMName_Err
 }
 
 func (d *DriverMock) CreateVirtualMachine(vmName string, path string, harddrivePath string,

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -186,6 +186,10 @@ func (d *HypervPS4Driver) AddVirtualMachineHardDrive(vmName string, vhdFile stri
 		diskBlockSize, controllerType)
 }
 
+func (d *HypervPS4Driver) CheckVMName(vmName string) error {
+	return hyperv.CheckVMName(vmName)
+}
+
 func (d *HypervPS4Driver) CreateVirtualMachine(vmName string, path string, harddrivePath string, ram int64,
 	diskSize int64, diskBlockSize int64, switchName string, generation uint, diffDisks bool,
 	fixedVHD bool, version string) error {

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -48,6 +48,14 @@ func (s *StepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 		path = v.(string)
 	}
 
+	err := driver.CheckVMName(s.VMName)
+	if err != nil {
+		s.KeepRegistered = true
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
 	// Determine if we even have an existing virtual harddrive to attach
 	harddrivePath := ""
 	if harddrivePathRaw, ok := state.GetOk("iso_path"); ok {
@@ -66,7 +74,7 @@ func (s *StepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 	diskSize := int64(s.DiskSize) * 1024 * 1024
 	diskBlockSize := int64(s.DiskBlockSize) * 1024 * 1024
 
-	err := driver.CreateVirtualMachine(s.VMName, path, harddrivePath, ramSize, diskSize, diskBlockSize,
+	err = driver.CreateVirtualMachine(s.VMName, path, harddrivePath, ramSize, diskSize, diskBlockSize,
 		s.SwitchName, s.Generation, s.DifferencingDisk, s.FixedVHD, s.Version)
 	if err != nil {
 		err := fmt.Errorf("Error creating virtual machine: %s", err)

--- a/builder/hyperv/common/step_create_vm_test.go
+++ b/builder/hyperv/common/step_create_vm_test.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/packer/helper/multistep"
+)
+
+func TestStepCreateVM_impl(t *testing.T) {
+	var _ multistep.Step = new(StepCreateVM)
+}
+
+func TestStepCreateVM(t *testing.T) {
+	state := testState(t)
+	step := new(StepCreateVM)
+
+	step.VMName = "test-VM-Name"
+	driver := state.Get("driver").(*DriverMock)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("Bad action: %v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("Should NOT have error")
+	}
+
+	// Test the driver
+	if !driver.CheckVMName_Called {
+		t.Fatal("Should have called CheckVMName")
+	}
+}
+
+func TestStepCreateVM_CheckVMNameErr(t *testing.T) {
+	state := testState(t)
+	step := new(StepCreateVM)
+
+	step.VMName = "test-VM-Name"
+	driver := state.Get("driver").(*DriverMock)
+	driver.CheckVMName_Err = fmt.Errorf("A virtual machine with the name is already" +
+		" defined in Hyper-V. To avoid a name collision, please set your " +
+		"vm_name to a unique value")
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionHalt {
+		t.Fatalf("Bad action: %v", action)
+	}
+	if _, ok := state.GetOk("error"); !ok {
+		t.Fatal("Should have error")
+	}
+
+	// Test the driver
+	if !driver.CheckVMName_Called {
+		t.Fatal("Should have called CheckVMName")
+	}
+}

--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -283,10 +283,23 @@ Hyper-V\New-VM -Name "{{ .VMName }}" -Path "{{ .Path }}" -MemoryStartupBytes {{ 
 	return final, nil
 }
 
+func CheckVMName(vmName string) error {
+	// Check that no vm with the same name is registered, to prevent
+	// namespace collisions
+	var gs powershell.PowerShellCmd
+	getVMCmd := fmt.Sprintf(`Hyper-V\Get-VM -Name "%s"`, vmName)
+	if err := gs.Run(getVMCmd); err == nil {
+		return fmt.Errorf("A virtual machine with the name %s is already"+
+			" defined in Hyper-V. To avoid a name collision, please set your "+
+			"vm_name to a unique value", vmName)
+	}
+
+	return nil
+}
+
 func CreateVirtualMachine(vmName string, path string, harddrivePath string, ram int64,
 	diskSize int64, diskBlockSize int64, switchName string, generation uint,
 	diffDisks bool, fixedVHD bool, version string) error {
-
 	opts := scriptOptions{
 		Version:            version,
 		VMName:             vmName,


### PR DESCRIPTION
Previously, we'd accidentally overwrite and then delete VMs with the same name as the Packer-created vm. This preserves them by forcing users to create unique names.

Closes #7671
Closes #4573