### PR TITLE
Update vagrant cloud post processor token example

### DIFF
--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -104,7 +104,7 @@ post-processor.
 ``` json
 {
   "variables": {
-    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
+    "cloud_token": "{{ env `VAGRANT_CLOUD_TOKEN` }}",
     "version": "1.0.{{timestamp}}"
   },
   "post-processors": [


### PR DESCRIPTION
This commit updates the Vagrant Cloud post processor example to use the
proper token name rather than the old Atlas one.