### PR TITLE
Support for SSH port tunneling

### DIFF
--- a/communicator/ssh/tunnel.go
+++ b/communicator/ssh/tunnel.go
@@ -1,0 +1,71 @@
+package ssh
+
+import (
+	"io"
+	"log"
+	"net"
+)
+
+// ProxyServe starts Accepting connections
+func ProxyServe(l net.Listener, done <-chan struct{}, dialer func() (net.Conn, error)) {
+	for {
+		// Accept will return if either the underlying connection is closed or if a connection is made.
+		// after returning, check to see if c.done can be received. If so, then Accept() returned because
+		// the connection has been closed.
+		client, err := l.Accept()
+		select {
+		case <-done:
+			log.Printf("[WARN] Tunnel: received Done event: %v", err)
+			return
+		default:
+			if err != nil {
+				log.Printf("[ERROR] Tunnel: listen.Accept failed: %v", err)
+				continue
+			}
+			log.Printf("[DEBUG] Tunnel: client '%s' accepted", client.RemoteAddr())
+			// Proxy bytes from one side to the other
+			go handleProxyClient(client, dialer)
+		}
+	}
+}
+
+// handleProxyClient will open a connection using the dialer, and ensure close events propagate to the brokers
+func handleProxyClient(clientConn net.Conn, dialer func() (net.Conn, error)) {
+	//We have a client connected, open an upstream connection to the destination
+	upstreamConn, err := dialer()
+	if err != nil {
+		log.Printf("[ERROR] Tunnel: failed to open connection to upstream: %v", err)
+		clientConn.Close()
+		return
+	}
+
+	// channels to wait on the close event for each connection
+	serverClosed := make(chan struct{}, 1)
+	upstreamClosed := make(chan struct{}, 1)
+
+	go brokerData(clientConn, upstreamConn, upstreamClosed)
+	go brokerData(upstreamConn, clientConn, serverClosed)
+
+	// Now we wait for the connections to close and notify the other side of the event
+	select {
+	case <-upstreamClosed:
+		clientConn.Close()
+		<-serverClosed
+	case <-serverClosed:
+		upstreamConn.Close()
+		<-upstreamClosed
+	}
+	log.Printf("[DEBUG] Tunnel: client ('%s') proxy closed", clientConn.RemoteAddr())
+}
+
+// brokerData is responsible for copying data src => dest. It will also close the src when there are no more bytes to transfer
+func brokerData(src net.Conn, dest net.Conn, srcClosed chan struct{}) {
+	_, err := io.Copy(src, dest)
+	if err != nil {
+		log.Printf("[ERROR] Tunnel: Copy error: %s", err)
+	}
+	if err := src.Close(); err != nil {
+		log.Printf("[ERROR] Tunnel: Close error: %s", err)
+	}
+	srcClosed <- struct{}{}
+}

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -44,6 +44,8 @@ type Config struct {
 	SSHBastionPassword        string        `mapstructure:"ssh_bastion_password"`
 	SSHBastionPrivateKeyFile  string        `mapstructure:"ssh_bastion_private_key_file"`
 	SSHFileTransferMethod     string        `mapstructure:"ssh_file_transfer_method"`
+	SSHRemoteTunnels          []string      `mapstructure:"ssh_remote_tunnels"`
+	SSHLocalTunnels           []string      `mapstructure:"ssh_local_tunnels"`
 	SSHProxyHost              string        `mapstructure:"ssh_proxy_host"`
 	SSHProxyPort              int           `mapstructure:"ssh_proxy_port"`
 	SSHProxyUsername          string        `mapstructure:"ssh_proxy_username"`
@@ -303,6 +305,22 @@ func (c *Config) prepareSSH(ctx *interpolate.Context) []error {
 
 	if c.SSHBastionHost != "" && c.SSHProxyHost != "" {
 		errs = append(errs, errors.New("please specify either ssh_bastion_host or ssh_proxy_host, not both"))
+	}
+
+	for _, v := range c.SSHLocalTunnels {
+		_, err := helperssh.ParseTunnelArgument(v, packerssh.UnsetTunnel)
+		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"ssh_local_tunnels ('%s') is invalid: %s", v, err))
+		}
+	}
+
+	for _, v := range c.SSHRemoteTunnels {
+		_, err := helperssh.ParseTunnelArgument(v, packerssh.UnsetTunnel)
+		if err != nil {
+			errs = append(errs, fmt.Errorf(
+				"ssh_remote_tunnels ('%s') is invalid: %s", v, err))
+		}
 	}
 
 	return errs

