### PR TITLE
Fix failed to copy binary when using make bin

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -144,7 +144,7 @@ IFS="${OLDIFS}"
 
 # Copy our OS/Arch to the bin/ directory
 echo "==> Copying binaries for this platform..."
-DEV_PLATFORM="./pkg/${XC_OS}_${XC_ARCH}"
+DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
 for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
     cp -v ${F} bin/
     cp -v ${F} "${MAIN_GOPATH}/bin/"


### PR DESCRIPTION
If we use make bin, XC_OS and XC_ARCH will be None, the binary will failed to be copied.

Closes #7749
