### PR TITLE
[WIP] Red herring eof abort

### DIFF
--- a/common/multistep_runner.go
+++ b/common/multistep_runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -71,28 +70,8 @@ func (s abortStep) Run(ctx context.Context, state multistep.StateBag) multistep.
 }
 
 func (s abortStep) Cleanup(state multistep.StateBag) {
-	_, alreadyLogged := state.GetOk("abort_step_logged")
-	err, ok := state.GetOk("error")
-	if ok && !alreadyLogged {
-		s.ui.Error(fmt.Sprintf("%s", err))
-		state.Put("abort_step_logged", true)
-	}
-	if _, ok := state.GetOk(multistep.StateCancelled); ok {
-		if !alreadyLogged {
-			s.ui.Error("Interrupted, aborting...")
-			state.Put("abort_step_logged", true)
-		} else {
-			s.ui.Error(fmt.Sprintf("aborted: skipping cleanup of step %q", typeName(s.step)))
-		}
-		return
-	}
-	if _, ok := state.GetOk(multistep.StateHalted); ok {
-		if !alreadyLogged {
-			s.ui.Error(fmt.Sprintf("Step %q failed, aborting...", typeName(s.step)))
-			state.Put("abort_step_logged", true)
-		} else {
-			s.ui.Error(fmt.Sprintf("aborted: skipping cleanup of step %q", typeName(s.step)))
-		}
+	shouldCleanup := handleAbortsAndInterupts(state, s.ui, typeName(s.step))
+	if !shouldCleanup {
 		return
 	}
 	s.step.Cleanup(state)
@@ -124,7 +103,8 @@ func (s askStep) Run(ctx context.Context, state multistep.StateBag) (action mult
 		case askCleanup:
 			return
 		case askAbort:
-			os.Exit(1)
+			state.Put("aborted", true)
+			return
 		case askRetry:
 			continue
 		}
@@ -132,6 +112,12 @@ func (s askStep) Run(ctx context.Context, state multistep.StateBag) (action mult
 }
 
 func (s askStep) Cleanup(state multistep.StateBag) {
+	if _, ok := state.GetOk("aborted"); ok {
+		shouldCleanup := handleAbortsAndInterupts(state, s.ui, typeName(s.step))
+		if !shouldCleanup {
+			return
+		}
+	}
 	s.step.Cleanup(state)
 }
 
@@ -181,4 +167,34 @@ func askPrompt(ui packer.Ui) askResponse {
 		}
 		ui.Say(fmt.Sprintf("Incorrect input: %#v", line))
 	}
+}
+
+func handleAbortsAndInterupts(state multistep.StateBag, ui packer.Ui, stepName string) bool {
+	// if returns false, don't run cleanup. If true, do run cleanup.
+	_, alreadyLogged := state.GetOk("abort_step_logged")
+
+	err, ok := state.GetOk("error")
+	if ok && !alreadyLogged {
+		ui.Error(fmt.Sprintf("%s", err))
+		state.Put("abort_step_logged", true)
+	}
+	if _, ok := state.GetOk(multistep.StateCancelled); ok {
+		if !alreadyLogged {
+			ui.Error("Interrupted, aborting...")
+			state.Put("abort_step_logged", true)
+		} else {
+			ui.Error(fmt.Sprintf("aborted: skipping cleanup of step %q", stepName))
+		}
+		return false
+	}
+	if _, ok := state.GetOk(multistep.StateHalted); ok {
+		if !alreadyLogged {
+			ui.Error(fmt.Sprintf("Step %q failed, aborting...", stepName))
+			state.Put("abort_step_logged", true)
+		} else {
+			ui.Error(fmt.Sprintf("aborted: skipping cleanup of step %q", stepName))
+		}
+		return false
+	}
+	return true
 }

--- a/log.go
+++ b/log.go
@@ -35,6 +35,9 @@ func logOutput() (logOutput io.Writer, err error) {
 					if strings.Contains(scanner.Text(), "ui:") {
 						continue
 					}
+					if strings.Contains(scanner.Text(), "ui error:") {
+						continue
+					}
 					os.Stderr.WriteString(fmt.Sprint(scanner.Text() + "\n"))
 				}
 			}(scanner)


### PR DESCRIPTION
When -on-error=abort is set, we call os.Exit(1) during the multistep runner cleanup. This makes the builder plugin disconnect uncleanly from the core, which causes an EOF error. I think this is a really confusing error that may mask for users the actual issues with their build, so I've tidied it away to make the abort step still skip cleanup but not exit out of the builder process prematurely.

This also contains a very small optimaziton to log.go to make packer output easier to read when streaming the logs through the console along with the UI.

Example output (PACKER_LOG=0) before change. Note the EOF

<img width="1026" alt="Screen Shot 2019-07-25 at 4 48 10 PM" src="https://user-images.githubusercontent.com/1008838/61916222-8c478600-aefc-11e9-88ab-3b82880d3fb4.png">

Example output (PACKER_LOG=0) after change. Note the EOF is gone and we also log which steps we are not cleaning up.

<img width="1043" alt="Screen Shot 2019-07-25 at 4 45 45 PM" src="https://user-images.githubusercontent.com/1008838/61916218-83ef4b00-aefc-11e9-96f9-279c67843a8c.png">


