### PR TITLE
add skip_save_build_region flag to fix naming conflicts when building…

### DIFF
--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -29,6 +29,7 @@ type AMIConfig struct {
 	SnapshotTags            TagMap            `mapstructure:"snapshot_tags"`
 	SnapshotUsers           []string          `mapstructure:"snapshot_users"`
 	SnapshotGroups          []string          `mapstructure:"snapshot_groups"`
+	AMISkipBuildRegion      bool              `mapstructure:"skip_save_build_region"`
 }
 
 func stringInSlice(s []string, searchstr string) bool {

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -21,8 +21,9 @@ type StepAMIRegionCopy struct {
 	Name              string
 	OriginalRegion    string
 
-	toDelete      string
-	getRegionConn func(*AccessConfig, string) (ec2iface.EC2API, error)
+	toDelete           string
+	getRegionConn      func(*AccessConfig, string) (ec2iface.EC2API, error)
+	AMISkipBuildRegion bool
 }
 
 func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -33,7 +34,9 @@ func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) m
 	ami := amis[s.OriginalRegion]
 	// Always copy back into original region to preserve the ami name
 	s.toDelete = ami
-	s.Regions = append(s.Regions, s.OriginalRegion)
+	if !s.AMISkipBuildRegion {
+		s.Regions = append(s.Regions, s.OriginalRegion)
+	}
 
 	if s.EncryptBootVolume != nil && *s.EncryptBootVolume {
 		// encrypt_boot is true, so we have to copy the temporary

--- a/builder/amazon/common/step_ami_region_copy_test.go
+++ b/builder/amazon/common/step_ami_region_copy_test.go
@@ -158,3 +158,28 @@ func TestStepAmiRegionCopy_true_encryption(t *testing.T) {
 		t.Fatalf("Should have added original ami to Regions")
 	}
 }
+
+func TestStepAmiRegionCopy_true_AMISkipBuildRegion(t *testing.T) {
+	// create step
+	stepAMIRegionCopy := StepAMIRegionCopy{
+		AccessConfig:       testAccessConfig(),
+		Regions:            make([]string, 0),
+		AMIKmsKeyId:        "",
+		RegionKeyIds:       make(map[string]string),
+		Name:               "fake-ami-name",
+		OriginalRegion:     "us-east-1",
+		AMISkipBuildRegion: true,
+	}
+	// mock out the region connection code
+	stepAMIRegionCopy.getRegionConn = getMockConn
+
+	state := tState()
+	stepAMIRegionCopy.Run(context.Background(), state)
+
+	if stepAMIRegionCopy.toDelete == "" {
+		t.Fatalf("Should delete original AMI if skip_save_build_region=true")
+	}
+	if len(stepAMIRegionCopy.Regions) == 0 {
+		t.Fatalf("Should not have added original ami to Regions")
+	}
+}

