### PR TITLE
vsphere-iso: add support for eagerly zeroed / scrubbed disks

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -53,6 +53,7 @@ type NIC struct {
 
 type CreateConfig struct {
 	DiskThinProvisioned bool
+	DiskEagerlyScrub    bool
 	DiskControllerType  string // example: "scsi", "pvscsi"
 	DiskSize            int64
 
@@ -503,6 +504,7 @@ func addDisk(_ *Driver, devices object.VirtualDeviceList, config *CreateConfig) 
 			Backing: &types.VirtualDiskFlatVer2BackingInfo{
 				DiskMode:        string(types.VirtualDiskModePersistent),
 				ThinProvisioned: types.NewBool(config.DiskThinProvisioned),
+				EagerlyScrub:    types.NewBool(config.DiskEagerlyScrub),
 			},
 		},
 		CapacityInKB: config.DiskSize * 1024,

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -30,6 +30,7 @@ type FlatConfig struct {
 	DiskControllerType        *string           `mapstructure:"disk_controller_type" cty:"disk_controller_type"`
 	DiskSize                  *int64            `mapstructure:"disk_size" cty:"disk_size"`
 	DiskThinProvisioned       *bool             `mapstructure:"disk_thin_provisioned" cty:"disk_thin_provisioned"`
+	DiskEagerlyScrub          *bool             `mapstructure:"disk_eagerly_scrub" cty:"disk_eagerly_scrub"`
 	Network                   *string           `mapstructure:"network" cty:"network"`
 	NetworkCard               *string           `mapstructure:"network_card" cty:"network_card"`
 	NICs                      []FlatNIC         `mapstructure:"network_adapters" cty:"network_adapters"`
@@ -151,6 +152,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_controller_type":         &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.String, Required: false},
 		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"disk_thin_provisioned":        &hcldec.AttrSpec{Name: "disk_thin_provisioned", Type: cty.Bool, Required: false},
+		"disk_eagerly_scrub":           &hcldec.AttrSpec{Name: "disk_eagerly_scrub", Type: cty.Bool, Required: false},
 		"network":                      &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
 		"network_card":                 &hcldec.AttrSpec{Name: "network_card", Type: cty.String, Required: false},
 		"network_adapters":             &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -42,6 +42,8 @@ type CreateConfig struct {
 	DiskSize int64 `mapstructure:"disk_size"`
 	// Enable VMDK thin provisioning for VM. Defaults to `false`.
 	DiskThinProvisioned bool `mapstructure:"disk_thin_provisioned"`
+	// Enable VMDK eager scrubbing for VM. Defaults to `false`.
+	DiskEagerlyScrub bool `mapstructure:"disk_eagerly_scrub"`
 	// Set network VM will be connected to.
 	Network string `mapstructure:"network"`
 	// Set VM network card type. Example `vmxnet3`.
@@ -115,6 +117,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 
 	vm, err = d.CreateVM(&driver.CreateConfig{
 		DiskThinProvisioned: s.Config.DiskThinProvisioned,
+		DiskEagerlyScrub:    s.Config.DiskEagerlyScrub,
 		DiskControllerType:  s.Config.DiskControllerType,
 		DiskSize:            s.Config.DiskSize,
 		Name:                s.Location.VMName,

--- a/builder/vsphere/iso/step_create.hcl2spec.go
+++ b/builder/vsphere/iso/step_create.hcl2spec.go
@@ -15,6 +15,7 @@ type FlatCreateConfig struct {
 	DiskControllerType  *string   `mapstructure:"disk_controller_type" cty:"disk_controller_type"`
 	DiskSize            *int64    `mapstructure:"disk_size" cty:"disk_size"`
 	DiskThinProvisioned *bool     `mapstructure:"disk_thin_provisioned" cty:"disk_thin_provisioned"`
+	DiskEagerlyScrub    *bool     `mapstructure:"disk_eagerly_scrub" cty:"disk_eagerly_scrub"`
 	Network             *string   `mapstructure:"network" cty:"network"`
 	NetworkCard         *string   `mapstructure:"network_card" cty:"network_card"`
 	NICs                []FlatNIC `mapstructure:"network_adapters" cty:"network_adapters"`
@@ -40,6 +41,7 @@ func (*FlatCreateConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_controller_type":  &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.String, Required: false},
 		"disk_size":             &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"disk_thin_provisioned": &hcldec.AttrSpec{Name: "disk_thin_provisioned", Type: cty.Bool, Required: false},
+		"disk_eagerly_scrub":    &hcldec.AttrSpec{Name: "disk_eagerly_scrub", Type: cty.Bool, Required: false},
 		"network":               &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
 		"network_card":          &hcldec.AttrSpec{Name: "network_card", Type: cty.String, Required: false},
 		"network_adapters":      &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},

--- a/website/source/partials/builder/vsphere/iso/_CreateConfig-not-required.html.md
+++ b/website/source/partials/builder/vsphere/iso/_CreateConfig-not-required.html.md
@@ -17,6 +17,8 @@
     
 -   `disk_thin_provisioned` (bool) - Enable VMDK thin provisioning for VM. Defaults to `false`.
     
+-   `disk_eagerly_scrub` (bool) - Enable VMDK eager scrubbing for VM. Defaults to `false`.
+    
 -   `network` (string) - Set network VM will be connected to.
     
 -   `network_card` (string) - Set VM network card type. Example `vmxnet3`.


### PR DESCRIPTION
Add support for eager scrubbing of created disks. This is equivalent to thick provisioned eager zeroed.