### PR TITLE
Fixer Housekeeping

### DIFF
--- a/command/fix.go
+++ b/command/fix.go
@@ -120,46 +120,16 @@ Usage: packer fix [options] TEMPLATE
   If the template cannot be fixed due to an error, the command will exit
   with a non-zero exit status. Error messages will appear on standard error.
 
-Fixes that are run:
+Fixes that are run (in order):
 
-  iso-md5                    Replaces "iso_md5" in builders with newer
-                             "iso_checksum"
-  createtime                 Replaces ".CreateTime" in builder configs with
-                             "{{timestamp}}"
-  virtualbox-gaattach        Updates VirtualBox builders using
-                             "guest_additions_attach" to use
-                             "guest_additions_mode"
-  pp-vagrant-override        Replaces old-style provider overrides for the
-                             Vagrant post-processor to new-style as of Packer
-                             0.5.0.
-  virtualbox-rename          Updates "virtualbox" builders to "virtualbox-iso"
-  vmware-rename              Updates "vmware" builders to "vmware-iso"
-  parallels-headless         Removes unused "headless" setting from Parallels
-                             builders
-  parallels-deprecations     Removes deprecated "parallels_tools_host_path" from
-                             Parallels builders
-  sshkeypath                 Updates builders using "ssh_key_path" to use
-                             "ssh_private_key_file"
-  sshdisableagent            Updates builders using "ssh_disable_agent" to use
-                             "ssh_disable_agent_forwarding"
-  manifest-filename          Updates "manifest" post-processor so any "filename"
-                             field is renamed to "output"
-  amazon-shutdown_behavior   Changes "shutdown_behaviour" to "shutdown_behavior"
-                             in Amazon builders
-  amazon-enhanced-networking Replaces "enhanced_networking" in builders with
-                             "ena_support"
-  amazon-private-ip          Replaces "ssh_private_ip": true in amazon builders
-                             with "ssh_interface": "private_ip"
-  docker-email               Removes "login_email" from the Docker builder
-  powershell-escapes         Removes PowerShell escapes from user env vars and
-                             elevated username and password strings
-  hyperv-deprecations        Removes the deprecated "vhd_temp_path" setting from
-                             Hyper-V ISO builder templates
-  hyperv-vmxc-typo           Corrects a typo in the "clone_from_vmxc_path"
-                             setting. Replaces with "clone_from_vmcx_path".
-  vmware-compaction          Adds "skip_compaction = true" to "vmware-iso"
-                             builders with incompatible disk_type_id
+`
 
+	for _, name := range fix.FixerOrder {
+		helpText += fmt.Sprintf(
+			"\t%-30s\t%s\n",name, fix.Fixers[name].Synopsis())
+	}
+
+	helpText += `
 Options:
 
   -validate=true      If true (default), validates the fixed template.

