### PR TITLE
update jdcloud statebag to use pointers for config, to bring in line …

### DIFF
--- a/builder/jdcloud/builder.go
+++ b/builder/jdcloud/builder.go
@@ -46,7 +46,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	state := new(multistep.BasicStateBag)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
-	state.Put("config", b.config)
+	state.Put("config", &b.config)
 
 	steps := []multistep.Step{
 

--- a/builder/jdcloud/step_create_instance.go
+++ b/builder/jdcloud/step_create_instance.go
@@ -142,7 +142,7 @@ func (s *stepCreateJDCloudInstance) Cleanup(state multistep.StateBag) {
 
 func createElasticIp(state multistep.StateBag) (string, error) {
 
-	generalConfig := state.Get("config").(Config)
+	generalConfig := state.Get("config").(*Config)
 	regionId := generalConfig.RegionId
 	credential := core.NewCredentials(generalConfig.AccessKey, generalConfig.SecretKey)
 	vpcclient := vpcClient.NewVpcClient(credential)


### PR DESCRIPTION
Most of Packer uses *config when accessing configs, so that they can be written back to. for ease of maintainability, it makes sense to make this the case for all builders.

Related: #8520 