### PR TITLE
better error handling when using interpolate funcs; don't swallow fun…

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -3,6 +3,7 @@ package packer
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	ttmp "text/template"
 
@@ -367,12 +368,10 @@ func (c *Core) init() error {
 				ctx.UserVariables = c.variables
 			case ttmp.ExecError:
 				castError := err.(ttmp.ExecError)
-				switch castError.Err.(type) {
-				case interpolate.ErrVariableNotSet:
+				if strings.Contains(castError.Error(), interpolate.ErrVariableNotSetString) {
 					shouldRetry = true
 					failedInterpolation = fmt.Sprintf(`"%s": "%s"; error: %s`, k, v, err)
-					continue
-				default:
+				} else {
 					return err
 				}
 			default:

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -47,6 +47,14 @@ var FuncGens = map[string]FuncGenerator{
 	"lower": funcGenPrimitive(strings.ToLower),
 }
 
+type ErrVariableNotSet struct {
+	Var string // Name of template.
+}
+
+func (e ErrVariableNotSet) Error() string {
+	return fmt.Sprintf("variable %s not set", e.Var)
+}
+
 // FuncGenerator is a function that given a context generates a template
 // function for the template.
 type FuncGenerator func(*Context) interface{}
@@ -168,7 +176,7 @@ func funcGenUser(ctx *Context) interface{} {
 			// error and retry if we're interpolating UserVariables. But if
 			// we're elsewhere in the template, just return the empty string.
 			if !ok {
-				return "", errors.New(fmt.Sprintf("variable %s not set", k))
+				return "", ErrVariableNotSet{k}
 			}
 		}
 		return val, nil

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -47,13 +47,7 @@ var FuncGens = map[string]FuncGenerator{
 	"lower": funcGenPrimitive(strings.ToLower),
 }
 
-type ErrVariableNotSet struct {
-	Var string // Name of template.
-}
-
-func (e ErrVariableNotSet) Error() string {
-	return fmt.Sprintf("variable %s not set", e.Var)
-}
+var ErrVariableNotSetString = "Error: variable not set:"
 
 // FuncGenerator is a function that given a context generates a template
 // function for the template.
@@ -176,7 +170,7 @@ func funcGenUser(ctx *Context) interface{} {
 			// error and retry if we're interpolating UserVariables. But if
 			// we're elsewhere in the template, just return the empty string.
 			if !ok {
-				return "", ErrVariableNotSet{k}
+				return "", fmt.Errorf("%s %s", ErrVariableNotSetString, k)
 			}
 		}
 		return val, nil


### PR DESCRIPTION
Previously, the specific template execution errors thrown by interpolate functions were getting swallowed, making debugging harder.

closes #7838