### PR TITLE
vSphere ISO supports more common options

### DIFF
--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -1,3 +1,4 @@
+//go:generate struct-markdown
 //go:generate mapstructure-to-hcl2 -type Config
 
 package iso
@@ -33,7 +34,10 @@ type Config struct {
 
 	common.ShutdownConfig `mapstructure:",squash"`
 
-	CreateSnapshot    bool `mapstructure:"create_snapshot"`
+	// Create a snapshot when set to `true`, so the VM can be used as a base
+	// for linked clones. Defaults to `false`.
+	CreateSnapshot bool `mapstructure:"create_snapshot"`
+	// Convert VM to a template. Defaults to `false`.
 	ConvertToTemplate bool `mapstructure:"convert_to_template"`
 
 	ctx interpolate.Context

--- a/website/source/docs/builders/vsphere-iso.html.md.erb
+++ b/website/source/docs/builders/vsphere-iso.html.md.erb
@@ -43,6 +43,8 @@ references for [ISO](#iso-configuration),
 configuration references, which are
 necessary for this build to succeed and can be found further down the page.
 
+<%= partial "partials/builder/vsphere/iso/Config-not-required" %>
+
 ### Connection Configuration
 <%= partial "partials/builder/vsphere/common/ConnectConfig-not-required" %>
 

--- a/website/source/partials/builder/vsphere/iso/_Config-not-required.html.md
+++ b/website/source/partials/builder/vsphere/iso/_Config-not-required.html.md
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the Config struct in builder/vsphere/iso/config.go; DO NOT EDIT MANUALLY -->
+
+-   `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
+    for linked clones. Defaults to `false`.
+    
+-   `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
+    


### PR DESCRIPTION
The `convert_to_template` and `create_snapshot` are supported across
both builders, but currently only shown in the vSphere Clone docs, this adds
them to it.