### PR TITLE
[WIP]Add support to set boot volume size

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -63,6 +63,9 @@ type Config struct {
 	// Instance
 	InstanceName string `mapstructure:"instance_name"`
 
+	// Source Details
+	BootVolumeSizeInGBs string `mapstructure:"boot_volume_size_in_GBs"`
+
 	// Metadata optionally contains custom metadata key/value pairs provided in the
 	// configuration. While this can be used to set metadata["user_data"] the explicit
 	// "user_data" and "user_data_file" values will have precedence.

--- a/builder/oracle/oci/config.hcl2spec.go
+++ b/builder/oracle/oci/config.hcl2spec.go
@@ -73,6 +73,7 @@ type FlatConfig struct {
 	Shape                     *string                           `mapstructure:"shape" cty:"shape"`
 	ImageName                 *string                           `mapstructure:"image_name" cty:"image_name"`
 	InstanceName              *string                           `mapstructure:"instance_name" cty:"instance_name"`
+	BootVolumeSizeInGBs       *string                           `mapstructure:"boot_volume_size_in_GBs" cty:"boot_volume_size_in_GBs"`
 	Metadata                  map[string]string                 `mapstructure:"metadata" cty:"metadata"`
 	UserData                  *string                           `mapstructure:"user_data" cty:"user_data"`
 	UserDataFile              *string                           `mapstructure:"user_data_file" cty:"user_data_file"`
@@ -157,6 +158,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shape":                        &hcldec.AttrSpec{Name: "shape", Type: cty.String, Required: false},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
+		"boot_volume_size_in_GBs":      &hcldec.AttrSpec{Name: "boot_volume_size_in_GBs", Type: cty.String, Required: false},
 		"metadata":                     &hcldec.BlockAttrsSpec{TypeName: "metadata", ElementType: cty.String, Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	core "github.com/oracle/oci-go-sdk/core"
@@ -51,10 +52,18 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 		metadata["user_data"] = d.cfg.UserData
 	}
 
+	instanceSourceViaImageDetails := core.InstanceSourceViaImageDetails{ImageId: &d.cfg.BaseImageID}
+	if d.cfg.BootVolumeSizeInGBs != "" {
+		result, err := strconv.Atoi(d.cfg.BootVolumeSizeInGBs)
+		if err != nil {
+			return "", err
+		}
+		instanceSourceViaImageDetails.BootVolumeSizeInGBs = &result
+	}
 	instanceDetails := core.LaunchInstanceDetails{
 		AvailabilityDomain: &d.cfg.AvailabilityDomain,
 		CompartmentId:      &d.cfg.CompartmentID,
-		ImageId:            &d.cfg.BaseImageID,
+		SourceDetails:		instanceSourceViaImageDetails,
 		Shape:              &d.cfg.Shape,
 		SubnetId:           &d.cfg.SubnetID,
 		Metadata:           metadata,

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -63,7 +63,7 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 	instanceDetails := core.LaunchInstanceDetails{
 		AvailabilityDomain: &d.cfg.AvailabilityDomain,
 		CompartmentId:      &d.cfg.CompartmentID,
-		SourceDetails:		instanceSourceViaImageDetails,
+		SourceDetails:      instanceSourceViaImageDetails,
 		Shape:              &d.cfg.Shape,
 		SubnetId:           &d.cfg.SubnetID,
 		Metadata:           metadata,


### PR DESCRIPTION
A new parameter `boot_volume_size_in_GBs` is introduced for Oracle OCI builder. If it is not set, default value will be applied. This change also removes the deprecated `imageId` but uses `sourceDetails` instead.

This pull request is still WIP because there are something still unclear to me:

* Do we have a last know good commit? I keep on getting error `rm: missing operand`
* What is the best way to test this? I tried to dig into `step_create_instance_test.go` and `config_test.go` but function `CreateInstance` is never called.