### PR TITLE
Revert "fix: persist default drive/device"

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -266,10 +266,13 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 				arg = defaultArgs[key].([]string)
 			}
 			inArgs[key] = arg
-		} else {
-			if key == "-device" || key == "-drive" {
-				inArgs[key] = append(defaultArgs[key].([]string), inArgs[key]...)
-			}
+		}
+	}
+
+	// Check if we are missing the netDevice #6804
+	if x, ok := inArgs["-device"]; ok {
+		if !strings.Contains(strings.Join(x, ""), config.NetDevice) {
+			inArgs["-device"] = append(inArgs["-device"], fmt.Sprintf("%s,netdev=user.0", config.NetDevice))
 		}
 	}
 


### PR DESCRIPTION
Revert a change that was supposed to make things easier and ended up causing more side effects than expected.

Closes #8436
