### PR TITLE
virtualbox/vm.Builder: use config  as a non pointer to avoid a panic

### DIFF
--- a/builder/virtualbox/vm/builder.go
+++ b/builder/virtualbox/vm/builder.go
@@ -16,7 +16,7 @@ import (
 // Builder implements packer.Builder and builds the actual VirtualBox
 // images.
 type Builder struct {
-	config *Config
+	config Config
 	runner multistep.Runner
 }
 


### PR DESCRIPTION
this is a continuation to #8513

fix #8575