### PR TITLE
Fix: mispelled variables names in packer/build.go docs

### DIFF
--- a/packer/build.go
+++ b/packer/build.go
@@ -312,10 +312,10 @@ PostProcessorRunSeqLoop:
 			}
 
 			keep := defaultKeep
-			// When user has not set keep_input_artifuact
+			// When user has not set keep_input_artifact
 			// corePP.keepInputArtifact is nil.
 			// In this case, use the keepDefault provided by the postprocessor.
-			// When user _has_ set keep_input_atifact, go with that instead.
+			// When user _has_ set keep_input_artifact, go with that instead.
 			// Exception: for postprocessors that will fail/become
 			// useless if keep isn't true, heed forceOverride and keep the
 			// input artifact regardless of user preference.


### PR DESCRIPTION
I hate to be that `README.md` kind of guy, but there were misspelled variable references in some of the documentation and it bothered me a bit. 😄 

- `packer/build.go`
   + `keep_input_artifuact` => `keep_input_artifact`
   + `keep_input_atifact` => `keep_input_artifact`