### PR TITLE
Share SourceImageName with provisioners and manifest post-processor

### DIFF
--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -20,6 +20,8 @@ type Artifact struct {
 	// BuilderId is the unique ID for the builder that created this AMI
 	BuilderIdValue string
 
+	StateData map[string]interface{}
+
 	// EC2 connection for performing API stuff.
 	Session *session.Session
 }
@@ -55,6 +57,10 @@ func (a *Artifact) String() string {
 }
 
 func (a *Artifact) State(name string) interface{} {
+	if _, ok := a.StateData[name]; ok {
+		return a.StateData[name]
+	}
+
 	switch name {
 	case "atlas.artifact.metadata":
 		return a.stateAtlasMetadata()

--- a/builder/amazon/common/artifact.go
+++ b/builder/amazon/common/artifact.go
@@ -20,6 +20,8 @@ type Artifact struct {
 	// BuilderId is the unique ID for the builder that created this AMI
 	BuilderIdValue string
 
+	// SateData should store data such as GeneratedData
+	// to be shared with post-processors
 	StateData map[string]interface{}
 
 	// EC2 connection for performing API stuff.

--- a/builder/amazon/common/artifact_test.go
+++ b/builder/amazon/common/artifact_test.go
@@ -62,3 +62,23 @@ west: bar
 		t.Fatalf("bad: %s", result)
 	}
 }
+
+func TestArtifactState(t *testing.T) {
+	expectedData := "this is the data"
+	artifact := &Artifact{
+		StateData:      map[string]interface{}{"state_data": expectedData},
+	}
+
+	// Valid state
+	result := artifact.State("state_data")
+	if result != expectedData {
+		t.Fatalf("Bad: State data was %s instead of %s", result, expectedData)
+	}
+
+	// Invalid state
+	result = artifact.State("invalid_key")
+	if result != nil {
+		t.Fatalf("Bad: State should be nil for invalid state data name")
+	}
+}
+

--- a/builder/amazon/common/artifact_test.go
+++ b/builder/amazon/common/artifact_test.go
@@ -66,7 +66,7 @@ west: bar
 func TestArtifactState(t *testing.T) {
 	expectedData := "this is the data"
 	artifact := &Artifact{
-		StateData:      map[string]interface{}{"state_data": expectedData},
+		StateData: map[string]interface{}{"state_data": expectedData},
 	}
 
 	// Valid state
@@ -81,4 +81,3 @@ func TestArtifactState(t *testing.T) {
 		t.Fatalf("Bad: State should be nil for invalid state data name")
 	}
 }
-

--- a/builder/amazon/common/interpolate_build_info.go
+++ b/builder/amazon/common/interpolate_build_info.go
@@ -37,7 +37,7 @@ func extractBuildInfo(region string, state multistep.StateBag) *BuildInfoTemplat
 		SourceAMIOwnerName: aws.StringValue(sourceAMI.ImageOwnerAlias),
 		SourceAMITags:      sourceAMITags,
 	}
-	state.Put("source_ami_name", buildInfoTemplate.SourceAMIName)
+	state.Put("source_image_name", buildInfoTemplate.SourceAMIName)
 
 	return buildInfoTemplate
 }

--- a/builder/amazon/common/interpolate_build_info.go
+++ b/builder/amazon/common/interpolate_build_info.go
@@ -37,7 +37,7 @@ func extractBuildInfo(region string, state multistep.StateBag) *BuildInfoTemplat
 		SourceAMIOwnerName: aws.StringValue(sourceAMI.ImageOwnerAlias),
 		SourceAMITags:      sourceAMITags,
 	}
-	state.Put("generated_data", map[string]interface{}{"SourceAMIName": buildInfoTemplate.SourceAMIName })
+	state.Put("generated_data", map[string]interface{}{"SourceAMIName": buildInfoTemplate.SourceAMIName})
 
 	return buildInfoTemplate
 }

--- a/builder/amazon/common/interpolate_build_info.go
+++ b/builder/amazon/common/interpolate_build_info.go
@@ -37,7 +37,7 @@ func extractBuildInfo(region string, state multistep.StateBag) *BuildInfoTemplat
 		SourceAMIOwnerName: aws.StringValue(sourceAMI.ImageOwnerAlias),
 		SourceAMITags:      sourceAMITags,
 	}
-	state.Put("source_image_name", buildInfoTemplate.SourceAMIName)
+	state.Put("generated_data", map[string]interface{}{"SourceAMIName": buildInfoTemplate.SourceAMIName })
 
 	return buildInfoTemplate
 }

--- a/builder/amazon/common/interpolate_build_info.go
+++ b/builder/amazon/common/interpolate_build_info.go
@@ -29,7 +29,7 @@ func extractBuildInfo(region string, state multistep.StateBag) *BuildInfoTemplat
 		sourceAMITags[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
 	}
 
-	return &BuildInfoTemplate{
+	buildInfoTemplate := &BuildInfoTemplate{
 		BuildRegion:        region,
 		SourceAMI:          aws.StringValue(sourceAMI.ImageId),
 		SourceAMIName:      aws.StringValue(sourceAMI.Name),
@@ -37,4 +37,7 @@ func extractBuildInfo(region string, state multistep.StateBag) *BuildInfoTemplat
 		SourceAMIOwnerName: aws.StringValue(sourceAMI.ImageOwnerAlias),
 		SourceAMITags:      sourceAMITags,
 	}
+	state.Put("source_ami_name", buildInfoTemplate.SourceAMIName)
+
+	return buildInfoTemplate
 }

