### PR TITLE
remove unnecessary retries for locked port when there isn't a range t…

### DIFF
--- a/common/net/configure_port.go
+++ b/common/net/configure_port.go
@@ -77,12 +77,7 @@ func (lc ListenRangeConfig) Listen(ctx context.Context) (*Listener, error) {
 		ShouldRetry: func(err error) bool {
 			_, ok := err.(ErrPortFileLocked)
 			if ok {
-				if portRange > 0 {
-					// there are other ports to try
-					return true
-				}
-				// this port is locked and we have no other ports to try
-				return false
+				return portRange > 0
 			}
 			// try again if the error isn't that the port is locked.
 			return true


### PR DESCRIPTION
Last night, I started seeing a "too many open files" error in TestListenRangeConfig_Listen when I ran `make test` locally. 

I originally thought it was a side effect of a file descriptor leak, maybe from another test, that was recently created, but I did a bisect and it's failing for me all the way back to when this test and the port lock functionality were added in v1.4.1-dev.  So something must have changed on my computer with my ulimit to make this test suddenly start failing -- however, even if it's my computer that changed recently, this looks an awful lot like a real file descriptor leak that I uncovered. 

I think the leak is happening inside the retry function. Originally I tried just adding a lock.Close() here: https://github.com/hashicorp/packer/blob/master/common/net/configure_port.go#L93-L95 but that wasn't resolving the issue, and I'm not seeing where else a leak could be occurring in this code pathway. 

For now, I've added a ShouldRetry func so we don't keep repeating the try if there are no other valid ports to attempt. @azr I'd appreciate your thoughts on this.

Closes #8035