### PR TITLE
Support floppy_files for vmx on esxi

### DIFF
--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -88,14 +88,18 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Directories: b.config.FloppyConfig.FloppyDirectories,
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
-		&stepRemoteUpload{
-			Key:       "floppy_path",
-			Message:   "Uploading Floppy to remote machine...",
-			DoCleanup: true,
+		&vmwcommon.StepRemoteUpload{
+			Key:          "floppy_path",
+			Message:      "Uploading Floppy to remote machine...",
+			DoCleanup:    true,
+			Checksum:     "",
+			ChecksumType: "none",
 		},
-		&stepRemoteUpload{
-			Key:     "iso_path",
-			Message: "Uploading ISO to remote machine...",
+		&vmwcommon.StepRemoteUpload{
+			Key:          "iso_path",
+			Message:      "Uploading ISO to remote machine...",
+			Checksum:     b.config.ISOChecksum,
+			ChecksumType: b.config.ISOChecksumType,
 		},
 		&stepCreateDisk{},
 		&stepCreateVMX{},

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -84,6 +84,13 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Directories: b.config.FloppyConfig.FloppyDirectories,
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
+		&vmwcommon.StepRemoteUpload{
+			Key:          "floppy_path",
+			Message:      "Uploading Floppy to remote machine...",
+			DoCleanup:    true,
+			Checksum:     "",
+			ChecksumType: "none",
+		},
 		&StepCloneVMX{
 			OutputDir: b.config.OutputDir,
 			Path:      b.config.SourcePath,


### PR DESCRIPTION
Current Behaviour:

when floppy_files are used with vmware-vmx builder on esxi (remote), VM does not come up on the ESXi as path for floppy0.filename in VMX file refers to a local path (not remote path on esxi)

Fix:
Changes are done to upload the local floppy file to packer_cache on remote.

Use Case:
We use a two step build process. The first step we use vmware-iso to generate an OVA. in second step we use vmware-vmx to provision extra stuff on the VM. Unfortunately we do not have DHCP enabled. Have to assign IP address statically.

First step will include a script to that run on boot in step 2. I will check for networking config in a floppy and configure interface with static IP address.

Test: Testing has been done manually against ESXi 6.5, there are no test cases i found for a similar feature in vmware-iso ( may be due to the that it is a remote upload operation )

Documentation: Unlike vmware-iso, vmware-vmx does not create a new VMX file. it uses existing vmx file and modifies it with additional stuff. In order to avoid miss configured VMX file trying to boot from floppy drive, we must include "bios.bootorder": "hdd" or whatever suites the needs in vmx_data

Note: I am not an expert in go. please help if anything extra needed.