### PR TITLE
builder/openstack: remove dead testConfig() function

### DIFF
--- a/builder/openstack/builder_test.go
+++ b/builder/openstack/builder_test.go
@@ -6,18 +6,6 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
-func testConfig() map[string]interface{} {
-	return map[string]interface{}{
-		"username":     "foo",
-		"password":     "bar",
-		"region":       "DFW",
-		"image_name":   "foo",
-		"source_image": "foo",
-		"flavor":       "foo",
-		"ssh_username": "root",
-	}
-}
-
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}


### PR DESCRIPTION
This PR removes the unused `testConfig()` function from `builder/openstack`.