### PR TITLE
[Salt] Replace scp with scp + mv to handle non-root case

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -399,9 +399,14 @@ func (p *Provisioner) uploadFile(ui packer.Ui, comm packer.Communicator, dst, sr
 	}
 	defer f.Close()
 
-	if err = comm.Upload(dst, f, nil); err != nil {
+	_, temp_dst := filepath.Split(dst)
+
+	if err = comm.Upload(temp_dst, f, nil); err != nil {
 		return fmt.Errorf("Error uploading %s: %s", src, err)
 	}
+
+	p.moveFile(ui, comm, dst, temp_dst)
+
 	return nil
 }
 
@@ -468,14 +473,9 @@ func (p *Provisioner) removeDir(ui packer.Ui, comm packer.Communicator, dir stri
 }
 
 func (p *Provisioner) uploadDir(ui packer.Ui, comm packer.Communicator, dst, src string, ignore []string) error {
-	if err := p.createDir(ui, comm, dst); err != nil {
+	_, temp_dst := filepath.Split(dst)
+	if err := comm.UploadDir(temp_dst, src, ignore); err != nil {
 		return err
 	}
-
-	// Make sure there is a trailing "/" so that the directory isn't
-	// created on the other side.
-	if src[len(src)-1] != '/' {
-		src = src + "/"
-	}
-	return comm.UploadDir(dst, src, ignore)
+	return p.moveFile(ui, comm, dst, temp_dst)
 }


### PR DESCRIPTION
If the SSH user is not privileged, you cannot directly SCP a file/folder to the destination if the destination is inaccessible to the SSH user. The general recommended solution appears to be upload to the user's home directory and then mv with sudo to the final destination.
