### PR TITLE
 validate Target ami in the region based on account-id

### DIFF
--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -204,9 +204,18 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	}
 
 	// Build the steps
+	//for b.config.AMIUsers, we can pass ami_users from packer.json file in below format
+	//Since it is slice and can contain multiple account-id, for now picking first one to make
+	//owner of it
+	//example : `   "ami_users": [
+        //                "{{user `aws_account_id`}}"
+        //              ],`
+	//in this way if user does not pass any value,we have empty string on first index
+	//TODO: there can be a better way
 	steps := []multistep.Step{
 		&awscommon.StepPreValidate{
 			DestAmiName:        b.config.AMIName,
+			DestAmiOwner:        b.config.AMIUsers[0],
 			ForceDeregister:    b.config.AMIForceDeregister,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 			VpcId:              b.config.VpcId,


### PR DESCRIPTION
Description : Right now packer Prevalidate Target ami based on "name" only,
                     and because of that a single region can have only one ami-id with a specific name.
                    to reduce the scope of the same, we can prevalidate the target ami with account-id 
                    and name as filter, so that two different account can create same name of ami in the 
                   same region.
`
  for example: "account1" create "test-ami" in region "us-east-2"
   "account2" is also trying to create "test-ami" in "us-east-2" region but failed with error:
    "AMI Name: 'test-ami' is used by an existing AMI: ami-1234"
`
**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer PR:

https://github.com/hashicorp/packer/blob/master/.github/CONTRIBUTING.md#opening-an-pull-request

Describe the change you are making here!

Please include tests. Check out these examples:

- https://github.com/hashicorp/packer/blob/master/builder/virtualbox/common/ssh_config_test.go#L19-L37
- https://github.com/hashicorp/packer/blob/master/post-processor/compress/post-processor_test.go#L153-L182

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx
