### PR TITLE
[post-processor/vsphere-template] Simplify method to use vm.MarkAsTemplate (optionally)

### DIFF
--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -37,7 +37,7 @@ type Config struct {
 	SnapshotEnable      bool   `mapstructure:"snapshot_enable"`
 	SnapshotName        string `mapstructure:"snapshot_name"`
 	SnapshotDescription string `mapstructure:"snapshot_description"`
-	ReregisterVM        bool   `mapstructure:"reregister_vm" default:true`
+	ReregisterVM        bool   `mapstructure:"reregister_vm" default:"true"`
 
 	ctx interpolate.Context
 }

--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -37,6 +37,7 @@ type Config struct {
 	SnapshotEnable      bool   `mapstructure:"snapshot_enable"`
 	SnapshotName        string `mapstructure:"snapshot_name"`
 	SnapshotDescription string `mapstructure:"snapshot_description"`
+	ReregisterVM        bool   `mapstructure:"reregister_vm" default:true`
 
 	ctx interpolate.Context
 }
@@ -135,7 +136,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 			Folder: p.config.Folder,
 		},
 		NewStepCreateSnapshot(artifact, p),
-		NewStepMarkAsTemplate(artifact),
+		NewStepMarkAsTemplate(artifact, p),
 	}
 	runner := common.NewRunnerWithPauseFn(steps, p.config.PackerConfig, ui, state)
 	runner.Run(ctx, state)

--- a/post-processor/vsphere-template/post-processor.hcl2spec.go
+++ b/post-processor/vsphere-template/post-processor.hcl2spec.go
@@ -25,7 +25,7 @@ type FlatConfig struct {
 	SnapshotEnable      *bool             `mapstructure:"snapshot_enable" cty:"snapshot_enable"`
 	SnapshotName        *string           `mapstructure:"snapshot_name" cty:"snapshot_name"`
 	SnapshotDescription *string           `mapstructure:"snapshot_description" cty:"snapshot_description"`
-	ReregisterVM        *bool             `mapstructure:"reregister_vm" cty:"reregister_vm"`
+	ReregisterVM        *bool             `mapstructure:"reregister_vm" default:"true" cty:"reregister_vm"`
 }
 
 // FlatMapstructure returns a new FlatConfig.

--- a/post-processor/vsphere-template/post-processor.hcl2spec.go
+++ b/post-processor/vsphere-template/post-processor.hcl2spec.go
@@ -25,6 +25,7 @@ type FlatConfig struct {
 	SnapshotEnable      *bool             `mapstructure:"snapshot_enable" cty:"snapshot_enable"`
 	SnapshotName        *string           `mapstructure:"snapshot_name" cty:"snapshot_name"`
 	SnapshotDescription *string           `mapstructure:"snapshot_description" cty:"snapshot_description"`
+	ReregisterVM        *bool             `mapstructure:"reregister_vm" cty:"reregister_vm"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -55,6 +56,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"snapshot_enable":            &hcldec.AttrSpec{Name: "snapshot_enable", Type: cty.Bool, Required: false},
 		"snapshot_name":              &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"snapshot_description":       &hcldec.AttrSpec{Name: "snapshot_description", Type: cty.String, Required: false},
+		"reregister_vm":              &hcldec.AttrSpec{Name: "reregister_vm", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -44,7 +44,6 @@ func (s *stepMarkAsTemplate) Run(ctx context.Context, state multistep.StateBag) 
 	folder := state.Get("folder").(*object.Folder)
 	dcPath := state.Get("dcPath").(string)
 
-
 	vm, err := findRuntimeVM(cli, dcPath, s.VMName, s.RemoteFolder)
 	if err != nil {
 		state.Put("error", err)

--- a/website/source/docs/post-processors/vsphere-template.html.md
+++ b/website/source/docs/post-processors/vsphere-template.html.md
@@ -76,6 +76,12 @@ Optional:
 -   `snapshot_description` (string) - Description for the snapshot. Required
     when `snapshot_enable` is `true`
 
+-    `reregister_vm` (boolean) - Use the method of unregister VM and reregister
+    as a template, rather than using the markAsTemplate method in vmWare.
+    NOTE: If you are getting permission denied errors when trying to mark as a
+    template, but it works fine in the vSphere UI, try setting this to false.
+    Default is true.
+
 ## Using the vSphere Template with local builders
 
 Once the [vSphere](/docs/post-processors/vsphere.html) takes an artifact from


### PR DESCRIPTION
This changes the method used to mark a VM as a template to use the *much* simpler `vm.MarkAsTemplate` like the govc cli is doing here: https://github.com/vmware/govmomi/blob/master/govc/vm/markastemplate.go I think this functionality was added in ~2016, so its possible that this "unregister/register" process was required prior to that.

In our case, we have a limited access service account that does not have permission to "unregister" a VM.

This should not require any new tests, because it does not actually change any interfaces or any functionality.

Closes #8505 

~tommy