### PR TITLE
builder/azure-arm: Set WinRMPassword on the communicator config 

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -166,7 +166,6 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	b.setRuntimeParameters(b.stateBag)
 	b.setTemplateParameters(b.stateBag)
 	b.setImageParameters(b.stateBag)
-	var steps []multistep.Step
 
 	deploymentName := b.stateBag.Get(constants.ArmDeploymentName).(string)
 
@@ -195,6 +194,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		b.stateBag.Put(constants.ArmManagedImageSharedGalleryReplicationRegions, b.config.SharedGalleryDestination.SigDestinationReplicationRegions)
 	}
 
+	var steps []multistep.Step
 	if b.config.OSType == constants.Target_Linux {
 		steps = []multistep.Step{
 			NewStepCreateResourceGroup(azureClient, ui),
@@ -240,7 +240,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 				WinRMConfig: func(multistep.StateBag) (*communicator.WinRMConfig, error) {
 					return &communicator.WinRMConfig{
 						Username: b.config.UserName,
-						Password: b.config.tmpAdminPassword,
+						Password: b.config.Comm.WinRMPassword,
 					}, nil
 				},
 			},

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -640,8 +640,13 @@ func setUserNamePassword(c *Config) {
 
 	if c.Comm.SSHPassword != "" {
 		c.Password = c.Comm.SSHPassword
-	} else {
-		c.Password = c.tmpAdminPassword
+		return
+	}
+
+	// Configure password settings using Azure generated credentials
+	c.Password = c.tmpAdminPassword
+	if c.Comm.WinRMPassword == "" {
+		c.Comm.WinRMPassword = c.Password
 	}
 }
 


### PR DESCRIPTION
This change fixes an issue where the specified value of WinRMPassword (either via a build config or via the randomly generated password) was not being set by the builder. The updated builder sets WinRMPassword to the generated password if it is not specified in a user's build config and uses that value to connect to the provisioned instance via WimRM. 

Before this change the Azure builder would use the generated password for connecting via WinRM and would not set a value for WinRMPassword; thus leaving the WinRMPassword as an empty string. 

<details>
<summary>Elevated User Test</summary>

Build results before change
```
azure-arm: output will be in this color.

==> azure-arm: Running builder ...
azure-arm:
==> azure-arm: Provisioning with Powershell...
==> azure-arm: Provisioning with powershell script:
/tmp/powershell-provisioner922851060
==> azure-arm: Exception calling "RegisterTaskDefinition" with "7" argument(s): "(38,4):Task:"
==> azure-arm: At C:\Windows\Temp\packer-elevated-shell-5e320d29-bdbd-b619-9e64-0c8a301b9d1d.p
==> azure-arm: s1:60 char:1 ==> azure-arm: + $f.RegisterTaskDefinition($name, $t, 6,
"packer", $password, $logon_type,
==> azure-arm: $null) ...
==> azure-arm: +
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> azure-arm: ~~~
==> azure-arm:     + CategoryInfo          : NotSpecified:
(:) [], MethodInvocationException
==> azure-arm:     + FullyQualifiedErrorId :
ComMethodTargetInvocation
==> azure-arm:
==> azure-arm: Exception calling "GetTask" with "1"
argument(s): "The system cannot find the
==> azure-arm: file specified. (Exception from HRESULT:
0x80070002)"
==> azure-arm: At
C:\Windows\Temp\packer-elevated-shell-5e320d29-bdbd-b619-9e64-0c8a301b9d1d.p
==> azure-arm: s1:61 char:1
==> azure-arm: + $t = $f.GetTask("\$name")
==> azure-arm: + ~~~~~~~~~~~~~~~~~~~~~~~~~
==> azure-arm:     + CategoryInfo          : NotSpecified:
(:) [], MethodInvocationException
==> azure-arm:     + FullyQualifiedErrorId :
ComMethodTargetInvocation
==> azure-arm:
==> azure-arm: Method invocation failed because
[System.__ComObject] does not contain a
==> azure-arm: method named 'Run'.
==> azure-arm: At
C:\Windows\Temp\packer-elevated-shell-5e320d29-bdbd-b619-9e64-0c8a301b9d1d.p
==> azure-arm: s1:62 char:1
==> azure-arm: + $t.Run($null) | Out-Null
==> azure-arm: + ~~~~~~~~~~~~~~~~~~~~~~~~
==> azure-arm:     + CategoryInfo          :
InvalidOperation: (Run:String) [], RuntimeExcept
==> azure-arm:    ion
==> azure-arm:     + FullyQualifiedErrorId : MethodNotFound
==> azure-arm:
Cancelling build after receiving interrupt
==> azure-arm: Removing the created Deployment object:
'pkrdp087bb80ibj'
==> azure-arm: Removing the created Deployment object:
'kvpkrdp087bb80ibj'
==> azure-arm:
==> azure-arm: Cleanup requested, deleting resource group
...
==> azure-arm: Resource group has been deleted.
Build 'azure-arm' errored: Build was cancelled.
Cleanly cancelled builds after being interrupted.
```

Build results after change
```
azure-arm: WinRM connected.
==> azure-arm: <Objs Version="1.1.0.1"
xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64
N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S="progress" RefId="1"><TNRef RefId="0" /><MS><I64 N="SourceId">2</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S="progress" RefId="2"><TNRef RefId="0" /><MS><I64 N="SourceId">3</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>
==> azure-arm: Connected to WinRM!
==> azure-arm: Running local shell script:
/tmp/packer-shell091779215 azure-arm: 022xUtbwAH3DdqIoRCOh9caZi8tOYqcY
==> azure-arm: Provisioning with Powershell...
==> azure-arm: Provisioning with powershell script: /tmp/powershell-provisioner469853889
azure-arm: HELLO NEW USER; automatically generated aws password is: 022xUtbwAH3DdqIoRCOh9caZi8tOYqcY
==> azure-arm: Querying the machine's properties ...
```
</details>

Closes #4818
Closes #8619