### PR TITLE
make friendlier message warning user that their creds may be wrong

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -403,12 +403,8 @@ github.com/vmware/govmomi v0.0.0-20170707011325-c2105a174311 h1:s5pyxd5S6wRs2WpE
 github.com/vmware/govmomi v0.0.0-20170707011325-c2105a174311/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0 h1:NJrcIkdzq0C3I8ypAZwFE9RHtGbfp+mJvqIcoFATZuk=
 github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0/go.mod h1:sBh287mCRwCz6zyXHMmw7sSZGPohVpnx+o+OY4M+i3A=
-github.com/yandex-cloud/go-genproto v0.0.0-20190802103534-6089d9ff8d82 h1:HLQoCLW2021qJKLrGQbcdEikBJ3gfYF94JYqZuw6Qxg=
-github.com/yandex-cloud/go-genproto v0.0.0-20190802103534-6089d9ff8d82/go.mod h1:HEUYX/p8966tMUHHT+TsS0hF/Ca/NYwqprC5WXSDMfE=
 github.com/yandex-cloud/go-genproto v0.0.0-20190916101622-7617782d381e h1:hzwq5GUKP0aQzDja1XP4sBYyOmnezs/RVtzP+xiLbfI=
 github.com/yandex-cloud/go-genproto v0.0.0-20190916101622-7617782d381e/go.mod h1:HEUYX/p8966tMUHHT+TsS0hF/Ca/NYwqprC5WXSDMfE=
-github.com/yandex-cloud/go-sdk v0.0.0-20190802103531-4ab1dac90bf7 h1:rWXARBMLHylvASK6spamDC8zSL5v2voZop3M6SBul9Y=
-github.com/yandex-cloud/go-sdk v0.0.0-20190802103531-4ab1dac90bf7/go.mod h1:Eml0jFLU4VVHgIN8zPHMuNwZXVzUMILyO6lQZSfz854=
 github.com/yandex-cloud/go-sdk v0.0.0-20190916101744-c781afa45829 h1:2FGwbx03GpP1Ulzg/L46tSoKh9t4yg8BhMKQl/Ff1x8=
 github.com/yandex-cloud/go-sdk v0.0.0-20190916101744-c781afa45829/go.mod h1:Eml0jFLU4VVHgIN8zPHMuNwZXVzUMILyO6lQZSfz854=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=

--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -215,6 +215,12 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, ctx context.Contex
 			if strings.Contains(err.Error(), "authenticate") {
 				log.Printf(
 					"[DEBUG] Detected authentication error. Increasing handshake attempts.")
+				err = fmt.Errorf("Packer experienced an authentication error "+
+					"when trying to connect via SSH. This can happen if your "+
+					"username/password are wrong. You may want to double-check"+
+					" your credentials as part of your debugging process. "+
+					"original error: %s",
+					err)
 				handshakeAttempts += 1
 			}
 

--- a/website/source/partials/builder/amazon/common/_AMIConfig-not-required.html.md
+++ b/website/source/partials/builder/amazon/common/_AMIConfig-not-required.html.md
@@ -59,6 +59,10 @@
     copying a provisioned instance to an AMI. By default, Packer will keep the
     encryption setting to what it was in the source image. Setting false will
     result in an unencrypted image, and true will result in an encrypted one.
+    If you have used the `launch_block_device_mappings` to set an encryption
+    key and that key is the same as the one you want the image encrypted with
+    at the end, then you don't need to set this field; leaving it empty will
+    prevent an unnecessary extra copy step and save you some time.
     
 -   `kms_key_id` (string) - ID, alias or ARN of the KMS key to use for boot volume encryption. This
     only applies to the main `region`, other regions where the AMI will be


### PR DESCRIPTION
Make a slightly more helpful authentication error message, which will be surfaced in the event that we exceed our handshake attempts with the final failure being an authentication error.

Closes #8161
