### PR TITLE
feature: add run_tags to instance in tencentcloud builder

### DIFF
--- a/builder/tencentcloud/cvm/builder.go
+++ b/builder/tencentcloud/cvm/builder.go
@@ -107,6 +107,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			HostName:                 b.config.HostName,
 			InternetMaxBandwidthOut:  b.config.InternetMaxBandwidthOut,
 			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
+			Tags:                     b.config.RunTags,
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.TencentCloudRunConfig.Comm,

--- a/builder/tencentcloud/cvm/run_config.go
+++ b/builder/tencentcloud/cvm/run_config.go
@@ -11,26 +11,27 @@ import (
 )
 
 type TencentCloudRunConfig struct {
-	AssociatePublicIpAddress bool   `mapstructure:"associate_public_ip_address"`
-	SourceImageId            string `mapstructure:"source_image_id"`
-	InstanceType             string `mapstructure:"instance_type"`
-	InstanceName             string `mapstructure:"instance_name"`
-	DiskType                 string `mapstructure:"disk_type"`
-	DiskSize                 int64  `mapstructure:"disk_size"`
-	VpcId                    string `mapstructure:"vpc_id"`
-	VpcName                  string `mapstructure:"vpc_name"`
-	VpcIp                    string `mapstructure:"vpc_ip"`
-	SubnetId                 string `mapstructure:"subnet_id"`
-	SubnetName               string `mapstructure:"subnet_name"`
-	CidrBlock                string `mapstructure:"cidr_block"` // 10.0.0.0/16(default), 172.16.0.0/12, 192.168.0.0/16
-	SubnectCidrBlock         string `mapstructure:"subnect_cidr_block"`
-	InternetChargeType       string `mapstructure:"internet_charge_type"`
-	InternetMaxBandwidthOut  int64  `mapstructure:"internet_max_bandwidth_out"`
-	SecurityGroupId          string `mapstructure:"security_group_id"`
-	SecurityGroupName        string `mapstructure:"security_group_name"`
-	UserData                 string `mapstructure:"user_data"`
-	UserDataFile             string `mapstructure:"user_data_file"`
-	HostName                 string `mapstructure:"host_name"`
+	AssociatePublicIpAddress bool              `mapstructure:"associate_public_ip_address"`
+	SourceImageId            string            `mapstructure:"source_image_id"`
+	InstanceType             string            `mapstructure:"instance_type"`
+	InstanceName             string            `mapstructure:"instance_name"`
+	DiskType                 string            `mapstructure:"disk_type"`
+	DiskSize                 int64             `mapstructure:"disk_size"`
+	VpcId                    string            `mapstructure:"vpc_id"`
+	VpcName                  string            `mapstructure:"vpc_name"`
+	VpcIp                    string            `mapstructure:"vpc_ip"`
+	SubnetId                 string            `mapstructure:"subnet_id"`
+	SubnetName               string            `mapstructure:"subnet_name"`
+	CidrBlock                string            `mapstructure:"cidr_block"` // 10.0.0.0/16(default), 172.16.0.0/12, 192.168.0.0/16
+	SubnectCidrBlock         string            `mapstructure:"subnect_cidr_block"`
+	InternetChargeType       string            `mapstructure:"internet_charge_type"`
+	InternetMaxBandwidthOut  int64             `mapstructure:"internet_max_bandwidth_out"`
+	SecurityGroupId          string            `mapstructure:"security_group_id"`
+	SecurityGroupName        string            `mapstructure:"security_group_name"`
+	UserData                 string            `mapstructure:"user_data"`
+	UserDataFile             string            `mapstructure:"user_data_file"`
+	HostName                 string            `mapstructure:"host_name"`
+	RunTags                  map[string]string `mapstructure:"run_tags"`
 
 	// Communicator settings
 	Comm         communicator.Config `mapstructure:",squash"`
@@ -118,6 +119,10 @@ func (cf *TencentCloudRunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if cf.HostName == "" {
 		cf.HostName = cf.InstanceName[:15]
+	}
+
+	if cf.RunTags == nil {
+		cf.RunTags = make(map[string]string)
 	}
 
 	return errs

--- a/builder/tencentcloud/cvm/step_run_instance.go
+++ b/builder/tencentcloud/cvm/step_run_instance.go
@@ -26,6 +26,7 @@ type stepRunInstance struct {
 	HostName                 string
 	InternetMaxBandwidthOut  int64
 	AssociatePublicIpAddress bool
+	Tags                     map[string]string
 }
 
 func (s *stepRunInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -89,6 +90,22 @@ func (s *stepRunInstance) Run(ctx context.Context, state multistep.StateBag) mul
 	req.ClientToken = &s.InstanceName
 	req.HostName = &s.HostName
 	req.UserData = &userData
+	var tags []*cvm.Tag
+	for k, v := range s.Tags {
+		tags = append(tags, &cvm.Tag{
+			Key:   &k,
+			Value: &v,
+		})
+	}
+	resourceType := "instance"
+	if len(tags) > 0 {
+		req.TagSpecification = []*cvm.TagSpecification{
+			&cvm.TagSpecification{
+				ResourceType: &resourceType,
+				Tags:         tags,
+			},
+		}
+	}
 
 	resp, err := client.RunInstances(req)
 	if err != nil {

--- a/examples/tencentcloud/basic.json
+++ b/examples/tencentcloud/basic.json
@@ -15,7 +15,10 @@
     "image_name": "PackerTest",
     "disk_type": "CLOUD_PREMIUM",
     "packer_debug": true,
-    "associate_public_ip_address": true
+    "associate_public_ip_address": true,
+    "run_tags": {
+      "good": "luck"
+    }
   }],
   "provisioners": [{
     "type": "shell",

--- a/website/source/docs/builders/tencentcloud-cvm.html.md
+++ b/website/source/docs/builders/tencentcloud-cvm.html.md
@@ -116,6 +116,9 @@ builder.
 
 -   `host_name` (string) - host name.
 
+-   `run_tags` (map of strings) - Tags to apply to the instance that is *launched* to create the image.
+    These tags are *not* applied to the resulting image.
+
 ## Basic Example
 
 Here is a basic example for Tencentcloud.
@@ -137,7 +140,10 @@ Here is a basic example for Tencentcloud.
     "ssh_username" : "root",
     "image_name": "packerTest2",
     "packer_debug": true,
-    "associate_public_ip_address": true
+    "associate_public_ip_address": true,
+    "run_tags": {
+      "good": "luck"
+    }
   }],
   "provisioners": [{
     "type": "shell",


### PR DESCRIPTION
Instance tags are useful, our customer asks us to support it in packer as
well, to enable them to identify the purpose of the instance, even the
instance runs in a very short time.