### PR TITLE
[Proxmox] Add ability to select CPU type

### DIFF
--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Memory  int          `mapstructure:"memory"`
 	Cores   int          `mapstructure:"cores"`
 	Sockets int          `mapstructure:"sockets"`
+	CPUType string       `mapstructure:"cpu_type"`
 	OS      string       `mapstructure:"os"`
 	NICs    []nicConfig  `mapstructure:"network_adapters"`
 	Disks   []diskConfig `mapstructure:"disks"`
@@ -128,6 +129,10 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	if c.Sockets < 1 {
 		log.Printf("Number of sockets %d is too small, using default: 1", c.Sockets)
 		c.Sockets = 1
+	}
+	if c.CPUType == "" {
+		log.Printf("CPU type not set, using default 'kvm64'")
+		c.CPUType = "kvm64"
 	}
 	if c.OS == "" {
 		log.Printf("OS not set, using default 'other'")

--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -39,7 +39,7 @@ type Config struct {
 
 	Memory         int          `mapstructure:"memory"`
 	Cores          int          `mapstructure:"cores"`
-  CPUType        string       `mapstructure:"cpu_type"`
+	CPUType        string       `mapstructure:"cpu_type"`
 	Sockets        int          `mapstructure:"sockets"`
 	OS             string       `mapstructure:"os"`
 	NICs           []nicConfig  `mapstructure:"network_adapters"`

--- a/builder/proxmox/config_test.go
+++ b/builder/proxmox/config_test.go
@@ -90,6 +90,7 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	// Memory 0 is too small, using default: 512
 	// Number of cores 0 is too small, using default: 1
 	// Number of sockets 0 is too small, using default: 1
+	// CPU type not set, using default 'kvm64'
 	// OS not set, using default 'other'
 	// NIC 0 model not set, using default 'e1000'
 	// Disk 0 cache mode not set, using default 'none'
@@ -103,6 +104,9 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	}
 	if b.config.Sockets != 1 {
 		t.Errorf("Expected Sockets to be 1, got %d", b.config.Sockets)
+	}
+	if b.config.CPUType != "kvm64" {
+		t.Errorf("Expected CPU type to be 'kvm64', got %s", b.config.CPUType)
 	}
 	if b.config.OS != "other" {
 		t.Errorf("Expected OS to be 'other', got %s", b.config.OS)

--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -31,7 +31,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Name:         c.VMName,
 		Agent:        agent,
 		Boot:         "cdn", // Boot priority, c:CDROM -> d:Disk -> n:Network
-		QemuCpu:      "host",
+		QemuCpu:      c.CPUType,
 		Description:  "Packer ephemeral build VM",
 		Memory:       c.Memory,
 		QemuCores:    c.Cores,

--- a/website/source/docs/builders/proxmox.html.md
+++ b/website/source/docs/builders/proxmox.html.md
@@ -73,6 +73,10 @@ builder.
 -   `sockets` (int) - How many CPU sockets to give the virtual machine.
     Defaults to `1`
 
+-   `cpu_type` (string) - The CPU type to emulate. See the Proxmox API
+    documentation for the complete list of accepted values. For best
+    performance, set this to `host`. Defaults to `kvm64`.
+
 -   `os` (string) - The operating system. Can be `wxp`, `w2k`, `w2k3`, `w2k8`,
     `wvista`, `win7`, `win8`, `win10`, `l24` (Linux 2.4), `l26` (Linux 2.6+),
     `solaris` or `other`. Defaults to `other`.


### PR DESCRIPTION
The only CPU type used in Proxmox VMs generated by Packer is `host`. While this improves performance, it can create issues when live migrating VMs between Proxmox hosts with different CPU types (e.g. Intel to AMD or vice-versa) by causing the qemu process to stop (see the second paragraph of 'CPU Type' from the [Proxmox Wiki](https://pve.proxmox.com/wiki/Qemu/KVM_Virtual_Machines#qm_virtual_machines_settings)).

This PR adds the ability to set the CPU type through the `cpu_type` option for the Proxmox builder. Additionally, it changes the default CPU type from `host` to `kvm64` as this is the default used by Proxmox.
