### PR TITLE
Instance Running waiter not aware of global waiter settings

### DIFF
--- a/builder/amazon/common/state.go
+++ b/builder/amazon/common/state.go
@@ -66,6 +66,19 @@ func WaitUntilAMIAvailable(ctx aws.Context, conn ec2iface.EC2API, imageId string
 	return err
 }
 
+func WaitUntilInstanceRunning(ctx aws.Context, conn *ec2.EC2, instanceId string) error {
+
+	instanceInput := ec2.DescribeInstancesInput{
+		InstanceIds: []*string{&instanceId},
+	}
+
+	err := conn.WaitUntilInstanceRunningWithContext(
+		ctx,
+		&instanceInput,
+		getWaiterOptions()...)
+	return err
+}
+
 func WaitUntilInstanceTerminated(ctx aws.Context, conn *ec2.EC2, instanceId string) error {
 
 	instanceInput := ec2.DescribeInstancesInput{

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -233,7 +233,8 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 	describeInstance := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{aws.String(instanceId)},
 	}
-	if err := ec2conn.WaitUntilInstanceRunningWithContext(ctx, describeInstance); err != nil {
+
+	if err := WaitUntilInstanceRunning(ctx, ec2conn, instanceId); err != nil {
 		err := fmt.Errorf("Error waiting for instance (%s) to become ready: %s", instanceId, err)
 		state.Put("error", err)
 		ui.Error(err.Error())


### PR DESCRIPTION
This is related to https://github.com/hashicorp/packer/issues/6177.

The work done for #6177 didn't really address the hardcoded timeout issue for the run source instance step.
Specifically, it's not aware of the AWS_POLL_DELAY_SECONDS and AWS_TIMEOUT_SECONDS.