### PR TITLE
[builder/azure-arm] Use VM/build location for image location

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -111,12 +111,10 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	}
 
 	if b.config.isManagedImage() {
-		group, err := azureClient.GroupsClient.Get(ctx, b.config.ManagedImageResourceGroupName)
+		_, err := azureClient.GroupsClient.Get(ctx, b.config.ManagedImageResourceGroupName)
 		if err != nil {
 			return nil, fmt.Errorf("Cannot locate the managed image resource group %s.", b.config.ManagedImageResourceGroupName)
 		}
-
-		b.config.manageImageLocation = *group.Location
 
 		// If a managed image already exists it cannot be overwritten.
 		_, err = azureClient.ImagesClient.Get(ctx, b.config.ManagedImageResourceGroupName, b.config.ManagedImageName, "")
@@ -311,7 +309,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			return NewManagedImageArtifactWithSIGAsDestination(b.config.OSType,
 				b.config.ManagedImageResourceGroupName,
 				b.config.ManagedImageName,
-				b.config.manageImageLocation,
+				b.config.Location,
 				managedImageID,
 				b.config.ManagedImageOSDiskSnapshotName,
 				b.config.ManagedImageDataDiskSnapshotPrefix,
@@ -321,7 +319,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		return NewManagedImageArtifact(b.config.OSType,
 			b.config.ManagedImageResourceGroupName,
 			b.config.ManagedImageName,
-			b.config.manageImageLocation,
+			b.config.Location,
 			managedImageID,
 			b.config.ManagedImageOSDiskSnapshotName,
 			b.config.ManagedImageDataDiskSnapshotPrefix,
@@ -448,7 +446,6 @@ func (b *Builder) configureStateBag(stateBag multistep.StateBag) {
 // Parameters that are only known at runtime after querying Azure.
 func (b *Builder) setRuntimeParameters(stateBag multistep.StateBag) {
 	stateBag.Put(constants.ArmLocation, b.config.Location)
-	stateBag.Put(constants.ArmManagedImageLocation, b.config.manageImageLocation)
 }
 
 func (b *Builder) setTemplateParameters(stateBag multistep.StateBag) {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -233,7 +233,6 @@ type Config struct {
 	// disk(s) is created with the same prefix as this value before the VM is
 	// captured.
 	ManagedImageDataDiskSnapshotPrefix string `mapstructure:"managed_image_data_disk_snapshot_prefix" required:"false"`
-	manageImageLocation                string
 	// Store the image in zone-resilient storage. You need to create it in a
 	// region that supports [availability
 	// zones](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).

--- a/builder/azure/arm/step_capture_image.go
+++ b/builder/azure/arm/step_capture_image.go
@@ -77,7 +77,7 @@ func (s *StepCaptureImage) Run(ctx context.Context, state multistep.StateBag) mu
 	var isManagedImage = state.Get(constants.ArmIsManagedImage).(bool)
 	var targetManagedImageResourceGroupName = state.Get(constants.ArmManagedImageResourceGroupName).(string)
 	var targetManagedImageName = state.Get(constants.ArmManagedImageName).(string)
-	var targetManagedImageLocation = state.Get(constants.ArmManagedImageLocation).(string)
+	var targetManagedImageLocation = state.Get(constants.ArmLocation).(string)
 
 	s.say(fmt.Sprintf(" -> Compute ResourceGroupName : '%s'", resourceGroupName))
 	s.say(fmt.Sprintf(" -> Compute Name              : '%s'", computeName))

--- a/builder/azure/arm/step_capture_image_test.go
+++ b/builder/azure/arm/step_capture_image_test.go
@@ -131,7 +131,6 @@ func createTestStateBagStepCaptureImage() multistep.StateBag {
 	stateBag.Put(constants.ArmIsManagedImage, false)
 	stateBag.Put(constants.ArmManagedImageResourceGroupName, "")
 	stateBag.Put(constants.ArmManagedImageName, "")
-	stateBag.Put(constants.ArmManagedImageLocation, "")
 	stateBag.Put(constants.ArmImageParameters, &compute.Image{})
 
 	return stateBag

--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -131,15 +131,15 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 		miSigReplicaCount = constants.SharedImageGalleryImageVersionDefaultMaxReplicaCount
 	}
 
-	s.say(fmt.Sprintf(" -> MDI ID used for SIG publish		: '%s'", mdiID))
-	s.say(fmt.Sprintf(" -> SIG publish resource group		: '%s'", miSigPubRg))
-	s.say(fmt.Sprintf(" -> SIG gallery name				: '%s'", miSIGalleryName))
-	s.say(fmt.Sprintf(" -> SIG image name				: '%s'", miSGImageName))
-	s.say(fmt.Sprintf(" -> SIG image version			: '%s'", miSGImageVersion))
-	s.say(fmt.Sprintf(" -> SIG replication regions			: '%v'", miSigReplicationRegions))
-	s.say(fmt.Sprintf(" -> SIG image version endoflife date		: '%s'", miSGImageVersionEndOfLifeDate))
-	s.say(fmt.Sprintf(" -> SIG image version exclude from latest	: '%t'", miSGImageVersionExcludeFromLatest))
-	s.say(fmt.Sprintf(" -> SIG replica count [1, 10] 		: '%d'", miSigReplicaCount))
+	s.say(fmt.Sprintf(" -> MDI ID used for SIG publish           : '%s'", mdiID))
+	s.say(fmt.Sprintf(" -> SIG publish resource group            : '%s'", miSigPubRg))
+	s.say(fmt.Sprintf(" -> SIG gallery name                      : '%s'", miSIGalleryName))
+	s.say(fmt.Sprintf(" -> SIG image name                        : '%s'", miSGImageName))
+	s.say(fmt.Sprintf(" -> SIG image version                     : '%s'", miSGImageVersion))
+	s.say(fmt.Sprintf(" -> SIG replication regions               : '%v'", miSigReplicationRegions))
+	s.say(fmt.Sprintf(" -> SIG image version endoflife date      : '%s'", miSGImageVersionEndOfLifeDate))
+	s.say(fmt.Sprintf(" -> SIG image version exclude from latest : '%t'", miSGImageVersionExcludeFromLatest))
+	s.say(fmt.Sprintf(" -> SIG replica count [1, 10]             : '%d'", miSigReplicaCount))
 
 	createdGalleryImageVersionID, err := s.publish(ctx, mdiID, miSigPubRg, miSIGalleryName, miSGImageName, miSGImageVersion, miSigReplicationRegions, miSGImageVersionEndOfLifeDate, miSGImageVersionExcludeFromLatest, miSigReplicaCount, location, tags)
 

--- a/builder/azure/common/constants/stateBag.go
+++ b/builder/azure/common/constants/stateBag.go
@@ -40,7 +40,6 @@ const (
 
 	ArmIsManagedImage                                         string = "arm.IsManagedImage"
 	ArmManagedImageResourceGroupName                          string = "arm.ManagedImageResourceGroupName"
-	ArmManagedImageLocation                                   string = "arm.ManagedImageLocation"
 	ArmManagedImageName                                       string = "arm.ManagedImageName"
 	ArmManagedImageSigPublishResourceGroup                    string = "arm.ManagedImageSigPublishResourceGroup"
 	ArmManagedImageSharedGalleryName                          string = "arm.ManagedImageSharedGalleryName"

--- a/builder/azure/dtl/builder.go
+++ b/builder/azure/dtl/builder.go
@@ -313,7 +313,6 @@ func (b *Builder) configureStateBag(stateBag multistep.StateBag) {
 // Parameters that are only known at runtime after querying Azure.
 func (b *Builder) setRuntimeParameters(stateBag multistep.StateBag) {
 	stateBag.Put(constants.ArmLocation, b.config.Location)
-	stateBag.Put(constants.ArmManagedImageLocation, b.config.Location)
 }
 
 func (b *Builder) setTemplateParameters(stateBag multistep.StateBag) {


### PR DESCRIPTION
The builder was using the location of the containing resource group as
the image location, but the API call can only create images in the same
location as the source VM that is being captured.

Closes #8895
