### PR TITLE
Remove net_device prepare validation

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -39,31 +39,6 @@ var accels = map[string]struct{}{
 	"whpx": {},
 }
 
-var netDevice = map[string]bool{
-	"ne2k_pci":       true,
-	"i82551":         true,
-	"i82557b":        true,
-	"i82559er":       true,
-	"rtl8139":        true,
-	"e1000":          true,
-	"pcnet":          true,
-	"virtio":         true,
-	"virtio-net":     true,
-	"virtio-net-pci": true,
-	"usb-net":        true,
-	"i82559a":        true,
-	"i82559b":        true,
-	"i82559c":        true,
-	"i82550":         true,
-	"i82562":         true,
-	"i82557a":        true,
-	"i82557c":        true,
-	"i82801":         true,
-	"vmxnet3":        true,
-	"i82558a":        true,
-	"i82558b":        true,
-}
-
 var diskInterface = map[string]bool{
 	"ide":         true,
 	"scsi":        true,
@@ -524,11 +499,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	if _, ok := accels[b.config.Accelerator]; !ok {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("invalid accelerator, only 'kvm', 'tcg', 'xen', 'hax', 'hvf', 'whpx', or 'none' are allowed"))
-	}
-
-	if _, ok := netDevice[b.config.NetDevice]; !ok {
-		errs = packer.MultiErrorAppend(
-			errs, errors.New("unrecognized network device type"))
 	}
 
 	if _, ok := diskInterface[b.config.DiskInterface]; !ok {


### PR DESCRIPTION
Removes `net_device` validation and let Qemu deal with non-valid devices. 

Setting an invalid net_device the output using PACKER_LOG=1 now is: 
```
2020/04/01 09:40:27 packer_linux plugin: Qemu stderr: qemu-system-x86_64: -device xyz,netdev=user.0: 'xyz' is not a valid device model name
2020/04/01 09:40:27 packer_linux plugin: failed to unlock port lockfile: close tcp 127.0.0.1:5940: use of closed network connection
2020/04/01 09:40:27 packer_linux plugin: failed to unlock port lockfile: close tcp 127.0.0.1:4188: use of closed network connection
==> qemu: Error launching VM: Qemu failed to start. Please run with PACKER_LOG=1 to get more info.

```

Closes https://github.com/hashicorp/packer/issues/8443
Closes https://github.com/hashicorp/packer/issues/7437