### PR TITLE
Fix a panic encountered when using the Amazon ebssurrogate builder

### DIFF
--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -64,7 +64,7 @@ func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) m
 	ui := state.Get("ui").(packer.Ui)
 	amis := state.Get("amis").(map[string]string)
 	snapshots := state.Get("snapshots").(map[string][]string)
-	intermediary := state.Get("intermediary_image").(bool)
+	intermediary, _ := state.Get("intermediary_image").(bool)
 
 	s.DeduplicateRegions(intermediary)
 	ami := amis[s.OriginalRegion]

--- a/builder/amazon/common/step_ami_region_copy_test.go
+++ b/builder/amazon/common/step_ami_region_copy_test.go
@@ -271,6 +271,31 @@ func TestStepAmiRegionCopy_true_encryption(t *testing.T) {
 	}
 }
 
+func TestStepAmiRegionCopy_nil_intermediary(t *testing.T) {
+	// create step
+	stepAMIRegionCopy := StepAMIRegionCopy{
+		AccessConfig:      testAccessConfig(),
+		Regions:           make([]string, 0),
+		AMIKmsKeyId:       "",
+		RegionKeyIds:      make(map[string]string),
+		EncryptBootVolume: aws.Bool(false),
+		Name:              "fake-ami-name",
+		OriginalRegion:    "us-east-1",
+	}
+	// mock out the region connection code
+	stepAMIRegionCopy.getRegionConn = getMockConn
+
+	state := tState()
+	stepAMIRegionCopy.Run(context.Background(), state)
+
+	if stepAMIRegionCopy.toDelete != "" {
+		t.Fatalf("Should not delete original AMI if no intermediary")
+	}
+	if len(stepAMIRegionCopy.Regions) != 0 {
+		t.Fatalf("Should not have added original ami to Regions")
+	}
+}
+
 func TestStepAmiRegionCopy_AMISkipBuildRegion(t *testing.T) {
 	// ------------------------------------------------------------------------
 	// skip build region is true


### PR DESCRIPTION
@SwampDragons Hello!! Hope all is well...

Packer v1.4.3-dev (903a42202)

This PR fixes a panic encountered at the final stages of the Amazon ebssurrogate builder:

```
2019/07/28 10:56:42 packer: panic: interface conversion: interface {} is nil, not bool
2019/07/28 10:56:42 packer:
2019/07/28 10:56:42 packer: goroutine 26 [running]:
2019/07/28 10:56:42 packer: github.com/hashicorp/packer/builder/amazon/common.(*StepAMIRegionCopy).Run(0xc000412580, 0x4a563a0, 0xc000065380, 0x4a32f20, 0xc00048c720, 0x0)
2019/07/28 10:56:42 packer:     /Users/dan/working/go/src/github.com/hashicorp/packer/builder/amazon/common/step_ami_region_copy.go:67 +0x89e
```

The panic occurs because the ebssurrogate builder does not set a value for the `intermediary_image` key in the statebag.