### PR TITLE
[WIP] (help-wanted) Pass the `ssh_username` down to ansible

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -222,9 +222,9 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		SSHUsername:   getSSHUsername(p.config.PackerBuildName),
 	}
 	// FIXME: This doesn't do what I want it to. So how do I get the right value?
-	sshUser, err := interpolate.Render("{{.SSHUsername}}", &p.config.ctx)
-	if err != nil && sshUser != "" {
-		log.Printf("ssh_username is set to ('%s')", sshUser)
+	sshUser := getSSHUsername(p.config.PackerBuildName)
+	if sshUser != "" {
+		log.Printf("ssh_username is set, overriding ansible user from ('%s') to ('%s')", p.config.User, sshUser)
 		p.config.User = sshUser
 	}
 


### PR DESCRIPTION
**(help-wanted)** I attempted to fix this issue, but I am unable to determine how to get access to the builder's `ssh_username` information in the provisioner. (See Solution below). I could use some help with getting the right value here.

### Issue

If Packer runs as root and uses the `ansible` provisioner, Ansible is unable to correctly create it's tempdir on the target box. This specifically requires the local $USER account to exist on the target and the ssh user not to have privileges to write to the $USER's home. Ansible issues the following (opaque) error message:

```
mkdir: cannot create directory ‘/root’: Permission denied
```


Local Username | SSH/Remote Username | Result
---------------- | ------------------------ | ----------
dekimsey | centos | **yes**, Ansible resolves `~dekimsey/` to `/home/centos/~dekimsey/`
centos | centos | **yes**, Ansible resolves `~centos/` to `/home/centos/`
root | centos | **no**, Ansible resolves `~root/` to `/root/` which is not writable by `centos`

Interestingly this doesn't happen with a module like `ping` or `setup`. So I suspect it's something to do with how Ansible SSH pipelining setup works (need's a writable tmp dir).

Please refer to [gist](https://gist.github.com/dekimsey/8296df1dfd6d9aa3cd0bc905204ec260) for full logs and example packer.json & ansible playbook.

I tried forcing `-e ansible_user=centos` but that did not work as Packer [enforces](https://github.com/hashicorp/packer/blob/a1cc3c652db4578082df9ad8c764d77405ecdee3/provisioner/ansible/provisioner.go#L250) the username it expects. 

### Solution

I was able to get it work by hard-coding the [provisioner.go's p.config.User](https://github.com/hashicorp/packer/blob/master/provisioner/ansible/provisioner.go#L215) value to `centos`. As far as I can tell the correct value depends on the builder's `ssh_username: "..."` configuration. I tried fiddling with `PassthroughTemplate` to get the value of `ssh_username` from the builder, but I couldn't figure out how to do that (I mimicked WinRMPassword but that didn't work).

### Environment
```
# /packer --version
1.4.2
# ansible-playbook --version
ansible-playbook 2.8.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.5 (default, Oct 30 2018, 23:45:53) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]
# uname -a
Linux 423dce1e0927 4.9.125-linuxkit #1 SMP Fri Sep 7 08:20:28 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
# cat /etc/redhat-release
CentOS Linux release 7.6.1810 (Core)
```

### Log excerpts

I've trimmed this log for brevity. But the lines of interest are included. Ansible is logging in with the local $USER and appears to fail to create it's temporary directory on the target host (note it's writing to /root even though it's logged in as SSH user `centos`, but authenticated to the Packer Adapter as `root`).

#### Running as root 
```
2019/08/02 16:27:47 packer: 2019/08/02 16:27:47 SSH proxy: accepted connection
2019/08/02 16:27:47 packer: 2019/08/02 16:27:47 authentication attempt from 127.0.0.1:53130 to 127.0.0.1:41323 as root using none
2019/08/02 16:27:47 packer: 2019/08/02 16:27:47 authentication attempt from 127.0.0.1:53130 to 127.0.0.1:41323 as root using publickey
2019/08/02 16:27:47 packer: 2019/08/02 16:27:47 new exec request: /bin/sh -c 'echo ~root && sleep 0'
2019/08/02 16:27:48 packer: 2019/08/02 16:27:48 [INFO] RPC endpoint: Communicator ended with: 0
...
2019/08/02 16:27:49 packer: 2019/08/02 16:27:49 new exec request: /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1564763267.8-135248016340590 `" && echo ansible-tmp-1564763267.8-135248016340590="` echo /root/.ansible/tmp/ansible-tmp-1564763267.8-135248016340590 `" ) && sleep 0'
2019/08/02 16:27:49 packer: 2019/08/02 16:27:49 [INFO] RPC endpoint: Communicator ended with: 1
```
#### Running as non-root

```
2019/08/02 16:46:48 packer: 2019/08/02 16:46:48 SSH proxy: accepted connection
2019/08/02 16:46:48 packer: 2019/08/02 16:46:48 authentication attempt from 127.0.0.1:46124 to 127.0.0.1:44207 as not-a-root-user using none
2019/08/02 16:46:48 packer: 2019/08/02 16:46:48 authentication attempt from 127.0.0.1:46124 to 127.0.0.1:44207 as not-a-root-user using publickey
2019/08/02 16:46:48 packer: 2019/08/02 16:46:48 new exec request: /bin/sh -c 'echo ~not-a-root-user && sleep 0'
2019/08/02 16:46:48 packer: 2019/08/02 16:46:48 [INFO] RPC endpoint: Communicator ended with: 0
...
2019/08/02 16:46:49 packer: 2019/08/02 16:46:49 new exec request: /bin/sh -c '( umask 77 && mkdir -p "` echo ~not-a-root-user/.ansible/tmp/ansible-tmp-1564764408.25-276499091288021 `" && echo ansible-tmp-1564764408.25-276499091288021="` echo ~not-a-root-user/.ansible/tmp/ansible-tmp-1564764408.25-276499091288021 `" ) && sleep 0'
2019/08/02 16:46:49 packer: 2019/08/02 16:46:49 [INFO] RPC endpoint: Communicator ended with: 0
```

When I run these tmpdir creating commands Ansible is trying to issue myself manually (just to see what they are doing):
_Note, `not-a-root-user` does not exist on this sandbox, my account is non-root_

```
[dekimsey@sandbox ~]$ ( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1564764043.63-21905139479629 `" && echo ansible-tmp-1564764043.63-21905139479629="` echo /root/.ansible/tmp/ansible-tmp-1564764043.63-21905139479629 `" ) && sleep 0
mkdir: cannot create directory ‘/root’: Permission denied
[dekimsey@sandox ~]$ ( umask 77 && mkdir -p "` echo ~not-a-root-user/.ansible/tmp/ansible-tmp-1564764408.25-276499091288021 `" && echo ansible-tmp-1564764408.25-276499091288021="` echo ~not-a-root-user/.ansible/tmp/ansible-tmp-1564764408.25-276499091288021 `" ) && sleep 0
ansible-tmp-1564764408.25-276499091288021=~not-a-root-user/.ansible/tmp/ansible-tmp-1564764408.25-276499091288021
```
