### PR TITLE
Proxmox builder: Use global next vm id

### DIFF
--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -18,7 +18,7 @@ type stepStartVM struct{}
 
 func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
-	client := state.Get("proxmoxClient").(*proxmox.Client)
+	client := state.Get("proxmoxClient").(proxmox.PveClient)
 	c := state.Get("config").(*Config)
 
 	agent := 1

--- a/builder/proxmox/step_start_vm_id_mock.go
+++ b/builder/proxmox/step_start_vm_id_mock.go
@@ -1,0 +1,129 @@
+package proxmox
+import (
+	"io"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+)
+
+type vmIdMock struct {
+	getVmList func() (map[string]interface{})
+	getNextID func(int) (int)
+}
+func (m vmIdMock) StartVm(vmref *proxmox.VmRef) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) GetVmList() (map[string]interface{}, error) {
+	return m.getVmList(), nil
+}
+func (m vmIdMock) GetNextID(currentId int) (int, error) {
+	return m.getNextID(currentId), nil
+}
+func (m vmIdMock) createVMDisks(string, map[string]interface{}) (int, error) {
+	return 0, nil
+}
+func (m vmIdMock) CheckVmRef(vmref *proxmox.VmRef) (error) {
+	return nil
+}
+func (m vmIdMock) CloneQemuVm(*proxmox.VmRef, map[string]interface{}) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) CreateLxcContainer(string, map[string]interface{}) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) CreateQemuVm(string, map[string]interface{}) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) CreateTemplate(*proxmox.VmRef) error {
+	return nil
+}
+func (m vmIdMock) CreateVMDisk(string, string, string, map[string]interface{}) (error) {
+	return nil
+}
+func (m vmIdMock) DeleteVMDisks(string, []string) (error) {
+	return nil
+}
+func (m vmIdMock) DeleteVm(*proxmox.VmRef) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) GetJsonRetryable(string, *map[string]interface{}, int) error {
+	return nil
+}
+func (m vmIdMock) GetNodeList() (map[string]interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) GetTaskExitstatus(string) (interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) GetVmAgentNetworkInterfaces(*proxmox.VmRef) ([]proxmox.AgentNetworkInterface, error) {
+	return nil, nil
+}
+func (m vmIdMock) GetVmConfig(*proxmox.VmRef) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) GetVmInfo(*proxmox.VmRef) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) GetVmRefByName(string) (*proxmox.VmRef, error) {
+	return nil, nil
+}
+func (m vmIdMock) GetVmSpiceProxy(*proxmox.VmRef) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) GetVmState(*proxmox.VmRef) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) Login(string, string, string) (error) {
+	return nil
+}
+func (m vmIdMock) MonitorCmd(*proxmox.VmRef, string) (map[string]interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) MoveQemuDisk(*proxmox.VmRef, string, string) (interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) ResetVm(*proxmox.VmRef) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) ResizeQemuDisk(*proxmox.VmRef, string, int) (interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) ResumeVm(*proxmox.VmRef) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) RollbackQemuVm(*proxmox.VmRef, string) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) Sendkey(*proxmox.VmRef, string) error {
+	return nil
+}
+func (m vmIdMock) SetLxcConfig(*proxmox.VmRef, map[string]interface{}) (interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) SetVmConfig(*proxmox.VmRef, map[string]interface{}) (interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) ShutdownVm(*proxmox.VmRef) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) StatusChangeVm(*proxmox.VmRef, string) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) StopVm(*proxmox.VmRef) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) SuspendVm(*proxmox.VmRef) (string, error) {
+	return "", nil
+}
+func (m vmIdMock) UpdateVMHA(*proxmox.VmRef, string) (interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) UpdateVMPool(*proxmox.VmRef, string) (interface{}, error) {
+	return nil, nil
+}
+func (m vmIdMock) Upload(string, string, string, string, io.Reader) error {
+	return nil
+}
+func (m vmIdMock) WaitForCompletion(map[string]interface{}) (string, error) {
+	return "", nil
+}
+
+var _ proxmox.PveClient = &vmIdMock{}

--- a/builder/proxmox/step_start_vm_test.go
+++ b/builder/proxmox/step_start_vm_test.go
@@ -3,6 +3,7 @@ package proxmox
 import (
 	"fmt"
 	"testing"
+	"context"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -105,4 +106,127 @@ func TestCleanupStartVM(t *testing.T) {
 			}
 		})
 	}