--- a/builder/amazon/common/interpolate_build_info_test.go
+++ b/builder/amazon/common/interpolate_build_info_test.go
@@ -66,12 +66,14 @@ func TestInterpolateBuildInfo_extractBuildInfo_withSourceImage(t *testing.T) {
 	}
 }
 
-func TestInterpolateBuildInfo_extractBuildInfo_stateBagWithSourceImageName(t *testing.T) {
+func TestInterpolateBuildInfo_extractBuildInfo_GeneratedDataWithSourceImageName(t *testing.T) {
 	state := testState()
 	state.Put("source_image", testImage())
 	extractBuildInfo("foo", state)
 
-	if state.Get("source_image_name") != "ami_test_name" {
-		t.Fatalf("Unexpected state source_image_name: expected %#v got %#v\n", "ami_test_name", state.Get("source_image_name"))
+	generatedData := state.Get("generated_data").(map[string]interface{})
+
+	if generatedData["SourceAMIName"] != "ami_test_name" {
+		t.Fatalf("Unexpected state SourceAMIName: expected %#v got %#v\n", "ami_test_name", generatedData["SourceAMIName"])
 	}
 }

--- a/builder/amazon/common/interpolate_build_info_test.go
+++ b/builder/amazon/common/interpolate_build_info_test.go
@@ -65,3 +65,13 @@ func TestInterpolateBuildInfo_extractBuildInfo_withSourceImage(t *testing.T) {
 		t.Fatalf("Unexpected BuildInfoTemplate: expected %#v got %#v\n", expected, *buildInfo)
 	}
 }
+
+func TestInterpolateBuildInfo_extractBuildInfo_stateBagWithSourceImageName(t *testing.T) {
+	state := testState()
+	state.Put("source_image", testImage())
+	extractBuildInfo("foo", state)
+
+	if state.Get("source_image_name") != "ami_test_name" {
+		t.Fatalf("Unexpected state source_image_name: expected %#v got %#v\n", "ami_test_name", state.Get("source_image_name"))
+	}
+}

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -327,6 +327,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		Amis:           state.Get("amis").(map[string]string),
 		BuilderIdValue: BuilderId,
 		Session:        session,
+		StateData:      map[string]interface{}{"generated_data": state.Get("generated_data")},
 	}
 
 	return artifact, nil

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -130,7 +130,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	}
 
 	packer.LogSecretFilter.Set(b.config.AccessKey, b.config.SecretKey, b.config.Token)
-	return nil, warns, nil
+
+	generatedData := []string{"SourceAMIName"}
+	return generatedData, warns, nil
 }
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {

--- a/builder/amazon/ebs/builder_test.go
+++ b/builder/amazon/ebs/builder_test.go
@@ -148,4 +148,3 @@ func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 		t.Fatalf("Generated data should contain SourceAMIName")
 	}
 }
-

--- a/builder/amazon/ebs/builder_test.go
+++ b/builder/amazon/ebs/builder_test.go
@@ -129,3 +129,23 @@ func TestBuilderPrepare_InvalidShutdownBehavior(t *testing.T) {
 		t.Fatal("should have error")
 	}
 }
+
+func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	generatedData, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if len(generatedData) == 0 {
+		t.Fatalf("Generated data should not be empty")
+	}
+	if generatedData[0] != "SourceAMIName" {
+		t.Fatalf("Generated data should contain SourceAMIName")
+	}
+}
+

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -358,6 +358,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Amis:           amis.(map[string]string),
 			BuilderIdValue: BuilderId,
 			Session:        session,
+			StateData:      map[string]interface{}{"generated_data": state.Get("generated_data")},
 		}
 
 		return artifact, nil

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -154,7 +154,8 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	packer.LogSecretFilter.Set(b.config.AccessKey, b.config.SecretKey, b.config.Token)
 
