### PR TITLE
Smb getter

### DIFF
--- a/common/step_download.go
+++ b/common/step_download.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -108,6 +109,14 @@ func init() {
 }
 
 func (s *StepDownload) download(ctx context.Context, ui packer.Ui, source string) (string, error) {
+	if runtime.GOOS == "windows" {
+		// Check that the user specified a UNC path, and promote it to an smb:// uri.
+		if strings.HasPrefix(source, "\\\\") && len(source) > 2 && source[2] != '?' {
+			source = filepath.ToSlash(source[2:])
+			source = fmt.Sprintf("smb://%s", source)
+		}
+	}
+
 	u, err := urlhelper.Parse(source)
 	if err != nil {
 		return "", fmt.Errorf("url parse: %s", err)

--- a/common/step_download.go
+++ b/common/step_download.go
@@ -101,6 +101,9 @@ func init() {
 			// can leave the source file where it is & tell us where it is.
 			Copy: true,
 		}
+		getters["smb"] = &getter.FileGetter{
+			Copy: true,
+		}
 	}
 }
 


### PR DESCRIPTION
when we implemented go-getter, it broke UNC paths for smb shares on windows. This PR reimplements the logic to make both smb:// and \\\\ syntax work as expected for smb shares.

Closes #7783