### PR TITLE
Allow aws builder pre validation to pass when subnet filters are present

### DIFF
--- a/builder/amazon/common/step_pre_validate_test.go
+++ b/builder/amazon/common/step_pre_validate_test.go
@@ -45,6 +45,7 @@ func TestStepPreValidate_checkVpc(t *testing.T) {
 		{"NonDefaultVpcWithSubnet", StepPreValidate{VpcId: "vpc-1234567890", SubnetId: "subnet-1234567890"}, false},
 		{"SubnetWithNoVpc", StepPreValidate{SubnetId: "subnet-1234567890"}, false},
 		{"NoVpcInformation", StepPreValidate{}, false},
+		{"NonDefaultVpcWithSubnetFilter", StepPreValidate{VpcId: "vpc-1234567890", HasSubnetFilter: true}, false},
 	}
 
 	mockConn, err := getMockConn(nil, "")

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -209,6 +209,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 			VpcId:              b.config.VpcId,
 			SubnetId:           b.config.SubnetId,
+			HasSubnetFilter:    len(b.config.SubnetFilter.Filters) > 0,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -232,6 +232,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			ForceDeregister: b.config.AMIForceDeregister,
 			VpcId:           b.config.VpcId,
 			SubnetId:        b.config.SubnetId,
+			HasSubnetFilter: len(b.config.SubnetFilter.Filters) > 0,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -294,6 +294,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			ForceDeregister: b.config.AMIForceDeregister,
 			VpcId:           b.config.VpcId,
 			SubnetId:        b.config.SubnetId,
+			HasSubnetFilter: len(b.config.SubnetFilter.Filters) > 0,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,


### PR DESCRIPTION
Our packer builds use a non-default VPC and SubnetFilter to select an appropriate subnet. This worked in 1.4.x.

Commits https://github.com/hashicorp/packer/commit/f9f4726effe22a1c561e6677f57711d82119b6c7 and https://github.com/hashicorp/packer/commit/074be9942d6b96e247efcd9734ee6310ae795ac3 updated pre-validation to require a SubnetId when a non-default VPC is used. This, unintentionally I believe, broke our use case.

In this PR I've updated the validation code, the builder's use of it and the relevant test. I've also tested against our builder and it works.