### PR TITLE
Only validate the user has provided a subnet_id when vpc_id has been set

### DIFF
--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -121,8 +121,10 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 }
 
 func (s *StepPreValidate) checkVpc(conn ec2iface.EC2API) error {
-	if s.VpcId != "" && s.SubnetId != "" {
-		// skip validation if both VpcId and SubnetId are provided; AWS API will error if something is wrong.
+	if s.VpcId == "" || (s.VpcId != "" && s.SubnetId != "") {
+		// Skip validation if:
+		// * The user has not provided a VpcId.
+		// * Both VpcId and SubnetId are provided; AWS API will error if something is wrong.
 		return nil
 	}
 

--- a/builder/amazon/common/step_pre_validate_test.go
+++ b/builder/amazon/common/step_pre_validate_test.go
@@ -11,11 +11,8 @@ import (
 
 //DescribeVpcs mocks an ec2.DescribeVpcsOutput for a given input
 func (m *mockEC2Conn) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
-	m.lock.Lock()
-	m.copyImageCount++
-	m.lock.Unlock()
 
-	if input == nil || len(input.VpcIds) == 0 {
+	if input == nil || aws.StringValue(input.VpcIds[0]) == "" {
 		return nil, fmt.Errorf("oops looks like we need more input")
 	}
 


### PR DESCRIPTION
Version: Packer v1.5.0-dev (3571c585b)

Following #8360 I am getting the following error:

```
$ packer build centos-7.json
amazon-ebssurrogate output will be in this color.

==> amazon-ebssurrogate: Prevalidating any provided VPC information
==> amazon-ebssurrogate: Error retrieving VPC information for vpc_id ""
Build 'amazon-ebssurrogate' errored: Error retrieving VPC information for vpc_id ""

==> Some builds didn't complete successfully and had errors:
--> amazon-ebssurrogate: Error retrieving VPC information for vpc_id ""

==> Builds finished but no artifacts were created.
```

I've only had a quick chance to look at this. However, if I'm reading things right, it looks as though  #8360 was just missing the coded needed to skip the validation step when the user hasn't set `vpc_id`. The tests #8360 added seem to support this - the test cases already include the case where the `vpc_id` is unset. This PR fixes by adding the missing logic.

Ping @nywilken 