### PR TITLE
bumped to ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

Bump Ubuntu to 18.04 for longer term support.