### PR TITLE
update hashibot config not to comment when locking super old and stal…

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -14,6 +14,7 @@ poll "closed_issue_locker" "locker" {
   closed_for           = "720h" # 30 days
   max_issues           = 500
   sleep_between_issues = "5s"
+  no_comment_if_no_activity_for = "4320h" # 180 days
 
   message = <<-EOF
     I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.


### PR DESCRIPTION
User pointed out on twitter that it might be nice not to have hashibot comment explaining ticket closers for extremely stale tickets; not sure if removing the comment will prevent the emails for locking tickets, but it's worth a try.
