### PR TITLE
docs/virtualbox-ovf: Add VBoxManage config section to VirtualBox OVF builder docs

### DIFF
--- a/website/source/docs/builders/virtualbox-ovf.html.md.erb
+++ b/website/source/docs/builders/virtualbox-ovf.html.md.erb
@@ -78,6 +78,10 @@ necessary for this build to succeed and can be found further down the page.
 <%= partial "partials/builder/virtualbox/common/VBoxVersionConfig-not-required" %>
 <%= partial "partials/builder/virtualbox/common/GuestAdditionsConfig-not-required" %>
 
+### VBoxManage configuration
+
+<%= partial "partials/builder/virtualbox/common/VBoxManageConfig-not-required" %>
+
 ### Http directory configuration
 
 <%= partial "partials/common/HTTPConfig" %>


### PR DESCRIPTION
There is no mention of the `vboxmanage_post` config in the [VirtualBox OVF builder docs](https://packer.io/docs/builders/virtualbox-ovf.html). Added a specific VBoxManage config section similar to the [VirtualBox ISO builder section](https://packer.io/docs/builders/virtualbox-iso.html#vbox-manage-configuration) to resolve this.