### PR TITLE
Remove duplicated retry mechanism when deleting VM from VirtualBox

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -76,14 +76,7 @@ func (d *VBox42Driver) CreateSCSIController(vmName string, name string) error {
 }
 
 func (d *VBox42Driver) Delete(name string) error {
-	ctx := context.TODO()
-	return retry.Config{
-		Tries:      5,
-		RetryDelay: (&retry.Backoff{InitialBackoff: 1 * time.Second, MaxBackoff: 1 * time.Second, Multiplier: 2}).Linear,
-	}.Run(ctx, func(ctx context.Context) error {
-		err := d.VBoxManage("unregistervm", name, "--delete")
-		return err
-	})
+	return d.VBoxManage("unregistervm", name, "--delete")
 }
 
 func (d *VBox42Driver) Iso() (string, error) {


### PR DESCRIPTION
I realized the retry mechanism when deleting the VM was duplicated after the changes from my previous PR (https://github.com/hashicorp/packer/pull/8483) 

This retry was also added to fix a locked by session error reported in https://github.com/hashicorp/packer/issues/5501 and fixed in https://github.com/hashicorp/packer/pull/5512.