### PR TITLE
[WIP] Fix ability to load external plugins through Packer's core configuration file `PACKER_CONFIG`

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,9 +33,9 @@ type config struct {
 	PostProcessors packer.MapOfPostProcessor `json:"post-processors"`
 }
 
-// Decodes configuration in JSON format from the given io.Reader into
+// DecodeConfig decodes configuration in JSON format from the given io.Reader into
 // the config object pointed to.
-func decodeConfig(r io.Reader, c *config) error {
+func DecodeConfig(r io.Reader, c *config) error {
 	decoder := json.NewDecoder(r)
 	return decoder.Decode(c)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDecodeConfig_basic(t *testing.T) {
+
+	packerConfig := `
+	{
+		"PluginMinPort": 10001,
+		"PluginMaxPort": 26000,
+		"disable_checkpoint": true,
+		"disable_checkpoint_signature": true
+	}`
+
+	var cfg config
+	err := DecodeConfig(strings.NewReader(packerConfig), &cfg)
+	if err != nil {
+		t.Fatalf("error encountered decoding configuration: %v", err)
+	}
+
+	var expectedCfg config
+	json.NewDecoder(strings.NewReader(packerConfig)).Decode(&expectedCfg)
+	if !reflect.DeepEqual(cfg, expectedCfg) {
+		t.Errorf("failed to load custom configuration data; expected %v got %v", expectedCfg, cfg)
+	}
+
+}
+
+func TestDecodeConfig_provisioners(t *testing.T) {
+
+	packerConfig := `
+	{
+			"provisioners": {
+					"comment": "/tmp/packer-provisioner-comment"
+			}
+	}`
+
+	var cfg config
+	err := DecodeConfig(strings.NewReader(packerConfig), &cfg)
+
+	if err != nil {
+		t.Fatalf("error encountered decoding configuration: %v", err)
+	}
+
+	if _, ok := cfg.Provisioners["comment"]; !ok {
+		t.Errorf("provisioner by the name of comment was not found")
+	}
+
+}

--- a/config_test.go
+++ b/config_test.go
@@ -2,17 +2,23 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/packer/packer"
 )
 
 func TestDecodeConfig_basic(t *testing.T) {
 
 	packerConfig := `
 	{
-		"PluginMinPort": 10001,
-		"PluginMaxPort": 26000,
+		"PluginMinPort": 10,
+		"PluginMaxPort": 25,
 		"disable_checkpoint": true,
 		"disable_checkpoint_signature": true
 	}`
@@ -31,24 +37,59 @@ func TestDecodeConfig_basic(t *testing.T) {
 
 }
 
-func TestDecodeConfig_provisioners(t *testing.T) {
+func TestDecodeConfig_plugins(t *testing.T) {
 
-	packerConfig := `
+	dir, err := ioutil.TempDir("", "random-test-dir")
+	if err != nil {
+		t.Fatalf("failed to create temporary test directory: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	plugins := [...]string{
+		filepath.Join(dir, "packer-builder-comment"),
+		filepath.Join(dir, "packer-provisioner-comment"),
+		filepath.Join(dir, "packer-post-processor-comment"),
+	}
+	for _, plugin := range plugins {
+		_, err := os.Create(plugin)
+		if err != nil {
+			t.Fatalf("failed to create temporary plugin file (%s): %v", plugin, err)
+		}
+	}
+
+	packerConfig := fmt.Sprintf(`
 	{
-			"provisioners": {
-					"comment": "/tmp/packer-provisioner-comment"
-			}
-	}`
+		"builders": {
+			"comment": %q
+		},
+		"provisioners": {
+			"comment": %q
+		},
+		"post-processors": {
+			"comment": %q
+		}
+	}`, plugins[0], plugins[1], plugins[2])
 
 	var cfg config
-	err := DecodeConfig(strings.NewReader(packerConfig), &cfg)
+	cfg.Builders = packer.MapOfBuilder{}
+	cfg.PostProcessors = packer.MapOfPostProcessor{}
+	cfg.Provisioners = packer.MapOfProvisioner{}
+	err = DecodeConfig(strings.NewReader(packerConfig), &cfg)
 
 	if err != nil {
 		t.Fatalf("error encountered decoding configuration: %v", err)
 	}
 
-	if _, ok := cfg.Provisioners["comment"]; !ok {
-		t.Errorf("provisioner by the name of comment was not found")
+	if len(cfg.RawBuilders) != 1 || !cfg.Builders.Has("comment") {
+		t.Errorf("DecodeConfig failed to load external builders; got %#v as resulting config", cfg)
+	}
+
+	if len(cfg.RawProvisioners) != 1 || !cfg.Provisioners.Has("comment") {
+		t.Errorf("DecodeConfig failed to load external provisioners; got %#v as resulting config", cfg)
+	}
+
+	if len(cfg.RawPostProcessors) != 1 || !cfg.PostProcessors.Has("comment") {
+		t.Errorf("DecodeConfig failed to load external post-processors; got %#v as resulting config", cfg)
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -327,7 +327,7 @@ func loadConfig() (*config, error) {
 	}
 	defer f.Close()
 
-	if err := decodeConfig(f, &config); err != nil {
+	if err := DecodeConfig(f, &config); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
In Packer 1.5.0 the underlying configuration types for `config.Builders`, `config.Provisioners`, and `config.PostProcessors` were changed from `map[string]string` to custom types; respectively `MapOfBuilder`, `MapOfProvisioner`, `MapOfPostProcessor`. 

Packer 1.4.5
https://github.com/hashicorp/packer/blob/5d5189a9a20dfce9432f6fea502d0b3f56331560/config.go#L30-L32 

Packer 1.5.0
https://github.com/hashicorp/packer/blob/3c5ce79c2f722aac25c64b3c4fd06c9b4eb3e763/config.go#L31-L33

Given that Plugins are now maps of custom types unmarshalling a JSON based configuration file `~/.packerconfig` errors because it is unable to marshal the path of a plugin (stored as string) into a custom type. 

Example error message
 ```
    error encountered decoding configuration: json: cannot unmarshal string
    into Go struct field config.Provisioners of type func() (packer.Provisioner, error)
```

The changes within this PR are as follows: 
 
- Adds tests for config.go to test the loading of a config via a JSON configuration file.
- Takes a first attempt at fixing the loading of a packer config file by introducing a new set of fields to the config, which allows for the parsing of a configuration file.
- Introduces logic into the DecodeConfig method for loading the RawBuilders, RawProvisioners, and RawPostProcessors into their respective Func types.

https://github.com/hashicorp/packer/blob/c804b2bc25867fb8da9e29f0171c16b7283ef02f/config.go#L30-L35

