### PR TITLE
Add RetriedProvisioner to allow retry provisioners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ commands:
 jobs:
   test-linux:
     executor: golang
+    resource_class: large
     working_directory: /go/src/github.com/hashicorp/packer
     steps:
       - checkout

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -207,6 +207,23 @@ var (
 		},
 	}
 
+	emptyMockBuilder = &MockBuilder{
+		Config: MockConfig{
+			NestedMockConfig: NestedMockConfig{
+				Tags: []MockTag{},
+			},
+			Nested:      NestedMockConfig{},
+			NestedSlice: []NestedMockConfig{},
+		},
+	}
+
+	emptyMockProvisioner = &MockProvisioner{
+		Config: MockConfig{
+			NestedMockConfig: NestedMockConfig{Tags: []MockTag{}},
+			NestedSlice:      []NestedMockConfig{},
+		},
+	}
+
 	dynamicTagList = []MockTag{
 		{
 			Key:   "first_tag_key",

--- a/hcl2template/testdata/build/provisioner_paused_before_retry.pkr.hcl
+++ b/hcl2template/testdata/build/provisioner_paused_before_retry.pkr.hcl
@@ -1,0 +1,15 @@
+
+// starts resources to provision them.
+build {
+    sources = [
+        "source.virtualbox-iso.ubuntu-1204"
+    ]
+
+    provisioner "shell" {
+        pause_before = "10s"
+        max_retries = 5
+    }
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}

--- a/hcl2template/testdata/build/provisioner_timeout.pkr.hcl
+++ b/hcl2template/testdata/build/provisioner_timeout.pkr.hcl
@@ -1,0 +1,14 @@
+
+// starts resources to provision them.
+build {
+    sources = [
+        "source.virtualbox-iso.ubuntu-1204"
+    ]
+
+    provisioner "shell" {
+        timeout = "10s"
+    }
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -2,6 +2,7 @@ package hcl2template
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -10,8 +11,11 @@ import (
 
 // ProvisionerBlock references a detected but unparsed provisioner
 type ProvisionerBlock struct {
-	PType string
-	PName string
+	PType       string
+	PName       string
+	PauseBefore time.Duration
+	MaxRetries  int
+	Timeout     time.Duration
 	HCL2Ref
 }
 
@@ -21,17 +25,23 @@ func (p *ProvisionerBlock) String() string {
 
 func (p *Parser) decodeProvisioner(block *hcl.Block) (*ProvisionerBlock, hcl.Diagnostics) {
 	var b struct {
-		Name string   `hcl:"name,optional"`
-		Rest hcl.Body `hcl:",remain"`
+		Name        string        `hcl:"name,optional"`
+		PauseBefore time.Duration `hcl:"pause_before,optional"`
+		MaxRetries  int           `hcl:"max_retries,optional"`
+		Timeout     time.Duration `hcl:"timeout,optional"`
+		Rest        hcl.Body      `hcl:",remain"`
 	}
 	diags := gohcl.DecodeBody(block.Body, nil, &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 	provisioner := &ProvisionerBlock{
-		PType:   block.Labels[0],
-		PName:   b.Name,
-		HCL2Ref: newHCL2Ref(block, b.Rest),
+		PType:       block.Labels[0],
+		PName:       b.Name,
+		PauseBefore: b.PauseBefore,
+		MaxRetries:  b.MaxRetries,
+		Timeout:     b.Timeout,
+		HCL2Ref:     newHCL2Ref(block, b.Rest),
 	}
 
 	if !p.ProvisionersSchemas.Has(provisioner.PType) {

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -25,23 +25,44 @@ func (p *ProvisionerBlock) String() string {
 
 func (p *Parser) decodeProvisioner(block *hcl.Block) (*ProvisionerBlock, hcl.Diagnostics) {
 	var b struct {
-		Name        string        `hcl:"name,optional"`
-		PauseBefore time.Duration `hcl:"pause_before,optional"`
-		MaxRetries  int           `hcl:"max_retries,optional"`
-		Timeout     time.Duration `hcl:"timeout,optional"`
-		Rest        hcl.Body      `hcl:",remain"`
+		Name        string   `hcl:"name,optional"`
+		PauseBefore string   `hcl:"pause_before,optional"`
+		MaxRetries  int      `hcl:"max_retries,optional"`
+		Timeout     string   `hcl:"timeout,optional"`
+		Rest        hcl.Body `hcl:",remain"`
 	}
 	diags := gohcl.DecodeBody(block.Body, nil, &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}
+
 	provisioner := &ProvisionerBlock{
-		PType:       block.Labels[0],
-		PName:       b.Name,
-		PauseBefore: b.PauseBefore,
-		MaxRetries:  b.MaxRetries,
-		Timeout:     b.Timeout,
-		HCL2Ref:     newHCL2Ref(block, b.Rest),
+		PType:      block.Labels[0],
+		PName:      b.Name,
+		MaxRetries: b.MaxRetries,
+		HCL2Ref:    newHCL2Ref(block, b.Rest),
+	}
+
+	if b.PauseBefore != "" {
+		pauseBefore, err := time.ParseDuration(b.PauseBefore)
+		if err != nil {
+			return nil, append(diags, &hcl.Diagnostic{
+				Summary: "Failed to parse pause_before duration",
+				Detail:  err.Error(),
+			})
+		}
+		provisioner.PauseBefore = pauseBefore
+	}
+
+	if b.Timeout != "" {
+		timeout, err := time.ParseDuration(b.Timeout)
+		if err != nil {
+			return nil, append(diags, &hcl.Diagnostic{
+				Summary: "Failed to parse timeout duration",
+				Detail:  err.Error(),
+			})
+		}
+		provisioner.Timeout = timeout
 	}
 
 	if !p.ProvisionersSchemas.Has(provisioner.PType) {

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -195,6 +195,26 @@ func (p *Parser) getCoreBuildProvisioners(source *SourceBlock, blocks []*Provisi
 		if moreDiags.HasErrors() {
 			continue
 		}
+
+		// If we're pausing, we wrap the provisioner in a special pauser.
+		if pb.PauseBefore != 0 {
+			provisioner = &packer.PausedProvisioner{
+				PauseBefore: pb.PauseBefore,
+				Provisioner: provisioner,
+			}
+		} else if pb.Timeout != 0 {
+			provisioner = &packer.TimeoutProvisioner{
+				Timeout:     pb.Timeout,
+				Provisioner: provisioner,
+			}
+		}
+		if pb.MaxRetries != 0 {
+			provisioner = &packer.RetriedProvisioner{
+				MaxRetries:  pb.MaxRetries,
+				Provisioner: provisioner,
+			}
+		}
+
 		res = append(res, packer.CoreBuildProvisioner{
 			PType:       pb.PType,
 			PName:       pb.PName,

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -1,6 +1,7 @@
 package hcl2template
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -178,7 +179,7 @@ func TestParser_complete(t *testing.T) {
 			defaultParser,
 			parseTestArgs{"testdata/build/provisioner_paused_before_retry.pkr.hcl", nil, nil},
 			&PackerConfig{
-				Basedir: "testdata/build",
+				Basedir: filepath.Join("testdata", "build"),
 				Sources: map[SourceRef]*SourceBlock{
 					refVBIsoUbuntu1204: {Type: "virtualbox-iso", Name: "ubuntu-1204"},
 				},
@@ -222,7 +223,7 @@ func TestParser_complete(t *testing.T) {
 			defaultParser,
 			parseTestArgs{"testdata/build/provisioner_timeout.pkr.hcl", nil, nil},
 			&PackerConfig{
-				Basedir: "testdata/build",
+				Basedir: filepath.Join("testdata", "build"),
 				Sources: map[SourceRef]*SourceBlock{
 					refVBIsoUbuntu1204: {Type: "virtualbox-iso", Name: "ubuntu-1204"},
 				},

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -1,10 +1,11 @@
 package hcl2template
 
 import (
-	"github.com/hashicorp/packer/packer"
-	"github.com/zclconf/go-cty/cty"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/packer/packer"
+	"github.com/zclconf/go-cty/cty"
 )
 
 var (

--- a/packer/builder_mock.hcl2spec.go
+++ b/packer/builder_mock.hcl2spec.go
@@ -155,6 +155,7 @@ type FlatMockProvisioner struct {
 	PrepCalled       *bool         `cty:"prep_called"`
 	PrepConfigs      []interface{} `cty:"prep_configs"`
 	ProvCalled       *bool         `cty:"prov_called"`
+	ProvRetried      *bool         `cty:"prov_retried"`
 	ProvCommunicator Communicator  `cty:"prov_communicator"`
 	ProvUi           Ui            `cty:"prov_ui"`
 }
@@ -174,6 +175,7 @@ func (*FlatMockProvisioner) HCL2Spec() map[string]hcldec.Spec {
 		"prep_called":       &hcldec.AttrSpec{Name: "prep_called", Type: cty.Bool, Required: false},
 		"prep_configs":      &hcldec.AttrSpec{Name: "prep_configs", Type: cty.Bool, Required: false}, /* TODO(azr): could not find type */
 		"prov_called":       &hcldec.AttrSpec{Name: "prov_called", Type: cty.Bool, Required: false},
+		"prov_retried":      &hcldec.AttrSpec{Name: "prov_retried", Type: cty.Bool, Required: false},
 		"prov_communicator": &hcldec.AttrSpec{Name: "prov_communicator", Type: cty.Bool, Required: false}, /* TODO(azr): could not find type */
 		"prov_ui":           &hcldec.AttrSpec{Name: "prov_ui", Type: cty.Bool, Required: false},           /* TODO(azr): could not find type */
 	}

--- a/packer/core.go
+++ b/packer/core.go
@@ -170,9 +170,9 @@ func (c *Core) generateCoreBuildProvisioner(rawP *template.Provisioner, rawName 
 			Provisioner: provisioner,
 		}
 	}
-	if rawP.Retry != 0 {
+	if rawP.MaxRetries != 0 {
 		provisioner = &RetriedProvisioner{
-			Retry:       rawP.Retry,
+			MaxRetries:  rawP.MaxRetries,
 			Provisioner: provisioner,
 		}
 	}

--- a/packer/core.go
+++ b/packer/core.go
@@ -170,6 +170,12 @@ func (c *Core) generateCoreBuildProvisioner(rawP *template.Provisioner, rawName 
 			Provisioner: provisioner,
 		}
 	}
+	if rawP.Retry != 0 {
+		provisioner = &RetriedProvisioner{
+			Retry:       rawP.Retry,
+			Provisioner: provisioner,
+		}
+	}
 	cbp = CoreBuildProvisioner{
 		PType:       rawP.Type,
 		Provisioner: provisioner,

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -2,6 +2,7 @@ package packer
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -806,14 +807,11 @@ func TestCoreBuild_provRetry(t *testing.T) {
 	}
 
 	ui := testUi()
-	ctx, topCtxCancel := context.WithCancel(context.Background())
 	p.ProvFunc = func(ctx context.Context) error {
-		topCtxCancel()
-		<-ctx.Done()
-		return ctx.Err()
+		return errors.New("failed")
 	}
 
-	artifact, err := build.Run(ctx, ui)
+	artifact, err := build.Run(context.Background(), ui)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -165,7 +165,7 @@ func (p *PausedProvisioner) Provision(ctx context.Context, ui Ui, comm Communica
 // RetriedProvisioner is a Provisioner implementation that retries
 // the provisioner whenever there's an error.
 type RetriedProvisioner struct {
-	Retry       int
+	MaxRetries  int
 	Provisioner Provisioner
 }
 
@@ -179,7 +179,7 @@ func (r *RetriedProvisioner) Provision(ctx context.Context, ui Ui, comm Communic
 	err := r.Provisioner.Provision(ctx, ui, comm, generatedData)
 
 	retries := 0
-	for err != nil && retries < r.Retry {
+	for err != nil && retries < r.MaxRetries {
 		ui.Say("Retrying provisioner")
 		err = r.Provisioner.Provision(ctx, ui, comm, generatedData)
 		retries++

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -188,7 +188,7 @@ func (r *RetriedProvisioner) Provision(ctx context.Context, ui Ui, comm Communic
 		}
 
 		ui.Say(fmt.Sprintf("Provisioner failed with %q, retrying with %d trie(s) left", err, leftTries))
-		
+
 		err := r.Provisioner.Provision(ctx, ui, comm, generatedData)
 		if err == nil {
 			return nil

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -179,7 +179,8 @@ func (r *RetriedProvisioner) Provision(ctx context.Context, ui Ui, comm Communic
 	err := r.Provisioner.Provision(ctx, ui, comm, generatedData)
 
 	retries := 0
-	if err != nil && retries < r.Retry {
+	for err != nil && retries < r.Retry {
+		ui.Say("Retrying provisioner")
 		err = r.Provisioner.Provision(ctx, ui, comm, generatedData)
 		retries++
 	}

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -176,6 +176,10 @@ func (r *RetriedProvisioner) Prepare(raws ...interface{}) error {
 }
 
 func (r *RetriedProvisioner) Provision(ctx context.Context, ui Ui, comm Communicator, generatedData map[string]interface{}) error {
+	if ctx.Err() != nil { // context was cancelled
+		return ctx.Err()
+	}
+
 	err := r.Provisioner.Provision(ctx, ui, comm, generatedData)
 	if err == nil {
 		return nil

--- a/packer/provisioner_mock.go
+++ b/packer/provisioner_mock.go
@@ -14,6 +14,7 @@ type MockProvisioner struct {
 	PrepCalled       bool
 	PrepConfigs      []interface{}
 	ProvCalled       bool
+	ProvRetried      bool
 	ProvCommunicator Communicator
 	ProvUi           Ui
 }
@@ -29,6 +30,11 @@ func (t *MockProvisioner) Prepare(configs ...interface{}) error {
 }
 
 func (t *MockProvisioner) Provision(ctx context.Context, ui Ui, comm Communicator, generatedData map[string]interface{}) error {
+	if t.ProvCalled {
+		t.ProvRetried = true
+		return nil
+	}
+
 	t.ProvCalled = true
 	t.ProvCommunicator = comm
 	t.ProvUi = ui

--- a/packer/provisioner_test.go
+++ b/packer/provisioner_test.go
@@ -240,7 +240,10 @@ func TestRetriedProvisionerPrepare(t *testing.T) {
 		Provisioner: mock,
 	}
 
-	prov.Prepare(42)
+	err := prov.Prepare(42)
+	if err != nil {
+		t.Fatal("should not have errored")
+	}
 	if !mock.PrepCalled {
 		t.Fatal("prepare should be called")
 	}
@@ -267,7 +270,10 @@ func TestRetriedProvisionerProvision(t *testing.T) {
 
 	ui := testUi()
 	comm := new(MockCommunicator)
-	prov.Provision(ctx, ui, comm, make(map[string]interface{}))
+	err := prov.Provision(ctx, ui, comm, make(map[string]interface{}))
+	if err != nil {
+		t.Fatal("should not have errored")
+	}
 	if !mock.ProvCalled {
 		t.Fatal("prov should be called")
 	}

--- a/packer/provisioner_test.go
+++ b/packer/provisioner_test.go
@@ -261,7 +261,7 @@ func TestRetriedProvisionerProvision(t *testing.T) {
 	}
 
 	prov := &RetriedProvisioner{
-		Retry:       2,
+		MaxRetries:  2,
 		Provisioner: mock,
 	}
 

--- a/packer/provisioner_test.go
+++ b/packer/provisioner_test.go
@@ -229,3 +229,75 @@ func TestDebuggedProvisionerCancel(t *testing.T) {
 		t.Fatal("should have error")
 	}
 }
+
+func TestRetriedProvisioner_impl(t *testing.T) {
+	var _ Provisioner = new(RetriedProvisioner)
+}
+
+func TestRetriedProvisionerPrepare(t *testing.T) {
+	mock := new(MockProvisioner)
+	prov := &RetriedProvisioner{
+		Provisioner: mock,
+	}
+
+	prov.Prepare(42)
+	if !mock.PrepCalled {
+		t.Fatal("prepare should be called")
+	}
+	if mock.PrepConfigs[0] != 42 {
+		t.Fatal("should have proper configs")
+	}
+}
+
+func TestRetriedProvisionerProvision(t *testing.T) {
+	ctx, topCtxCancel := context.WithCancel(context.Background())
+
+	mock := &MockProvisioner{
+		ProvFunc: func(ctx context.Context) error {
+			topCtxCancel()
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	prov := &RetriedProvisioner{
+		Retry:       2,
+		Provisioner: mock,
+	}
+
+	ui := testUi()
+	comm := new(MockCommunicator)
+	prov.Provision(ctx, ui, comm, make(map[string]interface{}))
+	if !mock.ProvCalled {
+		t.Fatal("prov should be called")
+	}
+	if !mock.ProvRetried {
+		t.Fatal("prov should be retried")
+	}
+	if mock.ProvUi != ui {
+		t.Fatal("should have proper ui")
+	}
+	if mock.ProvCommunicator != comm {
+		t.Fatal("should have proper comm")
+	}
+}
+
+func TestRetriedProvisionerCancel(t *testing.T) {
+	topCtx, cancelTopCtx := context.WithCancel(context.Background())
+
+	mock := new(MockProvisioner)
+	prov := &RetriedProvisioner{
+		Provisioner: mock,
+	}
+
+	mock.ProvFunc = func(ctx context.Context) error {
+		cancelTopCtx()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	err := prov.Provision(topCtx, testUi(), new(MockCommunicator), make(map[string]interface{}))
+	if err == nil {
+		t.Fatal("should have err")
+	}
+}

--- a/packer/test-fixtures/build-prov-retry.json
+++ b/packer/test-fixtures/build-prov-retry.json
@@ -5,6 +5,6 @@
 
     "provisioners": [{
         "type": "test",
-        "retry": 1
+        "max_retries": 1
     }]
 }

--- a/packer/test-fixtures/build-prov-retry.json
+++ b/packer/test-fixtures/build-prov-retry.json
@@ -1,0 +1,10 @@
+{
+    "builders": [{
+        "type": "test"
+    }],
+
+    "provisioners": [{
+        "type": "test",
+        "retry": 1
+    }]
+}

--- a/provisioner/shell-local/provisioner_acc_test.go
+++ b/provisioner/shell-local/provisioner_acc_test.go
@@ -1,0 +1,64 @@
+package shell_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/packer/helper/tests/acc"
+	"github.com/hashicorp/packer/provisioner/shell"
+
+	"github.com/hashicorp/packer/packer"
+
+	"github.com/hashicorp/packer/command"
+)
+
+func TestShellLocalProvisionerWithRetryOption(t *testing.T) {
+	acc.TestProvisionersPreCheck("shell-local", t)
+	acc.TestProvisionersAgainstBuilders(new(ShellLocalProvisionerAccTest), t)
+}
+
+type ShellLocalProvisionerAccTest struct{}
+
+func (s *ShellLocalProvisionerAccTest) GetName() string {
+	return "file"
+}
+
+func (s *ShellLocalProvisionerAccTest) GetConfig() (string, error) {
+	filePath := filepath.Join("./test-fixtures", "shell-local-provisioner.txt")
+	config, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("Expected to find %s", filePath)
+	}
+	defer config.Close()
+
+	file, err := ioutil.ReadAll(config)
+	return string(file), err
+}
+
+func (s *ShellLocalProvisionerAccTest) GetProvisionerStore() packer.MapOfProvisioner {
+	return packer.MapOfProvisioner{
+		"shell-local": func() (packer.Provisioner, error) { return &shell.Provisioner{}, nil },
+	}
+}
+
+func (s *ShellLocalProvisionerAccTest) IsCompatible(builder string, vmOS string) bool {
+	return vmOS == "linux"
+}
+
+func (s *ShellLocalProvisionerAccTest) RunTest(c *command.BuildCommand, args []string) error {
+	if code := c.Run(args); code != 0 {
+		ui := c.Meta.Ui.(*packer.BasicUi)
+		out := ui.Writer.(*bytes.Buffer)
+		err := ui.ErrorWriter.(*bytes.Buffer)
+		return fmt.Errorf(
+			"Bad exit code.\n\nStdout:\n\n%s\n\nStderr:\n\n%s",
+			out.String(),
+			err.String())
+	}
+
+	return nil
+}

--- a/provisioner/shell-local/test-fixtures/script.sh
+++ b/provisioner/shell-local/test-fixtures/script.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ ! -f file.txt ]] ; then
+    echo 'hello' > file.txt
+    exit 1
+fi

--- a/provisioner/shell-local/test-fixtures/shell-local-provisioner.txt
+++ b/provisioner/shell-local/test-fixtures/shell-local-provisioner.txt
@@ -1,5 +1,5 @@
 {
     "type": "shell-local",
     "script": "test-fixtures/script.sh",
-    "retry" : 5
+    "max_retries" : 5
 }

--- a/provisioner/shell-local/test-fixtures/shell-local-provisioner.txt
+++ b/provisioner/shell-local/test-fixtures/shell-local-provisioner.txt
@@ -1,0 +1,5 @@
+{
+    "type": "shell-local",
+    "script": "test-fixtures/script.sh",
+    "retry" : 5
+}

--- a/template/parse.go
+++ b/template/parse.go
@@ -76,6 +76,7 @@ func (r *rawTemplate) decodeProvisioner(raw interface{}) (Provisioner, error) {
 	delete(p.Config, "only")
 	delete(p.Config, "override")
 	delete(p.Config, "pause_before")
+	delete(p.Config, "retry")
 	delete(p.Config, "type")
 	delete(p.Config, "timeout")
 

--- a/template/parse.go
+++ b/template/parse.go
@@ -76,7 +76,7 @@ func (r *rawTemplate) decodeProvisioner(raw interface{}) (Provisioner, error) {
 	delete(p.Config, "only")
 	delete(p.Config, "override")
 	delete(p.Config, "pause_before")
-	delete(p.Config, "retry")
+	delete(p.Config, "max_retries")
 	delete(p.Config, "type")
 	delete(p.Config, "timeout")
 

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -111,7 +111,7 @@ func TestParse(t *testing.T) {
 			&Template{
 				Provisioners: []*Provisioner{
 					{
-						Type:  "something",
+						Type:       "something",
 						MaxRetries: 5,
 					},
 				},

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -112,7 +112,7 @@ func TestParse(t *testing.T) {
 				Provisioners: []*Provisioner{
 					{
 						Type:  "something",
-						Retry: 5,
+						MaxRetries: 5,
 					},
 				},
 			},

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -107,6 +107,19 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"parse-provisioner-retry.json",
+			&Template{
+				Provisioners: []*Provisioner{
+					{
+						Type:  "something",
+						Retry: 5,
+					},
+				},
+			},
+			false,
+		},
+
+		{
 			"parse-provisioner-timeout.json",
 			&Template{
 				Provisioners: []*Provisioner{

--- a/template/template.go
+++ b/template/template.go
@@ -141,7 +141,7 @@ type Provisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty"`
 	Override    map[string]interface{} `json:"override,omitempty"`
 	PauseBefore time.Duration          `mapstructure:"pause_before" json:"pause_before,omitempty"`
-	MaxRetries       int                    `mapstructure:"max_retries" json:"retry,omitempty"`
+	MaxRetries  int                    `mapstructure:"max_retries" json:"retry,omitempty"`
 	Timeout     time.Duration          `mapstructure:"timeout" json:"timeout,omitempty"`
 }
 

--- a/template/template.go
+++ b/template/template.go
@@ -141,6 +141,7 @@ type Provisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty"`
 	Override    map[string]interface{} `json:"override,omitempty"`
 	PauseBefore time.Duration          `mapstructure:"pause_before" json:"pause_before,omitempty"`
+	Retry       int                    `mapstructure:"retry" json:"retry,omitempty"`
 	Timeout     time.Duration          `mapstructure:"timeout" json:"timeout,omitempty"`
 }
 

--- a/template/template.go
+++ b/template/template.go
@@ -141,7 +141,7 @@ type Provisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty"`
 	Override    map[string]interface{} `json:"override,omitempty"`
 	PauseBefore time.Duration          `mapstructure:"pause_before" json:"pause_before,omitempty"`
-	MaxRetries  int                    `mapstructure:"max_retries" json:"retry,omitempty"`
+	MaxRetries  int                    `mapstructure:"max_retries" json:"max_retries,omitempty"`
 	Timeout     time.Duration          `mapstructure:"timeout" json:"timeout,omitempty"`
 }
 

--- a/template/template.go
+++ b/template/template.go
@@ -141,7 +141,7 @@ type Provisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty"`
 	Override    map[string]interface{} `json:"override,omitempty"`
 	PauseBefore time.Duration          `mapstructure:"pause_before" json:"pause_before,omitempty"`
-	Retry       int                    `mapstructure:"retry" json:"retry,omitempty"`
+	MaxRetries       int                    `mapstructure:"max_retries" json:"retry,omitempty"`
 	Timeout     time.Duration          `mapstructure:"timeout" json:"timeout,omitempty"`
 }
 

--- a/template/template.hcl2spec.go
+++ b/template/template.hcl2spec.go
@@ -15,7 +15,7 @@ type FlatProvisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty" cty:"config"`
 	Override    map[string]interface{} `json:"override,omitempty" cty:"override"`
 	PauseBefore *string                `mapstructure:"pause_before" json:"pause_before,omitempty" cty:"pause_before"`
-	MaxRetries  *int                   `mapstructure:"max_retries" json:"retry,omitempty" cty:"max_retries"`
+	MaxRetries  *int                   `mapstructure:"max_retries" json:"max_retries,omitempty" cty:"max_retries"`
 	Timeout     *string                `mapstructure:"timeout" json:"timeout,omitempty" cty:"timeout"`
 }
 

--- a/template/template.hcl2spec.go
+++ b/template/template.hcl2spec.go
@@ -15,6 +15,7 @@ type FlatProvisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty" cty:"config"`
 	Override    map[string]interface{} `json:"override,omitempty" cty:"override"`
 	PauseBefore *string                `mapstructure:"pause_before" json:"pause_before,omitempty" cty:"pause_before"`
+	Retry       *int                   `mapstructure:"retry" json:"retry,omitempty" cty:"retry"`
 	Timeout     *string                `mapstructure:"timeout" json:"timeout,omitempty" cty:"timeout"`
 }
 
@@ -36,6 +37,7 @@ func (*FlatProvisioner) HCL2Spec() map[string]hcldec.Spec {
 		"config":       &hcldec.AttrSpec{Name: "config", Type: cty.Map(cty.String), Required: false},
 		"override":     &hcldec.AttrSpec{Name: "override", Type: cty.Map(cty.String), Required: false},
 		"pause_before": &hcldec.AttrSpec{Name: "pause_before", Type: cty.String, Required: false},
+		"retry":        &hcldec.AttrSpec{Name: "retry", Type: cty.Number, Required: false},
 		"timeout":      &hcldec.AttrSpec{Name: "timeout", Type: cty.String, Required: false},
 	}
 	return s

--- a/template/template.hcl2spec.go
+++ b/template/template.hcl2spec.go
@@ -15,7 +15,7 @@ type FlatProvisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty" cty:"config"`
 	Override    map[string]interface{} `json:"override,omitempty" cty:"override"`
 	PauseBefore *string                `mapstructure:"pause_before" json:"pause_before,omitempty" cty:"pause_before"`
-	Retry       *int                   `mapstructure:"retry" json:"retry,omitempty" cty:"retry"`
+	MaxRetries  *int                   `mapstructure:"max_retries" json:"retry,omitempty" cty:"max_retries"`
 	Timeout     *string                `mapstructure:"timeout" json:"timeout,omitempty" cty:"timeout"`
 }
 
@@ -37,7 +37,7 @@ func (*FlatProvisioner) HCL2Spec() map[string]hcldec.Spec {
 		"config":       &hcldec.AttrSpec{Name: "config", Type: cty.Map(cty.String), Required: false},
 		"override":     &hcldec.AttrSpec{Name: "override", Type: cty.Map(cty.String), Required: false},
 		"pause_before": &hcldec.AttrSpec{Name: "pause_before", Type: cty.String, Required: false},
-		"retry":        &hcldec.AttrSpec{Name: "retry", Type: cty.Number, Required: false},
+		"max_retries":  &hcldec.AttrSpec{Name: "max_retries", Type: cty.Number, Required: false},
 		"timeout":      &hcldec.AttrSpec{Name: "timeout", Type: cty.String, Required: false},
 	}
 	return s

--- a/template/test-fixtures/parse-provisioner-retry.json
+++ b/template/test-fixtures/parse-provisioner-retry.json
@@ -2,7 +2,7 @@
     "provisioners": [
         {
             "type": "something",
-            "retry": 5
+            "max_retries": 5
         }
     ]
 }

--- a/template/test-fixtures/parse-provisioner-retry.json
+++ b/template/test-fixtures/parse-provisioner-retry.json
@@ -1,0 +1,8 @@
+{
+    "provisioners": [
+        {
+            "type": "something",
+            "retry": 5
+        }
+    ]
+}

--- a/website/pages/docs/templates/provisioners.mdx
+++ b/website/pages/docs/templates/provisioners.mdx
@@ -184,14 +184,14 @@ Specifically, in cases where the provisioner depends on external processes that 
 
 
 Every provisioner definition in a Packer template can take a special
-configuration `retry` that is the maximum number of times a provisioner will retry on error.
-By default, there is no retry. An example is shown below:
+configuration `max_retries` that is the maximum number of times a provisioner will retry on error.
+By default, there `max_retries` is zero and there is no retry on error. An example is shown below:
 
 ```json
 {
   "type": "shell",
   "script": "script.sh",
-  "retry": 5
+  "max_retries": 5
 }
 ```
 

--- a/website/pages/docs/templates/provisioners.mdx
+++ b/website/pages/docs/templates/provisioners.mdx
@@ -177,6 +177,27 @@ that provisioner. By default, there is no pause. An example is shown below:
 For the above provisioner, Packer will wait 10 seconds before uploading and
 executing the shell script.
 
+## Retry on error
+
+With certain provisioners it is sometimes desirable to retry when it fails.
+Specifically, in cases where the provisioner depends on external processes that are not done yet.
+
+
+Every provisioner definition in a Packer template can take a special
+configuration `retry` that is the maximum number of times a provisioner will retry on error.
+By default, there is no retry. An example is shown below:
+
+```json
+{
+  "type": "shell",
+  "script": "script.sh",
+  "retry": 5
+}
+```
+
+For the above provisioner, Packer will retry maximum five times until stops failing.
+If after five retries the provisioner still fails, then the complete build will fail.
+
 ## Timeout
 
 Sometimes a command can take much more time than expected

--- a/website/pages/partials/provisioners/common-config.mdx
+++ b/website/pages/partials/provisioners/common-config.mdx
@@ -2,7 +2,7 @@ Parameters common to all provisioners:
 
 - `pause_before` (duration) - Sleep for duration before execution.
 
-- `retry` (int) - Max times the provisioner will retry in case of failure.
+- `max_retries` (int) - Max times the provisioner will retry in case of failure. Defaults to zero (0). Zero means an error will not be retried.
 
 - `only` (array of string) - Only run the provisioner for listed builder(s)
   by name.

--- a/website/pages/partials/provisioners/common-config.mdx
+++ b/website/pages/partials/provisioners/common-config.mdx
@@ -2,6 +2,8 @@ Parameters common to all provisioners:
 
 - `pause_before` (duration) - Sleep for duration before execution.
 
+- `retry` (int) - Max times the provisioner will retried in case of failure.
+
 - `only` (array of string) - Only run the provisioner for listed builder(s)
   by name.
 

--- a/website/pages/partials/provisioners/common-config.mdx
+++ b/website/pages/partials/provisioners/common-config.mdx
@@ -2,7 +2,7 @@ Parameters common to all provisioners:
 
 - `pause_before` (duration) - Sleep for duration before execution.
 
-- `retry` (int) - Max times the provisioner will retried in case of failure.
+- `retry` (int) - Max times the provisioner will retry in case of failure.
 
 - `only` (array of string) - Only run the provisioner for listed builder(s)
   by name.


### PR DESCRIPTION
This PR adds a `max_retries` option to all provisioners. If the retry option is set to 1 or more, the provisioner will retry until it doesn't fail anymore or reach the max number of retries. 
If used with `pause_before`, the provisioner will still pause before retrying again. 

<summary>shell-local provisioner acceptance test output logs</summary>
<details>

```
2020/04/14 15:26:21 ui: ==> amazon-ebs: Provisioning with shell script: test-fixtures/script.sh
2020/04/14 15:26:21 Opening test-fixtures/script.sh for reading
2020/04/14 15:26:21 [DEBUG] Opening new ssh session
2020/04/14 15:26:21 [DEBUG] Starting remote scp process:  scp -vt /tmp
2020/04/14 15:26:22 [DEBUG] Started SCP session, beginning transfers...
2020/04/14 15:26:22 [DEBUG] Copying input data into temporary file so we can read the length
2020/04/14 15:26:22 [DEBUG] scp: Uploading script_9959.sh: perms=C0644 size=85
2020/04/14 15:26:22 [DEBUG] SCP session complete, closing stdin pipe.
2020/04/14 15:26:22 [DEBUG] Waiting for SSH session to complete.
2020/04/14 15:26:22 [DEBUG] scp stderr (length 30): Sink: C0644 85 script_9959.sh
2020/04/14 15:26:22 [DEBUG] Opening new ssh session
2020/04/14 15:26:22 [DEBUG] starting remote command: chmod 0755 /tmp/script_9959.sh
2020/04/14 15:26:22 [DEBUG] Opening new ssh session
2020/04/14 15:26:22 [DEBUG] starting remote command: chmod +x /tmp/script_9959.sh; PACKER_BUILDER_TYPE='amazon-ebs' PACKER_BUILD_NAME='amazon-ebs'  /tmp/script_9959.sh
2020/04/14 15:26:22 [ERROR] Remote command exited with '1': chmod +x /tmp/script_9959.sh; PACKER_BUILDER_TYPE='amazon-ebs' PACKER_BUILD_NAME='amazon-ebs'  /tmp/script_9959.sh
2020/04/14 15:26:22 ui: ==> amazon-ebs: Retrying provisioner
2020/04/14 15:26:22 ui: ==> amazon-ebs: Provisioning with shell script: test-fixtures/script.sh
2020/04/14 15:26:22 Opening test-fixtures/script.sh for reading
2020/04/14 15:26:22 [DEBUG] Opening new ssh session
2020/04/14 15:26:23 [DEBUG] Starting remote scp process:  scp -vt /tmp
2020/04/14 15:26:23 [DEBUG] Started SCP session, beginning transfers...
2020/04/14 15:26:23 [DEBUG] Copying input data into temporary file so we can read the length
2020/04/14 15:26:23 [DEBUG] scp: Uploading script_9959.sh: perms=C0644 size=85
2020/04/14 15:26:23 [DEBUG] SCP session complete, closing stdin pipe.
2020/04/14 15:26:23 [DEBUG] Waiting for SSH session to complete.
2020/04/14 15:26:23 [DEBUG] scp stderr (length 30): Sink: C0644 85 script_9959.sh
2020/04/14 15:26:23 [DEBUG] Opening new ssh session
2020/04/14 15:26:23 [DEBUG] starting remote command: chmod 0755 /tmp/script_9959.sh
2020/04/14 15:26:23 [DEBUG] Opening new ssh session
2020/04/14 15:26:23 [DEBUG] starting remote command: chmod +x /tmp/script_9959.sh; PACKER_BUILDER_TYPE='amazon-ebs' PACKER_BUILD_NAME='amazon-ebs'  /tmp/script_9959.sh
2020/04/14 15:26:24 [DEBUG] Opening new ssh session
2020/04/14 15:26:24 [DEBUG] starting remote command: rm -f /tmp/script_9959.sh
2020/04/14 15:26:24 [DEBUG] Opening new ssh session
2020/04/14 15:26:24 [DEBUG] starting remote command: rm -f
2020/04/14 15:26:25 ui: ==> amazon-ebs: Stopping the source instance...
2020/04/14 15:26:25 ui:     amazon-ebs: Stopping instance
2020/04/14 15:26:26 ui: ==> amazon-ebs: Waiting for the instance to stop...
2020/04/14 15:27:16 ui: ==> amazon-ebs: Creating AMI packer-acc-test from instance i-0866cce11ee2289c2
2020/04/14 15:27:18 ui:     amazon-ebs: AMI: ami-00ea22d233759b39e
2020/04/14 15:27:18 ui: ==> amazon-ebs: Waiting for AMI to become ready...
2020/04/14 15:28:06 ui: ==> amazon-ebs: Adding tags to AMI (ami-00ea22d233759b39e)...
2020/04/14 15:28:07 ui: ==> amazon-ebs: Tagging snapshot: snap-03586084ddc2a16ec
2020/04/14 15:28:07 ui: ==> amazon-ebs: Creating AMI tags
2020/04/14 15:28:07 ui:     amazon-ebs: Adding tag: "packer-test": "true"
2020/04/14 15:28:07 ui: ==> amazon-ebs: Creating snapshot tags
2020/04/14 15:28:07 ui: ==> amazon-ebs: Terminating the source AWS instance...
2020/04/14 15:28:26 ui: ==> amazon-ebs: Cleaning up any extra volumes...
2020/04/14 15:28:28 ui: ==> amazon-ebs: No volumes to clean up, skipping
2020/04/14 15:28:28 ui: ==> amazon-ebs: Deleting temporary security group...
2020/04/14 15:28:29 ui: ==> amazon-ebs: Deleting temporary keypair...
2020/04/14 15:28:30 ui: Build 'amazon-ebs' finished.
2020/04/14 15:28:30 ui:
==> Builds finished. The artifacts of successful builds are:
```

</details>

Closes https://github.com/hashicorp/packer/issues/8972