### PR TITLE
[Website] Set security-focused page headers

### DIFF
--- a/website/config.rb
+++ b/website/config.rb
@@ -112,3 +112,4 @@ end
 
 # Netlify redirects/headers
 proxy '_redirects', 'netlify-redirects', ignore: true
+proxy '_headers', 'netlify-headers', ignore: true

--- a/website/source/netlify-headers
+++ b/website/source/netlify-headers
@@ -1,0 +1,3 @@
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  X-Frame-Options: SAMEORIGIN


### PR DESCRIPTION
This PR aims to mitigate security issues on the Packer website by applying the following headers to all pages:

- `X-Frame-Options: SAMEORIGIN` (mitigates possible click-jacking exploits)
- `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` (enforces HSTS)