### PR TITLE
Fix gosimple S1025 linting errors

### DIFF
--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -300,7 +300,7 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 		if len(createOutput.Errors) > 0 {
 			errString := fmt.Sprintf("Error waiting for fleet request (%s) to become ready:", *createOutput.FleetId)
 			for _, outErr := range createOutput.Errors {
-				errString = errString + fmt.Sprintf("%s", *outErr.ErrorMessage)
+				errString = errString + aws.StringValue(outErr.ErrorMessage)
 			}
 			err = fmt.Errorf(errString)
 			state.Put("error", err)

--- a/builder/docker/communicator.go
+++ b/builder/docker/communicator.go
@@ -186,12 +186,9 @@ func (c *Communicator) UploadDir(dst string, src string, exclude []string) error
 
 	*/
 
-	var dockerSource string
-
+	dockerSource := src
 	if src[len(src)-1] == '/' {
 		dockerSource = fmt.Sprintf("%s.", src)
-	} else {
-		dockerSource = fmt.Sprintf("%s", src)
 	}
 
 	// Make the directory, then copy into it

--- a/builder/qemu/step_copy_disk.go
+++ b/builder/qemu/step_copy_disk.go
@@ -18,7 +18,7 @@ func (s *stepCopyDisk) Run(ctx context.Context, state multistep.StateBag) multis
 	driver := state.Get("driver").(Driver)
 	isoPath := state.Get("iso_path").(string)
 	ui := state.Get("ui").(packer.Ui)
-	path := filepath.Join(config.OutputDir, fmt.Sprintf("%s", config.VMName))
+	path := filepath.Join(config.OutputDir, config.VMName)
 
 	command := []string{
 		"convert",

--- a/builder/qemu/step_create_disk.go
+++ b/builder/qemu/step_create_disk.go
@@ -29,13 +29,13 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	ui.Say("Creating required virtual machine disks")
 	// The 'main' or 'default' disk
 	diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, name))
-	diskSizes = append(diskSizes, fmt.Sprintf("%s", config.DiskSize))
+	diskSizes = append(diskSizes, config.DiskSize)
 	// Additional disks
 	if len(config.AdditionalDiskSize) > 0 {
 		for i, diskSize := range config.AdditionalDiskSize {
 			path := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d", name, i+1))
 			diskFullPaths = append(diskFullPaths, path)
-			size := fmt.Sprintf("%s", diskSize)
+			size := diskSize
 			diskSizes = append(diskSizes, size)
 		}
 	}

--- a/builder/qemu/step_resize_disk.go
+++ b/builder/qemu/step_resize_disk.go
@@ -23,7 +23,7 @@ func (s *stepResizeDisk) Run(ctx context.Context, state multistep.StateBag) mult
 		"resize",
 		"-f", config.Format,
 		path,
-		fmt.Sprintf("%s", config.DiskSize),
+		config.DiskSize,
 	}
 	if config.DiskImage == false {
 		return multistep.ActionContinue

--- a/builder/virtualbox/common/step_configure_vrdp.go
+++ b/builder/virtualbox/common/step_configure_vrdp.go
@@ -52,7 +52,7 @@ func (s *StepConfigureVRDP) Run(ctx context.Context, state multistep.StateBag) m
 
 	command := []string{
 		"modifyvm", vmName,
-		"--vrdeaddress", fmt.Sprintf("%s", s.VRDPBindAddress),
+		"--vrdeaddress", s.VRDPBindAddress,
 		"--vrdeauthtype", "null",
 		"--vrde", "on",
 		"--vrdeport",

--- a/builder/vmware/common/step_export.go
+++ b/builder/vmware/common/step_export.go
@@ -102,7 +102,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 		return multistep.ActionHalt
 	}
 
-	ui.Message(fmt.Sprintf("%s", out.String()))
+	ui.Message(out.String())
 
 	return multistep.ActionContinue
 }

--- a/common/shell-local/run.go
+++ b/common/shell-local/run.go
@@ -165,8 +165,8 @@ func createFlattenedEnvVars(config *Config) (string, error) {
 	envVars := make(map[string]string)
 
 	// Always available Packer provided env vars
-	envVars["PACKER_BUILD_NAME"] = fmt.Sprintf("%s", config.PackerBuildName)
-	envVars["PACKER_BUILDER_TYPE"] = fmt.Sprintf("%s", config.PackerBuilderType)
+	envVars["PACKER_BUILD_NAME"] = config.PackerBuildName
+	envVars["PACKER_BUILDER_TYPE"] = config.PackerBuilderType
 
 	// expose ip address variables
 	httpAddr := common.GetHTTPAddr()

--- a/common/step_http_server.go
+++ b/common/step_http_server.go
@@ -94,7 +94,7 @@ func GetHTTPPort() string {
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%s", port)
+	return port
 }
 
 func GetHTTPIP() string {
@@ -102,7 +102,7 @@ func GetHTTPIP() string {
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%s", ip)
+	return ip
 }
 
 func (s *StepHTTPServer) Cleanup(multistep.StateBag) {

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -217,8 +217,8 @@ func (p *PostProcessor) BuildArgs(source, ovftool_uri string) ([]string, error) 
 		args = append(args, p.config.Options...)
 	}
 
-	args = append(args, fmt.Sprintf(`%s`, source))
-	args = append(args, fmt.Sprintf(`%s`, ovftool_uri))
+	args = append(args, source)
+	args = append(args, ovftool_uri)
 
 	return args, nil
 }

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -406,8 +406,8 @@ func (p *Provisioner) escapeEnvVars() ([]string, map[string]string) {
 	envVars := make(map[string]string)
 
 	// Always available Packer provided env vars
-	envVars["PACKER_BUILD_NAME"] = fmt.Sprintf("%s", p.config.PackerBuildName)
-	envVars["PACKER_BUILDER_TYPE"] = fmt.Sprintf("%s", p.config.PackerBuilderType)
+	envVars["PACKER_BUILD_NAME"] = p.config.PackerBuildName
+	envVars["PACKER_BUILDER_TYPE"] = p.config.PackerBuilderType
 
 	// expose ip address variables
 	httpAddr := common.GetHTTPAddr()


### PR DESCRIPTION
Remove unneeded use of fmt.Sprintf for variables that are already strings.