### PR TITLE
Clarify sysprep log message in Azure example

### DIFF
--- a/examples/azure/windows.json
+++ b/examples/azure/windows.json
@@ -38,7 +38,7 @@
 
         "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
         "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit",
-        "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
+        "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; Write-Output $imageState.ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Start-Sleep -s 10 } else { break } }"
     ]
   }]
 }


### PR DESCRIPTION
The Azure example uses an inline PowerShell script to wait for sysprep to complete. While waiting, it prints out the current setup state *if the state is **not** complete*, otherwise it breaks and shuts down.

This logging behavior can be confusing because the last message logged says that sysprep is not completed. To clarify things, move the log statement ahead of the "if" check so the result of each polling operation is logged.