### PR TITLE
post-processor/vagrant-cloud: Update error handling for Vagrant Cloud API

### DIFF
--- a/post-processor/vagrant-cloud/client.go
+++ b/post-processor/vagrant-cloud/client.go
@@ -26,14 +26,22 @@ type VagrantCloudClient struct {
 }
 
 type VagrantCloudErrors struct {
-	Errors map[string][]string `json:"errors"`
+	Errors []interface{} `json:"errors"`
 }
 
 func (v VagrantCloudErrors) FormatErrors() string {
 	errs := make([]string, 0)
-	for e := range v.Errors {
-		msg := fmt.Sprintf("%s %s", e, strings.Join(v.Errors[e], ","))
-		errs = append(errs, msg)
+	for _, err := range v.Errors {
+		switch e := err.(type) {
+		case string:
+			errs = append(errs, e)
+		case map[string]interface{}:
+			for k, v := range e {
+				errs = append(errs, fmt.Sprintf("%s %s", k, v))
+			}
+		default:
+			errs = append(errs, fmt.Sprintf("%s", err))
+		}
 	}
 	return strings.Join(errs, ". ")
 }

--- a/post-processor/vagrant-cloud/client_test.go
+++ b/post-processor/vagrant-cloud/client_test.go
@@ -1,0 +1,30 @@
+package vagrantcloud
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestVagranCloudErrors(t *testing.T) {
+	testCases := []struct {
+		resp     string
+		expected string
+	}{
+		{`{"Status":"422 Unprocessable Entity", "StatusCode":422, "errors":[]}`, ""},
+		{`{"Status":"404 Artifact not found", "StatusCode":404, "errors":["error1", "error2"]}`, "error1. error2"},
+		{`{"StatusCode":403, "errors":[{"message":"Bad credentials"}]}`, "message Bad credentials"},
+		{`{"StatusCode":500, "errors":[["error in unexpected format"]]}`, "[error in unexpected format]"},
+	}
+
+	for _, tc := range testCases {
+		var cloudErrors VagrantCloudErrors
+		err := json.NewDecoder(strings.NewReader(tc.resp)).Decode(&cloudErrors)
+		if err != nil {
+			t.Errorf("failed to decode error response: %s", err)
+		}
+		if got := cloudErrors.FormatErrors(); got != tc.expected {
+			t.Errorf("failed to get expected response; expected %q, got %q", tc.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
This change updates the underlying type of VagrantCloudErrors.Errors to match the expected errors response type and adds a simple test to verify the parsing of various error responses.

Tests before change
```
--- FAIL: TestVagranCloudErrors (0.00s)
    client_test.go:23: failed to decode error response: json: cannot unmarshal array into Go struct field VagrantCloudErrors.errors of type map[string][]string
    client_test.go:23: failed to decode error response: json: cannot unmarshal array into Go struct field VagrantCloudErrors.errors of type map[string][]string
    client_test.go:26: failed to get expected response; expected "", got "error1. error2"
    client_test.go:23: failed to decode error response: json: cannot unmarshal array into Go struct field VagrantCloudErrors.errors of type map[string][]string
    client_test.go:26: failed to get expected response; expected "", got "message Bad credentials"

```

Test after change
```
--- PASS: TestVagranCloudErrors (0.00s)

```
Coses #8577
