### PR TITLE
[builder/google] Use "ssh-keys" metadata rather than deprecated "sshKeys"

### DIFF
--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -30,8 +31,9 @@ func (c *Config) createInstanceMetadata(sourceImage *Image, sshPublicKey string)
 	// supplied public key. This is possible if a private_key_file was
 	// specified.
 	if sshPublicKey != "" {
-		sshMetaKey := "sshKeys"
-		sshKeys := fmt.Sprintf("%s:%s", c.Comm.SSHUsername, sshPublicKey)
+		sshMetaKey := "ssh-keys"
+		sshPublicKey = strings.TrimSuffix(sshPublicKey, "\n")
+		sshKeys := fmt.Sprintf("%s:%s %s", c.Comm.SSHUsername, sshPublicKey, c.Comm.SSHUsername)
 		if confSshKeys, exists := instanceMetadata[sshMetaKey]; exists {
 			sshKeys = fmt.Sprintf("%s\n%s", sshKeys, confSshKeys)
 		}

--- a/builder/googlecompute/step_create_instance_test.go
+++ b/builder/googlecompute/step_create_instance_test.go
@@ -308,14 +308,14 @@ func TestCreateInstanceMetadata(t *testing.T) {
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 
 	// ensure our key is listed
-	assert.True(t, strings.Contains(metadata["sshKeys"], key), "Instance metadata should contain provided key")
+	assert.True(t, strings.Contains(metadata["ssh-keys"], key), "Instance metadata should contain provided key")
 }
 
 func TestCreateInstanceMetadata_noPublicKey(t *testing.T) {
 	state := testState(t)
 	c := state.Get("config").(*Config)
 	image := StubImage("test-image", "test-project", []string{}, 100)
-	sshKeys := c.Metadata["sshKeys"]
+	sshKeys := c.Metadata["ssh-keys"]
 
 	// create our metadata
 	metadata, err := c.createInstanceMetadata(image, "")
@@ -323,7 +323,7 @@ func TestCreateInstanceMetadata_noPublicKey(t *testing.T) {
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 
 	// ensure the ssh metadata hasn't changed
-	assert.Equal(t, metadata["sshKeys"], sshKeys, "Instance metadata should not have been modified")
+	assert.Equal(t, metadata["ssh-keys"], sshKeys, "Instance metadata should not have been modified")
 }
 
 func TestCreateInstanceMetadata_metadataFile(t *testing.T) {


### PR DESCRIPTION
Follow-up of PR https://github.com/hashicorp/packer/pull/6445.

Closes #8924
Closes #8939