### PR TITLE
Remove HCL2 var-files note from `packer build`

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -419,7 +419,7 @@ Options:
   -parallel-builds=1            Number of builds to run in parallel. 0 means no limit (Default: 0)
   -timestamp-ui                 Enable prefixing of each ui output with an RFC3339 timestamp.
   -var 'key=value'              Variable for templates, can be used multiple times.
-  -var-file=path                JSON file containing user variables. [ Note that even in HCL mode this expects file to contain JSON, a fix is comming soon ]
+  -var-file=path                JSON file containing user variables.
 `
 
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
Hello,

According to documentation and my tests, `-var-file` allow an HCL file. I supposed this comment has been forgotten.

Same comment is also presents in `command/validate.go` and `command/console.go` but currently I'm not sure it can be removed due to #8538 