### PR TITLE
Fix permission denied for external plugins, path was empty

### DIFF
--- a/config.go
+++ b/config.go
@@ -131,12 +131,12 @@ func (c *config) discoverExternalComponents(path string) error {
 	if err != nil {
 		return err
 	}
-	for plugin, path := range pluginPaths {
-		newPath := path // this needs to be stored in a new variable for the func below
-		c.Builders[plugin] = func() (packer.Builder, error) {
+	for pluginName, pluginPath := range pluginPaths {
+		newPath := pluginPath // this needs to be stored in a new variable for the func below
+		c.Builders[pluginName] = func() (packer.Builder, error) {
 			return c.pluginClient(newPath).Builder()
 		}
-		externallyUsed = append(externallyUsed, plugin)
+		externallyUsed = append(externallyUsed, pluginName)
 	}
 	if len(externallyUsed) > 0 {
 		sort.Strings(externallyUsed)
@@ -148,12 +148,12 @@ func (c *config) discoverExternalComponents(path string) error {
 	if err != nil {
 		return err
 	}
-	for plugin, path := range pluginPaths {
-		newPath := path // this needs to be stored in a new variable for the func below
-		c.PostProcessors[plugin] = func() (packer.PostProcessor, error) {
+	for pluginName, pluginPath := range pluginPaths {
+		newPath := pluginPath // this needs to be stored in a new variable for the func below
+		c.PostProcessors[pluginName] = func() (packer.PostProcessor, error) {
 			return c.pluginClient(newPath).PostProcessor()
 		}
-		externallyUsed = append(externallyUsed, plugin)
+		externallyUsed = append(externallyUsed, pluginName)
 	}
 	if len(externallyUsed) > 0 {
 		sort.Strings(externallyUsed)
@@ -165,12 +165,12 @@ func (c *config) discoverExternalComponents(path string) error {
 	if err != nil {
 		return err
 	}
-	for plugin, path := range pluginPaths {
-		newPath := path // this needs to be stored in a new variable for the func below
-		c.Provisioners[plugin] = func() (packer.Provisioner, error) {
+	for pluginName, pluginPath := range pluginPaths {
+		newPath := pluginPath // this needs to be stored in a new variable for the func below
+		c.Provisioners[pluginName] = func() (packer.Provisioner, error) {
 			return c.pluginClient(newPath).Provisioner()
 		}
-		externallyUsed = append(externallyUsed, plugin)
+		externallyUsed = append(externallyUsed, pluginName)
 	}
 	if len(externallyUsed) > 0 {
 		sort.Strings(externallyUsed)
@@ -209,9 +209,9 @@ func (c *config) discoverSingle(glob string) (map[string]string, error) {
 		}
 
 		// Look for foo-bar-baz. The plugin name is "baz"
-		plugin := file[len(prefix):]
-		log.Printf("[DEBUG] Discovered plugin: %s = %s", plugin, match)
-		res[plugin] = match
+		pluginName := file[len(prefix):]
+		log.Printf("[DEBUG] Discovered plugin: %s = %s", pluginName, match)
+		res[pluginName] = match
 	}
 
 	return res, nil

--- a/config.go
+++ b/config.go
@@ -132,10 +132,9 @@ func (c *config) discoverExternalComponents(path string) error {
 		return err
 	}
 	for plugin, path := range pluginPaths {
-		plugin := plugin
-		path := path
+		newPath := path // this needs to be stored in a new variable for the func below
 		c.Builders[plugin] = func() (packer.Builder, error) {
-			return c.pluginClient(path).Builder()
+			return c.pluginClient(newPath).Builder()
 		}
 		externallyUsed = append(externallyUsed, plugin)
 	}
@@ -150,10 +149,9 @@ func (c *config) discoverExternalComponents(path string) error {
 		return err
 	}
 	for plugin, path := range pluginPaths {
-		plugin := plugin
-		path := path
+		newPath := path // this needs to be stored in a new variable for the func below
 		c.PostProcessors[plugin] = func() (packer.PostProcessor, error) {
-			return c.pluginClient(path).PostProcessor()
+			return c.pluginClient(newPath).PostProcessor()
 		}
 		externallyUsed = append(externallyUsed, plugin)
 	}
@@ -168,10 +166,9 @@ func (c *config) discoverExternalComponents(path string) error {
 		return err
 	}
 	for plugin, path := range pluginPaths {
-		plugin := plugin
-		path := path
+		newPath := path // this needs to be stored in a new variable for the func below
 		c.Provisioners[plugin] = func() (packer.Provisioner, error) {
-			return c.pluginClient(path).Provisioner()
+			return c.pluginClient(newPath).Provisioner()
 		}
 		externallyUsed = append(externallyUsed, plugin)
 	}

--- a/config.go
+++ b/config.go
@@ -131,10 +131,11 @@ func (c *config) discoverExternalComponents(path string) error {
 	if err != nil {
 		return err
 	}
-	for plugin := range pluginPaths {
+	for plugin, path := range pluginPaths {
 		plugin := plugin
+		path := path
 		c.Builders[plugin] = func() (packer.Builder, error) {
-			return c.pluginClient(pluginPaths[plugin]).Builder()
+			return c.pluginClient(path).Builder()
 		}
 		externallyUsed = append(externallyUsed, plugin)
 	}
@@ -148,10 +149,11 @@ func (c *config) discoverExternalComponents(path string) error {
 	if err != nil {
 		return err
 	}
-	for plugin := range pluginPaths {
+	for plugin, path := range pluginPaths {
 		plugin := plugin
+		path := path
 		c.PostProcessors[plugin] = func() (packer.PostProcessor, error) {
-			return c.pluginClient(pluginPaths[plugin]).PostProcessor()
+			return c.pluginClient(path).PostProcessor()
 		}
 		externallyUsed = append(externallyUsed, plugin)
 	}
@@ -165,10 +167,11 @@ func (c *config) discoverExternalComponents(path string) error {
 	if err != nil {
 		return err
 	}
-	for plugin := range pluginPaths {
+	for plugin, path := range pluginPaths {
 		plugin := plugin
+		path := path
 		c.Provisioners[plugin] = func() (packer.Provisioner, error) {
-			return c.pluginClient(pluginPaths[plugin]).Provisioner()
+			return c.pluginClient(path).Provisioner()
 		}
 		externallyUsed = append(externallyUsed, plugin)
 	}


### PR DESCRIPTION
Fixes #8527

This fixes the missing path on external plugins. It simplifies the "range" so that the "path" is a local variable. I believe that the pluginPaths[plugin] was not being evaluated in the right scope (not until it was being called later).

~~I am still trying to figure out why the `plugin := plugin` line was there, it was being assigned in the "for" statement directly above it. There are more examples in the discoverInternalPlugins.~~

~tommy