### PR TITLE
Add cleanup_remote_cache config option to vmware-iso

### DIFF
--- a/builder/vmware/common/driver_config.go
+++ b/builder/vmware/common/driver_config.go
@@ -16,6 +16,9 @@ import (
 )
 
 type DriverConfig struct {
+	// When set to true will cleanup the ISO stored during the build on the remote machine.
+	// By default, this is set to false.
+	CleanUpRemoteCache bool `mapstructure:"cleanup_remote_cache" required:"false"`
 	// Path to "VMware Fusion.app". By default this is
 	// /Applications/VMware Fusion.app but this setting allows you to
 	// customize this.

--- a/builder/vmware/common/driver_config.go
+++ b/builder/vmware/common/driver_config.go
@@ -16,7 +16,7 @@ import (
 )
 
 type DriverConfig struct {
-	// When set to true will cleanup the ISO stored during the build on the remote machine.
+	// When set to true, Packer will cleanup the cache folder where the ISO file is stored during the build on the remote machine.
 	// By default, this is set to false.
 	CleanUpRemoteCache bool `mapstructure:"cleanup_remote_cache" required:"false"`
 	// Path to "VMware Fusion.app". By default this is

--- a/builder/vmware/common/remote_driver_mock.go
+++ b/builder/vmware/common/remote_driver_mock.go
@@ -26,6 +26,9 @@ type RemoteDriverMock struct {
 	UploadErr   error
 	DownloadErr error
 
+	RemovedCachePath string
+	CacheRemoved bool
+
 	ReloadVMErr error
 }
 
@@ -66,6 +69,8 @@ func (d *RemoteDriverMock) Download(src, dst string) error {
 }
 
 func (d *RemoteDriverMock) RemoveCache(localPath string) error {
+	d.RemovedCachePath = localPath
+	d.CacheRemoved = true
 	return nil
 }
 

--- a/builder/vmware/common/remote_driver_mock.go
+++ b/builder/vmware/common/remote_driver_mock.go
@@ -27,7 +27,7 @@ type RemoteDriverMock struct {
 	DownloadErr error
 
 	RemovedCachePath string
-	CacheRemoved bool
+	CacheRemoved     bool
 
 	ReloadVMErr error
 }

--- a/builder/vmware/common/step_remote_upload_test.go
+++ b/builder/vmware/common/step_remote_upload_test.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"github.com/hashicorp/packer/helper/multistep"
+	"testing"
+)
+
+func TestStepRemoteUpload_Cleanup(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	driver := new(RemoteDriverMock)
+	state.Put("driver", driver)
+	state.Put("path_key", "packer_cache")
+
+	// Should clean up cache
+	s := &StepRemoteUpload{
+		Key:       "path_key",
+		DoCleanup: true,
+	}
+	s.Cleanup(state)
+
+	if !driver.CacheRemoved {
+		t.Fatalf("bad: remote cache was not removed")
+	}
+	if driver.RemovedCachePath != "packer_cache" {
+		t.Fatalf("bad: removed cache path was expected to be packer_cache but was %s", driver.RemovedCachePath)
+	}
+
+	// Should NOT clean up cache
+	s = &StepRemoteUpload{
+		Key:       "path_key",
+	}
+	driver = new(RemoteDriverMock)
+	state.Put("driver", driver)
+	s.Cleanup(state)
+
+	if driver.CacheRemoved {
+		t.Fatalf("bad: remote cache was removed but was expected to not")
+	}
+}

--- a/builder/vmware/common/step_remote_upload_test.go
+++ b/builder/vmware/common/step_remote_upload_test.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	"github.com/hashicorp/packer/helper/multistep"
 	"testing"
+
+	"github.com/hashicorp/packer/helper/multistep"
 )
 
 func TestStepRemoteUpload_Cleanup(t *testing.T) {

--- a/builder/vmware/common/step_remote_upload_test.go
+++ b/builder/vmware/common/step_remote_upload_test.go
@@ -27,7 +27,7 @@ func TestStepRemoteUpload_Cleanup(t *testing.T) {
 
 	// Should NOT clean up cache
 	s = &StepRemoteUpload{
-		Key:       "path_key",
+		Key: "path_key",
 	}
 	driver = new(RemoteDriverMock)
 	state.Put("driver", driver)

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -98,6 +98,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&vmwcommon.StepRemoteUpload{
 			Key:          "iso_path",
 			Message:      "Uploading ISO to remote machine...",
+			DoCleanup:    b.config.DriverConfig.CleanUpRemoteCache,
 			Checksum:     b.config.ISOChecksum,
 			ChecksumType: b.config.ISOChecksumType,
 		},

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -34,6 +34,7 @@ type FlatConfig struct {
 	BootCommand               []string          `mapstructure:"boot_command" cty:"boot_command"`
 	DisableVNC                *bool             `mapstructure:"disable_vnc" cty:"disable_vnc"`
 	BootKeyInterval           *string           `mapstructure:"boot_key_interval" cty:"boot_key_interval"`
+	CleanUpRemoteCache        *bool             `mapstructure:"cleanup_remote_cache" required:"false" cty:"cleanup_remote_cache"`
 	FusionAppPath             *string           `mapstructure:"fusion_app_path" required:"false" cty:"fusion_app_path"`
 	RemoteType                *string           `mapstructure:"remote_type" required:"false" cty:"remote_type"`
 	RemoteDatastore           *string           `mapstructure:"remote_datastore" required:"false" cty:"remote_datastore"`
@@ -165,6 +166,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_command":                   &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},
 		"disable_vnc":                    &hcldec.AttrSpec{Name: "disable_vnc", Type: cty.Bool, Required: false},
 		"boot_key_interval":              &hcldec.AttrSpec{Name: "boot_key_interval", Type: cty.String, Required: false},
+		"cleanup_remote_cache":           &hcldec.AttrSpec{Name: "cleanup_remote_cache", Type: cty.Bool, Required: false},
 		"fusion_app_path":                &hcldec.AttrSpec{Name: "fusion_app_path", Type: cty.String, Required: false},
 		"remote_type":                    &hcldec.AttrSpec{Name: "remote_type", Type: cty.String, Required: false},
 		"remote_datastore":               &hcldec.AttrSpec{Name: "remote_datastore", Type: cty.String, Required: false},

--- a/builder/vmware/vmx/config.hcl2spec.go
+++ b/builder/vmware/vmx/config.hcl2spec.go
@@ -27,6 +27,7 @@ type FlatConfig struct {
 	BootCommand               []string          `mapstructure:"boot_command" cty:"boot_command"`
 	DisableVNC                *bool             `mapstructure:"disable_vnc" cty:"disable_vnc"`
 	BootKeyInterval           *string           `mapstructure:"boot_key_interval" cty:"boot_key_interval"`
+	CleanUpRemoteCache        *bool             `mapstructure:"cleanup_remote_cache" required:"false" cty:"cleanup_remote_cache"`
 	FusionAppPath             *string           `mapstructure:"fusion_app_path" required:"false" cty:"fusion_app_path"`
 	RemoteType                *string           `mapstructure:"remote_type" required:"false" cty:"remote_type"`
 	RemoteDatastore           *string           `mapstructure:"remote_datastore" required:"false" cty:"remote_datastore"`
@@ -134,6 +135,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_command":                   &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},
 		"disable_vnc":                    &hcldec.AttrSpec{Name: "disable_vnc", Type: cty.Bool, Required: false},
 		"boot_key_interval":              &hcldec.AttrSpec{Name: "boot_key_interval", Type: cty.String, Required: false},
+		"cleanup_remote_cache":           &hcldec.AttrSpec{Name: "cleanup_remote_cache", Type: cty.Bool, Required: false},
 		"fusion_app_path":                &hcldec.AttrSpec{Name: "fusion_app_path", Type: cty.String, Required: false},
 		"remote_type":                    &hcldec.AttrSpec{Name: "remote_type", Type: cty.String, Required: false},
 		"remote_datastore":               &hcldec.AttrSpec{Name: "remote_datastore", Type: cty.String, Required: false},

--- a/website/source/partials/builder/vmware/common/_DriverConfig-not-required.html.md
+++ b/website/source/partials/builder/vmware/common/_DriverConfig-not-required.html.md
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the DriverConfig struct in builder/vmware/common/driver_config.go; DO NOT EDIT MANUALLY -->
 
--   `cleanup_remote_cache` (bool) - When set to true will cleanup the ISO stored during the build on the remote machine.
+-   `cleanup_remote_cache` (bool) - When set to true, Packer will cleanup the cache folder where the ISO file is stored during the build on the remote machine.
     By default, this is set to false.
     
 -   `fusion_app_path` (string) - Path to "VMware Fusion.app". By default this is

--- a/website/source/partials/builder/vmware/common/_DriverConfig-not-required.html.md
+++ b/website/source/partials/builder/vmware/common/_DriverConfig-not-required.html.md
@@ -1,5 +1,8 @@
 <!-- Code generated from the comments of the DriverConfig struct in builder/vmware/common/driver_config.go; DO NOT EDIT MANUALLY -->
 
+-   `cleanup_remote_cache` (bool) - When set to true will cleanup the ISO stored during the build on the remote machine.
+    By default, this is set to false.
+    
 -   `fusion_app_path` (string) - Path to "VMware Fusion.app". By default this is
     /Applications/VMware Fusion.app but this setting allows you to
     customize this.


### PR DESCRIPTION
This PR adds the `cleanup_remote_cache` config option to the vmware-iso builder, to allow the iso cache folder clean up in the remote machine after a successful build.

Closes #8822 