### PR TITLE
Fix string pointer maps

### DIFF
--- a/builder/amazon/common/build_filter.go
+++ b/builder/amazon/common/build_filter.go
@@ -8,9 +8,11 @@ import (
 func buildEc2Filters(input map[string]string) []*ec2.Filter {
 	var filters []*ec2.Filter
 	for k, v := range input {
+		a := k
+		b := v
 		filters = append(filters, &ec2.Filter{
-			Name:   &k,
-			Values: []*string{&v},
+			Name:   &a,
+			Values: []*string{&b},
 		})
 	}
 	return filters

--- a/builder/amazon/common/build_filter_test.go
+++ b/builder/amazon/common/build_filter_test.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestStepSourceAmiInfo_BuildFilter(t *testing.T) {
+	filter_key := "name"
+	filter_value := "foo"
+	filter_key2 := "name2"
+	filter_value2 := "foo2"
+
+	inputFilter := map[string]string{filter_key: filter_value, filter_key2: filter_value2}
+	outputFilter := buildEc2Filters(inputFilter)
+
+	// deconstruct filter back into things we can test
+	foundMap := map[string]bool{filter_key: false, filter_key2: false}
+	for _, filter := range outputFilter {
+		for key, value := range inputFilter {
+			if *filter.Name == key && *filter.Values[0] == value {
+				foundMap[key] = true
+			}
+		}
+	}
+
+	for k, v := range foundMap {
+		if !v {
+			t.Fatalf("Fail: should have found value for key: %s", k)
+		}
+	}
+}


### PR DESCRIPTION
When we merged https://github.com/hashicorp/packer/commit/221e72e9c3952e5ce925b9f549ec0054638f8b76, we created a sneaky bug that messed up or AWS filter builder. This fixes that bug by reinitializing the variables afresh each time
