### PR TITLE
don't abort on a single error if another availability zone was able t…

### DIFF
--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -274,15 +274,20 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 		return multistep.ActionHalt
 	}
 
-	if len(createOutput.Errors) > 0 {
-		errString := fmt.Sprintf("Error waiting for fleet request (%s) to become ready:", *createOutput.FleetId)
-		for _, outErr := range createOutput.Errors {
-			errString = errString + fmt.Sprintf("%s", *outErr.ErrorMessage)
+	if len(createOutput.Instances) == 0 {
+		// We can end up with errors because one of the allowed availability
+		// zones doesn't have one of the allowed instance types; as long as
+		// an instance is launched, these errors aren't important.
+		if len(createOutput.Errors) > 0 {
+			errString := fmt.Sprintf("Error waiting for fleet request (%s) to become ready:", *createOutput.FleetId)
+			for _, outErr := range createOutput.Errors {
+				errString = errString + fmt.Sprintf("%s", *outErr.ErrorMessage)
+			}
+			err = fmt.Errorf(errString)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
 		}
-		err = fmt.Errorf(errString)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
 	}
 
 	instanceId = *createOutput.Instances[0].InstanceIds[0]


### PR DESCRIPTION
Turns out this call can return errors while still successfully creating an instance; we should check whether any instances are returned before erroring out. 

Closes #8169
