### PR TITLE
website - add -moz-osx-font-smoothing for smooth firefox osx fonts

### DIFF
--- a/website/source/assets/stylesheets/_global.scss
+++ b/website/source/assets/stylesheets/_global.scss
@@ -7,6 +7,7 @@ html {
 }
 
 body {
+  -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   color: $body-font-color;
   background-color: $white;


### PR DESCRIPTION
Adding `-moz-osx-font-smoothing: grayscale;` to `<body>`  in `global-styles` to smooth out fonts in Firefox on OSX.

Note that we are already using `-webkit-font-smoothing: antialiased;`.

#### Before
![Screen Shot 2019-11-07 at 12 58 05 PM](https://user-images.githubusercontent.com/5368111/68423247-f3611180-015e-11ea-8c77-deadfab8f131.png)


---

### After
![Screen Shot 2019-11-07 at 12 58 11 PM](https://user-images.githubusercontent.com/5368111/68423248-f3f9a800-015e-11ea-986b-01ddc9c6276f.png)


