### PR TITLE
Fix intense cpu usage in vmware plugin

### DIFF
--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"math"
 	"net"
@@ -1962,7 +1961,9 @@ func consumeFile(fd *os.File) (chan byte, sentinelSignaller) {
 		b := make([]byte, 1)
 		for {
 			_, err := fd.Read(b)
-			if err == io.EOF {
+			if err != nil {
+				// In case of any error we must stop
+				// ErrClosed may appear since file is closed and this goroutine still left running
 				break
 			}
 			fromfile <- b[0]


### PR DESCRIPTION
I've observed 300-400% CPU usage while packer was on step 'Waiting for SSH to become available...' 
Hence I've downloaded sources, [added some runtime profiling using pprof](https://gist.github.com/VladRassokhin/271d577ebb5a218fcefcd14134a696f8). 
Allocation profiling ([step-connect.allocs.gz](https://github.com/hashicorp/packer/files/3397177/step-connect.allocs.gz)) showed that 4.7 TB was allocated by `github.com/hashicorp/packer/builder/vmware/common.tokenizeNetworkingConfig.func1`. 
But better view is 'alloc_objects' which shows:
```
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                           3244180   100% |   os.(*File).Read /usr/local/Cellar/go/1.12.7/libexec/src/os/file.go:109
   3244180 47.67% 47.67%    3244180 47.67%                | os.(*File).wrapErr /usr/local/Cellar/go/1.12.7/libexec/src/os/file.go:317
----------------------------------------------------------+-------------
   3172779 46.62% 94.29%    3172779 46.62%                | github.com/hashicorp/packer/builder/vmware/common.tokenizeNetworkingConfig.func1 /Users/vladislav.rassokhin/GolandProjects/packer/builder/vmware/common/driver_parser.go:1153
----------------------------------------------------------+-------------
  .... skipped ....
----------------------------------------------------------+-------------
     16385  0.24% 97.42%      16385  0.24%                | github.com/hashicorp/packer/builder/vmware/common.consumeFile.func1 /Users/vladislav.rassokhin/GolandProjects/packer/builder/vmware/common/driver_parser.go:1968
----------------------------------------------------------+-------------
```

Too many allocated objects in wrapErr is suspicious, I've read code and find out that  'consumeFile.func1' was ignoring errors. File was closed by https://github.com/hashicorp/packer/blob/4ea3d1567a6e3f0b6dace64bb411733b2a3abc8c/builder/vmware/common/driver_fusion6.go#L109 while goroutine (actually four of them created in `driver.ReadNetworkingConfig` keep running).

My patch (see commit) resolved issue, I've tested that.