### PR TITLE
Add StepHTTPIPDiscover to virtualbox to allow HTTPIP and HTTPPort in vboxmanage

### DIFF
--- a/builder/virtualbox/common/step_http_ip_discover.go
+++ b/builder/virtualbox/common/step_http_ip_discover.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"context"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/multistep"
+)
+
+// Step to discover the http ip
+// which guests use to reach the vm host
+// To make sure the IP is set before boot command and http server steps
+type StepHTTPIPDiscover struct{}
+
+func (s *StepHTTPIPDiscover) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	hostIP := "10.0.2.2"
+	common.SetHTTPIP(hostIP)
+
+	return multistep.ActionContinue
+}
+
+func (s *StepHTTPIPDiscover) Cleanup(state multistep.StateBag) {}

--- a/builder/virtualbox/common/step_http_ip_discover_test.go
+++ b/builder/virtualbox/common/step_http_ip_discover_test.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"context"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/multistep"
+	"testing"
+)
+
+func TestStepHTTPIPDiscover_Run(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	step := new(StepHTTPIPDiscover)
+	hostIp := "10.0.2.2"
+	previousHttpIp := common.GetHTTPIP()
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+	httpIp := common.GetHTTPIP()
+	if httpIp != hostIp {
+		t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, hostIp)
+	}
+
+	common.SetHTTPIP(previousHttpIp)
+}

--- a/builder/virtualbox/common/step_type_boot_command.go
+++ b/builder/virtualbox/common/step_type_boot_command.go
@@ -63,8 +63,7 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		pauseFn = state.Get("pauseFn").(multistep.DebugPauseFn)
 	}
 
-	hostIP := "10.0.2.2"
-	common.SetHTTPIP(hostIP)
+	hostIP := common.GetHTTPIP()
 	s.Ctx.Data = &bootCommandTemplateData{
 		HTTPIP:       hostIP,
 		HTTPPort:     httpPort,

--- a/builder/virtualbox/common/step_vboxmanage.go
+++ b/builder/virtualbox/common/step_vboxmanage.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/packer/common"
 	"strings"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -11,6 +12,12 @@ import (
 )
 
 type commandTemplate struct {
+	// HTTPIP is the HTTP server's IP address.
+	HTTPIP string
+
+	// HTTPPort is the HTTP server port.
+	HTTPPort int
+
 	Name string
 }
 
@@ -37,8 +44,13 @@ func (s *StepVBoxManage) Run(ctx context.Context, state multistep.StateBag) mult
 		ui.Say("Executing custom VBoxManage commands...")
 	}
 
+	hostIP := common.GetHTTPIP()
+	httpPort := state.Get("http_port").(int)
+
 	s.Ctx.Data = &commandTemplate{
-		Name: vmName,
+		Name:     vmName,
+		HTTPIP:   hostIP,
+		HTTPPort: httpPort,
 	}
 
 	for _, originalCommand := range s.Commands {

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -308,6 +308,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Directories: b.config.FloppyConfig.FloppyDirectories,
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
+		new(vboxcommon.StepHTTPIPDiscover),
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,
 			HTTPPortMin: b.config.HTTPPortMin,

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -60,6 +60,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Directories: b.config.FloppyConfig.FloppyDirectories,
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
+		new(vboxcommon.StepHTTPIPDiscover),
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,
 			HTTPPortMin: b.config.HTTPPortMin,

--- a/builder/virtualbox/vm/builder.go
+++ b/builder/virtualbox/vm/builder.go
@@ -59,6 +59,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			AttachSnapshot: b.config.AttachSnapshot,
 			KeepRegistered: b.config.KeepRegistered,
 		},
+		new(vboxcommon.StepHTTPIPDiscover),
 		&common.StepHTTPServer{
 			HTTPDir:     b.config.HTTPDir,
 			HTTPPortMin: b.config.HTTPPortMin,


### PR DESCRIPTION
This PR will make it possible to use {{ .HTTPIP }} and {{ .HTTPPort }} inside vboxmanage commands. In order to do that, the StepHTTPIPDiscover was added before steps TypeBootCommand, VBoxManage and HTTPServer.

output log
```
vbox-ova: Executing: setextradata template-scratch VBoxInternal/Devices/pcbios/0/Config/DmiBoardSerial ds=nocloud-net;instance-id=packer;seedfrom=http://10.0.2.2:8624/
2020/02/06 16:54:52 packer-builder-virtualbox-ovf plugin: Executing VBoxManage: []string{"setextradata", "template-scratch", "VBoxInternal/Devices/pcbios/0/Config/DmiBoardSerial", "ds=nocloud-net;instance-id=packer;seedfrom=http://10.0.2.2:8624/"}
2020/02/06 16:54:52 packer-builder-virtualbox-ovf plugin: stdout:
2020/02/06 16:54:52 packer-builder-virtualbox-ovf plugin: stderr:
==> vbox-ova: Starting the virtual machine...
```

Closes #8692 