--- a/helper/ssh/tunnel.go
+++ b/helper/ssh/tunnel.go
@@ -1,0 +1,45 @@
+package ssh
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/packer/communicator/ssh"
+)
+
+// ParseTunnelArgument parses an SSH tunneling argument compatible with the openssh client form.
+// Valid formats:
+// `port:host:hostport`
+// NYI `[bind_address:]port:host:hostport`
+func ParseTunnelArgument(forward string, direction ssh.TunnelDirection) (ssh.TunnelSpec, error) {
+	parts := strings.SplitN(forward, ":", 2)
+	if len(parts) != 2 {
+		return ssh.TunnelSpec{}, fmt.Errorf("Error parsing tunnel '%s': %v", forward, parts)
+	}
+	listeningPort, forwardingAddr := parts[0], parts[1]
+
+	_, sPort, err := net.SplitHostPort(forwardingAddr)
+	if err != nil {
+		return ssh.TunnelSpec{}, fmt.Errorf("Error parsing forwarding, must be a tcp address: %s", err)
+	}
+	_, err = strconv.Atoi(sPort)
+	if err != nil {
+		return ssh.TunnelSpec{}, fmt.Errorf("Error parsing forwarding port, must be a valid port: %s", err)
+	}
+	_, err = strconv.Atoi(listeningPort)
+	if err != nil {
+		return ssh.TunnelSpec{}, fmt.Errorf("Error parsing listening port, must be a valid port: %s", err)
+	}
+
+	return ssh.TunnelSpec{
+		Direction:   direction,
+		ForwardAddr: forwardingAddr,
+		ForwardType: "tcp",
+		ListenAddr:  fmt.Sprintf("localhost:%s", listeningPort),
+		ListenType:  "tcp",
+	}, nil
+	// So we parsed all that, and are just going to ignore it now. We would
+	// have used the information to set the type here.
+}

--- a/helper/ssh/tunnel_test.go
+++ b/helper/ssh/tunnel_test.go
@@ -1,0 +1,78 @@
+package ssh
+
+import (
+	"github.com/hashicorp/packer/communicator/ssh"
+	"testing"
+)
+
+const (
+	tunnel8080ToLocal     = "8080:localhost:1234"
+	tunnel8080ToRemote    = "8080:example.com:80"
+	bindRemoteAddress_NYI = "redis:6379:localhost:6379"
+)
+
+func TestTCPToLocalTCP(t *testing.T) {
+	tun, err := ParseTunnelArgument(tunnel8080ToLocal, ssh.UnsetTunnel)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	expectedTun := ssh.TunnelSpec{
+		Direction:   ssh.UnsetTunnel,
+		ForwardAddr: "localhost:1234",
+		ForwardType: "tcp",
+		ListenAddr:  "localhost:8080",
+		ListenType:  "tcp",
+	}
+	if tun != expectedTun {
+		t.Errorf("Parsed tunnel (%v), want %v", tun, expectedTun)
+	}
+}
+
+func TestTCPToRemoteTCP(t *testing.T) {
+	tun, err := ParseTunnelArgument(tunnel8080ToRemote, ssh.UnsetTunnel)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	expectedTun := ssh.TunnelSpec{
+		Direction:   ssh.UnsetTunnel,
+		ForwardAddr: "example.com:80",
+		ForwardType: "tcp",
+		ListenAddr:  "localhost:8080",
+		ListenType:  "tcp",
+	}
+	if tun != expectedTun {
+		t.Errorf("Parsed tunnel (%v), want %v", tun, expectedTun)
+	}
+}
+
+func TestBindAddress_NYI(t *testing.T) {
+	tun, err := ParseTunnelArgument(bindRemoteAddress_NYI, ssh.UnsetTunnel)
+	if err == nil {
+		t.Fatal(err.Error())
+	}
+	expectedTun := ssh.TunnelSpec{
+		Direction:   ssh.UnsetTunnel,
+		ForwardAddr: "redis:6379",
+		ForwardType: "tcp",
+		ListenAddr:  "localhost:6379",
+		ListenType:  "tcp",
+	}
+	if tun == expectedTun {
+		t.Errorf("Parsed tunnel (%v), want %v", tun, expectedTun)
+	}
+}
+
+func TestInvalidTunnels(t *testing.T) {
+	invalids := []string{
+		"nope:8080",                       // insufficient parts
+		"nope:localhost:8080",             // listen port is not a number
+		"8080:localhost:nope",             // forwarding port is not a number
+		"/unix/is/no/go:/path/to/nowhere", // unix socket is unsupported
+	}
+	for _, tunnelStr := range invalids {
+		tun, err := ParseTunnelArgument(tunnelStr, ssh.UnsetTunnel)
+		if err == nil {
+			t.Errorf("Parsed tunnel %v, want error", tun)
+		}
+	}
+}

