### PR TITLE
Add version selection for chef-client provisioner

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -34,13 +34,13 @@ type guestOSTypeConfig struct {
 var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 	provisioner.UnixOSType: {
 		executeCommand: "{{if .Sudo}}sudo {{end}}chef-client --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "curl -L https://omnitruck.chef.io/install.sh | {{if .Sudo}}sudo {{end}}bash",
+		installCommand: "curl -L https://omnitruck.chef.io/install.sh | {{if .Sudo}}sudo {{end}}bash -s --{{if .Version}} -v {{.Version}}{{end}}",
 		knifeCommand:   "{{if .Sudo}}sudo {{end}}knife {{.Args}} {{.Flags}}",
 		stagingDir:     "/tmp/packer-chef-client",
 	},
 	provisioner.WindowsOSType: {
 		executeCommand: "c:/opscode/chef/bin/chef-client.bat --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install\"",
+		installCommand: "powershell.exe -Command \". { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; Install-Project{{if .Version}} -version {{.Version}}{{end}}\"",
 		knifeCommand:   "c:/opscode/chef/bin/knife.bat {{.Args}} {{.Flags}}",
 		stagingDir:     "C:/Windows/Temp/packer-chef-client",
 	},
@@ -77,6 +77,7 @@ type Config struct {
 	StagingDir                 string   `mapstructure:"staging_directory"`
 	ValidationClientName       string   `mapstructure:"validation_client_name"`
 	ValidationKeyPath          string   `mapstructure:"validation_key_path"`
+	Version                    string   `mapstructure:"version"`
 
 	ctx interpolate.Context
 }
@@ -114,7 +115,8 @@ type ExecuteTemplate struct {
 }
 
 type InstallChefTemplate struct {
-	Sudo bool
+	Sudo    bool
+	Version string
 }
 
 type KnifeTemplate struct {
@@ -256,7 +258,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 	serverUrl := p.config.ServerUrl
 
 	if !p.config.SkipInstall {
-		if err := p.installChef(ui, comm); err != nil {
+		if err := p.installChef(ui, comm, p.config.Version); err != nil {
 			return fmt.Errorf("Error installing Chef: %s", err)
 		}
 	}
@@ -604,12 +606,13 @@ func (p *Provisioner) executeChef(ui packer.Ui, comm packer.Communicator, config
 	return nil
 }
 
-func (p *Provisioner) installChef(ui packer.Ui, comm packer.Communicator) error {
+func (p *Provisioner) installChef(ui packer.Ui, comm packer.Communicator, version string) error {
 	ui.Message("Installing Chef...")
 	ctx := context.TODO()
 
 	p.config.ctx.Data = &InstallChefTemplate{
-		Sudo: !p.config.PreventSudo,
+		Sudo:    !p.config.PreventSudo,
+		Version: version,
 	}
 	command, err := interpolate.Render(p.config.InstallCommand, &p.config.ctx)
 	if err != nil {

--- a/provisioner/chef-client/provisioner.hcl2spec.go
+++ b/provisioner/chef-client/provisioner.hcl2spec.go
@@ -43,6 +43,7 @@ type FlatConfig struct {
 	StagingDir                 *string                `mapstructure:"staging_directory" cty:"staging_directory"`
 	ValidationClientName       *string                `mapstructure:"validation_client_name" cty:"validation_client_name"`
 	ValidationKeyPath          *string                `mapstructure:"validation_key_path" cty:"validation_key_path"`
+	Version                    *string                `mapstructure:"version" cty:"version"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -88,6 +89,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"staging_directory":              &hcldec.AttrSpec{Name: "staging_directory", Type: cty.String, Required: false},
 		"validation_client_name":         &hcldec.AttrSpec{Name: "validation_client_name", Type: cty.String, Required: false},
 		"validation_key_path":            &hcldec.AttrSpec{Name: "validation_key_path", Type: cty.String, Required: false},
+		"version":                        &hcldec.AttrSpec{Name: "version", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/website/source/docs/provisioners/chef-client.html.md.erb
+++ b/website/source/docs/provisioners/chef-client.html.md.erb
@@ -149,6 +149,9 @@ configuration is actually required.
     machine. If this is NOT set, then it is your responsibility via other means
     (shell provisioner, etc.) to get a validation key to where Chef expects it.
 
+-   `version` (string) - The version of Chef to be installed. By default this
+    is empty which will install the latest version of Chef.
+
 <%= partial "partials/provisioners/common-config" %>
 
 ## Chef Configuration


### PR DESCRIPTION
This PR allows to set a version for the chef-client to be installed. This was already possible with chef-solo.

Closes #6513
Closes #7664
