### PR TITLE
iam:GetInstanceProfile is now required

### DIFF
--- a/website/source/docs/builders/amazon.html.md
+++ b/website/source/docs/builders/amazon.html.md
@@ -202,7 +202,10 @@ work, but specifics will depend on your use-case.
 {
     "Sid": "PackerIAMPassRole",
     "Effect": "Allow",
-    "Action": "iam:PassRole",
+    "Action": [
+        "iam:PassRole",
+        "iam:GetInstanceProfile"
+    ],
     "Resource": [
         "*"
     ]


### PR DESCRIPTION
When #8247 was merged it made it so that in addition to `iam:PassRole` `iam:GetInstanceProfile` is now also a required permission, even if you're not using the temporary IAM profiles:

https://github.com/hashicorp/packer/blob/0bea6022eccd52f8bbd065309abba2129caa5874/builder/amazon/common/step_iam_instance_profile.go#L32-L37

When we upgraded from v1.3.x to v1.4.5 our AMI builds began failing with:

> `09:50:26  Build 'ami__ubuntu-2018.12.18__bionic' errored: Couldn't find specified instance profile: AccessDenied: User: arn:aws:sts::XXXX:assumed-role/YYYY/i-06a44245bb31ef259 is not authorized to perform: iam:GetInstanceProfile on resource: instance profile YYYY-profile\n	status code: 403`

Adding `iam:GetInstanceProfile` to our policy along with `iam:PassRole` allowed our builds to proceed again.

cc @SwampDragons 