### PR TITLE
default label issues & ssh/winrm issues guides link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: You're experiencing an issue with Packer that is different than the documented behavior.
-
+labels: bug
 ---
 
 When filing a bug, please include the following headings if possible. Any

--- a/.github/ISSUE_TEMPLATE/feature_requests.md
+++ b/.github/ISSUE_TEMPLATE/feature_requests.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: If you have something you think Packer could improve or add support for.
-
+labels: enhancement
 ---
 
 Please search the existing issues for relevant feature requests, and use the

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: If you have a question, please check out our other community resources instead of opening an issue.
-
+labels: question
 ---
 
 Issues on GitHub are intended to be related to bugs or feature requests, so we

--- a/.github/ISSUE_TEMPLATE/ssh_or_winrm_times_out.md
+++ b/.github/ISSUE_TEMPLATE/ssh_or_winrm_times_out.md
@@ -1,0 +1,24 @@
+---
+name: SSH or WinRM times out
+about: I have a waiting SSH or WinRM error.
+labels: communicator-question
+---
+
+Got one of the following errors ? See if the related guides can help.
+
+* `Waiting for WinRM to become available` ?
+
+  - See our basic WinRm Packer guide: https://www.packer.io/guides/automatic-operating-system-installs/autounattend_windows.html
+
+* `Waiting for SSH to become available` ?
+
+  - See our basic SSH Packer guide: https://www.packer.io/guides/automatic-operating-system-installs/preseed_ubuntu.html
+
+
+Issues on GitHub are intended to be related to bugs or feature requests, so we recommend using our other community resources instead of asking here if you have a question.
+
+- Packer Guides: https://www.packer.io/guides/index.html
+- Discussion List: https://groups.google.com/group/packer-tool
+- Any other questions can be sent to the packer section of the HashiCorp
+  forum: https://discuss.hashicorp.com/c/packer
+- Packer community links: https://www.packer.io/community.html


### PR DESCRIPTION
Hello this
* adds label by default upon issue creation 
* add a new issue template for ssh/winrm issue

Is the ssh/winrm issue covering enough cases ? Should we add more here ?

__

This is to be merged only after #8183 is deployed