### PR TITLE
Clarify `expect_disconnect` behavior

### DIFF
--- a/website/source/docs/provisioners/shell.html.md.erb
+++ b/website/source/docs/provisioners/shell.html.md.erb
@@ -66,7 +66,7 @@ The example below is fully functional.
     -   `EnvVarFile` is the path to the file containing env vars, if
         `use_env_var_file` is true.
 
--   `expect_disconnect` (boolean) - Defaults to `false`. Allow server to disconnect from us without throwing an error.
+-   `expect_disconnect` (boolean) - Defaults to `false`. When `true`, allow the server to disconnect from Packer without throwing an error.
     A disconnect might happen if you restart the ssh server or reboot the host.
 
 -   `inline_shebang` (string) - The

--- a/website/source/docs/provisioners/shell.html.md.erb
+++ b/website/source/docs/provisioners/shell.html.md.erb
@@ -65,9 +65,9 @@ The example below is fully functional.
     -   `Vars` is the list of `environment_vars`, if configured.
     -   `EnvVarFile` is the path to the file containing env vars, if
         `use_env_var_file` is true.
--   `expect_disconnect` (boolean) - Defaults to `false`. Whether to error if
-    the server disconnects us. A disconnect might happen if you restart the ssh
-    server or reboot the host.
+
+-   `expect_disconnect` (boolean) - Defaults to `false`. Allow server to disconnect from us without throwing an error.
+    A disconnect might happen if you restart the ssh server or reboot the host.
 
 -   `inline_shebang` (string) - The
     [shebang](https://en.wikipedia.org/wiki/Shebang_%28Unix%29) value to use


### PR DESCRIPTION
The description of the shell provisioner parameter `expect_disconnect` is confusing, and perhaps at odds with the parameter name.

TL;DR: PR clarifies the behavior with a minor wording change.

The shell_provisioner docs read:

> `expect_disconnect` (boolean) - Defaults to `false`. Whether to error if the server disconnects us.

The boolean value should be in agreement with both the parameter name (LHS) and the parameter's description (RHS)

If I _expect_ [event] to happen (`true`), then there should be _no_ error. If instead, I am _not_ anticipating a disconnect during the provisioner's execution, there _should_ be an error (`false` -> I do _not_ expect [event] to happen).

Removing the description's initial qualifier gives us an action statement, beginning with a verb: "error if the server disconnects us." In the context of this parameter, the verbs *expect* and *error* are opposites, putting the name and description in conflict.