### PR TITLE
config: Update loading of packerconfig to only log when a plugin is loaded

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -110,7 +110,8 @@ func TestLoadExternalComponentsFromConfig_onlyProvisioner(t *testing.T) {
 
 func TestLoadSingleComponent(t *testing.T) {
 
-	tmpFile, err := ioutil.TempFile(".", "packer-builder-")
+	// .exe will work everyone for testing purpose, but mostly here to help Window's test runs.
+	tmpFile, err := ioutil.TempFile(".", "packer-builder-*.exe")
 	if err != nil {
 		t.Fatalf("failed to create test file with error: %s", err)
 	}


### PR DESCRIPTION
Before this change loading of a packerconfig would display `loaded plugin ...` for any plugin defined in the packerconfig - even if it didn't exist on disk. This change updates how plugins defined in packerconfig are loaded to ensure that only successfully loaded plugins get the lovely message `loaded plugin ...`. For any plugin that fails to load Packer will log that it failed to load the plugin and continue processing any other defined plugins.

* Add a test to ensure loadSingleComponent errors when plugin does not exists

Related  #8582