### PR TITLE
execute_command in powershell wasn't interpolating build vars properly

### DIFF
--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -196,7 +196,23 @@ func funcGenBuild(ctx *Context) interface{} {
 			}
 			return "", fmt.Errorf("loaded data, but couldnt find %s in it.", s)
 		}
-
+		if data, ok := ctx.Data.(map[string]interface{}); ok {
+			// PlaceholderData has been passed into generator, so if the given
+			// key already exists in data, then we know it's an "allowed" key
+			if heldPlace, ok := data[s]; ok {
+				if hp, ok := heldPlace.(string); ok {
+					// If we're in the first interpolation pass, the goal is to
+					// make sure that we pass the value through.
+					// TODO match against an actual string constant
+					if strings.Contains(hp, common.PlaceholderMsg) {
+						return fmt.Sprintf("{{.%s}}", s), nil
+					} else {
+						return hp, nil
+					}
+				}
+			}
+			return "", fmt.Errorf("loaded data, but couldnt find %s in it.", s)
+		}
 		return "", fmt.Errorf("Error validating build variable: the given "+
 			"variable %s will not be passed into your plugin.", s)
 	}

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -164,57 +164,50 @@ func funcGenTemplateDir(ctx *Context) interface{} {
 	}
 }
 
+func passthroughOrInterpolate(data map[interface{}]interface{}, s string) (string, error) {
+	if heldPlace, ok := data[s]; ok {
+		if hp, ok := heldPlace.(string); ok {
+			// If we're in the first interpolation pass, the goal is to
+			// make sure that we pass the value through.
+			// TODO match against an actual string constant
+			if strings.Contains(hp, common.PlaceholderMsg) {
+				return fmt.Sprintf("{{.%s}}", s), nil
+			} else {
+				return hp, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("loaded data, but couldnt find %s in it.", s)
+
+}
 func funcGenBuild(ctx *Context) interface{} {
+	// Depending on where the context data is coming from, it could take a few
+	// different map types. The following switch standardizes the map types
+	// so we can act on them correctly.
 	return func(s string) (string, error) {
-		if data, ok := ctx.Data.(map[string]string); ok {
-			if heldPlace, ok := data[s]; ok {
-				// If we're in the first interpolation pass, the goal is to
-				// make sure that we pass the value through.
-				// TODO match against an actual string constant
-				if strings.Contains(heldPlace, common.PlaceholderMsg) {
-					return fmt.Sprintf("{{.%s}}", s), nil
-				} else {
-					return heldPlace, nil
-				}
+		switch data := ctx.Data.(type) {
+		case map[interface{}]interface{}:
+			return passthroughOrInterpolate(data, s)
+		case map[string]interface{}:
+			// convert to a map[interface{}]interface{} so we can use same
+			// parsing on it
+			passed := make(map[interface{}]interface{}, len(data))
+			for k, v := range data {
+				passed[k] = v
 			}
-			return "", fmt.Errorf("loaded data, but couldnt find %s in it.", s)
-		}
-		if data, ok := ctx.Data.(map[interface{}]interface{}); ok {
-			// PlaceholderData has been passed into generator, so if the given
-			// key already exists in data, then we know it's an "allowed" key
-			if heldPlace, ok := data[s]; ok {
-				if hp, ok := heldPlace.(string); ok {
-					// If we're in the first interpolation pass, the goal is to
-					// make sure that we pass the value through.
-					// TODO match against an actual string constant
-					if strings.Contains(hp, common.PlaceholderMsg) {
-						return fmt.Sprintf("{{.%s}}", s), nil
-					} else {
-						return hp, nil
-					}
-				}
+			return passthroughOrInterpolate(passed, s)
+		case map[string]string:
+			// convert to a map[interface{}]interface{} so we can use same
+			// parsing on it
+			passed := make(map[interface{}]interface{}, len(data))
+			for k, v := range data {
+				passed[k] = v
 			}
-			return "", fmt.Errorf("loaded data, but couldnt find %s in it.", s)
+			return passthroughOrInterpolate(passed, s)
+		default:
+			return "", fmt.Errorf("Error validating build variable: the given "+
+				"variable %s will not be passed into your plugin.", s)
 		}
-		if data, ok := ctx.Data.(map[string]interface{}); ok {
-			// PlaceholderData has been passed into generator, so if the given
-			// key already exists in data, then we know it's an "allowed" key
-			if heldPlace, ok := data[s]; ok {
-				if hp, ok := heldPlace.(string); ok {
-					// If we're in the first interpolation pass, the goal is to
-					// make sure that we pass the value through.
-					// TODO match against an actual string constant
-					if strings.Contains(hp, common.PlaceholderMsg) {
-						return fmt.Sprintf("{{.%s}}", s), nil
-					} else {
-						return hp, nil
-					}
-				}
-			}
-			return "", fmt.Errorf("loaded data, but couldnt find %s in it.", s)
-		}
-		return "", fmt.Errorf("Error validating build variable: the given "+
-			"variable %s will not be passed into your plugin.", s)
 	}
 }
 

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -384,6 +384,13 @@ func TestFuncPackerBuild(t *testing.T) {
 			Template:    "{{ build `MissingVar` }}",
 			OutVal:      "",
 		},
+		// Data map is a map[string]interface and contains value
+		{
+			DataMap:     map[string]interface{}{"PartyVar": "PartyVal"},
+			ErrExpected: false,
+			Template:    "{{ build `PartyVar` }}",
+			OutVal:      "PartyVal",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
I just tried to write up an example of modifying an execute_command to contain a build variable, and found that it wasn't working because the build func wasn't casting the generated_data properly. 

I added this type case with a straight copy/paste. If we end up having to do another iteration it's probably worth figuring out how to generalize the func to have less copypasta but it seems like a premature optimization for now. 

example template that does not work before and does work after this PR. 
```
{
  "builders": [
    {
      "type": "amazon-ebs",
      "region": "us-west-2",
      "instance_type": "t2.micro",
      "source_ami_filter": {
          "filters": {
            "name": "Windows_Server-2016-English-Full-Base-*"
          },
          "owners": ["801119661308"],
          "most_recent": true
      },
      "ami_name": "packer-demo-{{timestamp}}",
      "user_data_file": "./boot_config/packer_bootstrap_win.txt",
      "communicator": "winrm",
      "associate_public_ip_address": true,
      "winrm_insecure": true,
      "winrm_username": "Administrator",
      "winrm_password": "SuperS3cr3t!"
    }
  ],
  "provisioners": [
    {
            "execute_command": "powershell.exe -ExecutionPolicy ByPass -File {{.Path}} -HOST_IP {{ build `Host` }}",
            "script": "echo_ip.ps1",
            "type": "powershell"
    }
```