### PR TITLE
Remove config dependency from inside StepImport

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -185,7 +185,7 @@ func (d *VBox42Driver) VBoxManage(args ...string) error {
 		ShouldRetry: func(err error) bool {
 			return strings.Contains(err.Error(), "VBOX_E_INVALID_OBJECT_STATE")
 		},
-		RetryDelay: func() time.Duration { return 2 * time.Minute },
+		RetryDelay: func() time.Duration { return 1 * time.Minute },
 	}.Run(ctx, func(ctx context.Context) error {
 		_, err := d.VBoxManageWithOutput(args...)
 		return err

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -86,8 +86,9 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Url:          []string{b.config.SourcePath},
 		},
 		&StepImport{
-			Name:        b.config.VMName,
-			ImportFlags: b.config.ImportFlags,
+			Name:           b.config.VMName,
+			ImportFlags:    b.config.ImportFlags,
+			KeepRegistered: b.config.KeepRegistered,
 		},
 		&vboxcommon.StepAttachGuestAdditions{
 			GuestAdditionsMode:      b.config.GuestAdditionsMode,

--- a/builder/virtualbox/ovf/step_import.go
+++ b/builder/virtualbox/ovf/step_import.go
@@ -11,8 +11,9 @@ import (
 
 // This step imports an OVF VM into VirtualBox.
 type StepImport struct {
-	Name        string
-	ImportFlags []string
+	Name           string
+	ImportFlags    []string
+	KeepRegistered bool
 
 	vmName string
 }
@@ -42,11 +43,10 @@ func (s *StepImport) Cleanup(state multistep.StateBag) {
 
 	driver := state.Get("driver").(vboxcommon.Driver)
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
 
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)
-	if (config.KeepRegistered) && (!cancelled && !halted) {
+	if (s.KeepRegistered) && (!cancelled && !halted) {
 		ui.Say("Keeping virtual machine registered with VirtualBox host (keep_registered = true)")
 		return
 	}

--- a/builder/virtualbox/ovf/step_import.go
+++ b/builder/virtualbox/ovf/step_import.go
@@ -42,7 +42,7 @@ func (s *StepImport) Cleanup(state multistep.StateBag) {
 
 	driver := state.Get("driver").(vboxcommon.Driver)
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(*Config)
+	config := state.Get("config").(Config)
 
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)

--- a/builder/virtualbox/ovf/step_import_test.go
+++ b/builder/virtualbox/ovf/step_import_test.go
@@ -14,11 +14,8 @@ func TestStepImport_impl(t *testing.T) {
 
 func TestStepImport(t *testing.T) {
 	state := testState(t)
-	cfg := testConfig(t)
-	var c Config
-	c.Prepare(cfg)
 	state.Put("vm_path", "foo")
-	state.Put("config", c)
+
 	step := new(StepImport)
 	step.Name = "bar"
 
@@ -52,17 +49,12 @@ func TestStepImport_Cleanup(t *testing.T) {
 	state := testState(t)
 	state.Put("vm_path", "foo")
 
-	cfg := testConfig(t)
-	var c Config
-	c.Prepare(cfg)
-
 	step := new(StepImport)
 	step.vmName = "bar"
 
 	driver := state.Get("driver").(*vboxcommon.DriverMock)
 
-	c.KeepRegistered = true
-	state.Put("config", c)
+	step.KeepRegistered = true
 	step.Cleanup(state)
 	if driver.DeleteCalled {
 		t.Fatal("delete should not be called")


### PR DESCRIPTION
Prior to the HCL2 PR, the `Config` attribute of the virtualbox-ovf builder was a pointer and the `Cleanup` method for the StepImport was still converting the state bag config to a pointer causing now panic when trying to do so.

output logs before changes
```
==> virtualbox-ovf: Deleting output directory...
Build 'virtualbox-ovf' errored: unexpected EOF
Cleanly cancelled builds after being interrupted.
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: panic: interface conversion: interface {} is ovf.Config, not *ovf.Config
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin:
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: goroutine 48 [running]:
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: github.com/hashicorp/packer/builder/virtualbox/ovf.(*StepImport).Cleanup(0xc00025b580, 0x833a280, 0xc00053c120)
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: 	/Users/sylviamoss/go/src/github.com/hashicorp/packer/builder/virtualbox/ovf/step_import.go:45 +0x329
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: github.com/hashicorp/packer/helper/multistep.(*BasicRunner).Run(0xc00053c270, 0x835cfc0, 0xc00025b540, 0x833a280, 0xc00053c120)
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: 	/Users/sylviamoss/go/src/github.com/hashicorp/packer/helper/multistep/basic_runner.go:79 +0x2c6
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: github.com/hashicorp/packer/builder/virtualbox/ovf.(*Builder).Run(0xc0001a4580, 0x835cfc0, 0xc00025b540, 0x8377fc0, 0xc00053c0f0, 0x82e9980, 0xc000534d40, 0x203000, 0x203000, 0x203000, ...)
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: 	/Users/sylviamoss/go/src/github.com/hashicorp/packer/builder/virtualbox/ovf/builder.go:166 +0x12bc
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: github.com/hashicorp/packer/packer/rpc.(*BuilderServer).Run(0xc000240100, 0x1, 0xc0000583f0, 0x0, 0x0)
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: 	/Users/sylviamoss/go/src/github.com/hashicorp/packer/packer/rpc/builder.go:117 +0x27c
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: reflect.Value.call(0xc0000d4300, 0xc0004320f0, 0x13, 0x7c72011, 0x4, 0xc0000a0f18, 0x3, 0x3, 0xc000510678, 0x4006e3c, ...)
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: 	/usr/local/go/src/reflect/value.go:460 +0x5f6
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: reflect.Value.Call(0xc0000d4300, 0xc0004320f0, 0x13, 0xc000510718, 0x3, 0x3, 0xc00043b260, 0xc000569b00, 0xc000569b88)
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: 	/usr/local/go/src/reflect/value.go:321 +0xb4
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: net/rpc.(*service).call(0xc000240140, 0xc000448190, 0xc0000583b0, 0xc0000583c0, 0xc0001a8200, 0xc000444120, 0x7049c80, 0xc0000583bc, 0x18a, 0x6f887e0, ...)
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: 	/usr/local/go/src/net/rpc/server.go:377 +0x16f
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: created by net/rpc.(*Server).ServeCodec
2019/12/19 12:43:58 packer-builder-virtualbox-ovf plugin: 	/usr/local/go/src/net/rpc/server.go:474 +0x42b
2019/12/19 12:43:58 [INFO] (telemetry) ending virtualbox-ovf
```

output logs after changes

```
Cancelling build after receiving interrupt
2019/12/19 12:51:38 packer-builder-virtualbox-ovf plugin: Received interrupt signal (count: 1). Ignoring.
2019/12/19 12:51:38 Cancelling builder after context cancellation context canceled
2019/12/19 12:51:38 packer-builder-virtualbox-ovf plugin: [WARN] Interrupt detected, quitting waiting for SSH.
2019/12/19 12:51:38 packer-builder-virtualbox-ovf plugin: Executing VBoxManage: []string{"controlvm", "Demoshop-1576756040", "poweroff"}
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: [DEBUG] SSH handshake err: ssh: handshake failed: read tcp 127.0.0.1:56515->127.0.0.1:2766: read: connection reset by peer
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: stdout:
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: stderr: 0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: failed to unlock port lockfile: close tcp 127.0.0.1:2766: use of closed network connection
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: failed to unlock port lockfile: close tcp 127.0.0.1:5934: use of closed network connection
==> virtualbox-ovf: Deregistering and deleting imported VM...
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: Executing VBoxManage: []string{"unregistervm", "Demoshop-1576756040", "--delete"}
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: stdout:
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: stderr: VBoxManage: error: Cannot unregister the machine 'Demoshop-1576756040' while it is locked
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component MachineWrap, interface IMachine, callee nsISupports
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: VBoxManage: error: Context: "Unregister(CleanupMode_DetachAllReturnHardDisksOnly, ComSafeArrayAsOutParam(aMedia))" at line 154 of file VBoxManageMisc.cpp
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: Retryable error: VBoxManage error: VBoxManage: error: Cannot unregister the machine 'Demoshop-1576756040' while it is locked
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component MachineWrap, interface IMachine, callee nsISupports
2019/12/19 12:51:39 packer-builder-virtualbox-ovf plugin: VBoxManage: error: Context: "Unregister(CleanupMode_DetachAllReturnHardDisksOnly, ComSafeArrayAsOutParam(aMedia))" at line 154 of file VBoxManageMisc.cpp
2019/12/19 12:51:41 packer-builder-virtualbox-ovf plugin: [DEBUG] SSH wait cancelled. Exiting loop.
2019/12/19 12:52:39 packer-builder-virtualbox-ovf plugin: Executing VBoxManage: []string{"unregistervm", "Demoshop-1576756040", "--delete"}
2019/12/19 12:52:39 packer-builder-virtualbox-ovf plugin: stdout:
2019/12/19 12:52:39 packer-builder-virtualbox-ovf plugin: stderr: 0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
==> virtualbox-ovf: Deleting output directory...
2019/12/19 12:52:39 [INFO] (telemetry) ending virtualbox-ovf
Build 'virtualbox-ovf' errored: Build was cancelled.
Cleanly cancelled builds after being interrupted.
2019/12/19 12:52:39 [INFO] (telemetry) Finalizing.
2019/12/19 12:52:40 waiting for all plugin processes to complete...
2019/12/19 12:52:40 /Users/sylviamoss/go/src/github.com/hashicorp/packer/bin/packer: plugin process exited
```

Also, I decreased the waiting time to retry a command on VBoxManage. I realized it was taking more time than necessary.

----- updates
As suggested, the dependency over the `config` data was an anti-pattern and the better solution was removing it and making `KeepRegistered` a step variable.