### PR TITLE
missing bracket

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -38,7 +38,7 @@ if ($HostVMAdapter){
   if ($HostNetAdapter){
     $HostNetAdapterIfIndex = @()
     $HostNetAdapterIfIndex += $HostNetAdapter.ifIndex
-    $HostNetAdapterConfiguration = @(get-wmiobject win32_networkadapterconfiguration -filter "IPEnabled = 'TRUE'") | Where-Object { $HostNetAdapterIfIndex.Contains($_.InterfaceIndex)
+    $HostNetAdapterConfiguration = @(get-wmiobject win32_networkadapterconfiguration -filter "IPEnabled = 'TRUE'") | Where-Object { $HostNetAdapterIfIndex.Contains($_.InterfaceIndex)}
     if ($HostNetAdapterConfiguration){
       return @($HostNetAdapterConfiguration.IpAddress)[$addressIndex]
     }


### PR DESCRIPTION
Fix a missing bracket that broke one of the powershell scripts in the hyperv driver.

Closes #8194
