### PR TITLE
re-add backwards incompatible changes to 1.5.0

### DIFF
--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -39,5 +39,4 @@ func templateCleanAMIName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanAMIName,
-	"clean_ami_name":      packertpl.DeprecatedTemplateFunc("clean_ami_name", "clean_resource_name", templateCleanAMIName),
 }

--- a/builder/amazon/common/template_funcs.go
+++ b/builder/amazon/common/template_funcs.go
@@ -3,8 +3,6 @@ package common
 import (
 	"bytes"
 	"text/template"
-
-	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isalphanumeric(b byte) bool {

--- a/builder/azure/common/template_funcs.go
+++ b/builder/azure/common/template_funcs.go
@@ -3,8 +3,6 @@ package common
 import (
 	"bytes"
 	"text/template"
-
-	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isValidByteValue(b byte) bool {

--- a/builder/azure/common/template_funcs.go
+++ b/builder/azure/common/template_funcs.go
@@ -39,5 +39,4 @@ func templateCleanImageName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanImageName,
-	"clean_image_name":    packertpl.DeprecatedTemplateFunc("clean_image_name", "clean_resource_name", templateCleanImageName),
 }

--- a/builder/googlecompute/template_funcs.go
+++ b/builder/googlecompute/template_funcs.go
@@ -3,8 +3,6 @@ package googlecompute
 import (
 	"strings"
 	"text/template"
-
-	packertpl "github.com/hashicorp/packer/common/template"
 )
 
 func isalphanumeric(b byte) bool {

--- a/builder/googlecompute/template_funcs.go
+++ b/builder/googlecompute/template_funcs.go
@@ -37,5 +37,4 @@ func templateCleanImageName(s string) string {
 
 var TemplateFuncs = template.FuncMap{
 	"clean_resource_name": templateCleanImageName,
-	"clean_image_name":    packertpl.DeprecatedTemplateFunc("clean_image_name", "clean_resource_name", templateCleanImageName),
 }

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -147,9 +147,11 @@ type Config struct {
 	// one of the other listed interfaces. Using the `scsi` interface under
 	// these circumstances will cause the build to fail.
 	DiskInterface string `mapstructure:"disk_interface" required:"false"`
-	// The size, in megabytes, of the hard disk to create
-	// for the VM. By default, this is 40960 (40 GB).
-	DiskSize uint `mapstructure:"disk_size" required:"false"`
+	// The size in bytes, suffixes of the first letter of common byte types
+	// like "k" or "K", "M" for megabytes, G for gigabytes, T for terabytes.
+	// Will create the of the hard disk of the VM. By default, this is
+	// `40960M` (40 GB).
+	DiskSize string `mapstructure:"disk_size" required:"false"`
 	// The cache mode to use for disk. Allowed values include any of
 	// `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By
 	// default, this is set to `writeback`.
@@ -317,7 +319,6 @@ type Config struct {
 	// "BUILDNAME" is the name of the build. Currently, no file extension will be
 	// used unless it is specified in this option.
 	VMName string `mapstructure:"vm_name" required:"false"`
-
 	// These are deprecated, but we keep them around for BC
 	// TODO(@mitchellh): remove
 	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout" required:"false"`
@@ -345,11 +346,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 
 	var errs *packer.MultiError
 	warnings := make([]string, 0)
-
 	errs = packer.MultiErrorAppend(errs, b.config.ShutdownConfig.Prepare(&b.config.ctx)...)
 
-	if b.config.DiskSize == 0 {
-		b.config.DiskSize = 40960
+	if b.config.DiskSize == "" || b.config.DiskSize == "0" {
+		b.config.DiskSize = "40960M"
 	}
 
 	if b.config.DiskCache == "" {
@@ -701,7 +701,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		artifact.state["diskPaths"] = diskpaths
 	}
 	artifact.state["diskType"] = b.config.Format
-	artifact.state["diskSize"] = uint64(b.config.DiskSize)
+	artifact.state["diskSize"] = b.config.DiskSize
 	artifact.state["domainType"] = b.config.Accelerator
 
 	return artifact, nil

--- a/builder/qemu/builder.hcl2spec.go
+++ b/builder/qemu/builder.hcl2spec.go
@@ -81,7 +81,7 @@ type FlatConfig struct {
 	AdditionalDiskSize        []string          `mapstructure:"disk_additional_size" required:"false" cty:"disk_additional_size"`
 	CpuCount                  *int              `mapstructure:"cpus" required:"false" cty:"cpus"`
 	DiskInterface             *string           `mapstructure:"disk_interface" required:"false" cty:"disk_interface"`
-	DiskSize                  *uint             `mapstructure:"disk_size" required:"false" cty:"disk_size"`
+	DiskSize                  *string           `mapstructure:"disk_size" required:"false" cty:"disk_size"`
 	DiskCache                 *string           `mapstructure:"disk_cache" required:"false" cty:"disk_cache"`
 	DiskDiscard               *string           `mapstructure:"disk_discard" required:"false" cty:"disk_discard"`
 	DetectZeroes              *string           `mapstructure:"disk_detect_zeroes" required:"false" cty:"disk_detect_zeroes"`
@@ -192,7 +192,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_additional_size":         &hcldec.AttrSpec{Name: "disk_additional_size", Type: cty.List(cty.String), Required: false},
 		"cpus":                         &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
 		"disk_interface":               &hcldec.AttrSpec{Name: "disk_interface", Type: cty.String, Required: false},
-		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
+		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.String, Required: false},
 		"disk_cache":                   &hcldec.AttrSpec{Name: "disk_cache", Type: cty.String, Required: false},
 		"disk_discard":                 &hcldec.AttrSpec{Name: "disk_discard", Type: cty.String, Required: false},
 		"disk_detect_zeroes":           &hcldec.AttrSpec{Name: "disk_detect_zeroes", Type: cty.String, Required: false},

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -169,11 +169,11 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 		t.Fatalf("bad err: %s", err)
 	}
 
-	if b.config.DiskSize != 40960 {
-		t.Fatalf("bad size: %d", b.config.DiskSize)
+	if b.config.DiskSize != "40960M" {
+		t.Fatalf("bad size: %s", b.config.DiskSize)
 	}
 
-	config["disk_size"] = 60000
+	config["disk_size"] = "60000M"
 	b = Builder{}
 	warns, err = b.Prepare(config)
 	if len(warns) > 0 {
@@ -183,8 +183,8 @@ func TestBuilderPrepare_DiskSize(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 
-	if b.config.DiskSize != 60000 {
-		t.Fatalf("bad size: %d", b.config.DiskSize)
+	if b.config.DiskSize != "60000M" {
+		t.Fatalf("bad size: %s", b.config.DiskSize)
 	}
 }
 

--- a/builder/qemu/step_create_disk.go
+++ b/builder/qemu/step_create_disk.go
@@ -29,7 +29,7 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	ui.Say("Creating required virtual machine disks")
 	// The 'main' or 'default' disk
 	diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, name))
-	diskSizes = append(diskSizes, fmt.Sprintf("%dM", uint64(config.DiskSize)))
+	diskSizes = append(diskSizes, fmt.Sprintf("%s", config.DiskSize))
 	// Additional disks
 	if len(config.AdditionalDiskSize) > 0 {
 		for i, diskSize := range config.AdditionalDiskSize {

--- a/builder/qemu/step_resize_disk.go
+++ b/builder/qemu/step_resize_disk.go
@@ -23,9 +23,8 @@ func (s *stepResizeDisk) Run(ctx context.Context, state multistep.StateBag) mult
 		"resize",
 		"-f", config.Format,
 		path,
-		fmt.Sprintf("%vM", config.DiskSize),
+		fmt.Sprintf("%s", config.DiskSize),
 	}
-
 	if config.DiskImage == false {
 		return multistep.ActionContinue
 	}

--- a/builder/yandex/template_func.go
+++ b/builder/yandex/template_func.go
@@ -1,7 +1,9 @@
 package yandex
 
-import "strings"
-import "text/template"
+import (
+	"strings"
+	"text/template"
+)
 
 func isalphanumeric(b byte) bool {
 	if '0' <= b && b <= '9' {
@@ -13,9 +15,9 @@ func isalphanumeric(b byte) bool {
 	return false
 }
 
-// Clean up image name by replacing invalid characters with "-"
+// Clean up resource name by replacing invalid characters with "-"
 // and converting upper cases to lower cases
-func templateCleanImageName(s string) string {
+func templateCleanResourceName(s string) string {
 	if reImageFamily.MatchString(s) {
 		return s
 	}
@@ -32,5 +34,5 @@ func templateCleanImageName(s string) string {
 }
 
 var TemplateFuncs = template.FuncMap{
-	"clean_image_name": templateCleanImageName,
+	"clean_resource_name": templateCleanResourceName,
 }

--- a/website/source/docs/builders/qemu.html.md.erb
+++ b/website/source/docs/builders/qemu.html.md.erb
@@ -37,7 +37,7 @@ to files, URLS for ISOs and checksums.
       "iso_checksum_type": "md5",
       "output_directory": "output_centos_tdhtest",
       "shutdown_command": "echo 'packer' | sudo -S shutdown -P now",
-      "disk_size": 5000,
+      "disk_size": "5000M",
       "format": "qcow2",
       "accelerator": "kvm",
       "http_directory": "path/to/httpdir",

--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -41,7 +41,7 @@ Here is a full list of the available functions for reference.
     will convert upper cases to lower cases and replace illegal characters with
     a "-" character.  Example:
 
-   `"mybuild-{{isotime | clean_image_name}}"` will become
+   `"mybuild-{{isotime | clean_resource_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid Azure image names must match the regex
@@ -57,6 +57,9 @@ Here is a full list of the available functions for reference.
     clean_resource_name}}"` will cause your build to fail because the image
     name will start with a number, which is why in the above example we prepend
     the isotime with "mybuild".
+    Exact behavior of `clean_resource_name` will depend on which builder it is
+    being applied to; refer to build-specific docs below for more detail on how
+    each function will behave.
 -   `env` - Returns environment variables. See example in [using home
     variable](/docs/templates/user-variables.html#using-home-variable)
 -   `isotime [FORMAT]` - UTC time, which can be
@@ -84,19 +87,19 @@ Here is a full list of the available functions for reference.
 
 #### Specific to Amazon builders:
 
--   `clean_ami_name` - DEPRECATED use `clean_resource_name` instead - AMI names
+-   `clean_resource_name` - AMI names
     can only contain certain characters. This function will replace illegal
     characters with a '-" character. Example usage since ":" is not a legal AMI
-    name is: `{{isotime | clean_ami_name}}`.
+    name is: `{{isotime | clean_resource_name}}`.
 
 #### Specific to Google Compute builders:
 
--   `clean_image_name` - DEPRECATED use `clean_resource_name` instead - GCE
+-   `clean_resource_name` - GCE
     image names can only contain certain characters and the maximum length is
     63. This function will convert upper cases to lower cases and replace
         illegal characters with a "-" character. Example:
 
-    `"mybuild-{{isotime | clean_image_name}}"` will become
+    `"mybuild-{{isotime | clean_resource_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid GCE image names must match the regex
@@ -111,12 +114,12 @@ Here is a full list of the available functions for reference.
 
 #### Specific to Azure builders:
 
--   `clean_image_name` - DEPRECATED use `clean_resource_name` instead - Azure
+-   `clean_resource_name` - Azure
     managed image names can only contain certain characters and the maximum
     length is 80. This function will replace illegal characters with a "-"
     character. Example:
 
-    `"mybuild-{{isotime | clean_image_name}}"` will become
+    `"mybuild-{{isotime | clean_resource_name}}"` will become
     `mybuild-2017-10-18t02-06-30z`.
 
     Note: Valid Azure image names must match the regex

--- a/website/source/partials/builder/qemu/_Config-not-required.html.md
+++ b/website/source/partials/builder/qemu/_Config-not-required.html.md
@@ -47,8 +47,10 @@
     one of the other listed interfaces. Using the `scsi` interface under
     these circumstances will cause the build to fail.
     
--   `disk_size` (uint) - The size, in megabytes, of the hard disk to create
-    for the VM. By default, this is 40960 (40 GB).
+-   `disk_size` (string) - The size in bytes, suffixes of the first letter of common byte types
+    like "k" or "K", "M" for megabytes, G for gigabytes, T for terabytes.
+    Will create the of the hard disk of the VM. By default, this is
+    `40960M` (40 GB).
     
 -   `disk_cache` (string) - The cache mode to use for disk. Allowed values include any of
     `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By


### PR DESCRIPTION
Re-implement qemu disk size as string, etc, in prep for 1.5.0 release