### PR TITLE
feat(proxmox): add onboot directive support

### DIFF
--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	ISOStoragePool string       `mapstructure:"iso_storage_pool"`
 	Agent          bool         `mapstructure:"qemu_agent"`
 	SCSIController string       `mapstructure:"scsi_controller"`
+	Onboot         bool         `mapstructure:"onboot"`
 
 	TemplateName        string `mapstructure:"template_name"`
 	TemplateDescription string `mapstructure:"template_description"`

--- a/builder/proxmox/config.hcl2spec.go
+++ b/builder/proxmox/config.hcl2spec.go
@@ -91,6 +91,7 @@ type FlatConfig struct {
 	ISOStoragePool            *string           `mapstructure:"iso_storage_pool" cty:"iso_storage_pool"`
 	Agent                     *bool             `mapstructure:"qemu_agent" cty:"qemu_agent"`
 	SCSIController            *string           `mapstructure:"scsi_controller" cty:"scsi_controller"`
+	Onboot                    *bool             `mapstructure:"onboot" cty:"onboot"`
 	TemplateName              *string           `mapstructure:"template_name" cty:"template_name"`
 	TemplateDescription       *string           `mapstructure:"template_description" cty:"template_description"`
 	UnmountISO                *bool             `mapstructure:"unmount_iso" cty:"unmount_iso"`
@@ -190,6 +191,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"iso_storage_pool":             &hcldec.AttrSpec{Name: "iso_storage_pool", Type: cty.String, Required: false},
 		"qemu_agent":                   &hcldec.AttrSpec{Name: "qemu_agent", Type: cty.Bool, Required: false},
 		"scsi_controller":              &hcldec.AttrSpec{Name: "scsi_controller", Type: cty.String, Required: false},
+		"onboot":                       &hcldec.AttrSpec{Name: "onboot", Type: cty.Bool, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"template_description":         &hcldec.AttrSpec{Name: "template_description", Type: cty.String, Required: false},
 		"unmount_iso":                  &hcldec.AttrSpec{Name: "unmount_iso", Type: cty.Bool, Required: false},

--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -44,6 +44,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		QemuNetworks: generateProxmoxNetworkAdapters(c.NICs),
 		QemuDisks:    generateProxmoxDisks(c.Disks),
 		Scsihw:       c.SCSIController,
+		Onboot:       c.Onboot,
 	}
 
 	if c.VMID == 0 {

--- a/website/source/docs/builders/proxmox.html.md
+++ b/website/source/docs/builders/proxmox.html.md
@@ -180,6 +180,9 @@ builder.
 
 -   `unmount_iso` (bool) - If true, remove the mounted ISO from the template
     after finishing. Defaults to `false`.
+    
+    `onboot` (boolean) - Specifies whether a VM will be started during system
+    bootup. Defaults to `false`.
 
 -   `qemu_agent` (boolean) - Disables QEMU Agent option for this VM. When enabled,
     then `qemu-guest-agent` must be installed on the guest. When disabled, then 


### PR DESCRIPTION
Adds the ability to specify `onboot` in the proxmox builder template.

Closes #8934 