### PR TITLE
Add source AMI owner ID/name to build template

### DIFF
--- a/builder/amazon/common/interpolate_build_info.go
+++ b/builder/amazon/common/interpolate_build_info.go
@@ -7,10 +7,12 @@ import (
 )
 
 type BuildInfoTemplate struct {
-	BuildRegion   string
-	SourceAMI     string
-	SourceAMIName string
-	SourceAMITags map[string]string
+	BuildRegion        string
+	SourceAMI          string
+	SourceAMIName      string
+	SourceAMIOwner     string
+	SourceAMIOwnerName string
+	SourceAMITags      map[string]string
 }
 
 func extractBuildInfo(region string, state multistep.StateBag) *BuildInfoTemplate {
@@ -28,9 +30,11 @@ func extractBuildInfo(region string, state multistep.StateBag) *BuildInfoTemplat
 	}
 
 	return &BuildInfoTemplate{
-		BuildRegion:   region,
-		SourceAMI:     aws.StringValue(sourceAMI.ImageId),
-		SourceAMIName: aws.StringValue(sourceAMI.Name),
-		SourceAMITags: sourceAMITags,
+		BuildRegion:        region,
+		SourceAMI:          aws.StringValue(sourceAMI.ImageId),
+		SourceAMIName:      aws.StringValue(sourceAMI.Name),
+		SourceAMIOwner:     aws.StringValue(sourceAMI.OwnerId),
+		SourceAMIOwnerName: aws.StringValue(sourceAMI.ImageOwnerAlias),
+		SourceAMITags:      sourceAMITags,
 	}
 }

--- a/builder/amazon/common/interpolate_build_info_test.go
+++ b/builder/amazon/common/interpolate_build_info_test.go
@@ -11,8 +11,10 @@ import (
 
 func testImage() *ec2.Image {
 	return &ec2.Image{
-		ImageId: aws.String("ami-abcd1234"),
-		Name:    aws.String("ami_test_name"),
+		ImageId:         aws.String("ami-abcd1234"),
+		Name:            aws.String("ami_test_name"),
+		OwnerId:         aws.String("ami_test_owner_id"),
+		ImageOwnerAlias: aws.String("ami_test_owner_alias"),
 		Tags: []*ec2.Tag{
 			{
 				Key:   aws.String("key-1"),
@@ -49,9 +51,11 @@ func TestInterpolateBuildInfo_extractBuildInfo_withSourceImage(t *testing.T) {
 	buildInfo := extractBuildInfo("foo", state)
 
 	expected := BuildInfoTemplate{
-		BuildRegion:   "foo",
-		SourceAMI:     "ami-abcd1234",
-		SourceAMIName: "ami_test_name",
+		BuildRegion:        "foo",
+		SourceAMI:          "ami-abcd1234",
+		SourceAMIName:      "ami_test_name",
+		SourceAMIOwner:     "ami_test_owner_id",
+		SourceAMIOwnerName: "ami_test_owner_alias",
 		SourceAMITags: map[string]string{
 			"key-1": "value-1",
 			"key-2": "value-2",

--- a/website/source/docs/builders/amazon-chroot.html.md.erb
+++ b/website/source/docs/builders/amazon-chroot.html.md.erb
@@ -287,4 +287,6 @@ variables are available:
 -   `SourceAMIName` - The source AMI Name (for example
     `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
     build the AMI.
+-   `SourceAMIOwner` - The source AMI owner ID.
+-   `SourceAMIOwnerName` - The source AMI owner alias/name (for example `amazon`).
 -   `SourceAMITags` - The source AMI Tags, as a `map[string]string` object.

--- a/website/source/docs/builders/amazon-ebs.html.md.erb
+++ b/website/source/docs/builders/amazon-ebs.html.md.erb
@@ -194,6 +194,8 @@ variables are available:
 -   `SourceAMIName` - The source AMI Name (for example
     `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
     build the AMI.
+-   `SourceAMIOwner` - The source AMI owner ID.
+-   `SourceAMIOwnerName` - The source AMI owner alias/name (for example `amazon`).
 -   `SourceAMITags` - The source AMI Tags, as a `map[string]string` object.
 
 ## Tag Example

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
@@ -157,6 +157,8 @@ variables are available:
 -   `SourceAMIName` - The source AMI Name (for example
     `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
     build the AMI.
+-   `SourceAMIOwner` - The source AMI owner ID.
+-   `SourceAMIOwnerName` - The source AMI owner alias/name (for example `amazon`).
 -   `SourceAMITags` - The source AMI Tags, as a `map[string]string` object.
 
 -&gt; **Note:** Packer uses pre-built AMIs as the source for building images.

--- a/website/source/docs/builders/amazon-ebsvolume.html.md.erb
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md.erb
@@ -176,6 +176,8 @@ variables are available:
 -   `SourceAMIName` - The source AMI Name (for example
     `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
     build the AMI.
+-   `SourceAMIOwner` - The source AMI owner ID.
+-   `SourceAMIOwnerName` - The source AMI owner alias/name (for example `amazon`).
 -   `SourceAMITags` - The source AMI Tags, as a `map[string]string` object.
 
 -&gt; **Note:** Packer uses pre-built AMIs as the source for building images.

--- a/website/source/docs/builders/amazon-instance.html.md.erb
+++ b/website/source/docs/builders/amazon-instance.html.md.erb
@@ -159,6 +159,8 @@ variables are available:
 -   `SourceAMIName` - The source AMI Name (for example
     `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
     build the AMI.
+-   `SourceAMIOwner` - The source AMI owner ID.
+-   `SourceAMIOwnerName` - The source AMI owner alias/name (for example `amazon`).
 -   `SourceAMITags` - The source AMI Tags, as a `map[string]string` object.
 
 ## Custom Bundle Commands


### PR DESCRIPTION
Similar to changes made in #6088. This adds the source AMI's owner ID and alias to the build template data. This is intended to make it easier to track source image provenance when using AMI search filters.