### PR TITLE
Compliance with oAPI spec for Outscale osc-bsu builder

### DIFF
--- a/builder/osc/common/step_run_source_vm.go
+++ b/builder/osc/common/step_run_source_vm.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	RunSourceVmBSUExpectedRootDevice = "ebs"
+	RunSourceVmBSUExpectedRootDevice = "bsu"
 )
 
 type StepRunSourceVm struct {


### PR DESCRIPTION
Hello,

oAPI specs expects "bsu" for RootDeviceTypes in OMIs (https://docs.outscale.com/api#readimages) instead of "ebs". 
This MR fixes that.