### PR TITLE
don't fall for nil pointer dereference in account file

### DIFF
--- a/builder/googlecompute/step_create_windows_password.go
+++ b/builder/googlecompute/step_create_windows_password.go
@@ -55,12 +55,17 @@ func (s *StepCreateWindowsPassword) Run(ctx context.Context, state multistep.Sta
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, uint32(priv.E))
 
+	email := ""
+	if c.Account != nil {
+		email = c.Account.Email
+	}
+
 	data := WindowsPasswordConfig{
 		key:      priv,
 		UserName: c.Comm.WinRMUser,
 		Modulus:  base64.StdEncoding.EncodeToString(priv.N.Bytes()),
 		Exponent: base64.StdEncoding.EncodeToString(buf[1:]),
-		Email:    c.Account.Email,
+		Email:    email,
 		ExpireOn: time.Now().Add(time.Minute * 5),
 	}
 


### PR DESCRIPTION
Check whether account object exists before trying to extract email address.

Closes #8085 