### PR TITLE
fix config decode

### DIFF
--- a/builder/null/config.go
+++ b/builder/null/config.go
@@ -20,7 +20,7 @@ type Config struct {
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
-	err := config.Decode(&c, &config.DecodeOpts{
+	err := config.Decode(c, &config.DecodeOpts{
 		Interpolate:       true,
 		InterpolateFilter: &interpolate.RenderFilter{},
 	}, raws...)


### PR DESCRIPTION
Previously we took a pointer to the config, which caused a crash in the decoder. 

For repro and templates, see #8611.  

Closes #8611