### PR TITLE
prepare_changelog: Update regex to work with GNU grep

### DIFF
--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -30,7 +30,7 @@ fi
 get_prs(){
     # git log --merges v0.10.2...c3861d167533fb797b0fae0c380806625712e5f7 |
     git log --merges HEAD...${LAST_RELEASE} |
-    grep -o "Merge pull request #\(\d\+\)" | awk -F\# '{print $2}' | while read line
+    grep -o "Merge pull request #\([0-9]\+\)" | awk -F\# '{print $2}' | while read line
     do
         grep -q "GH-${line}" CHANGELOG.md
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
Simple change to the grep command to use basic digit regex
as opposed to PCRE compatible `\d`, which is default on BSD grep.

Before changes
```bash
> ./scripts/prepare_changelog.sh v1.4.5
```

After changes
```bash
> ./scripts/prepare_changelog.sh v1.4.5
https://github.com/hashicorp/packer/pull/8411

https://github.com/hashicorp/packer/pull/8430

https://github.com/hashicorp/packer/pull/8444

https://github.com/hashicorp/packer/pull/8438

https://github.com/hashicorp/packer/pull/8390

https://github.com/hashicorp/packer/pull/8365
```