### PR TITLE
remove clean_ami_name and clean_image_name; complete the deprecation …

### DIFF
--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -39,5 +39,4 @@ func templateCleanAMIName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanAMIName,
-	"clean_ami_name":      packertpl.DeprecatedTemplateFunc("clean_ami_name", "clean_resource_name", templateCleanAMIName),
 }

--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -3,8 +3,6 @@ package common
 import (
 	"bytes"
 	"text/template"
-
-	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isalphanumeric(b byte) bool {

--- a/builder/azure/common/template_funcs.go
+++ b/builder/azure/common/template_funcs.go
@@ -3,8 +3,6 @@ package common
 import (
 	"bytes"
 	"text/template"
-
-	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isValidByteValue(b byte) bool {

--- a/builder/azure/common/template_funcs.go
+++ b/builder/azure/common/template_funcs.go
@@ -39,5 +39,4 @@ func templateCleanImageName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanImageName,
-	"clean_image_name":    packertpl.DeprecatedTemplateFunc("clean_image_name", "clean_resource_name", templateCleanImageName),
 }

--- a/builder/googlecompute/template_funcs.go
+++ b/builder/googlecompute/template_funcs.go
@@ -3,8 +3,6 @@ package googlecompute
 import (
 	"strings"
 	"text/template"
-
-	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isalphanumeric(b byte) bool {

--- a/builder/googlecompute/template_funcs.go
+++ b/builder/googlecompute/template_funcs.go
@@ -37,5 +37,4 @@ func templateCleanImageName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanImageName,
-	"clean_image_name":    packertpl.DeprecatedTemplateFunc("clean_image_name", "clean_resource_name", templateCleanImageName),
 }

--- a/builder/yandex/template_func.go
+++ b/builder/yandex/template_func.go
@@ -1,7 +1,9 @@
 package yandex
 
-import "strings"
-import "text/template"
+import (
+	"strings"
+	"text/template"
+)
 
 func isalphanumeric(b byte) bool {
 	if '0' <= b && b <= '9' {
@@ -13,9 +15,9 @@ func isalphanumeric(b byte) bool {
 	return false
 }
 
-// Clean up image name by replacing invalid characters with "-"
+// Clean up resource name by replacing invalid characters with "-"
 // and converting upper cases to lower cases
-func templateCleanImageName(s string) string {
+func templateCleanResourceName(s string) string {
 	if reImageFamily.MatchString(s) {
 		return s
 	}
@@ -32,5 +34,5 @@ func templateCleanImageName(s string) string {
 }
 
 var TemplateFuncs = template.FuncMap{
-	"clean_image_name": templateCleanImageName,
+	"clean_resource_name": templateCleanResourceName,
 }

--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -41,7 +41,7 @@ Here is a full list of the available functions for reference.
     will convert upper cases to lower cases and replace illegal characters with
     a "-" character.  Example:
 
-   `"mybuild-{{isotime | clean_image_name}}"` will become
+   `"mybuild-{{isotime | clean_resource_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid Azure image names must match the regex
@@ -57,6 +57,9 @@ Here is a full list of the available functions for reference.
     clean_resource_name}}"` will cause your build to fail because the image
     name will start with a number, which is why in the above example we prepend
     the isotime with "mybuild".
+    Exact behavior of `clean_resource_name` will depend on which builder it is
+    being applied to; refer to build-specific docs below for more detail on how
+    each function will behave.
 -   `env` - Returns environment variables. See example in [using home
     variable](/docs/templates/user-variables.html#using-home-variable)
 -   `isotime [FORMAT]` - UTC time, which can be
@@ -80,19 +83,19 @@ Here is a full list of the available functions for reference.
 
 #### Specific to Amazon builders:
 
--   `clean_ami_name` - DEPRECATED use `clean_resource_name` instead - AMI names
+-   `clean_resource_name` - AMI names
     can only contain certain characters. This function will replace illegal
     characters with a '-" character. Example usage since ":" is not a legal AMI
-    name is: `{{isotime | clean_ami_name}}`.
+    name is: `{{isotime | clean_resource_name}}`.
 
 #### Specific to Google Compute builders:
 
--   `clean_image_name` - DEPRECATED use `clean_resource_name` instead - GCE
+-   `clean_resource_name` - GCE
     image names can only contain certain characters and the maximum length is
     63. This function will convert upper cases to lower cases and replace
         illegal characters with a "-" character. Example:
 
-    `"mybuild-{{isotime | clean_image_name}}"` will become
+    `"mybuild-{{isotime | clean_resource_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid GCE image names must match the regex
@@ -107,12 +110,12 @@ Here is a full list of the available functions for reference.
 
 #### Specific to Azure builders:
 
--   `clean_image_name` - DEPRECATED use `clean_resource_name` instead - Azure
+-   `clean_resource_name` - Azure
     managed image names can only contain certain characters and the maximum
     length is 80. This function will replace illegal characters with a "-"
     character. Example:
 
-    `"mybuild-{{isotime | clean_image_name}}"` will become
+    `"mybuild-{{isotime | clean_resource_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid Azure image names must match the regex


### PR DESCRIPTION
Finish deprecating old names in favor of more generic clean_resource_name

Closes #7471
