### PR TITLE
Fix a crash in the vagrant driver

### DIFF
--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -224,6 +224,7 @@ func (d *Vagrant_2_2_Driver) vagrantCmd(args ...string) (string, string, error) 
 					log.Printf("[vagrant driver] stderr: %s", line)
 				}
 				stderrString += line
+				break
 			default:
 				line, _ := stdout.ReadString('\n')
 				if line != "" {

--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -227,7 +227,7 @@ func (d *Vagrant_2_2_Driver) vagrantCmd(args ...string) (string, string, error) 
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Printf("error getting out pioe")
+		log.Printf("error getting out pipe")
 	}
 
 	err = cmd.Start()

--- a/builder/vagrant/step_add_box.go
+++ b/builder/vagrant/step_add_box.go
@@ -82,7 +82,8 @@ func (s *StepAddBox) Run(ctx context.Context, state multistep.StateBag) multiste
 		return multistep.ActionContinue
 	}
 
-	ui.Say("Adding box using vagrant box add..")
+	ui.Say("Adding box using vagrant box add ...")
+	ui.Message("(this can take some time if we need to download the box)")
 	addArgs := s.generateAddArgs()
 
 	log.Printf("[vagrant] Calling box add with following args %s", strings.Join(addArgs, " "))


### PR DESCRIPTION
Break out of read loop once wait is completed 😬 

Switch to using a scanner for reads. I haven't reproduced the bug since switching. I think we were accidentally causing a race condition that involved carriage returns instead of newlines when doing it the other way.

Closes #8606 
