### PR TITLE
Add prompt to use a specific directory for *.pkr.hcl

### DIFF
--- a/website/source/guides/hcl/variables/index.html.md.erb
+++ b/website/source/guides/hcl/variables/index.html.md.erb
@@ -19,7 +19,9 @@ Local variables can be a compound of input variables and local variables.
 Let's create a file `variables.pkr.hcl` with the following contents.
 
 -> **Note**: that the file can be named anything, since Packer loads all
-files ending in `.pkr.hcl` in a directory.
+files ending in `.pkr.hcl` in a directory. If you split your configuration 
+across multiple files, use `packer build <source directory>` to initiate
+a build.
 
 ```hcl
 # variables.pkr.hcl


### PR DESCRIPTION
This improves doc usability as many users will still expect to use `packer build <config file>.pkr.hcl` having run `packer build <config file>.json` in the past.