--- a/test/communicator_ssh.bats
+++ b/test/communicator_ssh.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+#
+# This tests the ssh communicator using AWS builder. The teardown function will automatically
+# delete any AMIs with a tag of `packer-test` being equal to "true" so
+# be sure any test cases set this.
+
+load test_helper
+verify_aws_cli
+fixtures communicator-ssh
+
+setup() {
+    cd $FIXTURE_ROOT
+}
+
+teardown() {
+    aws_ami_cleanup
+}
+
+@test "shell provisioner: local port tunneling" {
+    run packer build $FIXTURE_ROOT/local-tunnel.json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Connection to localhost port 10022 [tcp/*] succeeded"* ]]
+}
+
+@test "shell provisioner: remote port tunneling" {
+    run packer build $FIXTURE_ROOT/remote-tunnel.json
+    [ "$status" -eq 0 ]
+    MY_LOCAL_IP=$(curl -s https://ifconfig.co/)
+    [[ "$output" == *"$MY_LOCAL_IP"* ]]
+}

--- a/test/fixtures/communicator-ssh/local-tunnel.json
+++ b/test/fixtures/communicator-ssh/local-tunnel.json
@@ -1,0 +1,21 @@
+{
+    "builders": [{
+        "type": "amazon-ebs",
+        "ami_name": "packer-test {{timestamp}}",
+        "instance_type": "m1.small",
+        "region": "us-east-1",
+        "ssh_username": "ubuntu",
+        "ssh_local_tunnels": ["10022:localhost:22"],
+        "source_ami": "ami-0568456c",
+        "tags": {
+            "packer-test": "true"
+        }
+    }],
+
+    "provisioners": [{
+        "type": "shell-local",
+        "inline": [
+            "echo | nc -G 5 -w 5 -v localhost 10022 2>&1"
+        ]
+    }]
+}

--- a/test/fixtures/communicator-ssh/remote-tunnel.json
+++ b/test/fixtures/communicator-ssh/remote-tunnel.json
@@ -1,0 +1,22 @@
+{
+    "builders": [{
+        "type": "amazon-ebs",
+        "ami_name": "packer-test {{timestamp}}",
+        "instance_type": "t2.micro",
+        "region": "us-east-1",
+        "ssh_username": "ubuntu",
+        "ssh_remote_tunnels": ["8443:ifconfig.co:443"],
+        "source_ami": "ami-0111e8c43a763eb71",
+        "tags": {
+            "packer-test": "true"
+        }
+    }],
+    "provisioners": [{
+        "inline": [
+            "curl -kvs --connect-to ifconfig.co:443:localhost:8443 https://ifconfig.co/"
+        ],
+        "type": "shell"
+      }
+    ]
+  }
+  

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -108,9 +108,9 @@ The SSH communicator has the following options:
 
 -   `ssh_local_tunnels` (array of strings) - An array of OpenSSH-style tunnels to
     create. The port is bound on the *local packer host* and connections are
-    forwarded to the remote destinations. Note unless `GatewayPorts=yes` is set
-    in SSHD dameon, the target *must* be `localhost`. Example value:
-    `8080:localhost:8000`
+    forwarded to the remote destination. Note unless `GatewayPorts=yes` is set
+    in SSHD daemon, the target *must* be `localhost`. Example value:
+    `3306:localhost:3306`
 
 -   `ssh_password` (string) - A plaintext password to use to authenticate with
     SSH.
@@ -139,7 +139,7 @@ The SSH communicator has the following options:
     connection after a reboot. Example: `5m`. Disabled by default.
 
 -   `ssh_remote_tunnels` (array of strings) - An array of OpenSSH-style tunnels
-    to create. The port is bound on the *remote build host* and connections are
+    to create. The port is bound on the *remote build host* and connections to it are
     forwarded to the packer host's network. Non-localhost destinations may be set here.
     Example value: `8443:git.example.com:443`
 

--- a/website/source/docs/templates/communicator.html.md
+++ b/website/source/docs/templates/communicator.html.md
@@ -106,6 +106,12 @@ The SSH communicator has the following options:
     messages to the server. Set to a negative value (`-1s`) to disable. Example
     value: `10s`. Defaults to `5s`.
 
+-   `ssh_local_tunnels` (array of strings) - An array of OpenSSH-style tunnels to
+    create. The port is bound on the *local packer host* and connections are
+    forwarded to the remote destinations. Note unless `GatewayPorts=yes` is set
+    in SSHD dameon, the target *must* be `localhost`. Example value:
+    `8080:localhost:8000`
+
 -   `ssh_password` (string) - A plaintext password to use to authenticate with
     SSH.
 
@@ -131,6 +137,11 @@ The SSH communicator has the following options:
 -   `ssh_read_write_timeout` (string) - The amount of time to wait for a remote
     command to end. This might be useful if, for example, packer hangs on a
     connection after a reboot. Example: `5m`. Disabled by default.
+
+-   `ssh_remote_tunnels` (array of strings) - An array of OpenSSH-style tunnels
+    to create. The port is bound on the *remote build host* and connections are
+    forwarded to the packer host's network. Non-localhost destinations may be set here.
+    Example value: `8443:git.example.com:443`
 
 -   `ssh_timeout` (string) - The time to wait for SSH to become available.
     Packer uses this to determine when the machine has booted so this is


### PR DESCRIPTION
## Synopsis
This adds ssh port tunneling to the core ssh communicator. This allows any provisioner using the ssh communicator to access tunnels over the SSH connection.

## Use Case

This addresses cases of when there are local resources that may not be exposed to the internet at large but are needed for provisioning. For instance, git tarballs or yum repositories. There is also more advanced options like running a local proxy and having something like supporting `curl --proxy localhost:8080 https://git.company.com/...` just work.

## Example:

(See acceptance tests for other demos).

Assuming there's a webserver listening on `localhost:80` on our local workstation.

```json
{
  "builders": [{
      "type": "null",
      "ssh_host": "remote-host.example.com",
      "ssh_remote_tunnels": ["8080:localhost:80"],
      "ssh_agent_auth": true
    }
  ],
  "provisioners": [
    {
      "inline": ["curl -Isv http://localhost:8080/"],
      "type": "shell"
    }
  ]
}
```

## Changes
  - [x] Tunnels TCP packets from remote to local
  - [x] Tunnels TCP packets from local to remote
  - [x] Proper closing/handling of the proxy connections
  - [x] Clean up naming, there's some mixed naming that should be made more consistent
  - [x] Document new ssh settings in templates
  - [x] Add tests & examples


## Questions

How to propagate some errors to the `ui` object to report when binds fail (port in use, sshd rejects the request, etc)? Should the port tunneling setup happen in `communicator` package from `helper/communicator/step_connect_ssh.go` instead of where I implemented it in the `ssh` package from `communicator/ssh/communicator.go`? It appears the ui object (and a context) is available there.

Next question, how to acquire a context to shut down the tunnels preferably before the SSH connection is terminated. Right now, all I have access to is the `sshComm` object.

Unix sockets are not tested, they might work but I'd require explicit parsing support in the argument handling. I didn't do anything to prevent it from working. Just don't have a good test, in particular when SSH creates a remote unix socket it _does not clean it up_. So there's potential for unclean tear-downs. (May not be an issue for EC2-esque builders). Potentially would make it possible to forward things like a docker socket which would be interesting.

## Related Issues

Closes #6976 