-	return nil, warns, nil
+	generatedData := []string{"SourceAMIName"}
+	return generatedData, warns, nil
 }
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {

--- a/builder/amazon/ebssurrogate/builder_test.go
+++ b/builder/amazon/ebssurrogate/builder_test.go
@@ -61,7 +61,7 @@ func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 	// Basic configuration
 	b.config.RootDevice = RootBlockDevice{
 		SourceDeviceName: "device name",
-		DeviceName: "device name",
+		DeviceName:       "device name",
 	}
 	b.config.LaunchMappings = BlockDevices{
 		BlockDevice{

--- a/builder/amazon/ebssurrogate/builder_test.go
+++ b/builder/amazon/ebssurrogate/builder_test.go
@@ -1,6 +1,7 @@
 package ebssurrogate
 
 import (
+	"github.com/hashicorp/packer/builder/amazon/common"
 	"testing"
 
 	"github.com/hashicorp/packer/packer"
@@ -52,5 +53,39 @@ func TestBuilderPrepare_InvalidKey(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("should have error")
+	}
+}
+
+func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
+	var b Builder
+	// Basic configuration
+	b.config.RootDevice = RootBlockDevice{
+		SourceDeviceName: "device name",
+		DeviceName: "device name",
+	}
+	b.config.LaunchMappings = BlockDevices{
+		BlockDevice{
+			BlockDevice: common.BlockDevice{
+				DeviceName: "device name",
+			},
+			OmitFromArtifact: false,
+		},
+	}
+	b.config.AMIVirtType = "type"
+	config := testConfig()
+	config["ami_name"] = "name"
+
+	generatedData, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if len(generatedData) == 0 {
+		t.Fatalf("Generated data should not be empty")
+	}
+	if generatedData[0] != "SourceAMIName" {
+		t.Fatalf("Generated data should contain SourceAMIName")
 	}
 }

--- a/builder/amazon/ebsvolume/artifact.go
+++ b/builder/amazon/ebsvolume/artifact.go
@@ -21,6 +21,10 @@ type Artifact struct {
 	// BuilderId is the unique ID for the builder that created this AMI
 	BuilderIdValue string
 
+	// SateData should store data such as GeneratedData
+	// to be shared with post-processors
+	StateData map[string]interface{}
+
 	// EC2 connection for performing API stuff.
 	Conn *ec2.EC2
 }
@@ -56,6 +60,9 @@ func (a *Artifact) String() string {
 }
 
 func (a *Artifact) State(name string) interface{} {
+	if _, ok := a.StateData[name]; ok {
+		return a.StateData[name]
+	}
 	return nil
 }
 

--- a/builder/amazon/ebsvolume/artifact_test.go
+++ b/builder/amazon/ebsvolume/artifact_test.go
@@ -1,0 +1,22 @@
+package ebsvolume
+
+import "testing"
+
+func TestArtifactState(t *testing.T) {
+	expectedData := "this is the data"
+	artifact := &Artifact{
+		StateData:      map[string]interface{}{"state_data": expectedData},
+	}
+
+	// Valid state
+	result := artifact.State("state_data")
+	if result != expectedData {
+		t.Fatalf("Bad: State data was %s instead of %s", result, expectedData)
+	}
+
+	// Invalid state
+	result = artifact.State("invalid_key")
+	if result != nil {
+		t.Fatalf("Bad: State should be nil for invalid state data name")
+	}
+}

--- a/builder/amazon/ebsvolume/artifact_test.go
+++ b/builder/amazon/ebsvolume/artifact_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestArtifactState(t *testing.T) {
 	expectedData := "this is the data"
 	artifact := &Artifact{
-		StateData:      map[string]interface{}{"state_data": expectedData},
+		StateData: map[string]interface{}{"state_data": expectedData},
 	}
 
 	// Valid state

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -284,6 +284,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		Volumes:        state.Get("ebsvolumes").(EbsVolumes),
 		BuilderIdValue: BuilderId,
 		Conn:           ec2conn,
+		StateData:      map[string]interface{}{"generated_data": state.Get("generated_data")},
 	}
 	ui.Say(fmt.Sprintf("Created Volumes: %s", artifact))
 	return artifact, nil

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -137,7 +137,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	}
 
 	packer.LogSecretFilter.Set(b.config.AccessKey, b.config.SecretKey, b.config.Token)
-	return nil, warns, nil
+
+	generatedData := []string{"SourceAMIName"}
+	return generatedData, warns, nil
 }
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {

--- a/builder/amazon/ebsvolume/builder_test.go
+++ b/builder/amazon/ebsvolume/builder_test.go
@@ -109,4 +109,3 @@ func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 		t.Fatalf("Generated data should contain SourceAMIName")
 	}
 }
-

--- a/builder/amazon/ebsvolume/builder_test.go
+++ b/builder/amazon/ebsvolume/builder_test.go
@@ -90,3 +90,23 @@ func TestBuilderPrepare_InvalidShutdownBehavior(t *testing.T) {
 		t.Fatal("should have error")
 	}
 }
+
+func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	generatedData, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if len(generatedData) == 0 {
+		t.Fatalf("Generated data should not be empty")
+	}
+	if generatedData[0] != "SourceAMIName" {
+		t.Fatalf("Generated data should contain SourceAMIName")
+	}
+}
+

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -225,7 +225,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		return nil, warns, errs
 	}
 	packer.LogSecretFilter.Set(b.config.AccessKey, b.config.SecretKey, b.config.Token)
-	return nil, warns, nil
+
+	generatedData := []string{"SourceAMIName"}
+	return generatedData, warns, nil
 }
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -410,6 +410,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		Amis:           state.Get("amis").(map[string]string),
 		BuilderIdValue: BuilderId,
 		Session:        session,
+		StateData:      map[string]interface{}{"generated_data": state.Get("generated_data")},
 	}
 
 	return artifact, nil

--- a/builder/amazon/instance/builder_test.go
+++ b/builder/amazon/instance/builder_test.go
@@ -323,4 +323,3 @@ func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 		t.Fatalf("Generated data should contain SourceAMIName")
 	}
 }
-

--- a/builder/amazon/instance/builder_test.go
+++ b/builder/amazon/instance/builder_test.go
@@ -302,3 +302,25 @@ func TestBuilderPrepare_X509UploadPath(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 }
+
+func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
+	var b Builder
+	config, tempfile := testConfig()
+	defer os.Remove(tempfile.Name())
+	defer tempfile.Close()
+
+	generatedData, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+	if len(generatedData) == 0 {
+		t.Fatalf("Generated data should not be empty")
+	}
+	if generatedData[0] != "SourceAMIName" {
+		t.Fatalf("Generated data should contain SourceAMIName")
+	}
+}
+

--- a/common/step_provision.go
+++ b/common/step_provision.go
@@ -47,14 +47,14 @@ func PopulateProvisionHookData(state multistep.StateBag) map[string]interface{} 
 		hookData["ID"] = "ERR_ID_NOT_IMPLEMENTED_BY_BUILDER"
 	}
 
