### PR TITLE
Use inspec --input-file instead of --attrs to avoid deprecation warning

### DIFF
--- a/provisioner/inspec/provisioner.go
+++ b/provisioner/inspec/provisioner.go
@@ -342,7 +342,7 @@ func (p *Provisioner) executeInspec(ui packer.Ui, comm packer.Communicator, priv
 		args = append(args, "--port", strconv.Itoa(p.config.LocalPort))
 	}
 
-	args = append(args, "--attrs")
+	args = append(args, "--input-file")
 	args = append(args, p.config.AttributesFiles...)
 	args = append(args, p.config.ExtraArguments...)
 

--- a/website/source/docs/provisioners/inspec.html.md.erb
+++ b/website/source/docs/provisioners/inspec.html.md.erb
@@ -67,15 +67,15 @@ Optional Parameters:
     ```
 
 -   `attributes` (array of strings) - Attribute Files used by InSpec which will
-    be passed to the `--attrs` argument of the `inspec` command when this
+    be passed to the `--input-file` argument of the `inspec` command when this
     provisioner runs InSpec. Specify this if you want a different location.
-    Note using also `"--attrs"` in `extra_arguments` will override this
+    Note using also `"--input-file"` in `extra_arguments` will override this
     setting.
 
 -   `attributes_directory` (string) - The directory in which to place the
     temporary generated InSpec Attributes file. By default, this is the
     system-specific temporary file location. The fully-qualified name of this
-    temporary file will be passed to the `--attrs` argument of the `inspec`
+    temporary file will be passed to the `--input-file` argument of the `inspec`
     command when this provisioner runs InSpec. Specify this if you want a
     different location.
 


### PR DESCRIPTION
The Packer InSpec provisioner shows this deprecation warning since https://github.com/inspec/inspec/pull/3875 got merged into InSpec.

```
hyperv-iso: [2019-07-22T06:35:59+00:00] WARN: DEPRECATION: InSpec Attributes are being renamed to InSpec Inputs to avoid confusion with Chef Attributes. Use --input-file on the command line instead of --attrs.
```

This PR changes the `inspec exec` call to use `--input-file` instead of `--attrs`.
 