### PR TITLE
Fix azure winrm_password attribution and allow to set winrm_username

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -254,7 +254,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 				WinRMConfig: func(multistep.StateBag) (*communicator.WinRMConfig, error) {
 					return &communicator.WinRMConfig{
 						Username: b.config.UserName,
-						Password: b.config.Comm.WinRMPassword,
+						Password: b.config.Password,
 					}, nil
 				},
 			},

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/packer/common/random"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -528,7 +529,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	provideDefaultValues(c)
 	setRuntimeValues(c)
-	setUserNamePassword(c)
+	err = setUserNamePassword(c)
+	if err != nil {
+		return nil, err
+	}
 
 	// copy singular blocks
 	for _, kv := range c.AzureTag {
@@ -651,7 +655,7 @@ func setRuntimeValues(c *Config) {
 	c.tmpKeyVaultName = tempName.KeyVaultName
 }
 
-func setUserNamePassword(c *Config) {
+func setUserNamePassword(c *Config) error {
 	// SSH comm
 	if c.Comm.SSHUsername == "" {
 		c.Comm.SSHUsername = DefaultUserName
@@ -660,7 +664,7 @@ func setUserNamePassword(c *Config) {
 
 	if c.Comm.SSHPassword != "" {
 		c.Password = c.Comm.SSHPassword
-		return
+		return nil
 	}
 
 	// WinRM comm
@@ -673,7 +677,12 @@ func setUserNamePassword(c *Config) {
 		// Configure password settings using Azure generated credentials
 		c.Comm.WinRMPassword = c.tmpAdminPassword
 	}
+	if !isValidPassword(c.Comm.WinRMPassword) {
+		return fmt.Errorf("The supplied \"winrm_password\" must be between 8-123 characters long and must satisfy at least 3 from the following: \n1) Contains an uppercase character \n2) Contains a lowercase character\n3) Contains a numeric digit\n4) Contains a special character\n5) Control characters are not allowed")
+	}
 	c.Password = c.Comm.WinRMPassword
+
+	return nil
 }
 
 func setCustomData(c *Config) error {
@@ -1041,6 +1050,34 @@ func isValidAzureName(re *regexp.Regexp, rgn string) bool {
 	return re.Match([]byte(rgn)) &&
 		!strings.HasSuffix(rgn, ".") &&
 		!strings.HasSuffix(rgn, "-")
+}
+
+// The supplied password must be between 8-123 characters long and must satisfy at least 3 of password complexity requirements from the following:
+// 1) Contains an uppercase character
+// 2) Contains a lowercase character
+// 3) Contains a numeric digit
+// 4) Contains a special character
+// 5) Control characters are not allowed (a very specific case - not included in this validation)
+func isValidPassword(password string) bool {
+	if !(len(password) >= 8 && len(password) <= 123) {
+		return false
+	}
+
+	requirements := 0
+	if strings.ContainsAny(password, random.PossibleNumbers) {
+		requirements++
+	}
+	if strings.ContainsAny(password, random.PossibleLowerCase) {
+		requirements++
+	}
+	if strings.ContainsAny(password, random.PossibleUpperCase) {
+		requirements++
+	}
+	if strings.ContainsAny(password, random.PossibleSpecialCharacter) {
+		requirements++
+	}
+
+	return requirements >= 3
 }
 
 func (c *Config) validateLocationZoneResiliency(say func(s string)) {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -652,10 +652,10 @@ func setRuntimeValues(c *Config) {
 }
 
 func setUserNamePassword(c *Config) {
+	// SSH comm
 	if c.Comm.SSHUsername == "" {
 		c.Comm.SSHUsername = DefaultUserName
 	}
-
 	c.UserName = c.Comm.SSHUsername
 
 	if c.Comm.SSHPassword != "" {
@@ -663,11 +663,17 @@ func setUserNamePassword(c *Config) {
 		return
 	}
 
-	// Configure password settings using Azure generated credentials
-	c.Password = c.tmpAdminPassword
-	if c.Comm.WinRMPassword == "" {
-		c.Comm.WinRMPassword = c.Password
+	// WinRM comm
+	if c.Comm.WinRMUser == "" {
+		c.Comm.WinRMUser = DefaultUserName
 	}
+	c.UserName = c.Comm.WinRMUser
+
+	if c.Comm.WinRMPassword == "" {
+		// Configure password settings using Azure generated credentials
+		c.Comm.WinRMPassword = c.tmpAdminPassword
+	}
+	c.Password = c.Comm.WinRMPassword
 }
 
 func setCustomData(c *Config) error {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -4,6 +4,7 @@
 package arm
 
 import (
+
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -11,13 +12,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/packer/common/random"
 	"io/ioutil"
 	"math/big"
 	"net"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/packer/common/random"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -4,7 +4,6 @@
 package arm
 
 import (
-
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"

--- a/common/random/string.go
+++ b/common/random/string.go
@@ -7,9 +7,10 @@ import (
 )
 
 var (
-	PossibleNumbers   = "0123456789"
-	PossibleLowerCase = "abcdefghijklmnopqrstuvwxyz"
-	PossibleUpperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	PossibleNumbers          = "0123456789"
+	PossibleLowerCase        = "abcdefghijklmnopqrstuvwxyz"
+	PossibleUpperCase        = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	PossibleSpecialCharacter = " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 
 	PossibleAlphaNum      = PossibleNumbers + PossibleLowerCase + PossibleUpperCase
 	PossibleAlphaNumLower = PossibleNumbers + PossibleLowerCase


### PR DESCRIPTION
This PR fixes the `winrm_password` attribution to `confi.Password` which is used when opening a connection to deploy the VM. Before this fix, when trying to connect WinRM, Azure response had 401 status code, which means it fails the authorization. Besides this, the PR also adds the possibility of using another wrinm username.

output with fast fail for invalid winrm_passwords
```
azure-arm: output will be in this color.

The supplied "winrm_password" must be between 8-123 characters long and must satisfy at least 3 from the following:
1) Contains an uppercase character
2) Contains a lowercase character
3) Contains a numeric digit
4) Contains a special character
5) Control characters are not allowed
exit status 1
```

Fix https://github.com/hashicorp/packer/issues/8901