### PR TITLE
Vagrant pp: Add setting to allow box Vagrantfiles to be generated during the build

### DIFF
--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -42,11 +42,12 @@ var builtins = map[string]string{
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
-	CompressionLevel    int      `mapstructure:"compression_level"`
-	Include             []string `mapstructure:"include"`
-	OutputPath          string   `mapstructure:"output"`
-	Override            map[string]interface{}
-	VagrantfileTemplate string `mapstructure:"vagrantfile_template"`
+	CompressionLevel             int      `mapstructure:"compression_level"`
+	Include                      []string `mapstructure:"include"`
+	OutputPath                   string   `mapstructure:"output"`
+	Override                     map[string]interface{}
+	VagrantfileTemplate          string `mapstructure:"vagrantfile_template"`
+	VagrantfileTemplateGenerated bool   `mapstructure:"vagrantfile_template_generated"`
 
 	ctx interpolate.Context
 }
@@ -217,7 +218,7 @@ func (p *PostProcessor) configureSingle(c *Config, raws ...interface{}) error {
 	}
 
 	var errs *packer.MultiError
-	if c.VagrantfileTemplate != "" {
+	if c.VagrantfileTemplate != "" && c.VagrantfileTemplateGenerated == false {
 		_, err := os.Stat(c.VagrantfileTemplate)
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf(

--- a/post-processor/vagrant/post-processor_test.go
+++ b/post-processor/vagrant/post-processor_test.go
@@ -137,11 +137,16 @@ func TestPostProcessorPrepare_vagrantfileTemplateExists(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	var p PostProcessor
+
+	if err := p.Configure(c); err != nil {
+		t.Fatal("no error expected as vagrantfile_template exists")
+	}
+
 	if err := os.Remove(name); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	var p PostProcessor
 	if err := p.Configure(c); err == nil {
 		t.Fatal("expected an error since vagrantfile_template does not exist")
 	}

--- a/post-processor/vagrant/post-processor_test.go
+++ b/post-processor/vagrant/post-processor_test.go
@@ -148,7 +148,14 @@ func TestPostProcessorPrepare_vagrantfileTemplateExists(t *testing.T) {
 	}
 
 	if err := p.Configure(c); err == nil {
-		t.Fatal("expected an error since vagrantfile_template does not exist")
+		t.Fatal("expected error since vagrantfile_template does not exist and vagrantfile_template_generated is unset")
+	}
+
+	// The vagrantfile_template will be generated during the build process
+	c["vagrantfile_template_generated"] = true
+
+	if err := p.Configure(c); err != nil {
+		t.Fatal("no error expected due to missing vagrantfile_template as vagrantfile_template_generated is set")
 	}
 }
 

--- a/website/source/docs/post-processors/vagrant.html.md
+++ b/website/source/docs/post-processors/vagrant.html.md
@@ -83,6 +83,15 @@ more details about certain options in following sections.
 -   `vagrantfile_template` (string) - Path to a template to use for the
     Vagrantfile that is packaged with the box.
 
+-   `vagrantfile_template_generated` (boolean) - By default, Packer will
+    exit with an error if the file specified using the
+    `vagrantfile_template` variable is not found. However, under certain
+    circumstances, it may be desirable to dynamically generate the
+    Vagrantfile during the course of the build. Setting this variable to
+    `true` skips the start up check and allows the user to script the
+    creation of the Vagrantfile at some previous point in the build.
+    Defaults to `false`.
+
 ## Provider-Specific Overrides
 
 If you have a Packer template with multiple builder types within it, you may


### PR DESCRIPTION
Vagrant Post-Processor:

Currently Packer exits with an error if the Vagrantfile specied with `vagrantfile_template` does not exist when the build is started.

This PR adds a new setting `vagrantfile_template_dynamic` that, when set to `true`, causes this check to be skipped. This allows users to create the Vagrantfile during the build process via a script, prior to calling the vagrant post-processor. The intention is that various build settings can then be dynamically set in  the Vagrantfile.