### PR TITLE
Fix 5957

### DIFF
--- a/builder/amazon/common/ssh.go
+++ b/builder/amazon/common/ssh.go
@@ -24,7 +24,7 @@ var (
 func SSHHost(e ec2Describer, sshInterface string, host string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -259,7 +259,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Host: awscommon.SSHHost(
 				ec2conn,
 				b.config.SSHInterface,
-				b.config.Comm.SSHHost,
+				b.config.Comm.Host(),
 			),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -282,7 +282,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Host: awscommon.SSHHost(
 				ec2conn,
 				b.config.SSHInterface,
-				b.config.Comm.SSHHost,
+				b.config.Comm.Host(),
 			),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -252,7 +252,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Host: awscommon.SSHHost(
 				ec2conn,
 				b.config.SSHInterface,
-				b.config.Comm.SSHHost,
+				b.config.Comm.Host(),
 			),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -342,7 +342,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Host: awscommon.SSHHost(
 				ec2conn,
 				b.config.SSHInterface,
-				b.config.Comm.SSHHost,
+				b.config.Comm.Host(),
 			),
 			SSHConfig: b.config.RunConfig.Comm.SSHConfigFunc(),
 		},

--- a/builder/cloudstack/builder.go
+++ b/builder/cloudstack/builder.go
@@ -79,7 +79,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&stepDetachIso{},
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      communicator.CommHost(b.config.Comm.SSHHost, "ipaddress"),
+			Host:      communicator.CommHost(b.config.Comm.Host(), "ipaddress"),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 			SSHPort:   commPort,
 			WinRMPort: commPort,

--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -88,7 +88,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		new(stepDropletInfo),
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      communicator.CommHost(b.config.Comm.SSHHost, "droplet_ip"),
+			Host:      communicator.CommHost(b.config.Comm.Host(), "droplet_ip"),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		new(common.StepProvision),

--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -50,7 +50,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&StepRun{},
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      commHost(b.config.Comm.SSHHost),
+			Host:      commHost(b.config.Comm.Host()),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 			CustomConnect: map[string]multistep.Step{
 				"docker":                 &StepConnectDocker{},

--- a/builder/docker/comm.go
+++ b/builder/docker/comm.go
@@ -9,7 +9,7 @@ import (
 func commHost(host string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 		containerId := state.Get("container_id").(string)

--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -68,7 +68,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		},
 		&communicator.StepConnect{
 			Config:      &b.config.Comm,
-			Host:        communicator.CommHost(b.config.Comm.SSHHost, "instance_ip"),
+			Host:        communicator.CommHost(b.config.Comm.Host(), "instance_ip"),
 			SSHConfig:   b.config.Comm.SSHConfigFunc(),
 			WinRMConfig: winrmConfig,
 		},

--- a/builder/hyperv/common/ssh.go
+++ b/builder/hyperv/common/ssh.go
@@ -11,7 +11,7 @@ func CommHost(host string) func(multistep.StateBag) (string, error) {
 
 		// Skip IP auto detection if the configuration has an ssh host configured.
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 

--- a/builder/linode/builder.go
+++ b/builder/linode/builder.go
@@ -59,7 +59,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (ret 
 		&stepCreateLinode{client},
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      commHost(b.config.Comm.SSHHost),
+			Host:      commHost(b.config.Comm.Host()),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},
@@ -104,7 +104,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (ret 
 func commHost(host string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 

--- a/builder/oneandone/builder.go
+++ b/builder/oneandone/builder.go
@@ -46,7 +46,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		new(stepCreateServer),
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      communicator.CommHost(b.config.Comm.SSHHost, "server_ip"),
+			Host:      communicator.CommHost(b.config.Comm.Host(), "server_ip"),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/openstack/ssh.go
+++ b/builder/openstack/ssh.go
@@ -20,7 +20,7 @@ func CommHost(
 	sshipversion string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 

--- a/builder/oracle/classic/builder.go
+++ b/builder/oracle/classic/builder.go
@@ -103,7 +103,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			},
 			&communicator.StepConnect{
 				Config:    &b.config.Comm,
-				Host:      communicator.CommHost(b.config.Comm.SSHHost, "instance_ip"),
+				Host:      communicator.CommHost(b.config.Comm.Host(), "instance_ip"),
 				SSHConfig: b.config.Comm.SSHConfigFunc(),
 			},
 			&common.StepProvision{},
@@ -133,7 +133,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 				KeyName: fmt.Sprintf("packer-generated-key_%s", runID),
 				StepConnectSSH: &communicator.StepConnectSSH{
 					Config:    &b.config.BuilderComm,
-					Host:      communicator.CommHost(b.config.Comm.SSHHost, "instance_ip"),
+					Host:      communicator.CommHost(b.config.Comm.Host(), "instance_ip"),
 					SSHConfig: b.config.BuilderComm.SSHConfigFunc(),
 				},
 			},
@@ -166,7 +166,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			&stepCreateInstance{},
 			&communicator.StepConnect{
 				Config:    &b.config.Comm,
-				Host:      communicator.CommHost(b.config.Comm.SSHHost, "instance_ip"),
+				Host:      communicator.CommHost(b.config.Comm.Host(), "instance_ip"),
 				SSHConfig: b.config.Comm.SSHConfigFunc(),
 			},
 			&common.StepProvision{},

--- a/builder/oracle/oci/builder.go
+++ b/builder/oracle/oci/builder.go
@@ -67,7 +67,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      communicator.CommHost(b.config.Comm.SSHHost, "instance_ip"),
+			Host:      communicator.CommHost(b.config.Comm.Host(), "instance_ip"),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/parallels/common/ssh.go
+++ b/builder/parallels/common/ssh.go
@@ -10,7 +10,7 @@ import (
 func CommHost(host string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 		vmName := state.Get("vmName").(string)

--- a/builder/profitbricks/builder.go
+++ b/builder/profitbricks/builder.go
@@ -43,7 +43,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		new(stepCreateServer),
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      communicator.CommHost(b.config.Comm.SSHHost, "server_ip"),
+			Host:      communicator.CommHost(b.config.Comm.Host(), "server_ip"),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -652,7 +652,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		steps = append(steps,
 			&communicator.StepConnect{
 				Config:    &b.config.Comm,
-				Host:      commHost(b.config.Comm.SSHHost),
+				Host:      commHost(b.config.Comm.Host()),
 				SSHConfig: b.config.Comm.SSHConfigFunc(),
 				SSHPort:   commPort,
 				WinRMPort: commPort,

--- a/builder/qemu/ssh.go
+++ b/builder/qemu/ssh.go
@@ -9,7 +9,7 @@ import (
 func commHost(host string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 

--- a/builder/scaleway/builder.go
+++ b/builder/scaleway/builder.go
@@ -59,7 +59,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		new(stepServerInfo),
 		&communicator.StepConnect{
 			Config:    &b.config.Comm,
-			Host:      communicator.CommHost(b.config.Comm.SSHHost, "server_ip"),
+			Host:      communicator.CommHost(b.config.Comm.Host(), "server_ip"),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		new(common.StepProvision),

--- a/builder/triton/builder.go
+++ b/builder/triton/builder.go
@@ -67,7 +67,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&StepCreateSourceMachine{},
 		&communicator.StepConnect{
 			Config:    &config.Comm,
-			Host:      commHost(b.config.Comm.SSHHost),
+			Host:      commHost(b.config.Comm.Host()),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 		},
 		&common.StepProvision{},

--- a/builder/triton/ssh.go
+++ b/builder/triton/ssh.go
@@ -9,7 +9,7 @@ import (
 func commHost(host string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 

--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -62,7 +62,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			},
 			&communicator.StepConnect{
 				Config:    &b.config.Comm,
-				Host:      common.CommHost(b.config.Comm.SSHHost),
+				Host:      common.CommHost(b.config.Comm.Host()),
 				SSHConfig: b.config.Comm.SSHConfigFunc(),
 			},
 			&packerCommon.StepProvision{},

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -106,7 +106,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			},
 			&communicator.StepConnect{
 				Config:    &b.config.Comm,
-				Host:      common.CommHost(b.config.Comm.SSHHost),
+				Host:      common.CommHost(b.config.Comm.Host()),
 				SSHConfig: b.config.Comm.SSHConfigFunc(),
 			},
 			&packerCommon.StepProvision{},

--- a/cmd/struct-markdown/main.go
+++ b/cmd/struct-markdown/main.go
@@ -114,6 +114,8 @@ func main() {
 			switch fieldType {
 			case "time.Duration":
 				fieldType = `duration string | ex: "1h5m2s"`
+			case "config.Trilean":
+				fieldType = `boolean`
 			}
 
 			field := Field{

--- a/helper/communicator/comm_host.go
+++ b/helper/communicator/comm_host.go
@@ -11,7 +11,7 @@ import (
 func CommHost(host string, statebagKey string) func(multistep.StateBag) (string, error) {
 	return func(state multistep.StateBag) (string, error) {
 		if host != "" {
-			log.Printf("Using ssh_host value: %s", host)
+			log.Printf("Using host value: %s", host)
 			return host, nil
 		}
 		ipAddress, hasIP := state.Get(statebagKey).(string)

--- a/website/source/partials/builder/alicloud/ecs/_AlicloudDiskDevice-not-required.html.md
+++ b/website/source/partials/builder/alicloud/ecs/_AlicloudDiskDevice-not-required.html.md
@@ -30,7 +30,7 @@
 -   `disk_device` (string) - Device information of the related instance:
     such as /dev/xvdb It is null unless the Status is In_use.
     
--   `disk_encrypted` (config.Trilean) - Whether or not to encrypt the data disk.
+-   `disk_encrypted` (boolean) - Whether or not to encrypt the data disk.
     If this option is set to true, the data disk will be encryped and corresponding snapshot in the target image will also be encrypted. By
     default, if this is an extra data disk, Packer will not encrypt the
     data disk. Otherwise, Packer will keep the encryption setting to what

--- a/website/source/partials/builder/alicloud/ecs/_AlicloudImageConfig-not-required.html.md
+++ b/website/source/partials/builder/alicloud/ecs/_AlicloudImageConfig-not-required.html.md
@@ -19,7 +19,7 @@
     uppercase/lowercase letter or a Chinese character, and may contain numbers,
     _ or -. It cannot begin with http:// or https://.
     
--   `image_encrypted` (config.Trilean) - Whether or not to encrypt the target images,            including those copied if image_copy_regions is specified. If this option
+-   `image_encrypted` (boolean) - Whether or not to encrypt the target images,            including those copied if image_copy_regions is specified. If this option
     is set to true, a temporary image will be created from the provisioned
     instance in the main region and an encrypted copy will be generated in the
     same region. By default, Packer will keep the encryption setting to what

--- a/website/source/partials/builder/alicloud/ecs/_RunConfig-not-required.html.md
+++ b/website/source/partials/builder/alicloud/ecs/_RunConfig-not-required.html.md
@@ -3,7 +3,7 @@
 -   `associate_public_ip_address` (bool) - Associate Public Ip Address
 -   `zone_id` (string) - ID of the zone to which the disk belongs.
     
--   `io_optimized` (config.Trilean) - Whether an ECS instance is I/O optimized or not. If this option is not
+-   `io_optimized` (boolean) - Whether an ECS instance is I/O optimized or not. If this option is not
     provided, the value will be determined by product API according to what
     `instance_type` is used.
     

--- a/website/source/partials/builder/amazon/common/_AMIConfig-not-required.html.md
+++ b/website/source/partials/builder/amazon/common/_AMIConfig-not-required.html.md
@@ -32,7 +32,7 @@
     [template engine](/docs/templates/engine.html), see [Build template
     data](#build-template-data) for more information.
     
--   `ena_support` (config.Trilean) - Enable enhanced networking (ENA but not SriovNetSupport) on
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport) on
     HVM-compatible AMIs. If set, add `ec2:ModifyInstanceAttribute` to your
     AWS IAM policy.
     
@@ -54,7 +54,7 @@
     associated with AMIs, which have been deregistered by force_deregister.
     Default false.
     
--   `encrypt_boot` (config.Trilean) - Whether or not to encrypt the resulting AMI when
+-   `encrypt_boot` (boolean) - Whether or not to encrypt the resulting AMI when
     copying a provisioned instance to an AMI. By default, Packer will keep the
     encryption setting to what it was in the source image. Setting false will
     result in an unencrypted image, and true will result in an encrypted one.

--- a/website/source/partials/builder/amazon/common/_BlockDevice-not-required.html.md
+++ b/website/source/partials/builder/amazon/common/_BlockDevice-not-required.html.md
@@ -8,7 +8,7 @@
 -   `device_name` (string) - The device name exposed to the instance (for example, /dev/sdh or xvdh).
     Required for every device in the block device mapping.
     
--   `encrypted` (config.Trilean) - Indicates whether or not to encrypt the volume. By default, Packer will
+-   `encrypted` (boolean) - Indicates whether or not to encrypt the volume. By default, Packer will
     keep the encryption setting to what it was in the source image. Setting
     false will result in an unencrypted device, and true will result in an
     encrypted one.

--- a/website/source/partials/builder/amazon/ebsvolume/_Config-not-required.html.md
+++ b/website/source/partials/builder/amazon/ebsvolume/_Config-not-required.html.md
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the Config struct in builder/amazon/ebsvolume/builder.go; DO NOT EDIT MANUALLY -->
 
--   `ena_support` (config.Trilean) - Enable enhanced networking (ENA but not SriovNetSupport) on
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport) on
     HVM-compatible AMIs. If set, add `ec2:ModifyInstanceAttribute` to your
     AWS IAM policy. Note: you must make sure enhanced networking is enabled
     on your instance. See [Amazon's documentation on enabling enhanced


### PR DESCRIPTION
PR #7832 allowed users to manually override ssh_host even on the cloud builders, but it ignored the possibility that a user might want to override winrm_host. This PR makes the override communicator-agnostic by using the Host() function instead of the underlying communicator config value. 

Closes #5957
