### PR TITLE
post-processor/digitalocean-import/post-processor.go: Replace Deprecated session.New()

### DIFF
--- a/post-processor/digitalocean-import/post-processor.go
+++ b/post-processor/digitalocean-import/post-processor.go
@@ -198,7 +198,10 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 			logger: log.New(os.Stderr, "", log.LstdFlags),
 		},
 	}
-	sess := session.New(spacesConfig)
+	sess, err := session.NewSession(spacesConfig)
+	if err != nil {
+		return nil, false, false, err
+	}
 
 	ui.Message(fmt.Sprintf("Uploading %s to spaces://%s/%s", source, p.config.SpaceName, p.config.ObjectName))
 	err = uploadImageToSpaces(source, p, sess)


### PR DESCRIPTION
There is a deprecation warning on `github.com/aws/aws-sdk-go/aws/session.New()`
>  Deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.

This PR removes the deprecated `New()` function and replaces it with `NewSession()`.