### PR TITLE
F-8351: Changed stuct to accept array and tag each artifact

### DIFF
--- a/builder/docker/driver_mock.go
+++ b/builder/docker/driver_mock.go
@@ -51,9 +51,9 @@ type MockDriver struct {
 	SaveImageReader io.Reader
 	SaveImageError  error
 
-	TagImageCalled  bool
+	TagImageCalled  int
 	TagImageImageId string
-	TagImageRepo    string
+	TagImageRepo    []string
 	TagImageForce   bool
 	TagImageErr     error
 
@@ -177,9 +177,9 @@ func (d *MockDriver) StopContainer(id string) error {
 }
 
 func (d *MockDriver) TagImage(id string, repo string, force bool) error {
-	d.TagImageCalled = true
+	d.TagImageCalled += 1
 	d.TagImageImageId = id
-	d.TagImageRepo = repo
+	d.TagImageRepo = append(d.TagImageRepo, repo)
 	d.TagImageForce = force
 	return d.TagImageErr
 }

--- a/post-processor/docker-tag/post-processor.hcl2spec.go
+++ b/post-processor/docker-tag/post-processor.hcl2spec.go
@@ -17,7 +17,7 @@ type FlatConfig struct {
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables"`
 	Repository          *string           `mapstructure:"repository" cty:"repository"`
-	Tag                 *string           `mapstructure:"tag" cty:"tag"`
+	Tag                 []string          `mapstructure:"tag" cty:"tag"`
 	Force               *bool             `cty:"force"`
 }
 
@@ -38,7 +38,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_user_variables":      &hcldec.BlockAttrsSpec{TypeName: "packer_user_variables", ElementType: cty.String, Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"repository":                 &hcldec.AttrSpec{Name: "repository", Type: cty.String, Required: false},
-		"tag":                        &hcldec.AttrSpec{Name: "tag", Type: cty.String, Required: false},
+		"tag":                        &hcldec.AttrSpec{Name: "tag", Type: cty.List(cty.String), Required: false},
 		"force":                      &hcldec.AttrSpec{Name: "force", Type: cty.Bool, Required: false},
 	}
 	return s

--- a/post-processor/docker-tag/post-processor_test.go
+++ b/post-processor/docker-tag/post-processor_test.go
@@ -13,7 +13,7 @@ import (
 func testConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"repository": "foo",
-		"tag":        "bar",
+		"tag":        "bar,buzz",
 	}
 }
 
@@ -63,15 +63,21 @@ func TestPostProcessor_PostProcess(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if !driver.TagImageCalled {
+	if driver.TagImageCalled != 2 {
 		t.Fatal("should call TagImage")
 	}
 	if driver.TagImageImageId != "1234567890abcdef" {
 		t.Fatal("bad image id")
 	}
-	if driver.TagImageRepo != "foo:bar" {
+
+	if driver.TagImageRepo[0] != "foo:bar" {
 		t.Fatal("bad repo")
 	}
+
+	if driver.TagImageRepo[1] != "foo:buzz" {
+		t.Fatal("bad repo")
+	}
+
 	if driver.TagImageForce {
 		t.Fatal("bad force. force=false in default")
 	}
@@ -105,13 +111,16 @@ func TestPostProcessor_PostProcess_Force(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if !driver.TagImageCalled {
+	if driver.TagImageCalled != 2 {
 		t.Fatal("should call TagImage")
 	}
 	if driver.TagImageImageId != "1234567890abcdef" {
 		t.Fatal("bad image id")
 	}
-	if driver.TagImageRepo != "foo:bar" {
+	if driver.TagImageRepo[0] != "foo:bar" {
+		t.Fatal("bad repo")
+	}
+	if driver.TagImageRepo[1] != "foo:buzz" {
 		t.Fatal("bad repo")
 	}
 	if !driver.TagImageForce {


### PR DESCRIPTION
Tagging a docker image multiple times results in the same image being produced with several tags.
This meant I could not simply follow the changes recommended in the issue. I have also assumed that the atifact to be returned should be the one with the last tag in the array. This might need a wider discussion. I still have to write some tests to support this change.

To test the changes run `docker image ls | grep iron/base`

Rename the following file to test.json and run `packer build testfile.json`
[testfile.txt](https://github.com/hashicorp/packer/files/3871026/testfile.txt)

Run  then run `docker image ls | grep iron/base` 
The output should show something like the following new images:

iron/base                                     0.7                          87f4f8cd2998        10 hours ago        4.7MB
iron/base                                     14.1                         87f4f8cd2998        10 hours ago        4.7MB
iron/base                                     spaggeti                     87f4f8cd2998        10 hours ago        4.7MB


Closes #8351

