### PR TITLE
[amazon-ebs builder] Add a parameter to skip build

### DIFF
--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -30,6 +30,7 @@ type AMIConfig struct {
 	SnapshotUsers           []string          `mapstructure:"snapshot_users"`
 	SnapshotGroups          []string          `mapstructure:"snapshot_groups"`
 	AMISkipBuildRegion      bool              `mapstructure:"skip_save_build_region"`
+	AMISkipBuildIfExists    bool              `mapstructure:"skip_build_if_exists"`
 }
 
 func stringInSlice(s []string, searchstr string) bool {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -163,9 +163,10 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepPreValidate{
-			DestAmiName:        b.config.AMIName,
-			ForceDeregister:    b.config.AMIForceDeregister,
-			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
+			DestAmiName:          b.config.AMIName,
+			ForceDeregister:      b.config.AMIForceDeregister,
+			AMISkipBuildRegion:   b.config.AMISkipBuildRegion,
+			AMISkipBuildIfExists: b.config.AMISkipBuildIfExists,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,

--- a/website/source/docs/builders/amazon-ebs.html.md.erb
+++ b/website/source/docs/builders/amazon-ebs.html.md.erb
@@ -296,6 +296,9 @@ builder.
     shutdown in case Packer exits ungracefully. Possible values are "stop" and
     "terminate", default is `stop`.
 
+-   `skip_build_if_exists` (boolean) - Set to true if you want to skip building
+    an AMI if one with the same `ami_name` already exists. Default `false`.
+
 -   `skip_region_validation` (boolean) - Set to true if you want to skip
     validation of the region configuration option. Default `false`.
 


### PR DESCRIPTION
The packer build command throws an error when attempting to build an
AMI with a name that matches an existing AMI on AWS. This change adds
a new amazon-ebs builder parameter, `skip_build_if_exists`,  to make
packer ignore instead of fail a build in this situation.

Closes #8029

example run:
```
➜  packer build template.json
bbot-v1.0.0 output will be in this color.
weechat-v1.0.0 output will be in this color.

==> bbot-v1.0.0: Prevalidating AMI Name: bbot-v1.0.0
==> weechat-v1.0.0: Prevalidating AMI Name: weechat-v1.0.0
    bbot-v1.0.0: Info: AMI Name: 'bbot-v1.0.0' (ID: 'ami-07042b45ae1bf0ddf') already exists, skipping build
Build 'bbot-v1.0.0' finished.
    weechat-v1.0.0: Info: AMI Name: 'weechat-v1.0.0' (ID: 'ami-07d7b9a676b6ab017') already exists, skipping build
Build 'weechat-v1.0.0' finished.

==> Builds finished but no artifacts were created.
➜ echo $?
0
```
