### PR TITLE
make sure cli vars supercede var files

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -32,7 +32,16 @@ func TestBuild_VarArgs(t *testing.T) {
 			},
 			fileCheck: fileCheck{expected: []string{"apple.txt"}},
 		},
-
+		{
+			name: "json - json varfile sets an apple env var, " +
+				"override with banana cli var",
+			args: []string{
+				"-var", "fruit=banana",
+				"-var-file=" + filepath.Join(testFixture("var-arg"), "apple.json"),
+				filepath.Join(testFixture("var-arg"), "fruit_builder.json"),
+			},
+			fileCheck: fileCheck{expected: []string{"banana.txt"}},
+		},
 		{
 			name: "json - arg sets a pear env var",
 			args: []string{
@@ -401,6 +410,7 @@ func cleanup(moreFiles ...string) {
 	os.RemoveAll("lilas.txt")
 	os.RemoveAll("campanules.txt")
 	os.RemoveAll("ducky.txt")
+	os.RemoveAll("banana.txt")
 	for _, file := range moreFiles {
 		os.RemoveAll(file)
 	}

--- a/command/meta.go
+++ b/command/meta.go
@@ -44,17 +44,23 @@ func (m *Meta) Core(tpl *template.Template) (*packer.Core, error) {
 	config.Template = tpl
 
 	fj := &kvflag.FlagJSON{}
+	// First populate fj with contents from var files
 	for _, file := range m.varFiles {
 		err := fj.Set(file)
 		if err != nil {
 			return nil, err
 		}
 	}
+	// Now read fj values back into flagvars and set as config.Variables. Only
+	// add to flagVars if the key doesn't already exist, because flagVars comes
+	// from the command line and should not be overridden by variable files.
 	if m.flagVars == nil {
 		m.flagVars = map[string]string{}
 	}
 	for k, v := range *fj {
-		m.flagVars[k] = v
+		if _, exists := m.flagVars[k]; !exists {
+			m.flagVars[k] = v
+		}
 	}
 	config.Variables = m.flagVars
 


### PR DESCRIPTION
Make -var cli flag override values inside -var-file. Add tests to prevent this regression from happening again. 

Closes #8961 

