### PR TITLE
Fix loading external plugins defined in PACKER_CONFIG

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/packer/packer"
+)
+
+func TestDecodeConfig(t *testing.T) {
+
+	packerConfig := `
+	{
+		"PluginMinPort": 10,
+		"PluginMaxPort": 25,
+		"disable_checkpoint": true,
+		"disable_checkpoint_signature": true,
+		"provisioners": {
+		    "super-shell": "packer-provisioner-super-shell"
+		}
+	}`
+
+	var cfg config
+	err := decodeConfig(strings.NewReader(packerConfig), &cfg)
+	if err != nil {
+		t.Fatalf("error encountered decoding configuration: %v", err)
+	}
+
+	var expectedCfg config
+	json.NewDecoder(strings.NewReader(packerConfig)).Decode(&expectedCfg)
+	if !reflect.DeepEqual(cfg, expectedCfg) {
+		t.Errorf("failed to load custom configuration data; expected %v got %v", expectedCfg, cfg)
+	}
+
+}
+
+func TestLoadExternalComponentsFromConfig(t *testing.T) {
+	packerConfigData, cleanUpFunc, err := generateFakePackerConfigData()
+	if err != nil {
+		t.Fatalf("error encountered while creating fake Packer configuration data %v", err)
+	}
+	defer cleanUpFunc()
+
+	var cfg config
+	cfg.Builders = packer.MapOfBuilder{}
+	cfg.PostProcessors = packer.MapOfPostProcessor{}
+	cfg.Provisioners = packer.MapOfProvisioner{}
+
+	if err := decodeConfig(strings.NewReader(packerConfigData), &cfg); err != nil {
+		t.Fatalf("error encountered decoding configuration: %v", err)
+	}
+
+	cfg.LoadExternalComponentsFromConfig()
+
+	if len(cfg.Builders) != 1 || !cfg.Builders.Has("cloud-xyz") {
+		t.Errorf("failed to load external builders; got %v as the resulting config", cfg.Builders)
+	}
+
+	if len(cfg.Provisioners) != 1 || !cfg.Provisioners.Has("super-shell") {
+		t.Errorf("failed to load external provisioners; got %v as the resulting config", cfg.Provisioners)
+	}
+
+	if len(cfg.PostProcessors) != 1 || !cfg.PostProcessors.Has("noop") {
+		t.Errorf("failed to load external post-processors; got %v as the resulting config", cfg.PostProcessors)
+	}
+}
+
+func TestLoadExternalComponentsFromConfig_onlyProvisioner(t *testing.T) {
+	packerConfigData, cleanUpFunc, err := generateFakePackerConfigData()
+	if err != nil {
+		t.Fatalf("error encountered while creating fake Packer configuration data %v", err)
+	}
+	defer cleanUpFunc()
+
+	var cfg config
+	cfg.Provisioners = packer.MapOfProvisioner{}
+
+	if err := decodeConfig(strings.NewReader(packerConfigData), &cfg); err != nil {
+		t.Fatalf("error encountered decoding configuration: %v", err)
+	}
+
+	/* Let's clear out any custom Builders or PostProcessors that were part of the config.
+	This step does not remove them from disk, it just removes them from of plugins Packer knows about.
+	*/
+	cfg.RawBuilders = nil
+	cfg.RawPostProcessors = nil
+
+	cfg.LoadExternalComponentsFromConfig()
+
+	if len(cfg.Builders) != 0 || cfg.Builders.Has("cloud-xyz") {
+		t.Errorf("loaded external builders when it wasn't supposed to; got %v as the resulting config", cfg.Builders)
+	}
+
+	if len(cfg.Provisioners) != 1 || !cfg.Provisioners.Has("super-shell") {
+		t.Errorf("failed to load external provisioners; got %v as the resulting config", cfg.Provisioners)
+	}
+
+	if len(cfg.PostProcessors) != 0 || cfg.PostProcessors.Has("noop") {
+		t.Errorf("loaded external post-processors when it wasn't supposed to; got %v as the resulting config", cfg.PostProcessors)
+	}
+}
+
+/* generateFakePackerConfigData creates a collection of mock plugins along with a basic packerconfig.
+The return packerConfigData is a valid packerconfig file that can be used for configuring external plugins, cleanUpFunc is a function that should be called for cleaning up any generated mock data.
+This function will only clean up if there is an error, on successful runs the caller
+is responsible for cleaning up the data via cleanUpFunc().
+*/
+func generateFakePackerConfigData() (packerConfigData string, cleanUpFunc func(), err error) {
+	dir, err := ioutil.TempDir("", "random-testdata")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temporary test directory: %v", err)
+	}
+
+	cleanUpFunc = func() {
+		os.RemoveAll(dir)
+	}
+
+	var suffix string
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+
+	plugins := [...]string{
+		filepath.Join(dir, "packer-builder-cloud-xyz"+suffix),
+		filepath.Join(dir, "packer-provisioner-super-shell"+suffix),
+		filepath.Join(dir, "packer-post-processor-noop"+suffix),
+	}
+	for _, plugin := range plugins {
+		_, err := os.Create(plugin)
+		if err != nil {
+			cleanUpFunc()
+			return "", nil, fmt.Errorf("failed to create temporary plugin file (%s): %v", plugin, err)
+		}
+	}
+
+	packerConfigData = fmt.Sprintf(`
+	{
+		"PluginMinPort": 10,
+		"PluginMaxPort": 25,
+		"disable_checkpoint": true,
+		"disable_checkpoint_signature": true,
+		"builders": {
+			"cloud-xyz": %q
+		},
+		"provisioners": {
+			"super-shell": %q
+		},
+		"post-processors": {
+			"noop": %q
+		}
+	}`, plugins[0], plugins[1], plugins[2])
+
+	return
+}

