### PR TITLE
Fix boot command link in ssh communicator doc

### DIFF
--- a/website/source/docs/communicators/ssh.html.md
+++ b/website/source/docs/communicators/ssh.html.md
@@ -34,7 +34,7 @@ However, if you are building from a brand-new and unconfigured operating system
 image, you will almost always have to perform some extra work to configure SSH
 on the guest machine. For most operating system distributions, this work will
 be performed by a
-(boot command)[/docs/builders/vmware-iso.html#boot-configuration]
+[boot command](/docs/builders/vmware-iso.html#boot-configuration)
 that references a file which provides answers to the normally-interactive
 questions you get asked when installing an operating system. The name of this
 file varies by operating system; some common examples are the "preseed" file


### PR DESCRIPTION
Just fixing a link reference.