### PR TITLE
Fix 8163

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -206,7 +206,7 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 	var r *ec2.DescribeInstancesOutput
 	err = retry.Config{
 		Tries: 11,
-		ShouldRetry: func(error) bool {
+		ShouldRetry: func(err error) bool {
 			if awsErr, ok := err.(awserr.Error); ok {
 				switch awsErr.Code() {
 				case "InvalidInstanceID.NotFound":

--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -295,7 +295,6 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 	var describeOutput *ec2.DescribeInstancesOutput
 	err = retry.Config{
 		Tries:       11,
-		ShouldRetry: func(error) bool { return true },
 		RetryDelay:  (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 	}.Run(ctx, func(ctx context.Context) error {
 		describeOutput, err = ec2conn.DescribeInstances(&ec2.DescribeInstancesInput{

--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -294,8 +294,8 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 	// Get information about the created instance
 	var describeOutput *ec2.DescribeInstancesOutput
 	err = retry.Config{
-		Tries:       11,
-		RetryDelay:  (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
+		Tries:      11,
+		RetryDelay: (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 	}.Run(ctx, func(ctx context.Context) error {
 		describeOutput, err = ec2conn.DescribeInstances(&ec2.DescribeInstancesInput{
 			InstanceIds: []*string{aws.String(instanceId)},


### PR DESCRIPTION
The describeInstances call can suffer from amazon's eventual-consistency, so let's do some retries. 

Also, we don't need to call it 3 times for spot instances. Remove extra, wasteful code. 

Closes #8163 
