### PR TITLE
fix pps

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -136,11 +136,12 @@ func (c *BuildCommand) GetBuilds(path string) ([]packer.Build, int) {
 		return c.GetBuildsFromHCL(path)
 	}
 
-	c.Ui.Say(`Legacy JSON Configuration Will Be Used.
-The template will be parsed in the legacy configuration style. This style
-will continue to work but users are encouraged to move to the new style.
-See: https://packer.io/guides/hcl
-`)
+	// TODO: uncomment in v1.5.1 once we've polished HCL a bit more.
+	// c.Ui.Say(`Legacy JSON Configuration Will Be Used.
+	// The template will be parsed in the legacy configuration style. This style
+	// will continue to work but users are encouraged to move to the new style.
+	// See: https://packer.io/guides/hcl
+	// `)
 
 	// Parse the template
 	var tpl *template.Template

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -45,6 +45,7 @@ func (p *Parser) CoreBuildPostProcessors(blocks []*PostProcessorBlock) ([]packer
 			PType:         pp.PType,
 		})
 	}
+
 	return res, diags
 }
 
@@ -74,6 +75,10 @@ func (p *Parser) getBuilds(cfg *PackerConfig) ([]packer.Build, hcl.Diagnostics) 
 				continue
 			}
 			postProcessors, moreDiags := p.CoreBuildPostProcessors(build.PostProcessors)
+			pps := [][]packer.CoreBuildPostProcessor{}
+			if len(postProcessors) > 0 {
+				pps = [][]packer.CoreBuildPostProcessor{postProcessors}
+			}
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue
@@ -83,7 +88,7 @@ func (p *Parser) getBuilds(cfg *PackerConfig) ([]packer.Build, hcl.Diagnostics) 
 				Type:           src.Type,
 				Builder:        builder,
 				Provisioners:   provisioners,
-				PostProcessors: [][]packer.CoreBuildPostProcessor{postProcessors},
+				PostProcessors: pps,
 				Variables:      cfg.Variables,
 			}
 			res = append(res, pcb)


### PR DESCRIPTION
@nywilken  Found a bug where hcl2 would delete original artifacts even if no postprocessors were being run. 

Fixed it. 

Also removed the UI warning about deprecating template json. Given that HCL2 is still rough and not fully feature-complete, I don't want to get users riled up over a deprecation that's likely over a year away still. 