### PR TITLE
step_download: return without error if Urls is empty

### DIFF
--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -236,23 +236,15 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Force: b.config.PackerForce,
 			Path:  b.config.OutputDir,
 		},
-	}
-
-	if b.config.RawSingleISOUrl != "" || len(b.config.ISOUrls) > 0 {
-		steps = append(steps,
-			&common.StepDownload{
-				Checksum:     b.config.ISOChecksum,
-				ChecksumType: b.config.ISOChecksumType,
-				Description:  "ISO",
-				ResultKey:    "iso_path",
-				Url:          b.config.ISOUrls,
-				Extension:    b.config.TargetExtension,
-				TargetPath:   b.config.TargetPath,
-			},
-		)
-	}
-
-	steps = append(steps,
+		&common.StepDownload{
+			Checksum:     b.config.ISOChecksum,
+			ChecksumType: b.config.ISOChecksumType,
+			Description:  "ISO",
+			ResultKey:    "iso_path",
+			Url:          b.config.ISOUrls,
+			Extension:    b.config.TargetExtension,
+			TargetPath:   b.config.TargetPath,
+		},
 		&common.StepCreateFloppy{
 			Files:       b.config.FloppyFiles,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
@@ -367,9 +359,9 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			OutputDir:  b.config.OutputDir,
 			SkipExport: b.config.SkipExport,
 		},
+	}
 
-		// the clean up actions for each step will be executed reverse order
-	)
+	// the clean up actions for each step will be executed reverse order
 
 	// Run the steps.
 	b.runner = common.NewRunner(steps, b.config.PackerConfig, ui)

--- a/common/step_download.go
+++ b/common/step_download.go
@@ -53,12 +53,18 @@ type StepDownload struct {
 }
 
 func (s *StepDownload) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	if len(s.Url) == 0 {
+		log.Printf("No URLs were provided to Step Download. Continuing...")
+		return multistep.ActionContinue
+	}
+
 	defer log.Printf("Leaving retrieve loop for %s", s.Description)
 
 	ui := state.Get("ui").(packer.Ui)
 	ui.Say(fmt.Sprintf("Retrieving %s", s.Description))
 
 	var errs []error
+
 	for _, source := range s.Url {
 		if ctx.Err() != nil {
 			state.Put("error", fmt.Errorf("Download cancelled: %v", errs))

--- a/common/step_download_test.go
+++ b/common/step_download_test.go
@@ -63,6 +63,11 @@ func TestStepDownload_Run(t *testing.T) {
 		want      multistep.StepAction
 		wantFiles []string
 	}{
+		{"Empty URL field passes",
+			fields{Url: []string{}},
+			multistep.ActionContinue,
+			nil,
+		},
 		{"not passing a checksum passes",
 			fields{Url: []string{abs(t, "./test-fixtures/root/another.txt")}},
 			multistep.ActionContinue,


### PR DESCRIPTION
Update step_download to return an ActionContinue if the URls field is empty. This allows us to simplify the hyperv builder, and is still safe because all other builders and uses of step_download already validate that the iso url is not empty if that's what they need, most of them inside of the IsoConfig prepare function.

Closes #8562