### PR TITLE
Remove redundant placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
     [GH-8342]
 * builder/hyperone: Update builder schema and tags [GH-8444]
 * builder/qemu: Add display template option for qemu. [GH-7676]
+* builder/qemu: Disk Size is now read as a string to support units. [GH-8320]
+    [GH-7546]
 * builder/qemu: Add fixer to convert disk size from int to string [GH-8390]
 * builder/qemu: When a user adds a new drive in qemuargs, process it to make
     sure that necessary settings are applied to that drive. [GH-8380]
@@ -53,8 +55,6 @@
 ### BACKWARDS INCOMPATIBILITIES:
 * builder/amazon: Complete deprecation of clean_ami_name template func
     [GH-8320] [GH-8193]
-* builder/qemu: Disk Size is now read as a string to support units. [GH-8320]
-    [GH-7546]
 * core: Changes have been made to both the Prepare() method signature on the
     builder interface and on the Provision() method signature on the
     provisioner interface. [GH-7866]

--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -125,8 +125,6 @@ type KnifeTemplate struct {
 func (p *Provisioner) ConfigSpec() hcldec.ObjectSpec { return p.config.FlatMapstructure().HCL2Spec() }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
-	// Create passthrough for build-generated data
-	p.config.ctx.Data = packer.BasicPlaceholderData()
 	err := config.Decode(&p.config, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &p.config.ctx,

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -91,9 +91,6 @@ func (p *Provisioner) defaultExecuteCommand() string {
 func (p *Provisioner) ConfigSpec() hcldec.ObjectSpec { return p.config.FlatMapstructure().HCL2Spec() }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
-	// Create passthrough for build-generated data
-	p.config.ctx.Data = packer.BasicPlaceholderData()
-
 	err := config.Decode(&p.config, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &p.config.ctx,

--- a/provisioner/puppet-masterless/provisioner.go
+++ b/provisioner/puppet-masterless/provisioner.go
@@ -154,8 +154,6 @@ type EnvVarsTemplate struct {
 func (p *Provisioner) ConfigSpec() hcldec.ObjectSpec { return p.config.FlatMapstructure().HCL2Spec() }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
-	// Create passthrough for build-generated data
-	p.config.ctx.Data = packer.BasicPlaceholderData()
 	err := config.Decode(&p.config, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &p.config.ctx,

--- a/provisioner/puppet-server/provisioner.go
+++ b/provisioner/puppet-server/provisioner.go
@@ -148,9 +148,6 @@ type EnvVarsTemplate struct {
 func (p *Provisioner) ConfigSpec() hcldec.ObjectSpec { return p.config.FlatMapstructure().HCL2Spec() }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
-	// Create passthrough for build-generated data
-	p.config.ctx.Data = packer.BasicPlaceholderData()
-
 	err := config.Decode(&p.config, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &p.config.ctx,


### PR DESCRIPTION
Remove calls that overwrite the context. This is handled inside config.Decode now. 