### PR TITLE
Remove unnecessary source_path validation for virtualbox-ovf

### DIFF
--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -5,7 +5,6 @@ package ovf
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	vboxcommon "github.com/hashicorp/packer/builder/virtualbox/common"
@@ -83,8 +82,8 @@ type Config struct {
 	// VBoxManage import. This can be useful for passing keepallmacs or
 	// keepnatmacs options for existing ovf images.
 	ImportOpts string `mapstructure:"import_opts" required:"false"`
-	// The path to an OVF or OVA file that acts as the
-	// source of this build. This currently must be a local file.
+	// The filepath or URL to an OVF or OVA file that acts as the
+	// source of this build.
 	SourcePath string `mapstructure:"source_path" required:"true"`
 	// The path where the OVA should be saved
 	// after download. By default, it will go in the packer cache, with a hash of
@@ -161,11 +160,6 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	if c.SourcePath == "" {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("source_path is required"))
-	}
-
-	if _, err := os.Stat(c.SourcePath); err != nil {
-		packer.MultiErrorAppend(errs,
-			fmt.Errorf("Source file '%s' needs to exist at time of config validation! %v", c.SourcePath, err))
 	}
 
 	validMode := false

--- a/builder/virtualbox/ovf/config_test.go
+++ b/builder/virtualbox/ovf/config_test.go
@@ -65,28 +65,6 @@ func TestNewConfig_sourcePath(t *testing.T) {
 		t.Fatalf("should error with empty `source_path`")
 	}
 
-	// Want this to fail on validation
-	c = testConfig(t)
-	c["source_path"] = "/i/dont/exist"
-	_, warns, err = NewConfig(c)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err == nil {
-		t.Fatalf("Nonexistent file should throw a validation error!")
-	}
-
-	// Bad
-	c = testConfig(t)
-	c["source_path"] = "ftp://i/dont/exist"
-	_, warns, err = NewConfig(c)
-	if len(warns) > 0 {
-		t.Fatalf("bad: %#v", warns)
-	}
-	if err == nil {
-		t.Fatalf("should error")
-	}
-
 	// Good
 	tf := getTempFile(t)
 	defer os.Remove(tf.Name())

--- a/website/source/partials/builder/virtualbox/ovf/_Config-required.html.md
+++ b/website/source/partials/builder/virtualbox/ovf/_Config-required.html.md
@@ -7,6 +7,6 @@
     file or an URL, in which case checksum_type must be set to file; the
     go-getter will download it and use the first hash found.
     
--   `source_path` (string) - The path to an OVF or OVA file that acts as the
-    source of this build. This currently must be a local file.
+-   `source_path` (string) - The filepath or URL to an OVF or OVA file that acts as the
+    source of this build.
     


### PR DESCRIPTION
I believe the issue https://github.com/hashicorp/packer/issues/5753 was closed by https://github.com/hashicorp/packer/pull/6999. On the other hand, the PR also added a validation that removed the possibility to use URL as `source_path` for virtualbox-ovf builders. 
Since [go-getter](https://github.com/hashicorp/go-getter) already validates filepath and URL, the validation is no longer necessary inside the builder.

Closes #5753