### PR TITLE
scripts: close file after error handling

### DIFF
--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -53,10 +53,10 @@ func main() {
 
 	// Write our generated code to the command/plugin.go file
 	file, err := os.Create(target)
-	defer file.Close()
 	if err != nil {
 		log.Fatalf("Failed to open %s for writing: %s", target, err)
 	}
+	defer file.Close()
 
 	_, err = file.WriteString(output)
 	if err != nil {


### PR DESCRIPTION
This PR fixes a spot in `generate-plugins.go` where a file close was being deferred before error handling was performed.
