### PR TITLE
Allow use of the Artifice post-processor with the Vagrant Cloud post-processor

### DIFF
--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -252,7 +252,7 @@ func providerFromVagrantBox(boxfile string) (providerName string, err error) {
 			break
 		}
 		if err != nil {
-			return "", fmt.Errorf("%s", err)
+			return "", fmt.Errorf("Error reading header info from box tar archive: %s", err)
 		}
 
 		if hdr.Name == "metadata.json" {

--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -249,6 +249,9 @@ func providerFromVagrantBox(boxfile string) (providerName string, err error) {
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
+			if providerName == "" {
+				return "", fmt.Errorf("Error: Provider info was not found in box: %s", boxfile)
+			}
 			break
 		}
 		if err != nil {

--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -273,6 +273,9 @@ func providerFromVagrantBox(boxfile string) (providerName string, err error) {
 			if err != nil {
 				return "", fmt.Errorf("Error parsing metadata.json file: %s", err)
 			}
+			if md.ProviderName == "" {
+				return "", fmt.Errorf("Error: Could not determine Vagrant provider from box metadata.json file")
+			}
 			break
 		}
 	}

--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -226,5 +226,11 @@ func providerFromBuilderName(name string) string {
 // Returns the Vagrant provider the box is intended for use with by
 // reading the metadata file packaged inside the box
 func providerFromVagrantBox(boxfile string) (providerName string, err error) {
+	f, err := os.Open(boxfile)
+	if err != nil {
+		return "", fmt.Errorf("Error attempting to open box file: %s", err)
+	}
+	defer f.Close()
+
 	return "", nil
 }

--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"strings"
 
@@ -95,7 +96,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	// Accumulate any errors
 	errs := new(packer.MultiError)
 
-	// required configuration
+	// Required configuration
 	templates := map[string]*string{
 		"box_tag":      &p.config.Tag,
 		"version":      &p.config.Version,
@@ -109,7 +110,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		}
 	}
 
-	// create the HTTP client
+	// Create the HTTP client
 	p.client, err = VagrantCloudClient{}.New(p.config.VagrantCloudUrl, p.config.AccessToken, p.insecureSkipTLSVerify)
 	if err != nil {
 		errs = packer.MultiErrorAppend(
@@ -132,7 +133,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 	// We assume that there is only one .box file to upload
 	if !strings.HasSuffix(artifact.Files()[0], ".box") {
 		return nil, false, false, fmt.Errorf(
-			"Unknown files in artifact, vagrant box is required: %s", artifact.Files())
+			"Unknown files in artifact, Vagrant box with .box suffix is required as first artifact file: %s", artifact.Files())
 	}
 
 	if p.warnAtlasToken {
@@ -231,6 +232,8 @@ func providerFromBuilderName(name string) string {
 // Returns the Vagrant provider the box is intended for use with by
 // reading the metadata file packaged inside the box
 func providerFromVagrantBox(boxfile string) (providerName string, err error) {
+	log.Println("Attempting to determine provider from metadata in box file. This may take some time...")
+
 	f, err := os.Open(boxfile)
 	if err != nil {
 		return "", fmt.Errorf("Error attempting to open box file: %s", err)

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer/packer"
+	"github.com/stretchr/testify/assert"
 )
 
 type tarFiles []struct {
@@ -284,6 +285,26 @@ func TestProviderFromVagrantBox_no_metadata(t *testing.T) {
 		t.Fatalf("Should have error as box file does not include metadata.json file")
 	}
 	t.Logf("%s", err)
+}
+
+func TestProviderFromVagrantBox_metadata_ok(t *testing.T) {
+	// Good: The box contains the metadata.json file with the required
+	// 'provider' key/value
+	expectedProvider := "virtualbox"
+	files := tarFiles{
+		{"foo.txt", "This is a foo file"},
+		{"bar.txt", "This is a bar file"},
+		{"metadata.json", `{"provider":"` + expectedProvider + `"}`},
+	}
+	boxfile, err := createBox(files)
+	if err != nil {
+		t.Fatalf("Error creating test box: %s", err)
+	}
+	defer os.Remove(boxfile.Name())
+
+	provider, err := providerFromVagrantBox(boxfile.Name())
+	assert.Equal(t, expectedProvider, provider, "Error: Expected provider: '%s'. Got '%s'", expectedProvider, provider)
+	t.Logf("Expected provider '%s'. Got provider '%s'", expectedProvider, provider)
 }
 
 func newBoxFile() (boxfile *os.File, err error) {

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -307,6 +307,26 @@ func TestProviderFromVagrantBox_metadata_empty(t *testing.T) {
 	t.Logf("%s", err)
 }
 
+func TestProviderFromVagrantBox_metadata_bad_json(t *testing.T) {
+	// Bad: Create a box with bad JSON in the metadata.json file
+	files := tarFiles{
+		{"foo.txt", "This is a foo file"},
+		{"bar.txt", "This is a bar file"},
+		{"metadata.json", "{provider: badjson}"},
+	}
+	boxfile, err := createBox(files)
+	if err != nil {
+		t.Fatalf("Error creating test box: %s", err)
+	}
+	defer os.Remove(boxfile.Name())
+
+	_, err = providerFromVagrantBox(boxfile.Name())
+	if err == nil {
+		t.Fatalf("Should have error as box files metadata.json file is empty")
+	}
+	t.Logf("%s", err)
+}
+
 func TestProviderFromVagrantBox_metadata_provider_value_empty(t *testing.T) {
 	// Bad: The boxes metadata.json file 'provider' key has an empty value
 	files := tarFiles{

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -404,6 +404,14 @@ func TestGetProvider_artifice(t *testing.T) {
 	t.Logf("Expected provider '%s'. Got provider '%s'", expectedProvider, provider)
 }
 
+func TestGetProvider_other(t *testing.T) {
+	expectedProvider := "virtualbox"
+
+	provider, _ := getProvider(expectedProvider, "foo.box", "other")
+	assert.Equal(t, expectedProvider, provider, "Error: Expected provider: '%s'. Got '%s'", expectedProvider, provider)
+	t.Logf("Expected provider '%s'. Got provider '%s'", expectedProvider, provider)
+}
+
 func newBoxFile() (boxfile *os.File, err error) {
 	boxfile, err = ioutil.TempFile(os.TempDir(), "test*.box")
 	if err != nil {

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -197,3 +197,12 @@ func TestProviderFromBuilderName(t *testing.T) {
 		t.Fatal("should convert provider")
 	}
 }
+
+func TestProviderFromVagrantBox_missing_box(t *testing.T) {
+	boxfile := "i_dont_exist.box"
+	_, err := providerFromVagrantBox(boxfile)
+	if err == nil {
+		t.Fatal("Should have error as box file does not exist")
+	}
+	t.Logf("%s", err)
+}

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -157,6 +157,26 @@ func TestPostProcessor_PostProcess_checkArtifactType(t *testing.T) {
 	}
 }
 
+func TestPostProcessor_PostProcess_checkArtifactFileIsBox(t *testing.T) {
+	artifact := &packer.MockArtifact{
+		BuilderIdValue: "mitchellh.post-processor.vagrant", // good
+		FilesValue:     []string{"invalid.boxfile"},        // should have .box extension
+	}
+
+	config := testGoodConfig()
+	server := newSecureServer("foo", nil)
+	defer server.Close()
+	config["vagrant_cloud_url"] = server.URL
+	var p PostProcessor
+
+	p.Configure(config)
+	_, _, _, err := p.PostProcess(context.Background(), testUi(), artifact)
+	if !strings.Contains(err.Error(), "Unknown files in artifact") {
+		t.Fatalf("Should error with message 'Unknown files in artifact...' with artifact file: %s",
+			artifact.FilesValue[0])
+	}
+}
+
 func testUi() *packer.BasicUi {
 	return &packer.BasicUi{
 		Reader: new(bytes.Buffer),

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -199,10 +200,26 @@ func TestProviderFromBuilderName(t *testing.T) {
 }
 
 func TestProviderFromVagrantBox_missing_box(t *testing.T) {
+	// Bad: Box does not exist
 	boxfile := "i_dont_exist.box"
 	_, err := providerFromVagrantBox(boxfile)
 	if err == nil {
 		t.Fatal("Should have error as box file does not exist")
+	}
+	t.Logf("%s", err)
+}
+
+func TestProviderFromVagrantBox_empty_box(t *testing.T) {
+	// Bad: Empty box file
+	boxfile, err := ioutil.TempFile(os.TempDir(), "test*.box")
+	if err != nil {
+		t.Fatalf("Error creating test box file: %s", err)
+	}
+	defer os.Remove(boxfile.Name())
+
+	_, err = providerFromVagrantBox(boxfile.Name())
+	if err == nil {
+		t.Fatal("Should have error as box file is empty")
 	}
 	t.Logf("%s", err)
 }

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -386,6 +386,24 @@ func TestProviderFromVagrantBox_metadata_ok(t *testing.T) {
 	t.Logf("Expected provider '%s'. Got provider '%s'", expectedProvider, provider)
 }
 
+func TestGetProvider_artifice(t *testing.T) {
+	expectedProvider := "virtualbox"
+	files := tarFiles{
+		{"foo.txt", "This is a foo file"},
+		{"bar.txt", "This is a bar file"},
+		{"metadata.json", `{"provider":"` + expectedProvider + `"}`},
+	}
+	boxfile, err := createBox(files)
+	if err != nil {
+		t.Fatalf("Error creating test box: %s", err)
+	}
+	defer os.Remove(boxfile.Name())
+
+	provider, err := getProvider("", boxfile.Name(), "artifice")
+	assert.Equal(t, expectedProvider, provider, "Error: Expected provider: '%s'. Got '%s'", expectedProvider, provider)
+	t.Logf("Expected provider '%s'. Got provider '%s'", expectedProvider, provider)
+}
+
 func newBoxFile() (boxfile *os.File, err error) {
 	boxfile, err = ioutil.TempFile(os.TempDir(), "test*.box")
 	if err != nil {

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -287,9 +287,28 @@ func TestProviderFromVagrantBox_no_metadata(t *testing.T) {
 	t.Logf("%s", err)
 }
 
+func TestProviderFromVagrantBox_metadata_empty(t *testing.T) {
+	// Bad: Create a box with an empty metadata.json file
+	files := tarFiles{
+		{"foo.txt", "This is a foo file"},
+		{"bar.txt", "This is a bar file"},
+		{"metadata.json", ""},
+	}
+	boxfile, err := createBox(files)
+	if err != nil {
+		t.Fatalf("Error creating test box: %s", err)
+	}
+	defer os.Remove(boxfile.Name())
+
+	_, err = providerFromVagrantBox(boxfile.Name())
+	if err == nil {
+		t.Fatalf("Should have error as box files metadata.json file is empty")
+	}
+	t.Logf("%s", err)
+}
+
 func TestProviderFromVagrantBox_metadata_ok(t *testing.T) {
-	// Good: The box contains the metadata.json file with the required
-	// 'provider' key/value
+	// Good: The boxes metadata.json file has the 'provider' key/value pair
 	expectedProvider := "virtualbox"
 	files := tarFiles{
 		{"foo.txt", "This is a foo file"},

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -327,6 +327,26 @@ func TestProviderFromVagrantBox_metadata_bad_json(t *testing.T) {
 	t.Logf("%s", err)
 }
 
+func TestProviderFromVagrantBox_metadata_no_provider_key(t *testing.T) {
+	// Bad: Create a box with no 'provider' key in the metadata.json file
+	files := tarFiles{
+		{"foo.txt", "This is a foo file"},
+		{"bar.txt", "This is a bar file"},
+		{"metadata.json", `{"cows":"moo"}`},
+	}
+	boxfile, err := createBox(files)
+	if err != nil {
+		t.Fatalf("Error creating test box: %s", err)
+	}
+	defer os.Remove(boxfile.Name())
+
+	_, err = providerFromVagrantBox(boxfile.Name())
+	if err == nil {
+		t.Fatalf("Should have error as box files metadata.json file is empty")
+	}
+	t.Logf("%s", err)
+}
+
 func TestProviderFromVagrantBox_metadata_provider_value_empty(t *testing.T) {
 	// Bad: The boxes metadata.json file 'provider' key has an empty value
 	files := tarFiles{

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -307,6 +307,26 @@ func TestProviderFromVagrantBox_metadata_empty(t *testing.T) {
 	t.Logf("%s", err)
 }
 
+func TestProviderFromVagrantBox_metadata_provider_value_empty(t *testing.T) {
+	// Bad: The boxes metadata.json file 'provider' key has an empty value
+	files := tarFiles{
+		{"foo.txt", "This is a foo file"},
+		{"bar.txt", "This is a bar file"},
+		{"metadata.json", `{"provider":""}`},
+	}
+	boxfile, err := createBox(files)
+	if err != nil {
+		t.Fatalf("Error creating test box: %s", err)
+	}
+	defer os.Remove(boxfile.Name())
+
+	_, err = providerFromVagrantBox(boxfile.Name())
+	if err == nil {
+		t.Fatalf("Should have error as boxes metadata.json file 'provider' key is empty")
+	}
+	t.Logf("%s", err)
+}
+
 func TestProviderFromVagrantBox_metadata_ok(t *testing.T) {
 	// Good: The boxes metadata.json file has the 'provider' key/value pair
 	expectedProvider := "virtualbox"


### PR DESCRIPTION
This PR allows the Artifice post-processor to be used in conjuntion with the Vagrant Cloud post-processor to upload boxes to Vagrant Cloud. Currently, the Vagrant Cloud post-processor only accepts input artifacts from the Vagrant post-processor and Vagrant builder.

Allowing a Vagrant box to be uploaded to Vagrant Cloud in this way should prove useful in a number of scenarios e.g. for testing and development, upload of manually created boxes, fast fixes for previously failed uploads and so on.

As usual, please let me know if there is anything further you need from me.