### PR TITLE
use box_name instead of source_path when generating vagrant file

### DIFF
--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -199,7 +199,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&StepCreateVagrantfile{
 			Template:     b.config.Template,
 			SyncedFolder: b.config.SyncedFolder,
-			SourceBox:    b.config.SourceBox,
+			BoxName:      b.config.BoxName,
 			OutputDir:    b.config.OutputDir,
 			GlobalID:     b.config.GlobalID,
 		},

--- a/builder/vagrant/step_create_vagrantfile.go
+++ b/builder/vagrant/step_create_vagrantfile.go
@@ -14,10 +14,10 @@ import (
 
 type StepCreateVagrantfile struct {
 	Template     string
-	SourceBox    string
 	OutputDir    string
 	SyncedFolder string
 	GlobalID     string
+	BoxName      string
 }
 
 var DEFAULT_TEMPLATE = `Vagrant.configure("2") do |config|
@@ -56,7 +56,7 @@ func (s *StepCreateVagrantfile) createVagrantfile() (string, error) {
 
 	opts := &VagrantfileOptions{
 		SyncedFolder: s.SyncedFolder,
-		BoxName:      s.SourceBox,
+		BoxName:      s.BoxName,
 	}
 
 	err = tpl.Execute(templateFile, opts)

--- a/builder/vagrant/step_create_vagrantfile_test.go
+++ b/builder/vagrant/step_create_vagrantfile_test.go
@@ -20,7 +20,7 @@ func TestStepCreateVagrantfile_Impl(t *testing.T) {
 func TestCreateFile(t *testing.T) {
 	testy := StepCreateVagrantfile{
 		OutputDir: "./",
-		SourceBox: "bananas",
+		BoxName:   "bananas",
 	}
 	templatePath, err := testy.createVagrantfile()
 	if err != nil {


### PR DESCRIPTION
Use box name, not source path, as documented

Closes #7844 