### PR TITLE
bump the timeout to a very high level to protect against laggy CI mac…

### DIFF
--- a/builder/vmware/common/step_shutdown_test.go
+++ b/builder/vmware/common/step_shutdown_test.go
@@ -62,7 +62,7 @@ func TestStepShutdown_command(t *testing.T) {
 	var action multistep.StepAction
 	select {
 	case action = <-resultCh:
-	case <-time.After(300 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatal("should've returned by now")
 	}
 


### PR DESCRIPTION
Same day, different time-dependent test flaking on Travis.