### PR TITLE
Return exit code 1 when builder type is not found

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -166,6 +166,30 @@ func TestBuildExceptFileCommaFlags(t *testing.T) {
 	}
 }
 
+func TestBuildExceptNonExistingBuilder(t *testing.T) {
+	c := &BuildCommand{
+		Meta: testMetaFile(t),
+	}
+
+	args := []string{
+		"-parallel=false",
+		`-except=`,
+		filepath.Join(testFixture("build-only"), "not-found.json"),
+	}
+
+	defer cleanup()
+
+	if code := c.Run(args); code != 1 {
+		t.Errorf("Expected to find exit code 1, found %d", code)
+	}
+	if !fileExists("chocolate.txt") {
+		t.Errorf("Expected to find chocolate.txt")
+	}
+	if fileExists("vanilla.txt") {
+		t.Errorf("NOT expected to find vanilla.tx")
+	}
+}
+
 // fileExists returns true if the filename is found
 func fileExists(filename string) bool {
 	if _, err := os.Stat(filename); err == nil {
@@ -181,6 +205,9 @@ func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {
 		Builder: func(n string) (packer.Builder, error) {
 			if n == "file" {
 				return &file.Builder{}, nil
+			}
+			if n == "non-existing" {
+				return nil, fmt.Errorf("builder type not found")
 			}
 			return &null.Builder{}, nil
 		},

--- a/command/test-fixtures/build-only/not-found.json
+++ b/command/test-fixtures/build-only/not-found.json
@@ -1,0 +1,66 @@
+{
+    "builders": [
+        {
+            "name": "chocolate",
+            "type": "file",
+            "content": "chocolate",
+            "target": "chocolate.txt"
+        },
+        {
+            "name": "vanilla",
+            "type": "non-existing",
+            "content": "vanilla",
+            "target": "vanilla.txt"
+        }
+    ],
+    "post-processors": [
+        [
+            {
+                "name": "apple",
+                "type": "shell-local",
+                "inline": [
+                    "echo apple > apple.txt"
+                ]
+            },
+            {
+                "name": "peach",
+                "type": "shell-local",
+                "inline": [
+                    "echo peach > peach.txt"
+                ]
+            }
+        ],
+        [
+            {
+                "name": "pear",
+                "type": "shell-local",
+                "inline": [
+                    "echo pear > pear.txt"
+                ]
+            }
+        ],
+        [
+            {
+                "only": [
+                    "vanilla"
+                ],
+                "name": "tomato",
+                "type": "shell-local",
+                "inline": [
+                    "echo tomato > tomato.txt"
+                ]
+            }
+        ],
+        [
+            {
+                "only": [
+                    "chocolate"
+                ],
+                "type": "shell-local",
+                "inline": [
+                    "echo unnamed > unnamed.txt"
+                ]
+            }
+        ]
+    ]
+}

--- a/command/test-fixtures/build-only/not-found.json
+++ b/command/test-fixtures/build-only/not-found.json
@@ -16,31 +16,6 @@
     "post-processors": [
         [
             {
-                "name": "apple",
-                "type": "shell-local",
-                "inline": [
-                    "echo apple > apple.txt"
-                ]
-            },
-            {
-                "name": "peach",
-                "type": "shell-local",
-                "inline": [
-                    "echo peach > peach.txt"
-                ]
-            }
-        ],
-        [
-            {
-                "name": "pear",
-                "type": "shell-local",
-                "inline": [
-                    "echo pear > pear.txt"
-                ]
-            }
-        ],
-        [
-            {
                 "only": [
                     "vanilla"
                 ],


### PR DESCRIPTION
When a builder type is not found, the exit code is now also saved to the map of errors to make Packer return the same exit code.

Closes #8472 