### PR TITLE
Changed default disk size for when using googlecompute

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -215,7 +215,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.DiskSizeGb == 0 {
-		c.DiskSizeGb = 10
+		c.DiskSizeGb = 20
 	}
 
 	if c.DiskType == "" {


### PR DESCRIPTION
Google have changed there minimum disk size for compute instances. The long term fix would be to extract the minimum disk size from the api and use that if no specified but this solves the problems for now. 

Error message before this patch: 

`==> googlecompute: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.disks[0].initializeParams.diskSizeGb': '10'. Requested disk size cannot be smaller than the image size (20 GB), invalid
Build 'googlecompute' errored: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.disks[0].initializeParams.diskSizeGb': '10'. Requested disk size cannot be smaller than the image size (20 GB), invalid`

Closes #9023