### PR TITLE
Make Vagrant driver code pass through logs as it receives them rather…

### DIFF
--- a/builder/vagrant/step_up.go
+++ b/builder/vagrant/step_up.go
@@ -33,7 +33,7 @@ func (s *StepUp) Run(ctx context.Context, state multistep.StateBag) multistep.St
 	driver := state.Get("driver").(VagrantDriver)
 	ui := state.Get("ui").(packer.Ui)
 
-	ui.Say("Calling Vagrant Up...")
+	ui.Say("Calling Vagrant Up (this can take some time)...")
 
 	_, _, err := driver.Up(s.generateArgs())
 


### PR DESCRIPTION
This is a UX change rather than a functional one; it makes Packer no longer seem like it's hanging when it's just happily waiting for Vagrant to do its thing. 

Closes #8264 
