### PR TITLE
OpenStack builder store WinRM password for provisioners to use

### DIFF
--- a/website/source/docs/provisioners/ansible.html.md.erb
+++ b/website/source/docs/provisioners/ansible.html.md.erb
@@ -60,8 +60,8 @@ Optional Parameters:
       "ansible_env_vars": [ "ANSIBLE_HOST_KEY_CHECKING=False", "ANSIBLE_SSH_ARGS='-o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s'", "ANSIBLE_NOCOLOR=True" ]
     ```
 
-    If you are running a Windows build on AWS, Azure or Google Compute and
-    would like to access the auto-generated password that Packer uses to
+    If you are running a Windows build on AWS, Azure, Google Compute, or OpenStack
+    and would like to access the auto-generated password that Packer uses to
     connect to a Windows instance via WinRM, you can use the template variable
     {{.WinRMPassword}} in this option. For example:
 
@@ -85,8 +85,8 @@ Optional Parameters:
       "extra_arguments": [ "--extra-vars", "Region={{user `Region`}} Stage={{user `Stage`}}" ]
     ```
 
-    If you are running a Windows build on AWS, Azure or Google Compute and
-    would like to access the auto-generated password that Packer uses to
+    If you are running a Windows build on AWS, Azure, Google Compute, or OpenStack
+    and would like to access the auto-generated password that Packer uses to
     connect to a Windows instance via WinRM, you can use the template variable
     {{.WinRMPassword}} in this option. For example:
 

--- a/website/source/docs/provisioners/powershell.html.md.erb
+++ b/website/source/docs/provisioners/powershell.html.md.erb
@@ -50,8 +50,8 @@ The example below is fully functional.
     inject prior to the execute\_command. The format should be `key=value`.
     Packer injects some environmental variables by default into the
     environment, as well, which are covered in the section below. If you are
-    running on AWS, Azure or Google Compute and would like to access the
-    generated password that Packer uses to connect to the instance via WinRM,
+    running on AWS, Azure, Google Compute, or OpenStack and would like to access
+    the generated password that Packer uses to connect to the instance via WinRM,
     you can use the template variable `{{.WinRMPassword}}` to set this as an
     environment variable. For example:
 
@@ -84,9 +84,9 @@ The example below is fully functional.
 
 -   `elevated_user` and `elevated_password` (string) - If specified, the
     PowerShell script will be run with elevated privileges using the given
-    Windows user. If you are running a build on AWS, Azure or Google Compute
-    and would like to run using the generated password that Packer uses to
-    connect to the instance via WinRM, you may do so by using the template
+    Windows user. If you are running a build on AWS, Azure, Google Compute,
+    or OpenStack and would like to run using the generated password that Packer
+    uses to connect to the instance via WinRM, you may do so by using the template
     variable {{.WinRMPassword}}. For example:
 
     ``` json

--- a/website/source/docs/provisioners/shell-local.html.md.erb
+++ b/website/source/docs/provisioners/shell-local.html.md.erb
@@ -41,9 +41,9 @@ Exactly *one* of the following is required:
 
 -   `command` (string) - This is a single command to execute. It will be
     written to a temporary file and run using the `execute_command` call below.
-    If you are building a windows vm on AWS, Azure or Google Compute and would
-    like to access the generated password that Packer uses to connect to the
-    instance via WinRM, you can use the template variable `{{.WinRMPassword}}`
+    If you are building a windows vm on AWS, Azure, Google Compute, or OpenStack
+    and would like to access the generated password that Packer uses to connect
+    to the instance via WinRM, you can use the template variable `{{.WinRMPassword}}`
     to set this as an environment variable.
 
 -   `inline` (array of strings) - This is an array of commands to execute. The
@@ -68,10 +68,10 @@ Optional parameters:
     inject prior to the `execute_command`. The format should be `key=value`.
     Packer injects some environmental variables by default into the
     environment, as well, which are covered in the section below. If you are
-    building a windows vm on AWS, Azure or Google Compute and would like to
-    access the generated password that Packer uses to connect to the instance
-    via WinRM, you can use the template variable `{{.WinRMPassword}}` to set
-    this as an environment variable. For example:
+    building a windows vm on AWS, Azure, Google Compute, or OpenStack and would
+    like to access the generated password that Packer uses to connect to the
+    instance via WinRM, you can use the template variable `{{.WinRMPassword}}`
+    to set this as an environment variable. For example:
     `"environment_vars": "WINRMPASS={{.WinRMPassword}}"`
 
 -   `env_var_format` (string) - When we parse the environment\_vars that you
@@ -103,9 +103,9 @@ Optional parameters:
     sake of clarity, as even when you set only a single `command` to run,
     Packer writes it to a temporary file and then runs it as a script.
 
-    If you are building a windows vm on AWS, Azure or Google Compute and would
-    like to access the generated password that Packer uses to connect to the
-    instance via WinRM, you can use the template variable `{{.WinRMPassword}}`
+    If you are building a windows vm on AWS, Azure, Google Compute, or OpenStack
+    and would like to access the generated password that Packer uses to connect
+    to the instance via WinRM, you can use the template variable `{{.WinRMPassword}}`
     to set this as an environment variable.
 
 -   `inline_shebang` (string) - The


### PR DESCRIPTION
Following https://github.com/hashicorp/packer/issues/2663#issuecomment-504123414 by @SwampDragons this PR stores, and clears, the retrieved password so that the `{{.WinRMPassword}}` template variable can be used by provisioners (for example in a `shell-local` to configure the password for use with an external tool).