### PR TITLE
builder/azure-arm: Update logic for setting subscriptionID

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -64,7 +64,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		return nil, err
 	}
 
-	//When running Packer on an Azure instance FillParameters will update SubscriptionID from the instance
+	//When running Packer on an Azure instance using Managed Identity, FillParameters will update SubscriptionID from the instance
 	// so lets make sure to update our state bag with the valid subscriptionID.
 	if b.config.isManagedImage() && b.config.SharedGalleryDestination.SigDestinationGalleryName != "" {
 		b.stateBag.Put(constants.ArmManagedImageSubscription, b.config.ClientConfig.SubscriptionID)

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -64,6 +64,12 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		return nil, err
 	}
 
+	//When running Packer on an Azure instance FillParameters will update SubscriptionID from the instance
+	// so lets make sure to update our state bag with the valid subscriptionID.
+	if b.config.isManagedImage() && b.config.SharedGalleryDestination.SigDestinationGalleryName != "" {
+		b.stateBag.Put(constants.ArmManagedImageSubscription, b.config.ClientConfig.SubscriptionID)
+	}
+
 	log.Print(":: Configuration")
 	packerAzureCommon.DumpConfig(&b.config, func(s string) { log.Print(s) })
 
@@ -384,30 +390,34 @@ func (b *Builder) configureStateBag(stateBag multistep.StateBag) {
 	stateBag.Put(constants.ArmTags, b.config.AzureTags)
 	stateBag.Put(constants.ArmComputeName, b.config.tmpComputeName)
 	stateBag.Put(constants.ArmDeploymentName, b.config.tmpDeploymentName)
+
 	if b.config.OSType == constants.Target_Windows {
 		stateBag.Put(constants.ArmKeyVaultDeploymentName, fmt.Sprintf("kv%s", b.config.tmpDeploymentName))
 	}
+
 	stateBag.Put(constants.ArmKeyVaultName, b.config.tmpKeyVaultName)
 	stateBag.Put(constants.ArmNicName, b.config.tmpNicName)
 	stateBag.Put(constants.ArmPublicIPAddressName, b.config.tmpPublicIPAddressName)
-	if b.config.TempResourceGroupName != "" && b.config.BuildResourceGroupName != "" {
-		stateBag.Put(constants.ArmDoubleResourceGroupNameSet, true)
-	}
+	stateBag.Put(constants.ArmResourceGroupName, b.config.BuildResourceGroupName)
+	stateBag.Put(constants.ArmIsExistingResourceGroup, true)
+
 	if b.config.tmpResourceGroupName != "" {
 		stateBag.Put(constants.ArmResourceGroupName, b.config.tmpResourceGroupName)
 		stateBag.Put(constants.ArmIsExistingResourceGroup, false)
-	} else {
-		stateBag.Put(constants.ArmResourceGroupName, b.config.BuildResourceGroupName)
-		stateBag.Put(constants.ArmIsExistingResourceGroup, true)
-	}
-	stateBag.Put(constants.ArmStorageAccountName, b.config.StorageAccount)
 
+		if b.config.BuildResourceGroupName != "" {
+			stateBag.Put(constants.ArmDoubleResourceGroupNameSet, true)
+		}
+	}
+
+	stateBag.Put(constants.ArmStorageAccountName, b.config.StorageAccount)
 	stateBag.Put(constants.ArmIsManagedImage, b.config.isManagedImage())
 	stateBag.Put(constants.ArmManagedImageResourceGroupName, b.config.ManagedImageResourceGroupName)
 	stateBag.Put(constants.ArmManagedImageName, b.config.ManagedImageName)
 	stateBag.Put(constants.ArmManagedImageOSDiskSnapshotName, b.config.ManagedImageOSDiskSnapshotName)
 	stateBag.Put(constants.ArmManagedImageDataDiskSnapshotPrefix, b.config.ManagedImageDataDiskSnapshotPrefix)
 	stateBag.Put(constants.ArmAsyncResourceGroupDelete, b.config.AsyncResourceGroupDelete)
+
 	if b.config.isManagedImage() && b.config.SharedGalleryDestination.SigDestinationGalleryName != "" {
 		stateBag.Put(constants.ArmManagedImageSigPublishResourceGroup, b.config.SharedGalleryDestination.SigDestinationResourceGroup)
 		stateBag.Put(constants.ArmManagedImageSharedGalleryName, b.config.SharedGalleryDestination.SigDestinationGalleryName)

--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -106,17 +106,21 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 
 	s.say("Publishing to Shared Image Gallery ...")
 
-	var miSigPubRg = stateBag.Get(constants.ArmManagedImageSigPublishResourceGroup).(string)
-	var miSIGalleryName = stateBag.Get(constants.ArmManagedImageSharedGalleryName).(string)
-	var miSGImageName = stateBag.Get(constants.ArmManagedImageSharedGalleryImageName).(string)
-	var miSGImageVersion = stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersion).(string)
-	var location = stateBag.Get(constants.ArmLocation).(string)
-	var tags = stateBag.Get(constants.ArmTags).(map[string]*string)
-	var miSigReplicationRegions = stateBag.Get(constants.ArmManagedImageSharedGalleryReplicationRegions).([]string)
-	var targetManagedImageResourceGroupName = stateBag.Get(constants.ArmManagedImageResourceGroupName).(string)
-	var targetManagedImageName = stateBag.Get(constants.ArmManagedImageName).(string)
-	var managedImageSubscription = stateBag.Get(constants.ArmManagedImageSubscription).(string)
-	var mdiID = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s", managedImageSubscription, targetManagedImageResourceGroupName, targetManagedImageName)
+	location := stateBag.Get(constants.ArmLocation).(string)
+
+	miSigPubRg := stateBag.Get(constants.ArmManagedImageSigPublishResourceGroup).(string)
+	miSIGalleryName := stateBag.Get(constants.ArmManagedImageSharedGalleryName).(string)
+	miSGImageName := stateBag.Get(constants.ArmManagedImageSharedGalleryImageName).(string)
+	miSGImageVersion := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersion).(string)
+	miSigReplicationRegions := stateBag.Get(constants.ArmManagedImageSharedGalleryReplicationRegions).([]string)
+
+	tags := stateBag.Get(constants.ArmTags).(map[string]*string)
+	targetManagedImageResourceGroupName := stateBag.Get(constants.ArmManagedImageResourceGroupName).(string)
+	targetManagedImageName := stateBag.Get(constants.ArmManagedImageName).(string)
+
+	managedImageSubscription := stateBag.Get(constants.ArmManagedImageSubscription).(string)
+	mdiID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s", managedImageSubscription, targetManagedImageResourceGroupName, targetManagedImageName)
+
 	miSGImageVersionEndOfLifeDate, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionEndOfLifeDate).(string)
 	miSGImageVersionExcludeFromLatest, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionExcludeFromLatest).(bool)
 	miSigReplicaCount, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionReplicaCount).(int32)

--- a/common/retry/retry.go
+++ b/common/retry/retry.go
@@ -20,7 +20,7 @@ type Config struct {
 	// Max number of retries, 0 means infinite
 	Tries int
 
-	// ShouldRetry tells wether error should be retried. Nil defaults to always
+	// ShouldRetry tells whether error should be retried. Nil defaults to always
 	// true.
 	ShouldRetry func(error) bool
 }


### PR DESCRIPTION
Previously, when using managed identities, the Azure builder would set the subscriptionID in the Prepare method. But would not update it after getting the updated subscriptionID from the metadata server. This change updates the Run method to ensure a valid subscriptionID is saved to the statebag before continuing with an image build.

Closes #8515