### PR TITLE
Google vault oauth

### DIFF
--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -36,7 +36,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 // representing a GCE machine image.
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
 	driver, err := NewDriverGCE(
-		ui, b.config.ProjectId, b.config.Account)
+		ui, b.config.ProjectId, b.config.Account, b.config.VaultGCPOauthEngine)
 	if err != nil {
 		return nil, err
 	}

--- a/website/source/partials/builder/googlecompute/_Config-not-required.html.md
+++ b/website/source/partials/builder/googlecompute/_Config-not-required.html.md
@@ -125,3 +125,15 @@
 -   `use_internal_ip` (bool) - If true, use the instance's internal IP instead of its external IP
     during building.
     
+-   `vault_gcp_oauth_engine` (string) - Can be set instead of account_file. If set, this builder will use
+    HashiCorp Vault to generate an Oauth token for authenticating against
+    Google's cloud. The value should be the path of the token generator
+    within vault.
+    For information on how to configure your Vault + GCP engine to produce
+    Oauth tokens, see https://www.vaultproject.io/docs/auth/gcp.html
+    You must have the environment variables VAULT_ADDR and VAULT_TOKEN set,
+    along with any other relevant variables for accessing your vault
+    instance. For more information, see the Vault docs:
+    https://www.vaultproject.io/docs/commands/#environment-variables
+    Example:`"vault_gcp_oauth_engine": "gcp/token/my-project-editor",`
+    


### PR DESCRIPTION
Allows user to integrate with Vault for generating Google Compute Oauth tokens. 

Closes #7794

usage example:
```
  "builders": [
    {
      "type": "googlecompute",
      "image_name": "my-image-name",
      "vault_gcp_oauth_engine": "gcp/token/my-project-editor",
      "project_id": "my-project-id",
      "source_image_family": "ubuntu-1804-lts",
      "ssh_username": "packer",
      "zone": "us-central1-c",
      "state_timeout": "20m",
      "startup_script_file": "./startup.sh"
    }
  ],
```
