### PR TITLE
Support tilde expansion for Chef provisioner's validate_key_path

### DIFF
--- a/provisioner/chef-client/provisioner.go
+++ b/provisioner/chef-client/provisioner.go
@@ -276,8 +276,12 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 	}
 
 	if p.config.ValidationKeyPath != "" {
+		path, err := packer.ExpandUser(p.config.ValidationKeyPath)
+		if err != nil {
+			return fmt.Errorf("Error while expanding a tilde in the validation key: %s", err)
+		}
 		remoteValidationKeyPath = fmt.Sprintf("%s/validation.pem", p.config.StagingDir)
-		if err := p.uploadFile(ui, comm, remoteValidationKeyPath, p.config.ValidationKeyPath); err != nil {
+		if err := p.uploadFile(ui, comm, remoteValidationKeyPath, path); err != nil {
 			return fmt.Errorf("Error copying validation key: %s", err)
 		}
 	}


### PR DESCRIPTION
This PR closes #8441 [Support tilde ~ in validation_key_path for Chef provisioner](https://github.com/hashicorp/packer/issues/8441).

It is a very simple change; locate where `ValidationKeyPath` is used, and use the `ExpandUser()` function from the `packer` package to support tilde usage. This function is already tested in [here](https://github.com/hashicorp/packer/blob/master/packer/config_file_test.go).

## Questions
Do you think I've missed anything? Is there another place we can use the same functionality in this PR?