### PR TITLE
update the note about Windows symlinks

### DIFF
--- a/common/iso_config.go
+++ b/common/iso_config.go
@@ -29,11 +29,9 @@ import (
 // * Amazon S3
 //
 //
-// \~&gt; On windows - when referencing a local iso - if packer is running
-// without symlinking rights, the iso will be copied to the cache folder. Read
-// [Symlinks in Windows 10
-// !](https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/)
-// for more info.
+// \~&gt; On Windows, using a symlink to refer to local files is currently
+// unsupported. Packer will always copy a local iso into the Packer cache
+// directory.
 //
 // Examples:
 // go-getter can guess the checksum type based on `iso_checksum` len.

--- a/website/source/partials/common/_ISOConfig.html.md
+++ b/website/source/partials/common/_ISOConfig.html.md
@@ -12,11 +12,9 @@ go-getter supports the following protocols:
 * HTTP
 * Amazon S3
 
-\~&gt; On windows - when referencing a local iso - if packer is running
-without symlinking rights, the iso will be copied to the cache folder. Read
-[Symlinks in Windows 10
-!](https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/)
-for more info.
+\~&gt; On Windows, using a symlink to refer to local files is currently
+unsupported. Packer will always copy a local iso into the Packer cache
+directory.
 
 Examples:
 go-getter can guess the checksum type based on `iso_checksum` len.


### PR DESCRIPTION
GH-7534 and GH-7545 disabled the use of symlinks for copying local ISOs, per this comment:

https://github.com/hashicorp/packer/blob/master/common/step_download.go#L106

Update the documentation to match, as without reading the source it is implied that this should work.

