### PR TITLE
provisioner/shell: fix dropped test error

### DIFF
--- a/provisioner/shell/provisioner_acc_test.go
+++ b/provisioner/shell/provisioner_acc_test.go
@@ -40,7 +40,7 @@ func (s *ShellProvisionerAccTest) GetConfig() (string, error) {
 	defer config.Close()
 
 	file, err := ioutil.ReadAll(config)
-	return string(file), nil
+	return string(file), err
 }
 
 func (s *ShellProvisionerAccTest) GetProvisionerStore() packer.MapOfProvisioner {


### PR DESCRIPTION
This fixes a dropped error variable in `provisioner/shell`.