### PR TITLE
📝 incorrect documentation in `alicloud-ecs` builder, env for `security_token` should be `SECURITY_TOKEN` instead of `SecurityToken`

### DIFF
--- a/website/source/docs/builders/alicloud-ecs.html.md
+++ b/website/source/docs/builders/alicloud-ecs.html.md
@@ -235,7 +235,7 @@ builder.
 
 -   `security_token` (string) - STS access token, can be set through template
     or by exporting as environment variable such as
-    `export SecurityToken=value`.
+    `export SECURITY_TOKEN=value`.
 
 -   `skip_region_validation` (boolean) - The region validation can be skipped
     if this value is true, the default value is false.


### PR DESCRIPTION
# Overview
* 📝 incorrect documentation in `alicloud-ecs` builder, env for `security_token` should be `SECURITY_TOKEN` instead of `SecurityToken`

# Background
there's a typo/incorrect doc in `alicloud-ecs` builder documentation at this [line (on security_token)](https://github.com/hashicorp/packer/pull/8040/files#diff-0b654e7472e81f1465a3f3adf0a36476L238), looking at [this line in hashicorp/packer/builder/alicloud/ecs/access_config.go](https://github.com/hashicorp/packer/blob/master/builder/alicloud/ecs/access_config.go#L33), env for `security_token` input should be `SECURITY_TOKEN`

# Tests
```
➜  packer git:(doc/incorrect_documentation_in_alicloud-ecs_security_token) go test
PASS
ok  	github.com/hashicorp/packer	0.05
```


# Issues
no open issues related