### PR TITLE
fix winrmpass sanitization to account for empty string value.

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -495,7 +495,7 @@ func (p *Provisioner) executeAnsible(ui packer.Ui, comm packer.Communicator, pri
 	flattenedCmd := strings.Join(cmd.Args, " ")
 	sanitized := flattenedCmd
 	winRMPass, ok := p.generatedData["WinRMPassword"]
-	if ok {
+	if ok && winRMPass != "" {
 		sanitized = strings.Replace(sanitized,
 			winRMPass.(string), "*****", -1)
 	}


### PR DESCRIPTION
WinRMPass sanitizer was causing issues; just need to check for empty string. 

Closes #8537