### PR TITLE
Allow removing volume after image creation for Scaleway builder

### DIFF
--- a/builder/scaleway/builder.go
+++ b/builder/scaleway/builder.go
@@ -52,6 +52,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Debug:        b.config.PackerDebug,
 			DebugKeyPath: fmt.Sprintf("scw_%s.pem", b.config.PackerBuildName),
 		},
+		new(stepRemoveVolume),
 		new(stepCreateServer),
 		new(stepServerInfo),
 		&communicator.StepConnect{

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	Bootscript   string `mapstructure:"bootscript"`
 	BootType     string `mapstructure:"boottype"`
 
+	RemoveVolume bool `mapstructure:"remove_volume"`
+
 	UserAgent string
 	ctx       interpolate.Context
 }

--- a/builder/scaleway/step_remove_volume.go
+++ b/builder/scaleway/step_remove_volume.go
@@ -18,6 +18,12 @@ func (s *stepRemoveVolume) Run(ctx context.Context, state multistep.StateBag) mu
 }
 
 func (s *stepRemoveVolume) Cleanup(state multistep.StateBag) {
+	if _, ok := state.GetOk("snapshot_name"); !ok {
+		// volume will be detached to server only after sharpshooting ... so we don't
+		// need to remove volume before snapshot step.
+		return
+	}
+
 	client := state.Get("client").(*api.ScalewayAPI)
 	ui := state.Get("ui").(packer.Ui)
 	c := state.Get("config").(*Config)

--- a/builder/scaleway/step_remove_volume.go
+++ b/builder/scaleway/step_remove_volume.go
@@ -19,7 +19,7 @@ func (s *stepRemoveVolume) Run(ctx context.Context, state multistep.StateBag) mu
 
 func (s *stepRemoveVolume) Cleanup(state multistep.StateBag) {
 	if _, ok := state.GetOk("snapshot_name"); !ok {
-		// volume will be detached to server only after sharpshooting ... so we don't
+		// volume will be detached from server only after snapshotting ... so we don't
 		// need to remove volume before snapshot step.
 		return
 	}

--- a/builder/scaleway/step_remove_volume.go
+++ b/builder/scaleway/step_remove_volume.go
@@ -1,0 +1,38 @@
+package scaleway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/scaleway/scaleway-cli/pkg/api"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+type stepRemoveVolume struct{}
+
+func (s *stepRemoveVolume) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	// nothing to do ... only cleanup interests us
+	return multistep.ActionContinue
+}
+
+func (s *stepRemoveVolume) Cleanup(state multistep.StateBag) {
+	client := state.Get("client").(*api.ScalewayAPI)
+	ui := state.Get("ui").(packer.Ui)
+	c := state.Get("config").(*Config)
+	volumeID := state.Get("root_volume_id").(string)
+
+	if !c.RemoveVolume {
+		return
+	}
+
+	ui.Say("Removing Volume ...")
+
+	err := client.DeleteVolume(volumeID)
+	if err != nil {
+		err := fmt.Errorf("Error removing volume: %s", err)
+		state.Put("error", err)
+		ui.Error(fmt.Sprintf("Error removing volume: %s. (Ignored)", err))
+	}
+}

--- a/website/source/docs/builders/scaleway.html.md
+++ b/website/source/docs/builders/scaleway.html.md
@@ -74,10 +74,13 @@ builder.
     appear in your account. Default `packer-TIMESTAMP`
 
 -   `boottype` (string) - The type of boot, can be either `local` or
-    `bootscript`, Default `bootscript`
+    `bootscript`. Default `bootscript`
 
 -   `bootscript` (string) - The id of an existing bootscript to use when
     booting the server.
+
+-   `remove_volume` (boolean) - Force Packer to delete volume associated with 
+    the resulting snapshot after the build. Default `false`.
 
 ## Basic Example
 


### PR DESCRIPTION
This PR adds an optional step to the Scaleway builder to automatically delete the instance volume when the image is successfully created.  
This can be enabled using the builder parameter `remove_volume`.