### PR TITLE
[WIP] Feature7379 - https://github.com/hashicorp/packer/issues/7379

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
 	ocicommon "github.com/oracle/oci-go-sdk/common"
+	ociauth "github.com/oracle/oci-go-sdk/common/auth"
 )
 
 type Config struct {
@@ -26,6 +27,18 @@ type Config struct {
 	Comm                communicator.Config `mapstructure:",squash"`
 
 	configProvider ocicommon.ConfigurationProvider
+
+	// Instance Principals (OPTIONAL)
+	// If set to true the following can't have non empty values
+	// - AccessCfgFile
+	// - AccessCfgFileAccount
+	// - UserID
+	// - TenancyID
+	// - Region
+	// - Fingerprint
+	// - KeyFile
+	// - PassPhrase
+	InstancePrincipals bool `mapstructure:"use_instance_principals"`
 
 	AccessCfgFile        string `mapstructure:"access_cfg_file"`
 	AccessCfgFileAccount string `mapstructure:"access_cfg_file_account"`
@@ -86,84 +99,134 @@ func (c *Config) Prepare(raws ...interface{}) error {
 		return fmt.Errorf("Failed to mapstructure Config: %+v", err)
 	}
 
-	// Determine where the SDK config is located
-	if c.AccessCfgFile == "" {
-		c.AccessCfgFile, err = getDefaultOCISettingsPath()
-		if err != nil {
-			log.Println("Default OCI settings file not found")
-		}
-	}
-
-	if c.AccessCfgFileAccount == "" {
-		c.AccessCfgFileAccount = "DEFAULT"
-	}
-
-	var keyContent []byte
-	if c.KeyFile != "" {
-		path, err := packer.ExpandUser(c.KeyFile)
-		if err != nil {
-			return err
-		}
-
-		// Read API signing key
-		keyContent, err = ioutil.ReadFile(path)
-		if err != nil {
-			return err
-		}
-	}
-
-	fileProvider, _ := ocicommon.ConfigurationProviderFromFileWithProfile(c.AccessCfgFile, c.AccessCfgFileAccount, c.PassPhrase)
-	if c.Region == "" {
-		var region string
-		if fileProvider != nil {
-			region, _ = fileProvider.Region()
-		}
-		if region == "" {
-			c.Region = "us-phoenix-1"
-		}
-	}
-
-	providers := []ocicommon.ConfigurationProvider{
-		NewRawConfigurationProvider(c.TenancyID, c.UserID, c.Region, c.Fingerprint, string(keyContent), &c.PassPhrase),
-	}
-
-	if fileProvider != nil {
-		providers = append(providers, fileProvider)
-	}
-
-	// Load API access configuration from SDK
-	configProvider, err := ocicommon.ComposingConfigurationProvider(providers)
-	if err != nil {
-		return err
-	}
-
 	var errs *packer.MultiError
 	if es := c.Comm.Prepare(&c.ctx); len(es) > 0 {
 		errs = packer.MultiErrorAppend(errs, es...)
 	}
 
-	if userOCID, _ := configProvider.UserOCID(); userOCID == "" {
-		errs = packer.MultiErrorAppend(
-			errs, errors.New("'user_ocid' must be specified"))
-	}
+	var tenancyOCID string
 
-	tenancyOCID, _ := configProvider.TenancyOCID()
-	if tenancyOCID == "" {
-		errs = packer.MultiErrorAppend(
-			errs, errors.New("'tenancy_ocid' must be specified"))
-	}
+	if c.InstancePrincipals {
+		// We could go through all keys in one go and report that the below set
+		// of keys cannot coexist with use_instance_principals but decided to
+		// split them and report them seperately so that the user sees the specific
+		// key involved.
+		var message string = " cannot be present when use_instance_principals is set to true."
+		if c.AccessCfgFile != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("access_cfg_file"+message))
+		}
+		if c.AccessCfgFileAccount != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("access_cfg_file_account"+message))
+		}
+		if c.UserID != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("user_ocid"+message))
+		}
+		if c.TenancyID != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("tenancy_ocid"+message))
+		}
+		if c.Region != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("region"+message))
+		}
+		if c.Fingerprint != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("fingerprint"+message))
+		}
+		if c.KeyFile != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("key_file"+message))
+		}
+		if c.PassPhrase != "" {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("pass_phrase"+message))
+		}
+		// This check is used to facilitate testing. During testing a Mock struct
+		// is assigned to c.configProvider otherwise testing fails because Instance
+		// Principals cannot be obtained.
+		if c.configProvider == nil {
+			// Even though the previous configuraion checks might fail we don't want
+			// to skip this step. It seems that the logic behind the checks in this
+			// file is to check everything even getting the configProvider.
+			c.configProvider, err = ociauth.InstancePrincipalConfigurationProvider()
+			if err != nil {
+				return err
+			}
+		}
+		tenancyOCID, err = c.configProvider.TenancyOCID()
+		if err != nil {
+			return err
+		}
+	} else {
+		// Determine where the SDK config is located
+		if c.AccessCfgFile == "" {
+			c.AccessCfgFile, err = getDefaultOCISettingsPath()
+			if err != nil {
+				log.Println("Default OCI settings file not found")
+			}
+		}
 
-	if fingerprint, _ := configProvider.KeyFingerprint(); fingerprint == "" {
-		errs = packer.MultiErrorAppend(
-			errs, errors.New("'fingerprint' must be specified"))
-	}
+		if c.AccessCfgFileAccount == "" {
+			c.AccessCfgFileAccount = "DEFAULT"
+		}
 
-	if _, err := configProvider.PrivateRSAKey(); err != nil {
-		errs = packer.MultiErrorAppend(
-			errs, errors.New("'key_file' must be specified"))
-	}
+		var keyContent []byte
+		if c.KeyFile != "" {
+			path, err := packer.ExpandUser(c.KeyFile)
+			if err != nil {
+				return err
+			}
 
-	c.configProvider = configProvider
+			// Read API signing key
+			keyContent, err = ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		fileProvider, _ := ocicommon.ConfigurationProviderFromFileWithProfile(c.AccessCfgFile, c.AccessCfgFileAccount, c.PassPhrase)
+		if c.Region == "" {
+			var region string
+			if fileProvider != nil {
+				region, _ = fileProvider.Region()
+			}
+			if region == "" {
+				c.Region = "us-phoenix-1"
+			}
+		}
+
+		providers := []ocicommon.ConfigurationProvider{
+			NewRawConfigurationProvider(c.TenancyID, c.UserID, c.Region, c.Fingerprint, string(keyContent), &c.PassPhrase),
+		}
+
+		if fileProvider != nil {
+			providers = append(providers, fileProvider)
+		}
+
+		// Load API access configuration from SDK
+		configProvider, err := ocicommon.ComposingConfigurationProvider(providers)
+		if err != nil {
+			return err
+		}
+
+		if userOCID, _ := configProvider.UserOCID(); userOCID == "" {
+			errs = packer.MultiErrorAppend(
+				errs, errors.New("'user_ocid' must be specified"))
+		}
+
+		tenancyOCID, _ = configProvider.TenancyOCID()
+		if tenancyOCID == "" {
+			errs = packer.MultiErrorAppend(
+				errs, errors.New("'tenancy_ocid' must be specified"))
+		}
+
+		if fingerprint, _ := configProvider.KeyFingerprint(); fingerprint == "" {
+			errs = packer.MultiErrorAppend(
+				errs, errors.New("'fingerprint' must be specified"))
+		}
+
+		if _, err := configProvider.PrivateRSAKey(); err != nil {
+			errs = packer.MultiErrorAppend(
+				errs, errors.New("'key_file' must be specified"))
+		}
+
+		c.configProvider = configProvider
+	}
 
 	if c.AvailabilityDomain == "" {
 		errs = packer.MultiErrorAppend(

--- a/builder/oracle/oci/config.hcl2spec.go
+++ b/builder/oracle/oci/config.hcl2spec.go
@@ -56,6 +56,7 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool                             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl"`
 	WinRMInsecure             *bool                             `mapstructure:"winrm_insecure" cty:"winrm_insecure"`
 	WinRMUseNTLM              *bool                             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm"`
+	InstancePrincipals        *bool                             `mapstructure:"use_instance_principals" cty:"use_instance_principals"`
 	AccessCfgFile             *string                           `mapstructure:"access_cfg_file" cty:"access_cfg_file"`
 	AccessCfgFileAccount      *string                           `mapstructure:"access_cfg_file_account" cty:"access_cfg_file_account"`
 	UserID                    *string                           `mapstructure:"user_ocid" cty:"user_ocid"`
@@ -138,6 +139,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"use_instance_principals":      &hcldec.AttrSpec{Name: "use_instance_principals", Type: cty.Bool, Required: false},
 		"access_cfg_file":              &hcldec.AttrSpec{Name: "access_cfg_file", Type: cty.String, Required: false},
 		"access_cfg_file_account":      &hcldec.AttrSpec{Name: "access_cfg_file_account", Type: cty.String, Required: false},
 		"user_ocid":                    &hcldec.AttrSpec{Name: "user_ocid", Type: cty.String, Required: false},

--- a/builder/oracle/oci/instance_principal_configuration_provider_mock.go
+++ b/builder/oracle/oci/instance_principal_configuration_provider_mock.go
@@ -1,0 +1,34 @@
+package oci
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+// Mock struct to be used during testing to obtain Instance Principals.
+type instancePrincipalConfigurationProviderMock struct {
+}
+
+func (p instancePrincipalConfigurationProviderMock) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, 1024)
+}
+
+func (p instancePrincipalConfigurationProviderMock) KeyID() (string, error) {
+	return "some_random_key_id", nil
+}
+
+func (p instancePrincipalConfigurationProviderMock) TenancyOCID() (string, error) {
+	return "some_random_tenancy", nil
+}
+
+func (p instancePrincipalConfigurationProviderMock) UserOCID() (string, error) {
+	return "", nil
+}
+
+func (p instancePrincipalConfigurationProviderMock) KeyFingerprint() (string, error) {
+	return "", nil
+}
+
+func (p instancePrincipalConfigurationProviderMock) Region() (string, error) {
+	return "some_random_region", nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/common/auth/certificate_retriever.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/auth/certificate_retriever.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+
+package auth
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/common"
+	"sync"
+)
+
+// x509CertificateRetriever provides an X509 certificate with the RSA private key
+type x509CertificateRetriever interface {
+	Refresh() error
+	CertificatePemRaw() []byte
+	Certificate() *x509.Certificate
+	PrivateKeyPemRaw() []byte
+	PrivateKey() *rsa.PrivateKey
+}
+
+// urlBasedX509CertificateRetriever retrieves PEM-encoded X509 certificates from the given URLs.
+type urlBasedX509CertificateRetriever struct {
+	certURL           string
+	privateKeyURL     string
+	passphrase        string
+	certificatePemRaw []byte
+	certificate       *x509.Certificate
+	privateKeyPemRaw  []byte
+	privateKey        *rsa.PrivateKey
+	mux               sync.Mutex
+}
+
+func newURLBasedX509CertificateRetriever(certURL, privateKeyURL, passphrase string) x509CertificateRetriever {
+	return &urlBasedX509CertificateRetriever{
+		certURL:       certURL,
+		privateKeyURL: privateKeyURL,
+		passphrase:    passphrase,
+		mux:           sync.Mutex{},
+	}
+}
+
+// Refresh() is failure atomic, i.e., CertificatePemRaw(), Certificate(), PrivateKeyPemRaw(), and PrivateKey() would
+// return their previous values if Refresh() fails.
+func (r *urlBasedX509CertificateRetriever) Refresh() error {
+	common.Debugln("Refreshing certificate")
+
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	var err error
+
+	var certificatePemRaw []byte
+	var certificate *x509.Certificate
+	if certificatePemRaw, certificate, err = r.renewCertificate(r.certURL); err != nil {
+		return fmt.Errorf("failed to renew certificate: %s", err.Error())
+	}
+
+	var privateKeyPemRaw []byte
+	var privateKey *rsa.PrivateKey
+	if r.privateKeyURL != "" {
+		if privateKeyPemRaw, privateKey, err = r.renewPrivateKey(r.privateKeyURL, r.passphrase); err != nil {
+			return fmt.Errorf("failed to renew private key: %s", err.Error())
+		}
+	}
+
+	r.certificatePemRaw = certificatePemRaw
+	r.certificate = certificate
+	r.privateKeyPemRaw = privateKeyPemRaw
+	r.privateKey = privateKey
+	return nil
+}
+
+func (r *urlBasedX509CertificateRetriever) renewCertificate(url string) (certificatePemRaw []byte, certificate *x509.Certificate, err error) {
+	var body bytes.Buffer
+	if body, err = httpGet(url); err != nil {
+		return nil, nil, fmt.Errorf("failed to get certificate from %s: %s", url, err.Error())
+	}
+
+	certificatePemRaw = body.Bytes()
+	var block *pem.Block
+	block, _ = pem.Decode(certificatePemRaw)
+	if block == nil {
+		return nil, nil, fmt.Errorf("failed to parse the new certificate, not valid pem data")
+	}
+
+	if certificate, err = x509.ParseCertificate(block.Bytes); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse the new certificate: %s", err.Error())
+	}
+
+	return certificatePemRaw, certificate, nil
+}
+
+func (r *urlBasedX509CertificateRetriever) renewPrivateKey(url, passphrase string) (privateKeyPemRaw []byte, privateKey *rsa.PrivateKey, err error) {
+	var body bytes.Buffer
+	if body, err = httpGet(url); err != nil {
+		return nil, nil, fmt.Errorf("failed to get private key from %s: %s", url, err.Error())
+	}
+
+	privateKeyPemRaw = body.Bytes()
+	if privateKey, err = common.PrivateKeyFromBytes(privateKeyPemRaw, &passphrase); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse the new private key: %s", err.Error())
+	}
+
+	return privateKeyPemRaw, privateKey, nil
+}
+
+func (r *urlBasedX509CertificateRetriever) CertificatePemRaw() []byte {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	if r.certificatePemRaw == nil {
+		return nil
+	}
+
+	c := make([]byte, len(r.certificatePemRaw))
+	copy(c, r.certificatePemRaw)
+	return c
+}
+
+func (r *urlBasedX509CertificateRetriever) Certificate() *x509.Certificate {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	if r.certificate == nil {
+		return nil
+	}
+
+	c := *r.certificate
+	return &c
+}
+
+func (r *urlBasedX509CertificateRetriever) PrivateKeyPemRaw() []byte {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	if r.privateKeyPemRaw == nil {
+		return nil
+	}
+
+	c := make([]byte, len(r.privateKeyPemRaw))
+	copy(c, r.privateKeyPemRaw)
+	return c
+}
+
+func (r *urlBasedX509CertificateRetriever) PrivateKey() *rsa.PrivateKey {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	if r.privateKey == nil {
+		return nil
+	}
+
+	c := *r.privateKey
+	return &c
+}

