### PR TITLE
builder/vagrant: fix dropped errors in code and tests

### DIFF
--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -96,7 +96,13 @@ func (d *Vagrant_2_2_Driver) Verify() error {
 	}
 
 	constraints, err := version.NewConstraint(VAGRANT_MIN_VERSION)
+	if err != nil {
+		return fmt.Errorf("error parsing vagrant minimum version: %v", err)
+	}
 	vers, err := d.Version()
+	if err != nil {
+		return fmt.Errorf("error getting virtualbox version: %v", err)
+	}
 	v, err := version.NewVersion(vers)
 	if err != nil {
 		return fmt.Errorf("Error figuring out Vagrant version.")

--- a/builder/vagrant/step_create_vagrantfile_test.go
+++ b/builder/vagrant/step_create_vagrantfile_test.go
@@ -29,6 +29,9 @@ func TestCreateFile(t *testing.T) {
 	}
 	defer os.Remove(templatePath)
 	contents, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 	actual := string(contents)
 	expected := `Vagrant.configure("2") do |config|
   config.vm.define "source", autostart: false do |source|
@@ -56,6 +59,9 @@ func TestCreateFile_customSync(t *testing.T) {
 	}
 	defer os.Remove(templatePath)
 	contents, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 	actual := string(contents)
 	expected := `Vagrant.configure("2") do |config|
   config.vm.define "source", autostart: false do |source|


### PR DESCRIPTION
This PR fixes some dropped `error` variables in `builder/vagrant`, in both code and tests.