### PR TITLE
docs/provisioners/index: Add link to Template Provisioners section

### DIFF
--- a/website/source/docs/provisioners/index.html.md.erb
+++ b/website/source/docs/provisioners/index.html.md.erb
@@ -18,5 +18,6 @@ use cases for provisioners include:
 -   creating users
 -   downloading application code
 
-These are just a few examples, and the possibilities for provisioners are
-endless.
+See [Template Provisioners](/docs/templates/provisioners.html) to learn more
+about working with provisioners. For information on an individual provisioner,
+choose it from the sidebar.


### PR DESCRIPTION
This change adds a link from the Provisioners section back to the Template Provisioners page to help find all the documented provisioning goodies. 