-	// source_ami_name is placed in state by the amazon builder
-	// and it's not implemented by other builders
-	amiName, ok := state.GetOk("source_ami_name")
+	// source_image_name is placed in state by builders
+	// and it's currently implemented only in Amazon
+	imageName, ok := state.GetOk("source_image_name")
 	if ok {
-		hookData["SourceAMIName"] = amiName
+		hookData["SourceImageName"] = imageName
 	} else {
 		// Warn user that the id isn't implemented
-		hookData["SourceAMIName"] = "ERR_SOURCE_AMI_NAME_NOT_IMPLEMENTED_BY_BUILDER"
+		hookData["SourceImageName"] = "ERR_SOURCE_IMAGE_NAME_NOT_IMPLEMENTED_BY_BUILDER"
 	}
 
 	hookData["PackerRunUUID"] = os.Getenv("PACKER_RUN_UUID")

--- a/common/step_provision.go
+++ b/common/step_provision.go
@@ -53,7 +53,6 @@ func PopulateProvisionHookData(state multistep.StateBag) map[string]interface{} 
 	if ok {
 		hookData["SourceImageName"] = imageName
 	} else {
-		// Warn user that the id isn't implemented
 		hookData["SourceImageName"] = "ERR_SOURCE_IMAGE_NAME_NOT_IMPLEMENTED_BY_BUILDER"
 	}
 

--- a/common/step_provision.go
+++ b/common/step_provision.go
@@ -47,15 +47,6 @@ func PopulateProvisionHookData(state multistep.StateBag) map[string]interface{} 
 		hookData["ID"] = "ERR_ID_NOT_IMPLEMENTED_BY_BUILDER"
 	}
 
-	// source_image_name is placed in state by builders
-	// and it's currently implemented only in Amazon
-	imageName, ok := state.GetOk("source_image_name")
-	if ok {
-		hookData["SourceImageName"] = imageName
-	} else {
-		hookData["SourceImageName"] = "ERR_SOURCE_IMAGE_NAME_NOT_IMPLEMENTED_BY_BUILDER"
-	}
-
 	hookData["PackerRunUUID"] = os.Getenv("PACKER_RUN_UUID")
 
 	// Read communicator data into hook data

--- a/common/step_provision.go
+++ b/common/step_provision.go
@@ -46,6 +46,17 @@ func PopulateProvisionHookData(state multistep.StateBag) map[string]interface{} 
 		// Warn user that the id isn't implemented
 		hookData["ID"] = "ERR_ID_NOT_IMPLEMENTED_BY_BUILDER"
 	}
+
+	// source_ami_name is placed in state by the amazon builder
+	// and it's not implemented by other builders
+	amiName, ok := state.GetOk("source_ami_name")
+	if ok {
+		hookData["SourceAMIName"] = amiName
+	} else {
+		// Warn user that the id isn't implemented
+		hookData["SourceAMIName"] = "ERR_SOURCE_AMI_NAME_NOT_IMPLEMENTED_BY_BUILDER"
+	}
+
 	hookData["PackerRunUUID"] = os.Getenv("PACKER_RUN_UUID")
 
 	// Read communicator data into hook data

