### PR TITLE
fix execution policy parser to not interfere with legit integers, and…

### DIFF
--- a/provisioner/powershell/execution_policy.go
+++ b/provisioner/powershell/execution_policy.go
@@ -4,6 +4,7 @@ package powershell
 
 import (
 	"reflect"
+	"strconv"
 )
 
 // ExecutionPolicy setting to run the command(s).
@@ -27,5 +28,14 @@ func StringToExecutionPolicyHook(f reflect.Kind, t reflect.Kind, data interface{
 	}
 
 	raw := data.(string)
+	// It's possible that the thing being read is not supposed to be an
+	// execution policy; if the string provided is actally an int, just return
+	// the int.
+	i, err := strconv.Atoi(raw)
+	if err == nil {
+		return i, nil
+	}
+	// If it can't just be cast to an int, try to parse string into an
+	// execution policy.
 	return ExecutionPolicyString(raw)
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -188,6 +188,13 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		}
 	}
 
+	if p.config.ExecutionPolicy > 7 {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf(`Invalid execution `+
+			`policy provided. Please supply one of: "bypass", "allsigned",`+
+			` "default", "remotesigned", "restricted", "undefined", `+
+			`"unrestricted", "none".`))
+	}
+
 	if errs != nil {
 		return errs
 	}


### PR DESCRIPTION
The specialized Execution Policy decoding hook was getting in the way of other parts of the config where a string could legitimately be decoded into an Int. this was causing a valid_exit_codes list to be mis-parsed. This makes the hook function forgive actual ints disguised as strings, and adds tests to make sure it won't happen again.

Closes #8982
