### PR TITLE
website: Update middleman-hashicorp and Gemfile.lock

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.39"
+gem "middleman-hashicorp", "0.3.41"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    autoprefixer-rails (9.5.1)
+    autoprefixer-rails (9.6.1)
       execjs
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
@@ -41,8 +41,8 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    ffi (1.10.0)
-    haml (5.0.4)
+    ffi (1.11.1)
+    haml (5.1.2)
       temple (>= 0.8.0)
       tilt
     hike (1.2.3)
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.39)
+    middleman-hashicorp (0.3.41)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -95,16 +95,16 @@ GEM
       sprockets (~> 2.12.1)
       sprockets-helpers (~> 1.1.0)
       sprockets-sass (~> 1.3.0)
-    middleman-syntax (3.0.0)
+    middleman-syntax (3.2.0)
       middleman-core (>= 3.2)
-      rouge (~> 2.0)
+      rouge (~> 3.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     padrino-helpers (0.12.9)
       i18n (~> 0.6, >= 0.6.7)
@@ -117,16 +117,14 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    redcarpet (3.4.0)
-    rouge (2.2.1)
+    redcarpet (3.5.0)
+    rouge (3.9.0)
     sass (3.4.25)
-    sassc (2.0.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
-      rake
     sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -157,7 +155,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.39)
+  middleman-hashicorp (= 0.3.41)
 
 BUNDLED WITH
    1.17.1


### PR DESCRIPTION
Time marches on, and so do security vulnerabilities in Nokogiri. So it's time
for a new middleman-hashicorp version.

As with last time, here's a reminder for the next person who needs to update
this:

- Packer is different from all the other product sites. It uses a Netlify
  container to build, instead of either the basic middleman-hashicorp container
  or the hybrid thing that Vault uses. It doesn't come with all batteries
  included, so it has to take fifteen minutes to build the universe the first
  time you run it (or the first time you run it after an upgrade). After that,
  it caches all the gems it built the previous time.
- So the steps to update it are a bit different. (Simpler, but more sitting around.)
    - Update the Gemfile
    - Delete Gemfile.lock
    - `make website` until it comes up, then ctrl-C
    - Commit the changes