### PR TITLE
AmiFilterOptions: avoid taking the address of a loop iterator var

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -27,7 +27,8 @@ type AmiFilterOptions struct {
 func (d *AmiFilterOptions) GetOwners() []*string {
 	res := make([]*string, 0, len(d.Owners))
 	for _, owner := range d.Owners {
-		res = append(res, &owner)
+		i := owner
+		res = append(res, &i)
 	}
 	return res
 }


### PR DESCRIPTION
AmiFilterOptions GetOwners() method current builds a slice of string pointers by ranging over the Owners slice, and taking the address of the loop iterator, which doesn't change.

The end result is that, in the case of multiple owners, GetOwners() always returns a slice of pointers to the last value.

Example repro: https://play.golang.org/p/o8Lz9lkKmt6