### PR TITLE
vmware/iso: Update documentation of guest_os_type

### DIFF
--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -92,7 +92,9 @@ type Config struct {
 	// set in the VMware VMX. By default this is other. By specifying a more
 	// specific OS type, VMware may perform some optimizations or virtual hardware
 	// changes to better support the operating system running in the
-	// virtual machine.
+	// virtual machine. Valid values differ by platform and version numbers, and may
+	// not match other VMware API's representation of the guest OS names. Consult your
+	// platform for valid values.
 	GuestOSType string `mapstructure:"guest_os_type" required:"false"`
 	// The [vmx hardware
 	// version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746)

--- a/website/source/partials/builder/vmware/iso/_Config-not-required.html.md
+++ b/website/source/partials/builder/vmware/iso/_Config-not-required.html.md
@@ -59,7 +59,9 @@
     set in the VMware VMX. By default this is other. By specifying a more
     specific OS type, VMware may perform some optimizations or virtual hardware
     changes to better support the operating system running in the
-    virtual machine.
+    virtual machine. Valid values differ by platform and version numbers, and may
+    not match other VMware API's representation of the guest OS names. Consult your
+    platform for valid values.
     
 -   `version` (string) - The [vmx hardware
     version](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746)


### PR DESCRIPTION
Updates documentation to highlight that the `guest_os_type` depends on
the platform its on, and that it does not necessarily match other APIs
available.

Closes #8707