### PR TITLE
Fix error message when ovftool is missing

### DIFF
--- a/builder/vmware/common/step_export.go
+++ b/builder/vmware/common/step_export.go
@@ -73,7 +73,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 
 	ovftool := GetOVFTool()
 	if ovftool == "" {
-		err := fmt.Errorf("Error %s not found: ", ovftool)
+		err := fmt.Errorf("Error ovftool not found")
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt


### PR DESCRIPTION
When using the vmware-iso builder with remote_type set to esx5 you get the rather cryptic error message `Error  not found: ` if ovftool is not installed.

I haven't had much experience with go and haven't been able to successfully build locally, but I think the code here if pretty simple and my change should work.