### PR TITLE
error cleanup provisioner

### DIFF
--- a/builder/null/builder.go
+++ b/builder/null/builder.go
@@ -29,15 +29,13 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
 	steps := []multistep.Step{}
 
-	if b.config.CommConfig.Type != "none" {
-		steps = append(steps,
-			&communicator.StepConnect{
-				Config:    &b.config.CommConfig,
-				Host:      CommHost(b.config.CommConfig.Host()),
-				SSHConfig: b.config.CommConfig.SSHConfigFunc(),
-			},
-		)
-	}
+	steps = append(steps,
+		&communicator.StepConnect{
+			Config:    &b.config.CommConfig,
+			Host:      CommHost(b.config.CommConfig.Host()),
+			SSHConfig: b.config.CommConfig.SSHConfigFunc(),
+		},
+	)
 
 	steps = append(steps,
 		new(common.StepProvision),

--- a/command/build_cleanup_script_test.go
+++ b/command/build_cleanup_script_test.go
@@ -1,0 +1,29 @@
+package command
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildWithCleanupScript(t *testing.T) {
+	c := &BuildCommand{
+		Meta: testMetaFile(t),
+	}
+
+	args := []string{
+		"-parallel=false",
+		filepath.Join(testFixture("cleanup-script"), "template.json"),
+	}
+
+	defer cleanup()
+
+	// build should exit with error code!
+	if code := c.Run(args); code == 0 {
+		fatalCommand(t, c.Meta)
+	}
+
+	if !fileExists("ducky.txt") {
+		t.Errorf("Expected to find ducky.txt")
+	}
+
+}

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -10,8 +10,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/packer/builder/file"
+	"github.com/hashicorp/packer/builder/null"
 	"github.com/hashicorp/packer/packer"
 	shell_local "github.com/hashicorp/packer/post-processor/shell-local"
+	"github.com/hashicorp/packer/provisioner/shell"
+	sl "github.com/hashicorp/packer/provisioner/shell-local"
 )
 
 func TestBuildOnlyFileCommaFlags(t *testing.T) {
@@ -176,7 +179,18 @@ func fileExists(filename string) bool {
 func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {
 	components := packer.ComponentFinder{
 		Builder: func(n string) (packer.Builder, error) {
-			return &file.Builder{}, nil
+			if n == "file" {
+				return &file.Builder{}, nil
+			}
+			return &null.Builder{}, nil
+		},
+		Provisioner: func(n string) (packer.Provisioner, error) {
+			if n == "shell" {
+				return &shell.Provisioner{}, nil
+			} else if n == "shell-local" {
+				return &sl.Provisioner{}, nil
+			}
+			return nil, fmt.Errorf("requested provisioner not implemented in this test")
 		},
 		PostProcessor: func(n string) (packer.PostProcessor, error) {
 			return &shell_local.PostProcessor{}, nil
@@ -212,6 +226,7 @@ func cleanup() {
 	os.RemoveAll("fuchsias.txt")
 	os.RemoveAll("lilas.txt")
 	os.RemoveAll("campanules.txt")
+	os.RemoveAll("ducky.txt")
 }
 
 func TestBuildCommand_ParseArgs(t *testing.T) {

--- a/command/test-fixtures/cleanup-script/template.json
+++ b/command/test-fixtures/cleanup-script/template.json
@@ -11,7 +11,7 @@
 			"inline": ["exit 2"]
 		}
 	],
-	"on-error-script": {
+	"error-cleanup-provisioner": {
 		"type": "shell-local",
 		"inline": ["echo 'rubber ducky'> ducky.txt"]
 	}

--- a/command/test-fixtures/cleanup-script/template.json
+++ b/command/test-fixtures/cleanup-script/template.json
@@ -1,0 +1,18 @@
+{
+	"builders": [
+		{
+			"type": "null",
+			"communicator": "none"
+		}
+	],
+	"provisioners": [
+		{
+			"type": "shell-local",
+			"inline": ["exit 2"]
+		}
+	],
+	"on-error-script": {
+		"type": "shell-local",
+		"inline": ["echo 'rubber ducky'> ducky.txt"]
+	}
+}

--- a/common/step_provision.go
+++ b/common/step_provision.go
@@ -81,9 +81,9 @@ func (s *StepProvision) Run(ctx context.Context, state multistep.StateBag) multi
 }
 
 func (s *StepProvision) Cleanup(state multistep.StateBag) {
-	// We have a "final" provisioner that gets defined by "on-error-script"
+	// We have a "final" provisioner that gets defined by "error-cleanup-provisioner"
 	// which we only call if there's an error during the provision run and
-	// the "on-error-script" is defined.
+	// the "error-cleanup-provisioner" is defined.
 	if _, ok := state.GetOk("error"); ok {
 		s.runWithHook(context.Background(), state, packer.HookCleanupProvision)
 	}

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/mitchellh/go-fs v0.0.0-20180402234041-7b48fa161ea7
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
+	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/mitchellh/iochan v1.0.0
 	github.com/mitchellh/mapstructure v0.0.0-20180111000720-b4575eea38cc
 	github.com/mitchellh/panicwrap v0.0.0-20170106182340-fce601fe5557

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,6 @@ require (
 	github.com/mitchellh/go-fs v0.0.0-20180402234041-7b48fa161ea7
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
-	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/mitchellh/iochan v1.0.0
 	github.com/mitchellh/mapstructure v0.0.0-20180111000720-b4575eea38cc
 	github.com/mitchellh/panicwrap v0.0.0-20170106182340-fce601fe5557

--- a/go.sum
+++ b/go.sum
@@ -206,7 +206,6 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
@@ -302,8 +301,6 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed h1:FI2NIv6fpef6BQl2u3IZX/Cj20tfypRF4yd+uaHOMtI=
 github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed/go.mod h1:3rdaFaCv4AyBgu5ALFM0+tSuHrBh6v692nyQe3ikrq0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
-github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
-github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -406,12 +403,8 @@ github.com/vmware/govmomi v0.0.0-20170707011325-c2105a174311 h1:s5pyxd5S6wRs2WpE
 github.com/vmware/govmomi v0.0.0-20170707011325-c2105a174311/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0 h1:NJrcIkdzq0C3I8ypAZwFE9RHtGbfp+mJvqIcoFATZuk=
 github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0/go.mod h1:sBh287mCRwCz6zyXHMmw7sSZGPohVpnx+o+OY4M+i3A=
-github.com/yandex-cloud/go-genproto v0.0.0-20190802103534-6089d9ff8d82 h1:HLQoCLW2021qJKLrGQbcdEikBJ3gfYF94JYqZuw6Qxg=
-github.com/yandex-cloud/go-genproto v0.0.0-20190802103534-6089d9ff8d82/go.mod h1:HEUYX/p8966tMUHHT+TsS0hF/Ca/NYwqprC5WXSDMfE=
 github.com/yandex-cloud/go-genproto v0.0.0-20190916101622-7617782d381e h1:hzwq5GUKP0aQzDja1XP4sBYyOmnezs/RVtzP+xiLbfI=
 github.com/yandex-cloud/go-genproto v0.0.0-20190916101622-7617782d381e/go.mod h1:HEUYX/p8966tMUHHT+TsS0hF/Ca/NYwqprC5WXSDMfE=
-github.com/yandex-cloud/go-sdk v0.0.0-20190802103531-4ab1dac90bf7 h1:rWXARBMLHylvASK6spamDC8zSL5v2voZop3M6SBul9Y=
-github.com/yandex-cloud/go-sdk v0.0.0-20190802103531-4ab1dac90bf7/go.mod h1:Eml0jFLU4VVHgIN8zPHMuNwZXVzUMILyO6lQZSfz854=
 github.com/yandex-cloud/go-sdk v0.0.0-20190916101744-c781afa45829 h1:2FGwbx03GpP1Ulzg/L46tSoKh9t4yg8BhMKQl/Ff1x8=
 github.com/yandex-cloud/go-sdk v0.0.0-20190916101744-c781afa45829/go.mod h1:Eml0jFLU4VVHgIN8zPHMuNwZXVzUMILyO6lQZSfz854=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,7 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
@@ -301,6 +302,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed h1:FI2NIv6fpef6BQl2u3IZX/Cj20tfypRF4yd+uaHOMtI=
 github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed/go.mod h1:3rdaFaCv4AyBgu5ALFM0+tSuHrBh6v692nyQe3ikrq0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/packer/hook.go
+++ b/packer/hook.go
@@ -6,6 +6,7 @@ import (
 
 // This is the hook that should be fired for provisioners to run.
 const HookProvision = "packer_provision"
+const HookCleanupProvision = "packer_cleanup_provision"
 
 // A Hook is used to hook into an arbitrarily named location in a build,
 // allowing custom behavior to run at certain points along a build.

--- a/packer/hook.go
+++ b/packer/hook.go
@@ -45,7 +45,6 @@ func (h *DispatchHook) Run(ctx context.Context, name string, ui Ui, comm Communi
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-
 		if err := hook.Run(ctx, name, ui, comm, data); err != nil {
 			return err
 		}

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -50,7 +50,6 @@ func (h *ProvisionHook) Run(ctx context.Context, name string, ui Ui, comm Commun
 				"`communicator` config was set to \"none\". If you have any provisioners\n" +
 				"then a communicator is required. Please fix this to continue.")
 	}
-
 	for _, p := range h.Provisioners {
 		ts := CheckpointReporter.AddSpan(p.TypeName, "provisioner", p.Config)
 

--- a/template/parse.go
+++ b/template/parse.go
@@ -57,6 +57,34 @@ func (r *rawTemplate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+func (r *rawTemplate) decodeProvisioner(raw interface{}) (Provisioner, error) {
+	var p Provisioner
+	if err := r.decoder(&p, nil).Decode(raw); err != nil {
+		return p, fmt.Errorf("Error decoding provisioner: %s", err)
+
+	}
+
+	// Type is required before any richer validation
+	if p.Type == "" {
+		return p, fmt.Errorf("Provisioner missing 'type'")
+	}
+
+	// Set the raw configuration and delete any special keys
+	p.Config = raw.(map[string]interface{})
+
+	delete(p.Config, "except")
+	delete(p.Config, "only")
+	delete(p.Config, "override")
+	delete(p.Config, "pause_before")
+	delete(p.Config, "type")
+	delete(p.Config, "timeout")
+
+	if len(p.Config) == 0 {
+		p.Config = nil
+	}
+	return p, nil
+}
+
 // Template returns the actual Template object built from this raw
 // structure.
 func (r *rawTemplate) Template() (*Template, error) {
@@ -212,32 +240,11 @@ func (r *rawTemplate) Template() (*Template, error) {
 		result.Provisioners = make([]*Provisioner, 0, len(r.Provisioners))
 	}
 	for i, v := range r.Provisioners {
-		var p Provisioner
-		if err := r.decoder(&p, nil).Decode(v); err != nil {
+		p, err := r.decodeProvisioner(v)
+		if err != nil {
 			errs = multierror.Append(errs, fmt.Errorf(
 				"provisioner %d: %s", i+1, err))
 			continue
-		}
-
-		// Type is required before any richer validation
-		if p.Type == "" {
-			errs = multierror.Append(errs, fmt.Errorf(
-				"provisioner %d: missing 'type'", i+1))
-			continue
-		}
-
-		// Set the raw configuration and delete any special keys
-		p.Config = v.(map[string]interface{})
-
-		delete(p.Config, "except")
-		delete(p.Config, "only")
-		delete(p.Config, "override")
-		delete(p.Config, "pause_before")
-		delete(p.Config, "type")
-		delete(p.Config, "timeout")
-
-		if len(p.Config) == 0 {
-			p.Config = nil
 		}
 
 		result.Provisioners = append(result.Provisioners, &p)
@@ -245,31 +252,12 @@ func (r *rawTemplate) Template() (*Template, error) {
 
 	// Gather the error-cleanup-provisioner
 	if r.CleanupProvisioner != nil {
-		var p Provisioner
-		if err := r.decoder(&p, nil).Decode(r.CleanupProvisioner); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf(
-				"On Error Cleanup provisioner: %s", err))
+		p, err := r.decodeProvisioner(r.CleanupProvisioner)
+		if err != nil {
+			errs = multierror.Append(errs,
+				fmt.Errorf("On Error Cleanup Provisioner error: %s", err))
 		}
 
-		// Type is required before any richer validation
-		if p.Type == "" {
-			errs = multierror.Append(errs, fmt.Errorf(
-				"on error cleanup provisioner missing 'type'"))
-		}
-
-		// Set the raw configuration and delete any special keys
-		p.Config = r.CleanupProvisioner.(map[string]interface{})
-
-		delete(p.Config, "except")
-		delete(p.Config, "only")
-		delete(p.Config, "override")
-		delete(p.Config, "pause_before")
-		delete(p.Config, "type")
-		delete(p.Config, "timeout")
-
-		if len(p.Config) == 0 {
-			p.Config = nil
-		}
 		result.CleanupProvisioner = &p
 	}
 

--- a/template/parse.go
+++ b/template/parse.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"

--- a/template/parse.go
+++ b/template/parse.go
@@ -29,7 +29,7 @@ type rawTemplate struct {
 	Push               map[string]interface{} `json:"push,omitempty"`
 	PostProcessors     []interface{}          `mapstructure:"post-processors" json:"post-processors,omitempty"`
 	Provisioners       []interface{}          `json:"provisioners,omitempty"`
-	CleanupProvisioner interface{}            `mapstructure:"on-error-script" json:"on-error-script,omitempty"`
+	CleanupProvisioner interface{}            `mapstructure:"error-cleanup-provisioner" json:"error-cleanup-provisioner,omitempty"`
 	Variables          map[string]interface{} `json:"variables,omitempty"`
 	SensitiveVariables []string               `mapstructure:"sensitive-variables" json:"sensitive-variables,omitempty"`
 
@@ -244,7 +244,7 @@ func (r *rawTemplate) Template() (*Template, error) {
 		result.Provisioners = append(result.Provisioners, &p)
 	}
 
-	// Gather the on-error-script
+	// Gather the error-cleanup-provisioner
 	if r.CleanupProvisioner != nil {
 		var p Provisioner
 		if err := r.decoder(&p, nil).Decode(r.CleanupProvisioner); err != nil {

--- a/template/parse.go
+++ b/template/parse.go
@@ -245,7 +245,6 @@ func (r *rawTemplate) Template() (*Template, error) {
 	}
 
 	// Gather the on-error-script
-	log.Printf("r.CleanupProvisioner is %#v", r.CleanupProvisioner)
 	if r.CleanupProvisioner != nil {
 		var p Provisioner
 		if err := r.decoder(&p, nil).Decode(r.CleanupProvisioner); err != nil {

--- a/template/parse.go
+++ b/template/parse.go
@@ -253,7 +253,6 @@ func (r *rawTemplate) Template() (*Template, error) {
 		}
 
 		// Type is required before any richer validation
-		log.Printf("p is %#v", p)
 		if p.Type == "" {
 			errs = multierror.Append(errs, fmt.Errorf(
 				"on error cleanup provisioner missing 'type'"))

--- a/template/template.go
+++ b/template/template.go
@@ -24,6 +24,7 @@ type Template struct {
 	SensitiveVariables []*Variable
 	Builders           map[string]*Builder
 	Provisioners       []*Provisioner
+	CleanupProvisioner *Provisioner
 	PostProcessors     [][]*PostProcessor
 
 	// RawContents is just the raw data for this template


### PR DESCRIPTION
Creates a new root-level config slot for a single "cleanup" provisioner, to be run only if Packer errors. The cleanup provisioner can be any provisioner, but the assumed use case is that it'll be  a shell or powershell provisioner.  It will be run after the provisioning run fails, but before the instance is shut down and cleaned up or aborted. 

Closes #6760
