### PR TITLE
[WIP] implement custom data type "trilean" (tri-state-boolean) to track boo…

### DIFF
--- a/builder/alicloud/ecs/builder_test.go
+++ b/builder/alicloud/ecs/builder_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	helperconfig "github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 )
 
@@ -126,13 +127,16 @@ func TestBuilderPrepare_Devices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not have error: %s", err)
 	}
-	if !reflect.DeepEqual(b.config.ECSSystemDiskMapping, AlicloudDiskDevice{
+	expected := AlicloudDiskDevice{
 		DiskCategory: "cloud",
 		Description:  "system disk",
 		DiskName:     "system_disk",
 		DiskSize:     60,
-	}) {
-		t.Fatalf("system disk is not set properly, actual: %#v", b.config.ECSSystemDiskMapping)
+		RawEncrypted: helperconfig.TriUnset,
+		Encrypted:    nil,
+	}
+	if !reflect.DeepEqual(b.config.ECSSystemDiskMapping, expected) {
+		t.Fatalf("system disk is not set properly, actual: %v; expected: %v", b.config.ECSSystemDiskMapping, expected)
 	}
 	if !reflect.DeepEqual(b.config.ECSImagesDiskMappings, []AlicloudDiskDevice{
 		{

--- a/builder/alicloud/ecs/builder_test.go
+++ b/builder/alicloud/ecs/builder_test.go
@@ -132,8 +132,7 @@ func TestBuilderPrepare_Devices(t *testing.T) {
 		Description:  "system disk",
 		DiskName:     "system_disk",
 		DiskSize:     60,
-		RawEncrypted: helperconfig.TriUnset,
-		Encrypted:    nil,
+		Encrypted:    helperconfig.TriUnset,
 	}
 	if !reflect.DeepEqual(b.config.ECSSystemDiskMapping, expected) {
 		t.Fatalf("system disk is not set properly, actual: %v; expected: %v", b.config.ECSSystemDiskMapping, expected)

--- a/builder/alicloud/ecs/image_config.go
+++ b/builder/alicloud/ecs/image_config.go
@@ -17,9 +17,7 @@ type AlicloudDiskDevice struct {
 	Description        string         `mapstructure:"disk_description"`
 	DeleteWithInstance bool           `mapstructure:"disk_delete_with_instance"`
 	Device             string         `mapstructure:"disk_device"`
-	RawEncrypted       config.Trilean `mapstructure:"disk_encrypted"`
-
-	Encrypted *bool
+	Encrypted          config.Trilean `mapstructure:"disk_encrypted"`
 }
 
 type AlicloudDiskDevices struct {
@@ -35,7 +33,7 @@ type AlicloudImageConfig struct {
 	AlicloudImageUNShareAccounts      []string          `mapstructure:"image_unshare_account"`
 	AlicloudImageDestinationRegions   []string          `mapstructure:"image_copy_regions"`
 	AlicloudImageDestinationNames     []string          `mapstructure:"image_copy_names"`
-	RawImageEncrypted                 config.Trilean    `mapstructure:"image_encrypted"`
+	ImageEncrypted                    config.Trilean    `mapstructure:"image_encrypted"`
 	AlicloudImageForceDelete          bool              `mapstructure:"image_force_delete"`
 	AlicloudImageForceDeleteSnapshots bool              `mapstructure:"image_force_delete_snapshots"`
 	AlicloudImageForceDeleteInstances bool              `mapstructure:"image_force_delete_instances"`
@@ -43,8 +41,6 @@ type AlicloudImageConfig struct {
 	AlicloudImageSkipRegionValidation bool              `mapstructure:"skip_region_validation"`
 	AlicloudImageTags                 map[string]string `mapstructure:"tags"`
 	AlicloudDiskDevices               `mapstructure:",squash"`
-
-	ImageEncrypted *bool
 }
 
 func (c *AlicloudImageConfig) Prepare(ctx *interpolate.Context) []error {
@@ -78,13 +74,6 @@ func (c *AlicloudImageConfig) Prepare(ctx *interpolate.Context) []error {
 		}
 
 		c.AlicloudImageDestinationRegions = regions
-	}
-
-	c.ImageEncrypted = c.RawImageEncrypted.ToBoolPointer()
-
-	c.ECSSystemDiskMapping.Encrypted = c.RawImageEncrypted.ToBoolPointer()
-	for i := range c.ECSImagesDiskMappings {
-		c.ECSImagesDiskMappings[i].Encrypted = c.RawImageEncrypted.ToBoolPointer()
 	}
 
 	if len(errs) > 0 {

--- a/builder/alicloud/ecs/run_config.go
+++ b/builder/alicloud/ecs/run_config.go
@@ -8,35 +8,37 @@ import (
 
 	"github.com/hashicorp/packer/common/uuid"
 	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/template/interpolate"
 )
 
 type RunConfig struct {
-	AssociatePublicIpAddress bool   `mapstructure:"associate_public_ip_address"`
-	ZoneId                   string `mapstructure:"zone_id"`
-	IOOptimized              *bool  `mapstructure:"io_optimized"`
-	InstanceType             string `mapstructure:"instance_type"`
-	Description              string `mapstructure:"description"`
-	AlicloudSourceImage      string `mapstructure:"source_image"`
-	ForceStopInstance        bool   `mapstructure:"force_stop_instance"`
-	DisableStopInstance      bool   `mapstructure:"disable_stop_instance"`
-	SecurityGroupId          string `mapstructure:"security_group_id"`
-	SecurityGroupName        string `mapstructure:"security_group_name"`
-	UserData                 string `mapstructure:"user_data"`
-	UserDataFile             string `mapstructure:"user_data_file"`
-	VpcId                    string `mapstructure:"vpc_id"`
-	VpcName                  string `mapstructure:"vpc_name"`
-	CidrBlock                string `mapstructure:"vpc_cidr_block"`
-	VSwitchId                string `mapstructure:"vswitch_id"`
-	VSwitchName              string `mapstructure:"vswitch_id"`
-	InstanceName             string `mapstructure:"instance_name"`
-	InternetChargeType       string `mapstructure:"internet_charge_type"`
-	InternetMaxBandwidthOut  int    `mapstructure:"internet_max_bandwidth_out"`
-	WaitSnapshotReadyTimeout int    `mapstructure:"wait_snapshot_ready_timeout"`
+	AssociatePublicIpAddress bool           `mapstructure:"associate_public_ip_address"`
+	ZoneId                   string         `mapstructure:"zone_id"`
+	RawIOOptimized           config.Trilean `mapstructure:"io_optimized"`
+	InstanceType             string         `mapstructure:"instance_type"`
+	Description              string         `mapstructure:"description"`
+	AlicloudSourceImage      string         `mapstructure:"source_image"`
+	ForceStopInstance        bool           `mapstructure:"force_stop_instance"`
+	DisableStopInstance      bool           `mapstructure:"disable_stop_instance"`
+	SecurityGroupId          string         `mapstructure:"security_group_id"`
+	SecurityGroupName        string         `mapstructure:"security_group_name"`
+	UserData                 string         `mapstructure:"user_data"`
+	UserDataFile             string         `mapstructure:"user_data_file"`
+	VpcId                    string         `mapstructure:"vpc_id"`
+	VpcName                  string         `mapstructure:"vpc_name"`
+	CidrBlock                string         `mapstructure:"vpc_cidr_block"`
+	VSwitchId                string         `mapstructure:"vswitch_id"`
+	VSwitchName              string         `mapstructure:"vswitch_id"`
+	InstanceName             string         `mapstructure:"instance_name"`
+	InternetChargeType       string         `mapstructure:"internet_charge_type"`
+	InternetMaxBandwidthOut  int            `mapstructure:"internet_max_bandwidth_out"`
+	WaitSnapshotReadyTimeout int            `mapstructure:"wait_snapshot_ready_timeout"`
 
 	// Communicator settings
 	Comm         communicator.Config `mapstructure:",squash"`
 	SSHPrivateIp bool                `mapstructure:"ssh_private_ip"`
+	IOOptimized  *bool
 }
 
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
@@ -67,6 +69,8 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 			errs = append(errs, fmt.Errorf("user_data_file not found: %s", c.UserDataFile))
 		}
 	}
+
+	c.IOOptimized = c.RawIOOptimized.ToBoolPointer()
 
 	return errs
 }

--- a/builder/alicloud/ecs/run_config.go
+++ b/builder/alicloud/ecs/run_config.go
@@ -15,7 +15,7 @@ import (
 type RunConfig struct {
 	AssociatePublicIpAddress bool           `mapstructure:"associate_public_ip_address"`
 	ZoneId                   string         `mapstructure:"zone_id"`
-	RawIOOptimized           config.Trilean `mapstructure:"io_optimized"`
+	IOOptimized              config.Trilean `mapstructure:"io_optimized"`
 	InstanceType             string         `mapstructure:"instance_type"`
 	Description              string         `mapstructure:"description"`
 	AlicloudSourceImage      string         `mapstructure:"source_image"`
@@ -38,7 +38,6 @@ type RunConfig struct {
 	// Communicator settings
 	Comm         communicator.Config `mapstructure:",squash"`
 	SSHPrivateIp bool                `mapstructure:"ssh_private_ip"`
-	IOOptimized  *bool
 }
 
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
@@ -69,8 +68,6 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 			errs = append(errs, fmt.Errorf("user_data_file not found: %s", c.UserDataFile))
 		}
 	}
-
-	c.IOOptimized = c.RawIOOptimized.ToBoolPointer()
 
 	return errs
 }

--- a/builder/alicloud/ecs/step_create_image.go
+++ b/builder/alicloud/ecs/step_create_image.go
@@ -30,7 +30,7 @@ func (s *stepCreateAlicloudImage) Run(ctx context.Context, state multistep.State
 	ui := state.Get("ui").(packer.Ui)
 
 	tempImageName := config.AlicloudImageName
-	if config.ImageEncrypted != nil && *config.ImageEncrypted {
+	if config.ImageEncrypted.True() {
 		tempImageName = fmt.Sprintf("packer_%s", random.AlphaNum(7))
 		ui.Say(fmt.Sprintf("Creating temporary image for encryption: %s", tempImageName))
 	} else {
@@ -85,7 +85,7 @@ func (s *stepCreateAlicloudImage) Cleanup(state multistep.StateBag) {
 	}
 
 	config := state.Get("config").(*Config)
-	encryptedSet := config.ImageEncrypted != nil && *config.ImageEncrypted
+	encryptedSet := config.ImageEncrypted.True()
 
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)

--- a/builder/alicloud/ecs/step_create_instance.go
+++ b/builder/alicloud/ecs/step_create_instance.go
@@ -145,7 +145,7 @@ func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.
 
 	if s.IOOptimized.True() {
 		request.IoOptimized = IOOptimizedOptimized
-	} else if IOOptimized.False() {
+	} else if s.IOOptimized.False() {
 		request.IoOptimized = IOOptimizedNone
 	}
 

--- a/builder/alicloud/ecs/step_create_instance.go
+++ b/builder/alicloud/ecs/step_create_instance.go
@@ -18,7 +18,7 @@ import (
 )
 
 type stepCreateAlicloudInstance struct {
-	IOOptimized             *bool
+	IOOptimized             confighelper.Trilean
 	InstanceType            string
 	UserData                string
 	UserDataFile            string
@@ -143,12 +143,10 @@ func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.
 	request.InternetChargeType = s.InternetChargeType
 	request.InternetMaxBandwidthOut = requests.Integer(convertNumber(s.InternetMaxBandwidthOut))
 
-	if s.IOOptimized != nil {
-		if *s.IOOptimized {
-			request.IoOptimized = IOOptimizedOptimized
-		} else {
-			request.IoOptimized = IOOptimizedNone
-		}
+	if s.IOOptimized.True() {
+		request.IoOptimized = IOOptimizedOptimized
+	} else if IOOptimized.False() {
+		request.IoOptimized = IOOptimizedNone
 	}
 
 	config := state.Get("config").(*Config)

--- a/builder/alicloud/ecs/step_create_instance.go
+++ b/builder/alicloud/ecs/step_create_instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	confighelper "github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -174,8 +175,8 @@ func (s *stepCreateAlicloudInstance) buildCreateInstanceRequest(state multistep.
 		dataDisk.Description = imageDisk.Description
 		dataDisk.DeleteWithInstance = strconv.FormatBool(imageDisk.DeleteWithInstance)
 		dataDisk.Device = imageDisk.Device
-		if imageDisk.Encrypted != nil {
-			dataDisk.Encrypted = strconv.FormatBool(*imageDisk.Encrypted)
+		if imageDisk.Encrypted != confighelper.TriUnset {
+			dataDisk.Encrypted = strconv.FormatBool(imageDisk.Encrypted.True())
 		}
 
 		dataDisks = append(dataDisks, dataDisk)

--- a/builder/amazon/chroot/step_register_ami.go
+++ b/builder/amazon/chroot/step_register_ami.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
+	confighelper "github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -14,7 +15,7 @@ import (
 // StepRegisterAMI creates the AMI.
 type StepRegisterAMI struct {
 	RootVolumeSize           int64
-	EnableAMIENASupport      *bool
+	EnableAMIENASupport      confighelper.Trilean
 	EnableAMISriovNetSupport bool
 }
 
@@ -41,7 +42,7 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
 		registerOpts.SriovNetSupport = aws.String("simple")
 	}
-	if s.EnableAMIENASupport != nil && *s.EnableAMIENASupport {
+	if s.EnableAMIENASupport.True() {
 		// Set EnaSupport to true
 		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
 		registerOpts.EnaSupport = aws.Bool(true)

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -20,7 +20,7 @@ type AMIConfig struct {
 	AMIRegions              []string          `mapstructure:"ami_regions"`
 	AMISkipRegionValidation bool              `mapstructure:"skip_region_validation"`
 	AMITags                 TagMap            `mapstructure:"tags"`
-	RawAMIENASupport        config.Trilean    `mapstructure:"ena_support"`
+	AMIENASupport           config.Trilean    `mapstructure:"ena_support"`
 	AMISriovNetSupport      bool              `mapstructure:"sriov_support"`
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 	AMIForceDeleteSnapshot  bool              `mapstructure:"force_delete_snapshot"`
@@ -32,8 +32,6 @@ type AMIConfig struct {
 	SnapshotGroups          []string          `mapstructure:"snapshot_groups"`
 	AMISkipBuildRegion      bool              `mapstructure:"skip_save_build_region"`
 
-	// parsed from RawAMIENASupport above. Used in steps.
-	AMIENASupport        *bool
 	AMIEncryptBootVolume *bool
 }
 
@@ -65,7 +63,6 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 
 	errs = append(errs, c.prepareRegions(accessConfig)...)
 
-	c.AMIENASupport = c.RawAMIENASupport.ToBoolPointer()
 	c.AMIEncryptBootVolume = c.RawAMIEncryptBootVolume.ToBoolPointer()
 	// Prevent sharing of default KMS key encrypted volumes with other aws users
 	if len(c.AMIUsers) > 0 {

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -24,15 +24,13 @@ type AMIConfig struct {
 	AMISriovNetSupport      bool              `mapstructure:"sriov_support"`
 	AMIForceDeregister      bool              `mapstructure:"force_deregister"`
 	AMIForceDeleteSnapshot  bool              `mapstructure:"force_delete_snapshot"`
-	RawAMIEncryptBootVolume config.Trilean    `mapstructure:"encrypt_boot"`
+	AMIEncryptBootVolume    config.Trilean    `mapstructure:"encrypt_boot"`
 	AMIKmsKeyId             string            `mapstructure:"kms_key_id"`
 	AMIRegionKMSKeyIDs      map[string]string `mapstructure:"region_kms_key_ids"`
 	SnapshotTags            TagMap            `mapstructure:"snapshot_tags"`
 	SnapshotUsers           []string          `mapstructure:"snapshot_users"`
 	SnapshotGroups          []string          `mapstructure:"snapshot_groups"`
 	AMISkipBuildRegion      bool              `mapstructure:"skip_save_build_region"`
-
-	AMIEncryptBootVolume *bool
 }
 
 func stringInSlice(s []string, searchstr string) bool {
@@ -63,10 +61,9 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 
 	errs = append(errs, c.prepareRegions(accessConfig)...)
 
-	c.AMIEncryptBootVolume = c.RawAMIEncryptBootVolume.ToBoolPointer()
 	// Prevent sharing of default KMS key encrypted volumes with other aws users
 	if len(c.AMIUsers) > 0 {
-		if len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume != nil && *c.AMIEncryptBootVolume {
+		if len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume.True() {
 			errs = append(errs, fmt.Errorf("Cannot share AMI encrypted with default KMS key"))
 		}
 		if len(c.AMIRegionKMSKeyIDs) > 0 {
@@ -96,7 +93,7 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 	}
 
 	if len(c.SnapshotUsers) > 0 {
-		if len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume != nil && *c.AMIEncryptBootVolume {
+		if len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume.True() {
 			errs = append(errs, fmt.Errorf("Cannot share snapshot encrypted with default KMS key"))
 		}
 		if len(c.AMIRegionKMSKeyIDs) > 0 {

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -139,7 +139,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 
 	c.SnapshotUsers = []string{"foo", "bar"}
 	c.AMIKmsKeyId = "123-abc-456"
-	c.RawAMIEncryptBootVolume = config.TriTrue
+	c.AMIEncryptBootVolume = config.TriTrue
 	c.AMIRegions = []string{"us-east-1", "us-west-1"}
 	c.AMIRegionKMSKeyIDs = map[string]string{
 		"us-east-1": "123-456-7890",
@@ -162,7 +162,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {
 	c := testAMIConfig()
 	c.AMIUsers = []string{"testAccountID"}
-	c.RawAMIEncryptBootVolume = config.TriTrue
+	c.AMIEncryptBootVolume = config.TriTrue
 
 	accessConf := testAccessConfig()
 

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/hashicorp/packer/helper/config"
 )
 
 func testAMIConfig() *AMIConfig {
@@ -138,7 +139,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 
 	c.SnapshotUsers = []string{"foo", "bar"}
 	c.AMIKmsKeyId = "123-abc-456"
-	c.AMIEncryptBootVolume = &[]bool{true}[0]
+	c.RawAMIEncryptBootVolume = config.TriTrue
 	c.AMIRegions = []string{"us-east-1", "us-west-1"}
 	c.AMIRegionKMSKeyIDs = map[string]string{
 		"us-east-1": "123-456-7890",
@@ -161,7 +162,7 @@ func TestAMIConfigPrepare_regions(t *testing.T) {
 func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {
 	c := testAMIConfig()
 	c.AMIUsers = []string{"testAccountID"}
-	c.AMIEncryptBootVolume = &[]bool{true}[0]
+	c.RawAMIEncryptBootVolume = config.TriTrue
 
 	accessConf := testAccessConfig()
 

--- a/builder/amazon/common/ami_config_test.go
+++ b/builder/amazon/common/ami_config_test.go
@@ -178,7 +178,7 @@ func TestAMIConfigPrepare_Share_EncryptedBoot(t *testing.T) {
 
 func TestAMIConfigPrepare_ValidateKmsKey(t *testing.T) {
 	c := testAMIConfig()
-	c.AMIEncryptBootVolume = aws.Bool(true)
+	c.AMIEncryptBootVolume = config.TriTrue
 
 	accessConf := testAccessConfig()
 

--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -6,23 +6,26 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/template/interpolate"
 )
 
 // BlockDevice
 type BlockDevice struct {
-	DeleteOnTermination bool   `mapstructure:"delete_on_termination"`
-	DeviceName          string `mapstructure:"device_name"`
-	Encrypted           *bool  `mapstructure:"encrypted"`
-	IOPS                int64  `mapstructure:"iops"`
-	NoDevice            bool   `mapstructure:"no_device"`
-	SnapshotId          string `mapstructure:"snapshot_id"`
-	VirtualName         string `mapstructure:"virtual_name"`
-	VolumeType          string `mapstructure:"volume_type"`
-	VolumeSize          int64  `mapstructure:"volume_size"`
-	KmsKeyId            string `mapstructure:"kms_key_id"`
+	DeleteOnTermination bool           `mapstructure:"delete_on_termination"`
+	DeviceName          string         `mapstructure:"device_name"`
+	RawEncrypted        config.Trilean `mapstructure:"encrypted"`
+	IOPS                int64          `mapstructure:"iops"`
+	NoDevice            bool           `mapstructure:"no_device"`
+	SnapshotId          string         `mapstructure:"snapshot_id"`
+	VirtualName         string         `mapstructure:"virtual_name"`
+	VolumeType          string         `mapstructure:"volume_type"`
+	VolumeSize          int64          `mapstructure:"volume_size"`
+	KmsKeyId            string         `mapstructure:"kms_key_id"`
 	// ebssurrogate only
 	OmitFromArtifact bool `mapstructure:"omit_from_artifact"`
+
+	Encrypted *bool
 }
 
 type BlockDevices struct {
@@ -93,6 +96,7 @@ func (b *BlockDevice) Prepare(ctx *interpolate.Context) error {
 		return fmt.Errorf("The `device_name` must be specified " +
 			"for every device in the block device mapping.")
 	}
+	b.Encrypted = b.RawEncrypted.ToBoolPointer()
 	// Warn that encrypted must be true or nil when setting kms_key_id
 	if b.KmsKeyId != "" && b.Encrypted != nil && *b.Encrypted == false {
 		return fmt.Errorf("The device %v, must also have `encrypted: "+

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/packer/helper/config"
 )
 
 func TestBlockDevice(t *testing.T) {
@@ -71,7 +72,7 @@ func TestBlockDevice(t *testing.T) {
 				VolumeType:          "gp2",
 				VolumeSize:          8,
 				DeleteOnTermination: true,
-				Encrypted:           aws.Bool(true),
+				Encrypted:           config.TriTrue,
 			},
 
 			Result: &ec2.BlockDeviceMapping{
@@ -90,7 +91,7 @@ func TestBlockDevice(t *testing.T) {
 				VolumeType:          "gp2",
 				VolumeSize:          8,
 				DeleteOnTermination: true,
-				Encrypted:           aws.Bool(true),
+				Encrypted:           config.TriTrue,
 				KmsKeyId:            "2Fa48a521f-3aff-4b34-a159-376ac5d37812",
 			},
 

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -17,7 +18,7 @@ type StepAMIRegionCopy struct {
 	Regions           []string
 	AMIKmsKeyId       string
 	RegionKeyIds      map[string]string
-	EncryptBootVolume *bool // nil means preserve
+	EncryptBootVolume config.Trilean // nil means preserve
 	Name              string
 	OriginalRegion    string
 
@@ -74,7 +75,7 @@ func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) m
 		s.toDelete = ami
 	}
 
-	if s.EncryptBootVolume != nil && *s.EncryptBootVolume {
+	if s.EncryptBootVolume.True() {
 		// encrypt_boot is true, so we have to copy the temporary
 		// AMI with required encryption setting.
 		// temp image was created by stepCreateAMI.
@@ -102,7 +103,7 @@ func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) m
 		var regKeyID string
 		ui.Message(fmt.Sprintf("Copying to: %s", region))
 
-		if s.EncryptBootVolume != nil && *s.EncryptBootVolume {
+		if s.EncryptBootVolume.True() {
 			// Encrypt is true, explicitly
 			regKeyID = s.RegionKeyIds[region]
 		} else {
@@ -112,7 +113,9 @@ func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) m
 
 		go func(region string) {
 			defer wg.Done()
-			id, snapshotIds, err := s.amiRegionCopy(ctx, state, s.AccessConfig, s.Name, ami, region, s.OriginalRegion, regKeyID, s.EncryptBootVolume)
+			id, snapshotIds, err := s.amiRegionCopy(ctx, state, s.AccessConfig,
+				s.Name, ami, region, s.OriginalRegion, regKeyID,
+				s.EncryptBootVolume.ToBoolPointer())
 			lock.Lock()
 			defer lock.Unlock()
 			amis[region] = id

--- a/builder/amazon/common/step_ami_region_copy_test.go
+++ b/builder/amazon/common/step_ami_region_copy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -109,7 +110,7 @@ func TestStepAMIRegionCopy_duplicates(t *testing.T) {
 		AMIKmsKeyId:  "12345",
 		// Original region key in regionkeyids is different than in amikmskeyid
 		RegionKeyIds:      map[string]string{"us-east-1": "12345"},
-		EncryptBootVolume: aws.Bool(true),
+		EncryptBootVolume: config.TriTrue,
 		Name:              "fake-ami-name",
 		OriginalRegion:    "us-east-1",
 	}
@@ -153,7 +154,7 @@ func TestStepAMIRegionCopy_duplicates(t *testing.T) {
 	stepAMIRegionCopy = StepAMIRegionCopy{
 		AccessConfig:      testAccessConfig(),
 		Regions:           []string{"us-east-1"},
-		EncryptBootVolume: aws.Bool(false),
+		EncryptBootVolume: config.TriFalse,
 		Name:              "fake-ami-name",
 		OriginalRegion:    "us-east-1",
 	}
@@ -179,7 +180,7 @@ func TestStepAMIRegionCopy_duplicates(t *testing.T) {
 		AMIKmsKeyId: "IlikePancakes",
 		// Original region key in regionkeyids is different than in amikmskeyid
 		RegionKeyIds:      map[string]string{"us-east-1": "12345", "us-west-2": "abcde", "ap-east-1": "xyz"},
-		EncryptBootVolume: aws.Bool(true),
+		EncryptBootVolume: config.TriTrue,
 		Name:              "fake-ami-name",
 		OriginalRegion:    "us-east-1",
 	}
@@ -226,7 +227,7 @@ func TestStepAmiRegionCopy_nil_encryption(t *testing.T) {
 		Regions:           make([]string, 0),
 		AMIKmsKeyId:       "",
 		RegionKeyIds:      make(map[string]string),
-		EncryptBootVolume: nil,
+		EncryptBootVolume: config.TriUnset,
 		Name:              "fake-ami-name",
 		OriginalRegion:    "us-east-1",
 	}
@@ -252,7 +253,7 @@ func TestStepAmiRegionCopy_true_encryption(t *testing.T) {
 		Regions:           make([]string, 0),
 		AMIKmsKeyId:       "",
 		RegionKeyIds:      make(map[string]string),
-		EncryptBootVolume: aws.Bool(true),
+		EncryptBootVolume: config.TriTrue,
 		Name:              "fake-ami-name",
 		OriginalRegion:    "us-east-1",
 	}
@@ -278,7 +279,7 @@ func TestStepAmiRegionCopy_nil_intermediary(t *testing.T) {
 		Regions:           make([]string, 0),
 		AMIKmsKeyId:       "",
 		RegionKeyIds:      make(map[string]string),
-		EncryptBootVolume: aws.Bool(false),
+		EncryptBootVolume: config.TriFalse,
 		Name:              "fake-ami-name",
 		OriginalRegion:    "us-east-1",
 	}
@@ -360,7 +361,7 @@ func TestStepAmiRegionCopy_AMISkipBuildRegion(t *testing.T) {
 		Name:               "fake-ami-name",
 		OriginalRegion:     "us-east-1",
 		AMISkipBuildRegion: false,
-		EncryptBootVolume:  aws.Bool(true),
+		EncryptBootVolume:  config.TriTrue,
 	}
 	// mock out the region connection code
 	stepAMIRegionCopy.getRegionConn = getMockConn
@@ -386,7 +387,7 @@ func TestStepAmiRegionCopy_AMISkipBuildRegion(t *testing.T) {
 		Name:               "fake-ami-name",
 		OriginalRegion:     "us-east-1",
 		AMISkipBuildRegion: true,
-		EncryptBootVolume:  aws.Bool(true),
+		EncryptBootVolume:  config.TriTrue,
 	}
 	// mock out the region connection code
 	stepAMIRegionCopy.getRegionConn = getMockConn

--- a/builder/amazon/common/step_modify_ebs_instance.go
+++ b/builder/amazon/common/step_modify_ebs_instance.go
@@ -5,19 +5,20 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	confighelper "github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
 
 type StepModifyEBSBackedInstance struct {
-	EnableAMIENASupport      *bool
+	EnableAMIENASupport      confighelper.Trilean
 	EnableAMISriovNetSupport bool
 }
 
 func (s *StepModifyEBSBackedInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ec2conn := state.Get("ec2").(*ec2.EC2)
+	ec2conn := state.Get("ec2").(ec2iface.EC2API)
 	instance := state.Get("instance").(*ec2.Instance)
 	ui := state.Get("ui").(packer.Ui)
 
@@ -40,9 +41,9 @@ func (s *StepModifyEBSBackedInstance) Run(ctx context.Context, state multistep.S
 
 	// Handle EnaSupport flag.
 	// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
-	if s.EnableAMIENASupport != nil {
+	if s.EnableAMIENASupport != confighelper.TriUnset {
 		var prefix string
-		if *s.EnableAMIENASupport {
+		if s.EnableAMIENASupport.True() {
 			prefix = "En"
 		} else {
 			prefix = "Dis"
@@ -50,7 +51,7 @@ func (s *StepModifyEBSBackedInstance) Run(ctx context.Context, state multistep.S
 		ui.Say(fmt.Sprintf("%sabling Enhanced Networking (ENA)...", prefix))
 		_, err := ec2conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
 			InstanceId: instance.InstanceId,
-			EnaSupport: &ec2.AttributeBooleanValue{Value: aws.Bool(*s.EnableAMIENASupport)},
+			EnaSupport: &ec2.AttributeBooleanValue{Value: s.EnableAMIENASupport.ToBoolPointer()},
 		})
 		if err != nil {
 			err := fmt.Errorf("Error %sabling Enhanced Networking (ENA) on %s: %s", strings.ToLower(prefix), *instance.InstanceId, err)

--- a/builder/amazon/common/step_modify_ebs_instance_test.go
+++ b/builder/amazon/common/step_modify_ebs_instance_test.go
@@ -1,0 +1,105 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	helperconfig "github.com/hashicorp/packer/helper/config"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+// Define a mock struct to be used in unit tests for common aws steps.
+type mockEC2Conn_ModifyEBS struct {
+	ec2iface.EC2API
+	Config *aws.Config
+
+	// Counters to figure out what code path was taken
+	shouldError          bool
+	modifyImageAttrCount int
+}
+
+func (m *mockEC2Conn_ModifyEBS) ModifyInstanceAttribute(modifyInput *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
+	m.modifyImageAttrCount++
+	// don't need to define output since we always discard it anyway.
+	output := &ec2.ModifyInstanceAttributeOutput{}
+	if m.shouldError {
+		return output, fmt.Errorf("fake ModifyInstanceAttribute error")
+	}
+	return output, nil
+}
+
+// Create statebag for running test
+func fakeModifyEBSBackedInstanceState() multistep.StateBag {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	state.Put("instance", "i-12345")
+	return state
+}
+
+func StepModifyEBSBackedInstance_EnableAMIENASupport(t *testing.T) {
+	// Value is unset, so we shouldn't modify
+	stepModifyEBSBackedInstance := StepModifyEBSBackedInstance{
+		EnableAMIENASupport:      helperconfig.TriUnset,
+		EnableAMISriovNetSupport: false,
+	}
+
+	// mock out the region connection code
+	mockConn := &mockEC2Conn_ModifyEBS{
+		Config: aws.NewConfig(),
+	}
+
+	state := fakeModifyEBSBackedInstanceState()
+	state.Put("ec2", mockConn)
+	stepModifyEBSBackedInstance.Run(context.Background(), state)
+
+	if mockConn.modifyImageAttrCount > 0 {
+		t.Fatalf("Should not have modified image since EnableAMIENASupport is unset")
+	}
+
+	// Value is true, so we should modify
+	stepModifyEBSBackedInstance = StepModifyEBSBackedInstance{
+		EnableAMIENASupport:      helperconfig.TriTrue,
+		EnableAMISriovNetSupport: false,
+	}
+
+	// mock out the region connection code
+	mockConn = &mockEC2Conn_ModifyEBS{
+		Config: aws.NewConfig(),
+	}
+
+	state = fakeModifyEBSBackedInstanceState()
+	state.Put("ec2", mockConn)
+	stepModifyEBSBackedInstance.Run(context.Background(), state)
+
+	if mockConn.modifyImageAttrCount != 1 {
+		t.Fatalf("Should have modified image, since EnableAMIENASupport is true")
+	}
+
+	// Value is false, so we should modify
+	stepModifyEBSBackedInstance = StepModifyEBSBackedInstance{
+		EnableAMIENASupport:      helperconfig.TriFalse,
+		EnableAMISriovNetSupport: false,
+	}
+
+	// mock out the region connection code
+	mockConn = &mockEC2Conn_ModifyEBS{
+		Config: aws.NewConfig(),
+	}
+
+	state = fakeModifyEBSBackedInstanceState()
+	state.Put("ec2", mockConn)
+	stepModifyEBSBackedInstance.Run(context.Background(), state)
+
+	if mockConn.modifyImageAttrCount != 1 {
+		t.Fatalf("Should have modified image, since EnableAMIENASupport is true")
+	}
+}

--- a/builder/amazon/common/step_source_ami_info.go
+++ b/builder/amazon/common/step_source_ami_info.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	confighelper "github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -20,7 +21,7 @@ import (
 type StepSourceAMIInfo struct {
 	SourceAmi                string
 	EnableAMISriovNetSupport bool
-	EnableAMIENASupport      *bool
+	EnableAMIENASupport      confighelper.Trilean
 	AMIVirtType              string
 	AmiFilters               AmiFilterOptions
 }
@@ -94,7 +95,7 @@ func (s *StepSourceAMIInfo) Run(ctx context.Context, state multistep.StateBag) m
 
 	// Enhanced Networking can only be enabled on HVM AMIs.
 	// See http://goo.gl/icuXh5
-	if (s.EnableAMIENASupport != nil && *s.EnableAMIENASupport) || s.EnableAMISriovNetSupport {
+	if s.EnableAMIENASupport.True() || s.EnableAMISriovNetSupport {
 		err = s.canEnableEnhancedNetworking(image)
 		if err != nil {
 			state.Put("error", err)

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -72,7 +72,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, b.config.BlockDevices.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.RunConfig.Prepare(&b.config.ctx)...)
 
-	if b.config.IsSpotInstance() && ((b.config.AMIENASupport != nil && *b.config.AMIENASupport) || b.config.AMISriovNetSupport) {
+	if b.config.IsSpotInstance() && (b.config.AMIENASupport.True() || b.config.AMISriovNetSupport) {
 		errs = packer.MultiErrorAppend(errs,
 			fmt.Errorf("Spot instances do not support modification, which is required "+
 				"when either `ena_support` or `sriov_support` are set. Please ensure "+

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -27,7 +27,7 @@ func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 	// Create the image
 	amiName := config.AMIName
 	state.Put("intermediary_image", false)
-	if config.AMIEncryptBootVolume != nil && *config.AMIEncryptBootVolume != false || s.AMISkipBuildRegion {
+	if config.AMIEncryptBootVolume.True() || s.AMISkipBuildRegion {
 		state.Put("intermediary_image", true)
 
 		// From AWS SDK docs: You can encrypt a copy of an unencrypted snapshot,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -90,7 +90,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("no volume with name '%s' is found", b.config.RootDevice.SourceDeviceName))
 	}
 
-	if b.config.IsSpotInstance() && ((b.config.AMIENASupport != nil && *b.config.AMIENASupport) || b.config.AMISriovNetSupport) {
+	if b.config.IsSpotInstance() && (b.config.AMIENASupport.True() || b.config.AMISriovNetSupport) {
 		errs = packer.MultiErrorAppend(errs,
 			fmt.Errorf("Spot instances do not support modification, which is required "+
 				"when either `ena_support` or `sriov_support` are set. Please ensure "+

--- a/builder/amazon/ebssurrogate/step_register_ami.go
+++ b/builder/amazon/ebssurrogate/step_register_ami.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
+	confighelper "github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
@@ -16,7 +17,7 @@ type StepRegisterAMI struct {
 	RootDevice               RootBlockDevice
 	AMIDevices               []*ec2.BlockDeviceMapping
 	LaunchDevices            []*ec2.BlockDeviceMapping
-	EnableAMIENASupport      *bool
+	EnableAMIENASupport      confighelper.Trilean
 	EnableAMISriovNetSupport bool
 	Architecture             string
 	image                    *ec2.Image
@@ -46,7 +47,7 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
 		registerOpts.SriovNetSupport = aws.String("simple")
 	}
-	if s.EnableAMIENASupport != nil && *s.EnableAMIENASupport {
+	if s.EnableAMIENASupport.True() {
 		// Set EnaSupport to true
 		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
 		registerOpts.EnaSupport = aws.Bool(true)

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -24,13 +24,11 @@ type Config struct {
 	awscommon.RunConfig    `mapstructure:",squash"`
 
 	VolumeMappings     []BlockDevice  `mapstructure:"ebs_volumes"`
-	RawAMIENASupport   config.Trilean `mapstructure:"ena_support"`
+	AMIENASupport      config.Trilean `mapstructure:"ena_support"`
 	AMISriovNetSupport bool           `mapstructure:"sriov_support"`
 
 	launchBlockDevices awscommon.BlockDevices
 	ctx                interpolate.Context
-
-	AMIENASupport *bool
 }
 
 type Builder struct {
@@ -77,9 +75,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packer.MultiErrorAppend(errs, err)
 	}
 
-	b.config.AMIENASupport = b.config.RawAMIENASupport.ToBoolPointer()
-
-	if b.config.IsSpotInstance() && ((b.config.AMIENASupport != nil && *b.config.AMIENASupport) || b.config.AMISriovNetSupport) {
+	if b.config.IsSpotInstance() && ((b.config.AMIENASupport.True()) || b.config.AMISriovNetSupport) {
 		errs = packer.MultiErrorAppend(errs,
 			fmt.Errorf("Spot instances do not support modification, which is required "+
 				"when either `ena_support` or `sriov_support` are set. Please ensure "+

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -23,12 +23,14 @@ type Config struct {
 	awscommon.AccessConfig `mapstructure:",squash"`
 	awscommon.RunConfig    `mapstructure:",squash"`
 
-	VolumeMappings     []BlockDevice `mapstructure:"ebs_volumes"`
-	AMIENASupport      *bool         `mapstructure:"ena_support"`
-	AMISriovNetSupport bool          `mapstructure:"sriov_support"`
+	VolumeMappings     []BlockDevice  `mapstructure:"ebs_volumes"`
+	RawAMIENASupport   config.Trilean `mapstructure:"ena_support"`
+	AMISriovNetSupport bool           `mapstructure:"sriov_support"`
 
 	launchBlockDevices awscommon.BlockDevices
 	ctx                interpolate.Context
+
+	AMIENASupport *bool
 }
 
 type Builder struct {
@@ -74,6 +76,8 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	if err != nil {
 		errs = packer.MultiErrorAppend(errs, err)
 	}
+
+	b.config.AMIENASupport = b.config.RawAMIENASupport.ToBoolPointer()
 
 	if b.config.IsSpotInstance() && ((b.config.AMIENASupport != nil && *b.config.AMIENASupport) || b.config.AMISriovNetSupport) {
 		errs = packer.MultiErrorAppend(errs,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -157,7 +157,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 			errs, fmt.Errorf("x509_key_path points to bad file: %s", err))
 	}
 
-	if b.config.IsSpotInstance() && ((b.config.AMIENASupport != nil && *b.config.AMIENASupport) || b.config.AMISriovNetSupport) {
+	if b.config.IsSpotInstance() && ((b.config.AMIENASupport.True()) || b.config.AMISriovNetSupport) {
 		errs = packer.MultiErrorAppend(errs,
 			fmt.Errorf("Spot instances do not support modification, which is required "+
 				"when either `ena_support` or `sriov_support` are set. Please ensure "+

--- a/builder/amazon/instance/step_register_ami.go
+++ b/builder/amazon/instance/step_register_ami.go
@@ -7,12 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
+	confighelper "github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 )
 
 type StepRegisterAMI struct {
-	EnableAMIENASupport      *bool
+	EnableAMIENASupport      confighelper.Trilean
 	EnableAMISriovNetSupport bool
 }
 
@@ -38,7 +39,7 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 		// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)
 		registerOpts.SriovNetSupport = aws.String("simple")
 	}
-	if s.EnableAMIENASupport != nil && *s.EnableAMIENASupport {
+	if s.EnableAMIENASupport.True() {
 		// Set EnaSupport to true
 		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
 		registerOpts.EnaSupport = aws.Bool(true)

--- a/helper/config/custom_types.go
+++ b/helper/config/custom_types.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"strconv"
+)
+
+type Trilean uint8
+
+const (
+	// This will assign unset to 0, which is the default value in interpolation
+	TriUnset Trilean = iota
+	TriTrue
+	TriFalse
+)
+
+func (t Trilean) ToString() string {
+	if t == TriTrue {
+		return "TriTrue"
+	} else if t == TriFalse {
+		return "TriFalse"
+	}
+	return "TriUnset"
+}
+
+func (t Trilean) ToBoolPointer() *bool {
+	if t == TriTrue {
+		return boolPointer(true)
+	} else if t == TriFalse {
+		return boolPointer(false)
+	}
+	return nil
+}
+
+func (t Trilean) True() bool {
+	if t == TriTrue {
+		return true
+	}
+	return false
+}
+
+func (t Trilean) False() bool {
+	if t == TriFalse {
+		return true
+	}
+	return false
+}
+
+func TrileanFromString(s string) (Trilean, error) {
+	if s == "" {
+		return TriUnset, nil
+	}
+
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return TriUnset, err
+	} else if b == true {
+		return TriTrue, nil
+	} else {
+		return TriFalse, nil
+	}
+}
+
+func TrileanFromBool(b bool) Trilean {
+	if b {
+		return TriTrue
+	}
+	return TriFalse
+}
+
+func boolPointer(b bool) *bool {
+	return &b
+}

--- a/helper/config/custom_types_test.go
+++ b/helper/config/custom_types_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestTrilianParsing(t *testing.T) {
+	type testCase struct {
+		Input       string
+		Output      Trilean
+		ErrExpected bool
+	}
+	testCases := []testCase{
+		{"true", TriTrue, false}, {"True", TriTrue, false},
+		{"false", TriFalse, false}, {"False", TriFalse, false},
+		{"", TriUnset, false}, {"badvalue", TriUnset, true},
+		{"FAlse", TriUnset, true}, {"TrUe", TriUnset, true},
+	}
+	for _, tc := range testCases {
+		tril, err := TrileanFromString(tc.Input)
+		if err != nil {
+			if tc.ErrExpected == false {
+				t.Fatalf("Didn't expect error: %v", tc)
+			}
+		}
+		if tc.Output != tril {
+			t.Fatalf("Didn't return proper trilean. %v", tc)
+		}
+	}
+}

--- a/helper/config/decode_test.go
+++ b/helper/config/decode_test.go
@@ -13,6 +13,7 @@ func TestDecode(t *testing.T) {
 		Name    string
 		Address string
 		Time    time.Duration
+		Trilean Trilean
 	}
 
 	cases := map[string]struct {
@@ -23,13 +24,27 @@ func TestDecode(t *testing.T) {
 		"basic": {
 			[]interface{}{
 				map[string]interface{}{
-					"name": "bar",
-					"time": "5s",
+					"name":    "bar",
+					"time":    "5s",
+					"trilean": "true",
 				},
 			},
 			&Target{
-				Name: "bar",
-				Time: 5 * time.Second,
+				Name:    "bar",
+				Time:    5 * time.Second,
+				Trilean: TriTrue,
+			},
+			nil,
+		},
+
+		"empty-string-trilean": {
+			[]interface{}{
+				map[string]interface{}{
+					"trilean": "",
+				},
+			},
+			&Target{
+				Trilean: TriUnset,
 			},
 			nil,
 		},


### PR DESCRIPTION
There are some config options (example: encryption) where we want to behave differently depending on whether a boolean value was true, false, or left unset. Previously we used a *bool and tested on nil, but if a user was setting encryption via a template variable, the variable would never evaluate to "unset" -- an empty string would evaluate to "false", causing unpredictable behavior.

This implements a custom data type to help us parse booleans where we want to preserve the "unset" state rather than evaluating to false.  

Closes #7959