### PR TITLE
when using a slice of an imported field type, the Underlying still re…

### DIFF
--- a/cmd/mapstructure-to-hcl2/mapstructure-to-hcl2.go
+++ b/cmd/mapstructure-to-hcl2/mapstructure-to-hcl2.go
@@ -343,7 +343,7 @@ func getUsedImports(s *types.Struct) map[NamePath]*types.Package {
 			fieldType = p.Elem()
 		}
 		if p, ok := fieldType.(*types.Slice); ok {
-			fieldType = p.Underlying()
+			fieldType = p.Elem()
 		}
 		namedType, ok := fieldType.(*types.Named)
 		if !ok {


### PR DESCRIPTION
Found a bug in the mapstructure to hcl2 generation code; this was causing a contribution to ucloud (PR #8261) to fail because the generated code can't build.