### PR TITLE
Add no_ephemeral template option to nuke ephemeral drives from launch mappings

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -127,10 +127,9 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		// don't clutter up console views and cause confusion.
 		log.Printf("no_ephemeral was set, so creating drives xvdca-xvdcz as empty mappings")
 		DefaultEphemeralDeviceLetters := "abcdefghijklmnopqrstuvwxyz"
-		for i := 0; i < len(DefaultEphemeralDeviceLetters); i++ {
-
+		for _, letter := range DefaultEphemeralDeviceLetters {
 			bd := &ec2.BlockDeviceMapping{
-				DeviceName: aws.String("xvdc" + string(DefaultEphemeralDeviceLetters[i])),
+				DeviceName: aws.String("xvdc" + string(letter)),
 				NoDevice:   aws.String(""),
 			}
 			runOpts.BlockDeviceMappings = append(runOpts.BlockDeviceMappings, bd)

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -35,6 +35,7 @@ type StepRunSourceInstance struct {
 	UserData                          string
 	UserDataFile                      string
 	VolumeTags                        TagMap
+	NoEphemeral                       bool
 
 	instanceId string
 }
@@ -114,6 +115,26 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		BlockDeviceMappings: s.LaunchMappings.BuildEC2BlockDeviceMappings(),
 		Placement:           &ec2.Placement{AvailabilityZone: &az},
 		EbsOptimized:        &s.EbsOptimized,
+	}
+
+	if s.NoEphemeral {
+		// This is only relevant for windows guests. Ephemeral drives by
+		// default are assigned to drive names xvdca-xvdcz.
+		// When vms are launched from the AWS console, they're automatically
+		// removed from the block devices if the user hasn't said to use them,
+		// but the SDK does not perform this cleanup. The following code just
+		// manually removes the ephemeral drives from the mapping so that they
+		// don't clutter up console views and cause confusion.
+		log.Printf("no_ephemeral was set, so creating drives xvdca-xvdcz as empty mappings")
+		DefaultEphemeralDeviceLetters := "abcdefghijklmnopqrstuvwxyz"
+		for i := 0; i < len(DefaultEphemeralDeviceLetters); i++ {
+
+			bd := &ec2.BlockDeviceMapping{
+				DeviceName: aws.String("xvdc" + string(DefaultEphemeralDeviceLetters[i])),
+				NoDevice:   aws.String(""),
+			}
+			runOpts.BlockDeviceMappings = append(runOpts.BlockDeviceMappings, bd)
+		}
 	}
 
 	if s.EnableT2Unlimited {

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -53,6 +53,12 @@ type Config struct {
 	// engine](/docs/templates/engine.html), see [Build template
 	// data](#build-template-data) for more information.
 	VolumeRunTags awscommon.TagMap `mapstructure:"run_volume_tags"`
+	// If you set this flag, we'll add clauses to the
+	// launch_block_device_mappings that make sure ephemeral drives don't show
+	// up in the EC2 console. If you launched from the EC2 console, you'd get
+	// this automatically, but the SDK does not provide this service.
+	// This only applies when you are not running spot instances.
+	NoEphemeral bool `mapstructure:"no_ephemeral" required:"false"`
 
 	ctx interpolate.Context
 }
@@ -181,6 +187,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,
+			NoEphemeral:                       b.config.NoEphemeral,
 		}
 	}
 

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -172,6 +172,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,
+			NoEphemeral:                       b.config.NoEphemeral,
 		}
 	} else {
 		instanceStep = &awscommon.StepRunSourceInstance{

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -53,11 +53,15 @@ type Config struct {
 	// engine](/docs/templates/engine.html), see [Build template
 	// data](#build-template-data) for more information.
 	VolumeRunTags awscommon.TagMap `mapstructure:"run_volume_tags"`
-	// If you set this flag, we'll add clauses to the
-	// launch_block_device_mappings that make sure ephemeral drives don't show
-	// up in the EC2 console. If you launched from the EC2 console, you'd get
-	// this automatically, but the SDK does not provide this service.
-	// This only applies when you are not running spot instances.
+	// Relevant only to Windows guests: If you set this flag, we'll add clauses
+	// to the launch_block_device_mappings that make sure ephemeral drives
+	// don't show up in the EC2 console. If you launched from the EC2 console,
+	// you'd get this automatically, but the SDK does not provide this service.
+	// For more information, see
+	// https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/InstanceStorage.html.
+	// Because we don't validate the OS type of your guest, it is up to you to
+	// make sure you don't set this for *nix guests; behavior may be
+	// unpredictable.
 	NoEphemeral bool `mapstructure:"no_ephemeral" required:"false"`
 
 	ctx interpolate.Context

--- a/builder/amazon/ebs/builder.hcl2spec.go
+++ b/builder/amazon/ebs/builder.hcl2spec.go
@@ -120,6 +120,7 @@ type FlatConfig struct {
 	AMIMappings                               []common.FlatBlockDevice               `mapstructure:"ami_block_device_mappings" required:"false" cty:"ami_block_device_mappings"`
 	LaunchMappings                            []common.FlatBlockDevice               `mapstructure:"launch_block_device_mappings" required:"false" cty:"launch_block_device_mappings"`
 	VolumeRunTags                             common.TagMap                          `mapstructure:"run_volume_tags" cty:"run_volume_tags"`
+	NoEphemeral                               *bool                                  `mapstructure:"no_ephemeral" required:"false" cty:"no_ephemeral"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -241,6 +242,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ami_block_device_mappings":             &hcldec.BlockListSpec{TypeName: "ami_block_device_mappings", Nested: &hcldec.BlockSpec{TypeName: "ami_block_device_mappings", Nested: hcldec.ObjectSpec((*common.FlatBlockDevice)(nil).HCL2Spec())}},
 		"launch_block_device_mappings":          &hcldec.BlockListSpec{TypeName: "launch_block_device_mappings", Nested: &hcldec.BlockSpec{TypeName: "launch_block_device_mappings", Nested: hcldec.ObjectSpec((*common.FlatBlockDevice)(nil).HCL2Spec())}},
 		"run_volume_tags":                       &hcldec.BlockAttrsSpec{TypeName: "common.TagMap", ElementType: cty.String, Required: false},
+		"no_ephemeral":                          &hcldec.AttrSpec{Name: "no_ephemeral", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/website/source/partials/builder/amazon/ebs/_Config-not-required.html.md
+++ b/website/source/partials/builder/amazon/ebs/_Config-not-required.html.md
@@ -22,3 +22,9 @@
     engine](/docs/templates/engine.html), see [Build template
     data](#build-template-data) for more information.
     
+-   `no_ephemeral` (bool) - If you set this flag, we'll add clauses to the
+    launch_block_device_mappings that make sure ephemeral drives don't show
+    up in the EC2 console. If you launched from the EC2 console, you'd get
+    this automatically, but the SDK does not provide this service.
+    This only applies when you are not running spot instances.
+    

--- a/website/source/partials/builder/amazon/ebs/_Config-not-required.html.md
+++ b/website/source/partials/builder/amazon/ebs/_Config-not-required.html.md
@@ -22,9 +22,13 @@
     engine](/docs/templates/engine.html), see [Build template
     data](#build-template-data) for more information.
     
--   `no_ephemeral` (bool) - If you set this flag, we'll add clauses to the
-    launch_block_device_mappings that make sure ephemeral drives don't show
-    up in the EC2 console. If you launched from the EC2 console, you'd get
-    this automatically, but the SDK does not provide this service.
-    This only applies when you are not running spot instances.
+-   `no_ephemeral` (bool) - Relevant only to Windows guests: If you set this flag, we'll add clauses
+    to the launch_block_device_mappings that make sure ephemeral drives
+    don't show up in the EC2 console. If you launched from the EC2 console,
+    you'd get this automatically, but the SDK does not provide this service.
+    For more information, see
+    https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/InstanceStorage.html.
+    Because we don't validate the OS type of your guest, it is up to you to
+    make sure you don't set this for *nix guests; behavior may be
+    unpredictable.
     


### PR DESCRIPTION
If a user launches an instance using the EC2 console, ephemeral drives don't show up in the mappings; if launched using the AWS SDK, they do show up unless you explicitly set no_device for all 26 potential ephemeral drive mappings (xvdca-xvdcz), so this option tells Packer to automatically do that rather than forcing users to add 26 meaningless mappings to their Packer templates

Closes #8362 