+}
+
+
+func TestGetNextId(t *testing.T) {
+
+	// Defines the users and their view of the clusters resources.
+	// Assume three users with limited access to the clusters resources:
+	//  - User1 owns VM 101 and 103
+	//  - User2 owns VM 102
+	//  - User3 does not own any resources yet
+	// For instance, User2 does not know that User1 owns VM 103, however, User2 can
+	// assume that other users created VMs by querying the global nextId, which is
+	// the suggested next id to use for a new VM.
+
+	resourcesUser1 := []Config { {
+		VMID:			101,
+		Pool:			"user1",
+	}, {
+		VMID:			103,
+		Pool:			"user1",
+	} }
+
+	resourcesUser2 := []Config { {
+		VMID:			102,
+		Pool:			"user2",
+	} }
+
+	//resourcesUser3 := []Config{}
+
+	// Each test case simulations creation of a new VM for a user (User1/User2/User3)
+	// Thus, not all cluster resources visible in every run, e.g., in the third
+	// run User3 is not able to see any resources, but can query the global nextId.
+
+	testCases := []struct {
+		name			string
+		clusterResources	[]Config
+
+		// set new VM id manually,
+		// mutually exclusive with clusterResources
+		manualVmId		int
+	}{
+		{
+			name:			"Because User1 created the latest VM with the highest id, vmRef state of User1s new VM should be set to nextId",
+			clusterResources:	resourcesUser1,
+		},
+		{
+			name:			"Because User2s maxId is not the most recent vm, vmRef state of User2s new VM should be set to nextId",
+			clusterResources:	resourcesUser2,
+		},
+		{
+			name:			"when custom vmId is specified, vmRef state should contain this vmId",
+			manualVmId:	199,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// with the set of users and cluster resources (vms 101,102,103),
+			// the global next id (expected next id) is 104 for all users
+			var globalNextId int = 104
+
+			idMock := vmIdMock {
+				// loops through the resources for this testcase/user
+				// and simulates the PVE api json response
+				getVmList: func() (map[string]interface{}) {
+					var vmMap map[string]interface{}
+					var data []interface{}
+					for _, r := range(testCase.clusterResources) {
+						vm := map[string]interface{}{
+							"vmid": float64(r.VMID),
+							"pool": r.Pool,
+						}
+						data = append(data, vm)
+					}
+					vmMap = map[string]interface{}{ "data":data }
+					return vmMap
+				},
+				getNextID: func(currentId int) (int) {
+					return globalNextId
+				},
+			}
+
+			state := new(multistep.BasicStateBag)
+			state.Put("ui", packer.TestUi(t))
+			state.Put("proxmoxClient", idMock)
+
+			// put an empty config by default to use next free id
+			state.Put("config", &Config{})
+
+			if testCase.manualVmId != 0 {
+				// define a manual id for thew new VM
+				state.Put("config", &Config {VMID: testCase.manualVmId})
+			}
+
+			// simulate the start of a new VM
+			step := stepStartVM{}
+			step.Run(context.TODO(), state)
+
+			// receive the vmRef for the new VM
+			// and fetch the modified config state
+			vmRef := state.Get("vmRef").(*proxmox.VmRef)
+			config := state.Get("config").(*Config)
+
+			// the VMID in the config should be the same as the id in the vmRef
+			if config.VMID != vmRef.VmId() {
+				t.Error("Expected id of the new vmRef to be equal to the VMID in the config")
+			}
+
+			if testCase.manualVmId == 0 {
+				// If there was no preference for an id, the automatically chosen global next id is used.
+				// The next VM id should always be greater or equal to the global next id.
+				if vmRef.VmId() < globalNextId {
+					t.Error("Expected next VM id to be greater or equal to the global nextId")
+				}
+			} else {
+				// if a manual id is used, this should be the next id
+				if vmRef.VmId() != testCase.manualVmId {
+					t.Error("Expected id of the new vmRef to be equal to the manually specified id")
+				}
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
I was struggling to create a new template because another user already created vms with ids that where bigger than the vm [ids visible to the user running the `packer build`](https://github.com/hashicorp/packer/blob/master/builder/proxmox/step_start_vm.go#L49).

The `packer build tmpl.json` failed:
```
==> proxmox: Error creating VM: 500 lvcreate 'pve/vm-143-disk-0' error:
             Logical Volume "vm-143-disk-0" already exists in volume group "pve"
```

This is reasonable, because another user created a vm with that id in the mean time. Therefore, I suggest to use the global [`/cluster/nextid`](https://pve.proxmox.com/pve-docs/api-viewer/) instead of the [maxid](https://github.com/hashicorp/packer/blob/master/builder/proxmox/step_start_vm.go#L49) of the current user.

Luckily, [`proxmox-api-go`](https://github.com/hashicorp/packer/blob/master/vendor/github.com/Telmate/proxmox-api-go/proxmox/client.go#L578) already provides the necessary code to fetch the `nextid`.

Thus, this PR changes the logic for selecting the next "free" vm id for the builder to account for additional vms not visible to the user that runs `packer build`.

Steps to reproduce:
1. Create vms with user1 in a resource pool owned by user1 alone 
2. Create more vms in a resource pool owned by user2 alone
3. Create vm template with `packer build` in the resource pool solely owned by user1

Expected results:
1. Vms created, user1s local `maxid` and the global `nextid` are increased simultaneously
2. Vms created, user2s local `maxid` and the global `nextid` are increased simultaneously. User1s `maxid` remains unchanged.
3. Vm created with a vm id `nextid + 1`

Actual results:
1. Vms created, user1s local `maxid` and the global `nextid` are increased simultaneously
2. Vms created, user2s local `maxid` and the global `nextid` are increased simultaneously. User1s `maxid` remains unchanged.
3. Vm not created, because `maxid + 1` is owned/created by user2 already

Following test scenario (to make the problem evident):
```
# fetch user1 maxid as in "builder/proxmox/step_start_vm.go#L49"
curl -s -XGET -b "$cookie" "$PM_API_URL/cluster/resources?type=vm" | jq -r '.data[].vmid'
111
112
142

# the current implementation of `packer build` would try to create
# a vm with id 143

# fetch global nextid
curl -s -XGET -b "$cookie" "$PM_API_URL/cluster/nextid" | jq -r '.data'
148

# user1 is unaware of vm 148, because user1 has no access
# to the resource pool of user2 which created vms 143,144,..,148

# user1 tries to create a vm template with maxid + 1 = 142 + 1 = 143,
# where it should create a new vm with nextid + 1 = 148 + 1 = 149
packer build tmpl.json
```

The PR still includes the call `MaxVmId` because the call to `GetNextID` requires a start id, where the local maxid of the user could be used as a starting point (if available).