### PR TITLE
vsphere/iso: Add support for ovf export options

### DIFF
--- a/builder/vsphere/common/step_export.go
+++ b/builder/vsphere/common/step_export.go
@@ -64,7 +64,7 @@ type ExportConfig struct {
 	// * nodevicesubtypes - resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported
 	//
 	// For example, adding the following export config option would output the mac addresses for all Ethernet devices in the ovf file:
-
+	//
 	// ```json
 	// ...
 	//   "export": {

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -139,6 +139,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Images:    b.config.Export.Images,
 			Manifest:  b.config.Export.Manifest,
 			OutputDir: b.config.Export.OutputDir.OutputDir,
+			Options:   b.config.Export.Options,
 		})
 	}
 

--- a/website/source/partials/builder/vsphere/common/_ExportConfig-not-required.html.md
+++ b/website/source/partials/builder/vsphere/common/_ExportConfig-not-required.html.md
@@ -8,7 +8,15 @@
     
 -   `manifest` (string) - generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
     
--   `options` ([]string) - ```json
+-   `options` ([]string) - Advanced ovf export options. Options can include:
+    * mac - MAC address is exported for all ethernet devices
+    * uuid - UUID is exported for all virtual machines
+    * extraconfig - all extra configuration options are exported for a virtual machine
+    * nodevicesubtypes - resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported
+    
+    For example, adding the following export config option would output the mac addresses for all Ethernet devices in the ovf file:
+    
+    ```json
     ...
       "export": {
         "options": ["mac"]


### PR DESCRIPTION
Fast follow PR for the recently added ovf export support in the VSphere builder

This change also fixes the generated documentation for the additional export options field.