### PR TITLE
check container os, not host os, when creating container dir default

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -125,7 +125,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	}
 
 	if c.ContainerDir == "" {
-		if runtime.GOOS == "windows" {
+		if c.WindowsContainer {
 			c.ContainerDir = "c:/packer-files"
 		} else {
 			c.ContainerDir = "/packer-files"

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"


### PR DESCRIPTION
See title. This was causing failures for people using docker on windows to build linux.
Closes #7938
