### PR TITLE
Use 'log.Printf()' for StepDownload debug instead of 'ui.Say()'.

### DIFF
--- a/common/step_download.go
+++ b/common/step_download.go
@@ -54,7 +54,7 @@ type StepDownload struct {
 
 func (s *StepDownload) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
-	defer ui.Say(fmt.Sprintf("leaving retrieve loop for %s", s.Description))
+	defer log.Printf("Leaving retrieve loop for %s", s.Description)
 
 	ui.Say(fmt.Sprintf("Retrieving %s", s.Description))
 

--- a/common/step_download.go
+++ b/common/step_download.go
@@ -53,9 +53,9 @@ type StepDownload struct {
 }
 
 func (s *StepDownload) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ui := state.Get("ui").(packer.Ui)
 	defer log.Printf("Leaving retrieve loop for %s", s.Description)
 
+	ui := state.Get("ui").(packer.Ui)
 	ui.Say(fmt.Sprintf("Retrieving %s", s.Description))
 
 	var errs []error


### PR DESCRIPTION
There appears to be a debug log message being printed using the `ui.Say()` method in the `StepDownload.Run()` method. I changed this to `log.Printf()`... Although, I am not sure if the message should be there at all. I just noticed it while using the VirtualBox builders.