### PR TITLE
Use context for timeouts, interruption in ssh and winrm communicators

### DIFF
--- a/helper/communicator/step_connect_winrm.go
+++ b/helper/communicator/step_connect_winrm.go
@@ -33,23 +33,23 @@ type StepConnectWinRM struct {
 	WinRMPort   func(multistep.StateBag) (int, error)
 }
 
-func (s *StepConnectWinRM) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepConnectWinRM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
 	var comm packer.Communicator
 	var err error
 
-	cancel := make(chan struct{})
+	subCtx, cancel := context.WithCancel(ctx)
 	waitDone := make(chan bool, 1)
 	go func() {
 		ui.Say("Waiting for WinRM to become available...")
-		comm, err = s.waitForWinRM(state, cancel)
+		comm, err = s.waitForWinRM(state, subCtx)
+		cancel() // just to make 'possible context leak' analysis happy
 		waitDone <- true
 	}()
 
 	log.Printf("Waiting for WinRM, up to timeout: %s", s.Config.WinRMTimeout)
 	timeout := time.After(s.Config.WinRMTimeout)
-WaitLoop:
 	for {
 		// Wait for either WinRM to become available, a timeout to occur,
 		// or an interrupt to come through.
@@ -62,39 +62,40 @@ WaitLoop:
 
 			ui.Say("Connected to WinRM!")
 			state.Put("communicator", comm)
-			break WaitLoop
+			return multistep.ActionContinue
 		case <-timeout:
 			err := fmt.Errorf("Timeout waiting for WinRM.")
 			state.Put("error", err)
 			ui.Error(err.Error())
-			close(cancel)
+			cancel()
+			return multistep.ActionHalt
+		case <-ctx.Done():
+			// The step sequence was cancelled, so cancel waiting for WinRM
+			// and just start the halting process.
+			cancel()
+			log.Println("Interrupt detected, quitting waiting for WinRM.")
 			return multistep.ActionHalt
 		case <-time.After(1 * time.Second):
-			if _, ok := state.GetOk(multistep.StateCancelled); ok {
-				// The step sequence was cancelled, so cancel waiting for WinRM
-				// and just start the halting process.
-				close(cancel)
-				log.Println("Interrupt detected, quitting waiting for WinRM.")
-				return multistep.ActionHalt
-			}
 		}
 	}
-
-	return multistep.ActionContinue
 }
 
 func (s *StepConnectWinRM) Cleanup(multistep.StateBag) {
 }
 
-func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, cancel <-chan struct{}) (packer.Communicator, error) {
-	ctx := context.TODO()
+func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, ctx context.Context) (packer.Communicator, error) {
 	var comm packer.Communicator
+	first := true
 	for {
-		select {
-		case <-cancel:
-			log.Println("[INFO] WinRM wait cancelled. Exiting loop.")
-			return nil, errors.New("WinRM wait cancelled")
-		case <-time.After(5 * time.Second):
+		// Don't check for cancel or wait on first iteration
+		if !first {
+			select {
+			case <-ctx.Done():
+				log.Println("[INFO] WinRM wait cancelled. Exiting loop.")
+				return nil, errors.New("WinRM wait cancelled")
+			case <-time.After(5 * time.Second):
+			}
+			first = false
 		}
 
 		host, err := s.Host(state)
@@ -157,7 +158,7 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, cancel <-chan 
 		cmd.Stdout = &buf
 		cmd.Stdout = io.MultiWriter(cmd.Stdout, &buf2)
 		select {
-		case <-cancel:
+		case <-ctx.Done():
 			log.Println("WinRM wait canceled, exiting loop")
 			return comm, fmt.Errorf("WinRM wait canceled")
 		case <-time.After(retryableSleep):


### PR DESCRIPTION
Also don't waste 5 seconds waiting before first winrm connection attempt
Minor code cleanup as well