### PR TITLE
scripts/prepare_changelog: Update git log to only display PR merged commits

### DIFF
--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -30,7 +30,7 @@ fi
 
 get_prs(){
     # git log v0.10.2...c3861d167533fb797b0fae0c380806625712e5f7 |
-    git log HEAD...${LAST_RELEASE} |
+    git log HEAD...${LAST_RELEASE} --first-parent --oneline --grep="Merge pull request #[0-9]\+" --grep="\(#[0-9]\+\)$" |
     grep -o "#\([0-9]\+\)" | awk -F\# '{print $2}' | while read line
     do
         grep -q "GH-${line}" CHANGELOG.md

--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -30,7 +30,7 @@ fi
 
 get_prs(){
     # git log v0.10.2...c3861d167533fb797b0fae0c380806625712e5f7 |
-    git log HEAD...${LAST_RELEASE} --first-parent --oneline --grep="Merge pull request #[0-9]\+" --grep="\(#[0-9]\+\)$" |
+    git log HEAD...${LAST_RELEASE} --first-parent --oneline --grep="Merge pull request #[0-9]\+" --grep="(#[0-9]\+)$" |
     grep -o "#\([0-9]\+\)" | awk -F\# '{print $2}' | while read line
     do
         grep -q "GH-${line}" CHANGELOG.md


### PR DESCRIPTION
This change uses git flags to shorten the log messages to titles only, and uses the grep pattern on git to filter only commits that match merged commits, including squashed and merged commits.

Fixes issue where the script was previously matching commit messages that included references to GitHub issues (e.g Fix 8898).

Results before change
```
⇶  ./scripts/prepare_changelog.sh v1.5.5
https://github.com/hashicorp/packer/pull/8898

https://github.com/hashicorp/packer/pull/8867

https://github.com/hashicorp/packer/pull/8781
```

Results after change
```
⇶  ./scripts/prepare_changelog.sh v1.5.5

```