### PR TITLE
dont bother with a targetpath for the vbox additions; use a hash like…

### DIFF
--- a/builder/virtualbox/common/step_download_guest_additions.go
+++ b/builder/virtualbox/common/step_download_guest_additions.go
@@ -158,7 +158,6 @@ func (s *StepDownloadGuestAdditions) downloadAdditionsSHA256(ctx context.Context
 	downStep := &common.StepDownload{
 		Description: "Guest additions checksums",
 		ResultKey:   "guest_additions_checksums_path",
-		TargetPath:  checksumsFile.Name(),
 		Url:         []string{checksumsUrl},
 	}
 


### PR DESCRIPTION
Fix windows pathing problem for guest additions checksum download. Don't bother creating a target path; hashing the shasum will do just fine. 

Closes #7925