### PR TITLE
Create .hashibot.hcl

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -5,7 +5,7 @@ behavior "regexp_issue_labeler" "panic_label" {
 }
 
 behavior "remove_labels_on_reply" "remove_stale" {
-    labels = ["waiting-response", "stale"]
+    labels = ["waiting-reply", "stale"]
     only_non_maintainers = true
 }
 

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,0 +1,23 @@
+
+behavior "regexp_issue_labeler" "panic_label" {
+    regexp = "panic:"
+    labels = ["crash", "bug"]
+}
+
+behavior "remove_labels_on_reply" "remove_stale" {
+    labels = ["waiting-response", "stale"]
+    only_non_maintainers = true
+}
+
+poll "closed_issue_locker" "locker" {
+  schedule             = "0 50 1 * * *"
+  closed_for           = "720h" # 30 days
+  max_issues           = 500
+  sleep_between_issues = "5s"
+
+  message = <<-EOF
+    I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+    If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+  EOF
+}


### PR DESCRIPTION
Hello, this creates a basic .hashibot.hcl setting that will auto lock issues after 30 days of inactivity, in batches of 500 issues.

It also removes any `"waiting-reply", "stale"` labels when someone (not a maintainer) comments on an issue.