### PR TITLE
teach HCL mode builds to honor -only and -except options

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -220,9 +220,6 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, args []string) int {
 	}
 
 	builds, ret := c.GetBuilds(cfg.Path)
-	if ret != 0 {
-		return ret
-	}
 
 	if cfg.Debug {
 		c.Ui.Say("Debug mode enabled. Builds will not be parallelized.")

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -394,6 +394,80 @@ func TestBuildExceptFileCommaFlags(t *testing.T) {
 	}
 }
 
+func testHCLOnlyExceptFlags(t *testing.T, args, present, notPresent []string) {
+	c := &BuildCommand{
+		Meta: testMetaFile(t),
+	}
+
+	defer cleanup()
+
+	finalArgs := []string{"-parallel=false"}
+	for _, arg := range args {
+		finalArgs = append(finalArgs, arg)
+	}
+	finalArgs = append(finalArgs, testFixture("hcl-only-except"))
+
+	if code := c.Run(finalArgs); code != 0 {
+		fatalCommand(t, c.Meta)
+	}
+
+	for _, f := range notPresent {
+		if fileExists(f) {
+			t.Errorf("Expected NOT to find %s", f)
+		}
+	}
+	for _, f := range present {
+		if !fileExists(f) {
+			t.Errorf("Expected to find %s", f)
+		}
+	}
+}
+
+func TestBuildCommand_HCLOnlyExceptOptions(t *testing.T) {
+	tests := []struct {
+		args       []string
+		present    []string
+		notPresent []string
+	}{
+		{
+			[]string{"-only=chocolate"},
+			[]string{},
+			[]string{"chocolate.txt", "vanilla.txt", "cherry.txt"},
+		},
+		{
+			[]string{"-only=*chocolate*"},
+			[]string{"chocolate.txt"},
+			[]string{"vanilla.txt", "cherry.txt"},
+		},
+		{
+			[]string{"-except=*chocolate*"},
+			[]string{"vanilla.txt", "cherry.txt"},
+			[]string{"chocolate.txt"},
+		},
+		{
+			[]string{"-except=*ch*"},
+			[]string{"vanilla.txt"},
+			[]string{"chocolate.txt", "cherry.txt"},
+		},
+		{
+			[]string{"-only=*chocolate*", "-only=*vanilla*"},
+			[]string{"chocolate.txt", "vanilla.txt"},
+			[]string{"cherry.txt"},
+		},
+		{
+			[]string{"-except=*chocolate*", "-except=*vanilla*"},
+			[]string{"cherry.txt"},
+			[]string{"chocolate.txt", "vanilla.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s", tt.args), func(t *testing.T) {
+			testHCLOnlyExceptFlags(t, tt.args, tt.present, tt.notPresent)
+		})
+	}
+}
+
 func TestBuildWithNonExistingBuilder(t *testing.T) {
 	c := &BuildCommand{
 		Meta: testMetaFile(t),

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -402,9 +402,7 @@ func testHCLOnlyExceptFlags(t *testing.T, args, present, notPresent []string) {
 	defer cleanup()
 
 	finalArgs := []string{"-parallel=false"}
-	for _, arg := range args {
-		finalArgs = append(finalArgs, arg)
-	}
+	finalArgs = append(finalArgs, args...)
 	finalArgs = append(finalArgs, testFixture("hcl-only-except"))
 
 	if code := c.Run(finalArgs); code != 0 {

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -459,6 +459,16 @@ func TestBuildCommand_HCLOnlyExceptOptions(t *testing.T) {
 			[]string{"cherry.txt"},
 			[]string{"chocolate.txt", "vanilla.txt"},
 		},
+		{
+			[]string{"-only=file.chocolate"},
+			[]string{"chocolate.txt"},
+			[]string{"vanilla.txt", "cherry.txt"},
+		},
+		{
+			[]string{"-except=file.chocolate"},
+			[]string{"vanilla.txt", "cherry.txt"},
+			[]string{"chocolate.txt"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/command/test-fixtures/hcl-only-except/build.pkr.hcl
+++ b/command/test-fixtures/hcl-only-except/build.pkr.hcl
@@ -1,0 +1,22 @@
+source "file" "chocolate" {
+  content = "chocolate"
+  target = "chocolate.txt"
+}
+
+source "file" "vanilla" {
+  content = "vanilla"
+  target = "vanilla.txt"
+}
+
+source "file" "cherry" {
+  content = "cherry"
+  target = "cherry.txt"
+}
+
+build {
+  sources = [
+    "file.chocolate",
+    "file.vanilla",
+    "file.cherry",
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ini/ini v1.25.4
 	github.com/go-ole/go-ole v1.2.4 // indirect
-	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gobwas/glob v0.2.3
 	github.com/gocolly/colly v1.2.0
 	github.com/gofrs/flock v0.7.1
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -115,7 +115,7 @@ func testParse(t *testing.T, tests []parseTest) {
 				return
 			}
 
-			gotBuilds, gotDiags := tt.parser.getBuilds(gotCfg)
+			gotBuilds, gotDiags := tt.parser.getBuilds(gotCfg, nil, nil)
 			if tt.getBuildsWantDiags == (gotDiags == nil) {
 				t.Fatalf("Parser.getBuilds() unexpected diagnostics. %s", gotDiags)
 			}

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -298,7 +298,7 @@ func (p *Parser) getBuilds(cfg *PackerConfig, onlyBuilds []string, exceptBuilds 
 			}
 
 			// Apply the -only and -except command-line options to exclude matching builds.
-			buildName := fmt.Sprintf("%s-%s", src.Type, src.Name)
+			buildName := fmt.Sprintf("%s.%s", src.Type, src.Name)
 
 			// -only
 			if len(onlyGlobs) > 0 {

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -352,7 +352,7 @@ func (p *Parser) getBuilds(cfg *PackerConfig, onlyGlobs []glob.Glob, exceptGlobs
 }
 
 // Convert -only and -except globs to glob.Glob instances.
-func convertFilterOption(patterns []string) ([]glob.Glob, hcl.Diagnostics) {
+func convertFilterOption(patterns []string, optionName string) ([]glob.Glob, hcl.Diagnostics) {
 	var globs []glob.Glob
 	var diags hcl.Diagnostics
 
@@ -360,7 +360,7 @@ func convertFilterOption(patterns []string) ([]glob.Glob, hcl.Diagnostics) {
 		g, err := glob.Compile(pattern)
 		if err != nil {
 			diags = append(diags, &hcl.Diagnostic{
-				Summary:  fmt.Sprintf("Invalid -only pattern %s: %s", pattern, err),
+				Summary:  fmt.Sprintf("Invalid -%s pattern %s: %s", optionName, pattern, err),
 				Severity: hcl.DiagError,
 			})
 		}
@@ -383,7 +383,7 @@ func convertFilterOption(patterns []string) ([]glob.Glob, hcl.Diagnostics) {
 func (p *Parser) Parse(path string, varFiles []string, argVars map[string]string, onlyBuilds []string, exceptBuilds []string) ([]packer.Build, hcl.Diagnostics) {
 	var onlyGlobs []glob.Glob
 	if len(onlyBuilds) > 0 {
-		og, diags := convertFilterOption(onlyBuilds)
+		og, diags := convertFilterOption(onlyBuilds, "only")
 		if diags.HasErrors() {
 			return nil, diags
 		}
@@ -392,7 +392,7 @@ func (p *Parser) Parse(path string, varFiles []string, argVars map[string]string
 
 	var exceptGlobs []glob.Glob
 	if len(exceptBuilds) > 0 {
-		eg, diags := convertFilterOption(exceptBuilds)
+		eg, diags := convertFilterOption(exceptBuilds, "except")
 		if diags.HasErrors() {
 			return nil, diags
 		}

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -306,6 +306,7 @@ func (p *Parser) getBuilds(cfg *PackerConfig) ([]packer.Build, hcl.Diagnostics) 
 
 			pcb := &packer.CoreBuild{
 				Type:           src.Type,
+				Label:          src.Name,
 				Builder:        builder,
 				Provisioners:   provisioners,
 				PostProcessors: pps,

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -262,3 +262,25 @@ func TestParser_complete(t *testing.T) {
 	}
 	testParse(t, tests)
 }
+
+func TestParser_ValidateFilterOption(t *testing.T) {
+	tests := []struct {
+		pattern     string
+		expectError bool
+	}{
+		{"*foo*", false},
+		{"foo[]bar", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.pattern, func(t *testing.T) {
+			_, diags := convertFilterOption([]string{test.pattern})
+			if diags.HasErrors() && !test.expectError {
+				t.Fatalf("Expected %s to parse as glob", test.pattern)
+			}
+			if !diags.HasErrors() && test.expectError {
+				t.Fatalf("Expected %s to fail to parse as glob", test.pattern)
+			}
+		})
+	}
+}

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -101,6 +101,7 @@ func TestParser_complete(t *testing.T) {
 			[]packer.Build{
 				&packer.CoreBuild{
 					Type:     "virtualbox-iso",
+					Label:    "ubuntu-1204",
 					Prepared: true,
 					Builder:  basicMockBuilder,
 					Provisioners: []packer.CoreBuildProvisioner{

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -101,7 +101,6 @@ func TestParser_complete(t *testing.T) {
 			[]packer.Build{
 				&packer.CoreBuild{
 					Type:     "virtualbox-iso",
-					Label:    "ubuntu-1204",
 					Prepared: true,
 					Builder:  basicMockBuilder,
 					Provisioners: []packer.CoreBuildProvisioner{

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -274,7 +274,7 @@ func TestParser_ValidateFilterOption(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.pattern, func(t *testing.T) {
-			_, diags := convertFilterOption([]string{test.pattern})
+			_, diags := convertFilterOption([]string{test.pattern}, "")
 			if diags.HasErrors() && !test.expectError {
 				t.Fatalf("Expected %s to parse as glob", test.pattern)
 			}

--- a/packer/build.go
+++ b/packer/build.go
@@ -87,7 +87,6 @@ type Build interface {
 // as VirtualBox, EC2, etc.).
 type CoreBuild struct {
 	Type               string
-	Label              string
 	Builder            Builder
 	BuilderConfig      interface{}
 	BuilderType        string
@@ -129,11 +128,7 @@ type CoreBuildProvisioner struct {
 
 // Returns the name of the build.
 func (b *CoreBuild) Name() string {
-	if b.Label != "" {
-		return fmt.Sprintf("%s.%s", b.Type, b.Label)
-	} else {
-		return b.Type
-	}
+	return b.Type
 }
 
 // Prepare prepares the build by doing some initialization for the builder

--- a/packer/build.go
+++ b/packer/build.go
@@ -87,6 +87,7 @@ type Build interface {
 // as VirtualBox, EC2, etc.).
 type CoreBuild struct {
 	Type               string
+	Label              string
 	Builder            Builder
 	BuilderConfig      interface{}
 	BuilderType        string
@@ -128,7 +129,7 @@ type CoreBuildProvisioner struct {
 
 // Returns the name of the build.
 func (b *CoreBuild) Name() string {
-	return b.Type
+	return fmt.Sprintf("%s.%s", b.Type, b.Label)
 }
 
 // Prepare prepares the build by doing some initialization for the builder

--- a/packer/build.go
+++ b/packer/build.go
@@ -129,7 +129,11 @@ type CoreBuildProvisioner struct {
 
 // Returns the name of the build.
 func (b *CoreBuild) Name() string {
-	return fmt.Sprintf("%s.%s", b.Type, b.Label)
+	if b.Label != "" {
+		return fmt.Sprintf("%s.%s", b.Type, b.Label)
+	} else {
+		return b.Type
+	}
 }
 
 // Prepare prepares the build by doing some initialization for the builder


### PR DESCRIPTION
This PR fixes a regression when running `packer build` on HCL configs where the `-only` and `-except` options are not honored. This is because https://github.com/hashicorp/packer/blob/5623dfd5c9b1e8d3c933846a94f02e8cea779fa0/command/build.go#L136 short-circuits the older JSON config code that would have done eventually filtered on `-only` and `-except` (via https://github.com/hashicorp/packer/blob/5623dfd5c9b1e8d3c933846a94f02e8cea779fa0/command/meta.go#L72).

I discovered this regression when I had two build sections and two sources that look like this:

```
build {
  sources = [
    "source.amazon-ebs.ubuntu1804",
  ]

  provisioner "shell" {
    scripts = [
      "scripts/packages.sh",
      "scripts/aws-specific.sh",
      "scripts/company.sh",
    ]
  }
}

build {
  sources = [
    "source.virtualbox-iso.ubuntu1804",
  ]

  provisioner "shell" {
    scripts = [
      "scripts/packages.sh",
      "scripts/company.sh",
    ]
  }
}
```

I wanted to build only one source, but when I ran `packer build -only=virtualbox-iso .` (where my current directory is the directory with the HCL files), packer still tried to build from both the `amazon-ebs` source and the `virtualbox-iso` source. I had expected no output from the `amazon-ebs` builder when selecting `virtualbox-iso`.

With this PR, the filtering again works as expected.

Caveats:

- This fixes the regression but duplicates the existing logic in https://github.com/hashicorp/packer/blob/5623dfd5c9b1e8d3c933846a94f02e8cea779fa0/command/meta.go#L72. I leave it to regular Packer developers to figure out properly how to deduplicate this logic given the complexity of these code paths.

- The command-line invocations logic between HCL mode and JSON mode could use some regression testing. What's the right place for that?
