### PR TITLE
builder/openstack: Fix dropped error

### DIFF
--- a/builder/openstack/step_source_image_info.go
+++ b/builder/openstack/step_source_image_info.go
@@ -40,6 +40,12 @@ func (s *StepSourceImageInfo) Run(ctx context.Context, state multistep.StateBag)
 	}
 
 	client, err := config.imageV2Client()
+	if err != nil {
+		err := fmt.Errorf("error creating image client: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
 
 	if s.SourceImageName != "" {
 		s.SourceImageOpts = images.ListOpts{


### PR DESCRIPTION
This PR picks off a dropped error in `builder/openstack`.

`StepSourceImageInfo.Run()` handles errors differently from most go functions, so I cadged the error handling seen on lines 98 and 105, which uses `multistep.StateBag` and `multistep.ActionHalt`.