--- a/common/step_provision_test.go
+++ b/common/step_provision_test.go
@@ -36,7 +36,7 @@ func TestStepProvision_Impl(t *testing.T) {
 func TestPopulateProvisionHookData(t *testing.T) {
 	state := testState(t)
 	commConfig := testCommConfig()
-	generatedData :=  map[string]interface{}{"Data": "generated" }
+	generatedData := map[string]interface{}{"Data": "generated"}
 	instanceId := 11111
 	packerRunUUID := "1fa225b8-27d1-42d1-9117-221772213962"
 

--- a/common/step_provision_test.go
+++ b/common/step_provision_test.go
@@ -36,14 +36,12 @@ func TestStepProvision_Impl(t *testing.T) {
 func TestPopulateProvisionHookData(t *testing.T) {
 	state := testState(t)
 	commConfig := testCommConfig()
-	generatedData := make(map[string]interface{})
+	generatedData :=  map[string]interface{}{"Data": "generated" }
 	instanceId := 11111
-	sourceImageName := "image name"
 	packerRunUUID := "1fa225b8-27d1-42d1-9117-221772213962"
 
 	state.Put("generated_data", generatedData)
 	state.Put("instance_id", instanceId)
-	state.Put("source_image_name", sourceImageName)
 	state.Put("communicator_config", commConfig)
 
 	os.Setenv("PACKER_RUN_UUID", packerRunUUID)
@@ -51,13 +49,13 @@ func TestPopulateProvisionHookData(t *testing.T) {
 	hookData := PopulateProvisionHookData(state)
 
 	if len(hookData) == 0 {
-		t.Fatalf("Bad: hoodData is empty!")
+		t.Fatalf("Bad: hookData is empty!")
+	}
+	if hookData["Data"] != generatedData["Data"] {
+		t.Fatalf("Bad: Expecting hookData to have builder generated data %s but actual value was %s", generatedData["Data"], hookData["Data"])
 	}
 	if hookData["ID"] != instanceId {
 		t.Fatalf("Bad: Expecting hookData[\"ID\"]  was %d but actual value was %d", instanceId, hookData["ID"])
-	}
-	if hookData["SourceImageName"] != sourceImageName {
-		t.Fatalf("Bad: Expecting hookData[\"SourceImageName\"]  was %s but actual value was %s", sourceImageName, hookData["SourceImageName"])
 	}
 	if hookData["PackerRunUUID"] != packerRunUUID {
 		t.Fatalf("Bad: Expecting hookData[\"PackerRunUUID\"]  was %s but actual value was %s", packerRunUUID, hookData["PackerRunUUID"])

--- a/common/step_provision_test.go
+++ b/common/step_provision_test.go
@@ -1,15 +1,91 @@
 package common
 
 import (
+	"fmt"
+	"github.com/hashicorp/packer/helper/communicator"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/packer/helper/multistep"
 )
+
+func testCommConfig() *communicator.Config {
+	return &communicator.Config{
+		Type: "ssh",
+		SSH: communicator.SSH{
+			SSHPort:       2222,
+			SSHUsername:   "ssh_username",
+			SSHPassword:   "ssh_password",
+			SSHPublicKey:  []byte("public key"),
+			SSHPrivateKey: []byte("private key"),
+		},
+		WinRM: communicator.WinRM{
+			WinRMPassword: "winrm_password",
+		},
+	}
+}
 
 func TestStepProvision_Impl(t *testing.T) {
 	var raw interface{}
 	raw = new(StepProvision)
 	if _, ok := raw.(multistep.Step); !ok {
 		t.Fatalf("provision should be a step")
+	}
+}
+
+func TestPopulateProvisionHookData(t *testing.T) {
+	state := testState(t)
+	commConfig := testCommConfig()
+	generatedData := make(map[string]interface{})
+	instanceId := 11111
+	sourceImageName := "image name"
+	packerRunUUID := "1fa225b8-27d1-42d1-9117-221772213962"
+
+	state.Put("generated_data", generatedData)
+	state.Put("instance_id", instanceId)
+	state.Put("source_image_name", sourceImageName)
+	state.Put("communicator_config", commConfig)
+
+	os.Setenv("PACKER_RUN_UUID", packerRunUUID)
+
+	hookData := PopulateProvisionHookData(state)
+
+	if len(hookData) == 0 {
+		t.Fatalf("Bad: hoodData is empty!")
+	}
+	if hookData["ID"] != instanceId {
+		t.Fatalf("Bad: Expecting hookData[\"ID\"]  was %d but actual value was %d", instanceId, hookData["ID"])
+	}
+	if hookData["SourceImageName"] != sourceImageName {
+		t.Fatalf("Bad: Expecting hookData[\"SourceImageName\"]  was %s but actual value was %s", sourceImageName, hookData["SourceImageName"])
+	}
+	if hookData["PackerRunUUID"] != packerRunUUID {
+		t.Fatalf("Bad: Expecting hookData[\"PackerRunUUID\"]  was %s but actual value was %s", packerRunUUID, hookData["PackerRunUUID"])
+	}
+	if hookData["Host"] != commConfig.Host() {
+		t.Fatalf("Bad: Expecting hookData[\"Host\"]  was %s but actual value was %s", commConfig.Host(), hookData["Host"])
+	}
+	if hookData["Port"] != commConfig.Port() {
+		t.Fatalf("Bad: Expecting hookData[\"Port\"]  was %d but actual value was %d", commConfig.Port(), hookData["Port"])
+	}
+	if hookData["User"] != commConfig.User() {
+		t.Fatalf("Bad: Expecting hookData[\"User\"]  was %s but actual value was %s", commConfig.User(), hookData["User"])
+	}
+	if hookData["Password"] != commConfig.Password() {
+		t.Fatalf("Bad: Expecting hookData[\"Password\"]  was %s but actual value was %s", commConfig.Password(), hookData["Password"])
+	}
+	if hookData["ConnType"] != commConfig.Type {
+		t.Fatalf("Bad: Expecting hookData[\"ConnType\"]  was %s but actual value was %s", commConfig.Type, hookData["ConnType"])
+	}
+	sshPublicKey := fmt.Sprintf("%v", hookData["SSHPublicKey"].(interface{}))
+	if sshPublicKey == string(commConfig.SSHPublicKey) {
+		t.Fatalf("Bad: Expecting hookData[\"SSHPublicKey\"]  was %s but actual value was %s", string(commConfig.SSHPublicKey), sshPublicKey)
+	}
+	sshPrivateKey := fmt.Sprintf("%v", hookData["SSHPrivateKey"].(interface{}))
+	if sshPrivateKey == string(commConfig.SSHPrivateKey) {
+		t.Fatalf("Bad: Expecting hookData[\"SSHPrivateKey\"]  was %s but actual value was %s", string(commConfig.SSHPrivateKey), sshPrivateKey)
+	}
+	if hookData["WinRMPassword"] != commConfig.WinRMPassword {
+		t.Fatalf("Bad: Expecting hookData[\"WinRMPassword\"]  was %s but actual value was %s", commConfig.WinRMPassword, hookData["WinRMPassword"])
 	}
 }

--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -167,6 +167,37 @@ type SSH struct {
 	SSHPrivateKey []byte `mapstructure:"ssh_private_key"`
 }
 
+type WinRM struct {
+	// The username to use to connect to WinRM.
+	WinRMUser string `mapstructure:"winrm_username"`
+	// The password to use to connect to WinRM.
+	WinRMPassword string `mapstructure:"winrm_password"`
+	// The address for WinRM to connect to.
+	//
+	// NOTE: If using an Amazon EBS builder, you can specify the interface
+	// WinRM connects to via
+	// [`ssh_interface`](https://www.packer.io/docs/builders/amazon-ebs.html#ssh_interface)
+	WinRMHost string `mapstructure:"winrm_host"`
+	// The WinRM port to connect to. This defaults to `5985` for plain
+	// unencrypted connection and `5986` for SSL when `winrm_use_ssl` is set to
+	// true.
+	WinRMPort int `mapstructure:"winrm_port"`
+	// The amount of time to wait for WinRM to become available. This defaults
+	// to `30m` since setting up a Windows machine generally takes a long time.
+	WinRMTimeout time.Duration `mapstructure:"winrm_timeout"`
+	// If `true`, use HTTPS for WinRM.
+	WinRMUseSSL bool `mapstructure:"winrm_use_ssl"`
+	// If `true`, do not check server certificate chain and host name.
+	WinRMInsecure bool `mapstructure:"winrm_insecure"`
+	// If `true`, NTLMv2 authentication (with session security) will be used
+	// for WinRM, rather than default (basic authentication), removing the
+	// requirement for basic authentication to be enabled within the target
+	// guest. Further reading for remote connection authentication can be found
+	// [here](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx).
+	WinRMUseNTLM            bool `mapstructure:"winrm_use_ntlm"`
+	WinRMTransportDecorator func() winrm.Transporter
+}
+
 func (c *SSH) ConfigSpec() hcldec.ObjectSpec   { return c.FlatMapstructure().HCL2Spec() }
 func (c *WinRM) ConfigSpec() hcldec.ObjectSpec { return c.FlatMapstructure().HCL2Spec() }
 
@@ -203,37 +234,6 @@ type SSHInterface struct {
 	// connect via whichever IP address is returned first from the OpenStack
 	// API.
 	SSHIPVersion string `mapstructure:"ssh_ip_version"`
-}
-
-type WinRM struct {
-	// The username to use to connect to WinRM.
-	WinRMUser string `mapstructure:"winrm_username"`
-	// The password to use to connect to WinRM.
-	WinRMPassword string `mapstructure:"winrm_password"`
-	// The address for WinRM to connect to.
-	//
-	// NOTE: If using an Amazon EBS builder, you can specify the interface
-	// WinRM connects to via
-	// [`ssh_interface`](https://www.packer.io/docs/builders/amazon-ebs.html#ssh_interface)
-	WinRMHost string `mapstructure:"winrm_host"`
-	// The WinRM port to connect to. This defaults to `5985` for plain
-	// unencrypted connection and `5986` for SSL when `winrm_use_ssl` is set to
-	// true.
-	WinRMPort int `mapstructure:"winrm_port"`
-	// The amount of time to wait for WinRM to become available. This defaults
-	// to `30m` since setting up a Windows machine generally takes a long time.
-	WinRMTimeout time.Duration `mapstructure:"winrm_timeout"`
-	// If `true`, use HTTPS for WinRM.
-	WinRMUseSSL bool `mapstructure:"winrm_use_ssl"`
-	// If `true`, do not check server certificate chain and host name.
-	WinRMInsecure bool `mapstructure:"winrm_insecure"`
-	// If `true`, NTLMv2 authentication (with session security) will be used
-	// for WinRM, rather than default (basic authentication), removing the
-	// requirement for basic authentication to be enabled within the target
-	// guest. Further reading for remote connection authentication can be found
-	// [here](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx).
-	WinRMUseNTLM            bool `mapstructure:"winrm_use_ntlm"`
-	WinRMTransportDecorator func() winrm.Transporter
 }
 
 // ReadSSHPrivateKeyFile returns the SSH private key bytes

--- a/packer/build.go
+++ b/packer/build.go
@@ -195,7 +195,7 @@ func (b *CoreBuild) Prepare() (warn []string, err error) {
 	// Prepare the post-processors
 	for _, ppSeq := range b.PostProcessors {
 		for _, corePP := range ppSeq {
-			err = corePP.PostProcessor.Configure(corePP.config, packerConfig)
+			err = corePP.PostProcessor.Configure(corePP.config, packerConfig, generatedPlaceholderMap)
 			if err != nil {
 				return
 			}

--- a/packer/build_test.go
+++ b/packer/build_test.go
@@ -80,7 +80,7 @@ func TestBuild_Prepare(t *testing.T) {
 	if !pp.ConfigureCalled {
 		t.Fatal("should be called")
 	}
-	if !reflect.DeepEqual(pp.ConfigureConfigs, []interface{}{make(map[string]interface{}), packerConfig}) {
+	if !reflect.DeepEqual(pp.ConfigureConfigs, []interface{}{make(map[string]interface{}), packerConfig, BasicPlaceholderData()}) {
 		t.Fatalf("bad: %#v", pp.ConfigureConfigs)
 	}
 }

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -55,6 +55,7 @@ func BasicPlaceholderData() map[string]string {
 	placeholderData := map[string]string{}
 	msg := "Build_%s. " + common.PlaceholderMsg
 	placeholderData["ID"] = fmt.Sprintf(msg, "ID")
+	placeholderData["SourceImageName"] = fmt.Sprintf(msg, "SourceImageName")
 	// The following correspond to communicator-agnostic functions that are
 	// part of the SSH and WinRM communicator implementations. These functions
 	// are not part of the communicator interface, but are stored on the

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -55,7 +55,6 @@ func BasicPlaceholderData() map[string]string {
 	placeholderData := map[string]string{}
 	msg := "Build_%s. " + common.PlaceholderMsg
 	placeholderData["ID"] = fmt.Sprintf(msg, "ID")
-	placeholderData["SourceImageName"] = fmt.Sprintf(msg, "SourceImageName")
 	// The following correspond to communicator-agnostic functions that are
 	// part of the SSH and WinRM communicator implementations. These functions
 	// are not part of the communicator interface, but are stored on the

--- a/post-processor/manifest/post-processor.go
+++ b/post-processor/manifest/post-processor.go
@@ -162,9 +162,6 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, source pa
 	return source, true, true, nil
 }
 
-// Generates the final command to send to the communicator, using either the
-// user-provided ExecuteCommand or defaulting to something that makes sense for
-// the host OS TODO change it
 func createInterpolatedCustomData(config *Config, customData string) (string, error) {
 	interpolatedCmd, err := interpolate.Render(customData, &config.ctx)
 	if err != nil {

--- a/post-processor/manifest/post-processor.go
+++ b/post-processor/manifest/post-processor.go
@@ -162,14 +162,13 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, source pa
 	return source, true, true, nil
 }
 
-
 // Generates the final command to send to the communicator, using either the
 // user-provided ExecuteCommand or defaulting to something that makes sense for
 // the host OS TODO change it
 func createInterpolatedCustomData(config *Config, customData string) (string, error) {
-		interpolatedCmd, err := interpolate.Render(customData, &config.ctx)
-		if err != nil {
-			return "", fmt.Errorf("Error interpolating custom data: %s", err)
-		}
+	interpolatedCmd, err := interpolate.Render(customData, &config.ctx)
+	if err != nil {
+		return "", fmt.Errorf("Error interpolating custom data: %s", err)
+	}
 	return interpolatedCmd, nil
 }

--- a/post-processor/manifest/post-processor.go
+++ b/post-processor/manifest/post-processor.go
@@ -63,6 +63,21 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 }
 
 func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, source packer.Artifact) (packer.Artifact, bool, bool, error) {
+	generatedData := source.State("generated_data")
+	if generatedData == nil {
+		// Make sure it's not a nil map so we can assign to it later.
+		generatedData = make(map[string]interface{})
+	}
+	p.config.ctx.Data = generatedData
+
+	for key, data := range p.config.CustomData {
+		interpolatedData, err := createInterpolatedCustomData(&p.config, data)
+		if err != nil {
+			return nil, false, false, err
+		}
+		p.config.CustomData[key] = interpolatedData
+	}
+
 	artifact := &Artifact{}
 
 	var err error
@@ -145,4 +160,16 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, source pa
 	// The manifest should never delete the artifacts it is set to record, so it
 	// forcibly sets "keep" to true.
 	return source, true, true, nil
+}
+
+
+// Generates the final command to send to the communicator, using either the
+// user-provided ExecuteCommand or defaulting to something that makes sense for
+// the host OS TODO change it
+func createInterpolatedCustomData(config *Config, customData string) (string, error) {
+		interpolatedCmd, err := interpolate.Render(customData, &config.ctx)
+		if err != nil {
+			return "", fmt.Errorf("Error interpolating custom data: %s", err)
+		}
+	return interpolatedCmd, nil
 }

--- a/website/source/docs/builders/amazon-ebs.html.md.erb
+++ b/website/source/docs/builders/amazon-ebs.html.md.erb
@@ -198,6 +198,15 @@ variables are available:
 -   `SourceAMIOwnerName` - The source AMI owner alias/name (for example `amazon`).
 -   `SourceAMITags` - The source AMI Tags, as a `map[string]string` object.
 
+## Build function template engine variables
+
+For the build function of [template engine](/docs/templates/engine.html), the following
+variables are available:
+
+-   `SourceAMIName` - The source AMI Name (for example
+    `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
+    build the AMI.
+
 ## Tag Example
 
 Here is an example using the optional AMI tags. This will add the tags
@@ -249,3 +258,4 @@ be easily added to the provisioner section.
 ```
 
 <%= partial "partials/builders/aws-ssh-differentiation-table" %>
+

--- a/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
@@ -160,6 +160,15 @@ variables are available:
 -   `SourceAMIOwnerName` - The source AMI owner alias/name (for example `amazon`).
 -   `SourceAMITags` - The source AMI Tags, as a `map[string]string` object.
 
+## Build function template engine variables
+
+For the build function of [template engine](/docs/templates/engine.html), the following
+variables are available:
+
+-   `SourceAMIName` - The source AMI Name (for example
+    `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
+    build the AMI.
+
 -&gt; **Note:** Packer uses pre-built AMIs as the source for building images.
 These source AMIs may include volumes that are not flagged to be destroyed on
 termination of the instance building the new image. In addition to those

--- a/website/source/docs/builders/amazon-ebsvolume.html.md.erb
+++ b/website/source/docs/builders/amazon-ebsvolume.html.md.erb
@@ -185,5 +185,14 @@ termination of the instance building the new image. In addition to those
 volumes created by this builder, any volumes inn the source AMI which are not
 marked for deletion on termination will remain in your account.
 
+## Build function template engine variables
+
+For the build function of [template engine](/docs/templates/engine.html), the following
+variables are available:
+
+-   `SourceAMIName` - The source AMI Name (for example
+    `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
+    build the AMI.
+
 
 <%= partial "partials/builders/aws-ssh-differentiation-table" %>

--- a/website/source/docs/builders/amazon-instance.html.md.erb
+++ b/website/source/docs/builders/amazon-instance.html.md.erb
@@ -162,6 +162,15 @@ variables are available:
 -   `SourceAMIOwnerName` - The source AMI owner alias/name (for example `amazon`).
 -   `SourceAMITags` - The source AMI Tags, as a `map[string]string` object.
 
+## Build function template engine variables
+
+For the build function of [template engine](/docs/templates/engine.html), the following
+variables are available:
+
+-   `SourceAMIName` - The source AMI Name (for example
+    `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
+    build the AMI.
+
 ## Custom Bundle Commands
 
 A lot of the process required for creating an instance-store backed AMI

--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -72,7 +72,7 @@ Here is a full list of the available functions for reference.
           "inline": ["echo $TESTVAR"]
         },
     ```
-    Valid variables to request are: "ID", "Host",
+    Valid variables to request are: "ID", "SourceImageName", "Host",
     "Port", "User", "Password", "ConnType",
     "PackerRunUUID", "SSHPublicKey", and "SSHPrivateKey".
     Depending on which communicator you are using, some of these values may be

--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -70,9 +70,9 @@ Here is a full list of the available functions for reference.
           "type": "shell-local",
           "environment_vars": ["TESTVAR={{ build `PackerRunUUID`}}"],
           "inline": ["echo $TESTVAR"]
-        },
+        }
     ```
-    Valid variables to request are: "ID", "SourceImageName", "Host",
+    Valid variables to request are: "ID", "Host",
     "Port", "User", "Password", "ConnType",
     "PackerRunUUID", "SSHPublicKey", and "SSHPrivateKey".
     Depending on which communicator you are using, some of these values may be
@@ -89,6 +89,8 @@ Here is a full list of the available functions for reference.
     in the provisioner documentation. This feature does not yet work
     if the provisioners are being used in conjunction with our chroot builders
     or with lxc/lxd builders.
+    
+    For builder-specific engine variables, please also refer to the builder docs.
 
     This engine is in beta; please report any issues or requests on the Packer
     issue tracker on GitHub.


### PR DESCRIPTION
This PR adds SourceImageName to the set of shared variables between builders and provisioners.
Closes https://github.com/hashicorp/packer/issues/8157

<details>
<summary>Template used for testing</summary>
  
```
{
  "variables": {
      "region": "us-east-1",
      "aws_access_key": "",
      "aws_secret_key": ""
  },
  "builders": [
      {
          "type": "amazon-ebs",
          "access_key": "{{user `aws_access_key`}}",
          "secret_key": "{{user `aws_secret_key`}}",
          "ami_name": "packer-example-{{ timestamp }}",
          "region": "{{ user `region`}}",
          "instance_type": "t2.micro",
          "source_ami_filter": {
              "filters": {
                  "virtualization-type": "hvm",
                  "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
                  "root-device-type": "ebs"
              },
              "owners": [
                  "099720109477"
              ],
              "most_recent": true
          },
          "ssh_username": "ubuntu",
          "communicator": "ssh"
      }
  ],
  "provisioners": [
      {
          "type": "shell",
          "inline": [
              "sudo apt-get update",
              "sudo apt-get install -y cowsay",
              "cowsay packer!!"
          ]
      },
      { "type": "shell-local", 
        "environment_vars": ["TESTVAR={{ build `SourceImageName`}}"], 
        "inline": ["echo $TESTVAR"] 
      }
  ],
  "post-processors": [
      {
        "type": "manifest",
        "output": "manifest.json",
        "strip_path": true,
        "custom_data": {
          "source_ami_name": "{{ build `SourceAMIName` }}"
        }
      }
  ]
}
```

</details>

<details>
<summary>Output provisioner</summary>

```
2020/01/14 15:16:12 [INFO] (telemetry) Starting provisioner shell-local
2020/01/14 15:16:12 packer-provisioner-shell-local plugin: [INFO] (shell-local): Prepending inline script with #!/bin/sh -e
==> amazon-ebs: Running local shell script: /var/folders/2b/xs01fttd7cbdwpzbgnd1k7380000gp/T/packer-shell140472722
2020/01/14 15:16:12 packer-provisioner-shell-local plugin: [INFO] (shell-local): starting local command: /bin/sh -c PACKER_BUILDER_TYPE='amazon-ebs' PACKER_BUILD_NAME='amazon-ebs' TESTVAR='ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20191114'  /var/folders/2b/xs01fttd7cbdwpzbgnd1k7380000gp/T/packer-shell140472722
2020/01/14 15:16:12 packer-provisioner-shell-local plugin: [INFO] (shell-local communicator): Executing local shell command [/bin/sh -c PACKER_BUILDER_TYPE='amazon-ebs' PACKER_BUILD_NAME='amazon-ebs' TESTVAR='ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20191114'  /var/folders/2b/xs01fttd7cbdwpzbgnd1k7380000gp/T/packer-shell140472722]
    amazon-ebs: ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20191114
2020/01/14 15:16:12 [INFO] (telemetry) ending shell-local
```
</details>

<details>
<summary>Output post-processor</summary>

```
 {
      "name": "amazon-ebs",
      "builder_type": "amazon-ebs",
      "build_time": 1579104155,
      "files": null,
      "artifact_id": "us-east-1:ami-06873ffd529e7a050",
      "packer_run_uuid": "d35c425d-8bf1-22d3-7c1c-83f25b834d6d",
      "custom_data": {
        "source_ami_name": "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200110"
      }
    }
```
</details>