### PR TITLE
Fix regression in docker-tag post-processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * builder/virtualbox-vm: use config as a non pointer to avoid a panic [GH-8576]
 * core: Fix crash when build.sources is set to an invalid name [GH-8569]
 * core: Fix loading of external plugins. GH-8543]
+* post-processor/docker-tag: Fix regression if no tags were specified. [GH-8593]
 * post-processor/vagrant: correctly handle the diskSize property as a qemu size
     string [GH-8567]
 * provisioner/ansible: Fix password sanitization to account for empty string

--- a/post-processor/docker-tag/post-processor.go
+++ b/post-processor/docker-tag/post-processor.go
@@ -68,17 +68,26 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 
 	importRepo := p.config.Repository
 	var lastTaggedRepo = importRepo
-	for _, tag := range p.config.Tag {
-		local := importRepo + ":" + tag
-		ui.Message("Tagging image: " + artifact.Id())
-		ui.Message("Repository: " + local)
+	if len(p.config.Tag) > 0 {
+		for _, tag := range p.config.Tag {
+			local := importRepo + ":" + tag
+			ui.Message("Tagging image: " + artifact.Id())
+			ui.Message("Repository: " + local)
 
-		err := driver.TagImage(artifact.Id(), local, p.config.Force)
+			err := driver.TagImage(artifact.Id(), local, p.config.Force)
+			if err != nil {
+				return nil, false, true, err
+			}
+
+			lastTaggedRepo = local
+		}
+	} else {
+		ui.Message("Tagging image: " + artifact.Id())
+		ui.Message("Repository: " + importRepo)
+		err := driver.TagImage(artifact.Id(), importRepo, p.config.Force)
 		if err != nil {
 			return nil, false, true, err
 		}
-
-		lastTaggedRepo = local
 	}
 
 	// Build the artifact


### PR DESCRIPTION
GH-8392 introduced the feature that multiple tags can be specified. This
(presumably inadvertently) broke the option to tag an image without the
actual tag specified -- Docker handles this by assuming `latest` as the
tag.

In addition, use-cases exist for the `repository` field containing the
tag already, which was also broken.