### PR TITLE
builder/azure/chroot: fix dropped error

### DIFF
--- a/builder/azure/chroot/step_verify_shared_image_destination.go
+++ b/builder/azure/chroot/step_verify_shared_image_destination.go
@@ -92,6 +92,11 @@ func (s *StepVerifySharedImageDestination) Run(ctx context.Context, state multis
 		s.Image.GalleryName,
 		s.Image.ImageName)
 
+	if err != nil {
+		return errorMessage("Could not ListByGalleryImageComplete group:%v gallery:%v image:%v",
+			s.Image.ResourceGroup, s.Image.GalleryName, s.Image.ImageName)
+	}
+
 	for versions.NotDone() {
 		version := versions.Value()
 


### PR DESCRIPTION
This fixes a dropped error variable in `builder/azure/chroot`.