### PR TITLE
Fix request retry mechanism  to launch aws instance

### DIFF
--- a/builder/amazon/common/step_iam_instance_profile.go
+++ b/builder/amazon/common/step_iam_instance_profile.go
@@ -3,11 +3,12 @@ package common
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"log"
-	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
 
 	"encoding/json"
+
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/packer/common/uuid"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -138,8 +139,6 @@ func (s *StepIamInstanceProfile) Run(ctx context.Context, state multistep.StateB
 
 		s.roleIsAttached = true
 		state.Put("iamInstanceProfile", aws.StringValue(profileResp.InstanceProfile.InstanceProfileName))
-
-		time.Sleep(5 * time.Second)
 	}
 
 	return multistep.ActionContinue

--- a/builder/amazon/common/step_iam_instance_profile.go
+++ b/builder/amazon/common/step_iam_instance_profile.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-
 	"encoding/json"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/packer/common/uuid"
 	"github.com/hashicorp/packer/helper/multistep"

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -194,9 +194,20 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		runOpts.InstanceInitiatedShutdownBehavior = &s.InstanceInitiatedShutdownBehavior
 	}
 
-	runReq, runResp := ec2conn.RunInstancesRequest(runOpts)
-	runReq.RetryCount = 11
-	err = runReq.Send()
+	var runResp *ec2.Reservation
+	err = retry.Config{
+		Tries: 11,
+		ShouldRetry: func(err error) bool {
+			if isAWSErr(err, "InvalidParameterValue", "iamInstanceProfile") {
+				return true
+			}
+			return false
+		},
+		RetryDelay: (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
+	}.Run(ctx, func(ctx context.Context) error {
+		runResp, err = ec2conn.RunInstances(runOpts)
+		return err
+	})
 
 	if isAWSErr(err, "VPCIdNotSpecified", "No default VPC for this user") && subnetId == "" {
 		err := fmt.Errorf("Error launching source instance: a valid Subnet Id was not specified")


### PR DESCRIPTION
Fix and replace retry mechanism with new logic that only retries whenever the error is iamInstanceProfile as InvalidParameterValue. This allowed me to remove the 5 seconds sleep when adding the iam instance profile.

Closes #8359 