### PR TITLE
Fixed the formatting for one of the examples.

### DIFF
--- a/website/source/docs/commands/console.html.md
+++ b/website/source/docs/commands/console.html.md
@@ -62,7 +62,7 @@ your example_template's variable section:
 },
 ...
 ```
-and you enter `{{user `myvar`}}` in the Packer console, you'll see the value of
+and you enter ```{{user `myvar`}}``` in the Packer console, you'll see the value of
 myvar:
 
 ```


### PR DESCRIPTION
Just a backtick formatting fix for [this page](https://www.packer.io/docs/commands/console.html)'s first example.