### PR TITLE
google compute builder documentation example code cleanup

### DIFF
--- a/website/source/docs/builders/googlecompute.html.md.erb
+++ b/website/source/docs/builders/googlecompute.html.md.erb
@@ -45,8 +45,13 @@ scopes when launching the instance.
 For `gcloud`, do this via the `--scopes` parameter:
 
 ``` shell
-$ gcloud compute --project YOUR_PROJECT instances create "INSTANCE-NAME" ... \
-    --scopes "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control" \
+$ gcloud compute instances create INSTANCE-NAME \
+  --project YOUR_GCP_PROJECT \
+  --image-family ubuntu-1804-lts \
+  --image-project gce-uefi-images \
+  --network YOUR_GCP_NETWORK \
+  --zone YOUR_GCP_BAKERY_ZONE \
+  --scopes "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control"
 ```
 
 For the [Google Developers Console](https://console.developers.google.com):

--- a/website/source/docs/builders/googlecompute.html.md.erb
+++ b/website/source/docs/builders/googlecompute.html.md.erb
@@ -50,7 +50,7 @@ $ gcloud compute instances create INSTANCE-NAME \
   --image-family ubuntu-1804-lts \
   --image-project gce-uefi-images \
   --network YOUR_GCP_NETWORK \
-  --zone YOUR_GCP_BAKERY_ZONE \
+  --zone YOUR_GCP_ZONE \
   --scopes "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control"
 ```
 


### PR DESCRIPTION
This pull request cleans up the code example for the GCP Builder documentation.  Because it is a documentation PR, there are no tests to be run or issues to close.

---

Existing Documentation Code Example:

```
$ gcloud compute --project YOUR_PROJECT instances create "INSTANCE-NAME" ... \
    --scopes "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control" \
```

Issues I see as an end user reading these docs:

* the line should be broken up using Linux cli best practices which limits each line to one cli flag for readability
* the `gcloud` cli command should not be broken up with cli flags
* cli flags should be one per line and after the `gcloud` command is completed
* this causes a side scroll bar making it difficult to copy paste correctly

---

Proposed Documentation Code Example

``` 
$ gcloud compute instances create INSTANCE-NAME \
  --project YOUR_GCP_PROJECT \
  --image-family ubuntu-1804-lts \
  --image-project gce-uefi-images \
  --network YOUR_GCP_NETWORK \
  --zone YOUR_GCP_ZONE \
  --scopes "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control"
```

Reasons why I want to see this change to the docs:

* readability - everything visible without side scrolling (with the exception of the last line with scopes which will side scroll but the reader expects that as they are URLs)
* easy copy & paste into a terminal or textdoc to edit before running
* adds the GCE Image Family so I do not end up with a unknown default (GCE defaults to Debian)
* adds a secured boot base GCE image for security
* declares my network which may not be `default`
* declares my GCP Zone which normally has the GCE Bakery confined to a single GCP Project and GCP Zone