### PR TITLE
add the floppy label option

### DIFF
--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -393,6 +393,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -432,6 +432,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,

--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -169,6 +169,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,

--- a/builder/parallels/pvm/builder.go
+++ b/builder/parallels/pvm/builder.go
@@ -61,6 +61,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&StepImport{
 			Name:       b.config.VMName,

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -413,6 +413,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		new(stepCreateDisk),
 		new(stepCopyDisk),

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -223,6 +223,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -57,6 +57,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -86,6 +86,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&stepRemoteUpload{
 			Key:       "floppy_path",

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -82,6 +82,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
+			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&StepCloneVMX{
 			OutputDir: b.config.OutputDir,

--- a/common/floppy_config.go
+++ b/common/floppy_config.go
@@ -12,6 +12,7 @@ import (
 type FloppyConfig struct {
 	FloppyFiles       []string `mapstructure:"floppy_files"`
 	FloppyDirectories []string `mapstructure:"floppy_dirs"`
+	FloppyLabel       string   `mapstructure:"floppy_label"`
 }
 
 func (c *FloppyConfig) Prepare(ctx *interpolate.Context) []error {

--- a/common/step_create_floppy.go
+++ b/common/step_create_floppy.go
@@ -37,7 +37,7 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	if s.Label == "" {
 		s.Label = "packer"
 	} else {
-		log.Println("Floppy label is set to %s", s.Label)
+		log.Printf("Floppy label is set to %s", s.Label)
 	}
 
 	s.FilesAdded = make(map[string]bool)

--- a/common/step_create_floppy.go
+++ b/common/step_create_floppy.go
@@ -21,6 +21,7 @@ import (
 type StepCreateFloppy struct {
 	Files       []string
 	Directories []string
+	Label       string
 
 	floppyPath string
 
@@ -31,6 +32,12 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	if len(s.Files) == 0 && len(s.Directories) == 0 {
 		log.Println("No floppy files specified. Floppy disk will not be made.")
 		return multistep.ActionContinue
+	}
+
+	if s.Label == "" {
+		s.Label = "packer"
+	} else {
+		log.Println("Floppy label is set to %s", s.Label)
 	}
 
 	s.FilesAdded = make(map[string]bool)
@@ -70,8 +77,8 @@ func (s *StepCreateFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	log.Println("Formatting the block device with a FAT filesystem...")
 	formatConfig := &fat.SuperFloppyConfig{
 		FATType: fat.FAT12,
-		Label:   "packer",
-		OEMName: "packer",
+		Label:   s.Label,
+		OEMName: s.Label,
 	}
 	if err := fat.FormatSuperFloppy(device, formatConfig); err != nil {
 		state.Put("error", fmt.Errorf("Error creating floppy: %s", err))

--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -134,6 +134,11 @@ builder.
     (`*`, `?`, and `[]`) are allowed. Directory names are also allowed, which
     will add all the files found in the directory to the floppy.
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `generation` (number) - The Hyper-V generation for the virtual machine. By
     default, this is 1. Generation 2 Hyper-V virtual machines do not support
     floppy drives. In this scenario use `secondary_iso_images` instead. Hard

--- a/website/source/docs/builders/hyperv-vmcx.html.md.erb
+++ b/website/source/docs/builders/hyperv-vmcx.html.md.erb
@@ -171,6 +171,11 @@ builder.
     (`*`, `?`, and `[]`) are allowed. Directory names are also allowed, which
     will add all the files found in the directory to the floppy.
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `guest_additions_mode` (string) - If set to `attach` then attach and
     mount the ISO image specified in `guest_additions_path`. If set to
     `none` then guest additions are not attached and mounted; This is the

--- a/website/source/docs/builders/parallels-iso.html.md.erb
+++ b/website/source/docs/builders/parallels-iso.html.md.erb
@@ -111,6 +111,11 @@ builder.
     your floppy disk includes drivers or if you just want to organize it's
     contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are allowed.
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `guest_os_type` (string) - The guest OS type being installed. By default
     this is "other", but you can get *dramatic* performance improvements by
     setting this to the proper value. To view all available values for this run

--- a/website/source/docs/builders/parallels-pvm.html.md.erb
+++ b/website/source/docs/builders/parallels-pvm.html.md.erb
@@ -95,6 +95,11 @@ builder.
     your floppy disk includes drivers or if you just want to organize it's
     contents as a hierarchy. Wildcard characters (\*, ?, and \[\]) are allowed.
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `output_directory` (string) - This is the path to the directory where the
     resulting virtual machine will be created. This may be relative or absolute.
     If relative, the path is relative to the working directory when `packer`

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -209,6 +209,11 @@ Linux server and have not enabled X11 forwarding (`ssh -X`).
     listed files must not exceed 1.44 MB. The supported ways to move large
     files into the OS are using `http_directory` or [the file provisioner](https://www.packer.io/docs/provisioners/file.html).
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `format` (string) - Either `qcow2` or `raw`, this specifies the output
     format of the virtual machine image. This defaults to `qcow2`.
 

--- a/website/source/docs/builders/virtualbox-iso.html.md.erb
+++ b/website/source/docs/builders/virtualbox-iso.html.md.erb
@@ -136,6 +136,11 @@ builder.
     and \[\]) are allowed. Directory names are also allowed, which will add all
     the files found in the directory to the floppy.
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `format` (string) - Either `ovf` or `ova`, this specifies the output format
     of the exported virtual machine. This defaults to `ovf`.
 

--- a/website/source/docs/builders/virtualbox-ovf.html.md.erb
+++ b/website/source/docs/builders/virtualbox-ovf.html.md.erb
@@ -153,6 +153,11 @@ builder.
     and \[\]) are allowed. Directory names are also allowed, which will add all
     the files found in the directory to the floppy.
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `format` (string) - Either `ovf` or `ova`, this specifies the output format
     of the exported virtual machine. This defaults to `ovf`.
 

--- a/website/source/docs/builders/vmware-iso.html.md.erb
+++ b/website/source/docs/builders/vmware-iso.html.md.erb
@@ -160,6 +160,11 @@ builder.
     and \[\]) are allowed. Directory names are also allowed, which will add all
     the files found in the directory to the floppy.
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `fusion_app_path` (string) - Path to "VMware Fusion.app". By default this is
     `/Applications/VMware Fusion.app` but this setting allows you to
     customize this.

--- a/website/source/docs/builders/vmware-vmx.html.md.erb
+++ b/website/source/docs/builders/vmware-vmx.html.md.erb
@@ -102,6 +102,11 @@ builder.
     and \[\]) are allowed. Directory names are also allowed, which will add all
     the files found in the directory to the floppy.
 
+-  `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+
 -   `fusion_app_path` (string) - Path to "VMware Fusion.app". By default this is
     `/Applications/VMware Fusion.app` but this setting allows you to
     customize this.


### PR DESCRIPTION
Duplicate of #7891 

This functionality can help solve the following issue: https://github.com/hashicorp/packer/issues/6482
Because labels on floppy disks can be used to skip using VNC for some use-cases.

E.g:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-howto             (26.2.5)

Includes the same changes as #7891 with a little change for the documentation part.
