### PR TITLE
post-processor/vagrant-cloud: fix dropped errors

### DIFF
--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -145,6 +145,9 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 
 	// Determine the name of the provider for Vagrant Cloud, and Vagrant
 	providerName, err := getProvider(artifact.Id(), artifact.Files()[0], builtins[artifact.BuilderId()])
+	if err != nil {
+		return nil, false, false, fmt.Errorf("error getting provider name: %s", err)
+	}
 
 	p.config.ctx.Data = &boxDownloadUrlTemplate{
 		ArtifactId: artifact.Id(),

--- a/post-processor/vagrant-cloud/step_create_provider.go
+++ b/post-processor/vagrant-cloud/step_create_provider.go
@@ -46,6 +46,9 @@ func (s *stepCreateProvider) Run(ctx context.Context, state multistep.StateBag) 
 	if err != nil || (resp.StatusCode != 200) {
 		cloudErrors := &VagrantCloudErrors{}
 		err = decodeBody(resp, cloudErrors)
+		if err != nil {
+			ui.Error(fmt.Sprintf("error decoding error response: %s", err))
+		}
 		state.Put("error", fmt.Errorf("Error creating provider: %s", cloudErrors.FormatErrors()))
 		return multistep.ActionHalt
 	}

--- a/post-processor/vagrant-cloud/step_create_version.go
+++ b/post-processor/vagrant-cloud/step_create_version.go
@@ -43,6 +43,9 @@ func (s *stepCreateVersion) Run(ctx context.Context, state multistep.StateBag) m
 	if err != nil || (resp.StatusCode != 200) {
 		cloudErrors := &VagrantCloudErrors{}
 		err = decodeBody(resp, cloudErrors)
+		if err != nil {
+			ui.Error(fmt.Sprintf("error decoding error response: %s", err))
+		}
 		state.Put("error", fmt.Errorf("Error creating version: %s", cloudErrors.FormatErrors()))
 		return multistep.ActionHalt
 	}

--- a/post-processor/vagrant-cloud/step_prepare_upload.go
+++ b/post-processor/vagrant-cloud/step_prepare_upload.go
@@ -36,6 +36,9 @@ func (s *stepPrepareUpload) Run(ctx context.Context, state multistep.StateBag) m
 		} else {
 			cloudErrors := &VagrantCloudErrors{}
 			err = decodeBody(resp, cloudErrors)
+			if err != nil {
+				ui.Error(fmt.Sprintf("error decoding error response: %s", err))
+			}
 			state.Put("error", fmt.Errorf("Error preparing upload: %s", cloudErrors.FormatErrors()))
 		}
 		return multistep.ActionHalt

--- a/post-processor/vagrant-cloud/step_verify_box.go
+++ b/post-processor/vagrant-cloud/step_verify_box.go
@@ -43,6 +43,9 @@ func (s *stepVerifyBox) Run(ctx context.Context, state multistep.StateBag) multi
 	if resp.StatusCode != 200 {
 		cloudErrors := &VagrantCloudErrors{}
 		err = decodeBody(resp, cloudErrors)
+		if err != nil {
+			ui.Error(fmt.Sprintf("error decoding error response: %s", err))
+		}
 		state.Put("error", fmt.Errorf("Error retrieving box: %s", cloudErrors.FormatErrors()))
 		return multistep.ActionHalt
 	}


### PR DESCRIPTION
This PR fixes some dropped errors in the `vagrant-cloud` post-processor.