### PR TITLE
Use first adapter attached to host OS's VM switch

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -32,7 +32,7 @@ type scriptOptions struct {
 func GetHostAdapterIpAddressForSwitch(switchName string) (string, error) {
 	var script = `
 param([string]$switchName, [int]$addressIndex)
-$HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName
+$HostVMAdapter = Hyper-V\Get-VMNetworkAdapter -ManagementOS -SwitchName $switchName | Select-Object -First 1
 if ($HostVMAdapter){
   $HostNetAdapter = Get-NetAdapter | Where-Object { $_.DeviceId -eq $HostVMAdapter.DeviceId }
   if ($HostNetAdapter){


### PR DESCRIPTION
By introducing this change underlying PowerShell script will use the first attached adapter to the host OS if more then one adapter is attached to that Hyper-V VM switch as rest of the script expects just one adapter to be present:
https://github.com/hashicorp/packer/blob/046f94c99674827b5debeb3eae6da7453e4bbce3/common/powershell/hyperv/hyperv.go#L37

I've also opened an issue with a more detailed explanation with #8233.

Closes #8233