### PR TITLE
Replace Amazon with Outscale for OSC BSU doc

### DIFF
--- a/website/source/docs/builders/osc-bsuvolume.html.md
+++ b/website/source/docs/builders/osc-bsuvolume.html.md
@@ -3,7 +3,7 @@ description: |
     The osc-bsuvolume Packer builder is like the BSU builder, but is intended to
     create BSU volumes rather than a machine image.
 layout: docs
-page_title: 'Amazon BSU Volume - Builders'
+page_title: 'Outscale BSU Volume - Builders'
 sidebar_current: 'docs-builders-osc-bsuvolume'
 ---
 


### PR DESCRIPTION
Hello,

Fixes a leftover by replacing Amazon with Outscale for Outscale BSU builder.