### PR TITLE
builder/ncloud: fix dropped error

### DIFF
--- a/builder/ncloud/step_create_public_ip_instance.go
+++ b/builder/ncloud/step_create_public_ip_instance.go
@@ -81,6 +81,9 @@ func (s *StepCreatePublicIPInstance) createPublicIPInstance(serverInstanceNo str
 	s.Say(fmt.Sprintf("Public IP Instance [%s:%s] is created", publicIPInstance.PublicIPInstanceNo, publicIP))
 
 	err = s.waiterAssociatePublicIPToServerInstance(serverInstanceNo, publicIP)
+	if err != nil {
+		return nil, err
+	}
 
 	return &publicIPInstance, nil
 }


### PR DESCRIPTION
This fixes a dropped error in the `builder/ncloud` package.