### PR TITLE
Fix bug while publishing SIG destination id for every managed image

### DIFF
--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -35,13 +35,26 @@ type Artifact struct {
 	ManagedImageId                     string
 	ManagedImageOSDiskSnapshotName     string
 	ManagedImageDataDiskSnapshotPrefix string
-	ManagedImageSharedImageGalleryId   string
+	// ARM resource id for Shared Image Gallery
+	ManagedImageSharedImageGalleryId string
 
 	// Additional Disks
 	AdditionalDisks *[]AdditionalDiskArtifact
 }
 
-func NewManagedImageArtifact(osType, resourceGroup, name, location, id, osDiskSnapshotName, dataDiskSnapshotPrefix, destinationSharedImageGalleryId string) (*Artifact, error) {
+func NewManagedImageArtifact(osType, resourceGroup, name, location, id, osDiskSnapshotName, dataDiskSnapshotPrefix string) (*Artifact, error) {
+	return &Artifact{
+		ManagedImageResourceGroupName:      resourceGroup,
+		ManagedImageName:                   name,
+		ManagedImageLocation:               location,
+		ManagedImageId:                     id,
+		OSType:                             osType,
+		ManagedImageOSDiskSnapshotName:     osDiskSnapshotName,
+		ManagedImageDataDiskSnapshotPrefix: dataDiskSnapshotPrefix,
+	}, nil
+}
+
+func NewManagedImageArtifactWithSIGAsDestination(osType, resourceGroup, name, location, id, osDiskSnapshotName, dataDiskSnapshotPrefix, destinationSharedImageGalleryId string) (*Artifact, error) {
 	return &Artifact{
 		ManagedImageResourceGroupName:      resourceGroup,
 		ManagedImageName:                   name,

--- a/builder/azure/arm/artifact_test.go
+++ b/builder/azure/arm/artifact_test.go
@@ -42,7 +42,7 @@ func TestArtifactIdVHD(t *testing.T) {
 }
 
 func TestArtifactIDManagedImage(t *testing.T) {
-	artifact, err := NewManagedImageArtifact("Linux", "fakeResourceGroup", "fakeName", "fakeLocation", "fakeID", "fakeOsDiskSnapshotName", "fakeDataDiskSnapshotPrefix", "fakeSharedImageGalleryId")
+	artifact, err := NewManagedImageArtifact("Linux", "fakeResourceGroup", "fakeName", "fakeLocation", "fakeID", "fakeOsDiskSnapshotName", "fakeDataDiskSnapshotPrefix")
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
@@ -56,7 +56,6 @@ ManagedImageId: fakeID
 ManagedImageLocation: fakeLocation
 ManagedImageOSDiskSnapshotName: fakeOsDiskSnapshotName
 ManagedImageDataDiskSnapshotPrefix: fakeDataDiskSnapshotPrefix
-ManagedImageSharedImageGalleryId: fakeSharedImageGalleryId
 `
 
 	result := artifact.String()
@@ -66,7 +65,7 @@ ManagedImageSharedImageGalleryId: fakeSharedImageGalleryId
 }
 
 func TestArtifactIDManagedImageWithoutOSDiskSnapshotName(t *testing.T) {
-	artifact, err := NewManagedImageArtifact("Linux", "fakeResourceGroup", "fakeName", "fakeLocation", "fakeID", "", "fakeDataDiskSnapshotPrefix", "fakeSharedImageGalleryId")
+	artifact, err := NewManagedImageArtifact("Linux", "fakeResourceGroup", "fakeName", "fakeLocation", "fakeID", "", "fakeDataDiskSnapshotPrefix")
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
@@ -79,7 +78,6 @@ ManagedImageName: fakeName
 ManagedImageId: fakeID
 ManagedImageLocation: fakeLocation
 ManagedImageDataDiskSnapshotPrefix: fakeDataDiskSnapshotPrefix
-ManagedImageSharedImageGalleryId: fakeSharedImageGalleryId
 `
 
 	result := artifact.String()
@@ -89,7 +87,7 @@ ManagedImageSharedImageGalleryId: fakeSharedImageGalleryId
 }
 
 func TestArtifactIDManagedImageWithoutDataDiskSnapshotPrefix(t *testing.T) {
-	artifact, err := NewManagedImageArtifact("Linux", "fakeResourceGroup", "fakeName", "fakeLocation", "fakeID", "fakeOsDiskSnapshotName", "", "fakeSharedImageGalleryId")
+	artifact, err := NewManagedImageArtifact("Linux", "fakeResourceGroup", "fakeName", "fakeLocation", "fakeID", "fakeOsDiskSnapshotName", "")
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
@@ -102,7 +100,6 @@ ManagedImageName: fakeName
 ManagedImageId: fakeID
 ManagedImageLocation: fakeLocation
 ManagedImageOSDiskSnapshotName: fakeOsDiskSnapshotName
-ManagedImageSharedImageGalleryId: fakeSharedImageGalleryId
 `
 
 	result := artifact.String()
@@ -111,8 +108,8 @@ ManagedImageSharedImageGalleryId: fakeSharedImageGalleryId
 	}
 }
 
-func TestArtifactIDManagedImageWithoutSharedImageGalleryId(t *testing.T) {
-	artifact, err := NewManagedImageArtifact("Linux", "fakeResourceGroup", "fakeName", "fakeLocation", "fakeID", "fakeOsDiskSnapshotName", "fakeDataDiskSnapshotPrefix", "")
+func TestArtifactIDManagedImageWithSharedImageGalleryId(t *testing.T) {
+	artifact, err := NewManagedImageArtifactWithSIGAsDestination("Linux", "fakeResourceGroup", "fakeName", "fakeLocation", "fakeID", "fakeOsDiskSnapshotName", "fakeDataDiskSnapshotPrefix", "fakeSharedImageGallery")
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
@@ -126,6 +123,7 @@ ManagedImageId: fakeID
 ManagedImageLocation: fakeLocation
 ManagedImageOSDiskSnapshotName: fakeOsDiskSnapshotName
 ManagedImageDataDiskSnapshotPrefix: fakeDataDiskSnapshotPrefix
+ManagedImageSharedImageGalleryId: fakeSharedImageGallery
 `
 
 	result := artifact.String()

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -302,7 +302,10 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 
 	if b.config.isManagedImage() {
 		managedImageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s", b.config.SubscriptionID, b.config.ManagedImageResourceGroupName, b.config.ManagedImageName)
-		return NewManagedImageArtifact(b.config.OSType, b.config.ManagedImageResourceGroupName, b.config.ManagedImageName, b.config.manageImageLocation, managedImageID, b.config.ManagedImageOSDiskSnapshotName, b.config.ManagedImageDataDiskSnapshotPrefix, b.stateBag.Get(constants.ArmManagedImageSharedGalleryId).(string))
+		if b.config.SharedGalleryDestination.SigDestinationGalleryName != "" {
+			return NewManagedImageArtifactWithSIGAsDestination(b.config.OSType, b.config.ManagedImageResourceGroupName, b.config.ManagedImageName, b.config.manageImageLocation, managedImageID, b.config.ManagedImageOSDiskSnapshotName, b.config.ManagedImageDataDiskSnapshotPrefix, b.stateBag.Get(constants.ArmManagedImageSharedGalleryId).(string))
+		}
+		return NewManagedImageArtifact(b.config.OSType, b.config.ManagedImageResourceGroupName, b.config.ManagedImageName, b.config.manageImageLocation, managedImageID, b.config.ManagedImageOSDiskSnapshotName, b.config.ManagedImageDataDiskSnapshotPrefix)
 	} else if template, ok := b.stateBag.GetOk(constants.ArmCaptureTemplate); ok {
 		return NewArtifact(
 			template.(*CaptureTemplate),


### PR DESCRIPTION
I have tested locally with managed image being published to Azure Shared Image Gallery and a managed image not being published to Azure Shared Image Gallery. 

@SwampDragons This should unblock folks NOT publishing to Azure Shared Image Gallery who were running into errors. 

