### PR TITLE
builder/amazon: Add validation for `subnet_id` when specifying `vpc_id`

### DIFF
--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer/common/retry"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -20,6 +21,8 @@ type StepPreValidate struct {
 	DestAmiName        string
 	ForceDeregister    bool
 	AMISkipBuildRegion bool
+	VpcId              string
+	SubnetId           string
 }
 
 func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -76,12 +79,21 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 		ui.Say("Force Deregister flag found, skipping prevalidating AMI Name")
 		return multistep.ActionContinue
 	}
+
 	if s.AMISkipBuildRegion {
 		ui.Say("skip_build_region was set; not prevalidating AMI name")
 		return multistep.ActionContinue
 	}
 
 	ec2conn := state.Get("ec2").(*ec2.EC2)
+
+	// Validate VPC settings for non-default VPCs
+	ui.Say("Prevalidating any provided VPC information")
+	if err := s.checkVpc(ec2conn); err != nil {
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
 
 	ui.Say(fmt.Sprintf("Prevalidating AMI Name: %s", s.DestAmiName))
 	req, resp := ec2conn.DescribeImagesRequest(&ec2.DescribeImagesInput{
@@ -91,13 +103,13 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 		}}})
 	req.RetryCount = 11
 
-	err := req.Send()
-	if err != nil {
-		err := fmt.Errorf("Error querying AMI: %s", err)
+	if err := req.Send(); err != nil {
+		err = fmt.Errorf("Error querying AMI: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
+
 	if len(resp.Images) > 0 {
 		err := fmt.Errorf("Error: AMI Name: '%s' is used by an existing AMI: %s", *resp.Images[0].Name, *resp.Images[0].ImageId)
 		state.Put("error", err)
@@ -108,4 +120,24 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 	return multistep.ActionContinue
 }
 
+func (s *StepPreValidate) checkVpc(conn ec2iface.EC2API) error {
+	if s.VpcId != "" && s.SubnetId != "" {
+		// skip validation if both VpcId and SubnetId are provided; AWS API will error if something is wrong.
+		return nil
+	}
+
+	res, err := conn.DescribeVpcs(&ec2.DescribeVpcsInput{VpcIds: []*string{aws.String(s.VpcId)}})
+	if isAWSErr(err, "InvalidVpcID.NotFound", "") || err != nil {
+		return fmt.Errorf("Error retrieving VPC information for vpc_id %q", s.VpcId)
+	}
+
+	if res != nil && len(res.Vpcs) == 1 && res.Vpcs[0] != nil {
+		if isDefault := aws.BoolValue(res.Vpcs[0].IsDefault); !isDefault {
+			return fmt.Errorf("Error: subnet_id must be provided for non-default VPCs (%s)", s.VpcId)
+		}
+	}
+	return nil
+}
+
+// Cleanup ...
 func (s *StepPreValidate) Cleanup(multistep.StateBag) {}

--- a/builder/amazon/common/step_pre_validate_test.go
+++ b/builder/amazon/common/step_pre_validate_test.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+//DescribeVpcs mocks an ec2.DescribeVpcsOutput for a given input
+func (m *mockEC2Conn) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	m.lock.Lock()
+	m.copyImageCount++
+	m.lock.Unlock()
+
+	if input == nil || len(input.VpcIds) == 0 {
+		return nil, fmt.Errorf("oops looks like we need more input")
+	}
+
+	var isDefault bool
+	vpcID := aws.StringValue(input.VpcIds[0])
+
+	//only one default VPC per region
+	if strings.Contains("vpc-default-id", vpcID) {
+		isDefault = true
+	}
+
+	output := &ec2.DescribeVpcsOutput{
+		Vpcs: []*ec2.Vpc{
+			&ec2.Vpc{IsDefault: aws.Bool(isDefault),
+				VpcId: aws.String(vpcID),
+			},
+		},
+	}
+	return output, nil
+}
+
+func TestStepPreValidate_checkVpc(t *testing.T) {
+	tt := []struct {
+		name          string
+		step          StepPreValidate
+		errorExpected bool
+	}{
+		{"DefaultVpc", StepPreValidate{VpcId: "vpc-default-id"}, false},
+		{"NonDefaultVpcNoSubnet", StepPreValidate{VpcId: "vpc-1234567890"}, true},
+		{"NonDefaultVpcWithSubnet", StepPreValidate{VpcId: "vpc-1234567890", SubnetId: "subnet-1234567890"}, false},
+		{"SubnetWithNoVpc", StepPreValidate{SubnetId: "subnet-1234567890"}, false},
+		{"NoVpcInformation", StepPreValidate{}, false},
+	}
+
+	mockConn, err := getMockConn(nil, "")
+	if err != nil {
+		t.Fatal("unable to get a mock connection")
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.step.checkVpc(mockConn)
+
+			if tc.errorExpected && err == nil {
+				t.Errorf("expected a validation error for %q but got %q", tc.name, err)
+			}
+
+			if !tc.errorExpected && err != nil {
+				t.Errorf("expected a validation to pass for %q but got %q", tc.name, err)
+			}
+		})
+	}
+
+}

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -177,6 +177,14 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 	runReq, runResp := ec2conn.RunInstancesRequest(runOpts)
 	runReq.RetryCount = 11
 	err = runReq.Send()
