### PR TITLE
remove redundant nil check

### DIFF
--- a/packer/multi_error.go
+++ b/packer/multi_error.go
@@ -33,10 +33,6 @@ func MultiErrorAppend(err error, errs ...error) *MultiError {
 
 	switch err := err.(type) {
 	case *MultiError:
-		if err == nil {
-			err = new(MultiError)
-		}
-
 		for _, verr := range errs {
 			switch rhsErr := verr.(type) {
 			case *MultiError:


### PR DESCRIPTION
I found a redundant nil check, which err couldn't be nil after switch due to nil check at function's begining