### PR TITLE
interpolate builder type based on user variables.

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -88,6 +88,14 @@ func NewCore(c *CoreConfig) (*Core, error) {
 	// to do this at this point with the variables.
 	result.builds = make(map[string]*template.Builder)
 	for _, b := range c.Template.Builders {
+		t, err := interpolate.Render(b.Type, result.Context())
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error interpolating builder '%s': %s",
+				b.Type, err)
+		}
+		b.Type = t
+
 		v, err := interpolate.Render(b.Name, result.Context())
 		if err != nil {
 			return nil, fmt.Errorf(


### PR DESCRIPTION
This allows users to set builder type via user variables.

I'm not 100% convinced this is a good idea, but I coded it to see if it was possible. It's easy to do, but I need to decide whether it's _wise_ before merging.

Closes #7811 