### PR TITLE
Add disable_shutdown option to VSphere builders

### DIFF
--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -92,6 +92,7 @@ type FlatConfig struct {
 	WinRMUseNTLM              *bool                    `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm"`
 	Command                   *string                  `mapstructure:"shutdown_command" cty:"shutdown_command"`
 	Timeout                   *string                  `mapstructure:"shutdown_timeout" cty:"shutdown_timeout"`
+	DisableShutdown           *bool                    `mapstructure:"disable_shutdown" cty:"disable_shutdown"`
 	CreateSnapshot            *bool                    `mapstructure:"create_snapshot" cty:"create_snapshot"`
 	ConvertToTemplate         *bool                    `mapstructure:"convert_to_template" cty:"convert_to_template"`
 	Export                    *common.FlatExportConfig `mapstructure:"export" cty:"export"`
@@ -191,6 +192,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"shutdown_command":             &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":             &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
+		"disable_shutdown":             &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
 		"create_snapshot":              &hcldec.AttrSpec{Name: "create_snapshot", Type: cty.Bool, Required: false},
 		"convert_to_template":          &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
 		"export":                       &hcldec.BlockSpec{TypeName: "export", Nested: hcldec.ObjectSpec((*common.FlatExportConfig)(nil).HCL2Spec())},

--- a/builder/vsphere/common/step_shutdown.hcl2spec.go
+++ b/builder/vsphere/common/step_shutdown.hcl2spec.go
@@ -9,8 +9,9 @@ import (
 // FlatShutdownConfig is an auto-generated flat version of ShutdownConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatShutdownConfig struct {
-	Command *string `mapstructure:"shutdown_command" cty:"shutdown_command"`
-	Timeout *string `mapstructure:"shutdown_timeout" cty:"shutdown_timeout"`
+	Command         *string `mapstructure:"shutdown_command" cty:"shutdown_command"`
+	Timeout         *string `mapstructure:"shutdown_timeout" cty:"shutdown_timeout"`
+	DisableShutdown *bool   `mapstructure:"disable_shutdown" cty:"disable_shutdown"`
 }
 
 // FlatMapstructure returns a new FlatShutdownConfig.
@@ -27,6 +28,7 @@ func (*FlatShutdownConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"shutdown_command": &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout": &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
+		"disable_shutdown": &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -454,6 +454,15 @@ func (vm *VirtualMachine) PowerOff() error {
 	return err
 }
 
+func (vm *VirtualMachine) IsPoweredOff() (bool, error) {
+	state, err := vm.vm.PowerState(vm.driver.ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return state == types.VirtualMachinePowerStatePoweredOff, nil
+}
+
 func (vm *VirtualMachine) StartShutdown() error {
 	err := vm.vm.ShutdownGuest(vm.driver.ctx)
 	return err
@@ -462,11 +471,11 @@ func (vm *VirtualMachine) StartShutdown() error {
 func (vm *VirtualMachine) WaitForShutdown(ctx context.Context, timeout time.Duration) error {
 	shutdownTimer := time.After(timeout)
 	for {
-		powerState, err := vm.vm.PowerState(vm.driver.ctx)
+		off, err := vm.IsPoweredOff()
 		if err != nil {
 			return err
 		}
-		if powerState == "poweredOff" {
+		if off {
 			break
 		}
 

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -118,6 +118,7 @@ type FlatConfig struct {
 	WinRMUseNTLM              *bool                    `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm"`
 	Command                   *string                  `mapstructure:"shutdown_command" cty:"shutdown_command"`
 	Timeout                   *string                  `mapstructure:"shutdown_timeout" cty:"shutdown_timeout"`
+	DisableShutdown           *bool                    `mapstructure:"disable_shutdown" cty:"disable_shutdown"`
 	CreateSnapshot            *bool                    `mapstructure:"create_snapshot" cty:"create_snapshot"`
 	ConvertToTemplate         *bool                    `mapstructure:"convert_to_template" cty:"convert_to_template"`
 	Export                    *common.FlatExportConfig `mapstructure:"export" cty:"export"`
@@ -243,6 +244,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"shutdown_command":             &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":             &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
+		"disable_shutdown":             &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
 		"create_snapshot":              &hcldec.AttrSpec{Name: "create_snapshot", Type: cty.Bool, Required: false},
 		"convert_to_template":          &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
 		"export":                       &hcldec.BlockSpec{TypeName: "export", Nested: hcldec.ObjectSpec((*common.FlatExportConfig)(nil).HCL2Spec())},

--- a/website/pages/partials/builder/vsphere/common/ShutdownConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/ShutdownConfig-not-required.mdx
@@ -3,6 +3,13 @@
 -   `shutdown_command` (string) - Specify a VM guest shutdown command. VMware guest tools are used by
     default.
     
--   `shutdown_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for graceful VM shutdown. Examples 45s and 10m.
-    Defaults to 5m(5 minutes).
+-   `shutdown_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for graceful VM shutdown.
+    Defaults to 5m or five minutes.
+    
+-   `disable_shutdown` (bool) - Packer normally halts the virtual machine after all provisioners have
+    run when no `shutdown_command` is defined. If this is set to `true`, Packer
+    *will not* halt the virtual machine but will assume that you will send the stop
+    signal yourself through the preseed.cfg or your final provisioner.
+    Packer will wait for a default of five minutes until the virtual machine is shutdown.
+    The timeout can be changed using `shutdown_timeout` option.
     


### PR DESCRIPTION
Also don't try to shut down VM if it's already off, otherwise VSphere would raise an error: "The attempted operation cannot be performed in the current state (Powered off)."

It's almost a copypaste from virtualbox builder, kudos to @sylviamoss.

I've actually stumbled across error powering off already powered off VM due to sysprep invocation in last provisioner.