### PR TITLE
builder/virtualbox/common/snapshot.go: avoid a panic on a too short slice.

### DIFF
--- a/builder/virtualbox/common/snapshot.go
+++ b/builder/virtualbox/common/snapshot.go
@@ -35,7 +35,7 @@ func ParseSnapshotData(snapshotData string) (*VBoxSnapshot, error) {
 				node.IsCurrent = true
 			} else {
 				matches := SnapshotNamePartsRe.FindStringSubmatch(txt)
-				if matches[1] == "Name" {
+				if len(matches) >= 2 && matches[1] == "Name" {
 					if nil == rootNode {
 						node = new(VBoxSnapshot)
 						rootNode = node


### PR DESCRIPTION
avoid a panic on a too short slice.
close #8325 