### PR TITLE
builders: Fix gosimple S1007 linting issue

### DIFF
--- a/builder/alicloud/ecs/image_config.go
+++ b/builder/alicloud/ecs/image_config.go
@@ -205,7 +205,7 @@ func (c *AlicloudImageConfig) Prepare(ctx *interpolate.Context) []error {
 		strings.HasPrefix(c.AlicloudImageName, "https://") {
 		errs = append(errs, fmt.Errorf("image_name can't start with 'http://' or 'https://'"))
 	}
-	reg := regexp.MustCompile("\\s+")
+	reg := regexp.MustCompile(`\s+`)
 	if reg.FindString(c.AlicloudImageName) != "" {
 		errs = append(errs, fmt.Errorf("image_name can't include spaces"))
 	}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -55,12 +55,12 @@ const (
 )
 
 var (
-	reCaptureContainerName = regexp.MustCompile("^[a-z0-9][a-z0-9\\-]{2,62}$")
-	reCaptureNamePrefix    = regexp.MustCompile("^[A-Za-z0-9][A-Za-z0-9_\\-\\.]{0,23}$")
+	reCaptureContainerName = regexp.MustCompile(`^[a-z0-9][a-z0-9\-]{2,62}$`)
+	reCaptureNamePrefix    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_\-\.]{0,23}$`)
 	reManagedDiskName      = regexp.MustCompile(validManagedDiskName)
 	reResourceGroupName    = regexp.MustCompile(validResourceGroupNameRe)
-	reSnapshotName         = regexp.MustCompile("^[A-Za-z0-9_]{1,79}$")
-	reSnapshotPrefix       = regexp.MustCompile("^[A-Za-z0-9_]{1,59}$")
+	reSnapshotName         = regexp.MustCompile(`^[A-Za-z0-9_]{1,79}$`)
+	reSnapshotPrefix       = regexp.MustCompile(`^[A-Za-z0-9_]{1,59}$`)
 )
 
 type PlanInformation struct {

--- a/builder/qemu/driver.go
+++ b/builder/qemu/driver.go
@@ -189,7 +189,7 @@ func (d *QemuDriver) Version() (string, error) {
 
 	versionOutput := strings.TrimSpace(stdout.String())
 	log.Printf("Qemu --version output: %s", versionOutput)
-	versionRe := regexp.MustCompile("[\\.[0-9]+]*")
+	versionRe := regexp.MustCompile(`[\.[0-9]+]*`)
 	matches := versionRe.FindStringSubmatch(versionOutput)
 	if len(matches) == 0 {
 		return "", fmt.Errorf("No version found: %s", versionOutput)


### PR DESCRIPTION
Results before change
```
⇶  golangci-lint run ./... --disable-all --enable=gosimple | grep 1007
builder/alicloud/ecs/image_config.go:208:9: S1007: should use raw string
post-processor/vsphere-template/step_mark_as_template.go:130:8: S1007: shape twice (gosimple)
builder/azure/arm/config.go:58:27: S1007: should use raw string (`...`)
builder/azure/arm/config.go:59:27: S1007: should use raw string (`...`)
builder/qemu/driver.go:192:15: S1007: should use raw string (`...`)
```

Results after change
```
⇶  golangci-lint run ./... --disable-all --enable=gosimple | grep 1007
```