### PR TITLE
Vagrant cloud pp config

### DIFF
--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -166,7 +166,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 
 	// Set up the state
 	state := new(multistep.BasicStateBag)
-	state.Put("config", p.config)
+	state.Put("config", &p.config)
 	state.Put("client", p.client)
 	state.Put("artifact", artifact)
 	state.Put("artifactFilePath", artifact.Files()[0])

--- a/post-processor/vagrant-cloud/step_create_version.go
+++ b/post-processor/vagrant-cloud/step_create_version.go
@@ -19,7 +19,7 @@ type stepCreateVersion struct {
 func (s *stepCreateVersion) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*VagrantCloudClient)
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 	box := state.Get("box").(*Box)
 
 	ui.Say(fmt.Sprintf("Creating version: %s", config.Version))

--- a/post-processor/vagrant-cloud/step_release_version.go
+++ b/post-processor/vagrant-cloud/step_release_version.go
@@ -17,7 +17,7 @@ func (s *stepReleaseVersion) Run(ctx context.Context, state multistep.StateBag) 
 	ui := state.Get("ui").(packer.Ui)
 	box := state.Get("box").(*Box)
 	version := state.Get("version").(*Version)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 
 	ui.Say(fmt.Sprintf("Releasing version: %s", version.Version))
 

--- a/post-processor/vagrant-cloud/step_verify_box.go
+++ b/post-processor/vagrant-cloud/step_verify_box.go
@@ -28,7 +28,7 @@ type stepVerifyBox struct {
 func (s *stepVerifyBox) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*VagrantCloudClient)
 	ui := state.Get("ui").(packer.Ui)
-	config := state.Get("config").(Config)
+	config := state.Get("config").(*Config)
 
 	ui.Say(fmt.Sprintf("Verifying box is accessible: %s", config.Tag))
 


### PR DESCRIPTION
Most of packer uses *configs so that they can be written back to. Makes sense to enforce this for postprocessors too.

On another note, I suspect that the config for the vagrant cloud pp can be removed from state altogether if we are better about passing variables to steps. This is something that would be an easy first task for a Packer contributor.

Related: #8520 