### PR TITLE
if someone logs a line longer than 64*1024 bytes before it contains a…

### DIFF
--- a/log.go
+++ b/log.go
@@ -43,6 +43,10 @@ func logOutput() (logOutput io.Writer, err error) {
 					}
 					os.Stderr.WriteString(fmt.Sprint(scanner.Text() + "\n"))
 				}
+				if err := scanner.Err(); err != nil {
+					os.Stderr.WriteString(err.Error())
+					w.Close()
+				}
 			}(scanner)
 			logOutput = w
 		}

--- a/log.go
+++ b/log.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -30,6 +31,8 @@ func logOutput() (logOutput io.Writer, err error) {
 			// calls.
 			r, w := io.Pipe()
 			scanner := bufio.NewScanner(r)
+			scanner.Split(ScanLinesSmallerThanBuffer)
+
 			go func(scanner *bufio.Scanner) {
 				for scanner.Scan() {
 					if strings.Contains(scanner.Text(), "ui:") {
@@ -46,4 +49,40 @@ func logOutput() (logOutput io.Writer, err error) {
 	}
 
 	return
+}
+
+// The below functions come from bufio.Scanner with a small tweak, to fix an
+// edgecase where the default ScanFunc fails: sometimes, if someone tries to
+// log a line that is longer than 64*1024 bytes long before it contains a
+// newline, the ScanLine will continue to return, requesting more data from the
+// buffer, which can't increase in size anymore, causing a hang.
+func dropCR(data []byte) []byte {
+	if len(data) > 0 && data[len(data)-1] == '\r' {
+		return data[0 : len(data)-1]
+	}
+	return data
+}
+
+func ScanLinesSmallerThanBuffer(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, dropCR(data[0:i]), nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), dropCR(data), nil
+	}
+
+	// Our tweak:
+	// Buffer is full, so we can't get more data. Just return what we have as
+	// its own token so we can keep going, even though there's no newline.
+	if len(data)+1 >= bufio.MaxScanTokenSize {
+		return len(data), data[0 : len(data)-1], nil
+	}
+
+	// Request more data.
+	return 0, nil, nil
 }


### PR DESCRIPTION
We have some logic in the log.go file that does a very basic deduplication of loglines to prevent annoying noise for people who run packer with PACKER_LOG=1 but not PACKER_LOG_PATH.

It turns out that if a logline exceeds 64*1024 bytes, the scanner that we used would hang. This PR implements a new scanner function that'll un-stick the log line scanning to keep Packer from hanging forever.

Closes #7879
