### PR TITLE
Fix typo in Dockerfiles section in Builders

### DIFF
--- a/website/source/docs/builders/docker.html.md.erb
+++ b/website/source/docs/builders/docker.html.md.erb
@@ -321,7 +321,7 @@ Instead, you can just provide shell scripts, Chef recipes, Puppet manifests,
 etc. to provision your Docker container just like you would a regular
 virtualized or dedicated machine.
 
-While Docker has many features, Packer views Docker simply as an container
+While Docker has many features, Packer views Docker simply as a container
 runner. To that end, Packer is able to repeatedly build these containers using
 portable provisioning scripts.
 


### PR DESCRIPTION
Fix: `an container runner` => `a container runner`