### PR TITLE
fix bug in step_region_copy

### DIFF
--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -66,15 +66,19 @@ func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 	ui.Say("Waiting for AMI to become ready...")
 	if err := awscommon.WaitUntilAMIAvailable(ctx, ec2conn, *createResp.ImageId); err != nil {
 		log.Printf("Error waiting for AMI: %s", err)
-		imagesResp, err := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
-		if err != nil {
+		imagesResp, imerr := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
+		if imerr != nil {
 			log.Printf("Unable to determine reason waiting for AMI failed: %s", err)
-			err = fmt.Errorf("Unknown error waiting for AMI.")
+			err = fmt.Errorf("Unknown error waiting for AMI; %s", err)
 		} else {
-			stateReason := imagesResp.Images[0].StateReason
-			err = fmt.Errorf("Error waiting for AMI. Reason: %s", stateReason)
+			if imagesResp != nil && len(imagesResp.Images) > 0 {
+				image := imagesResp.Images[0]
+				if image != nil {
+					stateReason := image.StateReason
+					err = fmt.Errorf("Error waiting for AMI. Reason: %s", stateReason)
+				}
+			}
 		}
-
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -71,7 +71,7 @@ func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 			log.Printf("Unable to determine reason waiting for AMI failed: %s", err)
 			err = fmt.Errorf("Unknown error waiting for AMI; %s", err)
 		} else {
-			if imagesResp != nil && len(imagesResp.Images) > 0 {
+			if len(imagesResp.Images) > 0 {
 				image := imagesResp.Images[0]
 				if image != nil {
 					stateReason := image.StateReason

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -66,17 +66,16 @@ func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 	ui.Say("Waiting for AMI to become ready...")
 	if err := awscommon.WaitUntilAMIAvailable(ctx, ec2conn, *createResp.ImageId); err != nil {
 		log.Printf("Error waiting for AMI: %s", err)
-		imagesResp, imerr := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
+		imResp, imerr := ec2conn.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{createResp.ImageId}})
 		if imerr != nil {
 			log.Printf("Unable to determine reason waiting for AMI failed: %s", err)
 			err = fmt.Errorf("Unknown error waiting for AMI; %s", err)
-		} else {
-			if len(imagesResp.Images) > 0 {
-				image := imagesResp.Images[0]
-				if image != nil {
-					stateReason := image.StateReason
-					err = fmt.Errorf("Error waiting for AMI. Reason: %s", stateReason)
-				}
+		}
+		if imResp != nil && len(imResp.Images) > 0 {
+			image := imResp.Images[0]
+			if image != nil {
+				stateReason := image.StateReason
+				err = fmt.Errorf("Error waiting for AMI. Reason: %s", stateReason)
 			}
 		}
 		state.Put("error", err)


### PR DESCRIPTION
I introduced a nil pointer dereference when trying to add more helpful logging to the region copy step. 