### PR TITLE
[WIP] Add instance_display_name for cloudstack builder

### DIFF
--- a/builder/cloudstack/config.go
+++ b/builder/cloudstack/config.go
@@ -78,6 +78,8 @@ type Config struct {
 	// The name of the instance. Defaults to
 	// "packer-UUID" where UUID is dynamically generated.
 	InstanceName string `mapstructure:"instance_name" required:"false"`
+	// The display name of the instance. Defaults to "Created by Packer".
+	InstanceDisplayName string `mapstructure:"instance_display_name" required:"false"`
 	// The name or ID of the network to connect the instance
 	// to.
 	Network string `mapstructure:"network" required:"true"`
@@ -208,6 +210,10 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 
 	if c.InstanceName == "" {
 		c.InstanceName = fmt.Sprintf("packer-%s", uuid.TimeOrderedUUID())
+	}
+
+	if c.InstanceDisplayName == "" {
+		c.InstanceDisplayName = "Created by Packer"
 	}
 
 	if c.TemplateName == "" {

--- a/builder/cloudstack/config.hcl2spec.go
+++ b/builder/cloudstack/config.hcl2spec.go
@@ -74,6 +74,7 @@ type FlatConfig struct {
 	Expunge                   *bool             `mapstructure:"expunge" required:"false" cty:"expunge"`
 	Hypervisor                *string           `mapstructure:"hypervisor" required:"false" cty:"hypervisor"`
 	InstanceName              *string           `mapstructure:"instance_name" required:"false" cty:"instance_name"`
+	InstanceDisplayName       *string           `mapstructure:"instance_display_name" required:"false" cty:"instance_display_name"`
 	Network                   *string           `mapstructure:"network" required:"true" cty:"network"`
 	Project                   *string           `mapstructure:"project" required:"false" cty:"project"`
 	PublicIPAddress           *string           `mapstructure:"public_ip_address" required:"false" cty:"public_ip_address"`
@@ -174,6 +175,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"expunge":                      &hcldec.AttrSpec{Name: "expunge", Type: cty.Bool, Required: false},
 		"hypervisor":                   &hcldec.AttrSpec{Name: "hypervisor", Type: cty.String, Required: false},
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
+		"instance_display_name":        &hcldec.AttrSpec{Name: "instance_display_name", Type: cty.String, Required: false},
 		"network":                      &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
 		"project":                      &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"public_ip_address":            &hcldec.AttrSpec{Name: "public_ip_address", Type: cty.String, Required: false},

--- a/builder/cloudstack/step_create_instance.go
+++ b/builder/cloudstack/step_create_instance.go
@@ -44,7 +44,7 @@ func (s *stepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 
 	// Configure the instance.
 	p.SetName(config.InstanceName)
-	p.SetDisplayname("Created by Packer")
+	p.SetDisplayname(config.InstanceDisplayName)
 
 	if len(config.Comm.SSHKeyPairName) != 0 {
 		ui.Message(fmt.Sprintf("Using keypair: %s", config.Comm.SSHKeyPairName))

--- a/website/source/partials/builder/cloudstack/_Config-not-required.html.md
+++ b/website/source/partials/builder/cloudstack/_Config-not-required.html.md
@@ -45,6 +45,8 @@
 -   `instance_name` (string) - The name of the instance. Defaults to
     "packer-UUID" where UUID is dynamically generated.
     
+-   `instance_display_name` (string) - The display name of the instance. Defaults to "Created by Packer".
+    
 -   `project` (string) - The name or ID of the project to deploy the instance
     to.
     


### PR DESCRIPTION
This change introduce optional "instance_display_name" template parameter for Cloudstack builder with "Created by Packer" as a default value.

Closes #8252
