### PR TITLE
make period stripping more strict so that users can disable provisine…

### DIFF
--- a/config.go
+++ b/config.go
@@ -296,7 +296,7 @@ func (c *config) discoverSingle(glob string) (map[string]string, error) {
 		}
 
 		// If the filename has a ".", trim up to there
-		if idx := strings.Index(file, "."); idx >= 0 {
+		if idx := strings.Index(file, ".exe"); idx >= 0 {
 			file = file[:idx]
 		}
 


### PR DESCRIPTION
This makes us a bit stricter about what plugins we'll load. For context, (from #8690)

>@SwampDragons there was a file in $GOPATH/bin called packer-builder-vsphere-clone.working. I am surprised it picked it up given its named wrong. Deleting it fixed it.

Closes #8731