### PR TITLE
Fix "Acces" typo in amazon-ebs.html.md.erb

### DIFF
--- a/website/source/docs/builders/amazon-ebs.html.md.erb
+++ b/website/source/docs/builders/amazon-ebs.html.md.erb
@@ -39,7 +39,7 @@ There are many configuration options available for the builder. In addition to
 the items listed here, you will want to look at the general configuration
 references for [AMI](#ami-configuration),
 [BlockDevices](#block-devices-configuration),
-[Access](#acces-configuration),
+[Access](#access-configuration),
 [Run](#run-configuration) and
 [Communicator](#communicator-configuration)
 configuration references, which are
@@ -59,7 +59,7 @@ necessary for this build to succeed and can be found further down the page.
 #### Optional:
 <%= partial "partials/builder/amazon/common/AMIConfig-not-required" %>
 
-### Acces Configuration
+### Access Configuration
 
 #### Required:
 


### PR DESCRIPTION
Found and fixed a typo in the Amazon EBS documentation for "Access"

Since this is a documentation-only PR I've not included any tests. I also did not see any issues open for this.

It's not much, but it's honest work.
