### PR TITLE
post-processor/vsphere: removed redundant whitelist check for builders as the PP will check for an ova, vmx or ovf file

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -19,11 +19,6 @@ import (
 	"github.com/hashicorp/packer/template/interpolate"
 )
 
-var builtins = map[string]string{
-	"mitchellh.vmware":     "vmware",
-	"mitchellh.vmware-esx": "vmware",
-}
-
 var ovftool string = "ovftool"
 
 var (
@@ -116,10 +111,6 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 }
 
 func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, bool, error) {
-	if _, ok := builtins[artifact.BuilderId()]; !ok {
-		return nil, false, false, fmt.Errorf("Unknown artifact type, can't build box: %s", artifact.BuilderId())
-	}
-
 	source := ""
 	for _, path := range artifact.Files() {
 		if strings.HasSuffix(path, ".vmx") || strings.HasSuffix(path, ".ovf") || strings.HasSuffix(path, ".ova") {

--- a/website/source/docs/post-processors/vsphere.html.md
+++ b/website/source/docs/post-processors/vsphere.html.md
@@ -1,7 +1,6 @@
 ---
 description: |
-    The Packer vSphere post-processor takes an artifact from the VMware builder and
-    uploads it to a vSphere endpoint.
+    The Packer vSphere post-processor takes an artifact and uploads it to a vSphere endpoint.
 layout: docs
 page_title: 'vSphere - Post-Processors'
 sidebar_current: 'docs-post-processors-vsphere'
@@ -11,8 +10,8 @@ sidebar_current: 'docs-post-processors-vsphere'
 
 Type: `vsphere`
 
-The Packer vSphere post-processor takes an artifact from the VMware builder and
-uploads it to a vSphere endpoint.
+The Packer vSphere post-processor takes an artifact and uploads it to a vSphere endpoint.
+The artifact must have a vmx/ova/ovf image.
 
 ## Configuration
 


### PR DESCRIPTION
Closes #8060 

This allows to assemble a ovf image without using the vmware builder

