### PR TITLE
post-processor/docker-push: drop unused test helper functions

### DIFF
--- a/post-processor/docker-push/post-processor_test.go
+++ b/post-processor/docker-push/post-processor_test.go
@@ -10,19 +10,6 @@ import (
 	dockerimport "github.com/hashicorp/packer/post-processor/docker-import"
 )
 
-func testConfig() map[string]interface{} {
-	return map[string]interface{}{}
-}
-
-func testPP(t *testing.T) *PostProcessor {
-	var p PostProcessor
-	if err := p.Configure(testConfig()); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	return &p
-}
-
 func testUi() *packer.BasicUi {
 	return &packer.BasicUi{
 		Reader: new(bytes.Buffer),


### PR DESCRIPTION
Removes two unused test helper functions from `post-processor/docker-push'.