### PR TITLE
allow Managed data disks to be used with azure shared image ga…

### DIFF
--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -95,7 +95,7 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 	}
 
 	if len(config.AdditionalDiskSize) > 0 {
-		isManaged := config.CustomManagedImageName != "" || (config.ManagedImageName != "" && config.ImagePublisher != "")
+		isManaged := config.CustomManagedImageName != "" || (config.ManagedImageName != "" && config.ImagePublisher != "") || config.SharedGallery.Subscription != ""
 		builder.SetAdditionalDisks(config.AdditionalDiskSize, isManaged, config.diskCachingType)
 	}
 


### PR DESCRIPTION
This is a simple PR. 

This will enable to attach data disk to images built based on Azure Shared image gallery (SIG).

Currently, when building images from Azure SIG & adding data disks (using 'disk_additional_size'), packer adds VHD. This (obviously) conflicts with the VM, since SIG images can only be managed disk based images.
