### PR TITLE
add the remote iso first so that it is first in boot order

### DIFF
--- a/builder/vsphere/iso/step_add_cdrom.go
+++ b/builder/vsphere/iso/step_add_cdrom.go
@@ -49,19 +49,19 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	ui.Say("Mounting ISO images...")
+	if path, ok := state.GetOk("iso_remote_path"); ok {
+		if err := vm.AddCdrom(s.Config.CdromType, path.(string)); err != nil {
+			state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
+			return multistep.ActionHalt
+		}
+	}
+
 	if len(s.Config.ISOPaths) > 0 {
 		for _, path := range s.Config.ISOPaths {
 			if err := vm.AddCdrom(s.Config.CdromType, path); err != nil {
 				state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
 				return multistep.ActionHalt
 			}
-		}
-	}
-
-	if path, ok := state.GetOk("iso_remote_path"); ok {
-		if err := vm.AddCdrom(s.Config.CdromType, path.(string)); err != nil {
-			state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
-			return multistep.ActionHalt
 		}
 	}
 	return multistep.ActionContinue

--- a/website/source/docs/builders/vsphere-iso.html.md.erb
+++ b/website/source/docs/builders/vsphere-iso.html.md.erb
@@ -27,8 +27,7 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 
 There are many configuration options available for this builder. In addition to
 the items listed here, you will want to look at the general configuration
-references for [ISO](#iso-configuration),
-[HTTP](#http-directory-configuration),
+references for [HTTP](#http-directory-configuration),
 [Floppy](#floppy-configuration),
 [Boot](#boot-configuration),
 [Driver](#driver-configuration),
@@ -63,7 +62,35 @@ necessary for this build to succeed and can be found further down the page.
 ### Wait Configuration
 <%= partial "partials/builder/vsphere/common/WaitIpConfig-not-required" %>
 
+### ISO Configuration
+
+<%= partial "partials/common/ISOConfig" %>
+
+#### Required:
+
+<%= partial "partials/common/ISOConfig-required" %>
+
+#### Optional:
+
+<%= partial "partials/common/ISOConfig-not-required" %>
+
 ### CDRom Configuration
+
+Each iso defined in the CDRom Configuration adds a new drive. If the "iso_url" is defined in
+addition to the "iso_paths", the "iso_url" is added to the VM first. This keeps the "iso_url" first in
+the boot order by default allowing the boot iso being defined by the iso_url and the vmware tools iso added
+from the datastore. Example:
+
+```json
+"iso_urls": [
+  "win10.iso",
+  "http://example.org/isos/win10.iso"
+],
+"iso_paths": [
+    "[] /usr/lib/vmware/isoimages/windows.iso"
+],
+```
+
 <%= partial "partials/builder/vsphere/iso/CDRomConfig-not-required" %>
 
 ### Create Configuration


### PR DESCRIPTION
in vsphere-iso builder, if both iso_urls and iso_paths are defined. The iso_urls (remote) should be added as a cdrom first so that it gets picked up as the default boot device. This allows the user to refer to the install iso using the iso_urls field, and also the vmware tools iso from the local datastore.