### PR TITLE
Retry command execution when VM session is locked

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -203,11 +203,11 @@ func (d *VBox42Driver) VBoxManageWithOutput(args ...string) (string, error) {
 
 	ctx := context.TODO()
 	err := retry.Config{
-		Tries: 11,
+		Tries: 5,
 		ShouldRetry: func(err error) bool {
-			return isSessionLocked(stderr)
+			return isLockedBySession(stderr)
 		},
-		RetryDelay: (&retry.Backoff{InitialBackoff: 30 * time.Second, MaxBackoff: 2 * time.Minute, Multiplier: 2}).Linear,
+		RetryDelay: (&retry.Backoff{InitialBackoff: 1 * time.Minute, MaxBackoff: 2 * time.Minute, Multiplier: 2}).Linear,
 	}.Run(ctx, func(ctx context.Context) error {
 		return cmd.Run()
 	})
@@ -234,9 +234,9 @@ func (d *VBox42Driver) VBoxManageWithOutput(args ...string) (string, error) {
 	return stdoutString, err
 }
 
-func isSessionLocked(stderr bytes.Buffer) bool {
+func isLockedBySession(stderr bytes.Buffer) bool {
 	stderrString := strings.TrimSpace(stderr.String())
-	return strings.Contains(stderrString, "VBOX_E_INVALID_OBJECT_STATE") && strings.Contains(stderrString, "LockMachine")
+	return strings.Contains(stderrString, "LockMachine") || strings.Contains(stderrString, "already locked by a session")
 }
 
 func (d *VBox42Driver) Verify() error {

--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -190,7 +190,7 @@ func (d *VBox42Driver) VBoxManage(args ...string) error {
 	err := retry.Config{
 		Tries: 5,
 		ShouldRetry: func(err error) bool {
-			return isLockedBySession(err.Error())
+			return strings.Contains(err.Error(), "VBOX_E_INVALID_OBJECT_STATE")
 		},
 		RetryDelay: func() time.Duration { return 2 * time.Minute },
 	}.Run(ctx, func(ctx context.Context) error {
@@ -230,10 +230,6 @@ func (d *VBox42Driver) VBoxManageWithOutput(args ...string) (string, error) {
 	log.Printf("stderr: %s", stderrString)
 
 	return stdoutString, err
-}
-
-func isLockedBySession(err string) bool {
-	return strings.Contains(err, "VBOX_E_INVALID_OBJECT_STATE")
 }
 
 func (d *VBox42Driver) Verify() error {

--- a/builder/virtualbox/common/shutdown_config.go
+++ b/builder/virtualbox/common/shutdown_config.go
@@ -41,5 +41,9 @@ func (c *ShutdownConfig) Prepare(ctx *interpolate.Context) []error {
 		c.ShutdownTimeout = 5 * time.Minute
 	}
 
+	if c.PostShutdownDelay == 0 {
+		c.PostShutdownDelay = 2 * time.Second
+	}
+
 	return nil
 }

--- a/builder/virtualbox/common/shutdown_config_test.go
+++ b/builder/virtualbox/common/shutdown_config_test.go
@@ -50,7 +50,7 @@ func TestShutdownConfigPrepare_PostShutdownDelay(t *testing.T) {
 		t.Fatalf("err: %#v", errs)
 	}
 	if c.PostShutdownDelay != 2*time.Second {
-		t.Fatalf("bad PostShutdownDelay should be 2 seconds but was %s", c.PostShutdownDelay)
+		t.Fatalf("bad: PostShutdownDelay should be 2 seconds but was %s", c.PostShutdownDelay)
 	}
 
 	// Test with a good one

--- a/builder/virtualbox/common/shutdown_config_test.go
+++ b/builder/virtualbox/common/shutdown_config_test.go
@@ -49,8 +49,8 @@ func TestShutdownConfigPrepare_PostShutdownDelay(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("err: %#v", errs)
 	}
-	if c.PostShutdownDelay.Nanoseconds() != 0 {
-		t.Fatalf("bad: %s", c.PostShutdownDelay)
+	if c.PostShutdownDelay != 2*time.Second {
+		t.Fatalf("bad PostShutdownDelay should be 2 seconds but was %s", c.PostShutdownDelay)
 	}
 
 	// Test with a good one


### PR DESCRIPTION
Whenever there's a session locking the VM, the driver should retry executing the command until the lock is released. If that's doesn't happen, after 5 retries, the current error will be returned to the parent method. 

Also, moving 2 seconds sleep after VM stop command to default config of `post_shutdown_delay` used [here](https://github.com/hashicorp/packer/blob/master/builder/virtualbox/common/step_shutdown.go#L72). 

With these changes, I expect to avoid other situations that be locked by session error.

Closes #8282
Closes #8059