### PR TITLE
vagrant builder: fix provisioning boxes, define source and output boxes

### DIFF
--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -199,6 +199,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&StepCreateVagrantfile{
 			Template:     b.config.Template,
 			SyncedFolder: b.config.SyncedFolder,
+			SourceBox:    b.config.SourceBox,
 			BoxName:      b.config.BoxName,
 			OutputDir:    b.config.OutputDir,
 			GlobalID:     b.config.GlobalID,

--- a/builder/vagrant/step_create_vagrantfile.go
+++ b/builder/vagrant/step_create_vagrantfile.go
@@ -17,11 +17,18 @@ type StepCreateVagrantfile struct {
 	OutputDir    string
 	SyncedFolder string
 	GlobalID     string
+	SourceBox    string
 	BoxName      string
 }
 
 var DEFAULT_TEMPLATE = `Vagrant.configure("2") do |config|
-  config.vm.box = "{{.BoxName}}"
+  config.vm.define "source", autostart: false do |source|
+	source.vm.box = "{{.SourceBox}}"
+  end
+  config.vm.define "output" do |output|
+	output.vm.box = "{{.BoxName}}"
+	output.vm.box_url = "file://package.box"
+  end
   {{ if ne .SyncedFolder "" -}}
   		config.vm.synced_folder "{{.SyncedFolder}}", "/vagrant"
   {{- else -}}
@@ -31,6 +38,7 @@ end`
 
 type VagrantfileOptions struct {
 	SyncedFolder string
+	SourceBox    string
 	BoxName      string
 }
 
@@ -57,6 +65,7 @@ func (s *StepCreateVagrantfile) createVagrantfile() (string, error) {
 	opts := &VagrantfileOptions{
 		SyncedFolder: s.SyncedFolder,
 		BoxName:      s.BoxName,
+		SourceBox:    s.SourceBox,
 	}
 
 	err = tpl.Execute(templateFile, opts)

--- a/builder/vagrant/step_create_vagrantfile_test.go
+++ b/builder/vagrant/step_create_vagrantfile_test.go
@@ -20,6 +20,7 @@ func TestStepCreateVagrantfile_Impl(t *testing.T) {
 func TestCreateFile(t *testing.T) {
 	testy := StepCreateVagrantfile{
 		OutputDir: "./",
+		SourceBox: "apples",
 		BoxName:   "bananas",
 	}
 	templatePath, err := testy.createVagrantfile()
@@ -30,7 +31,13 @@ func TestCreateFile(t *testing.T) {
 	contents, err := ioutil.ReadFile(templatePath)
 	actual := string(contents)
 	expected := `Vagrant.configure("2") do |config|
-  config.vm.box = "bananas"
+  config.vm.define "source", autostart: false do |source|
+	source.vm.box = "apples"
+  end
+  config.vm.define "output" do |output|
+	output.vm.box = "bananas"
+	output.vm.box_url = "file://package.box"
+  end
   config.vm.synced_folder ".", "/vagrant", disabled: true
 end`
 	if ok := strings.Compare(actual, expected); ok != 0 {
@@ -51,7 +58,13 @@ func TestCreateFile_customSync(t *testing.T) {
 	contents, err := ioutil.ReadFile(templatePath)
 	actual := string(contents)
 	expected := `Vagrant.configure("2") do |config|
-  config.vm.box = ""
+  config.vm.define "source", autostart: false do |source|
+	source.vm.box = ""
+  end
+  config.vm.define "output" do |output|
+	output.vm.box = ""
+	output.vm.box_url = "file://package.box"
+  end
   config.vm.synced_folder "myfolder/foldertimes", "/vagrant"
 end`
 	if ok := strings.Compare(actual, expected); ok != 0 {

--- a/builder/vagrant/step_up.go
+++ b/builder/vagrant/step_up.go
@@ -20,7 +20,8 @@ func (s *StepUp) Run(ctx context.Context, state multistep.StateBag) multistep.St
 
 	ui.Say("Calling Vagrant Up...")
 
-	var args []string
+	// start only the source box
+	args := []string{"source"}
 	if s.GlobalID != "" {
 		args = append(args, s.GlobalID)
 	}


### PR DESCRIPTION
I ran into issues using current master to build Vagrant boxes:

My impression is that https://github.com/hashicorp/packer/pull/7859 was intended to fix the issue that the Vagrantfiles we write were configured to use the source box, not the output box. Prior to that patch, the Vagrantfile was never updated to use the output box, so running `vagrant up` in the output directory ran the source box, and not the output box.

After that patch we create a Vagrantfile with `config.vm.box` set to `box_name` before we've run `vagrant up` and provisioned the box, so it doesn't exist, and we see this failure:

```
packer: Couldn't open file $PATH/TO/PACKER/DIR/$BOX_NAME
``` 

This prevents the builder from ever getting past the `vagrant up` step.

This patch changes the output Vagrantfile to have two boxes: `source` and `output`. The source box is the base box, the output box is the packaged, provisioned box output by the builder.

With this change, running the packer builder now creates a Vagrantfile that allows the following to happen:

`vagrant up` => start output box
`vagrant up source` => start base box

I've tested this using the config [here](https://github.com/milescrabill/monopacker/blob/master/packer.yaml#L44-L49) and my development build of packer.