### PR TITLE
fix: move adding metadata step after waiting for uploading step

### DIFF
--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -48,7 +48,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	var blockStorageClient *gophercloud.ServiceClient
 	if s.UseBlockStorageVolume {
 		// We need the v3 block storage client.
-		blockStorageClient, err := config.blockStorageV3Client()
+		blockStorageClient, err = config.blockStorageV3Client()
 		if err != nil {
 			err = fmt.Errorf("Error initializing block storage client: %s", err)
 			state.Put("error", err)


### PR DESCRIPTION
Fixes #8009.

Moves call to set Metadata for image while using `BlockStorageVolume` in openstack provisioner after waiting for image to be uploaded. Setting metadata for a image while it's being uploaded in not allowed.

Related to #7792.