### PR TITLE
Citrix XenServer packer plugin-#4295

### DIFF
--- a/website/source/partials/builders/_community_builders.html.md
+++ b/website/source/partials/builders/_community_builders.html.md
@@ -12,3 +12,5 @@
   for creating [Vultr](https://www.vultr.com/) snapshots.
 
 - [Huawei Cloud ECS builder](https://github.com/huaweicloud/packer-builder-huaweicloud-ecs) - Plugin for creating [Huawei Cloud ECS](https://www.huaweicloud.com/intl/en-us/) images.
+
+- [Citrix XenServer/Citrix Hypervisor](https://github.com/xenserver/packer-builder-xenserver) - Plugin for creating [Citrix XenServer/Citrix Hypervisor](https://xenserver.org/) images from an iso image or from an existing template.


### PR DESCRIPTION
Updating the references to the packer plugins for the Citrix XenServer/Citrix Hypervisor to the official  Github repository, maintained by Citrix Systems. I am opening this pull request since I have been made a maintainer of the Citrix XenServer packer plugin. I will be maintaining this plugin going forward and merging all the open PR's that have been unattended for a long time now. This is also the outcome of my discussion at: https://github.com/hashicorp/packer/issues/4733

Closes #4295

