### PR TITLE
link to guides in HCL docs

### DIFF
--- a/website/source/docs/configuration/from-1.5/index.html.md
+++ b/website/source/docs/configuration/from-1.5/index.html.md
@@ -11,7 +11,10 @@ description: |-
 # HCL Configuration Language
 
 Packer uses the Hashicorp Configuration Language - HCL - designed to allow
-concise descriptions of the required steps to get to a build file.
+concise descriptions of the required steps to get to a build file. This page
+describes the features of HCL2 exhaustively, if you would like to give a quick
+try to HCL2, you can also read the quicker [HCL2 getting started
+guide](/guides/hcl).
 
 ## Builds
 


### PR DESCRIPTION
I'd like to link the HCL getting started guides from the 'more complete' HCL docs