### PR TITLE
add some extra layers of validation to make sure that people don't tr…

### DIFF
--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -170,16 +170,22 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 		}
 	}
 
-	var kmsKeys []string
+	kmsKeys := make([]string, 0)
 	if len(c.AMIKmsKeyId) > 0 {
 		kmsKeys = append(kmsKeys, c.AMIKmsKeyId)
 	}
 	if len(c.AMIRegionKMSKeyIDs) > 0 {
 		for _, kmsKey := range c.AMIRegionKMSKeyIDs {
-			if len(kmsKey) == 0 {
-				kmsKeys = append(kmsKeys, c.AMIKmsKeyId)
+			if len(kmsKey) > 0 {
+				kmsKeys = append(kmsKeys, kmsKey)
 			}
 		}
+	}
+
+	if len(kmsKeys) > 0 && !c.AMIEncryptBootVolume.True() {
+		errs = append(errs, fmt.Errorf("If you have set either "+
+			"region_kms_key_ids or kms_key_id, encrypt_boot must also be true."))
+
 	}
 	for _, kmsKey := range kmsKeys {
 		if !validateKmsKey(kmsKey) {
@@ -188,8 +194,9 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 	}
 
 	if len(c.SnapshotUsers) > 0 {
-		if len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume.True() {
-			errs = append(errs, fmt.Errorf("Cannot share snapshot encrypted with default KMS key"))
+		if len(c.AMIKmsKeyId) == 0 && len(c.AMIRegionKMSKeyIDs) == 0 && c.AMIEncryptBootVolume.True() {
+			errs = append(errs, fmt.Errorf("Cannot share snapshot encrypted "+
+				"with default KMS key"))
 		}
 		if len(c.AMIRegionKMSKeyIDs) > 0 {
 			for _, kmsKey := range c.AMIRegionKMSKeyIDs {

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -83,9 +83,16 @@ func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) m
 			s.RegionKeyIds = make(map[string]string)
 		}
 
-		// Make sure the kms_key_id for the original region is in the map
-		if _, ok := s.RegionKeyIds[s.OriginalRegion]; !ok {
-			s.RegionKeyIds[s.OriginalRegion] = s.AMIKmsKeyId
+		// Make sure the kms_key_id for the original region is in the map, as
+		// long as the AMIKmsKeyId isn't being defaulted.
+		if s.AMIKmsKeyId != "" {
+			if _, ok := s.RegionKeyIds[s.OriginalRegion]; !ok {
+				s.RegionKeyIds[s.OriginalRegion] = s.AMIKmsKeyId
+			}
+		} else {
+			if regionKey, ok := s.RegionKeyIds[s.OriginalRegion]; ok {
+				s.AMIKmsKeyId = regionKey
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR does a couple of small but related things: 

- Adds new validation to make sure user has explicitly set encrypt_boot when they set up boot keys so we don't get confused by a potential nil state. This makes sure that any checking we do later in the code can assume consistent behavior.

- Fixes a broken piece of validation code that was supposed to be checking whether the provided region kms key ids were of a valid format, but was instead never checking keys that weren't empty strings 😬 

- if `kms_key_id` is _not set_ but a key belonging to the build region is set in `region_kms_key_ids`, then make sure we use that one rather than the default key for the build region. 

Closes #8271
