### PR TITLE
digitalocean-import: Fix panic when 'image_regions' not set (Fixes: #7843).

### DIFF
--- a/post-processor/digitalocean-import/post-processor.go
+++ b/post-processor/digitalocean-import/post-processor.go
@@ -119,13 +119,17 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		"spaces_region": &p.config.SpacesRegion,
 		"space_name":    &p.config.SpaceName,
 		"image_name":    &p.config.Name,
-		"image_regions": &p.config.ImageRegions[0],
 	}
 	for key, ptr := range requiredArgs {
 		if *ptr == "" {
 			errs = packer.MultiErrorAppend(
 				errs, fmt.Errorf("%s must be set", key))
 		}
+	}
+
+	if len(p.config.ImageRegions) == 0 {
+		errs = packer.MultiErrorAppend(
+			errs, fmt.Errorf("image_regions must be set"))
 	}
 
 	if len(errs.Errors) > 0 {


### PR DESCRIPTION
Fixes a panic when 'image_regions' not set when using the digitalocean-import post-processor.

Closes #7843