### PR TITLE
use a unique temp dir for each build to prevent concurrent builds fro…

### DIFF
--- a/builder/docker/step_temp_dir.go
+++ b/builder/docker/step_temp_dir.go
@@ -35,6 +35,16 @@ func ConfigTmpDir() (string, error) {
 		configdir = fp
 	}
 
+	_, err = os.Stat(configdir)
+	if os.IsNotExist(err) {
+		log.Printf("Config dir %s does not exist; creating...", configdir)
+		if err = os.MkdirAll(configdir, 0755); err != nil {
+			return "", err
+		}
+	} else if err != nil {
+		return "", err
+	}
+
 	td, err := ioutil.TempDir(configdir, "tmp")
 	if err != nil {
 		return "", fmt.Errorf("Error creating temp dir: %s", err)

--- a/builder/docker/step_temp_dir.go
+++ b/builder/docker/step_temp_dir.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -34,16 +35,7 @@ func ConfigTmpDir() (string, error) {
 		configdir = fp
 	}
 
-	td := filepath.Join(configdir, "tmp")
-	_, err = os.Stat(td)
-	if os.IsNotExist(err) {
-		log.Printf("Creating tempdir in %s", td)
-		if err = os.MkdirAll(td, 0755); err != nil {
-			return "", err
-		}
-	} else if err != nil {
-		return "", err
-	}
+	td, err := ioutil.TempDir(configdir, "tmp")
 	log.Printf("Set Packer temp dir to %s", td)
 	return td, nil
 }

--- a/builder/docker/step_temp_dir.go
+++ b/builder/docker/step_temp_dir.go
@@ -36,6 +36,10 @@ func ConfigTmpDir() (string, error) {
 	}
 
 	td, err := ioutil.TempDir(configdir, "tmp")
+	if err != nil {
+		return "", fmt.Errorf("Error creating temp dir: %s", err)
+
+	}
 	log.Printf("Set Packer temp dir to %s", td)
 	return td, nil
 }

--- a/builder/docker/step_temp_dir_test.go
+++ b/builder/docker/step_temp_dir_test.go
@@ -35,7 +35,7 @@ func testStepTempDir_impl(t *testing.T) string {
 	dir := dirRaw.(string)
 
 	if _, err := os.Stat(dir); err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("Stat for %s failed: err: %s", err, dir)
 	}
 
 	// Cleanup


### PR DESCRIPTION
Create a unique temp dir for each Docker build to prevent multiple Docker builds from taking control of or destroying the temp dir while another is using it.  

Closes #7904 
Closes #8015
