### PR TITLE
[cloudstack builder] Detach iso option step

### DIFF
--- a/builder/cloudstack/builder.go
+++ b/builder/cloudstack/builder.go
@@ -75,6 +75,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Debug: b.config.PackerDebug,
 		},
 		&stepSetupNetworking{},
+		&stepDetachIso{},
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
 			Host:      communicator.CommHost(b.config.Comm.SSHHost, "ipaddress"),

--- a/builder/cloudstack/config.go
+++ b/builder/cloudstack/config.go
@@ -20,12 +20,14 @@ type Config struct {
 	common.HTTPConfig   `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 
-	APIURL       string        `mapstructure:"api_url"`
-	APIKey       string        `mapstructure:"api_key"`
-	SecretKey    string        `mapstructure:"secret_key"`
-	AsyncTimeout time.Duration `mapstructure:"async_timeout"`
-	HTTPGetOnly  bool          `mapstructure:"http_get_only"`
-	SSLNoVerify  bool          `mapstructure:"ssl_no_verify"`
+	APIURL        string        `mapstructure:"api_url"`
+	APIKey        string        `mapstructure:"api_key"`
+	SecretKey     string        `mapstructure:"secret_key"`
+	AsyncTimeout  time.Duration `mapstructure:"async_timeout"`
+	HTTPGetOnly   bool          `mapstructure:"http_get_only"`
+	SSLNoVerify   bool          `mapstructure:"ssl_no_verify"`
+	EjectISO      bool          `mapstructure:"eject_iso"`
+	EjectISODelay time.Duration `mapstructure:"eject_iso_delay"`
 
 	CIDRList               []string `mapstructure:"cidr_list"`
 	CreateSecurityGroup    bool     `mapstructure:"create_security_group"`

--- a/builder/cloudstack/step_detach_iso.go
+++ b/builder/cloudstack/step_detach_iso.go
@@ -1,0 +1,60 @@
+package cloudstack
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"github.com/xanzy/go-cloudstack/cloudstack"
+)
+
+type stepDetachIso struct{}
+
+// Detaches currently ISO file attached to a virtual machine if any.
+func (s *stepDetachIso) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("config").(*Config)
+
+	// Check if state uses iso file and has need to eject it
+	if !config.EjectISO || config.SourceISO == "" {
+		return multistep.ActionContinue
+	}
+
+	ui.Say("Checking attached iso...")
+
+	// Wait to make call detachIso
+	if config.EjectISODelay > 0 {
+		ui.Message(fmt.Sprintf("Waiting for %v before detaching ISO from virtual machine...", config.EjectISODelay))
+		time.Sleep(config.EjectISODelay)
+	}
+
+	client := state.Get("client").(*cloudstack.CloudStackClient)
+
+	instanceID, ok := state.Get("instance_id").(string)
+	if !ok || instanceID == "" {
+		err := fmt.Errorf("Could not retrieve instance_id from state")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	ui.Message("Detaching iso from virtual machine...")
+
+	// Get a new DetachIsoParams and detaches Iso file from given virtualMachine instance
+	detachIsoParams := client.ISO.NewDetachIsoParams(instanceID)
+	response, err := client.ISO.DetachIso(detachIsoParams)
+	if err != nil || response == nil {
+		err := fmt.Errorf("Error detaching ISO from virtual machine: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepDetachIso) Cleanup(state multistep.StateBag) {
+	// Nothing to cleanup for this step.
+}

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -111,6 +111,16 @@ builder.
 -   `hypervisor` (string) - The target hypervisor (e.g. `XenServer`, `KVM`) for
     the new template. This option is required when using `source_iso`.
 
+-   `eject_iso` (boolean) - If `true`, make a call to the CloudStack API, after 
+    loading image to cache requesting to check and detach ISO file (if any) 
+    currently attached to a virtual machine. Defaults to `false`. This option 
+    is only available when using `source_iso`.
+
+-   `eject_iso_delay` (time.Duration) - Configure the duration time to wait, making
+    sure virtual machine is able to finish installing OS before it ejects safely. 
+    Requires `eject_iso` set to `true` and this option is only available when 
+    using `source_iso`.
+
 -   `keypair` (string) - The name of the SSH key pair that will be used to
     access the instance. The SSH key pair is assumed to be already available
     within CloudStack.

--- a/website/source/docs/builders/cloudstack.html.md
+++ b/website/source/docs/builders/cloudstack.html.md
@@ -111,8 +111,8 @@ builder.
 -   `hypervisor` (string) - The target hypervisor (e.g. `XenServer`, `KVM`) for
     the new template. This option is required when using `source_iso`.
 
--   `eject_iso` (boolean) - If `true`, make a call to the CloudStack API, after 
-    loading image to cache requesting to check and detach ISO file (if any) 
+-   `eject_iso` (boolean) - If `true` make a call to the CloudStack API, after 
+    loading image to cache, requesting to check and detach ISO file (if any) 
     currently attached to a virtual machine. Defaults to `false`. This option 
     is only available when using `source_iso`.
 


### PR DESCRIPTION
Option to detach iso file after loading image to cache, allowing OS to boot from
volume after the installation

For some cases, such installations with **KVM hypervisor** and **XenServer**, guestOS is unable to eject loaded image after the installation, so it keep booting using the image instead of booting from local hardrive/volume.

This PR add option to enable virtual machine handler calling directly cloudstack api detachIso handler when the configure option is set to true.

We are adding two new cloudstack environment parameters to make this option possible; 
bool _eject_iso_: to check if current request need to call this new step (it also checks if there is an iso file attached to virtual machine)
time.Duration _eject_iso_delay_: configure a sleep time wait to make sure virtual machine finish installing OS before it ejects safely.


Closes #7235