### PR TITLE
Add iso config test for checksum from file specific case

### DIFF
--- a/common/iso_config_test.go
+++ b/common/iso_config_test.go
@@ -266,7 +266,7 @@ func TestISOConfigPrepare_ISOChecksumURLMyTest(t *testing.T) {
 	i := ISOConfig{
 		ISOChecksumURL:  httpChecksums.URL + "/subfolder.sum",
 		ISOChecksumType: "sha256",
-		ISOUrls: []string{"http://hashicorp.com/ubuntu/dists/bionic-updates/main/installer-amd64/current/images/netboot/mini.iso"},
+		ISOUrls:         []string{"http://hashicorp.com/ubuntu/dists/bionic-updates/main/installer-amd64/current/images/netboot/mini.iso"},
 	}
 
 	// Test ISOChecksum overrides url

--- a/common/iso_config_test.go
+++ b/common/iso_config_test.go
@@ -275,7 +275,7 @@ func TestISOConfigPrepare_ISOChecksumURLMyTest(t *testing.T) {
 		t.Fatalf("Bad: should not have warnings")
 	}
 	if len(err) > 0 {
-		t.Fatalf("Bad; should have errored.")
+		t.Fatalf("Bad; should not have errored.")
 	}
 }
 

--- a/common/iso_config_test.go
+++ b/common/iso_config_test.go
@@ -5,6 +5,7 @@ package common
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -158,7 +159,7 @@ func TestISOConfigPrepare_ISOUrl(t *testing.T) {
 	}
 
 	// Test iso_url not set but checksum url is
-	ts := httptest.NewServer(http.FileServer(http.Dir("./test-fixtures/root")))
+	ts := httpTestModule("root")
 	defer ts.Close()
 	i = testISOConfig()
 	i.RawSingleISOUrl = ""
@@ -257,4 +258,35 @@ func TestISOConfigPrepare_TargetExtension(t *testing.T) {
 	if i.TargetExtension != "dmg" {
 		t.Fatalf("should've lowercased: %s", i.TargetExtension)
 	}
+}
+
+func TestISOConfigPrepare_ISOChecksumURLMyTest(t *testing.T) {
+	httpChecksums := httpTestModule("root")
+	defer httpChecksums.Close()
+	i := ISOConfig{
+		ISOChecksumURL:  httpChecksums.URL + "/subfolder.sum",
+		ISOChecksumType: "sha256",
+		ISOUrls: []string{"http://hashicorp.com/ubuntu/dists/bionic-updates/main/installer-amd64/current/images/netboot/mini.iso"},
+	}
+
+	// Test ISOChecksum overrides url
+	warns, err := i.Prepare(nil)
+	if len(warns) > 0 {
+		t.Fatalf("Bad: should not have warnings")
+	}
+	if len(err) > 0 {
+		t.Fatalf("Bad; should have errored.")
+	}
+}
+
+const fixtureDir = "./test-fixtures"
+
+func httpTestModule(n string) *httptest.Server {
+	p := filepath.Join(fixtureDir, n)
+	p, err := filepath.Abs(p)
+	if err != nil {
+		panic(err)
+	}
+
+	return httptest.NewServer(http.FileServer(http.Dir(p)))
 }

--- a/common/test-fixtures/root/subfolder.sum
+++ b/common/test-fixtures/root/subfolder.sum
@@ -1,0 +1,2 @@
+a264b6b009dfaa16286fdfd046a156a43587333b  ./hwe-netboot/mini.iso
+27c39bac2cf4640c00cacfc8982b0ba39e7b7f96  ./netboot/mini.iso

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/hashicorp/go-cty-funcs/filesystem v0.0.0-20200203151509-c92509f48b18
 	github.com/hashicorp/go-cty-funcs/uuid v0.0.0-20200203151509-c92509f48b18
 	github.com/hashicorp/go-getter v1.3.1-0.20190906090232-a0f878cb75da // indirect
-	github.com/hashicorp/go-getter/v2 v2.0.0-20200206160058-e2a28063d6e7
+	github.com/hashicorp/go-getter/v2 v2.0.0-20200318090939-0b1d527d9793
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-oracle-terraform v0.0.0-20181016190316-007121241b79
 	github.com/hashicorp/go-retryablehttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/hashicorp/go-getter v1.3.1-0.20190906090232-a0f878cb75da h1:HAasZmyRr
 github.com/hashicorp/go-getter v1.3.1-0.20190906090232-a0f878cb75da/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
 github.com/hashicorp/go-getter/v2 v2.0.0-20200206160058-e2a28063d6e7 h1:ODZKizgWGz4diUEZwCgf8qgIn/D+qVW/JOdVVV/z7k8=
 github.com/hashicorp/go-getter/v2 v2.0.0-20200206160058-e2a28063d6e7/go.mod h1:jlmxRRjTpY0KdWrV1Uq38GUVskrjIZUrjOAybo0OArw=
+github.com/hashicorp/go-getter/v2 v2.0.0-20200318090939-0b1d527d9793 h1:jH222Ag2I+p5tq5IagFwCfj5CnRzqcGW8RgcQ8jEPMs=
+github.com/hashicorp/go-getter/v2 v2.0.0-20200318090939-0b1d527d9793/go.mod h1:jlmxRRjTpY0KdWrV1Uq38GUVskrjIZUrjOAybo0OArw=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3 h1:zKjpN5BK/P5lMYrLmBHdBULWbJ0XpYR+7NGzqkZzoD4=

--- a/vendor/github.com/hashicorp/go-getter/v2/checksum.go
+++ b/vendor/github.com/hashicorp/go-getter/v2/checksum.go
@@ -274,6 +274,13 @@ func (c *Client) ChecksumFromFile(ctx context.Context, checksumURL, checksummedP
 				return checksum, nil
 			}
 		}
+		// The checksum filename can contain a sub folder to differ versions.
+		// e.g. ./netboot/mini.iso and ./hwe-netboot/mini.iso
+		// In this case we remove root folder characters to compare with the checksummed path
+		fn := strings.TrimLeft(checksum.Filename, "./")
+		if strings.Contains(checksummedPath, fn) {
+			return checksum, nil
+		}
 	}
 	return nil, fmt.Errorf("no checksum found in: %s", checksumURL)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -321,7 +321,7 @@ github.com/hashicorp/go-cty-funcs/filesystem
 github.com/hashicorp/go-cty-funcs/uuid
 # github.com/hashicorp/go-getter v1.3.1-0.20190906090232-a0f878cb75da
 github.com/hashicorp/go-getter/helper/url
-# github.com/hashicorp/go-getter/v2 v2.0.0-20200206160058-e2a28063d6e7
+# github.com/hashicorp/go-getter/v2 v2.0.0-20200318090939-0b1d527d9793
 github.com/hashicorp/go-getter/v2
 github.com/hashicorp/go-getter/v2/helper/url
 # github.com/hashicorp/go-immutable-radix v1.0.0


### PR DESCRIPTION
This adds a test case regarding https://github.com/hashicorp/packer/issues/8774. The actual changes were implemented at the go-getter site here https://github.com/hashicorp/go-getter/pull/239 
This PR should be merged once the go-getter changes are merged.