### PR TITLE
Fix Issue 5575 - OpenStack builder should warn instead of fail on terminate if instance is already shut down

### DIFF
--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -92,16 +92,18 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 		return multistep.ActionHalt
 	}
 
-	volume := state.Get("volume_id").(string)
-	if len(config.ImageMetadata) > 0 && s.UseBlockStorageVolume {
-		err = volumeactions.SetImageMetadata(blockStorageClient, volume, volumeactions.ImageMetadataOpts{
-			Metadata: config.ImageMetadata,
-		}).ExtractErr()
-		if err != nil {
-			err := fmt.Errorf("Error setting image metadata: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
+	if s.UseBlockStorageVolume {
+		volume := state.Get("volume_id").(string)
+		if len(config.ImageMetadata) > 0 {
+			err = volumeactions.SetImageMetadata(blockStorageClient, volume, volumeactions.ImageMetadataOpts{
+				Metadata: config.ImageMetadata,
+			}).ExtractErr()
+			if err != nil {
+				err := fmt.Errorf("Error setting image metadata: %s", err)
+				state.Put("error", err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix Packer failure when OpenStack builder tried to stop an already stopped instance. This situation may happen with Sysprep running to generalize a Windows instance for taking an image snapshot. In this case, the recommended way is to let Sysprep to shutdown Windows, leading to the error described in the reported issue.

The fix attempts to remedy this by checking if the instance is already stopped/shutoff and if so, it skips stopping it again.

Closes #5575