### PR TITLE
Allow accepting image for the members in OpenStack builder

### DIFF
--- a/builder/openstack/builder.hcl2spec.go
+++ b/builder/openstack/builder.hcl2spec.go
@@ -40,6 +40,7 @@ type FlatConfig struct {
 	ImageMetadata               map[string]string       `mapstructure:"metadata" required:"false" cty:"metadata"`
 	ImageVisibility             *images.ImageVisibility `mapstructure:"image_visibility" required:"false" cty:"image_visibility"`
 	ImageMembers                []string                `mapstructure:"image_members" required:"false" cty:"image_members"`
+	ImageAutoAcceptMembers      *bool                   `mapstructure:"image_auto_accept_members" required:"false" cty:"image_auto_accept_members"`
 	ImageDiskFormat             *string                 `mapstructure:"image_disk_format" required:"false" cty:"image_disk_format"`
 	ImageTags                   []string                `mapstructure:"image_tags" required:"false" cty:"image_tags"`
 	ImageMinDisk                *int                    `mapstructure:"image_min_disk" required:"false" cty:"image_min_disk"`
@@ -158,6 +159,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"metadata":                      &hcldec.BlockAttrsSpec{TypeName: "metadata", ElementType: cty.String, Required: false},
 		"image_visibility":              &hcldec.AttrSpec{Name: "image_visibility", Type: cty.String, Required: false},
 		"image_members":                 &hcldec.AttrSpec{Name: "image_members", Type: cty.List(cty.String), Required: false},
+		"image_auto_accept_members":     &hcldec.AttrSpec{Name: "image_auto_accept_members", Type: cty.Bool, Required: false},
 		"image_disk_format":             &hcldec.AttrSpec{Name: "image_disk_format", Type: cty.String, Required: false},
 		"image_tags":                    &hcldec.AttrSpec{Name: "image_tags", Type: cty.List(cty.String), Required: false},
 		"image_min_disk":                &hcldec.AttrSpec{Name: "image_min_disk", Type: cty.Number, Required: false},

--- a/builder/openstack/image_config.go
+++ b/builder/openstack/image_config.go
@@ -22,8 +22,9 @@ type ImageConfig struct {
 	// usually a project (also called the "tenant") with whom the image is
 	// shared.
 	ImageMembers []string `mapstructure:"image_members" required:"false"`
-	// True to perform the image accept so the member can see the image in his
-	// project.
+	// When true, perform the image accept so the members can see the image in their
+	// project. This requires a user with priveleges both in the build project and
+	// in the members provided. Defaults to false.
 	ImageAutoAcceptMembers bool `mapstructure:"image_auto_accept_members" required:"false"`
 	// Disk format of the resulting image. This option works if
 	// use_blockstorage_volume is true.

--- a/builder/openstack/image_config.go
+++ b/builder/openstack/image_config.go
@@ -22,6 +22,9 @@ type ImageConfig struct {
 	// usually a project (also called the "tenant") with whom the image is
 	// shared.
 	ImageMembers []string `mapstructure:"image_members" required:"false"`
+	// True to perform the image accept so the member can see the image in his
+	// project.
+	ImageAutoAcceptMembers bool `mapstructure:"image_auto_accept_members" required:"false"`
 	// Disk format of the resulting image. This option works if
 	// use_blockstorage_volume is true.
 	ImageDiskFormat string `mapstructure:"image_disk_format" required:"false"`

--- a/builder/openstack/step_add_image_members.go
+++ b/builder/openstack/step_add_image_members.go
@@ -38,16 +38,16 @@ func (s *stepAddImageMembers) Run(ctx context.Context, state multistep.StateBag)
 	}
 
 	if config.ImageAutoAcceptMembers {
-        for _, member := range config.ImageMembers {
-            ui.Say(fmt.Sprintf("Accepting image %s for member '%s'", imageId, member))
-            r := members.Update(imageClient, imageId, member, members.UpdateOpts{Status: "accepted"})
-            if _, err = r.Extract(); err != nil {
-                err = fmt.Errorf("Error accepting image for member: %s", err)
-                state.Put("error", err)
-                return multistep.ActionHalt
-            }
-        }
-    }
+		for _, member := range config.ImageMembers {
+			ui.Say(fmt.Sprintf("Accepting image %s for member '%s'", imageId, member))
+			r := members.Update(imageClient, imageId, member, members.UpdateOpts{Status: "accepted"})
+			if _, err = r.Extract(); err != nil {
+				err = fmt.Errorf("Error accepting image for member: %s", err)
+				state.Put("error", err)
+				return multistep.ActionHalt
+			}
+		}
+	}
 
 	return multistep.ActionContinue
 }

--- a/builder/openstack/step_add_image_members.go
+++ b/builder/openstack/step_add_image_members.go
@@ -37,6 +37,18 @@ func (s *stepAddImageMembers) Run(ctx context.Context, state multistep.StateBag)
 		}
 	}
 
+	if config.ImageAutoAcceptMembers {
+        for _, member := range config.ImageMembers {
+            ui.Say(fmt.Sprintf("Accepting image %s for member '%s'", imageId, member))
+            r := members.Update(imageClient, imageId, member, members.UpdateOpts{Status: "accepted"})
+            if _, err = r.Extract(); err != nil {
+                err = fmt.Errorf("Error accepting image for member: %s", err)
+                state.Put("error", err)
+                return multistep.ActionHalt
+            }
+        }
+    }
+
 	return multistep.ActionContinue
 }
 

--- a/website/source/partials/builder/openstack/_ImageConfig-not-required.html.md
+++ b/website/source/partials/builder/openstack/_ImageConfig-not-required.html.md
@@ -8,8 +8,9 @@
     usually a project (also called the "tenant") with whom the image is
     shared.
     
--   `image_auto_accept_members` (bool) - True to perform the image accept so the member can see the image in his
-    project.
+-   `image_auto_accept_members` (bool) - When true, perform the image accept so the members can see the image in their
+    project. This requires a user with priveleges both in the build project and
+    in the members provided. Defaults to false.
     
 -   `image_disk_format` (string) - Disk format of the resulting image. This option works if
     use_blockstorage_volume is true.

--- a/website/source/partials/builder/openstack/_ImageConfig-not-required.html.md
+++ b/website/source/partials/builder/openstack/_ImageConfig-not-required.html.md
@@ -8,6 +8,9 @@
     usually a project (also called the "tenant") with whom the image is
     shared.
     
+-   `image_auto_accept_members` (bool) - True to perform the image accept so the member can see the image in his
+    project.
+    
 -   `image_disk_format` (string) - Disk format of the resulting image. This option works if
     use_blockstorage_volume is true.
     


### PR DESCRIPTION
Hi, in openstack you can share an image for some members setting them in the **image_members** parameter, but then, for the members to see it on their proyect, you need to share the image ID with them, and they need to perform an accept action. This is documented [here](https://docs.openstack.org/image-guide/share-images.html)

This PR adds a configuration parameter **image_auto_accept_members** that performs this action after sharing the image with those members. This needs a user with special privileges but if you use it on your image pipeline, this could simplify it.