### PR TITLE
Fix Travis timeouts

### DIFF
--- a/builder/googlecompute/step_instance_info_test.go
+++ b/builder/googlecompute/step_instance_info_test.go
@@ -149,7 +149,7 @@ func TestStepInstanceInfo_errorTimeout(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		<-time.After(10 * time.Millisecond)
+		<-time.After(50 * time.Millisecond)
 		errCh <- nil
 	}()
 


### PR DESCRIPTION
This timeout regularly flakes on Travis, I suspect because the instances running the tests are brutally underpowered. This PR increases the fudge factor by 5x.