### PR TITLE
Added support for specifying Service Account in Google Compute export 

### DIFF
--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -30,6 +30,7 @@ type Config struct {
 	Subnetwork          string   `mapstructure:"subnetwork"`
 	VaultGCPOauthEngine string   `mapstructure:"vault_gcp_oauth_engine"`
 	Zone                string   `mapstructure:"zone"`
+	ServiceAccountEmail string   `mapstructure:"service_account_email"`
 
 	account *jwt.Config
 	ctx     interpolate.Context
@@ -149,6 +150,9 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 			"https://www.googleapis.com/auth/devstorage.full_control",
 			"https://www.googleapis.com/auth/userinfo.email",
 		},
+	}
+	if p.config.ServiceAccountEmail != "" {
+		exporterConfig.ServiceAccountEmail = p.config.ServiceAccountEmail
 	}
 
 	driver, err := googlecompute.NewDriverGCE(ui, builderProjectId,


### PR DESCRIPTION
Added support for specifying Service Account (service_account_email) in Google Compute export post-processor. Enables Packer to export images in projects where the standard Compute Engine service account has been removed.