### PR TITLE
HCL2: pass on builder type and name

### DIFF
--- a/command/test-fixtures/build-name-and-type/all.json
+++ b/command/test-fixtures/build-name-and-type/all.json
@@ -1,0 +1,21 @@
+{
+    "builders": [
+        {
+            "name": "test",
+            "communicator": "none",
+            "type": "null"
+        },
+        {
+            "name": "potato",
+            "communicator": "none",
+            "type": "null"
+        }
+    ],
+    "post-processors": [
+        {
+            "type": "manifest",
+            "output": "manifest.json",
+            "strip_time": true
+        }
+    ]
+}

--- a/command/test-fixtures/build-name-and-type/all.pkr.hcl
+++ b/command/test-fixtures/build-name-and-type/all.pkr.hcl
@@ -1,0 +1,25 @@
+source "null" "test" {
+    communicator = "none"
+}
+
+source "null" "potato" {
+    communicator = "none"
+}
+
+build {
+    sources = [
+        "sources.null.test",
+        "sources.null.potato",
+    ]
+
+    provisioner "shell-local" {
+        inline = [
+            "echo '' > ${source.type}.${source.name}.txt"
+        ]
+    }
+
+    post-processor "manifest" {
+        output = "manifest.json"
+        strip_time = true
+    }
+}

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -166,7 +166,7 @@ func (p *Parser) parse(filename string, varFiles []string, argVars map[string]st
 func (p *Parser) decodeConfig(f *hcl.File, cfg *PackerConfig) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
-	body := dynblock.Expand(f.Body, cfg.EvalContext())
+	body := dynblock.Expand(f.Body, cfg.EvalContext(nil))
 	content, moreDiags := body.Content(configSchema)
 	diags = append(diags, moreDiags...)
 

--- a/hcl2template/types.build.post-processor.go
+++ b/hcl2template/types.build.post-processor.go
@@ -49,7 +49,7 @@ func (p *Parser) decodePostProcessor(block *hcl.Block) (*PostProcessorBlock, hcl
 	return postProcessor, diags
 }
 
-func (p *Parser) startPostProcessor(pp *PostProcessorBlock, ectx *hcl.EvalContext, generatedVars map[string]string) (packer.PostProcessor, hcl.Diagnostics) {
+func (p *Parser) startPostProcessor(source *SourceBlock, pp *PostProcessorBlock, ectx *hcl.EvalContext, generatedVars map[string]string) (packer.PostProcessor, hcl.Diagnostics) {
 	// ProvisionerBlock represents a detected but unparsed provisioner
 	var diags hcl.Diagnostics
 
@@ -64,7 +64,7 @@ func (p *Parser) startPostProcessor(pp *PostProcessorBlock, ectx *hcl.EvalContex
 	}
 	flatProvisinerCfg, moreDiags := decodeHCL2Spec(pp.Rest, ectx, postProcessor)
 	diags = append(diags, moreDiags...)
-	err = postProcessor.Configure(flatProvisinerCfg, generatedVars)
+	err = postProcessor.Configure(source.builderVariables(), flatProvisinerCfg, generatedVars)
 	if err != nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -46,7 +46,7 @@ func (p *Parser) decodeProvisioner(block *hcl.Block) (*ProvisionerBlock, hcl.Dia
 	return provisioner, diags
 }
 
-func (p *Parser) startProvisioner(pb *ProvisionerBlock, ectx *hcl.EvalContext, generatedVars map[string]string) (packer.Provisioner, hcl.Diagnostics) {
+func (p *Parser) startProvisioner(source *SourceBlock, pb *ProvisionerBlock, ectx *hcl.EvalContext, generatedVars map[string]string) (packer.Provisioner, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	provisioner, err := p.ProvisionersSchemas.Start(pb.PType)
@@ -69,7 +69,7 @@ func (p *Parser) startProvisioner(pb *ProvisionerBlock, ectx *hcl.EvalContext, g
 	// configs := make([]interface{}, 2)
 	// configs = append(, flatProvisionerCfg)
 	// configs = append(configs, generatedVars)
-	err = provisioner.Prepare(flatProvisionerCfg, generatedVars)
+	err = provisioner.Prepare(source.builderVariables(), flatProvisionerCfg, generatedVars)
 	if err != nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -35,18 +35,31 @@ type ValidationOptions struct {
 	Strict bool
 }
 
+const (
+	inputVariablesAccessor = "var"
+	localsAccessor         = "local"
+	sourcesAccessor        = "source"
+)
+
 // EvalContext returns the *hcl.EvalContext that will be passed to an hcl
 // decoder in order to tell what is the actual value of a var or a local and
 // the list of defined functions.
-func (cfg *PackerConfig) EvalContext() *hcl.EvalContext {
+func (cfg *PackerConfig) EvalContext(variables map[string]cty.Value) *hcl.EvalContext {
 	inputVariables, _ := cfg.InputVariables.Values()
 	localVariables, _ := cfg.LocalVariables.Values()
 	ectx := &hcl.EvalContext{
 		Functions: Functions(cfg.Basedir),
 		Variables: map[string]cty.Value{
-			"var":   cty.ObjectVal(inputVariables),
-			"local": cty.ObjectVal(localVariables),
+			inputVariablesAccessor: cty.ObjectVal(inputVariables),
+			localsAccessor:         cty.ObjectVal(localVariables),
+			sourcesAccessor: cty.ObjectVal(map[string]cty.Value{
+				"type": cty.UnknownVal(cty.String),
+				"name": cty.UnknownVal(cty.String),
+			}),
 		},
+	}
+	for k, v := range variables {
+		ectx.Variables[k] = v
 	}
 	return ectx
 }
@@ -157,7 +170,7 @@ func (c *PackerConfig) evaluateLocalVariables(locals []*Local) hcl.Diagnostics {
 func (c *PackerConfig) evaluateLocalVariable(local *Local) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
-	value, moreDiags := local.Expr.Value(c.EvalContext())
+	value, moreDiags := local.Expr.Value(c.EvalContext(nil))
 	diags = append(diags, moreDiags...)
 	if moreDiags.HasErrors() {
 		return diags
@@ -173,11 +186,11 @@ func (c *PackerConfig) evaluateLocalVariable(local *Local) hcl.Diagnostics {
 
 // getCoreBuildProvisioners takes a list of provisioner block, starts according
 // provisioners and sends parsed HCL2 over to it.
-func (p *Parser) getCoreBuildProvisioners(blocks []*ProvisionerBlock, ectx *hcl.EvalContext, generatedVars map[string]string) ([]packer.CoreBuildProvisioner, hcl.Diagnostics) {
+func (p *Parser) getCoreBuildProvisioners(source *SourceBlock, blocks []*ProvisionerBlock, ectx *hcl.EvalContext, generatedVars map[string]string) ([]packer.CoreBuildProvisioner, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	res := []packer.CoreBuildProvisioner{}
 	for _, pb := range blocks {
-		provisioner, moreDiags := p.startProvisioner(pb, ectx, generatedVars)
+		provisioner, moreDiags := p.startProvisioner(source, pb, ectx, generatedVars)
 		diags = append(diags, moreDiags...)
 		if moreDiags.HasErrors() {
 			continue
@@ -193,11 +206,11 @@ func (p *Parser) getCoreBuildProvisioners(blocks []*ProvisionerBlock, ectx *hcl.
 
 // getCoreBuildProvisioners takes a list of post processor block, starts
 // according provisioners and sends parsed HCL2 over to it.
-func (p *Parser) getCoreBuildPostProcessors(blocks []*PostProcessorBlock, ectx *hcl.EvalContext, generatedVars map[string]string) ([]packer.CoreBuildPostProcessor, hcl.Diagnostics) {
+func (p *Parser) getCoreBuildPostProcessors(source *SourceBlock, blocks []*PostProcessorBlock, ectx *hcl.EvalContext, generatedVars map[string]string) ([]packer.CoreBuildPostProcessor, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	res := []packer.CoreBuildPostProcessor{}
 	for _, ppb := range blocks {
-		postProcessor, moreDiags := p.startPostProcessor(ppb, ectx, generatedVars)
+		postProcessor, moreDiags := p.startPostProcessor(source, ppb, ectx, generatedVars)
 		diags = append(diags, moreDiags...)
 		if moreDiags.HasErrors() {
 			continue
@@ -230,10 +243,17 @@ func (p *Parser) getBuilds(cfg *PackerConfig) ([]packer.Build, hcl.Diagnostics) 
 				})
 				continue
 			}
-			builder, moreDiags, generatedVars := p.startBuilder(src, cfg.EvalContext())
+			builder, moreDiags, generatedVars := p.startBuilder(src, cfg.EvalContext(nil))
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue
+			}
+
+			variables := map[string]cty.Value{
+				sourcesAccessor: cty.ObjectVal(map[string]cty.Value{
+					"type": cty.StringVal(src.Type),
+					"name": cty.StringVal(src.Name),
+				}),
 			}
 
 			// If the builder has provided a list of to-be-generated variables that
@@ -249,12 +269,12 @@ func (p *Parser) getBuilds(cfg *PackerConfig) ([]packer.Build, hcl.Diagnostics) 
 				}
 			}
 
-			provisioners, moreDiags := p.getCoreBuildProvisioners(build.ProvisionerBlocks, cfg.EvalContext(), generatedPlaceholderMap)
+			provisioners, moreDiags := p.getCoreBuildProvisioners(src, build.ProvisionerBlocks, cfg.EvalContext(variables), generatedPlaceholderMap)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue
 			}
-			postProcessors, moreDiags := p.getCoreBuildPostProcessors(build.PostProcessors, cfg.EvalContext(), generatedPlaceholderMap)
+			postProcessors, moreDiags := p.getCoreBuildPostProcessors(src, build.PostProcessors, cfg.EvalContext(variables), generatedPlaceholderMap)
 			pps := [][]packer.CoreBuildPostProcessor{}
 			if len(postProcessors) > 0 {
 				pps = [][]packer.CoreBuildPostProcessor{postProcessors}

--- a/hcl2template/types.source.go
+++ b/hcl2template/types.source.go
@@ -57,10 +57,17 @@ func (p *Parser) startBuilder(source *SourceBlock, ectx *hcl.EvalContext) (packe
 		return nil, diags, nil
 	}
 
-	generatedVars, warning, err := builder.Prepare(decoded)
+	generatedVars, warning, err := builder.Prepare(source.builderVariables(), decoded)
 	moreDiags = warningErrorsToDiags(source.block, warning, err)
 	diags = append(diags, moreDiags...)
 	return builder, diags, generatedVars
+}
+
+func (source *SourceBlock) builderVariables() map[string]string {
+	return map[string]string{
+		"packer_build_name":   source.Name,
+		"packer_builder_type": source.Type,
+	}
 }
 
 func (source *SourceBlock) Ref() SourceRef {

--- a/post-processor/manifest/artifact.go
+++ b/post-processor/manifest/artifact.go
@@ -12,7 +12,7 @@ type ArtifactFile struct {
 type Artifact struct {
 	BuildName     string            `json:"name"`
 	BuilderType   string            `json:"builder_type"`
-	BuildTime     int64             `json:"build_time"`
+	BuildTime     int64             `json:"build_time,omitempty"`
 	ArtifactFiles []ArtifactFile    `json:"files"`
 	ArtifactId    string            `json:"artifact_id"`
 	PackerRunUUID string            `json:"packer_run_uuid"`

--- a/post-processor/manifest/post-processor.hcl2spec.go
+++ b/post-processor/manifest/post-processor.hcl2spec.go
@@ -18,6 +18,7 @@ type FlatConfig struct {
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables"`
 	OutputPath          *string           `mapstructure:"output" cty:"output"`
 	StripPath           *bool             `mapstructure:"strip_path" cty:"strip_path"`
+	StripTime           *bool             `mapstructure:"strip_time" cty:"strip_time"`
 	CustomData          map[string]string `mapstructure:"custom_data" cty:"custom_data"`
 }
 
@@ -42,6 +43,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"output":                     &hcldec.AttrSpec{Name: "output", Type: cty.String, Required: false},
 		"strip_path":                 &hcldec.AttrSpec{Name: "strip_path", Type: cty.Bool, Required: false},
+		"strip_time":                 &hcldec.AttrSpec{Name: "strip_time", Type: cty.Bool, Required: false},
 		"custom_data":                &hcldec.BlockAttrsSpec{TypeName: "custom_data", ElementType: cty.String, Required: false},
 	}
 	return s

--- a/website/pages/docs/post-processors/manifest.mdx
+++ b/website/pages/docs/post-processors/manifest.mdx
@@ -36,19 +36,13 @@ post-processors such as Docker and Artifice.
 
 ### Optional:
 
-- `output` (string) The manifest will be written to this file. This defaults
-  to `packer-manifest.json`.
-- `strip_path` (boolean) Write only filename without the path to the manifest
-  file. This defaults to false.
-- `custom_data` (map of strings) Arbitrary data to add to the manifest.
-  This is a [template engine](/docs/templates/engine). Therefore, you
-  may use user variables and template functions in this field.
-- `keep_input_artifact` (boolean) - Unlike most other post-processors, the
-  keep_input_artifact option will have no effect for the manifest
-  post-processor. We will always retain the input artifact for manifest,
-  since deleting the files we just recorded is not a behavior anyone should
-  ever expect. `keep_input_artifact will` therefore always be evaluated as
-  true, regardless of the value you enter into this field.
+@include 'post-processor/manifest/Config-not-required.mdx'
+-   `keep_input_artifact` (boolean) - Unlike most other post-processors, the
+    keep_input_artifact option will have no effect for the manifest
+    post-processor. We will always retain the input artifact for manifest,
+    since deleting the files we just recorded is not a behavior anyone should
+    ever expect. `keep_input_artifact will` therefore always be evaluated as
+    true, regardless of the value you enter into this field.
 
 ### Example Configuration
 

--- a/website/pages/partials/post-processor/manifest/Config-not-required.mdx
+++ b/website/pages/partials/post-processor/manifest/Config-not-required.mdx
@@ -1,0 +1,14 @@
+<!-- Code generated from the comments of the Config struct in post-processor/manifest/post-processor.go; DO NOT EDIT MANUALLY -->
+
+-   `output` (string) - The manifest will be written to this file. This defaults to
+    `packer-manifest.json`.
+    
+-   `strip_path` (bool) - Write only filename without the path to the manifest file. This defaults
+    to false.
+    
+-   `strip_time` (bool) - Don't write the `build_time` field from the output.
+    
+-   `custom_data` (map[string]string) - Arbitrary data to add to the manifest. This is a [template
+    engine](https://packer.io/docs/templates/engine.html). Therefore, you
+    may use user variables and template functions in this field.
+    


### PR DESCRIPTION
Howdy ! This :

* sets `packer_build_name` and `packer_builder_type` variables for builder provisioners and post-processors in HCL2
* allows to use the new `${source.type}` and `${source.name}` variables in HCL2 [ this is not required but this was the route I first took in order to test this and this has helped me a little, so I decided to leave it, please tell me if you think this is a bad idea ]
* fixes #8932 

Note that the common.PackerConfig is used everywhere and was not set for HCL2, this had some implications: 

For #8923 you can see the issue here:

https://github.com/hashicorp/packer/blob/dde74232f251434715cb76664426d9c1e1c91bd8/builder/lxd/config.go#L61-L63

More random examples of where this could cause an issue :

https://github.com/hashicorp/packer/blob/0785c2f6fca9c22bf25528e0176042799dd79df9/provisioner/ansible-local/provisioner.go#L380-L381

https://github.com/hashicorp/packer/blob/b4efd13a4d69a937a22caa5dd84eb98f7fdce5cf/builder/amazon/ebs/builder.go#L232-L236



* [All references to PackerConfig.PackerBuildName](https://sourcegraph.com/github.com/hashicorp/packer@ff6a039d5bb45e34ff761d9c52e8b98972288447/-/blob/common/packer_config.go#L7:2&tab=references)

* [All references to PackerConfig.PackerBuilderType](https://sourcegraph.com/github.com/hashicorp/packer@ff6a039d5bb45e34ff761d9c52e8b98972288447/-/blob/common/packer_config.go#L8:2&tab=references)