### PR TITLE
Check if post-processor is valid for builder in validation step

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -7,8 +7,8 @@ import (
 
 	ttmp "text/template"
 
-	multierror "github.com/hashicorp/go-multierror"
-	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/packer/template"
 	"github.com/hashicorp/packer/template/interpolate"
 )
@@ -231,6 +231,12 @@ func (c *Core) Build(n string) (Build, error) {
 		for _, rawP := range rawPs {
 			if rawP.Skip(rawName) {
 				continue
+			}
+			// Some Post Processors only works for specific builders
+			if !rawP.IsValidToBuilder(rawName) {
+				return nil, fmt.Errorf(
+					"post processor '%s' is not valid to be used with builder %s",
+					rawP.Name, rawName)
 			}
 			// -except skips post-processor & build
 			foundExcept := false

--- a/packer/core.go
+++ b/packer/core.go
@@ -233,7 +233,7 @@ func (c *Core) Build(n string) (Build, error) {
 				continue
 			}
 			// Some Post Processors only works for specific builders
-			if !rawP.IsValidToBuilder(rawName) {
+			if !rawP.IsValidWithBuilder(rawName) {
 				return nil, fmt.Errorf(
 					"post processor '%s' cannot be used with builder %s",
 					rawP.Name, rawName)

--- a/packer/core.go
+++ b/packer/core.go
@@ -7,8 +7,8 @@ import (
 
 	ttmp "text/template"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-version"
+	multierror "github.com/hashicorp/go-multierror"
+	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/packer/template"
 	"github.com/hashicorp/packer/template/interpolate"
 )
@@ -235,7 +235,7 @@ func (c *Core) Build(n string) (Build, error) {
 			// Some Post Processors only works for specific builders
 			if !rawP.IsValidToBuilder(rawName) {
 				return nil, fmt.Errorf(
-					"post processor '%s' is not valid to be used with builder %s",
+					"post processor '%s' cannot be used with builder %s",
 					rawP.Name, rawName)
 			}
 			// -except skips post-processor & build

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -435,7 +435,7 @@ func TestCoreBuild_invalidPostProcess(t *testing.T) {
 
 	_, err := core.Build("test")
 	if err == nil {
-		t.Fatalf("bad: build should faild to invalid post processor")
+		t.Fatalf("bad: build should fail due invalid post processor")
 	}
 	if err.Error() != "post processor 'vsphere' cannot be used with builder test" {
 		t.Fatalf("wrong err message: %s", err.Error())

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -437,7 +437,7 @@ func TestCoreBuild_invalidPostProcess(t *testing.T) {
 	if err == nil {
 		t.Fatalf("bad: build should faild to invalid post processor")
 	}
-	if err.Error() != "post processor 'vsphere' is not valid to be used with builder test" {
+	if err.Error() != "post processor 'vsphere' cannot be used with builder test" {
 		t.Fatalf("wrong err message: %s", err.Error())
 	}
 }

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -428,6 +428,20 @@ func TestCoreBuild_postProcess(t *testing.T) {
 	}
 }
 
+func TestCoreBuild_invalidPostProcess(t *testing.T) {
+	config := TestCoreConfig(t)
+	testCoreTemplate(t, config, fixtureDir("build-invalid-pp.json"))
+	core := TestCore(t, config)
+
+	_, err := core.Build("test")
+	if err == nil {
+		t.Fatalf("bad: build should faild to invalid post processor")
+	}
+	if err.Error() != "post processor 'vsphere' is not valid to be used with builder test" {
+		t.Fatalf("wrong err message: %s", err.Error())
+	}
+}
+
 func TestCoreBuild_templatePath(t *testing.T) {
 	config := TestCoreConfig(t)
 	testCoreTemplate(t, config, fixtureDir("build-template-path.json"))

--- a/packer/test-fixtures/build-invalid-pp.json
+++ b/packer/test-fixtures/build-invalid-pp.json
@@ -1,0 +1,7 @@
+{
+    "builders": [{
+        "type": "test"
+    }],
+
+    "post-processors": ["vsphere"]
+}

--- a/template/template.go
+++ b/template/template.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 // Template represents the parsed template that is used to configure
@@ -140,15 +140,17 @@ var validBuildersPerPostProcessor = map[string][]string{
 }
 
 func (p *PostProcessor) IsValidToBuilder(builder string) bool {
-	if builders, ok := validBuildersPerPostProcessor[p.Name]; ok {
-		for _, b := range builders {
-			if b == builder {
-				return true
-			}
-		}
-		return false
+	builders, ok := validBuildersPerPostProcessor[p.Name]
+	if !ok {
+		return true
 	}
-	return true
+
+	for _, b := range builders {
+		if b == builder {
+			return true
+		}
+	}
+	return false
 }
 
 // Provisioner represents a provisioner within the template.

--- a/template/template.go
+++ b/template/template.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 )
 
 // Template represents the parsed template that is used to configure
@@ -131,6 +131,24 @@ func (p *PostProcessor) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(m)
+}
+
+// If Post Processor Is not in this list it means that it's valid for all builders
+var validBuildersPerPostProcessor = map[string][]string{
+	"vsphere":          {"vmware-iso", "vmware-vmx"},
+	"vsphere-template": {"vmware-iso", "vmware-vmx"},
+}
+
+func (p *PostProcessor) IsValidToBuilder(builder string) bool {
+	if builders, ok := validBuildersPerPostProcessor[p.Name]; ok {
+		for _, b := range builders {
+			if b == builder {
+				return true
+			}
+		}
+		return false
+	}
+	return true
 }
 
 // Provisioner represents a provisioner within the template.

--- a/template/template.go
+++ b/template/template.go
@@ -139,7 +139,7 @@ var validBuildersPerPostProcessor = map[string][]string{
 	"vsphere-template": {"vmware-iso", "vmware-vmx"},
 }
 
-func (p *PostProcessor) IsValidToBuilder(builder string) bool {
+func (p *PostProcessor) IsValidWithBuilder(builder string) bool {
 	builders, ok := validBuildersPerPostProcessor[p.Name]
 	if !ok {
 		return true

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -140,3 +140,36 @@ func TestOnlyExceptSkip(t *testing.T) {
 		}
 	}
 }
+
+func TestPostProcessor_IsValidToBuilder(t *testing.T) {
+	pp := &PostProcessor{
+		Name: "vsphere",
+	}
+
+	// valid builder vmware-iso
+	valid := pp.IsValidToBuilder("vmware-iso")
+	if !valid {
+		t.Fatalf("vsphere post processor should be valid for vmware-iso builder")
+	}
+
+	// valid builder vmware-vmx
+	valid = pp.IsValidToBuilder("vmware-vmx")
+	if !valid {
+		t.Fatalf("vsphere post processor should be valid for vmware-vmx builder")
+	}
+
+	// invalid builder test
+	valid = pp.IsValidToBuilder("test")
+	if valid {
+		t.Fatalf("vsphere post processor should be valid for test builder")
+	}
+
+	// another post processor should be valid for any builder
+	pp = &PostProcessor{
+		Name: "test",
+	}
+	valid = pp.IsValidToBuilder("test")
+	if !valid {
+		t.Fatalf("test post processor should be valid for test builder")
+	}
+}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -147,19 +147,19 @@ func TestPostProcessor_IsValidToBuilder(t *testing.T) {
 	}
 
 	// valid builder vmware-iso
-	valid := pp.IsValidToBuilder("vmware-iso")
+	valid := pp.IsValidWithBuilder("vmware-iso")
 	if !valid {
 		t.Fatalf("vsphere post processor should be valid for vmware-iso builder")
 	}
 
 	// valid builder vmware-vmx
-	valid = pp.IsValidToBuilder("vmware-vmx")
+	valid = pp.IsValidWithBuilder("vmware-vmx")
 	if !valid {
 		t.Fatalf("vsphere post processor should be valid for vmware-vmx builder")
 	}
 
 	// invalid builder test
-	valid = pp.IsValidToBuilder("test")
+	valid = pp.IsValidWithBuilder("test")
 	if valid {
 		t.Fatalf("vsphere post processor should be valid for test builder")
 	}
@@ -168,7 +168,7 @@ func TestPostProcessor_IsValidToBuilder(t *testing.T) {
 	pp = &PostProcessor{
 		Name: "test",
 	}
-	valid = pp.IsValidToBuilder("test")
+	valid = pp.IsValidWithBuilder("test")
 	if !valid {
 		t.Fatalf("test post processor should be valid for test builder")
 	}


### PR DESCRIPTION
Check whether the post-processor is valid to be used with the current builder on validation step. 

If it's not valid it will fail and output the log:
```
==> Builds finished but no artifacts were created.
Failed to initialize build 'virtualbox-iso': post processor 'vsphere' is not valid be used with builder virtualbox-iso
```

Closes https://github.com/hashicorp/packer/issues/5636