### PR TITLE
don't store names of volumes we will be deleting when the instance te…

### DIFF
--- a/builder/amazon/ebsvolume/step_tag_ebs_volumes.go
+++ b/builder/amazon/ebsvolume/step_tag_ebs_volumes.go
@@ -24,6 +24,9 @@ func (s *stepTagEBSVolumes) Run(ctx context.Context, state multistep.StateBag) m
 	for _, instanceBlockDevices := range instance.BlockDeviceMappings {
 		for _, configVolumeMapping := range s.VolumeMapping {
 			if configVolumeMapping.DeviceName == *instanceBlockDevices.DeviceName {
+				if configVolumeMapping.DeleteOnTermination {
+					continue
+				}
 				volumes[*ec2conn.Config.Region] = append(
 					volumes[*ec2conn.Config.Region],
 					*instanceBlockDevices.Ebs.VolumeId)


### PR DESCRIPTION
We shouldn't be storing the artifact names for volumes that we're going to delete once the instance is terminated.  The "volumes" object stored in state is only created here and only used for artifacts, so this is a good place to change it.

Closes #7828 