### PR TITLE
Update public GCP cloud image projects - add suse-byos-cloud

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -184,6 +184,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		"rhel-sap-cloud",
 		"suse-cloud",
 		"suse-sap-cloud",
+		"suse-byos-cloud",
 		"ubuntu-os-cloud",
 		"windows-cloud",
 		"windows-sql-cloud",


### PR DESCRIPTION
I was trying to pull the sles-12-sp3-sap-byos image, but the build is failing with the following error:

```
==> googlecompute: Error getting source image for instance creation: Could not find image, sles-12-sp3-sap-byos-v20190221, in projects, [SANATIZED centos-cloud cos-cloud coreos-cloud debian-cloud rhel-cloud rhel-sap-cloud suse-cloud suse-sap-cloud ubuntu-os-cloud windows-cloud windows-sql-cloud gce-uefi-images gce-nvme google-containers opensuse-cloud]: 16 error(s) occurred:
==> googlecompute:
==> googlecompute: * googleapi: Error 404: The resource 'projects/SANATIZED/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/centos-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/cos-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/coreos-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/debian-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/rhel-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/rhel-sap-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/suse-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/suse-sap-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/ubuntu-os-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/windows-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/windows-sql-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/gce-uefi-images/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/gce-nvme/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/google-containers/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound
==> googlecompute: * googleapi: Error 404: The resource 'projects/opensuse-cloud/global/images/sles-12-sp3-sap-byos-v20190221' was not found, notFound

```

my googlecompute builder:
```
{
        "type": "googlecompute",
        "project_id": "SANATIZED",
        "network_project_id": "SANATIZED",
        "source_image": "sles-12-sp3-sap-byos-v20190221",
        "zone": "SANATIZED",
        "instance_name": "packer-sles-12-sp3-image-builder",
        "machine_type": "n1-standard-1",
        "network": "SANATIZED",
        "subnetwork": "SANATIZED",
        "omit_external_ip": "true",
        "use_internal_ip": "true",
        "ssh_username": "SANATIZED",
        "image_name": "packer-builder",
        "image_family": "custom-sles-12-sp3-sap",
        "image_description": "Image Generated with Packer",
        "disk_size": 10,
        "metadata": { 
          "enable-oslogin": "false"
        }
      }
```

On finding #6642, I added the following to the builder:
```
{
        "source_image": "sles-12-sp3-sap-byos-v20190221",
        "source_image_family": "sles-12-sp3-sap",
        "source_image_project_id": "suse-sap-cloud",
}
```

And was still getting resource not found. After a little bit more digging, I saw that the byos images for sles were hosted under a different project_id: 'suse-byos-cloud'

After building with:

```
{
        "source_image": "sles-12-sp3-sap-byos-v20190221",
        "source_image_family": "sles-12-sp3-sap",
        "source_image_project_id": "suse-byos-cloud",
}
```

The resource was found and the build was successful.