### PR TITLE
Fix user var recursion with env vars

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -350,7 +350,7 @@ func (c *Core) validate() error {
 func isDoneInterpolating(v string) (bool, error) {
 	// Check for whether the var contains any more references to `user`, wrapped
 	// in interpolation syntax.
-	filter := "{{\\s*|user\\s*|\\x60?.*\\x60?}}"
+	filter := `{{\s*|user\s*|\x60?.*\x60?}}`
 	matched, err := regexp.MatchString(filter, v)
 	if err != nil {
 		return false, fmt.Errorf("Can't tell if interpolation is done: %s", err)

--- a/packer/core.go
+++ b/packer/core.go
@@ -350,7 +350,7 @@ func (c *Core) validate() error {
 func isDoneInterpolating(v string) (bool, error) {
 	// Check for whether the var contains any more references to `user`, wrapped
 	// in interpolation syntax.
-	filter := `{{\s*|user\s*|\x60?.*\x60?}}`
+	filter := `{{\s*user\s*\x60.*\x60\s*}}`
 	matched, err := regexp.MatchString(filter, v)
 	if err != nil {
 		return false, fmt.Errorf("Can't tell if interpolation is done: %s", err)

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -679,7 +679,7 @@ func TestSensitiveVars(t *testing.T) {
 }
 
 // Normally I wouldn't test a little helper function, but it's regex.
-func testisDoneInterpolating(t *testing.T) {
+func TestIsDoneInterpolating(t *testing.T) {
 	cases := []struct {
 		inputString  string
 		expectedBool bool

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -721,24 +721,63 @@ func testisDoneInterpolating(t *testing.T) {
 	}
 }
 
-// func testCoreBuildWithInterpolatedEnvVars(t *testing.T) {
-// 	// Not a fan of using env vars in tests but in this case we need to make
-// 	// sure they get interpolated properly.
-// 	os.Setenv("CI_COMMIT_REF_NAME", "working")
-// 	os.Setenv("OUTPUT_DIR", "/u01/artifacts")
-// 	os.Setenv("OS_VERSION", "6")
-// 	os.Setenv("OS", "rhel")
-// 	os.Setenv("BASE_POSTFIX", "base")
-// 	os.Setenv("RULE", "vbox")
-// 	os.Setenv("POSTFIX", "base")
+func TestEnvAndFileVars(t *testing.T) {
+	os.Setenv("INTERPOLATE_TEST_ENV_1", "bulbasaur")
+	os.Setenv("INTERPOLATE_TEST_ENV_3", "/path/to/nowhere")
+	os.Setenv("INTERPOLATE_TEST_ENV_2", "5")
+	os.Setenv("INTERPOLATE_TEST_ENV_4", "bananas")
 
-// packer build \
-//   -var-file=common/vsphere.variables.json \
-//   -var-file=common/variables.json \
-//   -only=vbox-rhel-base \
-//   common/linux/redhat/template.json
+	// run the interpolations a bunch of times, because we have had issues
+	// where the behavior is different based on the order in which the
+	// vars are interpolated
+	for i := 0; i < 100; i++ {
+		f, err := os.Open(fixtureDir("complex-recursed-env-user-var-file.json"))
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
 
-// }
+		tpl, err := template.Parse(f)
+		f.Close()
+		if err != nil {
+			t.Fatalf("err: %s\n\n%s", "complex-recursed-env-user-var-file.json", err)
+		}
+
+		ccf, err := NewCore(&CoreConfig{
+			Template: tpl,
+			Version:  "1.0.0",
+			Variables: map[string]string{
+				"var_1":     "partyparrot",
+				"var_2":     "{{user `env_1`}}-{{user `env_2`}}{{user `env_3`}}-{{user `var_1`}}",
+				"final_var": "{{user `env_1`}}/{{user `env_2`}}/{{user `env_4`}}{{user `env_3`}}-{{user `var_1`}}/vmware/{{user `var_2`}}.vmx",
+			},
+		})
+		expected := map[string]string{
+			"var_1":     "partyparrot",
+			"var_2":     "bulbasaur-5/path/to/nowhere-partyparrot",
+			"final_var": "bulbasaur/5/bananas/path/to/nowhere-partyparrot/vmware/bulbasaur-5/path/to/nowhere-partyparrot.vmx",
+			"env_1":     "bulbasaur",
+			"env_2":     "5",
+			"env_3":     "/path/to/nowhere",
+			"env_4":     "bananas",
+		}
+		if err != nil {
+			t.Fatalf("err: %s\n\n%s", "complex-recursed-env-user-var-file.json", err)
+		}
+		for k, v := range ccf.variables {
+			if expected[k] != v {
+				t.Fatalf("Expected value %s for key %s but got %s",
+					expected[k], k, v)
+			}
+		}
+
+	}
+
+	// Clean up env vars
+	os.Unsetenv("INTERPOLATE_TEST_ENV_1")
+	os.Unsetenv("INTERPOLATE_TEST_ENV_3")
+	os.Unsetenv("INTERPOLATE_TEST_ENV_2")
+	os.Unsetenv("INTERPOLATE_TEST_ENV_4")
+}
 
 func testCoreTemplate(t *testing.T, c *CoreConfig, p string) {
 	tpl, err := template.ParseFile(p)

--- a/packer/test-fixtures/complex-recursed-env-user-var-file.json
+++ b/packer/test-fixtures/complex-recursed-env-user-var-file.json
@@ -1,0 +1,11 @@
+{
+  "variables": {
+    "env_1": "{{ env `INTERPOLATE_TEST_ENV_1` }}",
+    "env_2": "{{ env `INTERPOLATE_TEST_ENV_2` }}",
+    "env_3": "{{ env `INTERPOLATE_TEST_ENV_3` }}",
+    "env_4": "{{ env `INTERPOLATE_TEST_ENV_4` }}"
+  },
+    "builders": [{
+        "type": "test"
+    }]
+}


### PR DESCRIPTION
#8812 contains a reasonably complex recursion case that sometimes fails interpolation because we are not checking properly whether interpolation is truly complete. This PR fixes this issue by using a regex to check whether there are any more calls to the `{{ user ...  }}` template function, and using that information to more intelligently continue interpolating variables that need it. It also removes "finished" variables from the interpolation list to make interpolation more efficient. 

It also adds a test for this regex, and a test for the interpolation behavior. The added env var interpolation test fails on the master branch and passes on this branch. 

Closes #8812
