### PR TITLE
provisioners/shell: Add support for the `env_var_format` parameter

### DIFF
--- a/common/shell/shell.go
+++ b/common/shell/shell.go
@@ -39,4 +39,8 @@ type Provisioner struct {
 	// An array of environment variables that will be injected before
 	// your command(s) are executed.
 	Vars []string `mapstructure:"environment_vars"`
+
+	// This is used in the template generation to format environment variables
+	// inside the `ExecuteCommand` template.
+	EnvVarFormat string `mapstructure:"env_var_format"`
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -56,10 +56,6 @@ type Config struct {
 	StartRetryTimeout time.Duration `mapstructure:"start_retry_timeout"`
 
 	// This is used in the template generation to format environment variables
-	// inside the `ExecuteCommand` template.
-	EnvVarFormat string
-
-	// This is used in the template generation to format environment variables
 	// inside the `ElevatedExecuteCommand` template.
 	ElevatedEnvVarFormat string `mapstructure:"elevated_env_var_format"`
 

--- a/provisioner/powershell/provisioner.hcl2spec.go
+++ b/provisioner/powershell/provisioner.hcl2spec.go
@@ -24,10 +24,10 @@ type FlatConfig struct {
 	Scripts                []string          `cty:"scripts"`
 	ValidExitCodes         []int             `mapstructure:"valid_exit_codes" cty:"valid_exit_codes"`
 	Vars                   []string          `mapstructure:"environment_vars" cty:"environment_vars"`
+	EnvVarFormat           *string           `mapstructure:"env_var_format" cty:"env_var_format"`
 	RemoteEnvVarPath       *string           `mapstructure:"remote_env_var_path" cty:"remote_env_var_path"`
 	ElevatedExecuteCommand *string           `mapstructure:"elevated_execute_command" cty:"elevated_execute_command"`
 	StartRetryTimeout      *string           `mapstructure:"start_retry_timeout" cty:"start_retry_timeout"`
-	EnvVarFormat           *string           `cty:"env_var_format"`
 	ElevatedEnvVarFormat   *string           `mapstructure:"elevated_env_var_format" cty:"elevated_env_var_format"`
 	ElevatedUser           *string           `mapstructure:"elevated_user" cty:"elevated_user"`
 	ElevatedPassword       *string           `mapstructure:"elevated_password" cty:"elevated_password"`
@@ -58,10 +58,10 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"scripts":                    &hcldec.AttrSpec{Name: "scripts", Type: cty.List(cty.String), Required: false},
 		"valid_exit_codes":           &hcldec.AttrSpec{Name: "valid_exit_codes", Type: cty.List(cty.Number), Required: false},
 		"environment_vars":           &hcldec.AttrSpec{Name: "environment_vars", Type: cty.List(cty.String), Required: false},
+		"env_var_format":             &hcldec.AttrSpec{Name: "env_var_format", Type: cty.String, Required: false},
 		"remote_env_var_path":        &hcldec.AttrSpec{Name: "remote_env_var_path", Type: cty.String, Required: false},
 		"elevated_execute_command":   &hcldec.AttrSpec{Name: "elevated_execute_command", Type: cty.String, Required: false},
 		"start_retry_timeout":        &hcldec.AttrSpec{Name: "start_retry_timeout", Type: cty.String, Required: false},
-		"env_var_format":             &hcldec.AttrSpec{Name: "env_var_format", Type: cty.String, Required: false},
 		"elevated_env_var_format":    &hcldec.AttrSpec{Name: "elevated_env_var_format", Type: cty.String, Required: false},
 		"elevated_user":              &hcldec.AttrSpec{Name: "elevated_user", Type: cty.String, Required: false},
 		"elevated_password":          &hcldec.AttrSpec{Name: "elevated_password", Type: cty.String, Required: false},

--- a/provisioner/shell/provisioner.hcl2spec.go
+++ b/provisioner/shell/provisioner.hcl2spec.go
@@ -24,6 +24,7 @@ type FlatConfig struct {
 	Scripts             []string          `cty:"scripts"`
 	ValidExitCodes      []int             `mapstructure:"valid_exit_codes" cty:"valid_exit_codes"`
 	Vars                []string          `mapstructure:"environment_vars" cty:"environment_vars"`
+	EnvVarFormat        *string           `mapstructure:"env_var_format" cty:"env_var_format"`
 	InlineShebang       *string           `mapstructure:"inline_shebang" cty:"inline_shebang"`
 	PauseAfter          *string           `mapstructure:"pause_after" cty:"pause_after"`
 	UseEnvVarFile       *bool             `mapstructure:"use_env_var_file" cty:"use_env_var_file"`
@@ -58,6 +59,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"scripts":                    &hcldec.AttrSpec{Name: "scripts", Type: cty.List(cty.String), Required: false},
 		"valid_exit_codes":           &hcldec.AttrSpec{Name: "valid_exit_codes", Type: cty.List(cty.Number), Required: false},
 		"environment_vars":           &hcldec.AttrSpec{Name: "environment_vars", Type: cty.List(cty.String), Required: false},
+		"env_var_format":             &hcldec.AttrSpec{Name: "env_var_format", Type: cty.String, Required: false},
 		"inline_shebang":             &hcldec.AttrSpec{Name: "inline_shebang", Type: cty.String, Required: false},
 		"pause_after":                &hcldec.AttrSpec{Name: "pause_after", Type: cty.String, Required: false},
 		"use_env_var_file":           &hcldec.AttrSpec{Name: "use_env_var_file", Type: cty.Bool, Required: false},

--- a/provisioner/windows-shell/provisioner.go
+++ b/provisioner/windows-shell/provisioner.go
@@ -37,10 +37,6 @@ type Config struct {
 	// This can be set high to allow for reboots.
 	StartRetryTimeout time.Duration `mapstructure:"start_retry_timeout"`
 
-	// This is used in the template generation to format environment variables
-	// inside the `ExecuteCommand` template.
-	EnvVarFormat string `mapstructure:"env_var_format"`
-
 	ctx interpolate.Context
 }
 

--- a/provisioner/windows-shell/provisioner.hcl2spec.go
+++ b/provisioner/windows-shell/provisioner.hcl2spec.go
@@ -24,8 +24,8 @@ type FlatConfig struct {
 	Scripts             []string          `cty:"scripts"`
 	ValidExitCodes      []int             `mapstructure:"valid_exit_codes" cty:"valid_exit_codes"`
 	Vars                []string          `mapstructure:"environment_vars" cty:"environment_vars"`
-	StartRetryTimeout   *string           `mapstructure:"start_retry_timeout" cty:"start_retry_timeout"`
 	EnvVarFormat        *string           `mapstructure:"env_var_format" cty:"env_var_format"`
+	StartRetryTimeout   *string           `mapstructure:"start_retry_timeout" cty:"start_retry_timeout"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -52,8 +52,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"scripts":                    &hcldec.AttrSpec{Name: "scripts", Type: cty.List(cty.String), Required: false},
 		"valid_exit_codes":           &hcldec.AttrSpec{Name: "valid_exit_codes", Type: cty.List(cty.Number), Required: false},
 		"environment_vars":           &hcldec.AttrSpec{Name: "environment_vars", Type: cty.List(cty.String), Required: false},
-		"start_retry_timeout":        &hcldec.AttrSpec{Name: "start_retry_timeout", Type: cty.String, Required: false},
 		"env_var_format":             &hcldec.AttrSpec{Name: "env_var_format", Type: cty.String, Required: false},
+		"start_retry_timeout":        &hcldec.AttrSpec{Name: "start_retry_timeout", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/website/source/docs/provisioners/shell.html.md.erb
+++ b/website/source/docs/provisioners/shell.html.md.erb
@@ -40,6 +40,11 @@ The example below is fully functional.
     Packer injects some environmental variables by default into the
     environment, as well, which are covered in the section below.
 
+-   `env_var_format` (string) - When we parse the environment\_vars that you
+    provide, this gives us a string template to use in order to make sure that
+    we are setting the environment vars correctly. By default it is `"%s='%s' "`.
+    When used in conjunction with `use_env_var_file` the default is `"export %s='%s'\n"`
+
 -   `use_env_var_file` (boolean) - If true, Packer will write your environment
     variables to a tempfile and source them from that file, rather than
     declaring them inline in our execute\_command. The default


### PR DESCRIPTION
This change adds a new parameter `env_var_format` to the shell provisioner. The parameter works similar to that of the shell-local provisioner where users can change the default string template used for rendering environment variables. This change affects the output of `environment_vars` and of the contents of the generated file when `use_env_var_file=true`.

Tests after change
```
> make test TEST="./provisioner/shell/..." TESTARGS="-v -run=TestProvisioner_create"
==> Checking that only certain files are executable...
Check passed.
--- PASS: TestProvisioner_createFlattenedEnvVars (0.00s)
--- PASS: TestProvisioner_createFlattenedEnvVars_withEnvVarFormat (0.00s)
--- PASS: TestProvisioner_createEnvVarFileContent (0.00s)
--- PASS: TestProvisioner_createEnvVarFileContent_withEnvVarFormat (0.00s)
```

Closes #8283