### PR TITLE
Support defined tags for oci builder

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -63,7 +63,8 @@ type Config struct {
 	SubnetID string `mapstructure:"subnet_ocid"`
 
 	// Tagging
-	Tags map[string]string `mapstructure:"tags"`
+	Tags        map[string]string                 `mapstructure:"tags"`
+	DefinedTags map[string]map[string]interface{} `mapstructure:"defined_tags"`
 
 	ctx interpolate.Context
 }
@@ -206,6 +207,9 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 			}
 		}
 	}
+
+	//if c.DefinedTags != nil {
+	//	}
 
 	if c.ImageName == "" {
 		name, err := interpolate.Render("packer-{{timestamp}}", nil)

--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -208,9 +208,6 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 		}
 	}
 
-	//if c.DefinedTags != nil {
-	//	}
-
 	if c.ImageName == "" {
 		name, err := interpolate.Render("packer-{{timestamp}}", nil)
 		if err != nil {

--- a/builder/oracle/oci/config_test.go
+++ b/builder/oracle/oci/config_test.go
@@ -32,6 +32,9 @@ func testConfig(accessConfFile *os.File) map[string]interface{} {
 		"metadata": map[string]string{
 			"key": "value",
 		},
+		"defined_tags": map[string]map[string]interface{}{
+			"namespace": {"key": "value"},
+		},
 	}
 }
 

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -81,6 +81,7 @@ func (d *driverOCI) CreateImage(ctx context.Context, id string) (core.Image, err
 		InstanceId:    &id,
 		DisplayName:   &d.cfg.ImageName,
 		FreeformTags:  d.cfg.Tags,
+		DefinedTags:   d.cfg.DefinedTags,
 	}})
 
 	if err != nil {

--- a/website/source/docs/builders/oracle-oci.html.md
+++ b/website/source/docs/builders/oracle-oci.html.md
@@ -161,6 +161,19 @@ builder.
   "tag2": "value2"
 ```
 
+-   `defined_tags` (map of map of strings) - Add one or more defined tags for a given namespace to the resulting
+    custom image. See [the Oracle
+    docs](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/taggingoverview.htm)
+    for more details. Example:
+
+``` {.yaml}
+"tags":
+  "namespace": {
+    "tag1": "value1",
+    "tag2": "value2"
+  }
+```
+
 ## Basic Example
 
 Here is a basic example. Note that account specific configuration has been


### PR DESCRIPTION
OCI supports two types of tags, freeform and defined. Currently the oci builder supports freeform tags only.
In this change we allow predefined tags to be used in the spirit of the currently supported freeform tags.