### PR TITLE
docs/provisioners/ansible: Add playbook to basic example.

### DIFF
--- a/website/source/docs/provisioners/ansible.html.md.erb
+++ b/website/source/docs/provisioners/ansible.html.md.erb
@@ -25,6 +25,7 @@ provisioner.
 This is a fully functional template that will provision an image on
 DigitalOcean. Replace the mock `api_token` value with your own.
 
+Example Packer template:
 ``` json
 {
   "provisioners": [
@@ -43,6 +44,23 @@ DigitalOcean. Replace the mock `api_token` value with your own.
     }
   ]
 }
+```
+
+Example playbook:
+
+```
+---
+# playbook.yml
+- name: "Provision Image"
+  hosts: default
+  become: true
+
+  tasks:
+  - name: install Apache
+    package:
+      name: "httpd"
+      state: present
+
 ```
 
 ## Configuration Reference


### PR DESCRIPTION
Closes #8507

