### PR TITLE
Prevent busy loop while waiting for WinRM connection

### DIFF
--- a/helper/communicator/step_connect_winrm.go
+++ b/helper/communicator/step_connect_winrm.go
@@ -95,8 +95,8 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, ctx context.Co
 				return nil, errors.New("WinRM wait cancelled")
 			case <-time.After(5 * time.Second):
 			}
-			first = false
 		}
+		first = false
 
 		host, err := s.Host(state)
 		if err != nil {


### PR DESCRIPTION
Set first run variable outside conditional so it will properly be
updated during the first run and pause on subsequent runs.