### PR TITLE
Fix example json format in ansible provisioner doc

### DIFF
--- a/website/source/docs/provisioners/ansible.html.md.erb
+++ b/website/source/docs/provisioners/ansible.html.md.erb
@@ -27,7 +27,7 @@ DigitalOcean. Replace the mock `api_token` value with your own.
 
 Example Packer template:
 
-``` json
+```json
 {
   "provisioners": [
     {


### PR DESCRIPTION
### Before
<img width="872" alt="Screenshot 2020-03-09 at 11 48 41" src="https://user-images.githubusercontent.com/8526180/76206255-f8f96180-61fb-11ea-97a1-45ab46615796.png">

### After
<img width="890" alt="Screenshot 2020-03-09 at 11 46 46" src="https://user-images.githubusercontent.com/8526180/76206183-d8310c00-61fb-11ea-84c2-6f045a4112ef.png">

Closes https://github.com/hashicorp/packer/issues/8851