### PR TITLE
Correct HTTPIP == FALSE on HyperV builder

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -35,7 +35,7 @@ param([string]$switchName, [int]$addressIndex)
 
 $HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName
 if ($HostVMAdapter){
-    $HostNetAdapter = Get-NetAdapter | ?{ $HostVMAdapter.DeviceId.Contains($_.DeviceID) }
+    $HostNetAdapter = Get-NetAdapter | ?{ $_.DeviceId -eq $HostVMAdapter.DeviceId }
     if ($HostNetAdapter){
         $HostNetAdapterIfIndex = @()
         $HostNetAdapterIfIndex +=  $HostNetAdapter.ifIndex


### PR DESCRIPTION
PowerShell script contained a typo, that resulted in no network adapters matching the DeviceId of the ManagementOs switch. This appears to have been in the code immediately following the original port. This correction resolves #5023 for me.

May close: #5023 
