### PR TITLE
Added disk_block_size unit clarification to hyperv-iso doc

### DIFF
--- a/website/source/docs/builders/hyperv-iso.html.md.erb
+++ b/website/source/docs/builders/hyperv-iso.html.md.erb
@@ -93,9 +93,9 @@ builder.
     file representing the disk will not use the full size unless it is
     full.
 
--   `disk_block_size` (string) - The block size of the VHD to be created.
+-   `disk_block_size` (string) - The block size of the VHD to be created in MiB.
     Recommended disk block size for Linux hyper-v guests is 1 MiB. This
-    defaults to "32 MiB".
+    defaults to "32" (MiB).
 
 -   `disk_size` (number) - The size, in megabytes, of the hard disk to create
     for the VM. By default, this is 40 GB.


### PR DESCRIPTION
While trying to build a linux vm using the hyperv-iso builder, I set 
```
  "disk_block_size": "1 MiB",
```
as per the doc, which stated the default was `"32 MiB"`. 
This caused an error in the parser.

After checking the required units in https://github.com/hashicorp/packer/blob/master/builder/hyperv/iso/builder.go, I thought this field could be clarified in the docs.

Docfix, no test required?
