### PR TITLE
hyperv-vmcx builder documentation: Optional configuration key 'cpu' incorrect. Needs to be 'cpus'

### DIFF
--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -134,7 +134,7 @@ builder.
 -   `configuration_version` (string) - This allows you to set the vm version when
      calling New-VM to generate the vm.
 
--   `cpu` (number) - The number of CPUs the virtual machine should use. If
+-   `cpus` (number) - The number of CPUs the virtual machine should use. If
     this isn't specified, the default is 1 CPU.
 
 -   `enable_dynamic_memory` (boolean) - If `true` enable dynamic memory for
@@ -401,7 +401,7 @@ Packer config:
       "winrm_timeout" : "4h",
       "shutdown_command": "f:\\run-sysprep.cmd",
       "memory": 4096,
-      "cpu": 4,
+      "cpus": 4,
       "generation": 2,
       "switch_name":"LAN",
       "enable_secure_boot":true


### PR DESCRIPTION
Configuration key **cpu** should be **cpus**. (https://www.packer.io/docs/builders/hyperv-vmcx.html#cpu)

Fixed the key name + subsequent example further down the page.

