### PR TITLE
[Proxmox] Add support for SCSI controller selection

### DIFF
--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -37,14 +37,15 @@ type Config struct {
 	VMName string `mapstructure:"vm_name"`
 	VMID   int    `mapstructure:"vm_id"`
 
-	Memory  int          `mapstructure:"memory"`
-	Cores   int          `mapstructure:"cores"`
-	Sockets int          `mapstructure:"sockets"`
-	OS      string       `mapstructure:"os"`
-	NICs    []nicConfig  `mapstructure:"network_adapters"`
-	Disks   []diskConfig `mapstructure:"disks"`
-	ISOFile string       `mapstructure:"iso_file"`
-	Agent   bool         `mapstructure:"qemu_agent"`
+	Memory         int          `mapstructure:"memory"`
+	Cores          int          `mapstructure:"cores"`
+	Sockets        int          `mapstructure:"sockets"`
+	OS             string       `mapstructure:"os"`
+	NICs           []nicConfig  `mapstructure:"network_adapters"`
+	Disks          []diskConfig `mapstructure:"disks"`
+	ISOFile        string       `mapstructure:"iso_file"`
+	Agent          bool         `mapstructure:"qemu_agent"`
+	SCSIController string       `mapstructure:"scsi_controller"`
 
 	TemplateName        string `mapstructure:"template_name"`
 	TemplateDescription string `mapstructure:"template_description"`
@@ -158,6 +159,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 		if !contains([]string{"zfspool", "lvm"}, c.Disks[idx].StoragePoolType) && c.Disks[idx].DiskFormat == "" {
 			errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf("disk format must be specified for pool type %q", c.Disks[idx].StoragePoolType)))
 		}
+	}
+	if c.SCSIController == "" {
+		log.Printf("SCSI controller not set, using default 'lsi'")
+		c.SCSIController = "lsi"
 	}
 
 	errs = packer.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)

--- a/builder/proxmox/config_test.go
+++ b/builder/proxmox/config_test.go
@@ -94,6 +94,7 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	// NIC 0 model not set, using default 'e1000'
 	// Disk 0 cache mode not set, using default 'none'
 	// Agent not set, default is true
+	// SCSI controller not set, using default 'lsi'
 
 	if b.config.Memory != 512 {
 		t.Errorf("Expected Memory to be 512, got %d", b.config.Memory)
@@ -115,6 +116,9 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	}
 	if b.config.Agent != true {
 		t.Errorf("Expected Agent to be true, got %t", b.config.Agent)
+	}
+	if b.config.SCSIController != "lsi" {
+		t.Errorf("Expected SCSI controller to be 'lsi', got %s", b.config.SCSIController)
 	}
 }
 

--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -40,6 +40,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		QemuIso:      c.ISOFile,
 		QemuNetworks: generateProxmoxNetworkAdapters(c.NICs),
 		QemuDisks:    generateProxmoxDisks(c.Disks),
+		Scsihw:       c.SCSIController,
 	}
 
 	if c.VMID == 0 {

--- a/website/source/docs/builders/proxmox.html.md
+++ b/website/source/docs/builders/proxmox.html.md
@@ -152,6 +152,10 @@ builder.
     then `qemu-guest-agent` must be installed on the guest. When disabled, then 
     `ssh_host` should be used. Defaults to `true`.
 
+-   `scsi_controller` (string) - The SCSI controller model to emulate. Can be `lsi`,
+    `lsi53c810`, `virtio-scsi-pci`, `virtio-scsi-single`, `megasas`, or `pvscsi`.
+    Defaults to `lsi`.
+
 ## Example: Fedora with kickstart
 
 Here is a basic example creating a Fedora 29 server image with a Kickstart


### PR DESCRIPTION
Currently, you cannot select the SCSI controller to use with the Proxmox builder. This means that certain operating systems (like CentOS 7, see #7845) will fail to install on disks with the type `scsi`.

This PR adds the ability to choose the SCSI controller type used by the VM.
