### PR TITLE
fix: persist default drive/device

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -266,13 +266,10 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 				arg = defaultArgs[key].([]string)
 			}
 			inArgs[key] = arg
-		}
-	}
-
-	// Check if we are missing the netDevice #6804
-	if x, ok := inArgs["-device"]; ok {
-		if !strings.Contains(strings.Join(x, ""), config.NetDevice) {
-			inArgs["-device"] = append(inArgs["-device"], fmt.Sprintf("%s,netdev=user.0", config.NetDevice))
+		} else {
+			if key == "-device" || key == "-drive" {
+				inArgs[key] = append(defaultArgs[key].([]string), inArgs[key]...)
+			}
 		}
 	}
 


### PR DESCRIPTION
When a new device appears in qemuargs it will not overwrite.

This fix is a complement for the job done in [KVM/QEMU Network "has no peer"](https://github.com/hashicorp/packer/pull/6807)

Closes #8379
