### PR TITLE
builder/azure: Remove double override of GalleryImageVersionsClient.PollDuration

### DIFF
--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -237,7 +237,7 @@ func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string
 	azureClient.GalleryImagesClient.RequestInspector = withInspection(maxlen)
 	azureClient.GalleryImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GalleryImagesClient.UserAgent)
-	azureClient.GalleryImageVersionsClient.Client.PollingDuration = PollingDuration
+	azureClient.GalleryImagesClient.Client.PollingDuration = PollingDuration
 
 	keyVaultURL, err := url.Parse(cloud.KeyVaultEndpoint)
 	if err != nil {


### PR DESCRIPTION
Closes #7865

This change fixes an issues where custom timeouts set for the GalleryImagesVersionClient was being over written by the default client poll duration.

Packer build output before the fix:
```
==> azure-arm:  -> MDI ID used for SIG publish     :
==> azure-arm:  -> SIG publish resource group     : 'test-pkr'
==> azure-arm:  -> SIG gallery name     : 'PackerTestGallery'
==> azure-arm:  -> SIG image name     : 'packer-windows-test'
==> azure-arm:  -> SIG image version     : '1.0.1'
==> azure-arm:  -> SIG replication regions    : '[eastus westeurope australiaeast westcentralus]'
==> azure-arm:
[...]
==> azure-arm: Future#WaitForCompletion: context has been cancelled:
StatusCode=200 -- Original Error: context deadline exceeded
==> azure-arm: Provisioning step had errors: Running the cleanup
provisioner, if present...
==> azure-arm:
==> azure-arm: Cleanup requested, deleting resource group ...
==> azure-arm: Resource group has been deleted.
Build 'azure-arm' errored: Future#WaitForCompletion: context has been
cancelled: StatusCode=200 -- Original Error: context deadline exceeded

==> Some builds didn't complete successfully and had errors:
--> azure-arm: Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded

==> Builds finished but no artifacts were created.

```

Packer build output after the fix:
```bash
==> azure-arm:  -> SIG publish resource group     : 'test-pkr'
==> azure-arm:  -> SIG gallery name     : 'PackerTestGallery'
==> azure-arm:  -> SIG image name     : 'packer-windows-test'
==> azure-arm:  -> SIG image version     : '1.0.2'
==> azure-arm:  -> SIG replication regions    : '[eastus westeurope
australiaeast westcentralus]'
==> azure-arm:  -> Shared Gallery Image Version ID :
[...]
==> azure-arm: Deleting resource group ...
==> azure-arm:  -> ResourceGroupName :
'packer-Resource-Group-pcfrlpqn0m'
==> azure-arm:
==> azure-arm: The resource group was created by Packer, deleting ...
==> azure-arm: Deleting the temporary OS disk ...
==> azure-arm:  -> OS Disk : skipping, managed disk was used...
==> azure-arm: Deleting the temporary Additional disk ...
==> azure-arm:  -> Additional Disk : skipping, managed disk was used...
Build 'azure-arm' finished.

==> Builds finished. The artifacts of successful builds are:
--> azure-arm: Azure.ResourceManagement.VMImage:

```