### PR TITLE
builder/amazon: Add helper function for checking against AWSError

### DIFF
--- a/builder/amazon/common/helper_funcs.go
+++ b/builder/amazon/common/helper_funcs.go
@@ -3,11 +3,14 @@ package common
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
+// DestroyAMIs deregisters the AWS machine images in imageids from an active AWS account
 func DestroyAMIs(imageids []*string, ec2conn *ec2.EC2) error {
 	resp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{
 		ImageIds: imageids,
@@ -46,4 +49,15 @@ func DestroyAMIs(imageids []*string, ec2conn *ec2.EC2) error {
 		}
 	}
 	return nil
+}
+
+// Returns true if the error matches all these conditions:
+//  * err is of type awserr.Error
+//  * Error.Code() matches code
+//  * Error.Message() contains message
+func isAWSErr(err error, code string, message string) bool {
+	if err, ok := err.(awserr.Error); ok {
+		return err.Code() == code && strings.Contains(err.Message(), message)
+	}
+	return false
 }

--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/packer/common/retry"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -36,7 +35,7 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 			err := retry.Config{
 				Tries: 11,
 				ShouldRetry: func(err error) bool {
-					if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "AuthFailure" {
+					if isAWSErr(err, "AuthFailure", "") {
 						log.Printf("Waiting for Vault-generated AWS credentials" +
 							" to pass authentication... trying again.")
 						return true


### PR DESCRIPTION
Replace all straight forward occurrences of `if err, ok := err.(awserr.Error)` with the `isAWSErr` helper function

Acceptance tests after change
```bash
--- PASS: TestBuilderAcc_basic (196.10s)
--- PASS: TestBuilderAcc_regionCopy (464.87s)
```

Unit tests after change
```bash
> make test TEST=./builder/amazon/...
==> Checking that only certain files are executable...
Check passed.
ok      github.com/hashicorp/packer/builder/amazon/chroot       (cached)
ok      github.com/hashicorp/packer/builder/amazon/common       0.021s
ok      github.com/hashicorp/packer/builder/amazon/ebs  (cached)
ok      github.com/hashicorp/packer/builder/amazon/ebssurrogate (cached)
ok      github.com/hashicorp/packer/builder/amazon/ebsvolume    (cached)
ok      github.com/hashicorp/packer/builder/amazon/instance     (cached)
```