### PR TITLE
let product API determine the default value of io_optimized

### DIFF
--- a/builder/alicloud/ecs/run_config.go
+++ b/builder/alicloud/ecs/run_config.go
@@ -14,7 +14,7 @@ import (
 type RunConfig struct {
 	AssociatePublicIpAddress bool   `mapstructure:"associate_public_ip_address"`
 	ZoneId                   string `mapstructure:"zone_id"`
-	IOOptimized              bool   `mapstructure:"io_optimized"`
+	IOOptimized              *bool  `mapstructure:"io_optimized"`
 	InstanceType             string `mapstructure:"instance_type"`
 	Description              string `mapstructure:"description"`
 	AlicloudSourceImage      string `mapstructure:"source_image"`

--- a/builder/alicloud/ecs/step_create_instance.go
+++ b/builder/alicloud/ecs/step_create_instance.go
@@ -17,7 +17,7 @@ import (
 )
 
 type stepCreateAlicloudInstance struct {
-	IOOptimized             bool
+	IOOptimized             *bool
 	InstanceType            string
 	UserData                string
 	UserDataFile            string
@@ -142,11 +142,13 @@ func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.
 	request.InternetChargeType = s.InternetChargeType
 	request.InternetMaxBandwidthOut = requests.Integer(convertNumber(s.InternetMaxBandwidthOut))
 
-	ioOptimized := IOOptimizedNone
-	if s.IOOptimized {
-		ioOptimized = IOOptimizedOptimized
+	if s.IOOptimized != nil {
+		if *s.IOOptimized {
+			request.IoOptimized = IOOptimizedOptimized
+		} else {
+			request.IoOptimized = IOOptimizedNone
+		}
 	}
-	request.IoOptimized = ioOptimized
 
 	config := state.Get("config").(*Config)
 	password := config.Comm.SSHPassword

--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -218,7 +218,8 @@ builder.
         error is returned.
 
 -   `io_optimized` (boolean) - Whether an ECS instance is I/O optimized or not.
-    The default value is `false`.
+    If this option is not provided, the value will be determined by product API 
+    according to what `instance_type` is used.
 
 -   `security_group_id` (string) - ID of the security group to which a newly
     created instance belongs. Mutual access is allowed between instances in one


### PR DESCRIPTION
Current default value of `io_optimzed` is false. If a user choose an io optimized instance type, the process would fail because the mismatch between `io_optimized` and `instance_type`.

Therefore, we let product API to determine the default value of `io_optimized`. If this option is not provided, we'll keep it blank and product API will choose the default value according to the instance type.