### PR TITLE
Remove unnecessary 1 sec sleep in VirtualBox exporting step

### DIFF
--- a/builder/virtualbox/common/step_export.go
+++ b/builder/virtualbox/common/step_export.go
@@ -3,10 +3,8 @@ package common
 import (
 	"context"
 	"fmt"
-	"log"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
@@ -46,9 +44,6 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 		return multistep.ActionContinue
 	}
 
-	// Wait a second to ensure VM is really shutdown.
-	log.Println("1 second timeout to ensure VM is really shutdown")
-	time.Sleep(1 * time.Second)
 	ui.Say("Preparing to export machine...")
 
 	// Clear out the Packer-created forwarding rule


### PR DESCRIPTION
Since we have a timeout mechanism in the shutdown step, I believe the VM will be always shutdown when it gets to the exporting step. 
It's just 1 second but every second we remove is a second less of waiting time. 

Related to #8449 and 88e65ef59b90e65d1894390a2c748398a7c7df5f