### PR TITLE
this hack can be reverted now that we've fixed the underlying bug in …

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -135,11 +135,6 @@ var waitForRestart = func(ctx context.Context, p *Provisioner, comm packer.Commu
 	trycommand := TryCheckReboot
 	abortcommand := AbortReboot
 
-	// This sleep works around an azure/winrm bug. For more info see
-	// https://github.com/hashicorp/packer/issues/5257; we can remove the
-	// sleep when the underlying bug has been resolved.
-	time.Sleep(1 * time.Second)
-
 	// Stolen from Vagrant reboot checker
 	for {
 		log.Printf("Check if machine is rebooting...")


### PR DESCRIPTION
#8369 fixed the underlying bug that was causing this eof error; just tested against Azure and I can no longer reproduce the crash that caused the need for this sleep. 