### PR TITLE
update documentation for arm images builder

### DIFF
--- a/website/source/partials/builders/_community_builders.html.md
+++ b/website/source/partials/builders/_community_builders.html.md
@@ -1,7 +1,9 @@
 ### Community Builders
 
-- [ARM builder](https://github.com/mkaczanowski/packer-builder-arm) - A builder
+- [ARM builder]() - A builder
   for creating ARM images
+  * [packer-builder-arm-image](https://github.com/solo-io/packer-builder-arm-image) - simple builder lets you extend on existing system images.
+  * [packer-builder-arm](https://github.com/mkaczanowski/packer-builder-arm) - flexible builder lets you extend or build images from scratch with variety of options (ie. custom partition table).
 
 - [vSphere builder](https://github.com/jetbrains-infra/packer-builder-vsphere) -
   A builder for interacting directly with the vSphere API rather than the esx

--- a/website/source/partials/builders/_community_builders.html.md
+++ b/website/source/partials/builders/_community_builders.html.md
@@ -1,7 +1,6 @@
 ### Community Builders
 
-- [ARM builder]() - A builder
-  for creating ARM images
+- ARM builders
   * [packer-builder-arm-image](https://github.com/solo-io/packer-builder-arm-image) - simple builder lets you extend on existing system images.
   * [packer-builder-arm](https://github.com/mkaczanowski/packer-builder-arm) - flexible builder lets you extend or build images from scratch with variety of options (ie. custom partition table).
 

--- a/website/source/partials/builders/_community_builders.html.md
+++ b/website/source/partials/builders/_community_builders.html.md
@@ -1,6 +1,6 @@
 ### Community Builders
 
-- [ARM builder](https://github.com/solo-io/packer-builder-arm-image) - A builder
+- [ARM builder](https://github.com/mkaczanowski/packer-builder-arm) - A builder
   for creating ARM images
 
 - [vSphere builder](https://github.com/jetbrains-infra/packer-builder-vsphere) -


### PR DESCRIPTION
This is a proposal to replace the solo-io repo with a plugin that I wrote recently.

## Why not contributing to solo-io plugin?
A few reasons:
* there is a lot of copy pastes in the repo with the intent of re-usability (ex. ISO module for handling base image). This creates some level of confusion and combined with another portion of copy-pastes over the codebase makes the code to be harder to understand than it really is.
* functionality limitations - it seems the plugin was written to support the model where a base image (".iso") exists and it's being reused. Also there are assumptions made to how the partition layout looks like (this varies a lot across boards etc)
* it seems the only system supported is ~ubuntu/debian for raspberry pi
* the documentation is there but it's unclear in some places (like how flasher is supposed to work etc)
* the code doesn't build with trunk (behind packer v4 iirc)

## How is the `mkaczanowski/packer-builder-arm` better?
At first it tackles mentioned above issues. It's pretty extendable and works for variety of ARM boards with different OS'es etc.

So far I tested it with:
* raspberry pi
* parallella board
* odroid xu4 + odroid u3
* wandboard quad
* beaglebone black
* nvidia jetson

with ubuntu, rasbpian and archlinux. Each board has a bit different settings, like start sector or flashing process, so as you can see the flexibility is the key.

## Request for doc update
Just to be clear, I think the `solo-io` plugins is pretty good, however I think because of the limitations and issues I mentioned above, it's reasonable to update documentation and let people know there is something imho better.