### PR TITLE
Honor value of 'Comment' field in 'ssh.KeyPairFromPrivateKey()'.

### DIFF
--- a/helper/ssh/key_pair.go
+++ b/helper/ssh/key_pair.go
@@ -77,6 +77,7 @@ func KeyPairFromPrivateKey(config FromPrivateKeyConfig) (KeyPair, error) {
 			return KeyPair{}, err
 		}
 		return KeyPair{
+			Comment:                     config.Comment,
 			PrivateKeyPemBlock:          config.RawPrivateKeyPemBlock,
 			PublicKeyAuthorizedKeysLine: authorizedKeysLine(publicKey, config.Comment),
 		}, nil
@@ -86,6 +87,7 @@ func KeyPairFromPrivateKey(config FromPrivateKeyConfig) (KeyPair, error) {
 			return KeyPair{}, err
 		}
 		return KeyPair{
+			Comment:                     config.Comment,
 			PrivateKeyPemBlock:          config.RawPrivateKeyPemBlock,
 			PublicKeyAuthorizedKeysLine: authorizedKeysLine(publicKey, config.Comment),
 		}, nil

--- a/helper/ssh/key_pair_test.go
+++ b/helper/ssh/key_pair_test.go
@@ -237,49 +237,57 @@ func TestKeyPairFromPrivateKey(t *testing.T) {
 		pemRsa1024: {
 			t: Rsa,
 			d: expectedData{
-				bits: 1024,
+				bits:    1024,
+				comment: uuid.TimeOrderedUUID(),
 			},
 		},
 		pemRsa2048: {
 			t: Rsa,
 			d: expectedData{
-				bits: 2048,
+				bits:    2048,
+				comment: uuid.TimeOrderedUUID(),
 			},
 		},
 		pemOpenSshRsa1024: {
 			t: Rsa,
 			d: expectedData{
-				bits: 1024,
+				bits:    1024,
+				comment: uuid.TimeOrderedUUID(),
 			},
 		},
 		pemOpenSshRsa2048: {
 			t: Rsa,
 			d: expectedData{
-				bits: 2048,
+				bits:    2048,
+				comment: uuid.TimeOrderedUUID(),
 			},
 		},
 		pemDsa: {
 			t: Dsa,
 			d: expectedData{
-				bits: 1024,
+				bits:    1024,
+				comment: uuid.TimeOrderedUUID(),
 			},
 		},
 		pemEcdsa384: {
 			t: Ecdsa,
 			d: expectedData{
-				bits: 384,
+				bits:    384,
+				comment: uuid.TimeOrderedUUID(),
 			},
 		},
 		pemEcdsa521: {
 			t: Ecdsa,
 			d: expectedData{
-				bits: 521,
+				bits:    521,
+				comment: uuid.TimeOrderedUUID(),
 			},
 		},
 		pemOpenSshEd25519: {
 			t: Ed25519,
 			d: expectedData{
-				bits: 256,
+				bits:    256,
+				comment: uuid.TimeOrderedUUID(),
 			},
 		},
 	}
