### PR TITLE
These cancel functions have been obsolete since March 2019

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -343,16 +343,6 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 	return nil
 }
 
-func (p *Provisioner) Cancel() {
-	if p.done != nil {
-		close(p.done)
-	}
-	if p.adapter != nil {
-		p.adapter.Shutdown()
-	}
-	os.Exit(0)
-}
-
 func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, privKeyFile string) error {
 	playbook, _ := filepath.Abs(p.config.PlaybookFile)
 	inventory := p.config.InventoryFile

--- a/provisioner/breakpoint/provisioner.go
+++ b/provisioner/breakpoint/provisioner.go
@@ -3,7 +3,6 @@ package breakpoint
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"golang.org/x/sync/errgroup"
 
@@ -78,9 +77,4 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		return err
 	}
 	return nil
-}
-
-func (p *Provisioner) Cancel() {
-	// Just hard quit.
-	os.Exit(0)
 }

--- a/provisioner/converge/provisioner.go
+++ b/provisioner/converge/provisioner.go
@@ -234,9 +234,3 @@ func (p *Provisioner) applyModules(ui packer.Ui, comm packer.Communicator) error
 
 	return nil
 }
-
-// Cancel the provisioning process
-func (p *Provisioner) Cancel() {
-	// there's not an awful lot we can do to cancel Converge at the moment.
-	// The default semantics are fine.
-}

--- a/provisioner/inspec/provisioner.go
+++ b/provisioner/inspec/provisioner.go
@@ -317,15 +317,6 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 
 	return nil
 }
-func (p *Provisioner) Cancel() {
-	if p.done != nil {
-		close(p.done)
-	}
-	if p.adapter != nil {
-		p.adapter.Shutdown()
-	}
-	os.Exit(0)
-}
 
 func (p *Provisioner) executeInspec(ui packer.Ui, comm packer.Communicator, privKeyFile string) error {
 	var envvars []string

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -305,12 +305,6 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 	return nil
 }
 
-func (p *Provisioner) Cancel() {
-	// Just hard quit. It isn't a big deal if what we're doing keeps running
-	// on the other side.
-	os.Exit(0)
-}
-
 // Environment variables required within the remote environment are uploaded
 // within a PS script and then enabled by 'dot sourcing' the script
 // immediately prior to execution of the main command

--- a/provisioner/shell-local/provisioner.go
+++ b/provisioner/shell-local/provisioner.go
@@ -30,7 +30,3 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, _ packer.Comm
 
 	return retErr
 }
-
-func (p *Provisioner) Cancel() {
-	// Just do nothing. When the process ends, so will our provisioner
-}

--- a/provisioner/sleep/provisioner.go
+++ b/provisioner/sleep/provisioner.go
@@ -26,5 +26,3 @@ func (p *Provisioner) Provision(ctx context.Context, _ packer.Ui, _ packer.Commu
 		return nil
 	}
 }
-
-func (p *Provisioner) Cancel() {}


### PR DESCRIPTION
We removed the Cancel() func from the provisioner interface in c7ce4d598e50d455e8b8383c36dc2ac3b324ebd3, so these functions are never called. Cancellation is now handled through passing contexts.