--- a/vendor/github.com/oracle/oci-go-sdk/common/auth/configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/auth/configuration.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+
+package auth
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+type instancePrincipalConfigurationProvider struct {
+	keyProvider *instancePrincipalKeyProvider
+	region      *common.Region
+}
+
+//InstancePrincipalConfigurationProvider returns a configuration for instance principals
+func InstancePrincipalConfigurationProvider() (common.ConfigurationProvider, error) {
+	var err error
+	var keyProvider *instancePrincipalKeyProvider
+	if keyProvider, err = newInstancePrincipalKeyProvider(); err != nil {
+		return nil, fmt.Errorf("failed to create a new key provider for instance principal: %s", err.Error())
+	}
+	return instancePrincipalConfigurationProvider{keyProvider: keyProvider, region: nil}, nil
+}
+
+//InstancePrincipalConfigurationProviderForRegion returns a configuration for instance principals with a given region
+func InstancePrincipalConfigurationProviderForRegion(region common.Region) (common.ConfigurationProvider, error) {
+	var err error
+	var keyProvider *instancePrincipalKeyProvider
+	if keyProvider, err = newInstancePrincipalKeyProvider(); err != nil {
+		return nil, fmt.Errorf("failed to create a new key provider for instance principal: %s", err.Error())
+	}
+	return instancePrincipalConfigurationProvider{keyProvider: keyProvider, region: &region}, nil
+}
+
+func (p instancePrincipalConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	return p.keyProvider.PrivateRSAKey()
+}
+
+func (p instancePrincipalConfigurationProvider) KeyID() (string, error) {
+	return p.keyProvider.KeyID()
+}
+
+func (p instancePrincipalConfigurationProvider) TenancyOCID() (string, error) {
+	return p.keyProvider.TenancyOCID()
+}
+
+func (p instancePrincipalConfigurationProvider) UserOCID() (string, error) {
+	return "", nil
+}
+
+func (p instancePrincipalConfigurationProvider) KeyFingerprint() (string, error) {
+	return "", nil
+}
+
+func (p instancePrincipalConfigurationProvider) Region() (string, error) {
+	if p.region == nil {
+		return string(p.keyProvider.RegionForFederationClient()), nil
+	}
+	return string(*p.region), nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/common/auth/federation_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/auth/federation_client.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+
+// Package auth provides supporting functions and structs for authentication
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// federationClient is a client to retrieve the security token for an instance principal necessary to sign a request.
+// It also provides the private key whose corresponding public key is used to retrieve the security token.
+type federationClient interface {
+	PrivateKey() (*rsa.PrivateKey, error)
+	SecurityToken() (string, error)
+}
+
+// x509FederationClient retrieves a security token from Auth service.
+type x509FederationClient struct {
+	tenancyID                         string
+	sessionKeySupplier                sessionKeySupplier
+	leafCertificateRetriever          x509CertificateRetriever
+	intermediateCertificateRetrievers []x509CertificateRetriever
+	securityToken                     securityToken
+	authClient                        *common.BaseClient
+	mux                               sync.Mutex
+}
+
+func newX509FederationClient(region common.Region, tenancyID string, leafCertificateRetriever x509CertificateRetriever, intermediateCertificateRetrievers []x509CertificateRetriever) federationClient {
+	client := &x509FederationClient{
+		tenancyID:                         tenancyID,
+		leafCertificateRetriever:          leafCertificateRetriever,
+		intermediateCertificateRetrievers: intermediateCertificateRetrievers,
+	}
+	client.sessionKeySupplier = newSessionKeySupplier()
+	client.authClient = newAuthClient(region, client)
+	return client
+}
+
+var (
+	genericHeaders = []string{"date", "(request-target)"} // "host" is not needed for the federation endpoint.  Don't ask me why.
+	bodyHeaders    = []string{"content-length", "content-type", "x-content-sha256"}
+)
+
+func newAuthClient(region common.Region, provider common.KeyProvider) *common.BaseClient {
+	signer := common.RequestSigner(provider, genericHeaders, bodyHeaders)
+	client := common.DefaultBaseClientWithSigner(signer)
+	if region == common.RegionSEA {
+		client.Host = "https://auth.r1.oracleiaas.com"
+	} else {
+		client.Host = fmt.Sprintf(common.DefaultHostURLTemplate, "auth", string(region))
+	}
+	client.BasePath = "v1/x509"
+	return &client
+}
+
+// For authClient to sign requests to X509 Federation Endpoint
+func (c *x509FederationClient) KeyID() (string, error) {
+	tenancy := c.tenancyID
+	fingerprint := fingerprint(c.leafCertificateRetriever.Certificate())
+	return fmt.Sprintf("%s/fed-x509/%s", tenancy, fingerprint), nil
+}
+
+// For authClient to sign requests to X509 Federation Endpoint
+func (c *x509FederationClient) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	return c.leafCertificateRetriever.PrivateKey(), nil
+}
+
+func (c *x509FederationClient) PrivateKey() (*rsa.PrivateKey, error) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if err := c.renewSecurityTokenIfNotValid(); err != nil {
+		return nil, err
+	}
+	return c.sessionKeySupplier.PrivateKey(), nil
+}
+
+func (c *x509FederationClient) SecurityToken() (token string, err error) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if err = c.renewSecurityTokenIfNotValid(); err != nil {
+		return "", err
+	}
+	return c.securityToken.String(), nil
+}
+
+func (c *x509FederationClient) renewSecurityTokenIfNotValid() (err error) {
+	if c.securityToken == nil || !c.securityToken.Valid() {
+		if err = c.renewSecurityToken(); err != nil {
+			return fmt.Errorf("failed to renew security token: %s", err.Error())
+		}
+	}
+	return nil
+}
+
+func (c *x509FederationClient) renewSecurityToken() (err error) {
+	if err = c.sessionKeySupplier.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh session key: %s", err.Error())
+	}
+
+	if err = c.leafCertificateRetriever.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh leaf certificate: %s", err.Error())
+	}
+
+	updatedTenancyID := extractTenancyIDFromCertificate(c.leafCertificateRetriever.Certificate())
+	if c.tenancyID != updatedTenancyID {
+		err = fmt.Errorf("unexpected update of tenancy OCID in the leaf certificate. Previous tenancy: %s, Updated: %s", c.tenancyID, updatedTenancyID)
+		return
+	}
+
+	for _, retriever := range c.intermediateCertificateRetrievers {
+		if err = retriever.Refresh(); err != nil {
+			return fmt.Errorf("failed to refresh intermediate certificate: %s", err.Error())
+		}
+	}
+
+	if c.securityToken, err = c.getSecurityToken(); err != nil {
+		return fmt.Errorf("failed to get security token: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (c *x509FederationClient) getSecurityToken() (securityToken, error) {
+	request := c.makeX509FederationRequest()
+
+	var err error
+	var httpRequest http.Request
+	if httpRequest, err = common.MakeDefaultHTTPRequestWithTaggedStruct(http.MethodPost, "", request); err != nil {
+		return nil, fmt.Errorf("failed to make http request: %s", err.Error())
+	}
+
+	var httpResponse *http.Response
+	defer common.CloseBodyIfValid(httpResponse)
+	if httpResponse, err = c.authClient.Call(context.Background(), &httpRequest); err != nil {
+		return nil, fmt.Errorf("failed to call: %s", err.Error())
+	}
+
+	response := x509FederationResponse{}
+	if err = common.UnmarshalResponse(httpResponse, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the response: %s", err.Error())
+	}
+
+	return newInstancePrincipalToken(response.Token.Token)
+}
+
+type x509FederationRequest struct {
+	X509FederationDetails `contributesTo:"body"`
+}
+
+// X509FederationDetails x509 federation details
+type X509FederationDetails struct {
+	Certificate              string   `mandatory:"true" json:"certificate,omitempty"`
+	PublicKey                string   `mandatory:"true" json:"publicKey,omitempty"`
+	IntermediateCertificates []string `mandatory:"false" json:"intermediateCertificates,omitempty"`
+}
+
+type x509FederationResponse struct {
+	Token `presentIn:"body"`
+}
+
+// Token token
+type Token struct {
+	Token string `mandatory:"true" json:"token,omitempty"`
+}
+
+func (c *x509FederationClient) makeX509FederationRequest() *x509FederationRequest {
+	certificate := c.sanitizeCertificateString(string(c.leafCertificateRetriever.CertificatePemRaw()))
+	publicKey := c.sanitizeCertificateString(string(c.sessionKeySupplier.PublicKeyPemRaw()))
+	var intermediateCertificates []string
+	for _, retriever := range c.intermediateCertificateRetrievers {
+		intermediateCertificates = append(intermediateCertificates, c.sanitizeCertificateString(string(retriever.CertificatePemRaw())))
+	}
+
+	details := X509FederationDetails{
+		Certificate:              certificate,
+		PublicKey:                publicKey,
+		IntermediateCertificates: intermediateCertificates,
+	}
+	return &x509FederationRequest{details}
+}
+
+func (c *x509FederationClient) sanitizeCertificateString(certString string) string {
+	certString = strings.Replace(certString, "-----BEGIN CERTIFICATE-----", "", -1)
+	certString = strings.Replace(certString, "-----END CERTIFICATE-----", "", -1)
+	certString = strings.Replace(certString, "-----BEGIN PUBLIC KEY-----", "", -1)
+	certString = strings.Replace(certString, "-----END PUBLIC KEY-----", "", -1)
+	certString = strings.Replace(certString, "\n", "", -1)
+	return certString
+}
+
+// sessionKeySupplier provides an RSA keypair which can be re-generated by calling Refresh().
+type sessionKeySupplier interface {
+	Refresh() error
+	PrivateKey() *rsa.PrivateKey
+	PublicKeyPemRaw() []byte
+}
+
+// inMemorySessionKeySupplier implements sessionKeySupplier to vend an RSA keypair.
+// Refresh() generates a new RSA keypair with a random source, and keeps it in memory.
+//
+// inMemorySessionKeySupplier is not thread-safe.
+type inMemorySessionKeySupplier struct {
+	keySize         int
+	privateKey      *rsa.PrivateKey
+	publicKeyPemRaw []byte
+}
+
+// newSessionKeySupplier creates and returns a sessionKeySupplier instance which generates key pairs of size 2048.
+func newSessionKeySupplier() sessionKeySupplier {
+	return &inMemorySessionKeySupplier{keySize: 2048}
+}
+
+// Refresh() is failure atomic, i.e., PrivateKey() and PublicKeyPemRaw() would return their previous values
+// if Refresh() fails.
+func (s *inMemorySessionKeySupplier) Refresh() (err error) {
+	common.Debugln("Refreshing session key")
+
+	var privateKey *rsa.PrivateKey
+	privateKey, err = rsa.GenerateKey(rand.Reader, s.keySize)
+	if err != nil {
+		return fmt.Errorf("failed to generate a new keypair: %s", err)
+	}
+
+	var publicKeyAsnBytes []byte
+	if publicKeyAsnBytes, err = x509.MarshalPKIXPublicKey(privateKey.Public()); err != nil {
+		return fmt.Errorf("failed to marshal the public part of the new keypair: %s", err.Error())
+	}
+	publicKeyPemRaw := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: publicKeyAsnBytes,
+	})
+
+	s.privateKey = privateKey
+	s.publicKeyPemRaw = publicKeyPemRaw
+	return nil
+}
+
+func (s *inMemorySessionKeySupplier) PrivateKey() *rsa.PrivateKey {
+	if s.privateKey == nil {
+		return nil
+	}
+
+	c := *s.privateKey
+	return &c
+}
+
+func (s *inMemorySessionKeySupplier) PublicKeyPemRaw() []byte {
+	if s.publicKeyPemRaw == nil {
+		return nil
+	}
+
+	c := make([]byte, len(s.publicKeyPemRaw))
+	copy(c, s.publicKeyPemRaw)
+	return c
+}
+
+type securityToken interface {
+	fmt.Stringer
+	Valid() bool
+}
+
+type instancePrincipalToken struct {
+	tokenString string
+	jwtToken    *jwtToken
+}
+
+func newInstancePrincipalToken(tokenString string) (newToken securityToken, err error) {
+	var jwtToken *jwtToken
+	if jwtToken, err = parseJwt(tokenString); err != nil {
+		return nil, fmt.Errorf("failed to parse the token string \"%s\": %s", tokenString, err.Error())
+	}
+	return &instancePrincipalToken{tokenString, jwtToken}, nil
+}
+
+func (t *instancePrincipalToken) String() string {
+	return t.tokenString
+}
+
+func (t *instancePrincipalToken) Valid() bool {
+	return !t.jwtToken.expired()
+}

