### PR TITLE
Extract http ip discover to a new step

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -614,6 +614,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		new(stepCreateDisk),
 		new(stepCopyDisk),
 		new(stepResizeDisk),
+		new(stepHTTPIPDiscover),
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,
 			HTTPPortMin: b.config.HTTPPortMin,

--- a/builder/qemu/step_http_ip_discover.go
+++ b/builder/qemu/step_http_ip_discover.go
@@ -1,0 +1,21 @@
+package qemu
+
+import (
+	"context"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/multistep"
+)
+
+// Step to discover the http ip
+// which guests use to reach the vm host
+// To make sure the IP is set before boot command and http server steps
+type stepHTTPIPDiscover struct{}
+
+func (s *stepHTTPIPDiscover) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	hostIP := "10.0.2.2"
+	common.SetHTTPIP(hostIP)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepHTTPIPDiscover) Cleanup(state multistep.StateBag) {}

--- a/builder/qemu/step_http_ip_discover_test.go
+++ b/builder/qemu/step_http_ip_discover_test.go
@@ -1,0 +1,29 @@
+package qemu
+
+import (
+	"context"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/multistep"
+	"testing"
+)
+
+func TestStepHTTPIPDiscover_Run(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	step := new(stepHTTPIPDiscover)
+	hostIp := "10.0.2.2"
+	previousHttpIp := common.GetHTTPIP()
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+	httpIp := common.GetHTTPIP()
+	if httpIp != hostIp {
+		t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, hostIp)
+	}
+
+	common.SetHTTPIP(previousHttpIp)
+}

--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -96,8 +96,7 @@ func (s *stepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 
 	log.Printf("Connected to VNC desktop: %s", c.DesktopName)
 
-	hostIP := "10.0.2.2"
-	common.SetHTTPIP(hostIP)
+	hostIP := common.GetHTTPIP()
 	configCtx := config.ctx
 	configCtx.Data = &bootCommandTemplateData{
 		hostIP,

--- a/builder/vmware/common/step_http_ip_discover.go
+++ b/builder/vmware/common/step_http_ip_discover.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"log"
+)
+
+// Step to discover the http ip
+// which guests use to reach the vm host
+// To make sure the IP is set before boot command and http server steps
+type StepHTTPIPDiscover struct{}
+
+func (s *StepHTTPIPDiscover) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(Driver)
+	ui := state.Get("ui").(packer.Ui)
+
+	// Determine the host IP
+	hostIP, err := driver.HostIP(state)
+	if err != nil {
+		err := fmt.Errorf("Error detecting host IP: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	log.Printf("Host IP for the VMware machine: %s", hostIP)
+	common.SetHTTPIP(hostIP)
+
+	return multistep.ActionContinue
+}
+
+func (*StepHTTPIPDiscover) Cleanup(multistep.StateBag) {}

--- a/builder/vmware/common/step_http_ip_discover_test.go
+++ b/builder/vmware/common/step_http_ip_discover_test.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/multistep"
+	"testing"
+)
+
+func TestStepHTTPIPDiscover_Run(t *testing.T) {
+	state := testState(t)
+	step := new(StepHTTPIPDiscover)
+	driverMock := state.Get("driver").(Driver)
+	hostIp, _ := driverMock.HostIP(state)
+	previousHttpIp := common.GetHTTPIP()
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+	httpIp := common.GetHTTPIP()
+	if httpIp != hostIp {
+		t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, hostIp)
+	}
+
+	// Halt step when fails to get ip
+	state.Put("driver", &DriverMock{HostIPErr: errors.New("error")})
+	if action := step.Run(context.Background(), state); action != multistep.ActionHalt {
+		t.Fatalf("bad action: step was supposed to fail %#v", action)
+	}
+
+	common.SetHTTPIP(previousHttpIp)
+}

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -45,7 +45,6 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 	}
 
 	debug := state.Get("debug").(bool)
-	driver := state.Get("driver").(Driver)
 	httpPort := state.Get("http_port").(int)
 	ui := state.Get("ui").(packer.Ui)
 	vncIp := state.Get("vnc_ip").(string)

--- a/builder/vmware/common/step_type_boot_command.go
+++ b/builder/vmware/common/step_type_boot_command.go
@@ -99,18 +99,7 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 
 	log.Printf("Connected to VNC desktop: %s", c.DesktopName)
 
-	// Determine the host IP
-	hostIP, err := driver.HostIP(state)
-	if err != nil {
-		err := fmt.Errorf("Error detecting host IP: %s", err)
-		state.Put("error", err)
-		ui.Error(err.Error())
-		return multistep.ActionHalt
-	}
-
-	log.Printf("Host IP for the VMware machine: %s", hostIP)
-	common.SetHTTPIP(hostIP)
-
+	hostIP := common.GetHTTPIP()
 	s.Ctx.Data = &bootCommandTemplateData{
 		hostIP,
 		httpPort,

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -109,6 +109,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			DisplayName: b.config.VMXDisplayName,
 		},
 		&vmwcommon.StepSuppressMessages{},
