### PR TITLE
Fix IAM permissions for spot based on changes in 7682

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -175,9 +175,9 @@ for Packer to work:
 
 Note that if you'd like to create a spot instance, you must also add:
 
-    ec2:RequestSpotInstances,
-    ec2:CancelSpotInstanceRequests,
-    ec2:DescribeSpotInstanceRequests
+    ec2:CreateLaunchTemplate,
+    ec2:DeleteLaunchTemplate,
+    ec2:CreateFleet
 
 If you have the `spot_price` parameter set to `auto`, you must also add:
 


### PR DESCRIPTION
Couldn't run packer 1.42 with the published IAM permissions for Amazon builder using spot.  Here's what I reverse engineered from looking at the code and cloudtrail, etc.