### PR TITLE
template: replace deprecated os.SEEK_SET with io.SeekStart

### DIFF
--- a/template/parse.go
+++ b/template/parse.go
@@ -408,7 +408,7 @@ func ParseFile(path string) (*Template, error) {
 		defer os.Remove(f.Name())
 		defer f.Close()
 		io.Copy(f, os.Stdin)
-		f.Seek(0, os.SEEK_SET)
+		f.Seek(0, io.SeekStart)
 	} else {
 		f, err = os.Open(path)
 		if err != nil {
@@ -423,7 +423,7 @@ func ParseFile(path string) (*Template, error) {
 			return nil, err
 		}
 		// Rewind the file and get a better error
-		f.Seek(0, os.SEEK_SET)
+		f.Seek(0, io.SeekStart)
 		// Grab the error location, and return a string to point to offending syntax error
 		line, col, highlight := highlightPosition(f, syntaxErr.Offset)
 		err = fmt.Errorf("Error parsing JSON: %s\nAt line %d, column %d (offset %d):\n%s", err, line, col, syntaxErr.Offset, highlight)


### PR DESCRIPTION
This replaces two uses of the deprecated constant `os.SEEK_SET` with its replacement, `io.SeekStart`.
