### PR TITLE
added version compatibility to console command

### DIFF
--- a/website/source/docs/commands/console.html.md
+++ b/website/source/docs/commands/console.html.md
@@ -14,6 +14,8 @@ interpolations. You may access variables in the Packer config you called the
 console with, or provide variables when you call console using the -var or
 -var-file command line options.
 
+~> **Note:** `console` is available from version 1.4.2 and above.
+
 Type in the interpolation to test and hit \<enter\> to see the result.
 
 To exit the console, type "exit" and hit \<enter\>, or use Control-C.


### PR DESCRIPTION
let the user know that console is available from version 1.4.2 and above, I was using 1.3.5 and didn't see the console command. thought of updating the docs.

**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer PR:

https://github.com/hashicorp/packer/blob/master/.github/CONTRIBUTING.md#opening-an-pull-request

Describe the change you are making here!

Please include tests. Check out these examples:

- https://github.com/hashicorp/packer/blob/master/builder/virtualbox/common/ssh_config_test.go#L19-L37
- https://github.com/hashicorp/packer/blob/master/post-processor/compress/post-processor_test.go#L153-L182

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx
