### PR TITLE
Add support for configurable KeyVault SKU

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -257,9 +257,9 @@ type Config struct {
 	BuildResourceGroupName string `mapstructure:"build_resource_group_name"`
 	// Specify an existing key vault to use for uploading certificates to the
 	// instance to connect.
-	BuildKeyVaultName          string `mapstructure:"build_key_vault_name"`
+	BuildKeyVaultName string `mapstructure:"build_key_vault_name"`
 	// Specify the KeyVault SKU to use when building: standard or premium
-	BuildKeyVaultSKU string `mapstructure:"build_key_vault_sku"`
+	BuildKeyVaultSKU           string `mapstructure:"build_key_vault_sku"`
 	storageAccountBlobEndpoint string
 	// This value allows you to
 	// set a virtual_network_name and obtain a public IP. If this value is not

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -40,6 +40,7 @@ const (
 	DefaultUserName                          = "packer"
 	DefaultPrivateVirtualNetworkWithPublicIp = false
 	DefaultVMSize                            = "Standard_A1"
+	DefaultKeyVaultSKU                       = "standard"
 )
 
 const (
@@ -257,6 +258,8 @@ type Config struct {
 	// Specify an existing key vault to use for uploading certificates to the
 	// instance to connect.
 	BuildKeyVaultName          string `mapstructure:"build_key_vault_name"`
+	// Specify the KeyVault SKU to use when building: standard or premium
+	BuildKeyVaultSKU string `mapstructure:"build_key_vault_sku"`
 	storageAccountBlobEndpoint string
 	// This value allows you to
 	// set a virtual_network_name and obtain a public IP. If this value is not
@@ -682,6 +685,10 @@ func provideDefaultValues(c *Config) {
 
 	if c.ImagePublisher != "" && c.ImageVersion == "" {
 		c.ImageVersion = DefaultImageVersion
+	}
+
+	if c.BuildKeyVaultSKU == "" {
+		c.BuildKeyVaultSKU = DefaultKeyVaultSKU
 	}
 
 	c.ClientConfig.SetDefaultValues()

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -258,7 +258,8 @@ type Config struct {
 	// Specify an existing key vault to use for uploading certificates to the
 	// instance to connect.
 	BuildKeyVaultName string `mapstructure:"build_key_vault_name"`
-	// Specify the KeyVault SKU to use when building: standard or premium
+	// Specify the KeyVault SKU to create during the build. Valid values are
+	// standard or premium. The default value is standard.
 	BuildKeyVaultSKU           string `mapstructure:"build_key_vault_sku"`
 	storageAccountBlobEndpoint string
 	// This value allows you to

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -54,6 +54,7 @@ type FlatConfig struct {
 	TempResourceGroupName                      *string                            `mapstructure:"temp_resource_group_name" cty:"temp_resource_group_name"`
 	BuildResourceGroupName                     *string                            `mapstructure:"build_resource_group_name" cty:"build_resource_group_name"`
 	BuildKeyVaultName                          *string                            `mapstructure:"build_key_vault_name" cty:"build_key_vault_name"`
+	BuildKeyVaultSKU                           *string                            `mapstructure:"build_key_vault_sku" cty:"build_key_vault_sku"`
 	PrivateVirtualNetworkWithPublicIp          *bool                              `mapstructure:"private_virtual_network_with_public_ip" required:"false" cty:"private_virtual_network_with_public_ip"`
 	VirtualNetworkName                         *string                            `mapstructure:"virtual_network_name" required:"false" cty:"virtual_network_name"`
 	VirtualNetworkSubnetName                   *string                            `mapstructure:"virtual_network_subnet_name" required:"false" cty:"virtual_network_subnet_name"`
@@ -166,6 +167,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"temp_resource_group_name":                &hcldec.AttrSpec{Name: "temp_resource_group_name", Type: cty.String, Required: false},
 		"build_resource_group_name":               &hcldec.AttrSpec{Name: "build_resource_group_name", Type: cty.String, Required: false},
 		"build_key_vault_name":                    &hcldec.AttrSpec{Name: "build_key_vault_name", Type: cty.String, Required: false},
+		"build_key_vault_sku":                     &hcldec.AttrSpec{Name: "build_key_vault_sku", Type: cty.String, Required: false},
 		"private_virtual_network_with_public_ip":  &hcldec.AttrSpec{Name: "private_virtual_network_with_public_ip", Type: cty.Bool, Required: false},
 		"virtual_network_name":                    &hcldec.AttrSpec{Name: "virtual_network_name", Type: cty.String, Required: false},
 		"virtual_network_subnet_name":             &hcldec.AttrSpec{Name: "virtual_network_subnet_name", Type: cty.String, Required: false},

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -17,6 +17,7 @@ type templateFactoryFunc func(*Config) (*resources.Deployment, error)
 func GetKeyVaultDeployment(config *Config) (*resources.Deployment, error) {
 	params := &template.TemplateParameters{
 		KeyVaultName:        &template.TemplateParameter{Value: config.tmpKeyVaultName},
+		KeyVaultSKU:         &template.TemplateParameter{Value: config.BuildKeyVaultSKU},
 		KeyVaultSecretValue: &template.TemplateParameter{Value: config.winrmCertificate},
 		ObjectId:            &template.TemplateParameter{Value: config.ClientConfig.ObjectID},
 		TenantId:            &template.TemplateParameter{Value: config.ClientConfig.TenantID},

--- a/builder/azure/arm/template_factory_test.TestKeyVaultDeployment03.approved.json
+++ b/builder/azure/arm/template_factory_test.TestKeyVaultDeployment03.approved.json
@@ -39,7 +39,7 @@
         "enabledForTemplateDeployment": "true",
         "sku": {
           "family": "A",
-          "name": "standard"
+          "name": "[parameters('keyVaultSKU')]"
         },
         "tenantId": "[parameters('tenantId')]"
       },

--- a/builder/azure/arm/template_factory_test.TestKeyVaultDeployment03.approved.json
+++ b/builder/azure/arm/template_factory_test.TestKeyVaultDeployment03.approved.json
@@ -5,6 +5,9 @@
     "keyVaultName": {
       "type": "string"
     },
+    "keyVaultSKU": {
+      "type": "string"
+    },
     "keyVaultSecretValue": {
       "type": "securestring"
     },

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -482,6 +482,9 @@ const KeyVault = `{
     "keyVaultName": {
       "type": "string"
     },
+    "keyVaultSKU": {
+      "type": "string"
+    },
     "keyVaultSecretValue": {
       "type": "securestring"
     },
@@ -518,7 +521,7 @@ const KeyVault = `{
           }
         ],
         "sku": {
-          "name": "standard",
+          "name": "[parameters('keyVaultSKU')]",
           "family": "A"
         }
       },

--- a/builder/azure/common/template/template_parameters.go
+++ b/builder/azure/common/template/template_parameters.go
@@ -22,6 +22,7 @@ type TemplateParameters struct {
 	AdminPassword              *TemplateParameter `json:"adminPassword,omitempty"`
 	DnsNameForPublicIP         *TemplateParameter `json:"dnsNameForPublicIP,omitempty"`
 	KeyVaultName               *TemplateParameter `json:"keyVaultName,omitempty"`
+	KeyVaultSKU                *TemplateParameter `json:"keyVaultSKU,omitempty"`
 	KeyVaultSecretValue        *TemplateParameter `json:"keyVaultSecretValue,omitempty"`
 	ObjectId                   *TemplateParameter `json:"objectId,omitempty"`
 	NicName                    *TemplateParameter `json:"nicName,omitempty"`

--- a/website/source/partials/builder/azure/arm/_Config-not-required.html.md
+++ b/website/source/partials/builder/azure/arm/_Config-not-required.html.md
@@ -1,13 +1,13 @@
 <!-- Code generated from the comments of the Config struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
 -   `capture_name_prefix` (string) - Capture
-
+    
 -   `capture_container_name` (string) - Capture Container Name
 -   `shared_image_gallery` (SharedImageGallery) - Use a [Shared Gallery
     image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
     as the source for this build. *VHD targets are incompatible with this
     build type* - the target must be a *Managed Image*.
-
+    
         "shared_image_gallery": {
             "subscription": "00000000-0000-0000-0000-00000000000",
             "resource_group": "ResourceGroup",
@@ -17,11 +17,11 @@
         }
         "managed_image_name": "TargetImageName",
         "managed_image_resource_group_name": "TargetResourceGroup"
-
+    
 -   `shared_image_gallery_destination` (SharedImageGalleryDestination) - The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
-
+    
     Following is an example.
-
+    
         "shared_image_gallery_destination": {
             "resource_group": "ResourceGroup",
             "gallery_name": "GalleryName",
@@ -31,7 +31,7 @@
         }
         "managed_image_name": "TargetImageName",
         "managed_image_resource_group_name": "TargetResourceGroup"
-
+    
 -   `shared_image_gallery_timeout` (duration string | ex: "1h5m2s") - How long to wait for an image to be published to the shared image
     gallery before timing out. If your Packer build is failing on the
     Publishing to Shared Image Gallery step with the error `Original Error:
@@ -39,111 +39,107 @@
     Azure dashboard, then you probably need to increase this timeout from
     its default of "60m" (valid time units include `s` for seconds, `m` for
     minutes, and `h` for hours.)
-
+    
 -   `shared_gallery_image_version_end_of_life_date` (string) - The end of life date (2006-01-02T15:04:05.99Z) of the gallery Image Version. This property
     can be used for decommissioning purposes.
-
+    
 -   `shared_image_gallery_replica_count` (int32) - The number of replicas of the Image Version to be created per region. This
     property would take effect for a region when regionalReplicaCount is not specified.
     Replica count must be between 1 and 10.
-
+    
 -   `shared_gallery_image_version_exclude_from_latest` (bool) - If set to true, Virtual Machines deployed from the latest version of the
     Image Definition won't use this Image Version.
-
+    
 -   `image_version` (string) - Specify a specific version of an OS to boot from.
     Defaults to `latest`. There may be a difference in versions available
     across regions due to image synchronization latency. To ensure a consistent
     version across regions set this value to one that is available in all
     regions where you are deploying.
-
+    
     CLI example
     `az vm image list --location westus --publisher Canonical --offer UbuntuServer --sku 16.04.0-LTS --all`
-
+    
 -   `location` (string) - Location
 -   `vm_size` (string) - Size of the VM used for building. This can be changed when you deploy a
     VM from your VHD. See
     [pricing](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/)
     information. Defaults to `Standard_A1`.
-
+    
     CLI example `az vm list-sizes --location westus`
-
+    
 -   `managed_image_resource_group_name` (string) - Specify the managed image resource group name where the result of the
     Packer build will be saved. The resource group must already exist. If
     this value is set, the value managed_image_name must also be set. See
     documentation to learn more about managed images.
-
+    
 -   `managed_image_name` (string) - Specify the managed image name where the result of the Packer build will
     be saved. The image name must not exist ahead of time, and will not be
     overwritten. If this value is set, the value
     managed_image_resource_group_name must also be set. See documentation to
     learn more about managed images.
-
+    
 -   `managed_image_storage_account_type` (string) - Specify the storage account
     type for a managed image. Valid values are Standard_LRS and Premium_LRS.
     The default is Standard_LRS.
-
+    
 -   `managed_image_os_disk_snapshot_name` (string) - If
     managed_image_os_disk_snapshot_name is set, a snapshot of the OS disk
     is created with the same name as this value before the VM is captured.
-
+    
 -   `managed_image_data_disk_snapshot_prefix` (string) - If
     managed_image_data_disk_snapshot_prefix is set, snapshot of the data
     disk(s) is created with the same prefix as this value before the VM is
     captured.
-
+    
 -   `managed_image_zone_resilient` (bool) - Store the image in zone-resilient storage. You need to create it in a
     region that supports [availability
     zones](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).
-
+    
 -   `azure_tags` (map[string]\*string) - the user can define up to 15
     tags. Tag names cannot exceed 512 characters, and tag values cannot exceed
     256 characters. Tags are applied to every resource deployed by a Packer
     build, i.e. Resource Group, VM, NIC, VNET, Public IP, KeyVault, etc.
-
+    
 -   `resource_group_name` (string) - Resource group under which the final artifact will be stored.
-
+    
 -   `storage_account` (string) - Storage account under which the final artifact will be stored.
-
+    
 -   `temp_compute_name` (string) - temporary name assigned to the VM. If this
     value is not set, a random value will be assigned. Knowing the resource
     group and VM name allows one to execute commands to update the VM during a
     Packer build, e.g. attach a resource disk to the VM.
-
+    
 -   `temp_resource_group_name` (string) - name assigned to the temporary resource group created during the build.
     If this value is not set, a random value will be assigned. This resource
     group is deleted at the end of the build.
-
+    
 -   `build_resource_group_name` (string) - Specify an existing resource group to run the build in.
-
+    
 -   `build_key_vault_name` (string) - Specify an existing key vault to use for uploading certificates to the
     instance to connect.
-
--   `build_key_vault_sku` (string) - Specify the KeyVault SKU to create during
-    the build. Valid values are standard or premium. The default value is
-    standard.
-
+    
 -   `private_virtual_network_with_public_ip` (bool) - This value allows you to
     set a virtual_network_name and obtain a public IP. If this value is not
     set and virtual_network_name is defined Packer is only allowed to be
     executed from a host on the same subnet / virtual network.
-
+    
 -   `virtual_network_name` (string) - Use a pre-existing virtual network for the
     VM. This option enables private communication with the VM, no public IP
     address is used or provisioned (unless you set
     private_virtual_network_with_public_ip).
-
+    
 -   `virtual_network_subnet_name` (string) - If virtual_network_name is set,
     this value may also be set. If virtual_network_name is set, and this
     value is not set the builder attempts to determine the subnet to use with
     the virtual network. If the subnet cannot be found, or it cannot be
     disambiguated, this value should be set.
-
+    
 -   `virtual_network_resource_group_name` (string) - If virtual_network_name is
     set, this value may also be set. If virtual_network_name is set, and
     this value is not set the builder attempts to determine the resource group
     containing the virtual network. If the resource group cannot be found, or
     it cannot be disambiguated, this value should be set.
-
+    
 -   `custom_data_file` (string) - Specify a file containing custom data to inject into the cloud-init
     process. The contents of the file are read and injected into the ARM
     template. The custom data will be passed to cloud-init for processing at
@@ -151,15 +147,15 @@
     [documentation](http://cloudinit.readthedocs.io/en/latest/topics/examples.html)
     to learn more about custom data, and how it can be used to influence the
     provisioning process.
-
+    
 -   `plan_info` (PlanInformation) - Used for creating images from Marketplace images. Please refer to
     [Deploy an image with Marketplace
     terms](https://aka.ms/azuremarketplaceapideployment) for more details.
     Not all Marketplace images support programmatic deployment, and support
     is controlled by the image publisher.
-
+    
     An example plan\_info object is defined below.
-
+    
     ``` json
     {
       "plan_info": {
@@ -169,22 +165,22 @@
       }
     }
     ```
-
+    
     `plan_name` (string) - The plan name, required. `plan_product` (string) -
     The plan product, required. `plan_publisher` (string) - The plan publisher,
     required. `plan_promotion_code` (string) - Some images accept a promotion
     code, optional.
-
+    
     Images created from the Marketplace with `plan_info` **must** specify
     `plan_info` whenever the image is deployed. The builder automatically adds
     tags to the image to ensure this information is not lost. The following
     tags are added.
-
+    
     1.  PlanName
     2.  PlanProduct
     3.  PlanPublisher
     4.  PlanPromotionCode
-
+    
 -   `polling_duration_timeout` (duration string | ex: "1h5m2s") - The default PollingDuration for azure is 15mins, this property will override
     that value. See [Azure DefaultPollingDuration](https://godoc.org/github.com/Azure/go-autorest/autorest#pkg-constants)
     If your Packer build is failing on the
@@ -192,15 +188,15 @@
     context deadline exceeded`, then you probably need to increase this timeout from
     its default of "15m" (valid time units include `s` for seconds, `m` for
     minutes, and `h` for hours.)
-
+    
 -   `os_type` (string) - If either Linux or Windows is specified Packer will
     automatically configure authentication credentials for the provisioned
     machine. For Linux this configures an SSH authorized key. For Windows
     this configures a WinRM certificate.
-
+    
 -   `os_disk_size_gb` (int32) - Specify the size of the OS disk in GB
     (gigabytes). Values of zero or less than zero are ignored.
-
+    
 -   `disk_additional_size` ([]int32) - The size(s) of any additional hard disks for the VM in gigabytes. If
     this is not specified then the VM will only contain an OS disk. The
     number of additional disks and maximum size of a disk depends on the
@@ -209,28 +205,29 @@
     or
     [Linux](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/about-disks-and-vhds)
     for more information.
-
+    
     For VHD builds the final artifacts will be named
     `PREFIX-dataDisk-<n>.UUID.vhd` and stored in the specified capture
     container along side the OS disk. The additional disks are included in
     the deployment template `PREFIX-vmTemplate.UUID`.
-
+    
     For Managed build the final artifacts are included in the managed image.
     The additional disk will have the same storage account type as the OS
     disk, as specified with the `managed_image_storage_account_type`
     setting.
-
+    
 -   `disk_caching_type` (string) - Specify the disk caching type. Valid values
     are None, ReadOnly, and ReadWrite. The default value is ReadWrite.
-
+    
 -   `allowed_inbound_ip_addresses` ([]string) - Specify the list of IP addresses and CIDR blocks that should be
     allowed access to the VM. If provided, an Azure Network Security
     Group will be created with corresponding rules and be bound to
     the subnet of the VM.
     Providing `allowed_inbound_ip_addresses` in combination with
     `virtual_network_name` is not allowed.
-
+    
 -   `async_resourcegroup_delete` (bool) - If you want packer to delete the
     temporary resource group asynchronously set this value. It's a boolean
     value and defaults to false. Important Setting this true means that
     your builds are faster, however any failed deletes are not reported.
+    

--- a/website/source/partials/builder/azure/arm/_Config-not-required.html.md
+++ b/website/source/partials/builder/azure/arm/_Config-not-required.html.md
@@ -1,13 +1,13 @@
 <!-- Code generated from the comments of the Config struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
 -   `capture_name_prefix` (string) - Capture
-    
+
 -   `capture_container_name` (string) - Capture Container Name
 -   `shared_image_gallery` (SharedImageGallery) - Use a [Shared Gallery
     image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
     as the source for this build. *VHD targets are incompatible with this
     build type* - the target must be a *Managed Image*.
-    
+
         "shared_image_gallery": {
             "subscription": "00000000-0000-0000-0000-00000000000",
             "resource_group": "ResourceGroup",
@@ -17,11 +17,11 @@
         }
         "managed_image_name": "TargetImageName",
         "managed_image_resource_group_name": "TargetResourceGroup"
-    
+
 -   `shared_image_gallery_destination` (SharedImageGalleryDestination) - The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
-    
+
     Following is an example.
-    
+
         "shared_image_gallery_destination": {
             "resource_group": "ResourceGroup",
             "gallery_name": "GalleryName",
@@ -31,7 +31,7 @@
         }
         "managed_image_name": "TargetImageName",
         "managed_image_resource_group_name": "TargetResourceGroup"
-    
+
 -   `shared_image_gallery_timeout` (duration string | ex: "1h5m2s") - How long to wait for an image to be published to the shared image
     gallery before timing out. If your Packer build is failing on the
     Publishing to Shared Image Gallery step with the error `Original Error:
@@ -39,107 +39,111 @@
     Azure dashboard, then you probably need to increase this timeout from
     its default of "60m" (valid time units include `s` for seconds, `m` for
     minutes, and `h` for hours.)
-    
+
 -   `shared_gallery_image_version_end_of_life_date` (string) - The end of life date (2006-01-02T15:04:05.99Z) of the gallery Image Version. This property
     can be used for decommissioning purposes.
-    
+
 -   `shared_image_gallery_replica_count` (int32) - The number of replicas of the Image Version to be created per region. This
     property would take effect for a region when regionalReplicaCount is not specified.
     Replica count must be between 1 and 10.
-    
+
 -   `shared_gallery_image_version_exclude_from_latest` (bool) - If set to true, Virtual Machines deployed from the latest version of the
     Image Definition won't use this Image Version.
-    
+
 -   `image_version` (string) - Specify a specific version of an OS to boot from.
     Defaults to `latest`. There may be a difference in versions available
     across regions due to image synchronization latency. To ensure a consistent
     version across regions set this value to one that is available in all
     regions where you are deploying.
-    
+
     CLI example
     `az vm image list --location westus --publisher Canonical --offer UbuntuServer --sku 16.04.0-LTS --all`
-    
+
 -   `location` (string) - Location
 -   `vm_size` (string) - Size of the VM used for building. This can be changed when you deploy a
     VM from your VHD. See
     [pricing](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/)
     information. Defaults to `Standard_A1`.
-    
+
     CLI example `az vm list-sizes --location westus`
-    
+
 -   `managed_image_resource_group_name` (string) - Specify the managed image resource group name where the result of the
     Packer build will be saved. The resource group must already exist. If
     this value is set, the value managed_image_name must also be set. See
     documentation to learn more about managed images.
-    
+
 -   `managed_image_name` (string) - Specify the managed image name where the result of the Packer build will
     be saved. The image name must not exist ahead of time, and will not be
     overwritten. If this value is set, the value
     managed_image_resource_group_name must also be set. See documentation to
     learn more about managed images.
-    
+
 -   `managed_image_storage_account_type` (string) - Specify the storage account
     type for a managed image. Valid values are Standard_LRS and Premium_LRS.
     The default is Standard_LRS.
-    
+
 -   `managed_image_os_disk_snapshot_name` (string) - If
     managed_image_os_disk_snapshot_name is set, a snapshot of the OS disk
     is created with the same name as this value before the VM is captured.
-    
+
 -   `managed_image_data_disk_snapshot_prefix` (string) - If
     managed_image_data_disk_snapshot_prefix is set, snapshot of the data
     disk(s) is created with the same prefix as this value before the VM is
     captured.
-    
+
 -   `managed_image_zone_resilient` (bool) - Store the image in zone-resilient storage. You need to create it in a
     region that supports [availability
     zones](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).
-    
+
 -   `azure_tags` (map[string]\*string) - the user can define up to 15
     tags. Tag names cannot exceed 512 characters, and tag values cannot exceed
     256 characters. Tags are applied to every resource deployed by a Packer
     build, i.e. Resource Group, VM, NIC, VNET, Public IP, KeyVault, etc.
-    
+
 -   `resource_group_name` (string) - Resource group under which the final artifact will be stored.
-    
+
 -   `storage_account` (string) - Storage account under which the final artifact will be stored.
-    
+
 -   `temp_compute_name` (string) - temporary name assigned to the VM. If this
     value is not set, a random value will be assigned. Knowing the resource
     group and VM name allows one to execute commands to update the VM during a
     Packer build, e.g. attach a resource disk to the VM.
-    
+
 -   `temp_resource_group_name` (string) - name assigned to the temporary resource group created during the build.
     If this value is not set, a random value will be assigned. This resource
     group is deleted at the end of the build.
-    
+
 -   `build_resource_group_name` (string) - Specify an existing resource group to run the build in.
-    
+
 -   `build_key_vault_name` (string) - Specify an existing key vault to use for uploading certificates to the
     instance to connect.
-    
+
+-   `build_key_vault_sku` (string) - Specify the KeyVault SKU to create during
+    the build. Valid values are standard or premium. The default value is
+    standard.
+
 -   `private_virtual_network_with_public_ip` (bool) - This value allows you to
     set a virtual_network_name and obtain a public IP. If this value is not
     set and virtual_network_name is defined Packer is only allowed to be
     executed from a host on the same subnet / virtual network.
-    
+
 -   `virtual_network_name` (string) - Use a pre-existing virtual network for the
     VM. This option enables private communication with the VM, no public IP
     address is used or provisioned (unless you set
     private_virtual_network_with_public_ip).
-    
+
 -   `virtual_network_subnet_name` (string) - If virtual_network_name is set,
     this value may also be set. If virtual_network_name is set, and this
     value is not set the builder attempts to determine the subnet to use with
     the virtual network. If the subnet cannot be found, or it cannot be
     disambiguated, this value should be set.
-    
+
 -   `virtual_network_resource_group_name` (string) - If virtual_network_name is
     set, this value may also be set. If virtual_network_name is set, and
     this value is not set the builder attempts to determine the resource group
     containing the virtual network. If the resource group cannot be found, or
     it cannot be disambiguated, this value should be set.
-    
+
 -   `custom_data_file` (string) - Specify a file containing custom data to inject into the cloud-init
     process. The contents of the file are read and injected into the ARM
     template. The custom data will be passed to cloud-init for processing at
@@ -147,15 +151,15 @@
     [documentation](http://cloudinit.readthedocs.io/en/latest/topics/examples.html)
     to learn more about custom data, and how it can be used to influence the
     provisioning process.
-    
+
 -   `plan_info` (PlanInformation) - Used for creating images from Marketplace images. Please refer to
     [Deploy an image with Marketplace
     terms](https://aka.ms/azuremarketplaceapideployment) for more details.
     Not all Marketplace images support programmatic deployment, and support
     is controlled by the image publisher.
-    
+
     An example plan\_info object is defined below.
-    
+
     ``` json
     {
       "plan_info": {
@@ -165,22 +169,22 @@
       }
     }
     ```
-    
+
     `plan_name` (string) - The plan name, required. `plan_product` (string) -
     The plan product, required. `plan_publisher` (string) - The plan publisher,
     required. `plan_promotion_code` (string) - Some images accept a promotion
     code, optional.
-    
+
     Images created from the Marketplace with `plan_info` **must** specify
     `plan_info` whenever the image is deployed. The builder automatically adds
     tags to the image to ensure this information is not lost. The following
     tags are added.
-    
+
     1.  PlanName
     2.  PlanProduct
     3.  PlanPublisher
     4.  PlanPromotionCode
-    
+
 -   `polling_duration_timeout` (duration string | ex: "1h5m2s") - The default PollingDuration for azure is 15mins, this property will override
     that value. See [Azure DefaultPollingDuration](https://godoc.org/github.com/Azure/go-autorest/autorest#pkg-constants)
     If your Packer build is failing on the
@@ -188,15 +192,15 @@
     context deadline exceeded`, then you probably need to increase this timeout from
     its default of "15m" (valid time units include `s` for seconds, `m` for
     minutes, and `h` for hours.)
-    
+
 -   `os_type` (string) - If either Linux or Windows is specified Packer will
     automatically configure authentication credentials for the provisioned
     machine. For Linux this configures an SSH authorized key. For Windows
     this configures a WinRM certificate.
-    
+
 -   `os_disk_size_gb` (int32) - Specify the size of the OS disk in GB
     (gigabytes). Values of zero or less than zero are ignored.
-    
+
 -   `disk_additional_size` ([]int32) - The size(s) of any additional hard disks for the VM in gigabytes. If
     this is not specified then the VM will only contain an OS disk. The
     number of additional disks and maximum size of a disk depends on the
@@ -205,29 +209,28 @@
     or
     [Linux](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/about-disks-and-vhds)
     for more information.
-    
+
     For VHD builds the final artifacts will be named
     `PREFIX-dataDisk-<n>.UUID.vhd` and stored in the specified capture
     container along side the OS disk. The additional disks are included in
     the deployment template `PREFIX-vmTemplate.UUID`.
-    
+
     For Managed build the final artifacts are included in the managed image.
     The additional disk will have the same storage account type as the OS
     disk, as specified with the `managed_image_storage_account_type`
     setting.
-    
+
 -   `disk_caching_type` (string) - Specify the disk caching type. Valid values
     are None, ReadOnly, and ReadWrite. The default value is ReadWrite.
-    
+
 -   `allowed_inbound_ip_addresses` ([]string) - Specify the list of IP addresses and CIDR blocks that should be
     allowed access to the VM. If provided, an Azure Network Security
     Group will be created with corresponding rules and be bound to
     the subnet of the VM.
     Providing `allowed_inbound_ip_addresses` in combination with
     `virtual_network_name` is not allowed.
-    
+
 -   `async_resourcegroup_delete` (bool) - If you want packer to delete the
     temporary resource group asynchronously set this value. It's a boolean
     value and defaults to false. Important Setting this true means that
     your builds are faster, however any failed deletes are not reported.
-    

--- a/website/source/partials/builder/azure/arm/_Config-not-required.html.md
+++ b/website/source/partials/builder/azure/arm/_Config-not-required.html.md
@@ -118,6 +118,9 @@
 -   `build_key_vault_name` (string) - Specify an existing key vault to use for uploading certificates to the
     instance to connect.
     
+-   `build_key_vault_sku` (string) - Specify the KeyVault SKU to create during the build. Valid values are
+    standard or premium. The default value is standard.
+    
 -   `private_virtual_network_with_public_ip` (bool) - This value allows you to
     set a virtual_network_name and obtain a public IP. If this value is not
     set and virtual_network_name is defined Packer is only allowed to be


### PR DESCRIPTION
This adds a configurable field `build_key_vault_sku` to the Azure ARM builder that can be used to select either a Standard or Premium SKU. Some companies are using Azure Policy to require the use of Premium SKU KeyVault.