### PR TITLE
Fix 5413

### DIFF
--- a/cmd/struct-markdown/main.go
+++ b/cmd/struct-markdown/main.go
@@ -114,6 +114,8 @@ func main() {
 			switch fieldType {
 			case "time.Duration":
 				fieldType = `duration string | ex: "1h5m2s"`
+			case "config.Trilean":
+				fieldType = `boolean`
 			}
 
 			field := Field{

--- a/website/source/docs/post-processors/manifest.html.md
+++ b/website/source/docs/post-processors/manifest.html.md
@@ -38,8 +38,9 @@ post-processors such as Docker and Artifice.
     to `packer-manifest.json`.
 -   `strip_path` (boolean) Write only filename without the path to the manifest
     file. This defaults to false.
--   `custom_data` (map of strings) Arbitrary data to add to the manifest.
-
+-   `custom_data` (map of strings) Arbitrary data to add to the manifest. This
+    is a [template engine](/docs/templates/engine.html); see
+    [Build template data](#build-template-data) for more information.
 -   `keep_input_artifact` (boolean) - Unlike most other post-processors, the
     keep_input_artifact option will have no effect for the manifest
     post-processor. We will always retain the input artifact for manifest,
@@ -136,3 +137,20 @@ The above manifest was generated with this packer.json:
   ]
 }
 ```
+
+Example usage:
+
+The manifest can be very useful for cleaning up old artifacts, or printing
+important values to logs. The following example uses jq, a command-line tool for
+parsing json output, to find and echo the AWS ami-id of an ami created by a
+build.
+
+``` bash
+
+#!/bin/bash
+
+AMI_ID=$(jq -r '.builds[-1].artifact_id' manifest.json | cut -d ":" -f2)
+echo $AMI_ID
+
+```
+

--- a/website/source/partials/builder/alicloud/ecs/_AlicloudDiskDevice-not-required.html.md
+++ b/website/source/partials/builder/alicloud/ecs/_AlicloudDiskDevice-not-required.html.md
@@ -30,7 +30,7 @@
 -   `disk_device` (string) - Device information of the related instance:
     such as /dev/xvdb It is null unless the Status is In_use.
     
--   `disk_encrypted` (config.Trilean) - Whether or not to encrypt the data disk.
+-   `disk_encrypted` (boolean) - Whether or not to encrypt the data disk.
     If this option is set to true, the data disk will be encryped and corresponding snapshot in the target image will also be encrypted. By
     default, if this is an extra data disk, Packer will not encrypt the
     data disk. Otherwise, Packer will keep the encryption setting to what

--- a/website/source/partials/builder/alicloud/ecs/_AlicloudImageConfig-not-required.html.md
+++ b/website/source/partials/builder/alicloud/ecs/_AlicloudImageConfig-not-required.html.md
@@ -19,7 +19,7 @@
     uppercase/lowercase letter or a Chinese character, and may contain numbers,
     _ or -. It cannot begin with http:// or https://.
     
--   `image_encrypted` (config.Trilean) - Whether or not to encrypt the target images,            including those copied if image_copy_regions is specified. If this option
+-   `image_encrypted` (boolean) - Whether or not to encrypt the target images,            including those copied if image_copy_regions is specified. If this option
     is set to true, a temporary image will be created from the provisioned
     instance in the main region and an encrypted copy will be generated in the
     same region. By default, Packer will keep the encryption setting to what

--- a/website/source/partials/builder/alicloud/ecs/_RunConfig-not-required.html.md
+++ b/website/source/partials/builder/alicloud/ecs/_RunConfig-not-required.html.md
@@ -3,7 +3,7 @@
 -   `associate_public_ip_address` (bool) - Associate Public Ip Address
 -   `zone_id` (string) - ID of the zone to which the disk belongs.
     
--   `io_optimized` (config.Trilean) - Whether an ECS instance is I/O optimized or not. If this option is not
+-   `io_optimized` (boolean) - Whether an ECS instance is I/O optimized or not. If this option is not
     provided, the value will be determined by product API according to what
     `instance_type` is used.
     

--- a/website/source/partials/builder/amazon/common/_AMIConfig-not-required.html.md
+++ b/website/source/partials/builder/amazon/common/_AMIConfig-not-required.html.md
@@ -32,7 +32,7 @@
     [template engine](/docs/templates/engine.html), see [Build template
     data](#build-template-data) for more information.
     
--   `ena_support` (config.Trilean) - Enable enhanced networking (ENA but not SriovNetSupport) on
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport) on
     HVM-compatible AMIs. If set, add `ec2:ModifyInstanceAttribute` to your
     AWS IAM policy.
     
@@ -54,7 +54,7 @@
     associated with AMIs, which have been deregistered by force_deregister.
     Default false.
     
--   `encrypt_boot` (config.Trilean) - Whether or not to encrypt the resulting AMI when
+-   `encrypt_boot` (boolean) - Whether or not to encrypt the resulting AMI when
     copying a provisioned instance to an AMI. By default, Packer will keep the
     encryption setting to what it was in the source image. Setting false will
     result in an unencrypted image, and true will result in an encrypted one.

--- a/website/source/partials/builder/amazon/common/_BlockDevice-not-required.html.md
+++ b/website/source/partials/builder/amazon/common/_BlockDevice-not-required.html.md
@@ -8,7 +8,7 @@
 -   `device_name` (string) - The device name exposed to the instance (for example, /dev/sdh or xvdh).
     Required for every device in the block device mapping.
     
--   `encrypted` (config.Trilean) - Indicates whether or not to encrypt the volume. By default, Packer will
+-   `encrypted` (boolean) - Indicates whether or not to encrypt the volume. By default, Packer will
     keep the encryption setting to what it was in the source image. Setting
     false will result in an unencrypted device, and true will result in an
     encrypted one.

--- a/website/source/partials/builder/amazon/ebsvolume/_Config-not-required.html.md
+++ b/website/source/partials/builder/amazon/ebsvolume/_Config-not-required.html.md
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the Config struct in builder/amazon/ebsvolume/builder.go; DO NOT EDIT MANUALLY -->
 
--   `ena_support` (config.Trilean) - Enable enhanced networking (ENA but not SriovNetSupport) on
+-   `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport) on
     HVM-compatible AMIs. If set, add `ec2:ModifyInstanceAttribute` to your
     AWS IAM policy. Note: you must make sure enhanced networking is enabled
     on your instance. See [Amazon's documentation on enabling enhanced


### PR DESCRIPTION
Adds a basic usage example showing how to use jq to grab an ami-id from a manifest. 

Closes #5413