### PR TITLE
Fix bad header indentation

### DIFF
--- a/website/source/docs/provisioners/puppet-server.html.md.erb
+++ b/website/source/docs/provisioners/puppet-server.html.md.erb
@@ -108,7 +108,7 @@ listed below:
 
 <%= partial "partials/provisioners/common-config" %>
 
-    ## Execute Command
+## Execute Command
 
 By default, Packer uses the following command (broken across multiple lines for
 readability) to execute Puppet:


### PR DESCRIPTION
Resolves an issue where the header on https://www.packer.io/docs/provisioners/puppet-server.html shows up as a code block.

<img width="911" alt="Screen Shot 2019-12-01 at 22 14 40" src="https://user-images.githubusercontent.com/32345766/69911970-03cb8a00-1488-11ea-96e5-1daa1ab95d68.png">
