### PR TITLE
scripts/prepare_changelog: Update jq filter to ignore tech-debt labelled pull-requests

### DIFF
--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -5,7 +5,7 @@ DO_PR_CHECK=1
 
 set -o pipefail
 
-is_doc_pr(){
+is_doc_or_tech_debt_pr(){
     if ! (($+commands[jq])); then
         DO_PR_CHECK=0
         echo "jq not found"
@@ -39,16 +39,16 @@ get_prs(){
         fi
     done | while read PR_NUM
     do
-        if (($DO_PR_CHECK)) && is_doc_pr $PR_NUM; then
+        if (($DO_PR_CHECK)) && is_doc_or_tech_debt_pr $PR_NUM; then
             continue
         fi
         echo "https://github.com/hashicorp/packer/pull/${PR_NUM}"
     done
 }
 
-#is_doc_pr 52061111
-# is_doc_pr 5206 # non-doc pr
-#is_doc_pr 5434 # doc pr
+#is_doc_or_tech_debt_pr 52061111
+# is_doc_or_tech_debt_pr 5206 # non-doc pr
+#is_doc_or_tech_debt_pr 5434 # doc pr
 #echo $?
 #exit
 

--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -12,7 +12,8 @@ is_doc_pr(){
         return 1
     fi
     PR_NUM=$1
-    out=$(curl -fsS "https://api.github.com/repos/hashicorp/packer/issues/${PR_NUM}" | jq '[.labels[].name == "docs"] | any')
+    out=$(curl -fsS "https://api.github.com/repos/hashicorp/packer/issues/${PR_NUM}" \
+      | jq '[.labels[].name == "docs" or .labels[].name == "tech-debt"] | any')
     exy="$?"
     if [ $exy -ne 0 ]; then
         echo "bad response from github"


### PR DESCRIPTION
This change proposes that we use the tech-debt label for new pull-requests that address internal non-user facing changes that are not docs. If everyone is on board then the prepare_changelog script is being updated here to ignore both docs or tech-debt related PRs. 