### PR TITLE
Revert backwards incompatable changes for 1 4 5

### DIFF
--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -3,6 +3,8 @@ package common
 import (
 	"bytes"
 	"text/template"
+
+	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isalphanumeric(b byte) bool {

--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -37,4 +37,5 @@ func templateCleanAMIName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanAMIName,
+	"clean_ami_name":      packertpl.DeprecatedTemplateFunc("clean_ami_name", "clean_resource_name", templateCleanAMIName),
 }

--- a/builder/azure/common/template_funcs.go
+++ b/builder/azure/common/template_funcs.go
@@ -3,6 +3,8 @@ package common
 import (
 	"bytes"
 	"text/template"
+
+	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isValidByteValue(b byte) bool {

--- a/builder/azure/common/template_funcs.go
+++ b/builder/azure/common/template_funcs.go
@@ -37,4 +37,5 @@ func templateCleanImageName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanImageName,
+	"clean_image_name":    packertpl.DeprecatedTemplateFunc("clean_image_name", "clean_resource_name", templateCleanImageName),
 }

--- a/builder/googlecompute/template_funcs.go
+++ b/builder/googlecompute/template_funcs.go
@@ -35,4 +35,5 @@ func templateCleanImageName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanImageName,
+	"clean_image_name":    packertpl.DeprecatedTemplateFunc("clean_image_name", "clean_resource_name", templateCleanImageName),
 }

--- a/builder/googlecompute/template_funcs.go
+++ b/builder/googlecompute/template_funcs.go
@@ -3,6 +3,8 @@ package googlecompute
 import (
 	"strings"
 	"text/template"
+
+	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isalphanumeric(b byte) bool {

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -146,11 +146,9 @@ type Config struct {
 	// one of the other listed interfaces. Using the `scsi` interface under
 	// these circumstances will cause the build to fail.
 	DiskInterface string `mapstructure:"disk_interface" required:"false"`
-	// The size in bytes, suffixes of the first letter of common byte types
-	// like "k" or "K", "M" for megabytes, G for gigabytes, T for terabytes.
-	// Will create the of the hard disk of the VM. By default, this is
-	// `40960M` (40 GB).
-	DiskSize string `mapstructure:"disk_size" required:"false"`
+	// The size, in megabytes, of the hard disk to create
+	// for the VM. By default, this is 40960 (40 GB).
+	DiskSize uint `mapstructure:"disk_size" required:"false"`
 	// The cache mode to use for disk. Allowed values include any of
 	// `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By
 	// default, this is set to `writeback`.
@@ -318,6 +316,7 @@ type Config struct {
 	// "BUILDNAME" is the name of the build. Currently, no file extension will be
 	// used unless it is specified in this option.
 	VMName string `mapstructure:"vm_name" required:"false"`
+
 	// These are deprecated, but we keep them around for BC
 	// TODO(@mitchellh): remove
 	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout" required:"false"`
@@ -345,10 +344,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	var errs *packer.MultiError
 	warnings := make([]string, 0)
+
 	errs = packer.MultiErrorAppend(errs, b.config.ShutdownConfig.Prepare(&b.config.ctx)...)
 
-	if b.config.DiskSize == "" || b.config.DiskSize == "0" {
-		b.config.DiskSize = "40960M"
+	if b.config.DiskSize == 0 {
+		b.config.DiskSize = 40960
 	}
 
 	if b.config.DiskCache == "" {
@@ -700,7 +700,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		artifact.state["diskPaths"] = diskpaths
 	}
 	artifact.state["diskType"] = b.config.Format
-	artifact.state["diskSize"] = b.config.DiskSize
+	artifact.state["diskSize"] = uint64(b.config.DiskSize)
 	artifact.state["domainType"] = b.config.Accelerator
 
 	return artifact, nil

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -169,11 +169,11 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 		t.Fatalf("bad err: %s", err)
 	}
 
-	if b.config.DiskSize != "40960M" {
-		t.Fatalf("bad size: %s", b.config.DiskSize)
+	if b.config.DiskSize != 40960 {
+		t.Fatalf("bad size: %d", b.config.DiskSize)
 	}
 
-	config["disk_size"] = "60000M"
+	config["disk_size"] = 60000
 	b = Builder{}
 	warns, err = b.Prepare(config)
 	if len(warns) > 0 {
@@ -183,8 +183,8 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 
-	if b.config.DiskSize != "60000M" {
-		t.Fatalf("bad size: %s", b.config.DiskSize)
+	if b.config.DiskSize != 60000 {
+		t.Fatalf("bad size: %d", b.config.DiskSize)
 	}
 }
 

--- a/builder/qemu/step_create_disk.go
+++ b/builder/qemu/step_create_disk.go
@@ -29,7 +29,7 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	ui.Say("Creating required virtual machine disks")
 	// The 'main' or 'default' disk
 	diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, name))
-	diskSizes = append(diskSizes, fmt.Sprintf("%s", config.DiskSize))
+	diskSizes = append(diskSizes, fmt.Sprintf("%dM", uint64(config.DiskSize)))
 	// Additional disks
 	if len(config.AdditionalDiskSize) > 0 {
 		for i, diskSize := range config.AdditionalDiskSize {

--- a/builder/qemu/step_resize_disk.go
+++ b/builder/qemu/step_resize_disk.go
@@ -23,8 +23,9 @@ func (s *stepResizeDisk) Run(ctx context.Context, state multistep.StateBag) mult
 		"resize",
 		"-f", config.Format,
 		path,
-		fmt.Sprintf("%s", config.DiskSize),
+		fmt.Sprintf("%vM", config.DiskSize),
 	}
+
 	if config.DiskImage == false {
 		return multistep.ActionContinue
 	}

--- a/builder/yandex/template_func.go
+++ b/builder/yandex/template_func.go
@@ -1,9 +1,7 @@
 package yandex
 
-import (
-	"strings"
-	"text/template"
-)
+import "strings"
+import "text/template"
 
 func isalphanumeric(b byte) bool {
 	if '0' <= b && b <= '9' {
@@ -15,9 +13,9 @@ func isalphanumeric(b byte) bool {
 	return false
 }
 
-// Clean up resource name by replacing invalid characters with "-"
+// Clean up image name by replacing invalid characters with "-"
 // and converting upper cases to lower cases
-func templateCleanResourceName(s string) string {
+func templateCleanImageName(s string) string {
 	if reImageFamily.MatchString(s) {
 		return s
 	}
@@ -34,5 +32,5 @@ func templateCleanResourceName(s string) string {
 }
 
 var TemplateFuncs = template.FuncMap{
-	"clean_resource_name": templateCleanResourceName,
+	"clean_image_name": templateCleanImageName,
 }

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -37,7 +37,7 @@ to files, URLS for ISOs and checksums.
       "iso_checksum_type": "md5",
       "output_directory": "output_centos_tdhtest",
       "shutdown_command": "echo 'packer' | sudo -S shutdown -P now",
-      "disk_size": "5000M",
+      "disk_size": 5000,
       "format": "qcow2",
       "accelerator": "kvm",
       "http_directory": "path/to/httpdir",

--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -41,7 +41,7 @@ Here is a full list of the available functions for reference.
     will convert upper cases to lower cases and replace illegal characters with
     a "-" character.  Example:
 
-   `"mybuild-{{isotime | clean_resource_name}}"` will become
+   `"mybuild-{{isotime | clean_image_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid Azure image names must match the regex
@@ -57,9 +57,6 @@ Here is a full list of the available functions for reference.
     clean_resource_name}}"` will cause your build to fail because the image
     name will start with a number, which is why in the above example we prepend
     the isotime with "mybuild".
-    Exact behavior of `clean_resource_name` will depend on which builder it is
-    being applied to; refer to build-specific docs below for more detail on how
-    each function will behave.
 -   `env` - Returns environment variables. See example in [using home
     variable](/docs/templates/user-variables.html#using-home-variable)
 -   `isotime [FORMAT]` - UTC time, which can be
@@ -87,19 +84,19 @@ Here is a full list of the available functions for reference.
 
 #### Specific to Amazon builders:
 
--   `clean_resource_name` - AMI names
+-   `clean_ami_name` - DEPRECATED use `clean_resource_name` instead - AMI names
     can only contain certain characters. This function will replace illegal
     characters with a '-" character. Example usage since ":" is not a legal AMI
-    name is: `{{isotime | clean_resource_name}}`.
+    name is: `{{isotime | clean_ami_name}}`.
 
 #### Specific to Google Compute builders:
 
--   `clean_resource_name` - GCE
+-   `clean_image_name` - DEPRECATED use `clean_resource_name` instead - GCE
     image names can only contain certain characters and the maximum length is
     63. This function will convert upper cases to lower cases and replace
         illegal characters with a "-" character. Example:
 
-    `"mybuild-{{isotime | clean_resource_name}}"` will become
+    `"mybuild-{{isotime | clean_image_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid GCE image names must match the regex
@@ -114,12 +111,12 @@ Here is a full list of the available functions for reference.
 
 #### Specific to Azure builders:
 
--   `clean_resource_name` - Azure
+-   `clean_image_name` - DEPRECATED use `clean_resource_name` instead - Azure
     managed image names can only contain certain characters and the maximum
     length is 80. This function will replace illegal characters with a "-"
     character. Example:
 
-    `"mybuild-{{isotime | clean_resource_name}}"` will become
+    `"mybuild-{{isotime | clean_image_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid Azure image names must match the regex

--- a/website/source/partials/builder/qemu/_Config-not-required.html.md
+++ b/website/source/partials/builder/qemu/_Config-not-required.html.md
@@ -47,10 +47,8 @@
     one of the other listed interfaces. Using the `scsi` interface under
     these circumstances will cause the build to fail.
     
--   `disk_size` (string) - The size in bytes, suffixes of the first letter of common byte types
-    like "k" or "K", "M" for megabytes, G for gigabytes, T for terabytes.
-    Will create the of the hard disk of the VM. By default, this is
-    `40960M` (40 GB).
+-   `disk_size` (uint) - The size, in megabytes, of the hard disk to create
+    for the VM. By default, this is 40960 (40 GB).
     
 -   `disk_cache` (string) - The cache mode to use for disk. Allowed values include any of
     `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By


### PR DESCRIPTION
We've decided to add a 1.4.5 release between now and the 1.5.0 release in mid December. Revert the backwards-breaking changes we'd already merged for 1.5.0 so that the patch isn't backwards breaking.