### PR TITLE
fix(virtualbox-vm) LoadSnapshots should succeed even if machine has no snapshots

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -252,17 +252,18 @@ func (d *VBox42Driver) LoadSnapshots(vmName string) (*VBoxSnapshot, error) {
 	}
 	log.Printf("Executing LoadSnapshots: VM: %s", vmName)
 
+	var rootNode *VBoxSnapshot
 	stdoutString, err := d.VBoxManageWithOutput("snapshot", vmName, "list", "--machinereadable")
+	if stdoutString == "This machine does not have any snapshots" {
+		return rootNode, nil
+	}
 	if nil != err {
 		return nil, err
 	}
 
-	var rootNode *VBoxSnapshot
-	if stdoutString != "This machine does not have any snapshots" {
-		rootNode, err = ParseSnapshotData(stdoutString)
-		if nil != err {
-			return nil, err
-		}
+	rootNode, err = ParseSnapshotData(stdoutString)
+	if nil != err {
+		return nil, err
 	}
 
 	return rootNode, nil


### PR DESCRIPTION
With VirtualBox 6.0.10, VBoxManage returns an exit code of 1 if the machine has no snapshots. The code currently handles this use case but only if VBoxManage returns an exit code of 0. I assume this is because in earlier versions the exit code was 0 - @tmeckel - perhaps you could confirm as you initially wrote this code? This change aims to address this by handling both cases in that stdout is checked prior to checking exit code.