--- a/vendor/github.com/oracle/oci-go-sdk/common/auth/instance_principal_key_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/auth/instance_principal_key_provider.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+
+package auth
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+const (
+	regionURL                            = `http://169.254.169.254/opc/v1/instance/region`
+	leafCertificateURL                   = `http://169.254.169.254/opc/v1/identity/cert.pem`
+	leafCertificateKeyURL                = `http://169.254.169.254/opc/v1/identity/key.pem`
+	leafCertificateKeyPassphrase         = `` // No passphrase for the private key for Compute instances
+	intermediateCertificateURL           = `http://169.254.169.254/opc/v1/identity/intermediate.pem`
+	intermediateCertificateKeyURL        = ``
+	intermediateCertificateKeyPassphrase = `` // No passphrase for the private key for Compute instances
+)
+
+// instancePrincipalKeyProvider implements KeyProvider to provide a key ID and its corresponding private key
+// for an instance principal by getting a security token via x509FederationClient.
+//
+// The region name of the endpoint for x509FederationClient is obtained from the metadata service on the compute
+// instance.
+type instancePrincipalKeyProvider struct {
+	regionForFederationClient common.Region
+	federationClient          federationClient
+	tenancyID                 string
+}
+
+// newInstancePrincipalKeyProvider creates and returns an instancePrincipalKeyProvider instance based on
+// x509FederationClient.
+//
+// NOTE: There is a race condition between PrivateRSAKey() and KeyID().  These two pieces are tightly coupled; KeyID
+// includes a security token obtained from Auth service by giving a public key which is paired with PrivateRSAKey.
+// The x509FederationClient caches the security token in memory until it is expired.  Thus, even if a client obtains a
+// KeyID that is not expired at the moment, the PrivateRSAKey that the client acquires at a next moment could be
+// invalid because the KeyID could be already expired.
+func newInstancePrincipalKeyProvider() (provider *instancePrincipalKeyProvider, err error) {
+	var region common.Region
+	if region, err = getRegionForFederationClient(regionURL); err != nil {
+		err = fmt.Errorf("failed to get the region name from %s: %s", regionURL, err.Error())
+		common.Logln(err)
+		return nil, err
+	}
+
+	leafCertificateRetriever := newURLBasedX509CertificateRetriever(
+		leafCertificateURL, leafCertificateKeyURL, leafCertificateKeyPassphrase)
+	intermediateCertificateRetrievers := []x509CertificateRetriever{
+		newURLBasedX509CertificateRetriever(
+			intermediateCertificateURL, intermediateCertificateKeyURL, intermediateCertificateKeyPassphrase),
+	}
+
+	if err = leafCertificateRetriever.Refresh(); err != nil {
+		err = fmt.Errorf("failed to refresh the leaf certificate: %s", err.Error())
+		return nil, err
+	}
+	tenancyID := extractTenancyIDFromCertificate(leafCertificateRetriever.Certificate())
+
+	federationClient := newX509FederationClient(
+		region, tenancyID, leafCertificateRetriever, intermediateCertificateRetrievers)
+
+	provider = &instancePrincipalKeyProvider{regionForFederationClient: region, federationClient: federationClient, tenancyID: tenancyID}
+	return
+}
+
+func getRegionForFederationClient(url string) (r common.Region, err error) {
+	var body bytes.Buffer
+	if body, err = httpGet(url); err != nil {
+		return
+	}
+	return common.StringToRegion(body.String()), nil
+}
+
+func (p *instancePrincipalKeyProvider) RegionForFederationClient() common.Region {
+	return p.regionForFederationClient
+}
+
+func (p *instancePrincipalKeyProvider) PrivateRSAKey() (privateKey *rsa.PrivateKey, err error) {
+	if privateKey, err = p.federationClient.PrivateKey(); err != nil {
+		err = fmt.Errorf("failed to get private key: %s", err.Error())
+		return nil, err
+	}
+	return privateKey, nil
+}
+
+func (p *instancePrincipalKeyProvider) KeyID() (string, error) {
+	var securityToken string
+	var err error
+	if securityToken, err = p.federationClient.SecurityToken(); err != nil {
+		return "", fmt.Errorf("failed to get security token: %s", err.Error())
+	}
+	return fmt.Sprintf("ST$%s", securityToken), nil
+}
+
+func (p *instancePrincipalKeyProvider) TenancyOCID() (string, error) {
+	return p.tenancyID, nil
+}

