### PR TITLE
WIP Add ssh_wait_timeout back for backward compatibility

### DIFF
--- a/builder/parallels/common/ssh_config.go
+++ b/builder/parallels/common/ssh_config.go
@@ -3,14 +3,24 @@ package common
 import (
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/template/interpolate"
+	"time"
 )
 
 // SSHConfig contains the configuration for SSH communicator.
 type SSHConfig struct {
 	Comm communicator.Config `mapstructure:",squash"`
+
+	// These are deprecated, but we keep them around for BC
+	// TODO: remove later
+	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout" required:"false"`
 }
 
 // Prepare sets the default values for SSH communicator properties.
 func (c *SSHConfig) Prepare(ctx *interpolate.Context) []error {
+	// Backwards compatibility
+	if c.SSHWaitTimeout != 0 {
+		c.Comm.SSHTimeout = c.SSHWaitTimeout
+	}
+
 	return c.Comm.Prepare(ctx)
 }

--- a/builder/parallels/common/ssh_config_test.go
+++ b/builder/parallels/common/ssh_config_test.go
@@ -1,12 +1,12 @@
 package common
 
 import (
+	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/template/interpolate"
 	"io/ioutil"
 	"os"
 	"testing"
-
-	"github.com/hashicorp/packer/helper/communicator"
-	"github.com/hashicorp/packer/template/interpolate"
+	"time"
 )
 
 func testSSHConfig() *SSHConfig {
@@ -77,6 +77,22 @@ func TestSSHConfigPrepare_SSHPrivateKey(t *testing.T) {
 	errs = c.Prepare(interpolate.NewContext())
 	if len(errs) > 0 {
 		t.Fatalf("should not have error: %#v", errs)
+	}
+}
+
+func TestCommConfigPrepare_BackwardsCompatibility(t *testing.T) {
+	var c *SSHConfig
+	sshTimeout := 2 * time.Minute
+
+	c = testSSHConfig()
+	c.SSHWaitTimeout = sshTimeout
+
+	err := c.Prepare(interpolate.NewContext())
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if c.Comm.SSHTimeout != sshTimeout {
+		t.Fatalf("SSHTimeout should be %s for backwards compatibility, but it was %s", sshTimeout.String(), c.Comm.SSHTimeout.String())
 	}
 }
 

--- a/builder/parallels/iso/builder.hcl2spec.go
+++ b/builder/parallels/iso/builder.hcl2spec.go
@@ -82,6 +82,7 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm"`
+	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" required:"false" cty:"ssh_wait_timeout"`
 	ParallelsToolsFlavor      *string           `mapstructure:"parallels_tools_flavor" required:"true" cty:"parallels_tools_flavor"`
 	ParallelsToolsGuestPath   *string           `mapstructure:"parallels_tools_guest_path" required:"false" cty:"parallels_tools_guest_path"`
 	ParallelsToolsMode        *string           `mapstructure:"parallels_tools_mode" required:"false" cty:"parallels_tools_mode"`
@@ -179,6 +180,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"ssh_wait_timeout":             &hcldec.AttrSpec{Name: "ssh_wait_timeout", Type: cty.String, Required: false},
 		"parallels_tools_flavor":       &hcldec.AttrSpec{Name: "parallels_tools_flavor", Type: cty.String, Required: false},
 		"parallels_tools_guest_path":   &hcldec.AttrSpec{Name: "parallels_tools_guest_path", Type: cty.String, Required: false},
 		"parallels_tools_mode":         &hcldec.AttrSpec{Name: "parallels_tools_mode", Type: cty.String, Required: false},

--- a/builder/parallels/pvm/config.hcl2spec.go
+++ b/builder/parallels/pvm/config.hcl2spec.go
@@ -63,6 +63,7 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm"`
+	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" required:"false" cty:"ssh_wait_timeout"`
 	ShutdownCommand           *string           `mapstructure:"shutdown_command" required:"false" cty:"shutdown_command"`
 	ShutdownTimeout           *string           `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout"`
 	BootGroupInterval         *string           `mapstructure:"boot_keygroup_interval" cty:"boot_keygroup_interval"`
@@ -143,6 +144,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"ssh_wait_timeout":             &hcldec.AttrSpec{Name: "ssh_wait_timeout", Type: cty.String, Required: false},
 		"shutdown_command":             &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":             &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"boot_keygroup_interval":       &hcldec.AttrSpec{Name: "boot_keygroup_interval", Type: cty.String, Required: false},

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/common"
@@ -327,6 +328,10 @@ type Config struct {
 	// used unless it is specified in this option.
 	VMName string `mapstructure:"vm_name" required:"false"`
 
+	// These are deprecated, but we keep them around for BC
+	// TODO: remove later
+	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout" required:"false"`
+
 	// TODO(mitchellh): deprecate
 	RunOnce bool `mapstructure:"run_once"`
 
@@ -466,6 +471,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	if b.config.DiskInterface == "" {
 		b.config.DiskInterface = "virtio"
+	}
+
+	// Backwards compatibility
+	if b.config.SSHWaitTimeout != 0 {
+		b.config.Comm.SSHTimeout = b.config.SSHWaitTimeout
 	}
 
 	if b.config.ISOSkipCache {

--- a/builder/qemu/builder.hcl2spec.go
+++ b/builder/qemu/builder.hcl2spec.go
@@ -108,6 +108,7 @@ type FlatConfig struct {
 	VNCPortMin                *int              `mapstructure:"vnc_port_min" required:"false" cty:"vnc_port_min"`
 	VNCPortMax                *int              `mapstructure:"vnc_port_max" cty:"vnc_port_max"`
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name"`
+	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" required:"false" cty:"ssh_wait_timeout"`
 	RunOnce                   *bool             `mapstructure:"run_once" cty:"run_once"`
 }
 
@@ -222,6 +223,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vnc_port_min":                 &hcldec.AttrSpec{Name: "vnc_port_min", Type: cty.Number, Required: false},
 		"vnc_port_max":                 &hcldec.AttrSpec{Name: "vnc_port_max", Type: cty.Number, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
+		"ssh_wait_timeout":             &hcldec.AttrSpec{Name: "ssh_wait_timeout", Type: cty.String, Required: false},
 		"run_once":                     &hcldec.AttrSpec{Name: "run_once", Type: cty.Bool, Required: false},
 	}
 	return s

--- a/builder/virtualbox/common/comm_config.go
+++ b/builder/virtualbox/common/comm_config.go
@@ -4,6 +4,7 @@ package common
 
 import (
 	"errors"
+	"time"
 
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -31,9 +32,16 @@ type CommConfig struct {
 	SSHHostPortMax int `mapstructure:"ssh_host_port_max"`
 	// TODO: remove later
 	SSHSkipNatMapping bool `mapstructure:"ssh_skip_nat_mapping" required:"false"`
+	// TODO: remove later
+	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout" required:"false"`
 }
 
 func (c *CommConfig) Prepare(ctx *interpolate.Context) []error {
+	// Backwards compatibility
+	if c.SSHWaitTimeout != 0 {
+		c.Comm.SSHTimeout = c.SSHWaitTimeout
+	}
+
 	// Backwards compatibility
 	if c.SSHHostPortMin != 0 {
 		c.HostPortMin = c.SSHHostPortMin

--- a/builder/virtualbox/common/comm_config_test.go
+++ b/builder/virtualbox/common/comm_config_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -116,11 +117,13 @@ func TestCommConfigPrepare_BackwardsCompatibility(t *testing.T) {
 	hostPortMin := 1234
 	hostPortMax := 4321
 	skipNatMapping := true
+	sshTimeout := 2 * time.Minute
 
 	c = testCommConfig()
 	c.SSHHostPortMin = hostPortMin
 	c.SSHHostPortMax = hostPortMax
 	c.SSHSkipNatMapping = skipNatMapping
+	c.SSHWaitTimeout = sshTimeout
 
 	err := c.Prepare(interpolate.NewContext())
 	if err != nil {
@@ -137,6 +140,10 @@ func TestCommConfigPrepare_BackwardsCompatibility(t *testing.T) {
 
 	if c.SkipNatMapping != skipNatMapping {
 		t.Fatalf("SkipNatMapping should be %t for backwards compatibility, but it was %t", skipNatMapping, c.SkipNatMapping)
+	}
+
+	if c.Comm.SSHTimeout != sshTimeout {
+		t.Fatalf("SSHTimeout should be %s for backwards compatibility, but it was %s", sshTimeout.String(), c.Comm.SSHTimeout.String())
 	}
 }
 

--- a/builder/virtualbox/iso/builder.hcl2spec.go
+++ b/builder/virtualbox/iso/builder.hcl2spec.go
@@ -90,6 +90,7 @@ type FlatConfig struct {
 	SSHHostPortMin            *int              `mapstructure:"ssh_host_port_min" required:"false" cty:"ssh_host_port_min"`
 	SSHHostPortMax            *int              `mapstructure:"ssh_host_port_max" cty:"ssh_host_port_max"`
 	SSHSkipNatMapping         *bool             `mapstructure:"ssh_skip_nat_mapping" required:"false" cty:"ssh_skip_nat_mapping"`
+	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" required:"false" cty:"ssh_wait_timeout"`
 	CpuCount                  *int              `mapstructure:"cpus" required:"false" cty:"cpus"`
 	MemorySize                *int              `mapstructure:"memory" required:"false" cty:"memory"`
 	Sound                     *string           `mapstructure:"sound" required:"false" cty:"sound"`
@@ -209,6 +210,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_host_port_min":            &hcldec.AttrSpec{Name: "ssh_host_port_min", Type: cty.Number, Required: false},
 		"ssh_host_port_max":            &hcldec.AttrSpec{Name: "ssh_host_port_max", Type: cty.Number, Required: false},
 		"ssh_skip_nat_mapping":         &hcldec.AttrSpec{Name: "ssh_skip_nat_mapping", Type: cty.Bool, Required: false},
+		"ssh_wait_timeout":             &hcldec.AttrSpec{Name: "ssh_wait_timeout", Type: cty.String, Required: false},
 		"cpus":                         &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"sound":                        &hcldec.AttrSpec{Name: "sound", Type: cty.String, Required: false},

--- a/builder/virtualbox/ovf/config.hcl2spec.go
+++ b/builder/virtualbox/ovf/config.hcl2spec.go
@@ -78,6 +78,7 @@ type FlatConfig struct {
 	SSHHostPortMin            *int              `mapstructure:"ssh_host_port_min" required:"false" cty:"ssh_host_port_min"`
 	SSHHostPortMax            *int              `mapstructure:"ssh_host_port_max" cty:"ssh_host_port_max"`
 	SSHSkipNatMapping         *bool             `mapstructure:"ssh_skip_nat_mapping" required:"false" cty:"ssh_skip_nat_mapping"`
+	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" required:"false" cty:"ssh_wait_timeout"`
 	ShutdownCommand           *string           `mapstructure:"shutdown_command" required:"false" cty:"shutdown_command"`
 	ShutdownTimeout           *string           `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout"`
 	PostShutdownDelay         *string           `mapstructure:"post_shutdown_delay" required:"false" cty:"post_shutdown_delay"`
@@ -183,6 +184,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_host_port_min":            &hcldec.AttrSpec{Name: "ssh_host_port_min", Type: cty.Number, Required: false},
 		"ssh_host_port_max":            &hcldec.AttrSpec{Name: "ssh_host_port_max", Type: cty.Number, Required: false},
 		"ssh_skip_nat_mapping":         &hcldec.AttrSpec{Name: "ssh_skip_nat_mapping", Type: cty.Bool, Required: false},
+		"ssh_wait_timeout":             &hcldec.AttrSpec{Name: "ssh_wait_timeout", Type: cty.String, Required: false},
 		"shutdown_command":             &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":             &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"post_shutdown_delay":          &hcldec.AttrSpec{Name: "post_shutdown_delay", Type: cty.String, Required: false},

--- a/builder/virtualbox/vm/config.hcl2spec.go
+++ b/builder/virtualbox/vm/config.hcl2spec.go
@@ -78,6 +78,7 @@ type FlatConfig struct {
 	SSHHostPortMin            *int              `mapstructure:"ssh_host_port_min" required:"false" cty:"ssh_host_port_min"`
 	SSHHostPortMax            *int              `mapstructure:"ssh_host_port_max" cty:"ssh_host_port_max"`
 	SSHSkipNatMapping         *bool             `mapstructure:"ssh_skip_nat_mapping" required:"false" cty:"ssh_skip_nat_mapping"`
+	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" required:"false" cty:"ssh_wait_timeout"`
 	ShutdownCommand           *string           `mapstructure:"shutdown_command" required:"false" cty:"shutdown_command"`
 	ShutdownTimeout           *string           `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout"`
 	PostShutdownDelay         *string           `mapstructure:"post_shutdown_delay" required:"false" cty:"post_shutdown_delay"`
@@ -179,6 +180,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_host_port_min":            &hcldec.AttrSpec{Name: "ssh_host_port_min", Type: cty.Number, Required: false},
 		"ssh_host_port_max":            &hcldec.AttrSpec{Name: "ssh_host_port_max", Type: cty.Number, Required: false},
 		"ssh_skip_nat_mapping":         &hcldec.AttrSpec{Name: "ssh_skip_nat_mapping", Type: cty.Bool, Required: false},
+		"ssh_wait_timeout":             &hcldec.AttrSpec{Name: "ssh_wait_timeout", Type: cty.String, Required: false},
 		"shutdown_command":             &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":             &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"post_shutdown_delay":          &hcldec.AttrSpec{Name: "post_shutdown_delay", Type: cty.String, Required: false},


### PR DESCRIPTION
This PR rolls back the `ssh_wait_timeout` changes from https://github.com/hashicorp/packer/pull/8584/files

After realizing most of the tutorials and examples from the community use `ssh_wait_timeout`, we decide to keep it valid to avoid deprecating these materials. Now, when someone uses this deprecated option they should see a warning telling them to use `ssh_timeout`.