### PR TITLE
website: update Netlify redirect syntax

### DIFF
--- a/website/source/netlify-redirects
+++ b/website/source/netlify-redirects
@@ -3,24 +3,24 @@
 # See https://www.netlify.com/docs/redirects/ for documentation. Please do not
 # modify or delete existing redirects without first verifying internally.
 
-/docs/installation.html                         /docs/install/index.html
-/docs/command-line/machine-readable.html        /docs/commands/index.html
-/docs/command-line/introduction.html            /docs/commands/index.html
-/docs/templates/introduction.html               /docs/templates/index.html
-/docs/builders/azure-setup.html                 /docs/builders/azure.html
-/docs/templates/veewee-to-packer.html           /guides/veewee-to-packer.html
-/docs/extend/developing-plugins.html            /docs/extending/plugins.html
-/docs/extending/developing-plugins.html         /docs/extending/plugins.html
-/docs/extend/builder.html                       /docs/extending/custom-builders.html
-/docs/getting-started/setup.html                /docs/getting-started/install.html
-/docs/other/community.html                      /community-tools.html
-/downloads-community.html                       /community-tools.html
-/community                                      /community.html
-/community/index.html                           /community.html
-/docs/other/environmental-variables.html        /docs/other/environment-variables.html
-/docs/platforms.html                            /docs/builders/index.html
-/intro/platforms.html                           /docs/builders/index.html
-/docs/templates/configuration-templates.html    /docs/templates/engine.html
-/docs/machine-readable/*                        /docs/commands/index.html
-/docs/command-line/*                            /docs/commands/:splat
-/docs/extend/*                                  /docs/extending/:splat
+/docs/installation.html                         /docs/install/index.html                    301!
+/docs/command-line/machine-readable.html        /docs/commands/index.html                   301!
+/docs/command-line/introduction.html            /docs/commands/index.html                   301!
+/docs/templates/introduction.html               /docs/templates/index.html                  301!
+/docs/builders/azure-setup.html                 /docs/builders/azure.html                   301!
+/docs/templates/veewee-to-packer.html           /guides/veewee-to-packer.html               301!
+/docs/extend/developing-plugins.html            /docs/extending/plugins.html                301!
+/docs/extending/developing-plugins.html         /docs/extending/plugins.html                301!
+/docs/extend/builder.html                       /docs/extending/custom-builders.html        301!
+/docs/getting-started/setup.html                /docs/getting-started/install.html          301!
+/docs/other/community.html                      /community-tools.html                       301!
+/downloads-community.html                       /community-tools.html                       301!
+/community                                      /community.html                             301!
+/community/index.html                           /community.html                             301!
+/docs/other/environmental-variables.html        /docs/other/environment-variables.html      301!
+/docs/platforms.html                            /docs/builders/index.html                   301!
+/intro/platforms.html                           /docs/builders/index.html                   301!
+/docs/templates/configuration-templates.html    /docs/templates/engine.html                 301!
+/docs/machine-readable/*                        /docs/commands/index.html                   301!
+/docs/command-line/*                            /docs/commands/:splat                       301!
+/docs/extend/*                                  /docs/extending/:splat                      301!


### PR DESCRIPTION
Netlify [is adjusting the way they handle redirects](https://community.netlify.com/t/changed-behavior-in-redirects/10084) to be more explicit. If a path has content (i.e. it's not `404`), then any redirects _without_ the `!` after the status code will be ignored and the content will be served. 

We always want these redirect rules to be honored, even in the unlikely event that we had content at the source path. 

This PR adds the status code with the force directive (`301!`) to all redirects. Future redirects should follow this pattern, unless they are a proxy `200` redirect, or we want to take advantage of Netlify's conditional redirect behavior.