### PR TITLE
Fix: VirtualBox VM builder, target snapshot optional

### DIFF
--- a/builder/virtualbox/vm/builder.go
+++ b/builder/virtualbox/vm/builder.go
@@ -163,16 +163,16 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 
 	// If we were interrupted or cancelled, then just exit.
 	if _, ok := state.GetOk(multistep.StateCancelled); ok {
-		return nil, errors.New("Build was cancelled.")
+		return nil, errors.New("build was cancelled")
 	}
 
 	if _, ok := state.GetOk(multistep.StateHalted); ok {
-		return nil, errors.New("Build was halted.")
+		return nil, errors.New("build was halted")
 	}
 
 	if b.config.SkipExport {
 		return nil, nil
-	} else {
-		return vboxcommon.NewArtifact(b.config.OutputDir)
 	}
+
+	return vboxcommon.NewArtifact(b.config.OutputDir)
 }

--- a/builder/virtualbox/vm/config.go
+++ b/builder/virtualbox/vm/config.go
@@ -122,11 +122,18 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	// Warnings
 	var warnings []string
+	if c.TargetSnapshot == "" && c.SkipExport {
+		warnings = append(warnings,
+			"No target snapshot is specified (target_snapshot empty) and no export will be created (skip_export=true).\n"+
+				"You might lose all changes applied by this run, the next time you execute packer.")
+	}
+
 	if c.ShutdownCommand == "" {
 		warnings = append(warnings,
 			"A shutdown_command was not specified. Without a shutdown command, Packer\n"+
 				"will forcibly halt the virtual machine, which may result in data loss.")
 	}
+
 	driver, err := vboxcommon.NewDriver()
 	if err != nil {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("Failed creating VirtualBox driver: %s", err))


### PR DESCRIPTION
In contrast to the documentation, the `target_snapshot` setting is currently not optional. This PR corrects this and the setting can actually be used as documented.

References:

https://github.com/hashicorp/packer/pull/7780#discussion_r309920272
https://github.com/hashicorp/packer/pull/7780#pullrequestreview-269910416

