### PR TITLE
Add iso file name when targetPath is a directory

### DIFF
--- a/common/step_download_test.go
+++ b/common/step_download_test.go
@@ -272,7 +272,7 @@ func TestStepDownload_download(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bad: non expected error %s", err.Error())
 	}
-	if filepath.Ext(path) != "." + step.Extension {
+	if filepath.Ext(path) != "."+step.Extension {
 		t.Fatalf("bad: path should contain extension %s but it was %s", step.Extension, filepath.Ext(path))
 	}
 	os.RemoveAll(step.TargetPath)


### PR DESCRIPTION
When a path for a directory is provided in `iso_target_path` we add a file name with an extension to it. This because when trying to start Hyper-v driver later, this value was being used as the `iso_path ` in StepMountDvdDrive. 

Closes #8530