### PR TITLE
make sure we continue to default to Megabytes for qemu disk size to p…

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -149,10 +149,11 @@ type Config struct {
 	// one of the other listed interfaces. Using the `scsi` interface under
 	// these circumstances will cause the build to fail.
 	DiskInterface string `mapstructure:"disk_interface" required:"false"`
-	// The size in bytes, suffixes of the first letter of common byte types
-	// like "k" or "K", "M" for megabytes, G for gigabytes, T for terabytes.
-	// Will create the of the hard disk of the VM. By default, this is
-	// `40960M` (40 GB).
+	// The size in bytes of the hard disk of the VM. Suffix with the first
+	// letter of common byte types. Use "k" or "K" for kilobytes, "M" for
+	// megabytes, G for gigabytes, and T for terabytes. If no value is provided
+	// for disk_size, Packer uses a default of `40960M` (40 GB). If a disk_size
+	// number is provided with no units, Packer will default to Megabytes.
 	DiskSize string `mapstructure:"disk_size" required:"false"`
 	// The cache mode to use for disk. Allowed values include any of
 	// `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By

--- a/website/source/partials/builder/qemu/_Config-not-required.html.md
+++ b/website/source/partials/builder/qemu/_Config-not-required.html.md
@@ -47,10 +47,11 @@
     one of the other listed interfaces. Using the `scsi` interface under
     these circumstances will cause the build to fail.
     
--   `disk_size` (string) - The size in bytes, suffixes of the first letter of common byte types
-    like "k" or "K", "M" for megabytes, G for gigabytes, T for terabytes.
-    Will create the of the hard disk of the VM. By default, this is
-    `40960M` (40 GB).
+-   `disk_size` (string) - The size in bytes of the hard disk of the VM. Suffix with the first
+    letter of common byte types. Use "k" or "K" for kilobytes, "M" for
+    megabytes, G for gigabytes, and T for terabytes. If no value is provided
+    for disk_size, Packer uses a default of `40960M` (40 GB). If a disk_size
+    number is provided with no units, Packer will default to Megabytes.
     
 -   `disk_cache` (string) - The cache mode to use for disk. Allowed values include any of
     `writethrough`, `writeback`, `none`, `unsafe` or `directsync`. By


### PR DESCRIPTION
In v1.4.5 we defaulted to megabytes for the size of a qemu disk. Keep this default, if the value being read does not have units.

Addresses concerns raised in https://github.com/hashicorp/packer/issues/5969#issuecomment-560460901
