### PR TITLE
add insert_key option for toggling whether to add Vagrant's insecure key

### DIFF
--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -88,9 +88,9 @@ type Config struct {
 	// What box version to use when initializing Vagrant.
 	BoxVersion string `mapstructure:"box_version" required:"false"`
 	// a path to a golang template for a vagrantfile. Our default template can
-	// be found here. So far the only template variables available to you are
-	// {{ .BoxName }} and {{ .SyncedFolder }}, which correspond to the Packer
-	// options box_name and synced_folder.
+	// be found here. The template variables available to you are
+	// {{ .BoxName }}, {{ .SyncedFolder }}, and {{.InsertKey}}, which
+	// correspond to the Packer options box_name, synced_folder, and insert_key.
 	Template string `mapstructure:"template" required:"false"`
 
 	SyncedFolder string `mapstructure:"synced_folder"`

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -67,6 +67,10 @@ type Config struct {
 	// the name to give it. If left blank, will default to "packer_" plus your
 	// buildname.
 	BoxName string `mapstructure:"box_name" required:"false"`
+	// If true, Vagrant will automatically insert a keypair to use for SSH,
+	// replacing Vagrant's default insecure key inside the machine if detected.
+	// By default, Packer sets this to false.
+	InsertKey bool `mapstructure:"insert_key" required:"false"`
 	// The vagrant provider.
 	// This parameter is required when source_path have more than one provider,
 	// or when using vagrant-cloud post-processor. Defaults to unset.
@@ -255,6 +259,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			BoxName:      b.config.BoxName,
 			OutputDir:    b.config.OutputDir,
 			GlobalID:     b.config.GlobalID,
+			InsertKey:    b.config.InsertKey,
 		},
 		&StepAddBox{
 			BoxVersion:   b.config.BoxVersion,

--- a/builder/vagrant/builder.hcl2spec.go
+++ b/builder/vagrant/builder.hcl2spec.go
@@ -79,6 +79,7 @@ type FlatConfig struct {
 	Checksum                  *string           `mapstructure:"checksum" required:"false" cty:"checksum"`
 	ChecksumType              *string           `mapstructure:"checksum_type" required:"false" cty:"checksum_type"`
 	BoxName                   *string           `mapstructure:"box_name" required:"false" cty:"box_name"`
+	InsertKey                 *bool             `mapstructure:"insert_key" required:"false" cty:"insert_key"`
 	Provider                  *string           `mapstructure:"provider" required:"false" cty:"provider"`
 	VagrantfileTpl            *string           `mapstructure:"vagrantfile_template" cty:"vagrantfile_template"`
 	TeardownMethod            *string           `mapstructure:"teardown_method" required:"false" cty:"teardown_method"`
@@ -176,6 +177,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"checksum":                     &hcldec.AttrSpec{Name: "checksum", Type: cty.String, Required: false},
 		"checksum_type":                &hcldec.AttrSpec{Name: "checksum_type", Type: cty.String, Required: false},
 		"box_name":                     &hcldec.AttrSpec{Name: "box_name", Type: cty.String, Required: false},
+		"insert_key":                   &hcldec.AttrSpec{Name: "insert_key", Type: cty.Bool, Required: false},
 		"provider":                     &hcldec.AttrSpec{Name: "provider", Type: cty.String, Required: false},
 		"vagrantfile_template":         &hcldec.AttrSpec{Name: "vagrantfile_template", Type: cty.String, Required: false},
 		"teardown_method":              &hcldec.AttrSpec{Name: "teardown_method", Type: cty.String, Required: false},

--- a/builder/vagrant/step_create_vagrantfile.go
+++ b/builder/vagrant/step_create_vagrantfile.go
@@ -19,15 +19,18 @@ type StepCreateVagrantfile struct {
 	GlobalID     string
 	SourceBox    string
 	BoxName      string
+	InsertKey    bool
 }
 
 var DEFAULT_TEMPLATE = `Vagrant.configure("2") do |config|
   config.vm.define "source", autostart: false do |source|
 	source.vm.box = "{{.SourceBox}}"
+	config.ssh.insert_key = {{.InsertKey}}
   end
   config.vm.define "output" do |output|
 	output.vm.box = "{{.BoxName}}"
 	output.vm.box_url = "file://package.box"
+	config.ssh.insert_key = {{.InsertKey}}
   end
   {{ if ne .SyncedFolder "" -}}
   		config.vm.synced_folder "{{.SyncedFolder}}", "/vagrant"
@@ -40,6 +43,7 @@ type VagrantfileOptions struct {
 	SyncedFolder string
 	SourceBox    string
 	BoxName      string
+	InsertKey    bool
 }
 
 func (s *StepCreateVagrantfile) createVagrantfile() (string, error) {
@@ -66,6 +70,7 @@ func (s *StepCreateVagrantfile) createVagrantfile() (string, error) {
 		SyncedFolder: s.SyncedFolder,
 		BoxName:      s.BoxName,
 		SourceBox:    s.SourceBox,
+		InsertKey:    s.InsertKey,
 	}
 
 	err = tpl.Execute(templateFile, opts)

--- a/builder/vagrant/step_create_vagrantfile_test.go
+++ b/builder/vagrant/step_create_vagrantfile_test.go
@@ -36,10 +36,12 @@ func TestCreateFile(t *testing.T) {
 	expected := `Vagrant.configure("2") do |config|
   config.vm.define "source", autostart: false do |source|
 	source.vm.box = "apples"
+	config.ssh.insert_key = false
   end
   config.vm.define "output" do |output|
 	output.vm.box = "bananas"
 	output.vm.box_url = "file://package.box"
+	config.ssh.insert_key = false
   end
   config.vm.synced_folder ".", "/vagrant", disabled: true
 end`
@@ -66,12 +68,46 @@ func TestCreateFile_customSync(t *testing.T) {
 	expected := `Vagrant.configure("2") do |config|
   config.vm.define "source", autostart: false do |source|
 	source.vm.box = ""
+	config.ssh.insert_key = false
   end
   config.vm.define "output" do |output|
 	output.vm.box = ""
 	output.vm.box_url = "file://package.box"
+	config.ssh.insert_key = false
   end
   config.vm.synced_folder "myfolder/foldertimes", "/vagrant"
+end`
+	if ok := strings.Compare(actual, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, actual)
+	}
+}
+
+func TestCreateFile_InsertKeyTrue(t *testing.T) {
+	testy := StepCreateVagrantfile{
+		OutputDir: "./",
+		InsertKey: true,
+	}
+	templatePath, err := testy.createVagrantfile()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Remove(templatePath)
+	contents, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	actual := string(contents)
+	expected := `Vagrant.configure("2") do |config|
+  config.vm.define "source", autostart: false do |source|
+	source.vm.box = ""
+	config.ssh.insert_key = true
+  end
+  config.vm.define "output" do |output|
+	output.vm.box = ""
+	output.vm.box_url = "file://package.box"
+	config.ssh.insert_key = true
+  end
+  config.vm.synced_folder ".", "/vagrant", disabled: true
 end`
 	if ok := strings.Compare(actual, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, actual)

--- a/website/source/partials/builder/vagrant/_Config-not-required.html.md
+++ b/website/source/partials/builder/vagrant/_Config-not-required.html.md
@@ -16,6 +16,10 @@
     the name to give it. If left blank, will default to "packer_" plus your
     buildname.
     
+-   `insert_key` (bool) - If true, Vagrant will automatically insert a keypair to use for SSH,
+    replacing Vagrant's default insecure key inside the machine if detected.
+    By default, Packer sets this to false.
+    
 -   `provider` (string) - The vagrant provider.
     This parameter is required when source_path have more than one provider,
     or when using vagrant-cloud post-processor. Defaults to unset.

--- a/website/source/partials/builder/vagrant/_Config-not-required.html.md
+++ b/website/source/partials/builder/vagrant/_Config-not-required.html.md
@@ -33,9 +33,9 @@
 -   `box_version` (string) - What box version to use when initializing Vagrant.
     
 -   `template` (string) - a path to a golang template for a vagrantfile. Our default template can
-    be found here. So far the only template variables available to you are
-    {{ .BoxName }} and {{ .SyncedFolder }}, which correspond to the Packer
-    options box_name and synced_folder.
+    be found here. The template variables available to you are
+    {{ .BoxName }}, {{ .SyncedFolder }}, and {{.InsertKey}}, which
+    correspond to the Packer options box_name, synced_folder, and insert_key.
     
 -   `synced_folder` (string) - Synced Folder
 -   `skip_add` (bool) - Don't call "vagrant add" to add the box to your local environment; this


### PR DESCRIPTION
This option is a simple passthrough that adjusts the same-named vagrantfile option in the default vagrantfile template. 

Closes #7974
