### PR TITLE
circleci: VersionPrerelease: show tag or branch name and hash when building binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
         type: string
     steps:
       - checkout
-      - run: GOOS=<< parameters.GOOS >> go build -ldflags="-s -w" -o ./pkg/packer_<< parameters.GOOS >>_$(go env GOARCH) .
+      - run: GOOS=<< parameters.GOOS >> go build -ldflags="-s -w -X github.com/hashicorp/packer/version.GitCommit=${CIRCLE_SHA1}" -o ./pkg/packer_<< parameters.GOOS >>_$(go env GOARCH) .
       - run: zip ./pkg/packer_<< parameters.GOOS >>_$(go env GOARCH).zip ./pkg/packer_<< parameters.GOOS >>_$(go env GOARCH)
       - run: rm ./pkg/packer_<< parameters.GOOS >>_$(go env GOARCH)
       - persist_to_workspace:


### PR DESCRIPTION
fix #8833

```bash
❯ PACKER_LOG=1 ./packer_darwin_amd64
2020/03/06 16:46:20 [INFO] Packer version: 1.5.5-dev (60ae87b4733d2444d60113ba1086127ad92d700e) [go1.13.8 darwin amd64]
2020/03/06 16:46:20 [DEBUG] Discovered plugin: vsphere-clone = /Users/azr/.packer.d/plugins/packer-builder-vsphere-clone
2020/03/06 16:46:20 using external builders [vsphere-clone]
2020/03/06 16:46:20 Checking 'PACKER_CONFIG' for a config file path
2020/03/06 16:46:20 'PACKER_CONFIG' not set; checking the default config file path
2020/03/06 16:46:20 Attempting to open config file: /Users/azr/.packerconfig
2020/03/06 16:46:20 [WARN] Config file doesn't exist: /Users/azr/.packerconfig
2020/03/06 16:46:20 Setting cache directory: /Users/azr/packer_cache
2020/03/06 16:46:20 [INFO] (telemetry) Finalizing.
Usage: packer [--version] [--help] <command> [<args>]

Available commands are:
    build       build image(s) from template
    console     creates a console for testing variable interpolation
    fix         fixes templates from old versions of packer
    inspect     see components of a template
    validate    check that a template is valid
    version     Prints the Packer version

2020/03/06 16:46:20 waiting for all plugin processes to complete...
```