### PR TITLE
Parse out -PACKERSPACE- before looking for exec

### DIFF
--- a/config.go
+++ b/config.go
@@ -267,6 +267,14 @@ func (c *config) discoverInternalComponents() error {
 func (c *config) pluginClient(path string) *plugin.Client {
 	originalPath := path
 
+	// Check for special case using `packer plugin PLUGIN`
+	args := []string{}
+	if strings.Contains(path, PACKERSPACE) {
+		parts := strings.Split(path, PACKERSPACE)
+		path = parts[0]
+		args = parts[1:]
+	}
+
 	// First attempt to find the executable by consulting the PATH.
 	path, err := exec.LookPath(path)
 	if err != nil {
@@ -280,14 +288,6 @@ func (c *config) pluginClient(path string) *plugin.Client {
 			log.Printf("Current exe path: %s", exePath)
 			path = filepath.Join(filepath.Dir(exePath), filepath.Base(originalPath))
 		}
-	}
-
-	// Check for special case using `packer plugin PLUGIN`
-	args := []string{}
-	if strings.Contains(path, PACKERSPACE) {
-		parts := strings.Split(path, PACKERSPACE)
-		path = parts[0]
-		args = parts[1:]
 	}
 
 	// If everything failed, just use the original path and let the error


### PR DESCRIPTION
This just removes this excessive logging line:

```
2019/12/27 14:25:06 Plugin could not be found at /usr/local/bin/packer-PACKERSPACE-plugin-PACKERSPACE-packer-builder-virtualbox-iso (exec: "/usr/local/bin/packer-PACKERSPACE-plugin-PACKERSPACE-packer-builder-virtualbox-iso": stat /usr/local/bin/packer-PACKERSPACE-plugin-PACKERSPACE-packer-builder-virtualbox-iso: no such file or directory). Checking same directory as executable.
```
... by parsing out the "-PACKERSPACE-" before looking for the executable.

NOTE: this can be reproduced by simply running `PACKER_LOG=1 packer validate somefile.json` .. in the case above, I was building a virtualbox VM, but any internal plugins will cause this message to come out. It does work eventually, it is just looking for the executable before parsing out the 'spaces' and thus causes an erroneous log message. :)