### PR TITLE
Updating documentation for azure-arm builder

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -103,8 +103,9 @@ type Config struct {
 	// Authentication via OAUTH
 	ClientConfig client.Config `mapstructure:",squash"`
 
-	// Capture
-	CaptureNamePrefix    string `mapstructure:"capture_name_prefix"`
+	// VHD prefix.
+	CaptureNamePrefix string `mapstructure:"capture_name_prefix"`
+	// Destination container name.
 	CaptureContainerName string `mapstructure:"capture_container_name"`
 	// Use a [Shared Gallery
 	// image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
@@ -201,6 +202,7 @@ type Config struct {
 	CustomManagedImageResourceGroupName string `mapstructure:"custom_managed_image_resource_group_name" required:"true"`
 	customManagedImageID                string
 
+	// Azure datacenter in which your VM will build.
 	Location string `mapstructure:"location"`
 	// Size of the VM used for building. This can be changed when you deploy a
 	// VM from your VHD. See
@@ -330,10 +332,12 @@ type Config struct {
 	// tags to the image to ensure this information is not lost. The following
 	// tags are added.
 	//
+	// ```
 	// 1.  PlanName
 	// 2.  PlanProduct
 	// 3.  PlanPublisher
 	// 4.  PlanPromotionCode
+	// ```
 	//
 	PlanInfo PlanInformation `mapstructure:"plan_info" required:"false"`
 	// The default PollingDuration for azure is 15mins, this property will override

--- a/website/pages/docs/builders/azure/arm.mdx
+++ b/website/pages/docs/builders/azure/arm.mdx
@@ -9,7 +9,7 @@ sidebar_title: ARM
 
 Type: `azure-arm`
 
-Packer supports building VHDs and Managed Images in [Azure Resource
+Packer supports building Virtual Hard Disks (VHDs) and Managed Images in [Azure Resource
 Manager](https://azure.microsoft.com/en-us/documentation/articles/resource-group-overview/).
 Azure provides new users a [`$200` credit for the first 30
 days](https://azure.microsoft.com/en-us/free/); after which you will incur
@@ -68,7 +68,7 @@ you should specify `subscription_id`, `client_id` and one of `client_secret`,
 
 ### Azure ARM builder specific options
 
-The Azure builder can create either a VHD, or a managed image. If you are
+The Azure builder can create either a VHD or a managed image. If you are
 creating a VHD, you **must** start with a VHD. Likewise, if you want to create
 a managed image you **must** start with a managed image.
 
@@ -110,15 +110,15 @@ When creating a managed image the following additional options are required:
 
 #### Shared Image Gallery
 
-Managed images can optionally be published to [Shared Image Gallery](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
-as Shared Gallery Image version. Shared Image Gallery **only** works with Managed Images. **A VHD cannot be published to
+Managed images can optionally be published to a [Shared Image Gallery](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
+as a Shared Gallery Image version. Publishing to a Shared Image Gallery **only** works with Managed Images. **A VHD cannot be published to
 a Shared Image Gallery**.
 
 When publishing to a Shared Image Gallery the following options are required.
 
-- `shared_image_gallery_destination` (object) The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
+- `shared_image_gallery_destination` (object) - The name of the Shared Image Gallery under which the managed image will be published as an image version.
 
-Following is an example.
+The following is an example.
 
     "shared_image_gallery_destination": {
         "resource_group": "ResourceGroup",
@@ -129,6 +129,18 @@ Following is an example.
     }
     "managed_image_name": "TargetImageName",
     "managed_image_resource_group_name": "TargetResourceGroup"
+
+The `shared_image_gallery_destination` object expects the following attributes.
+
+- `resource_group` (string) - The resource group where the Shared Image Gallery is located.
+
+- `gallery_name` (string) - The name of the Shared Image Gallery where the managed image will be published.
+
+- `image_name` (string) - The name of the image definition within the Shared Image Gallery where the managed image will be published. This image definition must already exist.
+
+- `image_version` (string) - The version of the managed image to publish within the Shared Image Gallery.
+
+- `replication_regions` ([]string) - The regions where the published Share Image Gallery managed image should be replicated to.
 
 #### Resource Group Usage
 

--- a/website/pages/partials/builder/azure/arm/Config-not-required.mdx
+++ b/website/pages/partials/builder/azure/arm/Config-not-required.mdx
@@ -1,8 +1,9 @@
 <!-- Code generated from the comments of the Config struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
--   `capture_name_prefix` (string) - Capture
+-   `capture_name_prefix` (string) - VHD prefix.
     
--   `capture_container_name` (string) - Capture Container Name
+-   `capture_container_name` (string) - Destination container name.
+    
 -   `shared_image_gallery` (SharedImageGallery) - Use a [Shared Gallery
     image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
     as the source for this build. *VHD targets are incompatible with this
@@ -59,7 +60,8 @@
     CLI example
     `az vm image list --location westus --publisher Canonical --offer UbuntuServer --sku 16.04.0-LTS --all`
     
--   `location` (string) - Location
+-   `location` (string) - Azure datacenter in which your VM will build.
+    
 -   `vm_size` (string) - Size of the VM used for building. This can be changed when you deploy a
     VM from your VHD. See
     [pricing](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/)
@@ -184,10 +186,12 @@
     tags to the image to ensure this information is not lost. The following
     tags are added.
     
+    ```
     1.  PlanName
     2.  PlanProduct
     3.  PlanPublisher
     4.  PlanPromotionCode
+    ```
     
 -   `polling_duration_timeout` (duration string | ex: "1h5m2s") - The default PollingDuration for azure is 15mins, this property will override
     that value. See [Azure DefaultPollingDuration](https://godoc.org/github.com/Azure/go-autorest/autorest#pkg-constants)


### PR DESCRIPTION
The current documentation for the `azure-arm` builder did not document the attributes passed to the `shared_image_gallery_destination` object.