--- a/builder/amazon/common/step_ami_region_copy_test.go
+++ b/builder/amazon/common/step_ami_region_copy_test.go
@@ -101,11 +101,11 @@ func TestStepAmiRegionCopy_nil_encryption(t *testing.T) {
 	state := tState()
 	stepAMIRegionCopy.Run(context.Background(), state)
 
-	if stepAMIRegionCopy.toDelete != "ami-12345" {
-		t.Fatalf("Should delete original intermediary ami even if not encrypted")
+	if stepAMIRegionCopy.toDelete != "" {
+		t.Fatalf("Shouldn't have an intermediary ami if encrypt is nil")
 	}
-	if len(stepAMIRegionCopy.Regions) == 0 {
-		t.Fatalf("Should have added original ami to original region")
+	if len(stepAMIRegionCopy.Regions) != 0 {
+		t.Fatalf("Should not have added original ami to original region")
 	}
 }
 
@@ -179,7 +179,7 @@ func TestStepAmiRegionCopy_true_AMISkipBuildRegion(t *testing.T) {
 	if stepAMIRegionCopy.toDelete == "" {
 		t.Fatalf("Should delete original AMI if skip_save_build_region=true")
 	}
-	if len(stepAMIRegionCopy.Regions) == 0 {
+	if len(stepAMIRegionCopy.Regions) != 0 {
 		t.Fatalf("Should not have added original ami to Regions")
 	}
 }

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -18,8 +18,9 @@ import (
 // the build before actually doing any time consuming work
 //
 type StepPreValidate struct {
-	DestAmiName     string
-	ForceDeregister bool
+	DestAmiName        string
+	ForceDeregister    bool
+	AMISkipBuildRegion bool
 }
 
 func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -74,6 +75,10 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 
 	if s.ForceDeregister {
 		ui.Say("Force Deregister flag found, skipping prevalidating AMI Name")
+		return multistep.ActionContinue
+	}
+	if s.AMISkipBuildRegion {
+		ui.Say("skip_build_region was set; not prevalidating AMI name")
 		return multistep.ActionContinue
 	}
 

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -154,8 +154,9 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepPreValidate{
-			DestAmiName:     b.config.AMIName,
-			ForceDeregister: b.config.AMIForceDeregister,
+			DestAmiName:        b.config.AMIName,
+			ForceDeregister:    b.config.AMIForceDeregister,
+			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,
@@ -220,15 +221,18 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			AMIName:             b.config.AMIName,
 			Regions:             b.config.AMIRegions,
 		},
-		&stepCreateAMI{},
+		&stepCreateAMI{
+			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
+		},
 		&awscommon.StepAMIRegionCopy{
-			AccessConfig:      &b.config.AccessConfig,
-			Regions:           b.config.AMIRegions,
-			AMIKmsKeyId:       b.config.AMIKmsKeyId,
-			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
-			EncryptBootVolume: b.config.AMIEncryptBootVolume,
-			Name:              b.config.AMIName,
-			OriginalRegion:    *ec2conn.Config.Region,
+			AccessConfig:       &b.config.AccessConfig,
+			Regions:            b.config.AMIRegions,
+			AMIKmsKeyId:        b.config.AMIKmsKeyId,
+			RegionKeyIds:       b.config.AMIRegionKMSKeyIDs,
+			EncryptBootVolume:  b.config.AMIEncryptBootVolume,
+			Name:               b.config.AMIName,
+			OriginalRegion:     *ec2conn.Config.Region,
+			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -14,7 +14,8 @@ import (
 )
 
 type stepCreateAMI struct {
-	image *ec2.Image
+	image              *ec2.Image
+	AMISkipBuildRegion bool
 }
 
 func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -25,9 +26,9 @@ func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 
 	// Create the image
 	amiName := config.AMIName
-	if config.AMIEncryptBootVolume != nil {
-		// encrypt_boot was set, so we will create a temporary image
-		// and then create a copy of it with the correct encrypt_boot
+	if config.AMIEncryptBootVolume != nil || s.AMISkipBuildRegion {
+		// Create a temporary image and then create a copy of it with the
+		// correct encrypt_boot
 		amiName = random.AlphaNum(7)
 	}
 

--- a/website/source/docs/builders/amazon-ebs.html.md.erb
+++ b/website/source/docs/builders/amazon-ebs.html.md.erb
@@ -295,6 +295,12 @@ builder.
 -   `skip_region_validation` (boolean) - Set to true if you want to skip
     validation of the region configuration option. Default `false`.
 
+-   `skip_save_build_region` (boolean) - If true, Packer will not check whether
+    an AMI with the `ami_name` exists in the region it is building in. It will
+    use an intermediary AMI name, which it will not convert to an AMI in the
+    build region. It will copy the intermediary AMI into any regions provided
+    in `ami_regions`, then delete the intermediary AMI. Default `false`.
+
 -   `snapshot_groups` (array of strings) - A list of groups that have access to
     create volumes from the snapshot(s). By default no groups have permission
     to create volumes from the snapshot(s). `all` will make the snapshot


### PR DESCRIPTION
Some users don't want to save an AMI into the region they originally build in. If this is the case, they can now use the "skip_save_build_region" flag. This will create an intermediary AMI which can be copied into other regions and then deleted, avoiding naming conflicts with AMIs already present in the build region.

Closes #7199 
