### PR TITLE
use filepath.clean to catch any ugliness with multiple slashes that m…

### DIFF
--- a/common/iso_config.go
+++ b/common/iso_config.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	getter "github.com/hashicorp/go-getter"
@@ -77,7 +78,7 @@ func (c *ISOConfig) Prepare(ctx *interpolate.Context) (warnings []string, errs [
 		errs = append(errs, fmt.Errorf("A checksum must be specified"))
 	}
 	if c.ISOChecksumType == "file" {
-		u, err := url.Parse(c.ISOUrls[0])
+		u, err := url.Parse(filepath.Clean(c.ISOUrls[0]))
 		wd, err := os.Getwd()
 		if err != nil {
 			log.Printf("get working directory: %v", err)

--- a/common/step_download.go
+++ b/common/step_download.go
@@ -117,7 +117,7 @@ func (s *StepDownload) download(ctx context.Context, ui packer.Ui, source string
 		}
 	}
 
-	u, err := urlhelper.Parse(source)
+	u, err := urlhelper.Parse(filepath.Clean(source))
 	if err != nil {
 		return "", fmt.Errorf("url parse: %s", err)
 	}


### PR DESCRIPTION
Use filepath.Clean to fix up any duplicate slashes so that we can stat the file properly.

Closes #7714