### PR TITLE
fix googlecompute password interpolation

### DIFF
--- a/helper/communicator/step_connect_winrm.go
+++ b/helper/communicator/step_connect_winrm.go
@@ -131,6 +131,7 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, ctx context.Co
 			}
 			if config.Password != "" {
 				password = config.Password
+				s.Config.WinRMPassword = password
 			}
 		}
 


### PR DESCRIPTION
Make sure that any password returned by the WinRMConfig function is set into the communicator config. Fixes googlecompute WinRMPassword regression. 

Closes #8880 
