### PR TITLE
Decrease the delay between Hyper-V VM startup and hyper-v builder's ability to send keystrokes to the target VM.

### DIFF
--- a/builder/hyperv/common/step_type_boot_command.go
+++ b/builder/hyperv/common/step_type_boot_command.go
@@ -33,6 +33,7 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 	ui := state.Get("ui").(packer.Ui)
 	driver := state.Get("driver").(Driver)
 	vmName := state.Get("vmName").(string)
+	hostIp := common.GetHTTPIP()
 
 	// Wait the for the vm to boot.
 	if int64(s.BootWait) > 0 {
@@ -45,18 +46,6 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		}
 	}
 
-	hostIp, err := driver.GetHostAdapterIpAddressForSwitch(s.SwitchName)
-
-	if err != nil {
-		err := fmt.Errorf("Error getting host adapter ip address: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
-
-	ui.Say(fmt.Sprintf("Host IP for the HyperV machine: %s", hostIp))
-
-	common.SetHTTPIP(hostIp)
 	s.Ctx.Data = &bootCommandTemplateData{
 		hostIp,
 		httpPort,

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -449,7 +449,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		},
 
 		&hypervcommon.StepRun{
-			Headless: b.config.Headless,
+			Headless:   b.config.Headless,
+			SwitchName: b.config.SwitchName,
 		},
 
 		&hypervcommon.StepTypeBootCommand{

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -486,7 +486,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		},
 
 		&hypervcommon.StepRun{
-			Headless: b.config.Headless,
+			Headless:   b.config.Headless,
+			SwitchName: b.config.SwitchName,
 		},
 
 		&hypervcommon.StepTypeBootCommand{


### PR DESCRIPTION
The Hyper-V ISO builder attempts to determine the host's IP address after starting the target VM, waiting for the boot_wait value to expire, and before sending boot_command keystrokes. Because the amount of time to determine the host's IP address can vary the actual wait time before sending boot_command keystrokes is indeterminate. 

This commit moves the HostIp determination before the target VM is started, so that the boot_command keystrokes wait can be controlled in a more accurate manner. 

This commit also modifies the steps to connect to the VM (in non-headless mode) before the VM is started in an attempt to further ensure the boot wait timeout is not unintentionally extended.

May close: #7278 
