### PR TITLE
Fix incorrect `execute_command` defaults in shell-local post-processor docs

### DIFF
--- a/post-processor/shell-local/post-processor.go
+++ b/post-processor/shell-local/post-processor.go
@@ -47,7 +47,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 	}
 
 	// Force shell-local pp to keep the input artifact, because otherwise we'll
-	// lose it instead of being able to pass it through. If oyu want to delete
+	// lose it instead of being able to pass it through. If you want to delete
 	// the input artifact for a shell local pp, use the artifice pp to create a
 	// new artifact
 	return artifact, true, true, retErr

--- a/website/source/docs/post-processors/shell-local.html.md
+++ b/website/source/docs/post-processors/shell-local.html.md
@@ -68,18 +68,29 @@ Optional parameters:
     it is necessary below.
 
 -   `execute_command` (array of strings) - The command used to execute the
-    script. By default this is `["/bin/sh", "-c", "{{.Vars}}", "{{.Script}}"]`
-    on unix and `["cmd", "/c", "{{.Vars}}", "{{.Script}}"]` on windows. This is
-    treated as a [template engine](/docs/templates/engine.html). There are two
-    available variables: `Script`, which is the path to the script to run, and
-    `Vars`, which is the list of `environment_vars`, if configured. If you
-    choose to set this option, make sure that the first element in the array is
-    the shell program you want to use (for example, "sh" or
-    "/usr/local/bin/zsh" or even "powershell.exe" although anything other than
-    a flavor of the shell command language is not explicitly supported and may
-    be broken by assumptions made within Packer). It's worth noting that if you
-    choose to try to use shell-local for Powershell or other Windows commands,
-    the environment variables will not be set properly for your environment.
+    script. By default, on *nix systems this is:
+
+    ```
+    ["/bin/sh", "-c", "{{.Vars}} {{.Script}}"]
+    ```
+
+    While on Windows, `execute_command` defaults to:
+
+    ```
+    ["cmd", "/V", "/C", "{{.Vars}}", "call", "{{.Script}}"]
+    ```
+
+    This is treated as a [template engine](/docs/templates/engine.html).
+    There are two available variables: `Script`, which is the path to the
+    script to run, and `Vars`, which is the list of `environment_vars`, if
+    configured. If you choose to set this option, make sure that the first
+    element in the array is the shell program you want to use (for example,
+    "sh" or "/usr/local/bin/zsh" or even "powershell.exe" although anything
+    other than a flavor of the shell command language is not explicitly
+    supported and may be broken by assumptions made within Packer). It's
+    worth noting that if you choose to try to use shell-local for
+    Powershell or other Windows commands, the environment variables will
+    not be set properly for your environment.
 
     For backwards compatibility, `execute_command` will accept a string instead
     of an array of strings. If a single string or an array of strings with only


### PR DESCRIPTION
The default `execute_command`'s used for Windows and *nix shown in the shell-local post-processor documentation are wrong. The actual defaults are built for Windows [HERE](https://github.com/hashicorp/packer/blob/master/common/shell-local/config.go#L86-L96) and *nix [HERE](https://github.com/hashicorp/packer/blob/master/common/shell-local/config.go#L104-L110).

This PR fixes the post-processor documentation to show the correct default `execute_command`'s.
