### PR TITLE
hyper-v fix for compacting only .vhd|.vhdx files

### DIFF
--- a/common/powershell/hyperv/hyperv.go
+++ b/common/powershell/hyperv/hyperv.go
@@ -860,7 +860,7 @@ func CompactDisks(path string) (result string, err error) {
 	var script = `
 param([string]$srcPath)
 
-$disks = Get-ChildItem -Path $srcPath -Recurse -Filter *.vhd* -ErrorAction SilentlyContinue | % { $_.FullName }
+$disks = Get-ChildItem -Path $srcPath -Recurse -ErrorAction SilentlyContinue |where {$_.extension -in ".vhdx",".vhd"} |foreach { $_.FullName }
 # Failure to find any disks is treated as a 'soft' error. Simply print out
 # a warning and exit
 if ($disks.Length -eq 0) {


### PR DESCRIPTION
During compacting disk phase only .vhdx and .vhd files should be compacted. Files with 'avhdx' prefix as well as files with .mrt and .rct extension (usualy file name is somefile.vhdx.mrt and somefile.vhdx.rct) should be left alone, as compacting them will cause error.
