### PR TITLE
Fix small typo in amazon-ebssurrogate.html.md.erb

### DIFF
--- a/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
+++ b/website/source/docs/builders/amazon-ebssurrogate.html.md.erb
@@ -172,7 +172,7 @@ variables are available:
 -&gt; **Note:** Packer uses pre-built AMIs as the source for building images.
 These source AMIs may include volumes that are not flagged to be destroyed on
 termination of the instance building the new image. In addition to those
-volumes created by this builder, any volumes inn the source AMI which are not
+volumes created by this builder, any volumes in the source AMI which are not
 marked for deletion on termination will remain in your account.
 
 


### PR DESCRIPTION
This fixes a small typo in amazon-ebssurrogate.html.md.erb.