### PR TITLE
Update LXD directory upload command

### DIFF
--- a/builder/lxd/communicator.go
+++ b/builder/lxd/communicator.go
@@ -88,42 +88,19 @@ func (c *Communicator) Upload(dst string, r io.Reader, fi *os.FileInfo) error {
 }
 
 func (c *Communicator) UploadDir(dst string, src string, exclude []string) error {
-	// NOTE:lxc file push doesn't yet support directory uploads.
-	// As a work around, we tar up the folder, upload it as a file, then extract it
+	fileDestination := filepath.Join(c.ContainerName, dst)
 
-	// Don't use 'z' flag as compressing may take longer and the transfer is likely local.
-	// If this isn't the case, it is possible for the user to compress in another step then transfer.
-	// It wouldn't be possible to disable compression, without exposing this option.
-	tar, err := c.CmdWrapper(fmt.Sprintf("tar -cf - -C %s .", src))
+	cp, err := c.CmdWrapper(fmt.Sprintf("lxc file push -pr %s %s", src, fileDestination))
 	if err != nil {
 		return err
 	}
 
-	cp, err := c.CmdWrapper(fmt.Sprintf("lxc exec %s -- tar -xf - -C %s", c.ContainerName, dst))
-	if err != nil {
-		return err
-	}
-
-	tarCmd := ShellCommand(tar)
 	cpCmd := ShellCommand(cp)
-
-	cpCmd.Stdin, _ = tarCmd.StdoutPipe()
-	log.Printf("Starting tar command: %s", tar)
-	err = tarCmd.Start()
-	if err != nil {
-		return err
-	}
 
 	log.Printf("Running cp command: %s", cp)
 	err = cpCmd.Run()
 	if err != nil {
 		log.Printf("Error running cp command: %s", err)
-		return err
-	}
-
-	err = tarCmd.Wait()
-	if err != nil {
-		log.Printf("Error running tar command: %s", err)
 		return err
 	}
 


### PR DESCRIPTION
The LXD directory upload method currently used in Packer is a workaround that was introduced at a time when `lxc` did not have a recursive option that could be used to push directories into containers and only allowed files to be pushed into containers. This workaround does not seem to be working anymore. 

With the newer versions of LXD, directories can be pushed into containers using: 
```
lxc file push -r <source-path> <container-name>/<path>
```
This has been tested with `lxc` version 3.17. I do not anticipate any issues with versions >3. 

Please let me know if you need more information or need me to make any changes to this PR. 

#### References: 
* [File manipulation test file from LXD Github repo](https://github.com/lxc/lxd/blob/master/test/suites/filemanip.sh)
* [AskUbuntu - How do I copy a file/directory from host into a LXD container?](https://askubuntu.com/a/1051763/237634)