### PR TITLE
provisioner/powershell: Add cleanup step to remove any temporarily created scripts

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -53,7 +53,10 @@ type Config struct {
 	ElevatedExecuteCommand string `mapstructure:"elevated_execute_command"`
 
 	// Whether to clean scripts up after executing the provisioner.
-	// Defaults to false.
+	// Defaults to false. When true any script created by a non-elevated Powershell
+	// provisioner will be removed from the remote machine. Elevated scripts,
+	// along with the scheduled tasks, will always be removed regardless of the
+	// value set for `skip_clean`.
 	SkipClean bool `mapstructure:"skip_clean"`
 
 	// The timeout for retrying to start the process. Until this timeout is

--- a/provisioner/powershell/provisioner.hcl2spec.go
+++ b/provisioner/powershell/provisioner.hcl2spec.go
@@ -27,6 +27,7 @@ type FlatConfig struct {
 	ExecuteCommand         *string           `mapstructure:"execute_command" cty:"execute_command"`
 	RemoteEnvVarPath       *string           `mapstructure:"remote_env_var_path" cty:"remote_env_var_path"`
 	ElevatedExecuteCommand *string           `mapstructure:"elevated_execute_command" cty:"elevated_execute_command"`
+	SkipClean              *bool             `mapstructure:"skip_clean" cty:"skip_clean"`
 	StartRetryTimeout      *string           `mapstructure:"start_retry_timeout" cty:"start_retry_timeout"`
 	ElevatedEnvVarFormat   *string           `mapstructure:"elevated_env_var_format" cty:"elevated_env_var_format"`
 	ElevatedUser           *string           `mapstructure:"elevated_user" cty:"elevated_user"`
@@ -64,6 +65,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"execute_command":            &hcldec.AttrSpec{Name: "execute_command", Type: cty.String, Required: false},
 		"remote_env_var_path":        &hcldec.AttrSpec{Name: "remote_env_var_path", Type: cty.String, Required: false},
 		"elevated_execute_command":   &hcldec.AttrSpec{Name: "elevated_execute_command", Type: cty.String, Required: false},
+		"skip_clean":                 &hcldec.AttrSpec{Name: "skip_clean", Type: cty.Bool, Required: false},
 		"start_retry_timeout":        &hcldec.AttrSpec{Name: "start_retry_timeout", Type: cty.String, Required: false},
 		"elevated_env_var_format":    &hcldec.AttrSpec{Name: "elevated_env_var_format", Type: cty.String, Required: false},
 		"elevated_user":              &hcldec.AttrSpec{Name: "elevated_user", Type: cty.String, Required: false},

--- a/provisioner/powershell/provisioner_acc_test.go
+++ b/provisioner/powershell/provisioner_acc_test.go
@@ -8,24 +8,31 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/packer/provisioner/powershell"
-
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/packer/command"
 	"github.com/hashicorp/packer/helper/tests/acc"
 	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/provisioner/powershell"
+	windowsshellprovisioner "github.com/hashicorp/packer/provisioner/windows-shell"
 )
 
 const TestProvisionerName = "powershell"
 
-func TestPowershellProvisioner_Inline(t *testing.T) {
+func TestAccPowershellProvisioner_basic(t *testing.T) {
+	acc.TestProvisionersPreCheck(TestProvisionerName, t)
+
+	testProvisioner := PowershellProvisionerAccTest{"powershell-provisioner-cleanup.txt"}
+	acc.TestProvisionersAgainstBuilders(&testProvisioner, t)
+}
+
+func TestAccPowershellProvisioner_Inline(t *testing.T) {
 	acc.TestProvisionersPreCheck(TestProvisionerName, t)
 
 	testProvisioner := PowershellProvisionerAccTest{"powershell-inline-provisioner.txt"}
 	acc.TestProvisionersAgainstBuilders(&testProvisioner, t)
 }
 
-func TestPowershellProvisioner_Script(t *testing.T) {
+func TestAccPowershellProvisioner_Script(t *testing.T) {
 	acc.TestProvisionersPreCheck(TestProvisionerName, t)
 
 	testProvisioner := PowershellProvisionerAccTest{"powershell-script-provisioner.txt"}
@@ -55,6 +62,7 @@ func (s *PowershellProvisionerAccTest) GetConfig() (string, error) {
 func (s *PowershellProvisionerAccTest) GetProvisionerStore() packer.MapOfProvisioner {
 	return packer.MapOfProvisioner{
 		TestProvisionerName: func() (packer.Provisioner, error) { return &powershell.Provisioner{}, nil },
+		"windows-shell":     func() (packer.Provisioner, error) { return &windowsshellprovisioner.Provisioner{}, nil },
 	}
 }
 

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -15,16 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testConfig() map[string]interface{} {
-	return map[string]interface{}{
-		"inline": []interface{}{"foo", "bar"},
-	}
-}
-
-func init() {
-	//log.SetOutput(ioutil.Discard)
-}
-
 func TestProvisionerPrepare_extractScript(t *testing.T) {
 	config := testConfig()
 	p := new(Provisioner)
@@ -335,11 +325,6 @@ func testUi() *packer.BasicUi {
 	}
 }
 
-func testObjects() (packer.Ui, packer.Communicator) {
-	ui := testUi()
-	return ui, new(packer.MockCommunicator)
-}
-
 func TestProvisionerProvision_ValidExitCodes(t *testing.T) {
 	config := testConfig()
 	delete(config, "inline")
@@ -387,7 +372,8 @@ func TestProvisionerProvision_InvalidExitCodes(t *testing.T) {
 }
 
 func TestProvisionerProvision_Inline(t *testing.T) {
-	config := testConfig()
+	// skip_clean is set to true otherwise the last command executed by the provisioner is the cleanup.
+	config := testConfigWithSkipClean()
 	delete(config, "inline")
 
 	// Defaults provided by Packer
@@ -400,7 +386,7 @@ func TestProvisionerProvision_Inline(t *testing.T) {
 	p.config.PackerBuildName = "vmware"
 	p.config.PackerBuilderType = "iso"
 	comm := new(packer.MockCommunicator)
-	p.Prepare(config)
+	_ = p.Prepare(config)
 	err := p.Provision(context.Background(), ui, comm, make(map[string]interface{}))
 	if err != nil {
 		t.Fatal("should not have error")
@@ -439,7 +425,8 @@ func TestProvisionerProvision_Scripts(t *testing.T) {
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
-	config := testConfig()
+	// skip_clean is set to true otherwise the last command executed by the provisioner is the cleanup.
+	config := testConfigWithSkipClean()
 	delete(config, "inline")
 	config["scripts"] = []string{tempFile.Name()}
 	config["packer_build_name"] = "foobuild"
@@ -465,11 +452,12 @@ func TestProvisionerProvision_Scripts(t *testing.T) {
 
 func TestProvisionerProvision_ScriptsWithEnvVars(t *testing.T) {
 	tempFile, _ := ioutil.TempFile("", "packer")
-	config := testConfig()
 	ui := testUi()
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
+	// skip_clean is set to true otherwise the last command executed by the provisioner is the cleanup.
+	config := testConfigWithSkipClean()
 	delete(config, "inline")
 
 	config["scripts"] = []string{tempFile.Name()}
@@ -499,10 +487,56 @@ func TestProvisionerProvision_ScriptsWithEnvVars(t *testing.T) {
 	}
 }
 
-func TestProvisionerProvision_UISlurp(t *testing.T) {
-	// UI should be called n times
+func TestProvisionerProvision_SkipClean(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "packer")
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	}()
 
-	// UI should receive following messages / output
+	config := map[string]interface{}{
+		"scripts":     []string{tempFile.Name()},
+		"remote_path": "c:/Windows/Temp/script.ps1",
+	}
+
+	tt := []struct {
+		SkipClean                bool
+		LastExecutedCommandRegex string
+	}{
+		{
+			SkipClean:                true,
+			LastExecutedCommandRegex: `powershell -executionpolicy bypass "& { if \(Test-Path variable:global:ProgressPreference\){set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'};\. c:/Windows/Temp/packer-ps-env-vars-[[:alnum:]]{8}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{12}\.ps1; &'c:/Windows/Temp/script.ps1'; exit \$LastExitCode }"`,
+		},
+		{
+			SkipClean:                false,
+			LastExecutedCommandRegex: `powershell -executionpolicy bypass "& { if \(Test-Path variable:global:ProgressPreference\){set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'};\. c:/Windows/Temp/packer-ps-env-vars-[[:alnum:]]{8}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{12}\.ps1; &'c:/Windows/Temp/packer-cleanup-[[:alnum:]]{8}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{4}-[[:alnum:]]{12}\.ps1'; exit \$LastExitCode }"`,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		p := new(Provisioner)
+		ui := testUi()
+		comm := new(packer.MockCommunicator)
+
+		config["skip_clean"] = tc.SkipClean
+		if err := p.Prepare(config); err != nil {
+			t.Fatalf("failed to prepare config when SkipClean is %t: %s", tc.SkipClean, err)
+		}
+		err := p.Provision(context.Background(), ui, comm, make(map[string]interface{}))
+		if err != nil {
+			t.Fatal("should not have error")
+		}
+
+		// When SkipClean is false the last executed command should be the clean up command;
+		// otherwise it will be the execution command for the provisioning script.
+		cmd := comm.StartCmd.Command
+		re := regexp.MustCompile(tc.LastExecutedCommandRegex)
+		matched := re.MatchString(cmd)
+		if !matched {
+			t.Fatalf(`Got unexpected command when SkipClean is %t: %s`, tc.SkipClean, cmd)
+		}
+	}
 }
 
 func TestProvisionerProvision_UploadFails(t *testing.T) {
@@ -770,4 +804,17 @@ func TestProvision_uploadEnvVars(t *testing.T) {
 func TestCancel(t *testing.T) {
 	// Don't actually call Cancel() as it performs an os.Exit(0)
 	// which kills the 'go test' tool
+}
+
+func testConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"inline": []interface{}{"foo", "bar"},
+	}
+}
+
+func testConfigWithSkipClean() map[string]interface{} {
+	return map[string]interface{}{
+		"inline":     []interface{}{"foo", "bar"},
+		"skip_clean": true,
+	}
 }

--- a/provisioner/powershell/test-fixtures/powershell-provisioner-cleanup.txt
+++ b/provisioner/powershell/test-fixtures/powershell-provisioner-cleanup.txt
@@ -1,0 +1,13 @@
+{
+  "type": "powershell",
+  "remote_path": "c:/Windows/Temp/packer-acc-test-script-test.ps1",
+  "remote_env_var_path": "C:/Windows/Temp/packer-acc-test-vars.ps1",
+  "inline": [
+    "Write-Host \"Total files found in Temp directory\" ( dir C:/Windows/Temp/packer-*.ps1 | measure).Count;"
+  ]
+},
+{
+  "type": "windows-shell",
+  "inline": ["dir C:\\Windows\\Temp\\packer-*.ps1"],
+  "valid_exit_codes": ["1"]
+}

--- a/website/pages/docs/provisioners/powershell.mdx
+++ b/website/pages/docs/provisioners/powershell.mdx
@@ -142,6 +142,12 @@ The example below is fully functional.
   script is uploaded to. The value must be a writable location and any parent
   directories must already exist.
 
+- `skip_clean` (bool) - Whether to clean scripts up after executing the provisioner.
+	Defaults to false. When true any script created by a non-elevated Powershell
+	provisioner will be removed from the remote machine. Elevated scripts,
+	along with the scheduled tasks, will always be removed regardless of the
+	value set for `skip_clean`.
+
 - `start_retry_timeout` (string) - The amount of time to attempt to _start_
   the remote process. By default this is "5m" or 5 minutes. This setting
   exists in order to deal with times when SSH may restart, such as a system


### PR DESCRIPTION
This change add logic that collects all of the files created, and uploaded, during a Powershell provisioner run into a single powerscript file. Which is then used to remove the said files from the guest machine. The cleanup script is executed after the main the powershell command (e.g inline, script, or scripts) has been executed to ensure it doesn't delete the the envvar or script files before they are executed. The script is uploaded into the `c:/Windows/Temp` directory and once executed it to is also deleted so that there are no remainging Packer scripts lying around in the `remote_path`, if a custom path is provided, or in `c:/Windows/Temp`. 

Closes #4795

This change has been tested on Amazon and Azure with the following build configuration files. 
<details>
<summary>Azure</summary>

```
{
    "variables": {
        "client_id": "{{ env `ARM_CLIENT_ID` }}",
        "client_secret": "{{ env `ARM_CLIENT_SECRET` }}",
        "object_id": "{{ env `ARM_OBJECT_ID` }}",
        "subscription_id": "{{ env `ARM_SUBSCRIPTION_ID` }}",
        "tenant_id": "{{ env `ARM_TENANT_ID` }}",
        "resource_group_name": "{{ env `ARM_RESOURCE_GROUP_NAME` }}",
        "storage_account": "{{ env `ARM_STORAGE_ACCOUNT` }}"
    },
    "builders": [
        {
            "type": "azure-arm",

            "client_id": "{{ user `client_id` }}",
            "client_secret": "{{ user `client_secret` }}",
            "object_id": "{{ user `object_id` }}",
            "subscription_id": "{{ user `subscription_id` }}",
            "tenant_id": "{{ user `tenant_id` }}",
            "managed_image_name": "{{user `managed_image_name`}}",
            "managed_image_resource_group_name": "{{user `managed_image_resource_group_name`}}",

            "os_type": "Windows",
            "image_publisher": "MicrosoftWindowsServer",
            "image_offer": "WindowsServer",
            "image_sku": "2016-Datacenter",

            "communicator": "winrm",
            "winrm_use_ssl": "true",
            "winrm_insecure": "true",
            "winrm_timeout": "5m",
            "winrm_username": "packer",

            "location": "westus",
            "vm_size": "Standard_F64s_v2"
        }
    ],
  "provisioners": [
    {
      "type": "powershell",

      "elevated_user": "packer",
      "elevated_password": "{{.WinRMPassword}}",
      "inline": ["Write-Host \"HELLO NEW USER; automatically generated aws password is: $Env:WINRMPASS\""],
      "environment_vars": ["WINRMPASS={{ .WinRMPassword}}"]
    },
    {
      "type": "powershell",
      "inline": ["ls c:/Windows/Temp/*"]
    },
    {
      "type": "powershell",
      "inline": ["Write-Host \"Total files found in Temp directory\" ( dir c:/Windows/Temp | measure).Count;"]
    }
  ]
}
```

Total files in Temp Directory before change
```
==> azure-arm: Provisioning with powershell script: /tmp/powershell-provisioner042903247                                                           
    azure-arm: Total files found in Temp directory 9                                                                                               
==> azure-arm: Querying the machine's properties ...
```

Total files in Temp Directory after change 

```
==> azure-arm: Provisioning with powershell script: /tmp/powershell-provisioner829386067                                                           
    azure-arm: Total files found in Temp directory 5                                                                                               
==> azure-arm: Querying the machine's properties ...
```
After the final provisioner the 2 scripts along with the elevated user script should be deleted. 
</details>

<details>
<summary>Amazon</summary>

```
{
  "variables": {
    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
    "region":         "us-east-1"
  },
  "builders": [
    {
      "type": "amazon-ebs",
      "access_key": "{{ user `aws_access_key` }}",
      "secret_key": "{{ user `aws_secret_key` }}",
      "region": "{{ user `region` }}",
      "instance_type": "t2.micro",
      "source_ami_filter": {
        "filters": {
          "virtualization-type": "hvm",
          "name": "*Windows_Server-2012-R2*English-64Bit-Base*",
          "root-device-type": "ebs"
        },
        "most_recent": true,
        "owners": "amazon"
      },
      "ami_name": "packer-demo-{{timestamp}}",
      "user_data_file": "./bootstrap_win.txt",
      "communicator": "winrm",
      "winrm_username": "Administrator",
      "winrm_password": "SuperS3cr3t!!!!"
    }
  ],
  "provisioners": [
    {
      "script": "./sample_script.ps1",
      "type": "powershell",
      "environment_vars": [
        "VAR1=A$Dollar",
        "VAR2=A`Backtick",
        "VAR3=A'SingleQuote",
        "VAR4=A\"DoubleQuote"
      ]
    },
    {
      "type": "powershell",
      "inline": ["ls c:/Windows/Temp/*"]
    },
    {
      "type": "powershell",
      "elevated_user": "Administrator",
      "elevated_password": "{{.WinRMPassword}}",
      "inline": ["Write-Host \"Total files found in Temp directory\" ( dir c:/Windows/Temp | measure).Count;"]
    }
  ]
}
```

Total files in Temp Directory before change

```

==> amazon-ebs: Provisioning with powershell script: /tmp/powershell-provisioner770110605
    amazon-ebs: Total files found in Temp directory 13
==> amazon-ebs: Stopping the source instance...

```

Total files in Temp Directory after change

```
==> amazon-ebs: Provisioning with powershell script: /tmp/powershell-provisioner299272248                                                          
    amazon-ebs: Total files found in Temp directory 9                                                                                              
==> amazon-ebs: Stopping the source instance...

```

</details>

Pending issues:
- [x] (https://github.com/hashicorp/packer/pull/8908/commits/18a0f98d404339de69aac1eb7bfe735e0b7303bf) Handle elevated user scripts as those are uploaded from outside of the powershell provisioner
- [x] (https://github.com/hashicorp/packer/pull/8908/commits/0b048b4c1e314e02adc9015fd490097f5943bfdb) Add acceptance test to validate files have been removed.
- [x] ~retry logic when a hard reboot is contained in one of the provsioning scripts results in a failed cleanup - need to confirm the proper cleanup warning is given to the user if we can't recover.~ This is an unsupported case so striking it out as a requirement.
 