--- a/command/fix.go
+++ b/command/fix.go
@@ -126,7 +126,7 @@ Fixes that are run (in order):
 
 	for _, name := range fix.FixerOrder {
 		helpText += fmt.Sprintf(
-			"\t%-30s\t%s\n",name, fix.Fixers[name].Synopsis())
+			"  %-27s%s\n", name, fix.Fixers[name].Synopsis())
 	}
 
 	helpText += `

--- a/command/fix_test.go
+++ b/command/fix_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"github.com/hashicorp/packer/fix"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -60,29 +59,5 @@ func TestFix_invalidTemplateDisableValidation(t *testing.T) {
 	}
 	if code := c.Run(args); code != 0 {
 		fatalCommand(t, c.Meta)
-	}
-}
-
-func TestFix_allFixersEnabled(t *testing.T) {
-	f := fix.Fixers
-	o := fix.FixerOrder
-
-	if len(f) != len(o) {
-		t.Fatalf("Fixers length (%d) does not match FixerOrder length (%d)", len(f), len(o))
-	}
-
-	for fixer, _ := range f {
-		found := false
-
-		for _, orderedFixer := range o {
-			if orderedFixer == fixer {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			t.Fatalf("Did not find Fixer %s in FixerOrder", fixer)
-		}
 	}
 }

--- a/command/fix_test.go
+++ b/command/fix_test.go
@@ -71,10 +71,10 @@ func TestFix_allFixersEnabled(t *testing.T) {
 		t.Fatalf("Fixers length (%d) does not match FixerOrder length (%d)", len(f), len(o))
 	}
 
-	for fixer, _ := range(f) {
+	for fixer, _ := range f {
 		found := false
 
-		for _, orderedFixer := range(o) {
+		for _, orderedFixer := range o {
 			if orderedFixer == fixer {
 				found = true
 				break

--- a/command/fix_test.go
+++ b/command/fix_test.go
@@ -70,4 +70,19 @@ func TestFix_allFixersEnabled(t *testing.T) {
 	if len(f) != len(o) {
 		t.Fatalf("Fixers length (%d) does not match FixerOrder length (%d)", len(f), len(o))
 	}
+
+	for fixer, _ := range(f) {
+		found := false
+
+		for _, orderedFixer := range(o) {
+			if orderedFixer == fixer {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			t.Fatalf("Did not find Fixer %s in FixerOrder", fixer)
+		}
+	}
 }

--- a/command/fix_test.go
+++ b/command/fix_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"github.com/hashicorp/packer/fix"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -59,5 +60,14 @@ func TestFix_invalidTemplateDisableValidation(t *testing.T) {
 	}
 	if code := c.Run(args); code != 0 {
 		fatalCommand(t, c.Meta)
+	}
+}
+
+func TestFix_allFixersEnabled(t *testing.T) {
+	f := fix.Fixers
+	o := fix.FixerOrder
+
+	if len(f) != len(o) {
+		t.Fatalf("Fixers length (%d) does not match FixerOrder length (%d)", len(f), len(o))
 	}
 }

--- a/fix/fixer.go
+++ b/fix/fixer.go
@@ -66,6 +66,8 @@ func init() {
 		"docker-email",
 		"powershell-escapes",
 		"vmware-compaction",
+		"hyperv-deprecations",
+		"hyperv-vmxc-typo",
 		"hyperv-cpu-and-ram",
 		"clean-image-name",
 		"spot-price-auto-product",

--- a/fix/fixer_parallels_deprecations.go
+++ b/fix/fixer_parallels_deprecations.go
@@ -54,6 +54,5 @@ func (FixerParallelsDeprecations) Fix(input map[string]interface{}) (map[string]
 }
 
 func (FixerParallelsDeprecations) Synopsis() string {
-	return `Removes deprecated "parallels_tools_host_path" from Parallels builders
-	and changes "guest_os_distribution" to "guest_os_type".`
+	return `Removes deprecated "parallels_tools_host_path" from Parallels builders and changes "guest_os_distribution" to "guest_os_type".`
 }

--- a/fix/fixer_test.go
+++ b/fix/fixer_test.go
@@ -1,0 +1,29 @@
+package fix
+
+import (
+	"testing"
+)
+
+func TestFix_allFixersEnabled(t *testing.T) {
+	f := Fixers
+	o := FixerOrder
+
+	if len(f) != len(o) {
+		t.Fatalf("Fixers length (%d) does not match FixerOrder length (%d)", len(f), len(o))
+	}
+
+	for fixer, _ := range f {
+		found := false
+
+		for _, orderedFixer := range o {
+			if orderedFixer == fixer {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			t.Fatalf("Did not find Fixer %s in FixerOrder", fixer)
+		}
+	}
+}


### PR DESCRIPTION
Finally found some breathing room to tackle #7322. I sat down to get familiar with the fixer code again and got pretty confused. The usage prints 19 fixers, the `FixerOrder` holds 22 fixers, and `Fixers` holds 24. So, this PR:

* Adds the two missing fixers to `FixerOrder` (removed by e8f04c3 - please scream if there's a good reason for that).
* Adds a test to make sure the lengths match and that every `Fixer` appears in `FixerOrder` (paranoia about duplicate entries in `FixerOrder` but it doesn't hurt to test).
* Updates the `Help()` function to dynamically generate the list of fixers, in order, along with their synopses.

There's some work left to make them consistent (some end with periods, some don't, some have stray backticks, others have missing whitespace) but this feels more suited to live with the bulk of #7322's work as it will touch each and every provider.

**Please note that this DOES change the description of fixers which were present in the usage.** The exact old and new formats are pasted below for convenience. Let me know if there's anything you want me to do about this immediately. I have no idea what standards/opinions you have around user-facing documentation. 😄 

---

```
Fixes that are run:
  iso-md5                    Replaces "iso_md5" in builders with newer	
                             "iso_checksum"	
  createtime                 Replaces ".CreateTime" in builder configs with	
                             "{{timestamp}}"	
  virtualbox-gaattach        Updates VirtualBox builders using	
                             "guest_additions_attach" to use	
                             "guest_additions_mode"	
  pp-vagrant-override        Replaces old-style provider overrides for the	
                             Vagrant post-processor to new-style as of Packer	
                             0.5.0.	
  virtualbox-rename          Updates "virtualbox" builders to "virtualbox-iso"	
  vmware-rename              Updates "vmware" builders to "vmware-iso"	
  parallels-headless         Removes unused "headless" setting from Parallels	
                             builders	
  parallels-deprecations     Removes deprecated "parallels_tools_host_path" from	
                             Parallels builders	
  sshkeypath                 Updates builders using "ssh_key_path" to use	
                             "ssh_private_key_file"	
  sshdisableagent            Updates builders using "ssh_disable_agent" to use	
                             "ssh_disable_agent_forwarding"	
  manifest-filename          Updates "manifest" post-processor so any "filename"	
                             field is renamed to "output"	
  amazon-shutdown_behavior   Changes "shutdown_behaviour" to "shutdown_behavior"	
                             in Amazon builders	
  amazon-enhanced-networking Replaces "enhanced_networking" in builders with	
                             "ena_support"	
  amazon-private-ip          Replaces "ssh_private_ip": true in amazon builders	
                             with "ssh_interface": "private_ip"	
  docker-email               Removes "login_email" from the Docker builder	
  powershell-escapes         Removes PowerShell escapes from user env vars and	
                             elevated username and password strings	
  hyperv-deprecations        Removes the deprecated "vhd_temp_path" setting from	
                             Hyper-V ISO builder templates	
  hyperv-vmxc-typo           Corrects a typo in the "clone_from_vmxc_path"	
                             setting. Replaces with "clone_from_vmcx_path".	
  vmware-compaction          Adds "skip_compaction = true" to "vmware-iso"	
                             builders with incompatible disk_type_id
