### PR TITLE
Add custom-builders sharing info with post-processors doc

### DIFF
--- a/website/source/docs/templates/engine.html.md
+++ b/website/source/docs/templates/engine.html.md
@@ -62,7 +62,7 @@ Here is a full list of the available functions for reference.
     each function will behave.
 -   `env` - Returns environment variables. See example in [using home
     variable](/docs/templates/user-variables.html#using-home-variable)
--   `build` - This engine will allow you to access special variables that
+-   `build` - This engine will allow you to access, from provisioners and post-processors, special variables that
     provide connection information and basic instance state information.
     Usage example:
 


### PR DESCRIPTION
This adds the documentation related to https://github.com/hashicorp/packer/pull/8632