### PR TITLE
common: Resuscitate Floppy Tests

### DIFF
--- a/common/step_create_floppy_test.go
+++ b/common/step_create_floppy_test.go
@@ -116,7 +116,7 @@ func TestStepCreateFloppy(t *testing.T) {
 	}
 }
 
-func xxxTestStepCreateFloppy_missing(t *testing.T) {
+func TestStepCreateFloppy_missing(t *testing.T) {
 	state := testStepCreateFloppyState(t)
 	step := new(StepCreateFloppy)
 

--- a/common/step_create_floppy_test.go
+++ b/common/step_create_floppy_test.go
@@ -161,7 +161,7 @@ func xxxTestStepCreateFloppy_missing(t *testing.T) {
 	}
 }
 
-func xxxTestStepCreateFloppy_notfound(t *testing.T) {
+func TestStepCreateFloppy_notfound(t *testing.T) {
 	state := testStepCreateFloppyState(t)
 	step := new(StepCreateFloppy)
 


### PR DESCRIPTION
This PR turns on two tests that have been disabled since they were written in 2014.

`TestStepCreateFloppy_missing()` had an `xxx` prefix from its creation on 2014-04-29, so it looks to have never been active.

`TestStepCreateFloppy_notfound()` also had an `xxx` prefix, so it appears to have been just as dormant, though oddly some changes were made to it in 2016 and again in 2018.

I'm curious to run this through CI, maybe this was a roundabout way of achieving `t.Skip()` for certain architectures?
