### PR TITLE
Add extend packer build template engine docs

### DIFF
--- a/website/source/docs/extending/custom-builders.html.md
+++ b/website/source/docs/extending/custom-builders.html.md
@@ -163,7 +163,7 @@ they aren't documented here other than to tell you how to hook in provisioners.
 
 ### Build variables
 
-Packer makes it possible to provide custom template engine variables to be shared along 
+Packer makes it possible to provide custom template engine variables to be shared with 
 provisioners using the `build` function. 
  
 Part of the builder interface changes made in 1.5.0 was to make builder Prepare() methods 
@@ -183,7 +183,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 Returning the custom variable name(s) within the `generated_data` placeholder is necessary 
 for the template containing the build variable(s) to validate.  
     
-Once the placeholder is set, it's necessary to pass the variables real values when calling 
+Once the placeholder is set, it's necessary to pass the variables' real values when calling 
 the provisioner. This can be done as the example below:   
 
 ```

--- a/website/source/docs/extending/custom-builders.html.md
+++ b/website/source/docs/extending/custom-builders.html.md
@@ -161,37 +161,41 @@ they aren't documented here other than to tell you how to hook in provisioners.
 
 ## Template Engine
 
+### Build variables
+
 Packer makes it possible to provide custom template engine variables to be shared along 
 provisioners using the `build` function. 
  
 Part of the builder interface changes made in 1.5.0 was to make builder Prepare() methods 
 return a list of custom variables which we call `generated data`. 
 We use that list of variables to generate a custom placeholder map per builder that 
-combines custom variables with the placeholder of existing variables created by Packer.   
-An example of returning generated date placeholder inside Prepare() method:
+combines custom variables with the placeholder map of default build variables created by Packer.   
+Here's an example snippet telling packer what will be made available by the builder:
 
 ```
 func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
-    // custom prepare code
+    // ...
     
     generatedData := []string{"SourceImageName"}
     return generatedData, warns, nil
 }
 ```
-   
+Returning the custom variable name(s) within the `generated_data` placeholder is necessary 
+for the template containing the build variable(s) to validate.  
+    
 Once the placeholder is set, it's necessary to pass the variables real values when calling 
 the provisioner. This can be done as the example below:   
 
 ```
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
-    // custom run code
+    // ...
     
     // Create map of custom variable
-    generatedData := map[string]interface{}{"SourceImageName": buildInfoTemplate.SourceImageName}
+    generatedData := map[string]interface{}{"SourceImageName": "the source image name value"}
     // Pass map to provisioner
     hook.Run(context.Context, packer.HookProvision, ui, comm, generatedData)
     
-    // custom run code
+    // ...
 }
 ```
 

--- a/website/source/docs/extending/custom-builders.html.md
+++ b/website/source/docs/extending/custom-builders.html.md
@@ -159,3 +159,40 @@ necessary.
 and will likely change in a future version. They aren't fully "baked" yet, so
 they aren't documented here other than to tell you how to hook in provisioners.
 
+## Template Engine
+
+Packer makes it possible to provide custom template engine variables to be shared along 
+provisioners using the `build` function. 
+ 
+Part of the builder interface changes made in 1.5.0 was to make builder Prepare() methods 
+return a list of custom variables which we call `generated data`. 
+We use that list of variables to generate a custom placeholder map per builder that 
+combines custom variables with the placeholder of existing variables created by Packer.   
+An example of returning generated date placeholder inside Prepare() method:
+
+```
+func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
+    // custom prepare code
+    
+    generatedData := []string{"SourceImageName"}
+    return generatedData, warns, nil
+}
+```
+   
+Once the placeholder is set, it's necessary to pass the variables real values when calling 
+the provisioner. This can be done as the example below:   
+
+```
+func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
+    // custom run code
+    
+    // Create map of custom variable
+    generatedData := map[string]interface{}{"SourceImageName": buildInfoTemplate.SourceImageName}
+    // Pass map to provisioner
+    hook.Run(context.Context, packer.HookProvision, ui, comm, generatedData)
+    
+    // custom run code
+}
+```
+
+To know more about the template engine build function, please refer to the [template engine docs](/docs/templates/engine.html).

--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -64,14 +64,16 @@ Here is a full list of the available functions for reference.
     variable](/docs/templates/user-variables.html#using-home-variable)
 -   `build` - This engine will allow you to access special variables that
     provide connection information and basic instance state information.
-    Usage example:
+    Usage example:   
+    
     ```json
-        {
-          "type": "shell-local",
-          "environment_vars": ["TESTVAR={{ build `PackerRunUUID`}}"],
-          "inline": ["echo $TESTVAR"]
-        }
+    {
+      "type": "shell-local",
+      "environment_vars": ["TESTVAR={{ build `PackerRunUUID`}}"],
+      "inline": ["echo $TESTVAR"]
+    }
     ```
+    
     Valid variables to request are: "ID", "Host",
     "Port", "User", "Password", "ConnType",
     "PackerRunUUID", "SSHPublicKey", and "SSHPrivateKey".


### PR DESCRIPTION
This PR adds the guide to use custom template engine variables for shared variables. This was written based on what @SwampDragons shared in https://github.com/hashicorp/packer/pull/8603