### PR TITLE
Fix console help text

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -99,7 +99,7 @@ Options:
 }
 
 func (*ConsoleCommand) Synopsis() string {
-	return "check that a template is valid"
+	return "creates a console for testing variable interpolation"
 }
 
 func (*ConsoleCommand) AutocompleteArgs() complete.Predictor {


### PR DESCRIPTION
Changing the text so that it's not duplicated from the `validate` help

Before:

```
$ packer --help                                                                                         
Usage: packer [--version] [--help] <command> [<args>]

Available commands are:
    build       build image(s) from template
    console     check that a template is valid
    fix         fixes templates from old versions of packer
    inspect     see components of a template
    validate    check that a template is valid
    version     Prints the Packer version
```

After:

```
$ packer --help
Usage: packer [--version] [--help] <command> [<args>]

Available commands are:
    build       build image(s) from template
    console     creates a console for testing variable interpolation
    fix         fixes templates from old versions of packer
    inspect     see components of a template
    validate    check that a template is valid
    version     Prints the Packer version
```