### PR TITLE
remove docs about windows symlinks which are now inaccurage

### DIFF
--- a/common/iso_config.go
+++ b/common/iso_config.go
@@ -25,11 +25,6 @@ import (
 // * HTTP
 // * Amazon S3
 //
-//
-// \~&gt; On Windows, using a symlink to refer to local files is currently
-// unsupported. Packer will always copy a local iso into the Packer cache
-// directory.
-//
 // Examples:
 // go-getter can guess the checksum type based on `iso_checksum` len.
 //

--- a/website/source/partials/common/_ISOConfig.html.md
+++ b/website/source/partials/common/_ISOConfig.html.md
@@ -12,10 +12,6 @@ go-getter supports the following protocols:
 * HTTP
 * Amazon S3
 
-\~&gt; On Windows, using a symlink to refer to local files is currently
-unsupported. Packer will always copy a local iso into the Packer cache
-directory.
-
 Examples:
 go-getter can guess the checksum type based on `iso_checksum` len.
 


### PR DESCRIPTION
Removes the warning about windows symlinking vs iso copying, since this is now longer the case.