### PR TITLE
fix ssh and package steps to use source syntax.

### DIFF
--- a/builder/vagrant/step_package.go
+++ b/builder/vagrant/step_package.go
@@ -25,9 +25,12 @@ func (s *StepPackage) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 	ui.Say("Packaging box...")
 	packageArgs := []string{}
+	box := "source"
 	if s.GlobalID != "" {
-		packageArgs = append(packageArgs, s.GlobalID)
+		box = s.GlobalID
 	}
+
+	packageArgs = append(packageArgs, box)
 
 	if len(s.Include) > 0 {
 		packageArgs = append(packageArgs, "--include", strings.Join(s.Include, ","))

--- a/builder/vagrant/step_ssh_config.go
+++ b/builder/vagrant/step_ssh_config.go
@@ -30,7 +30,11 @@ func (s *StepSSHConfig) Run(ctx context.Context, state multistep.StateBag) multi
 	driver := state.Get("driver").(VagrantDriver)
 	config := state.Get("config").(*Config)
 
-	sshConfig, err := driver.SSHConfig(s.GlobalID)
+	box := "source"
+	if s.GlobalID != "" {
+		box = s.GlobalID
+	}
+	sshConfig, err := driver.SSHConfig(box)
 	if err != nil {
 		state.Put("error", err)
 		return multistep.ActionHalt


### PR DESCRIPTION
Fixes the last couple of regressions we've seen for the Vagrant builder in the last release.  Now my configs all build properly again.

Closes #8019 
Closes #8012 (or this one's already been closed by another of the Vagrant builder PRs that merged recently)