### PR TITLE
Remove incorrect troubleshooting information for Arch Linux

### DIFF
--- a/website/source/intro/getting-started/install.html.md
+++ b/website/source/intro/getting-started/install.html.md
@@ -126,9 +126,4 @@ To fix this, you can create a symlink to packer that uses a different name like
 `packer.io`, or invoke the `packer` binary you want using its absolute path,
 e.g. `/usr/local/packer`.
 
-On *Arch* Linux there is a package named `packer` in the main
-repository and in the AUR. The package `packer` in the AUR is an old
-name for a package management tool for Arch, it's not Hashicorp
-Packer.
-
 [Continue to building an image](./build-image.html)


### PR DESCRIPTION
The package for Packer in the arch linux repos now points to HashiCorp packer. 

https://www.archlinux.org/packages/community/x86_64/packer/
