### PR TITLE
Fix gosimple S1005 linting issue

### DIFF
--- a/fix/fixer_comm_config.go
+++ b/fix/fixer_comm_config.go
@@ -45,7 +45,7 @@ func (FixerCommConfig) Fix(input map[string]interface{}) (map[string]interface{}
 		} else if _, ok := builders["ssh_host_port_min"]; ok {
 
 			// replace ssh_host_port_min with host_port_min
-			sshHostPortMinRaw, _ := builders["ssh_host_port_min"]
+			sshHostPortMinRaw := builders["ssh_host_port_min"]
 			delete(builders, "ssh_host_port_min")
 			builders["host_port_min"] = sshHostPortMinRaw
 		}
@@ -61,7 +61,7 @@ func (FixerCommConfig) Fix(input map[string]interface{}) (map[string]interface{}
 		} else if _, ok := builders["ssh_host_port_max"]; ok {
 
 			// replace ssh_host_port_max with host_port_max
-			sshHostPortMaxRaw, _ := builders["ssh_host_port_max"]
+			sshHostPortMaxRaw := builders["ssh_host_port_max"]
 			delete(builders, "ssh_host_port_max")
 			builders["host_port_max"] = sshHostPortMaxRaw
 
@@ -78,7 +78,7 @@ func (FixerCommConfig) Fix(input map[string]interface{}) (map[string]interface{}
 		} else if _, ok := builders["ssh_skip_nat_mapping"]; ok {
 
 			// replace ssh_skip_nat_mapping with skip_nat_mapping
-			sshSkipNatMappingRaw, _ := builders["ssh_skip_nat_mapping"]
+			sshSkipNatMappingRaw := builders["ssh_skip_nat_mapping"]
 			sshSkipNatMappingBool, ok := sshSkipNatMappingRaw.(bool)
 			if ok {
 				delete(builders, "ssh_skip_nat_mapping")

--- a/packer/artifact_mock.go
+++ b/packer/artifact_mock.go
@@ -44,7 +44,7 @@ func (a *MockArtifact) String() string {
 }
 
 func (a *MockArtifact) State(name string) interface{} {
-	value, _ := a.StateValues[name]
+	value := a.StateValues[name]
 	return value
 }
 

--- a/packer/artifact_test.go
+++ b/packer/artifact_test.go
@@ -28,7 +28,7 @@ func (*TestArtifact) String() string {
 }
 
 func (a *TestArtifact) State(name string) interface{} {
-	value, _ := a.state[name]
+	value := a.state[name]
 	return value
 }
 


### PR DESCRIPTION
Results before change
```
⇶  golangci-lint run ./... --disable-all --enable=gosimple | grep 1005
fix/fixer_comm_config.go:48:4: S1005: should write `sshHostPortMinRaw := builders["ssh_host_port_min"]` instead of `sshHostPortMinRaw, _ := builders["ssh_host_port_min"]` (gosimple)
fix/fixer_comm_config.go:64:4: S1005: should write `sshHostPortMaxRaw := builders["ssh_host_port_max"]` instead of `sshHostPortMaxRaw, _ := builders["ssh_host_port_max"]` (gosimple)
fix/fixer_comm_config.go:81:4: S1005: should write `sshSkipNatMappingRaw := builders["ssh_skip_nat_mapping"]` instead of `sshSkipNatMappingRaw, _ := builders["ssh_skip_nat_mapping"]` (gosimple)
packer/artifact_mock.go:47:2: S1005: should write `value := a.StateValues[name]` instead of `value, _ := a.StateValues[name]` (gosimple)
packer/artifact_test.go:31:2: S1005: should write `value := a.state[name]` instead of `value, _ := a.state[name]` (gosimple)
```

Results after change
```
```