### PR TITLE
hcl2template/common_test.go: make testParse a helper

### DIFF
--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -134,6 +134,7 @@ type parseTest struct {
 }
 
 func testParse(t *testing.T, tests []parseTest) {
+	t.Helper()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
so that when an error happens we see the 'real' calling function.

I forgot this in the #8423 !