@@ -287,6 +295,7 @@ func TestKeyPairFromPrivateKey(t *testing.T) {
 	for rawPrivateKey, expected := range m {
 		kp, err := KeyPairFromPrivateKey(FromPrivateKeyConfig{
 			RawPrivateKeyPemBlock: []byte(rawPrivateKey),
+			Comment:               expected.d.comment,
 		})
 		if err != nil {
 			t.Fatal(err.Error())
@@ -340,6 +349,11 @@ func verifyEcdsaKeyPair(kp KeyPair, e expectedData) error {
 		return err
 	}
 
+	if kp.Comment != e.comment {
+		return fmt.Errorf("key pair comment should be:\n'%s'\nGot:\n'%s'",
+			e.comment, kp.Comment)
+	}
+
 	expectedBytes := bytes.TrimSuffix(gossh.MarshalAuthorizedKey(publicKey), []byte("\n"))
 	if len(e.comment) > 0 {
 		expectedBytes = append(expectedBytes, ' ')
@@ -374,6 +388,11 @@ func verifyRsaKeyPair(kp KeyPair, e expectedData) error {
 		return err
 	}
 
+	if kp.Comment != e.comment {
+		return fmt.Errorf("key pair comment should be:\n'%s'\nGot:\n'%s'",
+			e.comment, kp.Comment)
+	}
+
 	expectedBytes := bytes.TrimSuffix(gossh.MarshalAuthorizedKey(publicKey), []byte("\n"))
 	if len(e.comment) > 0 {
 		expectedBytes = append(expectedBytes, ' ')
@@ -404,6 +423,11 @@ func verifyDsaKeyPair(kp KeyPair, e fromPrivateExpectedData) error {
 		return err
 	}
 
+	if kp.Comment != e.d.comment {
+		return fmt.Errorf("key pair comment should be:\n'%s'\nGot:\n'%s'",
+			e.d.comment, kp.Comment)
+	}
+
 	expectedBytes := bytes.TrimSuffix(gossh.MarshalAuthorizedKey(publicKey), []byte("\n"))
 	if len(e.d.comment) > 0 {
 		expectedBytes = append(expectedBytes, ' ')
@@ -432,6 +456,11 @@ func verifyEd25519KeyPair(kp KeyPair, e fromPrivateExpectedData) error {
 	publicKey, err := gossh.NewPublicKey(pk.Public())
 	if err != nil {
 		return err
+	}
+
+	if kp.Comment != e.d.comment {
+		return fmt.Errorf("key pair comment should be:\n'%s'\nGot:\n'%s'",
+			e.d.comment, kp.Comment)
 	}
 
 	expectedBytes := bytes.TrimSuffix(gossh.MarshalAuthorizedKey(publicKey), []byte("\n"))


### PR DESCRIPTION
/cc @chrismarget,

The 'ssh.KeyPairFromPrivateKey()' function in the 'ssh' helper
library was not honoring the value of the 'Comment' field in the
'FromPrivateKeyConfig' struct. This commit fixes the issue, and
updates unit tests to catch the issue if it happens again.

## Discovery
When building a VirtualBox VM using an existing SSH private key, I noticed that packer was not removing the corresponding public key entry from the `authorized_keys` file.

## Cause
When building a VirtualBox VM using an existing SSH private key, the key pair is removed by [a `sed` call in common/step_cleanup_temp_keys.go](https://github.com/hashicorp/packer/blob/66f142adf1f3724a2018596a14a026a875f8c842/common/step_cleanup_temp_keys.go#L58). The sed call looks for the value of the `communicator.Config` struct's `SSHTemporaryKeyPairName` field. This comment identifies the key pair, which is set by [builder/virtualbox/common/step_ssh_key_pair.go](https://github.com/hashicorp/packer/blob/66f142adf1f3724a2018596a14a026a875f8c842/builder/virtualbox/common/step_ssh_key_pair.go#L49). The comment is a random value generated by packer when parsing the existing SSH private key using the [`ssh.KeyPairFromPrivateKey()` function](https://github.com/hashicorp/packer/blob/66f142adf1f3724a2018596a14a026a875f8c842/helper/ssh/key_pair.go#L64).

Because the function did not honor the comment value passed to it, the resulting `KeyPair` struct's Comment field is an empty string. The Comment in the Communicator's struct was set to this value - an empty string. Since the sed call is now looking for an empty string, it fails to remove the public key from the `authorized_keys` file.

## Security concerns
Sooooo, on the face of it, this is a pretty minor bug. However, the bug does potentially result in a rogue SSH key being left behind in `authorized_keys`. This is completely dependent on how the user has implemented the build process. I think this is worth considering when merging this. Apologies for creating such a silly bug. The unit tests should have considered this :(