### PR TITLE
Revert golangci-lint to use new-from-rev pinned at 1.23.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ install-gen-deps: ## Install dependencies for code generation
 	@go install ./cmd/mapstructure-to-hcl2
 
 install-lint-deps: ## Install linter dependencies
+	# Pinning golangci-lint at v1.23.8 as --new-from-rev seems to work properly; the latest 1.24.0 has caused issues with memory consumption
 	@echo "==> Updating linter dependencies..."
 	@curl -sSfL -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.23.8
 
@@ -86,7 +87,7 @@ lint: install-lint-deps ## Lint Go code
 
 ci-lint: install-lint-deps ## On ci only lint newly added Go source files
 	@echo "==> Running linter on newly added Go source files..."
-	@GO111MODULE=on sh -c "$(CURDIR)/scripts/lint.sh"
+	GO111MODULE=on golangci-lint run --new-from-rev=$(shell git merge-base origin/master HEAD) ./...
 
 fmt: ## Format Go code
 	@go fmt ./...

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-CHANGED_FILES=$(git diff --name-status `git merge-base origin/master HEAD`...HEAD | grep '^A.*\.go$'| awk '{print $2}')
-if [ ! -z "${CHANGED_FILES}" ]; then
-  echo $CHANGED_FILES | xargs -n1 golangci-lint run
-fi


### PR DESCRIPTION
Turns out linting each file individually causes issues with the linter not being able to find the import types.

Results of a bogus test file ci-run https://app.circleci.com/pipelines/github/hashicorp/packer/4623/workflows/672bc2da-dbbd-40c4-b8ad-861412686d34/jobs/45881

This change comes after an issue being reported at https://github.com/hashicorp/packer/pull/9043#issuecomment-613876899