--- a/main.go
+++ b/main.go
@@ -299,13 +299,14 @@ func loadConfig() (*config, error) {
 		return nil, err
 	}
 
+	// start by loading from PACKER_CONFIG if available
+	log.Print("Checking 'PACKER_CONFIG' for a config file path")
 	configFilePath := os.Getenv("PACKER_CONFIG")
-	if configFilePath != "" {
-		log.Printf("'PACKER_CONFIG' set, loading config from environment.")
-	} else {
-		var err error
-		configFilePath, err = packer.ConfigFile()
 
+	if configFilePath == "" {
+		var err error
+		log.Print("'PACKER_CONFIG' not set; checking the default config file path")
+		configFilePath, err = packer.ConfigFile()
 		if err != nil {
 			log.Printf("Error detecting default config file path: %s", err)
 		}
@@ -330,6 +331,8 @@ func loadConfig() (*config, error) {
 	if err := decodeConfig(f, &config); err != nil {
 		return nil, err
 	}
+
+	config.LoadExternalComponentsFromConfig()
 
 	return &config, nil
 }


### PR DESCRIPTION
In Packer 1.5.0 the underlying types for `config.Builders`, `config.Provisioners`, and `config.PostProcessors` were changed from `map[string]string` to custom types; respectively `MapOfBuilder`, `MapOfProvisioner`, `MapOfPostProcessor`. 

Packer 1.4.5
https://github.com/hashicorp/packer/blob/5d5189a9a20dfce9432f6fea502d0b3f56331560/config.go#L30-L32 

Packer 1.5.0
https://github.com/hashicorp/packer/blob/3c5ce79c2f722aac25c64b3c4fd06c9b4eb3e763/config.go#L31-L33

Given that Plugins are now maps of custom types unmarshalling a JSON based configuration file `~/.packerconfig` errors because it is unable to marshal the path of a plugin (stored as string) into a custom type. 

Example error message
 ```
    error encountered decoding configuration: json: cannot unmarshal string
    into Go struct field config.Provisioners of type func() (packer.Provisioner, error)
```

The changes within this PR are as follows: 
 
- Adds tests for config.go to test the loading of a config via a JSON configuration file.
- Takes a first attempt at fixing the loading of a packer config file by introducing a new set of fields to the config, which allows for the parsing of a configuration file.
- Introduces a method `config.loadExternalComponentsFromConfig` for loading the RawBuilders, RawProvisioners, and RawPostProcessors into their respective Func types.

<details>
<summary>TestDecodeConfig Results</summary>

Before change
```bash
> go test ./... -run=TestDecodeConfig -v
--- FAIL: TestDecodeConfig (0.00s)
    config_test.go:26: error encountered decoding configuration: json: cannot unmarshal string into Go struct field config.Provisioners of type func() (packer.Provisioner, error)
```

After change
```bash
> go test ./... -run=TestDecodeConfig -v
--- PASS: TestDecodeConfig (0.00s)
```
</details>

<details>
<summary>Packer build with packerconfig</summary>

```json

{
    "provisioners": {
        "comment": "/tmp/packer-provisioner-comment"
    },
    "builders": {
      "arm-image": "/tmp/packer-builder-arm-image"
    }

}
```

Log Output:
```bash
> PACKER_LOG=1 packer build build.json
2020/01/09 09:38:12 [INFO] Packer version: 1.5.2-dev (3339ce588+CHANGES) [go1.13 linux amd64]                                                                                                 
2020/01/09 09:38:12 Attempting to open config file: /home/wilken/.packerconfig                                                                                                                
2020/01/09 09:38:12 [DEBUG] Discovered plugin: arm-image = /tmp/packer-builder-arm-image                                                                                                      
2020/01/09 09:38:12 using external builders [arm-image]                                                                                                                                       
2020/01/09 09:38:12 [DEBUG] Discovered plugin: comment = /tmp/packer-provisioner-comment                                                                                                      
2020/01/09 09:38:12 using external provisioners [comment]                                                                                                                                     
2020/01/09 09:38:12 Setting cache directory: /home/wilken/Development/packer-provisioner-comment/packer_cache                                                                                 
2020/01/09 09:38:12 Creating plugin client for path: /home/wilken/bin/packer                                                                           
```
</details>



Closes: #8564 