### PR TITLE
builder/osc: fix ssh host detection in Public Cloud and Nets

### DIFF
--- a/builder/osc/bsu/builder.go
+++ b/builder/osc/bsu/builder.go
@@ -128,6 +128,10 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Comm:         &b.config.RunConfig.Comm,
 			DebugKeyPath: fmt.Sprintf("oapi_%s", b.config.PackerBuildName),
 		},
+		&osccommon.StepPublicIp{
+			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
+			Debug:                    b.config.PackerDebug,
+		},
 		&osccommon.StepSecurityGroup{
 			SecurityGroupFilter:   b.config.SecurityGroupFilter,
 			SecurityGroupIds:      b.config.SecurityGroupIds,
@@ -138,7 +142,6 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			BlockDevices: b.config.BlockDevices,
 		},
 		&osccommon.StepRunSourceVm{
-			AssociatePublicIpAddress:    b.config.AssociatePublicIpAddress,
 			BlockDevices:                b.config.BlockDevices,
 			Comm:                        &b.config.RunConfig.Comm,
 			Ctx:                         b.config.ctx,

--- a/builder/osc/bsusurrogate/builder.go
+++ b/builder/osc/bsusurrogate/builder.go
@@ -149,6 +149,10 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Comm:         &b.config.RunConfig.Comm,
 			DebugKeyPath: fmt.Sprintf("oapi_%s", b.config.PackerBuildName),
 		},
+		&osccommon.StepPublicIp{
+			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
+			Debug:                    b.config.PackerDebug,
+		},
 		&osccommon.StepSecurityGroup{
 			SecurityGroupFilter:   b.config.SecurityGroupFilter,
 			SecurityGroupIds:      b.config.SecurityGroupIds,
@@ -159,7 +163,6 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			BlockDevices: b.config.BlockDevices,
 		},
 		&osccommon.StepRunSourceVm{
-			AssociatePublicIpAddress:    b.config.AssociatePublicIpAddress,
 			BlockDevices:                b.config.BlockDevices,
 			Comm:                        &b.config.RunConfig.Comm,
 			Ctx:                         b.config.ctx,

--- a/builder/osc/bsuvolume/builder.go
+++ b/builder/osc/bsuvolume/builder.go
@@ -109,7 +109,6 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	log.Printf("[DEBUG] launch block devices %#v", b.config.launchBlockDevices)
 
 	instanceStep := &osccommon.StepRunSourceVm{
-		AssociatePublicIpAddress:    b.config.AssociatePublicIpAddress,
 		BlockDevices:                b.config.launchBlockDevices,
 		Comm:                        &b.config.RunConfig.Comm,
 		Ctx:                         b.config.ctx,
@@ -145,6 +144,10 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Debug:        b.config.PackerDebug,
 			Comm:         &b.config.RunConfig.Comm,
 			DebugKeyPath: fmt.Sprintf("oapi_%s.pem", b.config.PackerBuildName),
+		},
+		&osccommon.StepPublicIp{
+			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
+			Debug:                    b.config.PackerDebug,
 		},
 		&osccommon.StepSecurityGroup{
 			SecurityGroupFilter:   b.config.SecurityGroupFilter,

--- a/builder/osc/common/state.go
+++ b/builder/osc/common/state.go
@@ -88,7 +88,7 @@ func waitForState(errCh chan<- error, target string, refresh stateRefreshFunc) e
 
 func waitUntilVmStateFunc(conn *oapi.Client, id string) stateRefreshFunc {
 	return func() (string, error) {
-		log.Printf("[Debug] Check if SG with id %s exists", id)
+		log.Printf("[Debug] Retrieving state for VM with id %s", id)
 		resp, err := conn.POST_ReadVms(oapi.ReadVmsRequest{
 			Filters: oapi.FiltersVm{
 				VmIds: []string{id},
@@ -102,7 +102,7 @@ func waitUntilVmStateFunc(conn *oapi.Client, id string) stateRefreshFunc {
 		}
 
 		if resp.OK == nil {
-			return "", fmt.Errorf("Vm with ID %s. Not Found", id)
+			return "", fmt.Errorf("Vm with ID %s not Found", id)
 		}
 
 		if len(resp.OK.Vms) == 0 {

--- a/builder/osc/common/step_public_ip.go
+++ b/builder/osc/common/step_public_ip.go
@@ -1,0 +1,68 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"github.com/outscale/osc-go/oapi"
+)
+
+type StepPublicIp struct {
+	AssociatePublicIpAddress bool
+	Comm                     *communicator.Config
+	publicIpId               string
+	Debug                    bool
+
+	doCleanup bool
+}
+
+func (s *StepPublicIp) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	oapiconn := state.Get("oapi").(*oapi.Client)
+	netId := state.Get("net_id").(string)
+	subnetId := state.Get("subnet_id").(string)
+
+	if netId == "" || subnetId == "" || !s.AssociatePublicIpAddress {
+		// In this case, we are in the public Cloud, so we'll
+		// not explicitely allocate a public IP.
+		return multistep.ActionContinue
+	}
+
+	ui.Say(fmt.Sprintf("Creating temporary PublicIp for instance in subnet %s (net %s)", subnetId, netId))
+
+	publicIpResp, err := oapiconn.POST_CreatePublicIp(oapi.CreatePublicIpRequest{})
+	if err != nil {
+		state.Put("error", fmt.Errorf("Error creating temporary PublicIp: %s", err))
+		return multistep.ActionHalt
+	}
+
+	// From there, we have a Public Ip to destroy.
+	s.doCleanup = true
+
+	// Set some data for use in future steps
+	s.publicIpId = publicIpResp.OK.PublicIp.PublicIpId
+	state.Put("publicip_id", publicIpResp.OK.PublicIp.PublicIpId)
+
+	return multistep.ActionContinue
+}
+
+func (s *StepPublicIp) Cleanup(state multistep.StateBag) {
+	if !s.doCleanup {
+		return
+	}
+
+	oapiconn := state.Get("oapi").(*oapi.Client)
+	ui := state.Get("ui").(packer.Ui)
+
+	// Remove the Public IP
+	ui.Say("Deleting temporary PublicIp...")
+	_, err := oapiconn.POST_DeletePublicIp(oapi.DeletePublicIpRequest{PublicIpId: s.publicIpId})
+	if err != nil {
+		ui.Error(fmt.Sprintf(
+			"Error cleaning up PublicIp. Please delete the PublicIp manually: %s", s.publicIpId))
+	}
+
+}


### PR DESCRIPTION
Hello,

This PR aims to resolve two linked issues:

- when provisioning instances outside of a Net, the current osc builder breaks because Packer is unable to inventory the Public IPs of the Instance because of an API evolution.
- when provisioning instances inside a Net, the `associate_public_ip_address` feature was not fully implemented, and would break with a request format error.

As this is my first pull request on this project, I welcome any remarks on this code.

Thanks,
Aurélien