### PR TITLE
log name of postprocessor running to disambiguate long chains of pps

### DIFF
--- a/hcl2template/decode.go
+++ b/hcl2template/decode.go
@@ -10,6 +10,6 @@ type Decodable interface {
 	ConfigSpec() hcldec.ObjectSpec
 }
 
-func decodeHCL2Spec(block *hcl.Block, ctx *hcl.EvalContext, dec Decodable) (cty.Value, hcl.Diagnostics) {
-	return hcldec.Decode(block.Body, dec.ConfigSpec(), ctx)
+func decodeHCL2Spec(body hcl.Body, ctx *hcl.EvalContext, dec Decodable) (cty.Value, hcl.Diagnostics) {
+	return hcldec.Decode(body, dec.ConfigSpec(), ctx)
 }

--- a/hcl2template/testdata/complete/build.pkr.hcl
+++ b/hcl2template/testdata/complete/build.pkr.hcl
@@ -6,6 +6,7 @@ build {
     ]
 
     provisioner "shell" {
+        name     = "provisioner that does something"
         string   = "string"
         int      = 42
         int64    = 43
@@ -45,6 +46,46 @@ build {
     }
 
     provisioner "file" {
+        string   = "string"
+        int      = 42
+        int64    = 43
+        bool     = true
+        trilean  = true
+        duration = "10s"
+        map_string_string {
+            a = "b"
+            c = "d"
+        }
+        slice_string = [
+            "a",
+            "b",
+            "c",
+        ]
+
+        nested {
+            string   = "string"
+            int      = 42
+            int64    = 43
+            bool     = true
+            trilean  = true
+            duration = "10s"
+            map_string_string {
+                a = "b"
+                c = "d"
+            }
+            slice_string = [
+                "a",
+                "b",
+                "c",
+            ]
+        }
+
+        nested_slice {
+        }
+    }
+
+    post-processor "amazon-import" { 
+        name     = "something"
         string   = "string"
         int      = 42
         int64    = 43

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -78,7 +78,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block) (*BuildBlock, hcl.Diagnosti
 			}
 			build.ProvisionerBlocks = append(build.ProvisionerBlocks, p)
 		case buildPostProcessorLabel:
-			pp, moreDiags := p.decodePostProcessorGroup(block)
+			pp, moreDiags := p.decodePostProcessor(block)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -2,7 +2,9 @@ package hcl2template
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/packer/helper/common"
 	"github.com/hashicorp/packer/packer"
 )
@@ -10,21 +12,34 @@ import (
 // ProvisionerBlock represents a parsed provisioner
 type ProvisionerBlock struct {
 	PType string
-	block *hcl.Block
+	PName string
+	HCL2Ref
+}
+
+func (p *ProvisionerBlock) String() string {
+	return fmt.Sprintf(buildProvisionerLabel+"-block %q %q", p.PType, p.PName)
 }
 
 func (p *Parser) decodeProvisioner(block *hcl.Block) (*ProvisionerBlock, hcl.Diagnostics) {
-	provisioner := &ProvisionerBlock{
-		PType: block.Labels[0],
-		block: block,
+	var b struct {
+		Name string   `hcl:"name,optional"`
+		Rest hcl.Body `hcl:",remain"`
 	}
-	var diags hcl.Diagnostics
+	diags := gohcl.DecodeBody(block.Body, nil, &b)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	provisioner := &ProvisionerBlock{
+		PType:   block.Labels[0],
+		PName:   b.Name,
+		HCL2Ref: newHCL2Ref(block, b.Rest),
+	}
 
 	if !p.ProvisionersSchemas.Has(provisioner.PType) {
 		diags = append(diags, &hcl.Diagnostic{
-			Summary:  "Unknown " + buildProvisionerLabel + " type " + provisioner.PType,
+			Summary:  fmt.Sprintf("Unknown "+buildProvisionerLabel+" type %q", provisioner.PType),
 			Subject:  block.LabelRanges[0].Ptr(),
-			Detail:   fmt.Sprintf("known provisioners: %v", p.ProvisionersSchemas.List()),
+			Detail:   fmt.Sprintf("known "+buildProvisionerLabel+"s: %v", p.ProvisionersSchemas.List()),
 			Severity: hcl.DiagError,
 		})
 		return nil, diags
@@ -38,13 +53,13 @@ func (p *Parser) StartProvisioner(pb *ProvisionerBlock, generatedVars []string) 
 	provisioner, err := p.ProvisionersSchemas.Start(pb.PType)
 	if err != nil {
 		diags = append(diags, &hcl.Diagnostic{
-			Summary: "Failed loading " + pb.block.Type,
-			Subject: pb.block.LabelRanges[0].Ptr(),
+			Summary: fmt.Sprintf("failed loading %s", pb.PType),
+			Subject: pb.HCL2Ref.LabelsRanges[0].Ptr(),
 			Detail:  err.Error(),
 		})
 		return nil, diags
 	}
-	flatProvisionerCfg, moreDiags := decodeHCL2Spec(pb.block, nil, provisioner)
+	flatProvisionerCfg, moreDiags := decodeHCL2Spec(pb.HCL2Ref.Rest, nil, provisioner)
 	diags = append(diags, moreDiags...)
 	if diags.HasErrors() {
 		return nil, diags
@@ -71,9 +86,9 @@ func (p *Parser) StartProvisioner(pb *ProvisionerBlock, generatedVars []string) 
 	if err != nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Failed preparing " + pb.block.Type,
+			Summary:  fmt.Sprintf("Failed preparing %s", pb),
 			Detail:   err.Error(),
-			Subject:  pb.block.DefRange.Ptr(),
+			Subject:  pb.HCL2Ref.DefRange.Ptr(),
 		})
 		return nil, diags
 	}

--- a/hcl2template/types.hcl_ref.go
+++ b/hcl2template/types.hcl_ref.go
@@ -7,8 +7,19 @@ import (
 // reference to the source definition in configuration text file
 type HCL2Ref struct {
 	// reference to the source definition in configuration text file
-	DeclRange hcl.Range
+	DefRange     hcl.Range
+	TypeRange    hcl.Range
+	LabelsRanges []hcl.Range
 
 	// remainder of unparsed body
-	Remain hcl.Body
+	Rest hcl.Body
+}
+
+func newHCL2Ref(block *hcl.Block, rest hcl.Body) HCL2Ref {
+	return HCL2Ref{
+		Rest:         rest,
+		DefRange:     block.DefRange,
+		TypeRange:    block.TypeRange,
+		LabelsRanges: block.LabelRanges,
+	}
 }

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -25,6 +25,7 @@ func (p *Parser) CoreBuildProvisioners(blocks []*ProvisionerBlock, generatedVars
 		}
 		res = append(res, packer.CoreBuildProvisioner{
 			PType:       pb.PType,
+			PName:       pb.PName,
 			Provisioner: provisioner,
 		})
 	}
@@ -34,15 +35,16 @@ func (p *Parser) CoreBuildProvisioners(blocks []*ProvisionerBlock, generatedVars
 func (p *Parser) CoreBuildPostProcessors(blocks []*PostProcessorBlock) ([]packer.CoreBuildPostProcessor, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	res := []packer.CoreBuildPostProcessor{}
-	for _, pp := range blocks {
-		postProcessor, moreDiags := p.StartPostProcessor(pp)
+	for _, ppb := range blocks {
+		postProcessor, moreDiags := p.StartPostProcessor(ppb)
 		diags = append(diags, moreDiags...)
 		if moreDiags.HasErrors() {
 			continue
 		}
 		res = append(res, packer.CoreBuildPostProcessor{
 			PostProcessor: postProcessor,
-			PType:         pp.PType,
+			PName:         ppb.PName,
+			PType:         ppb.PType,
 		})
 	}
 
@@ -59,7 +61,7 @@ func (p *Parser) getBuilds(cfg *PackerConfig) ([]packer.Build, hcl.Diagnostics) 
 			if !found {
 				diags = append(diags, &hcl.Diagnostic{
 					Summary:  "Unknown " + sourceLabel + " " + from.String(),
-					Subject:  build.HCL2Ref.DeclRange.Ptr(),
+					Subject:  build.HCL2Ref.DefRange.Ptr(),
 					Severity: hcl.DiagError,
 				})
 				continue

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -26,11 +26,20 @@ func TestParser_complete(t *testing.T) {
 					&BuildBlock{
 						Froms: []SourceRef{refVBIsoUbuntu1204},
 						ProvisionerBlocks: []*ProvisionerBlock{
-							{PType: "shell"},
+							{
+								PType: "shell",
+								PName: "provisioner that does something",
+							},
 							{PType: "file"},
 						},
 						PostProcessors: []*PostProcessorBlock{
-							{PType: "amazon-import"},
+							{
+								PType: "amazon-import",
+								PName: "something",
+							},
+							{
+								PType: "amazon-import",
+							},
 						},
 					},
 				},
@@ -41,12 +50,24 @@ func TestParser_complete(t *testing.T) {
 					Type:    "virtualbox-iso",
 					Builder: basicMockBuilder,
 					Provisioners: []packer.CoreBuildProvisioner{
-						{PType: "shell", Provisioner: basicMockProvisioner},
+						{
+							PType:       "shell",
+							PName:       "provisioner that does something",
+							Provisioner: basicMockProvisioner,
+						},
 						{PType: "file", Provisioner: basicMockProvisioner},
 					},
 					PostProcessors: [][]packer.CoreBuildPostProcessor{
 						{
-							{PType: "amazon-import", PostProcessor: basicMockPostProcessor},
+							{
+								PType:         "amazon-import",
+								PName:         "something",
+								PostProcessor: basicMockPostProcessor,
+							},
+							{
+								PType:         "amazon-import",
+								PostProcessor: basicMockPostProcessor,
+							},
 						},
 					},
 				},

--- a/hcl2template/types.source.go
+++ b/hcl2template/types.source.go
@@ -52,7 +52,7 @@ func (p *Parser) StartBuilder(source *Source) (packer.Builder, hcl.Diagnostics, 
 		return builder, diags, nil
 	}
 
-	decoded, moreDiags := decodeHCL2Spec(source.block, nil, builder)
+	decoded, moreDiags := decodeHCL2Spec(source.block.Body, nil, builder)
 	diags = append(diags, moreDiags...)
 	if moreDiags.HasErrors() {
 		return nil, diags, nil

--- a/packer/build.go
+++ b/packer/build.go
@@ -109,6 +109,7 @@ type CoreBuild struct {
 type CoreBuildPostProcessor struct {
 	PostProcessor     PostProcessor
 	PType             string
+	PName             string
 	config            map[string]interface{}
 	keepInputArtifact *bool
 }
@@ -297,7 +298,11 @@ PostProcessorRunSeqLoop:
 				Ui:     originalUi,
 			}
 
-			builderUi.Say(fmt.Sprintf("Running post-processor: %s", corePP.PType))
+			if corePP.PName == corePP.PType {
+				builderUi.Say(fmt.Sprintf("Running post-processor: %s", corePP.PType))
+			} else {
+				builderUi.Say(fmt.Sprintf("Running post-processor: %s (type %s)", corePP.PName, corePP.PType))
+			}
 			ts := CheckpointReporter.AddSpan(corePP.PType, "post-processor", corePP.config)
 			artifact, defaultKeep, forceOverride, err := corePP.PostProcessor.PostProcess(ctx, ppUi, priorArtifact)
 			ts.End(err)

--- a/packer/build.go
+++ b/packer/build.go
@@ -118,6 +118,7 @@ type CoreBuildPostProcessor struct {
 // the provisioner within the build.
 type CoreBuildProvisioner struct {
 	PType       string
+	PName       string
 	Provisioner Provisioner
 	config      []interface{}
 }

--- a/packer/build_test.go
+++ b/packer/build_test.go
@@ -22,7 +22,10 @@ func testBuild() *CoreBuild {
 			"foo": {&MockHook{}},
 		},
 		Provisioners: []CoreBuildProvisioner{
-			{"mock-provisioner", &MockProvisioner{}, []interface{}{42}},
+			{
+				PType:       "mock-provisioner",
+				Provisioner: &MockProvisioner{},
+				config:      []interface{}{42}},
 		},
 		PostProcessors: [][]CoreBuildPostProcessor{
 			{

--- a/packer/build_test.go
+++ b/packer/build_test.go
@@ -26,7 +26,7 @@ func testBuild() *CoreBuild {
 		},
 		PostProcessors: [][]CoreBuildPostProcessor{
 			{
-				{&MockPostProcessor{ArtifactId: "pp"}, "testPP", make(map[string]interface{}), boolPointer(true)},
+				{&MockPostProcessor{ArtifactId: "pp"}, "testPP", "testPPName", make(map[string]interface{}), boolPointer(true)},
 			},
 		},
 		Variables: make(map[string]string),
@@ -281,7 +281,7 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build = testBuild()
 	build.PostProcessors = [][]CoreBuildPostProcessor{
 		{
-			{&MockPostProcessor{ArtifactId: "pp"}, "pp", make(map[string]interface{}), boolPointer(false)},
+			{&MockPostProcessor{ArtifactId: "pp"}, "pp", "testPPName", make(map[string]interface{}), boolPointer(false)},
 		},
 	}
 
@@ -306,10 +306,10 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build = testBuild()
 	build.PostProcessors = [][]CoreBuildPostProcessor{
 		{
-			{&MockPostProcessor{ArtifactId: "pp1"}, "pp", make(map[string]interface{}), boolPointer(false)},
+			{&MockPostProcessor{ArtifactId: "pp1"}, "pp", "testPPName", make(map[string]interface{}), boolPointer(false)},
 		},
 		{
-			{&MockPostProcessor{ArtifactId: "pp2"}, "pp", make(map[string]interface{}), boolPointer(true)},
+			{&MockPostProcessor{ArtifactId: "pp2"}, "pp", "testPPName", make(map[string]interface{}), boolPointer(true)},
 		},
 	}
 
@@ -334,12 +334,12 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build = testBuild()
 	build.PostProcessors = [][]CoreBuildPostProcessor{
 		{
-			{&MockPostProcessor{ArtifactId: "pp1a"}, "pp", make(map[string]interface{}), boolPointer(false)},
-			{&MockPostProcessor{ArtifactId: "pp1b"}, "pp", make(map[string]interface{}), boolPointer(true)},
+			{&MockPostProcessor{ArtifactId: "pp1a"}, "pp", "testPPName", make(map[string]interface{}), boolPointer(false)},
+			{&MockPostProcessor{ArtifactId: "pp1b"}, "pp", "testPPName", make(map[string]interface{}), boolPointer(true)},
 		},
 		{
-			{&MockPostProcessor{ArtifactId: "pp2a"}, "pp", make(map[string]interface{}), boolPointer(false)},
-			{&MockPostProcessor{ArtifactId: "pp2b"}, "pp", make(map[string]interface{}), boolPointer(false)},
+			{&MockPostProcessor{ArtifactId: "pp2a"}, "pp", "testPPName", make(map[string]interface{}), boolPointer(false)},
+			{&MockPostProcessor{ArtifactId: "pp2b"}, "pp", "testPPName", make(map[string]interface{}), boolPointer(false)},
 		},
 	}
 
@@ -365,7 +365,7 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build.PostProcessors = [][]CoreBuildPostProcessor{
 		{
 			{
-				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: true}, "pp", make(map[string]interface{}), boolPointer(false),
+				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: true}, "pp", "testPPName", make(map[string]interface{}), boolPointer(false),
 			},
 		},
 	}
@@ -393,7 +393,7 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build.PostProcessors = [][]CoreBuildPostProcessor{
 		{
 			{
-				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: false}, "pp", make(map[string]interface{}), boolPointer(false),
+				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: false}, "pp", "testPPName", make(map[string]interface{}), boolPointer(false),
 			},
 		},
 	}
@@ -420,7 +420,7 @@ func TestBuild_Run_Artifacts(t *testing.T) {
 	build.PostProcessors = [][]CoreBuildPostProcessor{
 		{
 			{
-				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: false}, "pp", make(map[string]interface{}), nil,
+				&MockPostProcessor{ArtifactId: "pp", Keep: true, ForceOverride: false}, "pp", "testPPName", make(map[string]interface{}), nil,
 			},
 		},
 	}

--- a/packer/core.go
+++ b/packer/core.go
@@ -258,6 +258,7 @@ func (c *Core) Build(n string) (Build, error) {
 			current = append(current, CoreBuildPostProcessor{
 				PostProcessor:     postProcessor,
 				PType:             rawP.Type,
+				PName:             rawP.Name,
 				config:            rawP.Config,
 				keepInputArtifact: rawP.KeepInputArtifact,
 			})


### PR DESCRIPTION
This only implements the change for json templates, not HCL2 ones. It's a bit harrier trying to add them to the hcl2 templates becuase it appears we don't already have a pName field. 

@azr, I'd love your insight about how best to add this tooling. Since we do have the ability to name postprocessors currently in json configs, it would be cool to be able to create feature parity with HCL2.
Closes #8595