+
+	if isAWSErr(err, "VPCIdNotSpecified", "No default VPC for this user") && subnetId == "" {
+		err := fmt.Errorf("Error launching source instance: a valid Subnet Id was not specified")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
 	if err != nil {
 		err := fmt.Errorf("Error launching source instance: %s", err)
 		state.Put("error", err)

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -190,6 +190,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			DestAmiName:        b.config.AMIName,
 			ForceDeregister:    b.config.AMIForceDeregister,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
+			VpcId:              b.config.VpcId,
+			SubnetId:           b.config.SubnetId,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -232,6 +232,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&awscommon.StepPreValidate{
 			DestAmiName:     b.config.AMIName,
 			ForceDeregister: b.config.AMIForceDeregister,
+			VpcId:           b.config.VpcId,
+			SubnetId:        b.config.SubnetId,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -286,6 +286,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&awscommon.StepPreValidate{
 			DestAmiName:     b.config.AMIName,
 			ForceDeregister: b.config.AMIForceDeregister,
+			VpcId:           b.config.VpcId,
+			SubnetId:        b.config.SubnetId,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,


### PR DESCRIPTION
Closes #7167

Changes made within this PR
* builder/amazon/step_pre_validate: Add validation for `subnet_id` when using a non-default `vpc_id`.
* builder/amazon: Add error handling for VPCIdNotSpecified

Test after change:
```
--- PASS: TestRunConfigPrepare (0.00s)
--- PASS: TestRunConfigPrepare_InstanceType (0.00s)
--- PASS: TestRunConfigPrepare_SourceAmi (0.00s)
--- PASS: TestRunConfigPrepare_SourceAmiFilterBlank (0.00s)
--- PASS: TestRunConfigPrepare_SourceAmiFilterOwnersBlank (0.00s)
--- PASS: TestRunConfigPrepare_SourceAmiFilterGood (0.00s)
--- PASS: TestRunConfigPrepare_EnableT2UnlimitedGood (0.00s)
--- PASS: TestRunConfigPrepare_EnableT2UnlimitedBadInstanceType (0.00s)
--- PASS:
TestRunConfigPrepare_EnableT2UnlimitedBadWithSpotInstanceRequest (0.00s)
--- PASS: TestRunConfigPrepare_SpotAuto (0.00s)
--- PASS: TestRunConfigPrepare_SSHPort (0.00s)
--- PASS: TestRunConfigPrepare_UserData (0.00s)
--- PASS: TestRunConfigPrepare_UserDataFile (0.00s)
--- PASS: TestRunConfigPrepare_TemporaryKeyPairName (0.00s)
--- PASS: TestRunConfigPrepare_VpcId (0.00s)
```

### Test Config
```json
{
  "variables": { },
  "builders": [{
    "type": "amazon-ebs",
    "region": "ap-northeast-1",
    "vpc_id": "{{ user `vpc_id` }}",
    "subnet_id": "{{ user `subnet_id` }}",
    "source_ami_filter": {
      "filters": {
        "virtualization-type": "hvm",
        "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
        "root-device-type": "ebs"
      },
      "owners": ["099720109477"],
      "most_recent": true
    },
    "instance_type": "t2.micro",
    "ssh_username": "ubuntu",
    "ami_name": "packer-example {{timestamp}}"
  }]
}
```
### No default VPC
Build error before change
```bash
> packer build -var="vpc_id=vpc-xxxxxxxxx" template.json                                                                     amazon-ebs output will be in this color.

==> amazon-ebs: Prevalidating AMI Name: packer-example 1573507537
    amazon-ebs: Found Image ID: ami-02be181636ed95ac5
==> amazon-ebs: Creating temporary keypair: packer_5dc9d1d1-5464-19c3-6ead-21d347493d2c
==> amazon-ebs: Creating temporary security group for this instance: packer_5dc9d1d9-d173-17b2-0888-cef2878b5f48
==> amazon-ebs: Authorizing access to port 22 from [0.0.0.0/0] in the temporary security groups...
==> amazon-ebs: Launching a source AWS instance...
==> amazon-ebs: Adding tags to source instance
    amazon-ebs: Adding tag: "Name": "Packer Builder"
==> amazon-ebs: Error launching source instance: VPCIdNotSpecified: No default VPC for this user
==> amazon-ebs:         status code: 400, request id: b68aa3df-eb1f-4af2-8b2b-aee9cc708b45
==> amazon-ebs: No volumes to clean up, skipping
==> amazon-ebs: Deleting temporary security group...
==> amazon-ebs: Deleting temporary keypair...
Build 'amazon-ebs' errored: Error launching source instance: VPCIdNotSpecified: No default VPC for this user
        status code: 400, request id: b68aa3df-eb1f-4af2-8b2b-aee9cc708b45

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Error launching source instance: VPCIdNotSpecified: No default VPC for this user
        status code: 400, request id: b68aa3df-eb1f-4af2-8b2b-aee9cc708b45

==> Builds finished but no artifacts were created.
```
Build error after change
```bash
> packer build -var="vpc_id=vpc-xxxxxxxxx" template.json 
amazon-ebs output will be in this color.

==> amazon-ebs: Validating subnet information for VPC "vpc-xxxxxxxxx"
Build 'amazon-ebs' errored: Error: subnet_id must be provided for non-default VPCs (vpc-xxxxxxxxx)

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Error: subnet_id must be provided for non-default VPCs (vpc-xxxxxxxxx)

==> Builds finished but no artifacts were created.
```
Build with `vpc_id` and `subnet_id`
```bash
> packer build -var "vpc_id=vpc-xxxxxxxxx" -var "subnet_id=subnet-xxxxxxxxx" template.json
amazon-ebs output will be in this color.

==> amazon-ebs: Prevalidating AMI Name: packer-example-1573678462
    amazon-ebs: Found Image ID: ami-0ec539abc2ecc4e85
==> amazon-ebs: Creating temporary keypair: packer_5dcc6d7e-3093-5b1b-fe28-f0bc8f97591f
==> amazon-ebs: Creating temporary security group for this instance: packer_5dcc6d82-a719-90da-5964-5b74b5668aa9
==> amazon-ebs: Authorizing access to port 22 from [0.0.0.0/0] in the temporary security groups...
==> amazon-ebs: Launching a source AWS instance...
==> amazon-ebs: Adding tags to source instance
    amazon-ebs: Adding tag: "Name": "Packer Builder"
    amazon-ebs: Instance ID: i-0e42233bff9fc0fdc
==> amazon-ebs: Waiting for instance (i-0e42233bff9fc0fdc) to become ready...
...
```

### Default VPC 
No subnet_id parameter needed as the AWS API will select the first default subnet id. 
```bash
> packer build -var="vpc_id=vpc-xxxxxxxxx" template.json 
```

### EC2 Classic
Doesn't have an VPC to start so just running the builder with out `vpc_id` or `subnet_id` should work as expected