### PR TITLE
scripts/build: Remove unsupported Freebsd/arm builds from build chain

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,6 +4,7 @@
 # Determine the arch/os combos we're building for
 ALL_XC_ARCH="386 amd64 arm arm64 ppc64le mips mips64 mipsle mipsle64 s390x"
 ALL_XC_OS="linux darwin windows freebsd openbsd solaris"
+SKIPPED_OSARCH="!darwin/arm !darwin/arm64 !freebsd/arm !freebsd/arm64"
 
 # Exit immediately if a command fails
 set -e
@@ -130,7 +131,7 @@ set +e
 ${GOX:?command not found} \
     -os="${XC_OS:-$ALL_XC_OS}" \
     -arch="${XC_ARCH:-$ALL_XC_ARCH}" \
-    -osarch="!darwin/arm !darwin/arm64" \
+    -osarch="${SKIPPED_OSARCH}" \
     -ldflags "${GOLDFLAGS}" \
     -output "pkg/{{.OS}}_{{.Arch}}/packer" \
     .


### PR DESCRIPTION
Note: Freebsd ARM builds have not been released for sometime now

Builds before change
```
⇶  make bin
WARN: 'make bin' is for debug / test builds only. Use 'make release' for
release builds.
==> Checking for necessary tools...
==> Entering Packer source dir...
==> Ensuring output directories are present...
==> Removing old builds...
==> Building...
Number of parallel builds: 3

-->     linux/s390x: github.com/hashicorp/packer
-->     linux/amd64: github.com/hashicorp/packer
-->       linux/arm: github.com/hashicorp/packer
-->   solaris/amd64: github.com/hashicorp/packer
-->      linux/mips: github.com/hashicorp/packer
-->     freebsd/386: github.com/hashicorp/packer
-->     linux/arm64: github.com/hashicorp/packer
-->    linux/mips64: github.com/hashicorp/packer
-->    linux/mipsle: github.com/hashicorp/packer
-->    darwin/amd64: github.com/hashicorp/packer
-->       linux/386: github.com/hashicorp/packer
-->      darwin/386: github.com/hashicorp/packer
-->     windows/386: github.com/hashicorp/packer
-->   windows/amd64: github.com/hashicorp/packer
-->   linux/ppc64le: github.com/hashicorp/packer
-->     openbsd/386: github.com/hashicorp/packer
-->     freebsd/arm: github.com/hashicorp/packer
-->   openbsd/amd64: github.com/hashicorp/packer
-->   freebsd/amd64: github.com/hashicorp/packer

1 errors occurred:
--> freebsd/arm error: exit status 2
Stderr: # github.com/shirou/gopsutil/cpu
../go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:25:16:
undefined: cpuTimes
../go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:42:31:
undefined: cpuTimes
../go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:66:38:
undefined: cpuTimes
../go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:72:15:
undefined: cpuTimes
../go/pkg/mod/github.com/shirou/gopsutil@v2.18.12+incompatible/cpu/cpu_freebsd.go:87:13:
undefined: cpuTimes

==> Copying binaries for this platform...
'./pkg/linux_amd64/packer' -> 'bin/packer'
'./pkg/linux_amd64/packer' -> '/home/wilken/Development/go/bin/packer'

==> Results:
total 111M
-rwxr-xr-x 1 wilken wilken 111M Apr 14 22:02 packer
```

Builds after change
```
⇶  make bin
WARN: 'make bin' is for debug / test builds only. Use 'make release' for
release builds.
==> Checking for necessary tools...
==> Entering Packer source dir...
==> Ensuring output directories are present...
==> Removing old builds...
==> Building...
Number of parallel builds: 3

-->   solaris/amd64: github.com/hashicorp/packer
-->   windows/amd64: github.com/hashicorp/packer
-->     linux/s390x: github.com/hashicorp/packer
-->    darwin/amd64: github.com/hashicorp/packer
-->      darwin/386: github.com/hashicorp/packer
-->     windows/386: github.com/hashicorp/packer
-->   freebsd/amd64: github.com/hashicorp/packer
-->     freebsd/386: github.com/hashicorp/packer
-->     openbsd/386: github.com/hashicorp/packer
-->   openbsd/amd64: github.com/hashicorp/packer
-->     linux/arm64: github.com/hashicorp/packer
-->       linux/386: github.com/hashicorp/packer
-->     linux/amd64: github.com/hashicorp/packer
-->       linux/arm: github.com/hashicorp/packer
-->      linux/mips: github.com/hashicorp/packer
-->   linux/ppc64le: github.com/hashicorp/packer
-->    linux/mips64: github.com/hashicorp/packer
-->    linux/mipsle: github.com/hashicorp/packer
==> Copying binaries for this platform...
'./pkg/linux_amd64/packer' -> 'bin/packer'
'./pkg/linux_amd64/packer' ->
'/home/wilken/Development/golang/bin/packer'

==> Results:
total 111M
-rwxr-xr-x 1 wilken wilken 111M Apr 15 20:52 packer
```