### PR TITLE
Remove all floppy controllers before adding a new one

### DIFF
--- a/builder/virtualbox/common/driver.go
+++ b/builder/virtualbox/common/driver.go
@@ -25,6 +25,9 @@ type Driver interface {
 	// Create an NVME controller
 	CreateNVMeController(vm string, controller string, portcount int) error
 
+	// Delete all floppy controllers
+	RemoveFloppyControllers(vm string) error
+
 	// Delete a VM by name
 	Delete(string) error
 

--- a/builder/virtualbox/common/driver_mock.go
+++ b/builder/virtualbox/common/driver_mock.go
@@ -17,6 +17,9 @@ type DriverMock struct {
 	CreateNVMeControllerController string
 	CreateNVMeControllerErr        error
 
+	RemoveFloppyControllersVM  string
+	RemoveFloppyControllersErr error
+
 	DeleteCalled bool
 	DeleteName   string
 	DeleteErr    error
@@ -79,6 +82,11 @@ func (d *DriverMock) CreateNVMeController(vm string, controller string, portcoun
 	d.CreateNVMeControllerVM = vm
 	d.CreateNVMeControllerController = vm
 	return d.CreateNVMeControllerErr
+}
+
+func (d *DriverMock) RemoveFloppyControllers(vm string) error {
+	d.RemoveFloppyControllersVM = vm
+	return d.RemoveFloppyControllersErr
 }
 
 func (d *DriverMock) Delete(name string) error {

--- a/builder/virtualbox/common/step_attach_floppy.go
+++ b/builder/virtualbox/common/step_attach_floppy.go
@@ -48,6 +48,12 @@ func (s *StepAttachFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	ui := state.Get("ui").(packer.Ui)
 	vmName := state.Get("vmName").(string)
 
+	ui.Say("Deleting any current floppy disk...")
+	if err := driver.RemoveFloppyControllers(vmName); err != nil {
+		state.Put("error", fmt.Errorf("Error deleting existing floppy controllers: %s", err))
+		return multistep.ActionHalt
+	}
+
 	ui.Say("Attaching floppy disk...")
 
 	// Create the floppy disk controller

--- a/builder/virtualbox/common/step_attach_floppy_test.go
+++ b/builder/virtualbox/common/step_attach_floppy_test.go
@@ -38,6 +38,10 @@ func TestStepAttachFloppy(t *testing.T) {
 		t.Fatal("should NOT have error")
 	}
 
+	if driver.RemoveFloppyControllersVM == "" {
+		t.Fatal("RemoveFloppyControllers was not called")
+	}
+
 	if len(driver.VBoxManageCalls) != 2 {
 		t.Fatal("not enough calls to VBoxManage")
 	}


### PR DESCRIPTION
This PR will make it possible to use VirtualBox-OVA builder with floppy configuration when the OVA image already has a floppy controller configured.

Closes #8816
