### PR TITLE
Fix linting on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,9 @@ jobs:
   check-lint:
     executor: golang
     resource_class: large
-    working_directory: /go/src/github.com/hashicorp/packer
     steps:
       - checkout
+      - run: git fetch --all
       - run:
           command: make ci-lint
           no_output_timeout: 30m

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,7 @@ lint: install-lint-deps ## Lint Go code
 
 ci-lint: install-lint-deps ## On ci only lint newly added Go source files
 	@echo "==> Running linter on newly added Go source files..."
-	GO111MODULE=on golangci-lint run --new-from-rev=`git merge-base master HEAD` ./...
-
+	@GO111MODULE=on sh -c "$(CURDIR)/scripts/lint.sh"
 
 fmt: ## Format Go code
 	@go fmt ./...

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+CHANGED_FILES=$(git diff --name-status `git merge-base origin/master HEAD`...HEAD | grep '^A.*\.go$'| awk '{print $2}')
+if [ ! -z "${CHANGED_FILES}" ]; then
+  echo $CHANGED_FILES | xargs -n1 golangci-lint run
+fi


### PR DESCRIPTION
After a number of runs with some test files I found a combination that appears to work on circle as well as locally every time. The following URL is to a build with the expected failures during my testing https://app.circleci.com/pipelines/github/hashicorp/packer/4560/workflows/8396dbc0-f4ea-4ee7-bd08-ca46d31cee6c/jobs/45000

This change includes the following three items:

* new-from-rev option is showing inconsistent results on circle and
locally. This change moves to a custom command that gets a list of added
go files and pipes them to golangci-lint for testing.
https://app.circleci.com/pipelines/github/hashicorp/packer/4564/workflows/3ee57292-c325-447e-ae34-5de015861935/jobs/45054

* Add a git fetch as a step before retrieving merge-base changes to fix
the issue described at https://discuss.circleci.com/t/checkout-script-adds-commits-to-master-from-circle-branch/14194/2

* Moved source code out of GOPATH to ensure go mod support and reduce
the risk of having golangci-lint trying to scan all of the files within
GOPATH. This was an issue in the past, in changing it I found less OOM
issues on circle.

