### PR TITLE
builder/docker: Fix interface conversion issue when getting config from state bag

### DIFF
--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -77,7 +77,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 
 	// Setup the state bag and initial state for the steps
 	state := new(multistep.BasicStateBag)
-	state.Put("config", b.config)
+	state.Put("config", &b.config)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
 

--- a/builder/docker/step_commit.go
+++ b/builder/docker/step_commit.go
@@ -14,11 +14,17 @@ type StepCommit struct {
 }
 
 func (s *StepCommit) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	config, ok := state.Get("config").(*Config)
+	if !ok {
+		err := fmt.Errorf("error encountered obtaining docker config")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
 	driver := state.Get("driver").(Driver)
 	containerId := state.Get("container_id").(string)
-	config := state.Get("config").(*Config)
-	ui := state.Get("ui").(packer.Ui)
-
 	if config.WindowsContainer {
 		// docker can't commit a running Windows container
 		err := driver.StopContainer(containerId)

--- a/builder/docker/step_connect_docker.go
+++ b/builder/docker/step_connect_docker.go
@@ -12,7 +12,13 @@ import (
 type StepConnectDocker struct{}
 
 func (s *StepConnectDocker) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(*Config)
+	config, ok := state.Get("config").(*Config)
+	if !ok {
+		err := fmt.Errorf("error encountered obtaining docker config")
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
 	containerId := state.Get("container_id").(string)
 	driver := state.Get("driver").(Driver)
 	tempDir := state.Get("temp_dir").(string)

--- a/builder/docker/step_pull.go
+++ b/builder/docker/step_pull.go
@@ -12,9 +12,14 @@ import (
 type StepPull struct{}
 
 func (s *StepPull) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	config := state.Get("config").(*Config)
-	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
+	config, ok := state.Get("config").(*Config)
+	if !ok {
+		err := fmt.Errorf("error encountered obtaining docker config")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
 
 	if !config.Pull {
 		log.Println("Pull disabled, won't docker pull")
@@ -38,6 +43,7 @@ func (s *StepPull) Run(ctx context.Context, state multistep.StateBag) multistep.
 		config.LoginPassword = password
 	}
 
+	driver := state.Get("driver").(Driver)
 	if config.Login || config.EcrLogin {
 		ui.Message("Logging in...")
 		err := driver.Login(


### PR DESCRIPTION
This change fixes a regression in the Docker builder. 

#### **Sample Configuration**
```json
{
  "variables": {
    "variable_one": "this is the song that never eeeeeeends"
  },
  "builders": [
    {
      "type":        "docker",
      "image": "ubuntu:xenial",
      "run_command": [ "-d", "-i", "-t", "--entrypoint=/bin/bash", "{{.Image}}" ],
      "commit": true,
      "changes": ["ENTRYPOINT [\"/bin/bash\", \"/var/www/start.sh\"]"]
    }
  ],
    "provisioners": [
        {
            "type": "shell",
            "inline": "ls -alh /tmp/",
            "execute_command": "cat {{.Path}}; chmod +x {{.Path}}; {{.Vars}} {{.Path}}"
        }
    ]
}
```

#### Build Results Before Change (Master)
```bash
> packer build build.json
...
2019/12/17 17:41:50 ui error: Build 'docker' errored: unexpected EOF
2019/12/17 17:41:50 machine readable: error-count []string{"1"}
2019/12/17 17:41:50 ui error: 
==> Some builds didn't complete successfully and had errors:
2019/12/17 17:41:50 machine readable: docker,error []string{"unexpected EOF"}
2019/12/17 17:41:50 ui error: --> docker: unexpected EOF
2019/12/17 17:41:50 ui: 
==> Builds finished but no artifacts were created.
2019/12/17 17:41:50 [INFO] (telemetry) Finalizing.
2019/12/17 17:41:50 waiting for all plugin processes to complete...
2019/12/17 17:41:50 /home/wilken/bin/packer: plugin process exited



!!!!!!!!!!!!!!!!!!!!!!!!!!! PACKER CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Packer crashed! This is always indicative of a bug within Packer.
A crash log has been placed at "crash.log" relative to your current
working directory. It would be immensely helpful if you could please
report the crash with Packer[1] so that we can fix this.

[1]: https://github.com/hashicorp/packer/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! PACKER CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

#### Build Results After Change
```bash
> packer build build.json
Legacy JSON Configuration Will Be Used.
The template will be parsed in the legacy configuration style. This style 
Will continue to work but users are encouraged to move to the new style, 
See: https://packer.io/guides/hcl2 .
docker: output will be in this color.

==> docker: Creating a temporary directory for sharing data...
==> docker: Pulling Docker image: ubuntu:xenial
    docker: xenial: Pulling from library/ubuntu
    docker: Digest: sha256:e10375c69cf9e22989c82b0a87c932a21e33619ee322d6c7ce6a61456f54c30c
    docker: Status: Image is up to date for ubuntu:xenial
    docker: docker.io/library/ubuntu:xenial
==> docker: Starting docker container...
    docker: Run command: docker run -v /home/wilken/.packer.d/tmp773000846:/packer-files -d -i -t --entrypoint=/bin/bash ubuntu:xenial
    docker: Container ID: a2bdc05e437fb8c61434aa7c4d8bdaf94a45f01060c740fe5cb7df7827ce8b16
==> docker: Using docker communicator to connect: 172.17.0.2
==> docker: Provisioning with shell script: /tmp/packer-shell439851641
    docker: #!/bin/sh -e
    docker: ls -alh /tmp/
    docker: total 12K
    docker: drwxrwxrwt 1 root root 4.0K Dec 17 22:43 .
    docker: drwxr-xr-x 1 root root 4.0K Dec 17 22:43 ..
    docker: -rwxr-xr-x 1 root 1000   27 Dec 17 22:43 script_3805.sh
==> docker: Committing the container
    docker: Image ID: sha256:8519191f074ef5df07c6b2dd18f5be3bb2ad0f2e9d42ee0bed09749070926754
==> docker: Killing the container: a2bdc05e437fb8c61434aa7c4d8bdaf94a45f01060c740fe5cb7df7827ce8b16
Build 'docker' finished.

==> Builds finished. The artifacts of successful builds are:
--> docker: Imported Docker image: sha256:8519191f074ef5df07c6b2dd18f5be3bb2ad0f2e9d42ee0bed09749070926754
```