### PR TITLE
remove image name check in tencentcloud builder

### DIFF
--- a/builder/tencentcloud/cvm/image_config.go
+++ b/builder/tencentcloud/cvm/image_config.go
@@ -2,7 +2,6 @@ package cvm
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/hashicorp/packer/template/interpolate"
 )
@@ -26,11 +25,6 @@ func (cf *TencentCloudImageConfig) Prepare(ctx *interpolate.Context) []error {
 		errs = append(errs, fmt.Errorf("image_name must be set"))
 	} else if len(cf.ImageName) > 20 {
 		errs = append(errs, fmt.Errorf("image_num length should not exceed 20 characters"))
-	} else {
-		regex := regexp.MustCompile("^[0-9a-zA-Z\\-]+$")
-		if !regex.MatchString(cf.ImageName) {
-			errs = append(errs, fmt.Errorf("image_name can only be composed of letters, numbers and minus sign"))
-		}
 	}
 
 	if len(cf.ImageDescription) > 60 {

--- a/builder/tencentcloud/cvm/image_config_test.go
+++ b/builder/tencentcloud/cvm/image_config_test.go
@@ -11,9 +11,9 @@ func TestTencentCloudImageConfig_Prepare(t *testing.T) {
 		t.Fatalf("shouldn't have err: %v", err)
 	}
 
-	cf.ImageName = "foo:"
-	if err := cf.Prepare(nil); err == nil {
-		t.Fatal("should have error")
+	cf.ImageName = "foo.:"
+	if err := cf.Prepare(nil); err != nil {
+		t.Fatal("shouldn't have error")
 	}
 
 	cf.ImageName = "foo"


### PR DESCRIPTION
Spinnaker uses packer to create images, but tencentcloud builder
has name check to forbidden special characters such as dot(.) while
it is absolutely valid in API side.

