### PR TITLE
make ucloud builder's base url configurable

### DIFF
--- a/builder/ucloud/uhost/access_config.go
+++ b/builder/ucloud/uhost/access_config.go
@@ -18,6 +18,7 @@ type AccessConfig struct {
 	PrivateKey string `mapstructure:"private_key"`
 	Region     string `mapstructure:"region"`
 	ProjectId  string `mapstructure:"project_id"`
+	BaseUrl    string `mapstructure:"base_url"`
 
 	client *UCloudClient
 }
@@ -30,6 +31,9 @@ func (c *AccessConfig) Client() (*UCloudClient, error) {
 	cfg := ucloud.NewConfig()
 	cfg.Region = c.Region
 	cfg.ProjectId = c.ProjectId
+	if c.BaseUrl != "" {
+		cfg.BaseUrl = c.BaseUrl
+	}
 	cfg.UserAgent = fmt.Sprintf("Packer-UCloud/%s", version.FormattedVersion())
 
 	cred := auth.NewCredential()

--- a/builder/ucloud/uhost/builder_acc_test.go
+++ b/builder/ucloud/uhost/builder_acc_test.go
@@ -3,6 +3,7 @@ package uhost
 import (
 	"fmt"
 	"github.com/hashicorp/packer/packer"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 
@@ -191,6 +192,17 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("UCLOUD_PROJECT_ID"); v == "" {
 		t.Fatal("UCLOUD_PROJECT_ID must be set for acceptance tests")
 	}
+}
+
+func TestUCloudClientBaseUrlConfigurable(t *testing.T) {
+	const url = "baseUrl"
+	access := &AccessConfig{BaseUrl: url}
+	client, err := access.Client()
+	assert.Nil(t, err)
+	assert.Equal(t, url, client.uaccountconn.Client.GetConfig().BaseUrl, "account conn's base url not configurable")
+	assert.Equal(t, url, client.uhostconn.Client.GetConfig().BaseUrl, "host conn's base url not configurable")
+	assert.Equal(t, url, client.unetconn.Client.GetConfig().BaseUrl, "net conn's base url not configurable")
+	assert.Equal(t, url, client.vpcconn.Client.GetConfig().BaseUrl, "vpc conn's base url not configurable")
 }
 
 func testUCloudClient() (*UCloudClient, error) {


### PR DESCRIPTION
UCloud sdk has a config named "base url" so user can call api in some private stack like azure stack. This PR makes ucloud client's base url configurable via packer code. It's empty by default and ucloud client'll use default url, and user can pass a new url to override it.