### PR TITLE
builder/proxmox: Shorten default boot_key_interval to 5ms from 100ms

### DIFF
--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -103,7 +103,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		c.RawBootKeyInterval = os.Getenv(common.PackerKeyEnv)
 	}
 	if c.RawBootKeyInterval == "" {
-		c.BootKeyInterval = common.PackerKeyDefault
+		c.BootKeyInterval = 5 * time.Millisecond
 	} else {
 		if interval, err := time.ParseDuration(c.RawBootKeyInterval); err == nil {
 			c.BootKeyInterval = interval


### PR DESCRIPTION
The current `boot_key_interval` defaults to `common.PackerKeyDefault`, which is 100ms. This seems to be driven by VNC limitations:

https://github.com/hashicorp/packer/blob/dad3ae15352dcb7ff41076547983913c933005e3/website/source/docs/builders/qemu.html.md.erb#L414-L416

For the proxmox builder, each key is sent via synchronous http request, so this probably doesn't apply here. So this PR reduces the interval to 5ms (also chosen pretty arbitrarily, if there are good reasons to go higher/lower, I'll change it).

Closes #7890 
