### PR TITLE
script/prepare_changelog: Update to show squashed merge commits

### DIFF
--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -29,8 +29,8 @@ if [ -z $LAST_RELEASE ]; then
 fi
 
 get_prs(){
-    # git log --merges v0.10.2...c3861d167533fb797b0fae0c380806625712e5f7 |
-    git log --merges HEAD...${LAST_RELEASE} |
+    # git log v0.10.2...c3861d167533fb797b0fae0c380806625712e5f7 |
+    git log HEAD...${LAST_RELEASE} |
     grep -o "#\([0-9]\+\)" | awk -F\# '{print $2}' | while read line
     do
         grep -q "GH-${line}" CHANGELOG.md

--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -31,7 +31,7 @@ fi
 get_prs(){
     # git log --merges v0.10.2...c3861d167533fb797b0fae0c380806625712e5f7 |
     git log --merges HEAD...${LAST_RELEASE} |
-    grep -o "Merge pull request #\([0-9]\+\)" | awk -F\# '{print $2}' | while read line
+    grep -o "#\([0-9]\+\)" | awk -F\# '{print $2}' | while read line
     do
         grep -q "GH-${line}" CHANGELOG.md
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
Before this change the prepare changelog script would look exclusively for merge commits. This change will search all commits for any commit message that contains, or what looks to be, a GitHub PR number and will presented it to the screen.


Before the change
```bash
https://github.com/hashicorp/packer/pull/8725

https://github.com/hashicorp/packer/pull/8690
```

After the change
```bash
⇶  ./scripts/prepare_changelog.sh v1.5.2
https://github.com/hashicorp/packer/pull/8725

https://github.com/hashicorp/packer/pull/8690

https://github.com/hashicorp/packer/pull/8727
```