### PR TITLE
post-processor/digitalocean-import: drop unused test functions

### DIFF
--- a/post-processor/digitalocean-import/post-processor_test.go
+++ b/post-processor/digitalocean-import/post-processor_test.go
@@ -1,31 +1,10 @@
 package digitaloceanimport
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/hashicorp/packer/packer"
 )
-
-func testConfig() map[string]interface{} {
-	return map[string]interface{}{}
-}
-
-func testPP(t *testing.T) *PostProcessor {
-	var p PostProcessor
-	if err := p.Configure(testConfig()); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	return &p
-}
-
-func testUi() *packer.BasicUi {
-	return &packer.BasicUi{
-		Reader: new(bytes.Buffer),
-		Writer: new(bytes.Buffer),
-	}
-}
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
 	var _ packer.PostProcessor = new(PostProcessor)


### PR DESCRIPTION
This removes three unused test functions from `post-processor/digitalocean-import`.