### PR TITLE
builder/oneandone: fix dropped errors

### DIFF
--- a/builder/oneandone/step_create_server.go
+++ b/builder/oneandone/step_create_server.go
@@ -73,11 +73,15 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 	}
 
 	server_id, server, err := api.CreateServer(&req)
+	if err != nil {
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
 
-	if err == nil {
-		// Wait until server is created and powered on for at most 60 x 10 seconds
-		err = api.WaitForState(server, "POWERED_ON", 10, c.Retries)
-	} else {
+	// Wait until server is created and powered on for at most 60 x 10 seconds
+	err = api.WaitForState(server, "POWERED_ON", 10, c.Retries)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Timeout waiting for server: %s", server_id))
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
@@ -118,8 +122,14 @@ func (s *stepCreateServer) Cleanup(state multistep.StateBag) {
 			ui.Error(err.Error())
 		}
 		err = api.WaitForState(server, "POWERED_OFF", 10, c.Retries)
+		if err != nil {
+			ui.Error(fmt.Sprintf(
+				"Error waiting for 1and1 POWERED_OFF state. Please destroy it manually: %s",
+				serverId))
+			ui.Error(err.Error())
+		}
 
-		server, err = api.DeleteServer(server.Id, false)
+		_, err = api.DeleteServer(server.Id, false)
 
 		if err != nil {
 			ui.Error(fmt.Sprintf("Error deleting 1and1 server. Please destroy it manually: %s", serverId))


### PR DESCRIPTION
This PR fixes some dropped errors (and a stray `server` variable) in the `builder/oneandone` package.