### PR TITLE
work around spot_tags related regression and bad fleet cleanup in spo…

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -155,10 +155,18 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 
 	if c.SpotTags != nil {
-		if c.SpotPrice == "" || c.SpotPrice == "0" {
-			errs = append(errs, fmt.Errorf(
-				"spot_tags should not be set when not requesting a spot instance"))
-		}
+		errs = append(errs, fmt.Errorf("the spot_tags option has suffered a"+
+			"regression in this "+
+			"version of Packer and will no longer properly tag the spot "+
+			"request; we hope to restore this functionality soon but if you "+
+			"need spot tags in the meantime, please revert to Packer v1.4.1 "+
+			"or lower. If you don't need spot_tags, just remove the spot_tags"+
+			"option from your Packer template and run again."+
+			"We're so sorry for the inconvenience."))
+		// if c.SpotPrice == "" || c.SpotPrice == "0" {
+		// 	errs = append(errs, fmt.Errorf(
+		// 		"spot_tags should not be set when not requesting a spot instance"))
+		// }
 	}
 
 	if c.UserData != "" && c.UserDataFile != "" {


### PR DESCRIPTION
When I implemented spot fleets at the request of the Amazon team, I didn't realize it meant I couldn't get hold of the spot request resource ID. This oversight means that I broke the spot_tags option. 

This PR doesn't fix spot_tags, because I haven't yet figured out how to do that. I'm in communication with Amazon about it. But in the meantime, since I'm a week overdue for the 1.4.3 release already, I'm merging this warning code that at least cleans up some of the surrounding regressions and warns users of spot_tags to revert.

Related to, but doesn't close, #7941