### PR TITLE
builder/azure/chroot: fix dropped error

### DIFF
--- a/builder/azure/chroot/step_create_new_disk.go
+++ b/builder/azure/chroot/step_create_new_disk.go
@@ -95,6 +95,9 @@ func (s StepCreateNewDisk) Cleanup(state multistep.StateBag) {
 
 		ui.Say(fmt.Sprintf("Waiting for disk %q detach to complete", diskResourceID))
 		err := NewDiskAttacher(azcli).WaitForDetach(context.Background(), diskResourceID)
+		if err != nil {
+			ui.Error(fmt.Sprintf("error detaching disk %q: %s", diskResourceID, err))
+		}
 
 		ui.Say(fmt.Sprintf("Deleting disk %q", diskResourceID))
 


### PR DESCRIPTION
This PR picks up a dropped error in `builder/azure/chroot` and reports it via the UI.