### PR TITLE
Fix powershell formatting. Match style for conditionals

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -35,21 +35,19 @@ param([string]$switchName, [int]$addressIndex)
 $HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName
 if ($HostVMAdapter){
   $HostNetAdapter = Get-NetAdapter | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
-   if ($HostNetAdapter){
-     $HostNetAdapterIfIndex = @()
-     $HostNetAdapterIfIndex +=  $HostNetAdapter.ifIndex
-     $HostNetAdapterConfiguration =  @(get-wmiobject win32_networkadapterconfiguration -filter "IPEnabled = 'TRUE'") | Where-Object { $HostNetAdapterIfIndex.Contains($_.InterfaceIndex) }
-       if ($HostNetAdapterConfiguration){
-         return @($HostNetAdapterConfiguration.IpAddress)[$addressIndex]
-     }
-   }
-}
-else {
+  if ($HostNetAdapter){
+    $HostNetAdapterIfIndex = @()
+    $HostNetAdapterIfIndex += $HostNetAdapter.ifIndex
+    $HostNetAdapterConfiguration = @(get-wmiobject win32_networkadapterconfiguration -filter "IPEnabled = 'TRUE'") | Where-Object { $HostNetAdapterIfIndex.Contains($_.InterfaceIndex)
+    if ($HostNetAdapterConfiguration){
+      return @($HostNetAdapterConfiguration.IpAddress)[$addressIndex]
+    }
+  }
+} else {
   $HostNetAdapterConfiguration=@(Get-NetIPAddress -CimSession $env:computername -AddressFamily IPv4 | Where-Object { ( $_.InterfaceAlias -notmatch 'Loopback' ) -and ( $_.SuffixOrigin -notmatch "Link" )})
   if ($HostNetAdapterConfiguration) {
     return @($HostNetAdapterConfiguration.IpAddress)[$addressIndex]
-  }
-  else {
+  } else {
     return $false
  }
 }


### PR DESCRIPTION
Fixes a couple of very minor nits, namely indentation and some double spacing. Also matches the style used for conditionals in the rest of the scripts. 
