### PR TITLE
clarify pathing requirements for hyperv-vmcx

### DIFF
--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -221,6 +221,21 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 					errs, fmt.Errorf("CloneFromVMCXPath does not exist: %s", err))
 			}
 		}
+		if strings.HasSuffix(strings.ToLower(b.config.CloneFromVMCXPath), ".vmcx") {
+			// User has provided the vmcx file itself rather than the containing
+			// folder.
+			if strings.Contains(b.config.CloneFromVMCXPath, "Virtual Machines") {
+				keep := strings.Split(b.config.CloneFromVMCXPath, "Virtual Machines")
+				b.config.CloneFromVMCXPath = keep[0]
+			} else {
+				errs = packer.MultiErrorAppend(errs, fmt.Errorf("Unable to "+
+					"parse the clone_from_vmcx_path to find the vm directory. "+
+					"Please provide the path to the folder containing the "+
+					"vmcx file, not the file itself. Example: instead of "+
+					"C:\\path\\to\\output-hyperv-iso\\Virtual Machines\\filename.vmcx"+
+					", provide C:\\path\\to\\output-hyperv-iso\\."))
+			}
+		}
 	}
 
 	if b.config.Generation < 1 || b.config.Generation > 2 {

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -33,7 +33,7 @@ Import from folder:
 ``` json
 {
   "type": "hyperv-vmcx",
-  "clone_from_vmcx_path": "c:/virtual machines/ubuntu-12.04.5-server-amd64",
+  "clone_from_vmcx_path": "c:/path/to/ubuntu-12.04.5-server-amd64",
   "ssh_username": "packer",
   "ssh_password": "packer",
   "shutdown_command": "echo 'packer' | sudo -S shutdown -P now"
@@ -76,6 +76,10 @@ builder.
 -   `clone_from_vmcx_path` (string) - The path to a directory containing a
     previously exported virtual machine. The exported machine will be used
     as the source for new VM.
+
+    note: You should provide the named directory that contains the
+    "Virtual Machines", "Snapshots", and/or "Virtual Hard Disks" subdirectories,
+    not the .vmcx file itself.
 
 
 ### Required for virtual machine clone:


### PR DESCRIPTION
Make a simple attempt to extrapolate folder from .vmcx file name but also clarify documentation to explain that this isn't how you should do it.