### PR TITLE
post-proc(vagrant-cloud) allow blank access_token (no auth) for private vagrant box hosting

### DIFF
--- a/post-processor/vagrant-cloud/client.go
+++ b/post-processor/vagrant-cloud/client.go
@@ -106,12 +106,10 @@ func (v *VagrantCloudClient) Delete(path string) (*http.Response, error) {
 	scrubbedUrl := strings.Replace(reqUrl, v.AccessToken, "ACCESS_TOKEN", -1)
 	log.Printf("Post-Processor Vagrant Cloud API DELETE: %s", scrubbedUrl)
 
-	req, err := http.NewRequest("DELETE", reqUrl, nil)
+	req, err := v.newRequest("DELETE", reqUrl, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", v.AccessToken))
 	resp, err := v.client.Do(req)
 
 	log.Printf("Post-Processor Vagrant Cloud API Response: \n\n%+v", resp)
@@ -196,6 +194,8 @@ func (v *VagrantCloudClient) newRequest(method, url string, body io.Reader) (*ht
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", v.AccessToken))
+	if len(v.AccessToken) > 0 {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", v.AccessToken))
+	}
 	return req, err
 }

--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -98,9 +98,8 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 	// Required configuration
 	templates := map[string]*string{
-		"box_tag":      &p.config.Tag,
-		"version":      &p.config.Version,
-		"access_token": &p.config.AccessToken,
+		"box_tag": &p.config.Tag,
+		"version": &p.config.Version,
 	}
 
 	for key, ptr := range templates {
@@ -108,6 +107,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 			errs = packer.MultiErrorAppend(
 				errs, fmt.Errorf("%s must be set", key))
 		}
+	}
+
+	if p.config.VagrantCloudUrl == VAGRANT_CLOUD_URL && p.config.AccessToken == "" {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("access_token must be set if vagrant_cloud_url has not been overriden"))
 	}
 
 	// Create the HTTP client

--- a/website/source/docs/post-processors/vagrant-cloud.html.md
+++ b/website/source/docs/post-processors/vagrant-cloud.html.md
@@ -54,12 +54,6 @@ on Vagrant Cloud, as well as authentication and version information.
 
 ### Required:
 
--   `access_token` (string) - Your access token for the Vagrant Cloud API. This
-    can be generated on your [tokens
-    page](https://app.vagrantup.com/settings/security). If not specified, the
-    environment will be searched. First, `VAGRANT_CLOUD_TOKEN` is checked, and
-    if nothing is found, finally `ATLAS_TOKEN` will be used.
-
 -   `box_tag` (string) - The shorthand tag for your box that maps to Vagrant
     Cloud, for example `hashicorp/precise64`, which is short for
     `vagrantcloud.com/hashicorp/precise64`.
@@ -70,15 +64,28 @@ on Vagrant Cloud, as well as authentication and version information.
     be semver, and doesn't validate that the version comes after your previous
     versions.
 
+-   `access_token` (string) - Your access token for the Vagrant Cloud API. This
+    can be generated on your [tokens
+    page](https://app.vagrantup.com/settings/security). If not specified, the
+    environment will be searched. First, `VAGRANT_CLOUD_TOKEN` is checked, and
+    if nothing is found, finally `ATLAS_TOKEN` will be used. This is required 
+    unless you are using a private hosting solution (i.e. `vagrant_cloud_url`
+    has been populated).
+
+    **or**
+
+-   `vagrant_cloud_url` (string) - Override the base URL for Vagrant Cloud.
+    This is useful if you're using Vagrant Private Cloud in your own network.
+    Defaults to `https://vagrantcloud.com/api/v1`. If this value is set to something 
+    other than the default then `access_token` can be left blank and no 
+    `Authorization` header will be added to requests sent by this post-processor.
+
+
 ### Optional:
 
 -   `no_release` (string) - If set to true, does not release the version on
     Vagrant Cloud, making it active. You can manually release the version via
     the API or Web UI. Defaults to false.
-
--   `vagrant_cloud_url` (string) - Override the base URL for Vagrant Cloud.
-    This is useful if you're using Vagrant Private Cloud in your own network.
-    Defaults to `https://vagrantcloud.com/api/v1`
 
 -   `insecure_skip_tls_verify` (boolean) - If set to true *and* `vagrant_cloud_url`
     is set to something different than its default, it will set TLS InsecureSkipVerify


### PR DESCRIPTION
We make use of a private solution for hosting vagrant boxes. Access to this is ultimately controlled via ACLs internally and until now we have just supplied `foo` as an `access_token` and ignored the `authorization` header this post-processor adds. The boxes themselves ultimately end up on S3 and so to improve the speed of the upload process we would like to make use of a pre-signed PUT request to an S3 acceleration endpoint. However, this causes issues as Amazon will not accept a request with both the `Authorization` header set and the pre-signed query string parameters. As such, we are looking to be able to drop the `Authorization` header completely by making this an optional parameter to this post-processor. This PR attempts to do just that whilst still ensuring that `access_token` is required and the `authorization` header is still set for standard Vagrant Cloud hosting. I understand that this is somewhat non-standard but as we have everything else in place I thought it was probably worth submitting a PR to this effect. Perhaps others could benefit from this functionality rather than me going off and writing my own plugin to achieve this. Side note: I also see that the self-signed SSL server follows a similar pattern here in breaking from the official Vagrant Cloud norms. 