### PR TITLE
fix builds on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,13 @@ EXECUTABLE_FILES=$(shell find . -type f -executable | egrep -v '^\./(website/[ve
 GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 GIT_COMMIT=$(shell git rev-parse --short HEAD)
 GIT_IMPORT=github.com/hashicorp/packer/version
-GOLDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)
+UNAME_S := $(shell uname -s)
+LDFLAGS = ""
+ifeq ($(UNAME_S),Linux)
+	LDFLAGS=-linkmode external -extldflags -static
+endif
+
+GOLDFLAGS="$(LDFLAGS) -X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
 
 export GOLDFLAGS
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq ($(UNAME_S),Linux)
 	LDFLAGS=-linkmode external -extldflags -static
 endif
 
-GOLDFLAGS="$(LDFLAGS) -X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
+GOLDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY) $(LDFLAGS)
 
 export GOLDFLAGS
 

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,7 @@ GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 GIT_COMMIT=$(shell git rev-parse --short HEAD)
 GIT_IMPORT=github.com/hashicorp/packer/version
 UNAME_S := $(shell uname -s)
-LDFLAGS = ""
-ifeq ($(UNAME_S),Linux)
-	LDFLAGS=-linkmode external -extldflags -static
-endif
-
+LDFLAGS=-s -w
 GOLDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY) $(LDFLAGS)
 
 export GOLDFLAGS

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -125,6 +125,7 @@ if [ -n "${PACKER_DEV+x}" ]; then
     XC_ARCH=$(go env GOARCH)
 fi
 
+export CGO_ENABLED=0
 set +e
 ${GOX:?command not found} \
     -os="${XC_OS:-$ALL_XC_OS}" \


### PR DESCRIPTION
This fixes linking when building the binaries from a linux machine. 

After updating the GOLDFLAGS I ran into issues building for arm and windows https://github.com/hashicorp/packer/pull/9031/commits/f151c8c2448e9116e23c19b2bedd1be87e04044a

I created a second PR off this branch #9057 with the changes that I found after researching the steps around cross compiling on Linux for us to review, test, and discuss. 