### PR TITLE
Revert "move SSHInterface/SSHIPVersion fields to communitator.Config …

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -88,7 +88,8 @@ type RunConfig struct {
 	WindowsPasswordTimeout            time.Duration              `mapstructure:"windows_password_timeout"`
 
 	// Communicator settings
-	Comm communicator.Config `mapstructure:",squash"`
+	Comm         communicator.Config `mapstructure:",squash"`
+	SSHInterface string              `mapstructure:"ssh_interface"`
 }
 
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
@@ -114,12 +115,12 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 	errs := c.Comm.Prepare(ctx)
 
 	// Validating ssh_interface
-	if c.Comm.SSHInterface != "public_ip" &&
-		c.Comm.SSHInterface != "private_ip" &&
-		c.Comm.SSHInterface != "public_dns" &&
-		c.Comm.SSHInterface != "private_dns" &&
-		c.Comm.SSHInterface != "" {
-		errs = append(errs, fmt.Errorf("Unknown interface type: %s", c.Comm.SSHInterface))
+	if c.SSHInterface != "public_ip" &&
+		c.SSHInterface != "private_ip" &&
+		c.SSHInterface != "public_dns" &&
+		c.SSHInterface != "private_dns" &&
+		c.SSHInterface != "" {
+		errs = append(errs, fmt.Errorf("Unknown interface type: %s", c.SSHInterface))
 	}
 
 	if c.Comm.SSHKeyPairName != "" {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -208,7 +208,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(
 				ec2conn,
-				b.config.Comm.SSHInterface),
+				b.config.SSHInterface),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -240,7 +240,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(
 				ec2conn,
-				b.config.Comm.SSHInterface),
+				b.config.SSHInterface),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -200,7 +200,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(
 				ec2conn,
-				b.config.Comm.SSHInterface),
+				b.config.SSHInterface),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -280,7 +280,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Config: &b.config.RunConfig.Comm,
 			Host: awscommon.SSHHost(
 				ec2conn,
-				b.config.Comm.SSHInterface),
+				b.config.SSHInterface),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -134,8 +134,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Config: &b.config.RunConfig.Comm,
 			Host: CommHost(
 				computeClient,
-				b.config.Comm.SSHInterface,
-				b.config.Comm.SSHIPVersion),
+				b.config.SSHInterface,
+				b.config.SSHIPVersion),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -13,7 +13,9 @@ import (
 // RunConfig contains configuration for running an instance from a source
 // image and details on how to access that launched image.
 type RunConfig struct {
-	Comm communicator.Config `mapstructure:",squash"`
+	Comm         communicator.Config `mapstructure:",squash"`
+	SSHInterface string              `mapstructure:"ssh_interface"`
+	SSHIPVersion string              `mapstructure:"ssh_ip_version"`
 
 	SourceImage        string            `mapstructure:"source_image"`
 	SourceImageName    string            `mapstructure:"source_image_name"`
@@ -132,7 +134,7 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		errs = append(errs, errors.New("A flavor must be specified"))
 	}
 
-	if c.Comm.SSHIPVersion != "" && c.Comm.SSHIPVersion != "4" && c.Comm.SSHIPVersion != "6" {
+	if c.SSHIPVersion != "" && c.SSHIPVersion != "4" && c.SSHIPVersion != "6" {
 		errs = append(errs, errors.New("SSH IP version must be either 4 or 6"))
 	}
 

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -32,8 +32,6 @@ type Config struct {
 	SSHTemporaryKeyPairName   string        `mapstructure:"temporary_key_pair_name"`
 	SSHClearAuthorizedKeys    bool          `mapstructure:"ssh_clear_authorized_keys"`
 	SSHPrivateKeyFile         string        `mapstructure:"ssh_private_key_file"`
-	SSHInterface              string        `mapstructure:"ssh_interface"`
-	SSHIPVersion              string        `mapstructure:"ssh_ip_version"`
 	SSHPty                    bool          `mapstructure:"ssh_pty"`
 	SSHTimeout                time.Duration `mapstructure:"ssh_timeout"`
 	SSHAgentAuth              bool          `mapstructure:"ssh_agent_auth"`


### PR DESCRIPTION
This change was a nice idea, but it means that users of builders which haven't implemented ssh interface logic don't fail in validation.

Revert the change so that builders implement ssh_interface independently.

Closes #7824