### PR TITLE
Clean linting issues for packages template and interpolate

### DIFF
--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -298,14 +298,14 @@ func funcGenVault(ctx *Context) interface{} {
 		vaultConfig := vaultapi.DefaultConfig()
 		cli, err := vaultapi.NewClient(vaultConfig)
 		if err != nil {
-			return "", errors.New(fmt.Sprintf("Error getting Vault client: %s", err))
+			return "", fmt.Errorf("Error getting Vault client: %s", err)
 		}
 		secret, err := cli.Logical().Read(path)
 		if err != nil {
-			return "", errors.New(fmt.Sprintf("Error reading vault secret: %s", err))
+			return "", fmt.Errorf("Error reading vault secret: %s", err)
 		}
 		if secret == nil {
-			return "", errors.New(fmt.Sprintf("Vault Secret does not exist at the given path."))
+			return "", errors.New("Vault Secret does not exist at the given path")
 		}
 
 		data, ok := secret.Data["data"]
@@ -317,8 +317,8 @@ func funcGenVault(ctx *Context) interface{} {
 			}
 
 			// neither v1 nor v2 proudced a valid value
-			return "", errors.New(fmt.Sprintf("Vault data was empty at the "+
-				"given path. Warnings: %s", strings.Join(secret.Warnings, "; ")))
+			return "", fmt.Errorf("Vault data was empty at the "+
+				"given path. Warnings: %s", strings.Join(secret.Warnings, "; "))
 		}
 
 		value := data.(map[string]interface{})[key].(string)

--- a/template/parse.go
+++ b/template/parse.go
@@ -476,8 +476,12 @@ func ParseFile(path string) (*Template, error) {
 		}
 		defer os.Remove(f.Name())
 		defer f.Close()
-		io.Copy(f, os.Stdin)
-		f.Seek(0, io.SeekStart)
+		if _, err = io.Copy(f, os.Stdin); err != nil {
+			return nil, err
+		}
+		if _, err = f.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
 	} else {
 		f, err = os.Open(path)
 		if err != nil {
@@ -492,7 +496,9 @@ func ParseFile(path string) (*Template, error) {
 			return nil, err
 		}
 		// Rewind the file and get a better error
-		f.Seek(0, io.SeekStart)
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
 		// Grab the error location, and return a string to point to offending syntax error
 		line, col, highlight := highlightPosition(f, syntaxErr.Offset)
 		err = fmt.Errorf("Error parsing JSON: %s\nAt line %d, column %d (offset %d):\n%s", err, line, col, syntaxErr.Offset, highlight)


### PR DESCRIPTION
This is a simple PR which cleans linting issues in packages `template` and `template/interpolate`.

Make sure of tests run after cleaning linting issues.