### PR TITLE
golangci-lint: Update --new-from-rev option to check only newly added commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ lint: install-lint-deps ## Lint Go code
 
 ci-lint: install-lint-deps ## On ci only lint newly added Go source files
 	@echo "==> Running linter on newly added Go source files..."
-	GO111MODULE=on golangci-lint run --new-from-rev=origin/master ./...
+	GO111MODULE=on golangci-lint run --new-from-rev=HEAD~1 ./...
 
 
 fmt: ## Format Go code

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ lint: install-lint-deps ## Lint Go code
 
 ci-lint: install-lint-deps ## On ci only lint newly added Go source files
 	@echo "==> Running linter on newly added Go source files..."
-	GO111MODULE=on golangci-lint run --new-from-rev=HEAD~1 ./...
+	GO111MODULE=on golangci-lint run --new-from-rev=`git merge-base master HEAD` ./...
 
 
 fmt: ## Format Go code


### PR DESCRIPTION
Currently, golangci-lint is checking against origin/master which can cause false positives if the branch within a given PR does not have the latest master.