### PR TITLE
vmware-iso esxi: Do not test if NIC is reachable when ssh bastion is required

### DIFF
--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -495,6 +495,15 @@ func (d *ESX5Driver) CommHost(state multistep.StateBag) (string, error) {
 		if record["IPAddress"] == "0.0.0.0" {
 			continue
 		}
+
+		// if ssh is going through a bastion, we can't easily check if the nic is reachable on the network
+		// so just pick the first one that is not 0.0.0.0
+		if sshc.SSHBastionHost != "" {
+			address := record["IPAddress"]
+			state.Put("vm_address", address)
+			return address, nil
+		}
+
 		// When multiple NICs are connected to the same network, choose
 		// one that has a route back. This Dial should ensure that.
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", record["IPAddress"], port), 2*time.Second)


### PR DESCRIPTION
This updates the `vmware-iso` esxi driver so that it will skip the check on NIC reachability if a `ssh_bastion_host` is configured.

Fixing the issue in this way seemed easier than trying to make the `net.DialTimeout` check work through the ssh bastion host, which would have required setting up the full ssh connection. This loses the check on if the NIC is actually reachable, but I think that is a fair tradeoff. 

I tested this by deploying the fix to the same environment I was using in https://github.com/hashicorp/packer/issues/8866 and verified I did not encounter that problem.

Closes https://github.com/hashicorp/packer/issues/8866
