### PR TITLE
builder/vmware: Add some additional debug logging to the driver version check

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -144,12 +144,13 @@ func NewDriver(dconfig *DriverConfig, config *SSHConfig, vmName string) (Driver,
 	errs := ""
 	for _, driver := range drivers {
 		err := driver.Verify()
-		log.Printf("Testing vmware driver %T. Success: %t",
-			driver, err == nil)
 
+		log.Printf("Testing against vmware driver %T, Success: %t", driver, err == nil)
 		if err == nil {
 			return driver, nil
 		}
+
+		log.Printf("skipping %T because it failed with the following error %s", driver, err)
 		errs += "* " + err.Error() + "\n"
 	}
 


### PR DESCRIPTION
This adds an additional log entry to output the reason why a particular Driver verification checked failed.


Related #9044