### PR TITLE
Add optional parameter http_ip in docs

### DIFF
--- a/website/source/partials/common/_HTTPConfig-not-required.html.md
+++ b/website/source/partials/common/_HTTPConfig-not-required.html.md
@@ -15,3 +15,5 @@
     are `8000` and `9000`, respectively.
     
 -   `http_port_max` (int) - HTTP Port Max
+
+-   `http_ip` (string) - HTTP IP


### PR DESCRIPTION
I noticed in the [Docs](https://www.packer.io/docs/builders/virtualbox-iso.html#http-directory-configuration) there is missing one optional parameter "http_ip"