### PR TITLE
Remove check/requirement for target_snapshot

### DIFF
--- a/builder/virtualbox/vm/config.go
+++ b/builder/virtualbox/vm/config.go
@@ -97,11 +97,6 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 			fmt.Errorf("vm_name is required"))
 	}
 
-	if c.TargetSnapshot == "" {
-		errs = packer.MultiErrorAppend(errs,
-			fmt.Errorf("target_snapshot is required"))
-	}
-
 	validMode := false
 	validModes := []string{
 		vboxcommon.GuestAdditionsModeDisable,


### PR DESCRIPTION
Remove check for presence of `target_snapshot` in configuration of Virtualbox Snapshot Builder. As per documentation, https://www.packer.io/docs/builders/virtualbox-vm.html, this isn't required. Presence of a populated value prior to snapshot creation is already present at https://github.com/hashicorp/packer/blob/c0e37e604563f87b22576b8df07147b562a1e3a0/builder/virtualbox/vm/step_create_snapshot.go#L21. 

Note: I haven't added tests for this as I suspect this check was mistakenly left in place but feel free to let me know if you do want this tested to prevent regression in future.
