### PR TITLE
update amazon-ebsvolume docs

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -22,7 +22,7 @@ import (
 // build instance at launch using a specific non-default kms key:
 //
 // ``` json
-// "launch_block_device_mappings": [{
+// "[{
 //		"device_name": "/dev/sda1",
 //		"encrypted": true,
 //		"kms_key_id": "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
@@ -32,9 +32,6 @@ import (
 // Documentation for Block Devices Mappings can be found here:
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
 //
-// These mappings give you control over either the volumes generated for the
-// Packer build via `launch_block_device_mappings`, or the volumes that Packer will
-// save with the artifact AMI via `ami_block_device_mappings`.
 type BlockDevice struct {
 	// Indicates whether the EBS volume is deleted on instance termination.
 	// Default false. NOTE: If this value is not explicitly set to true and

--- a/website/source/partials/builder/amazon/common/_BlockDevice.html.md
+++ b/website/source/partials/builder/amazon/common/_BlockDevice.html.md
@@ -8,7 +8,7 @@ The following mapping will tell Packer to encrypt the root volume of the
 build instance at launch using a specific non-default kms key:
 
 ``` json
-"launch_block_device_mappings": [{
+"[{
 		"device_name": "/dev/sda1",
 		"encrypted": true,
 		"kms_key_id": "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
@@ -17,7 +17,3 @@ build instance at launch using a specific non-default kms key:
 
 Documentation for Block Devices Mappings can be found here:
 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
-
-These mappings give you control over either the volumes generated for the
-Packer build via `launch_block_device_mappings`, or the volumes that Packer will
-save with the artifact AMI via `ami_block_device_mappings`.


### PR DESCRIPTION
This is just small documentation update.
`amazon-ebsvolume` builder uses `ebs_volumes` insted of `launch_block_device_mappings`.
