### PR TITLE
delete amazon import post-processor intermediary snapshots

### DIFF
--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -85,15 +85,10 @@ func (a *Artifact) Destroy() error {
 			errors = append(errors, err)
 		}
 
-		// Deregister ami
-		input := &ec2.DeregisterImageInput{
-			ImageId: &imageId,
-		}
-		if _, err := regionConn.DeregisterImage(input); err != nil {
+		err = DestroyAMIs([]*string{&imageId}, regionConn)
+		if err != nil {
 			errors = append(errors, err)
 		}
-
-		// TODO(mitchellh): Delete the snapshots associated with an AMI too
 	}
 
 	if len(errors) > 0 {

--- a/builder/amazon/common/helper_funcs.go
+++ b/builder/amazon/common/helper_funcs.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func DestroyAMIs(imageids []*string, ec2conn *ec2.EC2) error {
+	resp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: imageids,
+	})
+
+	if err != nil {
+		err := fmt.Errorf("Error describing AMI: %s", err)
+		return err
+	}
+
+	// Deregister image by name.
+	for _, i := range resp.Images {
+		_, err := ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
+			ImageId: i.ImageId,
+		})
+
+		if err != nil {
+			err := fmt.Errorf("Error deregistering existing AMI: %s", err)
+			return err
+		}
+		log.Printf("Deregistered AMI id: %s", *i.ImageId)
+
+		// Delete snapshot(s) by image
+		for _, b := range i.BlockDeviceMappings {
+			if b.Ebs != nil && aws.StringValue(b.Ebs.SnapshotId) != "" {
+				_, err := ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+					SnapshotId: b.Ebs.SnapshotId,
+				})
+
+				if err != nil {
+					err := fmt.Errorf("Error deleting existing snapshot: %s", err)
+					return err
+				}
+				log.Printf("Deleted snapshot: %s", *b.Ebs.SnapshotId)
+			}
+		}
+	}
+	return nil
+}

--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -159,48 +159,11 @@ func (s *StepAMIRegionCopy) Cleanup(state multistep.StateBag) {
 	// Delete the unencrypted amis and snapshots
 	ui.Say("Deregistering the AMI and deleting unencrypted temporary " +
 		"AMIs and snapshots")
-
-	resp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
-		ImageIds: []*string{&s.toDelete},
-	})
-
+	err := DestroyAMIs([]*string{&s.toDelete}, ec2conn)
 	if err != nil {
-		err := fmt.Errorf("Error describing AMI: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return
-	}
-
-	// Deregister image by name.
-	for _, i := range resp.Images {
-		_, err := ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
-			ImageId: i.ImageId,
-		})
-
-		if err != nil {
-			err := fmt.Errorf("Error deregistering existing AMI: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return
-		}
-		ui.Say(fmt.Sprintf("Deregistered AMI id: %s", *i.ImageId))
-
-		// Delete snapshot(s) by image
-		for _, b := range i.BlockDeviceMappings {
-			if b.Ebs != nil && aws.StringValue(b.Ebs.SnapshotId) != "" {
-				_, err := ec2conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
-					SnapshotId: b.Ebs.SnapshotId,
-				})
-
-				if err != nil {
-					err := fmt.Errorf("Error deleting existing snapshot: %s", err)
-					state.Put("error", err)
-					ui.Error(err.Error())
-					return
-				}
-				ui.Say(fmt.Sprintf("Deleted snapshot: %s", *b.Ebs.SnapshotId))
-			}
-		}
 	}
 }
 

--- a/post-processor/amazon-import/post-processor.go
+++ b/post-processor/amazon-import/post-processor.go
@@ -299,10 +299,9 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 			return nil, false, false, fmt.Errorf("Error waiting for AMI (%s): %s", *resp.ImageId, err)
 		}
 
-		_, err = ec2conn.DeregisterImage(&ec2.DeregisterImageInput{
-			ImageId: &createdami,
-		})
-
+		// Clean up intermediary image now that it has successfully been renamed.
+		ui.Message("Destroying intermediary AMI...")
+		err = awscommon.DestroyAMIs([]*string{&createdami}, ec2conn)
 		if err != nil {
 			return nil, false, false, fmt.Errorf("Error deregistering existing AMI: %s", err)
 		}


### PR DESCRIPTION
Delete intermediary snapshots in post-processer same as we do for the ami-region-copy.  Instead of copy/pasting, create helper function that works in both situations. 

bonus: use new helper function to complete TODO written in 2013 😆 

Closes #8116 
