### PR TITLE
Add builder CODEOWNERS to respective docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,24 +3,62 @@
 # builders
 
 /builder/alicloud/                      @chhaj5236
-/builder/azure/                         @paulmey
-/builder/hyperv/                        @taliesins
-/builder/jdcloud/                       @XiaohanLiang @remrain
-/builder/linode/                        @displague @ctreatma @stvnjacobs
-/builder/lxc/                           @ChrisLundquist
-/builder/lxd/                           @ChrisLundquist
-/builder/oneandone/                     @jasmingacic
-/builder/oracle/                        @prydie @owainlewis
-/builder/profitbricks/                  @jasmingacic
-/builder/triton/                        @sean-
-/builder/ncloud/                        @YuSungDuk
-/builder/proxmox/                       @carlpett
+/website/source/docs/builders/alicloud* @chhaj5236
+
+/builder/azure/                      @paulmey
+/website/source/docs/builders/azure* @paulmey
+
+/builder/hyperv/                      @taliesins
+/website/source/docs/builders/hyperv* @taliesins
+
+/builder/jdcloud/                      @XiaohanLiang @remrain
+/website/source/docs/builders/jdcloud* @XiaohanLiang @remrain
+
+/builder/linode/                      @displague @ctreatma @stvnjacobs
+/website/source/docs/builders/linode* @displague @ctreatma @stvnjacobs
+
+/builder/lxc/                      @ChrisLundquist
+/website/source/docs/builders/lxc* @ChrisLundquist
+
+/builder/lxd/                      @ChrisLundquist
+/website/source/docs/builders/lxd* @ChrisLundquist
+
+/builder/oneandone/                      @jasmingacic
+/website/source/docs/builders/oneandone* @jasmingacic
+
+/builder/oracle/                      @prydie @owainlewis
+/website/source/docs/builders/oracle* @prydie @owainlewis
+
+/builder/profitbricks/                      @jasmingacic
+/website/source/docs/builders/profitbricks* @jasmingacic
+
+/builder/triton/                      @sean-
+/website/source/docs/builders/triton* @sean-
+
+/builder/ncloud/                      @YuSungDuk
+/website/source/docs/builders/ncloud* @YuSungDuk
+
+/builder/proxmox/                      @carlpett
+/website/source/docs/builders/proxmox* @carlpett
+
 /builder/scaleway/                      @sieben @mvaude @jqueuniet @fflorens @brmzkw
-/builder/hcloud/                        @LKaemmerling
-/builder/hyperone                       @m110 @gregorybrzeski @ad-m
-/builder/ucloud/                        @shawnmssu
-/builder/yandex                         @GennadySpb @alexanderKhaustov @seukyaso
-/builder/osc                            @marinsalinas
+/website/source/docs/builders/scaleway* @sieben @mvaude @jqueuniet @fflorens @brmzkw
+
+/builder/hcloud/                      @LKaemmerling
+/website/source/docs/builders/hcloud* @LKaemmerling
+
+/builder/hyperone/                      @m110 @gregorybrzeski @ad-m
+/website/source/docs/builders/hyperone* @m110 @gregorybrzeski @ad-m
+
+/builder/ucloud/                      @shawnmssu
+/website/source/docs/builders/ucloud* @shawnmssu
+
+/builder/yandex/                      @GennadySpb @alexanderKhaustov @seukyaso
+/website/source/docs/builders/yandex* @GennadySpb @alexanderKhaustov @seukyaso
+
+/builder/osc/                      @marinsalinas
+/website/source/docs/builders/osc* @marinsalinas
+
 
 # provisioners
 


### PR DESCRIPTION
This PR adds the corresponding docs-files to builder CODEOWNERS for review-tagging.