```

becomes

```
Fixes that are run (in order):

  iso-md5                    Replaces "iso_md5" in builders with "iso_checksum"
  createtime                 Replaces ".CreateTime" in builder configs with "{{timestamp}}"
  virtualbox-gaattach        Updates VirtualBox builders using "guest_additions_attach" to use "guest_additions_mode"
  pp-vagrant-override        Fixes provider-specific overrides for Vagrant post-processor
  virtualbox-rename          Updates "virtualbox" builders to "virtualbox-iso"
  vmware-rename              Updates "vmware" builders to "vmware-iso"
  parallels-headless         Removes unused "headless" from Parallels builders
  parallels-deprecations     Removes deprecated "parallels_tools_host_path" from Parallels builders and changes "guest_os_distribution" to "guest_os_type".
  sshkeypath                 Updates builders using "ssh_key_path" to use "ssh_private_key_file"
  sshdisableagent            Updates builders using "ssh_disable_agent" to use "ssh_disable_agent_forwarding"
  scaleway-access-key        Updates builders using "access_key" to use "organization_id"
  manifest-filename          Updates "manifest" post-processor so any "filename" field is renamed to "output".
  amazon-shutdown_behavior   Changes "shutdown_behaviour" to "shutdown_behavior" in Amazon builders.
  amazon-enhanced-networking Replaces "enhanced_networking" in builders with "ena_support"
  amazon-private-ip          Replaces `"ssh_private_ip": true` in amazon builders with `"ssh_interface": "private_ip"`
  amazon-temp-sec-cidrs      Replaces "temporary_security_group_source_cidr" (string) with "temporary_security_group_source_cidrs" (list of strings)
  docker-email               Removes "login_email" from the Docker builder.
  powershell-escapes         Removes PowerShell escapes from user env vars and elevated username and password strings
  vmware-compaction          Adds "skip_compaction = true" to "vmware-iso" builders with incompatible disk_type_id
  hyperv-deprecations        Removes the deprecated "vhd_temp_path" setting from Hyper-V ISO builder templates
  hyperv-vmxc-typo           Fixes a typo replacing "clone_from_vmxc_path" with "clone_from_vmcx_path" in Hyper-V VMCX builder templates
  hyperv-cpu-and-ram         Replaces "cpu" with "cpus" and "ram_size" with "memory"in Hyper-V VMCX builder templates
  clean-image-name           Replaces /clean_(image|ami)_name/ in builder configs with "clean_resource_name"
  spot-price-auto-product    Removes the deprecated "spot_price_auto_product" setting from Amazon builder templates
```