### PR TITLE
helper/communicator/step_connect_ssh: Update proxy connection settings to use `SSHProxyUsername` and `SSHProxyPassword`

### DIFF
--- a/helper/communicator/step_connect_ssh.go
+++ b/helper/communicator/step_connect_ssh.go
@@ -106,8 +106,8 @@ func (s *StepConnectSSH) waitForSSH(state multistep.StateBag, ctx context.Contex
 		pAddr = fmt.Sprintf("%s:%d", s.Config.SSHProxyHost, s.Config.SSHProxyPort)
 		if s.Config.SSHProxyUsername != "" {
 			pAuth = new(proxy.Auth)
-			pAuth.User = s.Config.SSHBastionUsername
-			pAuth.Password = s.Config.SSHBastionPassword
+			pAuth.User = s.Config.SSHProxyUsername
+			pAuth.Password = s.Config.SSHProxyPassword
 		}
 
 	}


### PR DESCRIPTION
Closes #8373

Test Configuration using a local SOCKS proxy
```json
{
  "variables": { },
  "builders": [{
    "type": "amazon-ebs",
    "region": "ap-northeast-1",
    "source_ami_filter": {
      "filters": {
        "virtualization-type": "hvm",
        "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
        "root-device-type": "ebs"
      },
      "owners": ["099720109477"],
      "most_recent": true
    },
    "instance_type": "t2.micro",
    "ssh_username": "ubuntu",
    "ssh_proxy_host": "127.0.0.1",
    "ssh_proxy_port": "1337",
    "ssh_proxy_username": "user",
    "ssh_proxy_password": "password",
    "ami_name": "packer-example {{timestamp}}"
  }]
}
```

Using `ssh_proxy_username` and `ssh_proxy_password` with no Bastion settings
```
==> amazon-ebs: Waiting for SSH to become available...
2019/11/15 15:00:23 packer: 2019/11/15 15:00:23 [DEBUG] TCP connection to SSH ip/port failed: socks connect tcp 127.0.0.1:1337->xx.xxx.25.37:22: EOF
2019/11/15 15:00:28 packer: 2019/11/15 15:00:28 Using ssh_host value: xx.xxx.25.37
2019/11/15 15:00:28 packer: 2019/11/15 15:00:28 [INFO] Attempting SSH connection to xx.xxx.25.37:22...
2019/11/15 15:00:28 packer: 2019/11/15 15:00:28 [DEBUG] Config to
&ssh.Config{SSHConfig:(*ssh.ClientConfig)(0xc0003c8410), Connection:(func() (net.Conn, error))(0x1202b60), Pty:false, DisableAgentForwarding:false, HandshakeTimeout:0, UseSftp:false,
KeepAliveInterval:5000000000, Timeout:0,
Tunnels:[]ssh.TunnelSpec(nil)}...

```

Using `ssh_bastion_username` and `ssh_bastion_password`; keeping `ssh_proxy_* settings in place
```bash
==> amazon-ebs: Waiting for SSH to become available...
2019/11/15 14:53:29 packer: 2019/11/15 14:53:29 Using ssh_host value: xx.xxx.159.97
2019/11/15 14:53:29 packer: 2019/11/15 14:53:29 [INFO] Attempting SSH connection to xx.xxx.159.97:22...
2019/11/15 14:53:29 packer: 2019/11/15 14:53:29 [DEBUG] Config to &ssh.Config{SSHConfig:(*ssh.ClientConfig)(0xc00017e410), Connection:(func() (net.Conn, error))(0x1202b60), Pty:false,
DisableAgentForwarding:false, HandshakeTimeout:0, UseSftp:false,
KeepAliveInterval:5000000000, Timeout:0,
Tunnels:[]ssh.TunnelSpec(nil)}...
```

After change using only `ssh_proxy_username` and `ssh_proxy_password` with no Bastion settings
```bash
==> amazon-ebs: Waiting for SSH to become available...
2019/11/15 15:05:38 packer: 2019/11/15 15:05:38 Using ssh_host value: xx.xxx.57.189
2019/11/15 15:05:39 packer: 2019/11/15 15:05:39 [INFO] Attempting SSH connection to xx.xxx.57.189:22...
2019/11/15 15:05:39 packer: 2019/11/15 15:05:39 [DEBUG] Config to &ssh.Config{SSHConfig:(*ssh.ClientConfig)(0xc00012ec30), Connection:(func() (net.Conn, error))(0x1202b60), Pty:false,
DisableAgentForwarding:false, HandshakeTimeout:0, UseSftp:false,
KeepAliveInterval:5000000000, Timeout:0,
Tunnels:[]ssh.TunnelSpec(nil)}...
```