### PR TITLE
provisioner/powershell: Test Error Improvements

### DIFF
--- a/provisioner/powershell/provisioner_acc_test.go
+++ b/provisioner/powershell/provisioner_acc_test.go
@@ -44,11 +44,14 @@ func (s *PowershellProvisionerAccTest) GetConfig() (string, error) {
 	filePath := filepath.Join("./test-fixtures", s.ConfigName)
 	config, err := os.Open(filePath)
 	if err != nil {
-		return "", fmt.Errorf("Expected to find %s", filePath)
+		return "", fmt.Errorf("os.Open:%v", err)
 	}
 	defer config.Close()
 
 	file, err := ioutil.ReadAll(config)
+	if err != nil {
+		return "", fmt.Errorf("ioutil.ReadAll:%v", err)
+	}
 	return string(file), nil
 }
 


### PR DESCRIPTION
This changes two errors in `provisioner/powershell`.

One `err` was being dropped, which is now fixed.

One `err` was assuming that every `os.PathError` is the same kind of "file-not-found" error. This changes the log message to explicitly display the error instead of `filePath`.