### PR TITLE
Don't cache when TargetPath is non-nil

### DIFF
--- a/common/step_download.go
+++ b/common/step_download.go
@@ -150,11 +150,9 @@ func (s *StepDownload) download(ctx context.Context, ui packer.Ui, source string
 		if s.Extension != "" {
 			targetPath += "." + s.Extension
 		}
+		targetPath, err = packer.CachePath(targetPath)
 	}
-	targetPath, err = packer.CachePath(targetPath)
-	if err != nil {
-		return "", fmt.Errorf("CachePath: %s", err)
-	}
+
 	lockFile := targetPath + ".lock"
 
 	log.Printf("Acquiring lock for: %s (%s)", u.String(), lockFile)

--- a/common/step_download.go
+++ b/common/step_download.go
@@ -151,6 +151,9 @@ func (s *StepDownload) download(ctx context.Context, ui packer.Ui, source string
 			targetPath += "." + s.Extension
 		}
 		targetPath, err = packer.CachePath(targetPath)
+		if err != nil {
+			return "", fmt.Errorf("CachePath: %s", err)
+		}
 	}
 
 	lockFile := targetPath + ".lock"


### PR DESCRIPTION
Code introduced when we switched to go-getter made us cache all target paths, even non-hashed ones, and this breaks the `iso_target_path` iso option. 

Commit that caused this: https://github.com/hashicorp/packer/commit/9f82b75e57e35784564c25f3f7d5e07fd5495226#diff-b3d1961ee14a9810d37b74844dee8e2eR115

Closes #7925 (part 2 -- part 1 was already solved in #7996, which had a similar root cause but which I solved differently)
