### PR TITLE
struct-markdown should keep the same slash direction

### DIFF
--- a/cmd/struct-markdown/main.go
+++ b/cmd/struct-markdown/main.go
@@ -60,19 +60,20 @@ func main() {
 		}
 
 		fields := structDecl.Fields.List
+		sourcePath := filepath.ToSlash(paths[1])
 		header := Struct{
-			SourcePath: paths[1],
+			SourcePath: sourcePath,
 			Name:       typeSpec.Name.Name,
 			Filename:   "_" + typeSpec.Name.Name + ".html.md",
 			Header:     typeDecl.Doc.Text(),
 		}
 		required := Struct{
-			SourcePath: paths[1],
+			SourcePath: sourcePath,
 			Name:       typeSpec.Name.Name,
 			Filename:   "_" + typeSpec.Name.Name + "-required.html.md",
 		}
 		notRequired := Struct{
-			SourcePath: paths[1],
+			SourcePath: sourcePath,
 			Name:       typeSpec.Name.Name,
 			Filename:   "_" + typeSpec.Name.Name + "-not-required.html.md",
 		}


### PR DESCRIPTION
If struct-markdown is run on windows, it uses the '\' path separator. It should generate consistent output regardless of Windows or Linux.