### PR TITLE
Fix floppy doc markdown typo

### DIFF
--- a/common/floppy_config.go
+++ b/common/floppy_config.go
@@ -22,7 +22,7 @@ import (
 type FloppyConfig struct {
 	// A list of files to place onto a floppy disk that is attached when the VM
 	// is booted. Currently, no support exists for creating sub-directories on
-	// the floppy. Wildcard characters (\*, ?, and \[\]) are allowed. Directory
+	// the floppy. Wildcard characters (\\*, ?, and \[\]) are allowed. Directory
 	// names are also allowed, which will add all the files found in the
 	// directory to the floppy.
 	FloppyFiles []string `mapstructure:"floppy_files"`
@@ -30,7 +30,7 @@ type FloppyConfig struct {
 	// similar to the `floppy_files` option except that the directory structure
 	// is preserved. This is useful for when your floppy disk includes drivers
 	// or if you just want to organize it's contents as a hierarchy. Wildcard
-	// characters (\*, ?, and \[\]) are allowed. The maximum summary size of
+	// characters (\\*, ?, and \[\]) are allowed. The maximum summary size of
 	// all files in the listed directories are the same as in `floppy_files`.
 	FloppyDirectories []string `mapstructure:"floppy_dirs"`
 	FloppyLabel       string   `mapstructure:"floppy_label"`

--- a/website/source/partials/common/_FloppyConfig-not-required.html.md
+++ b/website/source/partials/common/_FloppyConfig-not-required.html.md
@@ -2,7 +2,7 @@
 
 -   `floppy_files` ([]string) - A list of files to place onto a floppy disk that is attached when the VM
     is booted. Currently, no support exists for creating sub-directories on
-    the floppy. Wildcard characters (\*, ?, and \[\]) are allowed. Directory
+    the floppy. Wildcard characters (\\*, ?, and \[\]) are allowed. Directory
     names are also allowed, which will add all the files found in the
     directory to the floppy.
     
@@ -10,7 +10,7 @@
     similar to the `floppy_files` option except that the directory structure
     is preserved. This is useful for when your floppy disk includes drivers
     or if you just want to organize it's contents as a hierarchy. Wildcard
-    characters (\*, ?, and \[\]) are allowed. The maximum summary size of
+    characters (\\*, ?, and \[\]) are allowed. The maximum summary size of
     all files in the listed directories are the same as in `floppy_files`.
     
 -   `floppy_label` (string) - Floppy Label


### PR DESCRIPTION
The markdown wasn't correct and the character `*` was making the text italic. The `*` should be part of the text instead. 

https://www.packer.io/docs/builders/virtualbox-iso.html#floppy_files