### PR TITLE
clarify docs by removing unclear string

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -70,10 +70,9 @@ type Config struct {
 	// manually set nvme_device_path and device_path.
 	NVMEDevicePath string `mapstructure:"nvme_device_path" required:"false"`
 	// Build a new volume instead of starting from an existing AMI root volume
-	// snapshot. Default false. If true, source_ami is no longer used and the
-	// following options become required: ami_virtualization_type,
-	// pre_mount_commands and root_volume_size. The below options are also
-	// required in this mode only:
+	// snapshot. Default false. If true, source_ami/source_ami_filter are no
+	// longer used and the following options become required:
+	// ami_virtualization_type, pre_mount_commands and root_volume_size.
 	FromScratch bool `mapstructure:"from_scratch" required:"false"`
 	// Options to supply the mount command when mounting devices. Each option
 	// will be prefixed with -o and supplied to the mount command ran by

--- a/website/source/partials/builder/amazon/chroot/_Config-not-required.html.md
+++ b/website/source/partials/builder/amazon/chroot/_Config-not-required.html.md
@@ -39,10 +39,9 @@
     manually set nvme_device_path and device_path.
     
 -   `from_scratch` (bool) - Build a new volume instead of starting from an existing AMI root volume
-    snapshot. Default false. If true, source_ami is no longer used and the
-    following options become required: ami_virtualization_type,
-    pre_mount_commands and root_volume_size. The below options are also
-    required in this mode only:
+    snapshot. Default false. If true, source_ami/source_ami_filter are no
+    longer used and the following options become required:
+    ami_virtualization_type, pre_mount_commands and root_volume_size.
     
 -   `mount_options` ([]string) - Options to supply the mount command when mounting devices. Each option
     will be prefixed with -o and supplied to the mount command ran by


### PR DESCRIPTION
Clarify documentation. I think this line was referring to the options already mentioned in the doc string.

Closes #8427
