### PR TITLE
Add `debug_mode` to PowerShell provisioner

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -222,6 +222,10 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			`"unrestricted", "none".`))
 	}
 
+	if !(p.config.DebugMode >= 0 && p.config.DebugMode <= 2) {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("%d is an invalid Trace level for `debug_mode`; valid values are 0, 1, and 2", p.config.DebugMode))
+	}
+
 	if errs != nil {
 		return errs
 	}

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -78,7 +78,13 @@ type Config struct {
 
 	remoteCleanUpScriptPath string
 
-	// If set, sets PowerShell's debug mode as part of the execute command
+	// If set, sets PowerShell's [PSDebug mode](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-psdebug?view=powershell-7)
+	//  in order to make script debugging easier. For instance, setting the
+	//    value to 1 results in adding this to the execute command:
+	//
+	//    ``` powershell
+	//    Set-PSDebug -Trace 1
+	//    ```
 	DebugMode int `mapstructure:"debug_mode"`
 
 	ctx interpolate.Context

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -78,6 +78,8 @@ type Config struct {
 
 	remoteCleanUpScriptPath string
 
+	DebugMode bool `mapstructure:"debug_mode"`
+
 	ctx interpolate.Context
 }
 
@@ -89,8 +91,13 @@ type Provisioner struct {
 
 func (p *Provisioner) defaultExecuteCommand() string {
 	baseCmd := `& { if (Test-Path variable:global:ProgressPreference)` +
-		`{set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'};` +
-		`. {{.Vars}}; &'{{.Path}}'; exit $LastExitCode }`
+		`{set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'};`
+
+	if p.config.DebugMode == true {
+		baseCmd += `Set-PsDebug -Trace 1;`
+	}
+
+	baseCmd += `. {{.Vars}}; &'{{.Path}}'; exit $LastExitCode }`
 
 	if p.config.ExecutionPolicy == ExecutionPolicyNone {
 		return baseCmd

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -78,7 +78,8 @@ type Config struct {
 
 	remoteCleanUpScriptPath string
 
-	DebugMode bool `mapstructure:"debug_mode"`
+	// If set, sets PowerShell's debug mode as part of the execute command
+	DebugMode int `mapstructure:"debug_mode"`
 
 	ctx interpolate.Context
 }
@@ -93,8 +94,8 @@ func (p *Provisioner) defaultExecuteCommand() string {
 	baseCmd := `& { if (Test-Path variable:global:ProgressPreference)` +
 		`{set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'};`
 
-	if p.config.DebugMode == true {
-		baseCmd += `Set-PsDebug -Trace 1;`
+	if p.config.DebugMode != 0 {
+		baseCmd += fmt.Sprintf(`Set-PsDebug -Trace %d;`, p.config.DebugMode)
 	}
 
 	baseCmd += `. {{.Vars}}; &'{{.Path}}'; exit $LastExitCode }`

--- a/provisioner/powershell/provisioner.hcl2spec.go
+++ b/provisioner/powershell/provisioner.hcl2spec.go
@@ -33,6 +33,7 @@ type FlatConfig struct {
 	ElevatedUser           *string           `mapstructure:"elevated_user" cty:"elevated_user"`
 	ElevatedPassword       *string           `mapstructure:"elevated_password" cty:"elevated_password"`
 	ExecutionPolicy        *string           `mapstructure:"execution_policy" cty:"execution_policy"`
+	DebugMode              *int              `mapstructure:"debug_mode" cty:"debug_mode"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -71,6 +72,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"elevated_user":              &hcldec.AttrSpec{Name: "elevated_user", Type: cty.String, Required: false},
 		"elevated_password":          &hcldec.AttrSpec{Name: "elevated_password", Type: cty.String, Required: false},
 		"execution_policy":           &hcldec.AttrSpec{Name: "execution_policy", Type: cty.String, Required: false},
+		"debug_mode":                 &hcldec.AttrSpec{Name: "debug_mode", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -85,7 +85,7 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 
 func TestProvisionerPrepare_Config(t *testing.T) {
 	config := testConfig()
-	config["debug_mode"] = true
+	config["debug_mode"] = 1
 	config["elevated_user"] = "{{user `user`}}"
 	config["elevated_password"] = "{{user `password`}}"
 	config[packer.UserVariablesConfigKey] = map[string]string{

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -122,6 +122,22 @@ func TestProvisionerPrepare_DebugMode(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_InvalidDebugMode(t *testing.T) {
+	config := testConfig()
+	config["debug_mode"] = -1
+
+	var p Provisioner
+	err := p.Prepare(config)
+	if err == nil {
+		t.Fatalf("should have error")
+	}
+
+	message := "invalid Trace level for `debug_mode`; valid values are 0, 1, and 2"
+	if !strings.Contains(err.Error(), message) {
+		t.Fatalf("expected Prepare() error %q to contain %q", err.Error(), message)
+	}
+}
+
 func TestProvisionerPrepare_InvalidKey(t *testing.T) {
 	var p Provisioner
 	config := testConfig()

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -85,6 +85,7 @@ func TestProvisionerPrepare_Defaults(t *testing.T) {
 
 func TestProvisionerPrepare_Config(t *testing.T) {
 	config := testConfig()
+	config["debug_mode"] = true
 	config["elevated_user"] = "{{user `user`}}"
 	config["elevated_password"] = "{{user `password`}}"
 	config[packer.UserVariablesConfigKey] = map[string]string{
@@ -104,7 +105,9 @@ func TestProvisionerPrepare_Config(t *testing.T) {
 	if p.config.ElevatedPassword != "mypassword" {
 		t.Fatalf("Expected 'mypassword' for key `elevated_password`: %s", p.config.ElevatedPassword)
 	}
-
+	if p.config.ExecuteCommand != `powershell -executionpolicy bypass "& { if (Test-Path variable:global:ProgressPreference){set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'};Set-PsDebug -Trace 1;. {{.Vars}}; &'{{.Path}}'; exit $LastExitCode }"` {
+		t.Fatalf(`Expected command should be 'powershell -executionpolicy bypass "& { if (Test-Path variable:global:ProgressPreference){set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'};Set-PsDebug -Trace 1;. {{.Vars}}; &'{{.Path}}'; exit $LastExitCode }' but got %s`, p.config.ExecuteCommand)
+	}
 }
 
 func TestProvisionerPrepare_InvalidKey(t *testing.T) {

--- a/website/pages/docs/provisioners/powershell.mdx
+++ b/website/pages/docs/provisioners/powershell.mdx
@@ -33,6 +33,13 @@ The example below is fully functional.
 
 @include 'provisioners/shell-config.mdx'
 
+- `debug_mode` - If set, sets PowerShell's [PSDebug mode](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-psdebug?view=powershell-7)
+   in order to make script debugging easier. For instance, setting the value to 1 results in adding this to the execute command:
+
+     ``` powershell
+     Set-PSDebug -Trace 1
+     ```
+
 - `elevated_execute_command` (string) - The command to use to execute the
   elevated script. By default this is as follows:
 


### PR DESCRIPTION
Add a `debug_mode` property to the PowerShell provisioner. If set, it set's PowerShell's [PSDebug mode](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-psdebug?view=powershell-7) as part of the execution command, which makes debugging scripts much easier.

Also updated execution command unit test to verify new behavior, and tested with local build.