--- a/vendor/github.com/oracle/oci-go-sdk/common/auth/jwt.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/auth/jwt.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+
+package auth
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type jwtToken struct {
+	raw     string
+	header  map[string]interface{}
+	payload map[string]interface{}
+}
+
+func (t *jwtToken) expired() bool {
+	exp := int64(t.payload["exp"].(float64))
+	return exp <= time.Now().Unix()
+}
+
+func parseJwt(tokenString string) (*jwtToken, error) {
+	parts := strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("the given token string contains an invalid number of parts")
+	}
+
+	token := &jwtToken{raw: tokenString}
+	var err error
+
+	// Parse Header part
+	var headerBytes []byte
+	if headerBytes, err = decodePart(parts[0]); err != nil {
+		return nil, fmt.Errorf("failed to decode the header bytes: %s", err.Error())
+	}
+	if err = json.Unmarshal(headerBytes, &token.header); err != nil {
+		return nil, err
+	}
+
+	// Parse Payload part
+	var payloadBytes []byte
+	if payloadBytes, err = decodePart(parts[1]); err != nil {
+		return nil, fmt.Errorf("failed to decode the payload bytes: %s", err.Error())
+	}
+	decoder := json.NewDecoder(bytes.NewBuffer(payloadBytes))
+	if err = decoder.Decode(&token.payload); err != nil {
+		return nil, fmt.Errorf("failed to decode the payload json: %s", err.Error())
+	}
+
+	return token, nil
+}
+
+func decodePart(partString string) ([]byte, error) {
+	if l := len(partString) % 4; 0 < l {
+		partString += strings.Repeat("=", 4-l)
+	}
+	return base64.URLEncoding.DecodeString(partString)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/common/auth/utils.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/auth/utils.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+
+package auth
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"crypto/x509"
+	"fmt"
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+)
+
+// httpGet makes a simple HTTP GET request to the given URL, expecting only "200 OK" status code.
+// This is basically for the Instance Metadata Service.
+func httpGet(url string) (body bytes.Buffer, err error) {
+	var response *http.Response
+	if response, err = http.Get(url); err != nil {
+		return
+	}
+
+	common.IfDebug(func() {
+		if dump, e := httputil.DumpResponse(response, true); e == nil {
+			common.Logf("Dump Response %v", string(dump))
+		} else {
+			common.Debugln(e)
+		}
+	})
+
+	defer response.Body.Close()
+	if _, err = body.ReadFrom(response.Body); err != nil {
+		return
+	}
+
+	if response.StatusCode != http.StatusOK {
+		err = fmt.Errorf("HTTP Get failed: URL: %s, Status: %s, Message: %s",
+			url, response.Status, body.String())
+		return
+	}
+
+	return
+}
+
+func extractTenancyIDFromCertificate(cert *x509.Certificate) string {
+	for _, nameAttr := range cert.Subject.Names {
+		value := nameAttr.Value.(string)
+		if strings.HasPrefix(value, "opc-tenant:") {
+			return value[len("opc-tenant:"):]
+		}
+	}
+	return ""
+}
+
+func fingerprint(certificate *x509.Certificate) string {
+	fingerprint := sha1.Sum(certificate.Raw)
+	return colonSeparatedString(fingerprint)
+}
+
+func colonSeparatedString(fingerprint [sha1.Size]byte) string {
+	spaceSeparated := fmt.Sprintf("% x", fingerprint)
+	return strings.Replace(spaceSeparated, " ", ":", -1)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -484,6 +484,7 @@ github.com/nu7hatch/gouuid
 github.com/olekukonko/tablewriter
 # github.com/oracle/oci-go-sdk v1.8.0
 github.com/oracle/oci-go-sdk/common
+github.com/oracle/oci-go-sdk/common/auth
 github.com/oracle/oci-go-sdk/core
 # github.com/outscale/osc-go v0.0.1
 github.com/outscale/osc-go/oapi

--- a/website/source/docs/builders/oracle-oci.html.md
+++ b/website/source/docs/builders/oracle-oci.html.md
@@ -33,6 +33,9 @@ authentication see the documentation on [Required Keys and
 OCIDs](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm)
 ([Oracle Cloud
 IDs](https://docs.us-phoenix-1.oraclecloud.com/Content/General/Concepts/identifiers.htm)).
+Alternatively you can use [Instance
+Principals](https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm)
+in which case you don't need the above user authorization.
 
 ## Configuration Reference
 
@@ -65,11 +68,6 @@ builder.
 -   `compartment_ocid` (string) - The OCID of the
     [compartment](https://docs.us-phoenix-1.oraclecloud.com/Content/GSG/Tasks/choosingcompartments.htm)
 
--   `fingerprint` (string) - Fingerprint for the OCI API signing key. Overrides
-    value provided by the [OCI config
-    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
-    if present.
-
 -   `shape` (string) - The template that determines the number of CPUs, amount
     of memory, and other resources allocated to a newly created instance.
 
@@ -90,41 +88,51 @@ builder.
 
 ### Optional
 
+-   `use_instance_principals` (boolean) - Whether to use [Instance
+    Principals](https://docs.cloud.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm)
+    instead of User Principals. If this key is set to true, setting any one of the `access_cfg_file`,
+    `access_cfg_file_account`, `region`, `tenancy_ocid`, `user_ocid`, `key_file`, `fingerprint`, 
+    `pass_phrase` will result in configuration validation errors.
+    Defaults to `false`.
+
 -   `access_cfg_file` (string) - The path to the [OCI config
     file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm).
+    This cannot be used along with the `use_instance_principals` key.
     Defaults to `$HOME/.oci/config`.
 
--   `access_cfg_file_account` (string) - The specific account in the [OCI
-    config
-    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
-    to use. Defaults to `DEFAULT`.
+-   `access_cfg_file_account` (string) - The specific account in the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm) to use.
+    This cannot be used along with the `use_instance_principals` key.
+    Defaults to `DEFAULT`.
+
+-   `region` (string) - An Oracle Cloud Infrastructure region. Overrides value provided by the
+    [OCI config file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present. This cannot be used along with the `use_instance_principals` key.
+
+-   `tenancy_ocid` (string) - The OCID of your tenancy. Overrides value provided by the [OCI config
+    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm) if present.
+    This cannot be used along with the `use_instance_principals` key.
+
+-   `user_ocid` (string) - The OCID of the user calling the OCI API. Overrides value provided by the
+    [OCI config file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present. This cannot be used along with the `use_instance_principals` key.
+
+-   `key_file` (string) - Full path and filename of the OCI API signing key. Overrides value provided
+    by the [OCI config file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present. This cannot be used along with the `use_instance_principals` key.
+
+-   `fingerprint` (string) - Fingerprint for the OCI API signing key. Overrides value provided by the
+    [OCI config file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm) if
+    present. This cannot be used along with the `use_instance_principals` key.
+
+-   `pass_phrase` (string) - Pass phrase used to decrypt the OCI API signing key. Overrides value provided
+    by the [OCI config file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
+    if present. This cannot be used along with the `use_instance_principals` key.
 
 -   `image_name` (string) - The name to assign to the resulting custom image.
 
--   `key_file` (string) - Full path and filename of the OCI API signing key.
-    Overrides value provided by the [OCI config
-    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
-    if present.
-
--   `pass_phrase` (string) - Pass phrase used to decrypt the OCI API signing
-    key. Overrides value provided by the [OCI config
-    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
-    if present.
-
--   `region` (string) - An Oracle Cloud Infrastructure region. Overrides value
-    provided by the [OCI config
-    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
-    if present.
-
--   `tenancy_ocid` (string) - The OCID of your tenancy. Overrides value
-    provided by the [OCI config
-    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
-    if present.
-
--   `user_ocid` (string) - The OCID of the user calling the OCI API. Overrides
-    value provided by the [OCI config
-    file](https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/sdkconfig.htm)
-    if present.
+-   `instance_name` (string) - The name to assign to the instance used for the image creation process.
+    If not set a name of the form `instanceYYYYMMDDhhmmss` will be used.
 
 -   `use_private_ip` (boolean) - Use private ip addresses to connect to the
     instance via ssh.
@@ -190,4 +198,47 @@ substituted with the letter `a` and OCIDS have been shortened for brevity.
     "subnet_ocid": "ocid1.subnet.oc1..aaa",
     "type": "oracle-oci"
 }
+```
+
+## Using Instance Principals
+
+Here is a basic example. Note that account specific configuration has been
+substituted with the letter `a` and OCIDS have been shortened for brevity.
+
+```json
+{
+    "use_instance_principals": "true",
+    "availability_domain": "aaaa:PHX-AD-1",
+    "base_image_ocid": "ocid1.image.oc1.phx.aaaaaaaa5yu6pw3riqtuhxzov7fdngi4tsteganmao54nq3pyxu3hxcuzmoa",
+    "compartment_ocid": "ocid1.compartment.oc1..aaa",
+    "image_name": "ExampleImage",
+    "shape": "VM.Standard2.1",
+    "ssh_username": "opc",
+    "subnet_ocid": "ocid1.subnet.oc1..aaa",
+    "type": "oracle-oci"
+}
+```
+
+```
+[opc@packerhost ~]$ packer build packer.json
+oracle-oci: output will be in this color.
+
+==> oracle-oci: Creating temporary ssh key for instance...
+==> oracle-oci: Creating instance...
+==> oracle-oci: Created instance (ocid1.instance.oc1.phx.aaa).
+==> oracle-oci: Waiting for instance to enter 'RUNNING' state...
+==> oracle-oci: Instance 'RUNNING'.
+==> oracle-oci: Instance has IP: 10.10.10.10.
+==> oracle-oci: Using ssh communicator to connect: 10.10.10.10
+==> oracle-oci: Waiting for SSH to become available...
+==> oracle-oci: Connected to SSH!
+==> oracle-oci: Creating image from instance...
+==> oracle-oci: Image created.
+==> oracle-oci: Terminating instance (ocid1.instance.oc1.phx.aaa)...
+==> oracle-oci: Terminated instance.
+Build 'oracle-oci' finished.
+
+==> Builds finished. The artifacts of successful builds are:
+--> oracle-oci: An image was created: 'ExampleImage' (OCID: ocid1.image.oc1.phx.aaa) in region 'us-phoenix-1'
+[opc@packerhost ~]$
 ```


### PR DESCRIPTION
```
=============
GO MOD VENDOR
=============
```

After running go mod vendor. I've only committed oracle/oci related changes as I cannot test the others.
```
user-laptop:packer itzimour$ git status
On branch feature7379
Your branch is up to date with 'itzimourakas/feature7379'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   vendor/github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server/LICENSE
	modified:   vendor/github.com/dimchansky/utfbom/.travis.yml
	modified:   vendor/github.com/golang-collections/collections/LICENSE
	modified:   vendor/github.com/golang-collections/collections/stack/stack.go
	modified:   vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
	modified:   vendor/github.com/hashicorp/hcl/.gitignore
	modified:   vendor/github.com/hashicorp/hcl/Makefile
	modified:   vendor/github.com/profitbricks/profitbricks-sdk-go/README.md
	modified:   vendor/github.com/sirupsen/logrus/appveyor.yml
	modified:   vendor/github.com/yandex-cloud/go-sdk/CONTRIBUTING.md
	modified:   vendor/modules.txt  <---------------------------------------------- (COMMITTED)

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	vendor/github.com/oracle/oci-go-sdk/common/auth/ <----------------------------- (COMMITTED)

no changes added to commit (use "git add" and/or "git commit -a")
user-laptop:packer itzimour$
```
```
=====================
MAKE INSTALL-GEN-DEPS
=====================
```
```
root@b67faa0ad825:/go/src/github.com/hashicorp/packer# make install-gen-deps
# to avoid having to tidy our go deps, we `go get` our binaries from a temp
# dir. `go get` will change our deps and the following deps are not part of
# out code dependencies; so a go mod tidy will remove them again. `go
# install` seems to install the last tagged version and we want to install
# master.
go: finding github.com master
go: finding github.com/mna/pigeon master
go: finding github.com/mna master
go: finding github.com master
go: finding github.com/alvaroloes/enumer master
go: finding github.com/alvaroloes master
root@b67faa0ad825:/go/src/github.com/hashicorp/packer#
```
```
===========
GO GENERATE
===========
```
```
root@b67faa0ad825:/go/src/github.com/hashicorp/packer# go generate ./builder/oracle/...
root@b67faa0ad825:/go/src/github.com/hashicorp/packer#
```
```
=========
MAKE LINT
=========
```
I've only run lint on oci and not classic as I don't have the means to test the classic builder.
The below errors are not related to my changes so I preferred to play it safely and don't change anything.
```
root@b67faa0ad825:/go/src/github.com/hashicorp/packer# make lint PKG_NAME=builder/oracle/oci
==> Updating linter dependencies...
golangci/golangci-lint info checking GitHub for tag 'v1.23.8'
golangci/golangci-lint info found version: 1.23.8 for v1.23.8/linux/amd64
golangci/golangci-lint info installed /go/bin/golangci-lint
golangci-lint run ./builder/oracle/oci/...
builder/oracle/oci/driver_oci.go:18:2: field `context` is unused (unused)
builder/oracle/oci/builder.go:22:7: const `ociAPIVersion` is unused (unused)
builder/oracle/oci/config_test.go:299:16: Error return value of `section.NewKey` is not checked (errcheck)
	section.NewKey("region", "us-ashburn-1")
	              ^
builder/oracle/oci/config_test.go:300:16: Error return value of `section.NewKey` is not checked (errcheck)
	section.NewKey("tenancy", "ocid1.tenancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
	              ^
builder/oracle/oci/config_test.go:301:16: Error return value of `section.NewKey` is not checked (errcheck)
	section.NewKey("user", "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
	              ^
builder/oracle/oci/config_test.go:302:16: Error return value of `section.NewKey` is not checked (errcheck)
	section.NewKey("fingerprint", "70:04:5z:b3:19:ab:90:75:a4:1f:50:d4:c7:c3:33:20")
	              ^
builder/oracle/oci/config_test.go:303:16: Error return value of `section.NewKey` is not checked (errcheck)
	section.NewKey("key_file", keyFile.Name())
	              ^
make: *** [Makefile:75: lint] Error 1
root@b67faa0ad825:/go/src/github.com/hashicorp/packer#
```
```
=======
TESTING
=======
```
```
root@b67faa0ad825:/go/src/github.com/hashicorp/packer# make test TEST=./builder/oracle/...
==> Checking that only certain files are executable...
Check passed.
ok  	github.com/hashicorp/packer/builder/oracle/classic	0.104s
?   	github.com/hashicorp/packer/builder/oracle/common	[no test files]
ok  	github.com/hashicorp/packer/builder/oracle/oci	2.788s
root@b67faa0ad825:/go/src/github.com/hashicorp/packer#
```
```
==================
ACCEPTANCE TESTING
==================
```
```
root@b67faa0ad825:/go/src/github.com/hashicorp/packer# make testacc TEST=./builder/oracle/oci
# to avoid having to tidy our go deps, we `go get` our binaries from a temp
# dir. `go get` will change our deps and the following deps are not part of
# out code dependencies; so a go mod tidy will remove them again. `go
# install` seems to install the last tagged version and we want to install
# master.
go: finding github.com/mna/pigeon master
go: finding github.com master
go: finding github.com/mna master
go: finding github.com master
go: finding github.com/alvaroloes/enumer master
go: finding github.com/alvaroloes master
==> removing autogenerated markdown...
==> removing autogenerated code...
go generate ./...
2020/03/15 00:00:31 Generated command/plugin.go
mapstructure-to-hcl2: ecs.[Config AlicloudDiskDevice]: skipping field AlicloudImageSkipRegionValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: chroot.[Config BlockDevices BlockDevice]: skipping field SkipValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: ebs.[Config]: skipping field AMISkipRegionValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: ebs.[Config]: skipping field SSHTemporaryKeyPairName ( duplicate `temporary_key_pair_name` cty tag  )
mapstructure-to-hcl2: ebssurrogate.[Config RootBlockDevice BlockDevice]: skipping field SSHTemporaryKeyPairName ( duplicate `temporary_key_pair_name` cty tag  )
mapstructure-to-hcl2: ebssurrogate.[Config RootBlockDevice BlockDevice]: skipping field AMISkipRegionValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: ebsvolume.[Config BlockDevice]: skipping field SSHTemporaryKeyPairName ( duplicate `temporary_key_pair_name` cty tag  )
mapstructure-to-hcl2: instance.[Config]: skipping field AMISkipRegionValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: instance.[Config]: skipping field SSHTemporaryKeyPairName ( duplicate `temporary_key_pair_name` cty tag  )
mapstructure-to-hcl2: iso.[Config]: skipping field Communicator ( duplicate `communicator` cty tag  )
mapstructure-to-hcl2: vmcx.[Config]: skipping field Communicator ( duplicate `communicator` cty tag  )
mapstructure-to-hcl2: bsu.[Config]: skipping field OMISkipRegionValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: bsu.[Config]: skipping field SSHTemporaryKeyPairName ( duplicate `temporary_key_pair_name` cty tag  )
mapstructure-to-hcl2: bsusurrogate.[Config RootBlockDevice]: skipping field SSHTemporaryKeyPairName ( duplicate `temporary_key_pair_name` cty tag  )
mapstructure-to-hcl2: bsusurrogate.[Config RootBlockDevice]: skipping field OMISkipRegionValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: bsuvolume.[Config BlockDevice]: skipping field SSHTemporaryKeyPairName ( duplicate `temporary_key_pair_name` cty tag  )
mapstructure-to-hcl2: chroot.[Config]: skipping field SkipValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: cvm.[Config]: skipping duplicate SkipValidation field
mapstructure-to-hcl2: vagrant.[Config]: skipping field Communicator ( duplicate `communicator` cty tag  )
mapstructure-to-hcl2: iso.[Config]: skipping duplicate Communicator field
mapstructure-to-hcl2: iso.[Config]: skipping duplicate GuestAdditionsMode field
mapstructure-to-hcl2: iso.[Config]: skipping field Communicator ( duplicate `communicator` cty tag  )
mapstructure-to-hcl2: ovf.[Config]: skipping duplicate Communicator field
mapstructure-to-hcl2: ovf.[Config]: skipping duplicate GuestAdditionsMode field
mapstructure-to-hcl2: ovf.[Config]: skipping field Communicator ( duplicate `communicator` cty tag  )
mapstructure-to-hcl2: vm.[Config]: skipping field Communicator ( duplicate `communicator` cty tag  )
mapstructure-to-hcl2: alicloudimport.[Config]: skipping duplicate AlicloudImageDescription field
mapstructure-to-hcl2: alicloudimport.[Config]: skipping duplicate AlicloudImageShareAccounts field
mapstructure-to-hcl2: alicloudimport.[Config]: skipping duplicate AlicloudImageDestinationRegions field
mapstructure-to-hcl2: alicloudimport.[Config]: skipping duplicate AlicloudImageForceDelete field
mapstructure-to-hcl2: alicloudimport.[Config]: skipping field AlicloudImageSkipRegionValidation ( duplicate `skip_region_validation` cty tag  )
mapstructure-to-hcl2: alicloudimport.[Config]: skipping field Tags ( duplicate `tags` cty tag  )
go fmt common/bootcommand/boot_command.go
go fmt command/plugin.go
command/plugin.go
WARN: Acceptance tests will take a long time to run and may cost money. Ctrl-C if you want to cancel.
PACKER_ACC=1 go test -v ./builder/oracle/oci  -timeout=45m
=== RUN   TestArtifactImpl
--- PASS: TestArtifactImpl (0.00s)
=== RUN   TestArtifactState_StateData
--- PASS: TestArtifactState_StateData (0.00s)
=== RUN   TestBuilder_ImplementsBuilder
--- PASS: TestBuilder_ImplementsBuilder (0.00s)
=== RUN   TestConfig
=== RUN   TestConfig/BaseConfig
=== RUN   TestConfig/NoAccessConfig
2020/03/15 00:59:44 Default OCI settings file not found
=== RUN   TestConfig/AccessConfigTemplateOnly
2020/03/15 00:59:44 Default OCI settings file not found
=== RUN   TestConfig/TenancyReadFromAccessCfgFile
=== RUN   TestConfig/RegionNotDefaultedToPHXWhenSetInOCISettings
=== RUN   TestConfig/availability_domain_required
=== RUN   TestConfig/base_image_ocid_required
=== RUN   TestConfig/shape_required
=== RUN   TestConfig/subnet_ocid_required
=== RUN   TestConfig/ImageNameDefaultedIfEmpty
=== RUN   TestConfig/user_ocid_overridden
=== RUN   TestConfig/tenancy_ocid_overidden
=== RUN   TestConfig/region_overidden
=== RUN   TestConfig/fingerprint_overidden
=== RUN   TestConfig/access_cfg_file_mixed_with_use_instance_principals
=== RUN   TestConfig/access_cfg_file_account_mixed_with_use_instance_principals
=== RUN   TestConfig/user_ocid_mixed_with_use_instance_principals
=== RUN   TestConfig/tenancy_ocid_mixed_with_use_instance_principals
=== RUN   TestConfig/region_mixed_with_use_instance_principals
=== RUN   TestConfig/fingerprint_mixed_with_use_instance_principals
=== RUN   TestConfig/key_file_mixed_with_use_instance_principals
=== RUN   TestConfig/pass_phrase_mixed_with_use_instance_principals
--- PASS: TestConfig (0.28s)
    --- PASS: TestConfig/BaseConfig (0.00s)
    --- PASS: TestConfig/NoAccessConfig (0.00s)
    --- PASS: TestConfig/AccessConfigTemplateOnly (0.01s)
    --- PASS: TestConfig/TenancyReadFromAccessCfgFile (0.00s)
    --- PASS: TestConfig/RegionNotDefaultedToPHXWhenSetInOCISettings (0.00s)
    --- PASS: TestConfig/availability_domain_required (0.01s)
    --- PASS: TestConfig/base_image_ocid_required (0.00s)
    --- PASS: TestConfig/shape_required (0.02s)
    --- PASS: TestConfig/subnet_ocid_required (0.00s)
    --- PASS: TestConfig/ImageNameDefaultedIfEmpty (0.00s)
    --- PASS: TestConfig/user_ocid_overridden (0.00s)
    --- PASS: TestConfig/tenancy_ocid_overidden (0.00s)
    --- PASS: TestConfig/region_overidden (0.00s)
    --- PASS: TestConfig/fingerprint_overidden (0.00s)
    --- PASS: TestConfig/access_cfg_file_mixed_with_use_instance_principals (0.00s)
    --- PASS: TestConfig/access_cfg_file_account_mixed_with_use_instance_principals (0.01s)
    --- PASS: TestConfig/user_ocid_mixed_with_use_instance_principals (0.01s)
    --- PASS: TestConfig/tenancy_ocid_mixed_with_use_instance_principals (0.00s)
    --- PASS: TestConfig/region_mixed_with_use_instance_principals (0.00s)
    --- PASS: TestConfig/fingerprint_mixed_with_use_instance_principals (0.00s)
    --- PASS: TestConfig/key_file_mixed_with_use_instance_principals (0.00s)
    --- PASS: TestConfig/pass_phrase_mixed_with_use_instance_principals (0.00s)
=== RUN   TestStepCreateInstance
2020/03/15 00:59:44 Default OCI settings file not found
2020/03/15 00:59:44 ui: Creating instance...
2020/03/15 00:59:44 ui: Created instance (ocid1...).
2020/03/15 00:59:44 ui: Waiting for instance to enter 'RUNNING' state...
2020/03/15 00:59:44 ui: Instance 'RUNNING'.
2020/03/15 00:59:44 ui: Terminating instance (ocid1...)...
2020/03/15 00:59:44 ui: Terminated instance.
2020/03/15 00:59:44 ui: Terminating instance (ocid1...)...
2020/03/15 00:59:44 ui: Terminated instance.
--- PASS: TestStepCreateInstance (0.29s)
=== RUN   TestStepCreateInstance_CreateInstanceErr
2020/03/15 00:59:44 Default OCI settings file not found
2020/03/15 00:59:44 ui: Creating instance...
2020/03/15 00:59:44 ui error: Problem creating instance: error
--- PASS: TestStepCreateInstance_CreateInstanceErr (0.51s)
=== RUN   TestStepCreateInstance_WaitForInstanceStateErr
2020/03/15 00:59:45 Default OCI settings file not found
2020/03/15 00:59:45 ui: Creating instance...
2020/03/15 00:59:45 ui: Created instance (ocid1...).
2020/03/15 00:59:45 ui: Waiting for instance to enter 'RUNNING' state...
2020/03/15 00:59:45 ui error: Error waiting for instance to start: error
2020/03/15 00:59:45 ui: Terminating instance (ocid1...)...
2020/03/15 00:59:45 ui error: Error terminating instance. Please terminate manually: error
--- PASS: TestStepCreateInstance_WaitForInstanceStateErr (0.14s)
=== RUN   TestStepCreateInstance_TerminateInstanceErr
2020/03/15 00:59:45 Default OCI settings file not found
2020/03/15 00:59:45 ui: Creating instance...
2020/03/15 00:59:45 ui: Created instance (ocid1...).
2020/03/15 00:59:45 ui: Waiting for instance to enter 'RUNNING' state...
2020/03/15 00:59:45 ui: Instance 'RUNNING'.
2020/03/15 00:59:45 ui: Terminating instance (ocid1...)...
2020/03/15 00:59:45 ui error: Error terminating instance. Please terminate manually: error
2020/03/15 00:59:45 ui: Terminating instance (ocid1...)...
2020/03/15 00:59:45 ui error: Error terminating instance. Please terminate manually: error
--- PASS: TestStepCreateInstance_TerminateInstanceErr (0.19s)
=== RUN   TestStepCreateInstanceCleanup_WaitForInstanceStateErr
2020/03/15 00:59:45 Default OCI settings file not found
2020/03/15 00:59:45 ui: Creating instance...
2020/03/15 00:59:45 ui: Created instance (ocid1...).
2020/03/15 00:59:45 ui: Waiting for instance to enter 'RUNNING' state...
2020/03/15 00:59:45 ui: Instance 'RUNNING'.
2020/03/15 00:59:45 ui: Terminating instance (ocid1...)...
2020/03/15 00:59:45 ui error: Error terminating instance. Please terminate manually: error
2020/03/15 00:59:45 ui: Terminating instance (ocid1...)...
2020/03/15 00:59:45 ui error: Error terminating instance. Please terminate manually: error
--- PASS: TestStepCreateInstanceCleanup_WaitForInstanceStateErr (0.20s)
=== RUN   TestStepImage
2020/03/15 00:59:45 Default OCI settings file not found
2020/03/15 00:59:45 ui: Creating image from instance...
2020/03/15 00:59:45 ui: Image created.
--- PASS: TestStepImage (0.13s)
=== RUN   TestStepImage_CreateImageErr
2020/03/15 00:59:45 Default OCI settings file not found
2020/03/15 00:59:45 ui: Creating image from instance...
2020/03/15 00:59:45 ui error: Error creating image from instance: error
--- PASS: TestStepImage_CreateImageErr (0.28s)
=== RUN   TestStepImage_WaitForImageCreationErr
2020/03/15 00:59:46 Default OCI settings file not found
2020/03/15 00:59:46 ui: Creating image from instance...
2020/03/15 00:59:46 ui error: Error waiting for image creation to finish: error
--- PASS: TestStepImage_WaitForImageCreationErr (0.27s)
=== RUN   TestInstanceInfo
2020/03/15 00:59:46 Default OCI settings file not found
2020/03/15 00:59:46 ui: Instance has IP: ip.
--- PASS: TestInstanceInfo (0.22s)
=== RUN   TestInstanceInfoPrivateIP
2020/03/15 00:59:46 Default OCI settings file not found
2020/03/15 00:59:46 ui: Instance has IP: private_ip.
--- PASS: TestInstanceInfoPrivateIP (0.22s)
=== RUN   TestInstanceInfo_GetInstanceIPErr
2020/03/15 00:59:47 Default OCI settings file not found
2020/03/15 00:59:47 ui error: Error getting instance's IP: error
--- PASS: TestInstanceInfo_GetInstanceIPErr (0.46s)
PASS
ok  	github.com/hashicorp/packer/builder/oracle/oci	3.234s
root@b67faa0ad825:/go/src/github.com/hashicorp/packer#
```
```
========
MAKE BIN
========
```
```
root@22e92489d58a:/go/src/github.com/hashicorp/packer# make bin
WARN: 'make bin' is for debug / test builds only. Use 'make release' for release builds.
==> Checking for necessary tools...
==> Entering Packer source dir...
==> Ensuring output directories are present...
==> Removing old builds...
==> Building...
Number of parallel builds: 1

-->   solaris/amd64: github.com/hashicorp/packer
-->     linux/s390x: github.com/hashicorp/packer
-->       linux/386: github.com/hashicorp/packer
-->     linux/amd64: github.com/hashicorp/packer
-->       linux/arm: github.com/hashicorp/packer
-->      darwin/386: github.com/hashicorp/packer
-->    darwin/amd64: github.com/hashicorp/packer
-->     windows/386: github.com/hashicorp/packer
-->   windows/amd64: github.com/hashicorp/packer
-->     freebsd/386: github.com/hashicorp/packer
-->   freebsd/amd64: github.com/hashicorp/packer
-->     freebsd/arm: github.com/hashicorp/packer
-->     openbsd/386: github.com/hashicorp/packer
-->   openbsd/amd64: github.com/hashicorp/packer
-->      linux/mips: github.com/hashicorp/packer
-->   linux/ppc64le: github.com/hashicorp/packer
-->    linux/mips64: github.com/hashicorp/packer
-->    linux/mipsle: github.com/hashicorp/packer
-->     linux/arm64: github.com/hashicorp/packer

1 errors occurred:
--> freebsd/arm error: exit status 2
Stderr: # github.com/shirou/gopsutil/cpu
/go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:25:16: undefined: cpuTimes
/go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:42:31: undefined: cpuTimes
/go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:66:38: undefined: cpuTimes
/go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:72:15: undefined: cpuTimes
/go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:87:13: undefined: cpuTimes

==> Copying binaries for this platform...
'./pkg/linux_amd64/packer' -> 'bin/packer'
'./pkg/linux_amd64/packer' -> '/go/bin/packer'

==> Results:
total 161M
-rwxr-xr-x 1 root root 147M Mar 15 15:27 packer
root@22e92489d58a:/go/src/github.com/hashicorp/packer#
```
```
=====================================
LIVE TEST WITHOUT INSTANCE PRINCIPALS
=====================================
```
```
[opc@somehost ~]$ ls -ltr ~/.oci/config
-rw------- 1 opc opc 293 Mar 15 15:57 /home/opc/.oci/config
[opc@somehost ~]$
[opc@somehost ~]$ cat packer.json
{
    "builders": [
        {
            "type": "oracle-oci",
            "availability_domain": "REPLACED_FOR_OBVIOUS_REASONS",
            "image_name": "packer-test",
            "base_image_ocid": "REPLACED_FOR_OBVIOUS_REASONS",
            "compartment_ocid": "REPLACED_FOR_OBVIOUS_REASONS",
            "subnet_ocid": "REPLACED_FOR_OBVIOUS_REASONS",
            "shape": "VM.Standard2.1",
            "ssh_username" : "REPLACED_FOR_OBVIOUS_REASONS",
            "use_private_ip": "true"
        }
    ]
}
[opc@somehost ~]$
[opc@somehost ~]$ ./packer build packer.json
oracle-oci: output will be in this color.

==> oracle-oci: Creating temporary ssh key for instance...
==> oracle-oci: Creating instance...
==> oracle-oci: Created instance (REPLACED_FOR_OBVIOUS_REASONS).
==> oracle-oci: Waiting for instance to enter 'RUNNING' state...
==> oracle-oci: Instance 'RUNNING'.
==> oracle-oci: Instance has IP: REPLACED_FOR_OBVIOUS_REASONS.
==> oracle-oci: Using ssh communicator to connect: REPLACED_FOR_OBVIOUS_REASONS
==> oracle-oci: Waiting for SSH to become available...
==> oracle-oci: Connected to SSH!
==> oracle-oci: Creating image from instance...
==> oracle-oci: Image created.
==> oracle-oci: Terminating instance (REPLACED_FOR_OBVIOUS_REASONS)...
==> oracle-oci: Terminated instance.
Build 'oracle-oci' finished.

==> Builds finished. The artifacts of successful builds are:
--> oracle-oci: An image was created: 'packer-test' (OCID: REPLACED_FOR_OBVIOUS_REASONS) in region 'REPLACED_FOR_OBVIOUS_REASONS'
[opc@somehost ~]$
```
```
==================================
LIVE TEST WITH INSTANCE PRINCIPALS
==================================
```
```
[opc@somehost ~]$ ls -ltr ~/.oci
ls: cannot access /home/opc/.oci: No such file or directory
[opc@somehost ~]$
[opc@somehost ~]$ cat packer.json
{
    "builders": [
        {
            "use_instance_principals": "true",
            "type": "oracle-oci",
            "availability_domain": "REPLACED_FOR_OBVIOUS_REASONS",
            "image_name": "packer-test",
            "base_image_ocid": "REPLACED_FOR_OBVIOUS_REASONS",
            "compartment_ocid": "REPLACED_FOR_OBVIOUS_REASONS",
            "subnet_ocid": "REPLACED_FOR_OBVIOUS_REASONS",
            "shape": "VM.Standard2.1",
            "ssh_username" : "REPLACED_FOR_OBVIOUS_REASONS",
            "use_private_ip": "true"
        }
    ]
}
[opc@somehost ~]$
[opc@somehost ~]$ ./packer build packer.json
oracle-oci: output will be in this color.

==> oracle-oci: Creating temporary ssh key for instance...
==> oracle-oci: Creating instance...
==> oracle-oci: Created instance (REPLACED_FOR_OBVIOUS_REASONS).
==> oracle-oci: Waiting for instance to enter 'RUNNING' state...
==> oracle-oci: Instance 'RUNNING'.
==> oracle-oci: Instance has IP: REPLACED_FOR_OBVIOUS_REASONS.
==> oracle-oci: Using ssh communicator to connect: REPLACED_FOR_OBVIOUS_REASONS
==> oracle-oci: Waiting for SSH to become available...
==> oracle-oci: Connected to SSH!
==> oracle-oci: Creating image from instance...
==> oracle-oci: Image created.
==> oracle-oci: Terminating instance (REPLACED_FOR_OBVIOUS_REASONS)...
==> oracle-oci: Terminated instance.
Build 'oracle-oci' finished.

==> Builds finished. The artifacts of successful builds are:
--> oracle-oci: An image was created: 'packer-test' (OCID: REPLACED_FOR_OBVIOUS_REASONS) in region 'REPLACED_FOR_OBVIOUS_REASONS'
[opc@somehost ~]$
```

Closes #7379