### PR TITLE
HCL2: docs warn about the fact that HCL2 support is still Beta at the top of each HCL docs page

### DIFF
--- a/website/pages/docs/from-1.5/expressions.mdx
+++ b/website/pages/docs/from-1.5/expressions.mdx
@@ -9,6 +9,10 @@ description: |-
 
 # Expressions
 
+-> **Note:** This page is about HCL2 in Packer 1.5 and later. HCL2 support for
+Packer is still in Beta. For the old-style stable configuration language see
+[template docs](/docs/templates).
+
 _Expressions_ are used to refer to or compute values within a configuration.
 The simplest expressions are just literal values, like `"hello"` or `5`, but
 HCL also allows more complex expressions such as references to data exported by

--- a/website/pages/docs/from-1.5/functions/index.mdx
+++ b/website/pages/docs/from-1.5/functions/index.mdx
@@ -9,6 +9,10 @@ description: |-
 
 # Built-in Functions
 
+-> **Note:** This page is about HCL2 in Packer 1.5 and later. HCL2 support for
+Packer is still in Beta. For the old-style stable configuration language see
+[template docs](/docs/templates).
+
 The HCL language includes a number of built-in functions that you can
 call from within expressions to transform and combine values. The general
 syntax for function calls is a function name followed by comma-separated

--- a/website/pages/docs/from-1.5/index.mdx
+++ b/website/pages/docs/from-1.5/index.mdx
@@ -10,6 +10,10 @@ description: |-
 
 # HCL Configuration Language
 
+-> **Note:** This page is about HCL2 in Packer 1.5 and later. HCL2 support for
+Packer is still in Beta. For the old-style stable configuration language see
+[template docs](/docs/templates).
+
 Packer uses the Hashicorp Configuration Language - HCL - designed to allow
 concise descriptions of the required steps to get to a build file. This page
 describes the features of HCL2 exhaustively, if you would like to give a quick

--- a/website/pages/docs/from-1.5/locals.mdx
+++ b/website/pages/docs/from-1.5/locals.mdx
@@ -9,6 +9,10 @@ description: >-
 
 # Local Values
 
+-> **Note:** This page is about HCL2 in Packer 1.5 and later. HCL2 support for
+Packer is still in Beta. For the old-style stable configuration language see
+[template docs](/docs/templates).
+
 Local values assign a name to an expression, that can then be used multiple
 times within a folder.
 

--- a/website/pages/docs/from-1.5/syntax-json.mdx
+++ b/website/pages/docs/from-1.5/syntax-json.mdx
@@ -9,6 +9,12 @@ description: |-
 
 # JSON Configuration Syntax
 
+-> **Note:** This page is about HCL2 in Packer 1.5 and later. Whilst HCL2
+supports JSON the JSON - JSON and the HCL2 - JSON have differents formats for
+Packer. HCL2 support for Packer is still in Beta. For the old-style stable
+configuration language see [template
+docs](/docs/templates).
+
 Most Packer configurations are written in [the native HCL
 syntax](/docs/from-1.5/syntax), which is designed to be easy for humans to read and
 update.

--- a/website/pages/docs/from-1.5/syntax.mdx
+++ b/website/pages/docs/from-1.5/syntax.mdx
@@ -10,6 +10,10 @@ description: |-
 
 # HCL Configuration Syntax
 
+-> **Note:** This page is about HCL2 in Packer 1.5 and later. HCL2 support for
+Packer is still in Beta. For the old-style stable configuration language see
+[template docs](/docs/templates).
+
 Other pages in this section have described various configuration constructs
 that can appear in HCL. This page describes the lower-level syntax of the
 language in more detail, revealing the building blocks that those constructs

--- a/website/pages/docs/from-1.5/variables.mdx
+++ b/website/pages/docs/from-1.5/variables.mdx
@@ -9,6 +9,10 @@ description: |-
 
 # Input Variables
 
+-> **Note:** This page is about HCL2 in Packer 1.5 and later. HCL2 support for
+Packer is still in Beta. For the old-style stable configuration language see
+[template docs](/docs/templates).
+
 Input variables serve as parameters for a Packer build, allowing aspects of the
 build to be customized without altering the build's own source code.
 


### PR DESCRIPTION

<img width="890" alt="Screenshot 2020-04-24 at 16 24 54" src="https://user-images.githubusercontent.com/1024852/80223120-25502c80-8648-11ea-92a7-edbdde6a74fc.png">

I also made a specific case for the HCL2-JSON page: I hope this is clear enough

<img width="913" alt="Screenshot 2020-04-24 at 16 25 13" src="https://user-images.githubusercontent.com/1024852/80223166-34cf7580-8648-11ea-8001-92ccb716ffa5.png">

fix #9112