+		&vmwcommon.StepHTTPIPDiscover{},
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,
 			HTTPPortMin: b.config.HTTPPortMin,

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -103,6 +103,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			DisplayName: b.config.VMXDisplayName,
 		},
 		&vmwcommon.StepSuppressMessages{},
+		&vmwcommon.StepHTTPIPDiscover{},
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,
 			HTTPPortMin: b.config.HTTPPortMin,

--- a/common/step_provision.go
+++ b/common/step_provision.go
@@ -48,6 +48,7 @@ func PopulateProvisionHookData(state multistep.StateBag) map[string]interface{} 
 	}
 
 	hookData["PackerRunUUID"] = os.Getenv("PACKER_RUN_UUID")
+	hookData["PackerHTTPAddr"] = GetHTTPAddr()
 
 	// Read communicator data into hook data
 	comm, ok := state.GetOk("communicator_config")

--- a/common/step_provision_test.go
+++ b/common/step_provision_test.go
@@ -39,12 +39,17 @@ func TestPopulateProvisionHookData(t *testing.T) {
 	generatedData := map[string]interface{}{"Data": "generated"}
 	instanceId := 11111
 	packerRunUUID := "1fa225b8-27d1-42d1-9117-221772213962"
+	httpIP := "10.0.2.2"
+	httpPort := "2222"
+	httpAddr := fmt.Sprintf("%s:%s", httpIP, httpPort)
 
 	state.Put("generated_data", generatedData)
 	state.Put("instance_id", instanceId)
 	state.Put("communicator_config", commConfig)
 
 	os.Setenv("PACKER_RUN_UUID", packerRunUUID)
+	SetHTTPIP(httpIP)
+	SetHTTPPort(httpPort)
 
 	hookData := PopulateProvisionHookData(state)
 
@@ -59,6 +64,9 @@ func TestPopulateProvisionHookData(t *testing.T) {
 	}
 	if hookData["PackerRunUUID"] != packerRunUUID {
 		t.Fatalf("Bad: Expecting hookData[\"PackerRunUUID\"]  was %s but actual value was %s", packerRunUUID, hookData["PackerRunUUID"])
+	}
+	if hookData["PackerHTTPAddr"] != httpAddr {
+		t.Fatalf("Bad: Expecting hookData[\"PackerHTTPAddr\"]  was %s but actual value was %s", httpAddr, hookData["PackerHTTPAddr"])
 	}
 	if hookData["Host"] != commConfig.Host() {
 		t.Fatalf("Bad: Expecting hookData[\"Host\"]  was %s but actual value was %s", commConfig.Host(), hookData["Host"])

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -68,6 +68,7 @@ func BasicPlaceholderData() map[string]string {
 	placeholderData["Password"] = fmt.Sprintf(msg, "Password")
 	placeholderData["ConnType"] = fmt.Sprintf(msg, "Type")
 	placeholderData["PackerRunUUID"] = fmt.Sprintf(msg, "PackerRunUUID")
+	placeholderData["PackerHTTPAddr"] = fmt.Sprintf(msg, "PackerHTTPAddr")
 	placeholderData["SSHPublicKey"] = fmt.Sprintf(msg, "SSHPublicKey")
 	placeholderData["SSHPrivateKey"] = fmt.Sprintf(msg, "SSHPrivateKey")
 

--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -76,7 +76,7 @@ Here is a full list of the available functions for reference.
     
     Valid variables to request are: "ID", "Host",
     "Port", "User", "Password", "ConnType",
-    "PackerRunUUID", "SSHPublicKey", and "SSHPrivateKey".
+    "PackerRunUUID", "PackerHTTPAddr", "SSHPublicKey", and "SSHPrivateKey".
     Depending on which communicator you are using, some of these values may be
     empty -- for example, the public and private keys are unique to the SSH
     communicator. InstanceID represents the vm being provisioned. For example,


### PR DESCRIPTION
This PR creates a new step for discovering the HTTP IP and adds this step before StepHTTPServer and StepTypeBootCommand for qemu and vmware builders.
The PACKER_HTTP_ADDR was added to the provisioners info sharing structure as `PackerHTTPAddr` which means this one can now also be accessed via build function. 

**Testing case**

builder: qemu
vm: Windows

testing bat script:
```
ECHO %PACKER_HTTP_ADDR%
```

Base template used: https://github.com/jakobadam/packer-qemu-templates/blob/master/windows/windows-vagrant.json

output:
```
2020/01/28 16:35:26 packer-builder-qemu plugin: <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>[INFO] starting remote command: set "PACKER_BUILDER_TYPE=qemu" && set "PACKER_BUILD_NAME=qemu" && set "PACKER_HTTP_ADDR=10.0.2.2:8931" && set "PACKER_HTTP_IP=10.0.2.2" && set "PACKER_HTTP_PORT=8931" && "c:/Windows/Temp/script.bat"
    qemu:
    qemu: C:\Users\vagrant>echo 10.0.2.2:8931
    qemu: 10.0.2.2:8931
    qemu: ==> Disabling UAC
```
Closes https://github.com/hashicorp/packer/issues/8583