### PR TITLE
packer: Prune Dead Code, Pick Up Dropped Err

### DIFF
--- a/packer/config_file_test.go
+++ b/packer/config_file_test.go
@@ -42,7 +42,7 @@ func TestExpandUser_Empty(t *testing.T) {
 	var path, expected string
 
 	// Try an invalid user
-	path, err := ExpandUser("~invalid-user-that-should-not-exist")
+	_, err := ExpandUser("~invalid-user-that-should-not-exist")
 	if err == nil {
 		t.Fatalf("expected failure")
 	}

--- a/packer/core.go
+++ b/packer/core.go
@@ -407,7 +407,7 @@ func (c *Core) init() error {
 		}
 	}
 
-	if (changed == false) && (shouldRetry == true) {
+	if !changed && shouldRetry {
 		return fmt.Errorf("Failed to interpolate %s: Please make sure that "+
 			"the variable you're referencing has been defined; Packer treats "+
 			"all variables used to interpolate other user varaibles as "+

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -670,17 +670,6 @@ func TestSensitiveVars(t *testing.T) {
 	}
 }
 
-func testComponentFinder() *ComponentFinder {
-	builderFactory := func(n string) (Builder, error) { return new(MockBuilder), nil }
-	ppFactory := func(n string) (PostProcessor, error) { return new(MockPostProcessor), nil }
-	provFactory := func(n string) (Provisioner, error) { return new(MockProvisioner), nil }
-	return &ComponentFinder{
-		Builder:       builderFactory,
-		PostProcessor: ppFactory,
-		Provisioner:   provFactory,
-	}
-}
-
 func testCoreTemplate(t *testing.T, c *CoreConfig, p string) {
 	tpl, err := template.ParseFile(p)
 	if err != nil {

--- a/packer/rpc/build_test.go
+++ b/packer/rpc/build_test.go
@@ -21,7 +21,6 @@ type testBuild struct {
 	setDebugCalled   bool
 	setForceCalled   bool
 	setOnErrorCalled bool
-	cancelCalled     bool
 
 	errRunResult bool
 }

--- a/packer/rpc/post_processor_test.go
+++ b/packer/rpc/post_processor_test.go
@@ -112,6 +112,9 @@ func TestPostProcessorRPC_cancel(t *testing.T) {
 	// Test Configure
 	config := 42
 	err := ppClient.Configure(config)
+	if err != nil {
+		t.Fatalf("error configuring post-processor client: %s", err)
+	}
 
 	// Test PostProcess
 	a := &packer.MockArtifact{


### PR DESCRIPTION
This PR removes some dead code from `packer`, and also visits `packer/rpc` to pick up a dropped test error and remove an unused struct field.