### PR TITLE
googlecompute: fail fast when image name is invalid, replace unusable characters w/ -'s

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -17,7 +17,8 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
-var reImageFamily = regexp.MustCompile(`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`)
+// used for ImageName and ImageFamily
+var validImageName = regexp.MustCompile(`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`)
 
 // Config is the configuration structure for the GCE builder. It stores
 // both the publicly settable state as well as the privately generated
@@ -142,17 +143,29 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		}
 	}
 
+	// used for ImageName and ImageFamily
+	imageErrorText := "Invalid image %s: The first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash"
+
+	if len(c.ImageName) > 63 {
+		errs = packer.MultiErrorAppend(errs,
+			errors.New("Invalid image name: Must not be longer than 63 characters"))
+	}
+
+	// replaces invalid characters with hyphens
+	c.ImageName = templateCleanImageName(c.ImageName)
+	if !validImageName.MatchString(c.ImageName) {
+		errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf(imageErrorText, "name")))
+	}
+
 	if len(c.ImageFamily) > 63 {
 		errs = packer.MultiErrorAppend(errs,
 			errors.New("Invalid image family: Must not be longer than 63 characters"))
 	}
 
 	if c.ImageFamily != "" {
-		if !reImageFamily.MatchString(c.ImageFamily) {
-			errs = packer.MultiErrorAppend(errs,
-				errors.New("Invalid image family: The first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash"))
+		if !validImageName.MatchString(c.ImageFamily) {
+			errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf(imageErrorText, "family")))
 		}
-
 	}
 
 	if c.InstanceName == "" {

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -144,17 +144,15 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	}
 
 	// used for ImageName and ImageFamily
-	imageErrorText := "Invalid image %s: The first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash"
+	imageErrorText := "Invalid image %s %q: The first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash"
 
 	if len(c.ImageName) > 63 {
 		errs = packer.MultiErrorAppend(errs,
 			errors.New("Invalid image name: Must not be longer than 63 characters"))
 	}
 
-	// replaces invalid characters with hyphens
-	c.ImageName = templateCleanImageName(c.ImageName)
 	if !validImageName.MatchString(c.ImageName) {
-		errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf(imageErrorText, "name")))
+		errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf(imageErrorText, "name", c.ImageName)))
 	}
 
 	if len(c.ImageFamily) > 63 {
@@ -164,7 +162,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	if c.ImageFamily != "" {
 		if !validImageName.MatchString(c.ImageFamily) {
-			errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf(imageErrorText, "family")))
+			errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf(imageErrorText, "family", c.ImageFamily)))
 		}
 	}
 

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -157,6 +157,24 @@ func TestConfigPrepare(t *testing.T) {
 			true,
 		},
 		{
+			// underscore will be replaced
+			"image_name",
+			"foo_bar",
+			false,
+		},
+		{
+			// too long
+			"image_name",
+			"foobar123xyz_abc-456-one-two_three_five_nine_seventeen_eleventy-seven",
+			true,
+		},
+		{
+			// starts with non-alphabetic character
+			"image_name",
+			"1boohoo",
+			true,
+		},
+		{
 			"image_encryption_key",
 			map[string]string{"kmsKeyName": "foo"},
 			false,

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -157,10 +157,10 @@ func TestConfigPrepare(t *testing.T) {
 			true,
 		},
 		{
-			// underscore will be replaced
+			// underscore is not allowed
 			"image_name",
 			"foo_bar",
-			false,
+			true,
 		},
 		{
 			// too long

--- a/builder/googlecompute/template_funcs.go
+++ b/builder/googlecompute/template_funcs.go
@@ -20,7 +20,7 @@ func isalphanumeric(b byte) bool {
 // Clean up image name by replacing invalid characters with "-"
 // and converting upper cases to lower cases
 func templateCleanImageName(s string) string {
-	if reImageFamily.MatchString(s) {
+	if validImageName.MatchString(s) {
 		return s
 	}
 	b := []byte(strings.ToLower(s))


### PR DESCRIPTION
this mirrors behavior in the amazon builder and prevents this kind of thing from happening:

`Error waiting for image: googleapi: Error 400: Invalid value for field 'resource.name': '<image name>'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)', invalid`
