### PR TITLE
(vsphere-iso) remove deprecated network and disk fields

### DIFF
--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -29,12 +29,7 @@ type FlatConfig struct {
 	GuestOSType               *string                  `mapstructure:"guest_os_type" cty:"guest_os_type"`
 	Firmware                  *string                  `mapstructure:"firmware" cty:"firmware"`
 	DiskControllerType        *string                  `mapstructure:"disk_controller_type" cty:"disk_controller_type"`
-	DiskSize                  *int64                   `mapstructure:"disk_size" cty:"disk_size"`
-	DiskThinProvisioned       *bool                    `mapstructure:"disk_thin_provisioned" cty:"disk_thin_provisioned"`
-	DiskEagerlyScrub          *bool                    `mapstructure:"disk_eagerly_scrub" cty:"disk_eagerly_scrub"`
 	Storage                   []FlatDiskConfig         `mapstructure:"storage" cty:"storage"`
-	Network                   *string                  `mapstructure:"network" cty:"network"`
-	NetworkCard               *string                  `mapstructure:"network_card" cty:"network_card"`
 	NICs                      []FlatNIC                `mapstructure:"network_adapters" cty:"network_adapters"`
 	USBController             *bool                    `mapstructure:"usb_controller" cty:"usb_controller"`
 	Notes                     *string                  `mapstructure:"notes" cty:"notes"`
@@ -158,12 +153,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"guest_os_type":                &hcldec.AttrSpec{Name: "guest_os_type", Type: cty.String, Required: false},
 		"firmware":                     &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"disk_controller_type":         &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.String, Required: false},
-		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
-		"disk_thin_provisioned":        &hcldec.AttrSpec{Name: "disk_thin_provisioned", Type: cty.Bool, Required: false},
-		"disk_eagerly_scrub":           &hcldec.AttrSpec{Name: "disk_eagerly_scrub", Type: cty.Bool, Required: false},
 		"storage":                      &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*FlatDiskConfig)(nil).HCL2Spec())},
-		"network":                      &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
-		"network_card":                 &hcldec.AttrSpec{Name: "network_card", Type: cty.String, Required: false},
 		"network_adapters":             &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},
 		"usb_controller":               &hcldec.AttrSpec{Name: "usb_controller", Type: cty.Bool, Required: false},
 		"notes":                        &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},

--- a/builder/vsphere/iso/step_create.hcl2spec.go
+++ b/builder/vsphere/iso/step_create.hcl2spec.go
@@ -9,19 +9,14 @@ import (
 // FlatCreateConfig is an auto-generated flat version of CreateConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatCreateConfig struct {
-	Version             *uint            `mapstructure:"vm_version" cty:"vm_version"`
-	GuestOSType         *string          `mapstructure:"guest_os_type" cty:"guest_os_type"`
-	Firmware            *string          `mapstructure:"firmware" cty:"firmware"`
-	DiskControllerType  *string          `mapstructure:"disk_controller_type" cty:"disk_controller_type"`
-	DiskSize            *int64           `mapstructure:"disk_size" cty:"disk_size"`
-	DiskThinProvisioned *bool            `mapstructure:"disk_thin_provisioned" cty:"disk_thin_provisioned"`
-	DiskEagerlyScrub    *bool            `mapstructure:"disk_eagerly_scrub" cty:"disk_eagerly_scrub"`
-	Storage             []FlatDiskConfig `mapstructure:"storage" cty:"storage"`
-	Network             *string          `mapstructure:"network" cty:"network"`
-	NetworkCard         *string          `mapstructure:"network_card" cty:"network_card"`
-	NICs                []FlatNIC        `mapstructure:"network_adapters" cty:"network_adapters"`
-	USBController       *bool            `mapstructure:"usb_controller" cty:"usb_controller"`
-	Notes               *string          `mapstructure:"notes" cty:"notes"`
+	Version            *uint            `mapstructure:"vm_version" cty:"vm_version"`
+	GuestOSType        *string          `mapstructure:"guest_os_type" cty:"guest_os_type"`
+	Firmware           *string          `mapstructure:"firmware" cty:"firmware"`
+	DiskControllerType *string          `mapstructure:"disk_controller_type" cty:"disk_controller_type"`
+	Storage            []FlatDiskConfig `mapstructure:"storage" cty:"storage"`
+	NICs               []FlatNIC        `mapstructure:"network_adapters" cty:"network_adapters"`
+	USBController      *bool            `mapstructure:"usb_controller" cty:"usb_controller"`
+	Notes              *string          `mapstructure:"notes" cty:"notes"`
 }
 
 // FlatMapstructure returns a new FlatCreateConfig.
@@ -36,19 +31,14 @@ func (*CreateConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.
 // The decoded values from this spec will then be applied to a FlatCreateConfig.
 func (*FlatCreateConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"vm_version":            &hcldec.AttrSpec{Name: "vm_version", Type: cty.Number, Required: false},
-		"guest_os_type":         &hcldec.AttrSpec{Name: "guest_os_type", Type: cty.String, Required: false},
-		"firmware":              &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
-		"disk_controller_type":  &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.String, Required: false},
-		"disk_size":             &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
-		"disk_thin_provisioned": &hcldec.AttrSpec{Name: "disk_thin_provisioned", Type: cty.Bool, Required: false},
-		"disk_eagerly_scrub":    &hcldec.AttrSpec{Name: "disk_eagerly_scrub", Type: cty.Bool, Required: false},
-		"storage":               &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*FlatDiskConfig)(nil).HCL2Spec())},
-		"network":               &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
-		"network_card":          &hcldec.AttrSpec{Name: "network_card", Type: cty.String, Required: false},
-		"network_adapters":      &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},
-		"usb_controller":        &hcldec.AttrSpec{Name: "usb_controller", Type: cty.Bool, Required: false},
-		"notes":                 &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
+		"vm_version":           &hcldec.AttrSpec{Name: "vm_version", Type: cty.Number, Required: false},
+		"guest_os_type":        &hcldec.AttrSpec{Name: "guest_os_type", Type: cty.String, Required: false},
+		"firmware":             &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
+		"disk_controller_type": &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.String, Required: false},
+		"storage":              &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*FlatDiskConfig)(nil).HCL2Spec())},
+		"network_adapters":     &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},
+		"usb_controller":       &hcldec.AttrSpec{Name: "usb_controller", Type: cty.Bool, Required: false},
+		"notes":                &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/fix/fixer.go
+++ b/fix/fixer.go
@@ -49,6 +49,7 @@ func init() {
 		"comm-config":                new(FixerCommConfig),
 		"ssh-wait-timeout":           new(FixerSSHTimout),
 		"docker-tag-tags":            new(FixerDockerTagtoTags),
+		"vsphere-iso-net-disk":       new(FixerVSphereNetworkDisk),
 	}
 
 	FixerOrder = []string{
@@ -81,5 +82,6 @@ func init() {
 		"galaxy-command",
 		"comm-config",
 		"ssh-wait-timeout",
+		"vsphere-iso-net-disk",
 	}
 }

--- a/fix/fixer_vsphere_network_storage.go
+++ b/fix/fixer_vsphere_network_storage.go
@@ -41,24 +41,14 @@ func (FixerVSphereNetworkDisk) Fix(input map[string]interface{}) (map[string]int
 
 		networkRaw, ok := builder["network"]
 		if ok {
-			networkRawString, ok := networkRaw.(string)
-			if !ok {
-				// TODO: error?
-				continue
-			}
-			nic["network"] = networkRawString
+			nic["network"] = networkRaw
 			delete(builder, "network")
 			hasNetwork = true
 		}
 
 		networkCardRaw, ok := builder["networkCard"]
 		if ok {
-			networkCardRawString, ok := networkCardRaw.(string)
-			if !ok {
-				// TODO: error?
-				continue
-			}
-			nic["networkCard"] = networkCardRawString
+			nic["networkCard"] = networkCardRaw
 			delete(builder, "networkCard")
 			hasNetwork = true
 		}
@@ -80,36 +70,21 @@ func (FixerVSphereNetworkDisk) Fix(input map[string]interface{}) (map[string]int
 
 		diskSizeRaw, ok := builder["disk_size"]
 		if ok {
-			diskSizeRawInt, ok := diskSizeRaw.(int)
-			if !ok {
-				// TODO: error?
-				continue
-			}
-			disk["disk_size"] = diskSizeRawInt
+			disk["disk_size"] = diskSizeRaw
 			delete(builder, "disk_size")
 			hasStorage = true
 		}
 
 		discThinProvisionedRaw, ok := builder["disk_thin_provisioned"]
 		if ok {
-			discThinProvisionedRawBool, ok := discThinProvisionedRaw.(bool)
-			if !ok {
-				// TODO: error?
-				continue
-			}
-			disk["disk_thin_provisioned"] = discThinProvisionedRawBool
+			disk["disk_thin_provisioned"] = discThinProvisionedRaw
 			hasStorage = true
 			delete(builder, "disk_thin_provisioned")
 		}
 
 		diskEagerlyScrubRaw, ok := builder["disk_eagerly_scrub"]
 		if ok {
-			diskEagerlyScrubRawBool, ok := diskEagerlyScrubRaw.(bool)
-			if !ok {
-				// TODO: error?
-				continue
-			}
-			disk["disk_eagerly_scrub"] = diskEagerlyScrubRawBool
+			disk["disk_eagerly_scrub"] = diskEagerlyScrubRaw
 			hasStorage = true
 			delete(builder, "disk_eagerly_scrub")
 		}

--- a/fix/fixer_vsphere_network_storage.go
+++ b/fix/fixer_vsphere_network_storage.go
@@ -106,5 +106,5 @@ func (FixerVSphereNetworkDisk) Fix(input map[string]interface{}) (map[string]int
 }
 
 func (FixerVSphereNetworkDisk) Synopsis() string {
-	return `Updates "vmware" builders to "vmware-iso"`
+	return `Removes deprecated network and disk fields from "vsphere-iso" builder`
 }

--- a/fix/fixer_vsphere_network_storage.go
+++ b/fix/fixer_vsphere_network_storage.go
@@ -1,0 +1,135 @@
+package fix
+
+import (
+	"github.com/mitchellh/mapstructure"
+)
+
+// FixerVSphereNetworkDisk changes vsphere-iso network and networkCard fields into a network adapter and
+// changes the disk_size, disk_thin_provisioned, and disk_eagerly_scrub into a storage adapter
+type FixerVSphereNetworkDisk struct{}
+
+func (FixerVSphereNetworkDisk) Fix(input map[string]interface{}) (map[string]interface{}, error) {
+	// The type we'll decode into; we only care about builders
+	type template struct {
+		Builders []map[string]interface{}
+	}
+
+	// Decode the input into our structure, if we can
+	var tpl template
+	if err := mapstructure.Decode(input, &tpl); err != nil {
+		return nil, err
+	}
+
+	for _, builder := range tpl.Builders {
+		builderTypeRaw, ok := builder["type"]
+		if !ok {
+			continue
+		}
+
+		builderType, ok := builderTypeRaw.(string)
+		if !ok {
+			continue
+		}
+
+		if builderType != "vsphere-iso" {
+			continue
+		}
+
+		var networkAdapters []interface{}
+		nic := make(map[string]interface{})
+		hasNetwork := false
+
+		networkRaw, ok := builder["network"]
+		if ok {
+			networkRawString, ok := networkRaw.(string)
+			if !ok {
+				// TODO: error?
+				continue
+			}
+			nic["network"] = networkRawString
+			delete(builder, "network")
+			hasNetwork = true
+		}
+
+		networkCardRaw, ok := builder["networkCard"]
+		if ok {
+			networkCardRawString, ok := networkCardRaw.(string)
+			if !ok {
+				// TODO: error?
+				continue
+			}
+			nic["networkCard"] = networkCardRawString
+			delete(builder, "networkCard")
+			hasNetwork = true
+		}
+
+		if hasNetwork {
+			networkAdapters = append(networkAdapters, nic)
+			adaptersRaw, ok := builder["network_adapters"]
+			if ok {
+				existingAdapters := adaptersRaw.([]interface{})
+				networkAdapters = append(networkAdapters, existingAdapters...)
+			}
+
+			builder["network_adapters"] = networkAdapters
+		}
+
+		var storage []interface{}
+		disk := make(map[string]interface{})
+		hasStorage := false
+
+		diskSizeRaw, ok := builder["disk_size"]
+		if ok {
+			diskSizeRawInt, ok := diskSizeRaw.(int)
+			if !ok {
+				// TODO: error?
+				continue
+			}
+			disk["disk_size"] = diskSizeRawInt
+			delete(builder, "disk_size")
+			hasStorage = true
+		}
+
+		discThinProvisionedRaw, ok := builder["disk_thin_provisioned"]
+		if ok {
+			discThinProvisionedRawBool, ok := discThinProvisionedRaw.(bool)
+			if !ok {
+				// TODO: error?
+				continue
+			}
+			disk["disk_thin_provisioned"] = discThinProvisionedRawBool
+			hasStorage = true
+			delete(builder, "disk_thin_provisioned")
+		}
+
+		diskEagerlyScrubRaw, ok := builder["disk_eagerly_scrub"]
+		if ok {
+			diskEagerlyScrubRawBool, ok := diskEagerlyScrubRaw.(bool)
+			if !ok {
+				// TODO: error?
+				continue
+			}
+			disk["disk_eagerly_scrub"] = diskEagerlyScrubRawBool
+			hasStorage = true
+			delete(builder, "disk_eagerly_scrub")
+		}
+
+		if hasStorage {
+			storage = append(storage, disk)
+			storageRaw, ok := builder["storage"]
+			if ok {
+				existingStorage := storageRaw.([]interface{})
+				storage = append(storage, existingStorage...)
+			}
+
+			builder["storage"] = storage
+		}
+	}
+
+	input["builders"] = tpl.Builders
+	return input, nil
+}
+
+func (FixerVSphereNetworkDisk) Synopsis() string {
+	return `Updates "vmware" builders to "vmware-iso"`
+}

--- a/fix/fixer_vsphere_network_storage_test.go
+++ b/fix/fixer_vsphere_network_storage_test.go
@@ -39,10 +39,12 @@ func TestFixerVSphereNetwork_Fix(t *testing.T) {
 		},
 		{
 			Input: map[string]interface{}{
-				"type":        "vsphere-iso",
-				"network":     "myNetwork",
-				"networkCard": "vmxnet3",
-				"disk_size":   5000,
+				"type":                  "vsphere-iso",
+				"network":               "myNetwork",
+				"networkCard":           "vmxnet3",
+				"disk_size":             5000,
+				"disk_thin_provisioned": true,
+				"disk_eagerly_scrub":    true,
 			},
 
 			Expected: map[string]interface{}{
@@ -55,17 +57,21 @@ func TestFixerVSphereNetwork_Fix(t *testing.T) {
 				},
 				"storage": []interface{}{
 					map[string]interface{}{
-						"disk_size": 5000,
+						"disk_size":             5000,
+						"disk_thin_provisioned": true,
+						"disk_eagerly_scrub":    true,
 					},
 				},
 			},
 		},
 		{
 			Input: map[string]interface{}{
-				"type":        "vsphere-iso",
-				"network":     "myNetwork",
-				"networkCard": "vmxnet3",
-				"disk_size":   5000,
+				"type":                  "vsphere-iso",
+				"network":               "myNetwork",
+				"networkCard":           "vmxnet3",
+				"disk_size":             5000,
+				"disk_thin_provisioned": true,
+				"disk_eagerly_scrub":    true,
 				"network_adapters": []interface{}{
 					map[string]interface{}{
 						"network":     "net1",
@@ -74,7 +80,9 @@ func TestFixerVSphereNetwork_Fix(t *testing.T) {
 				},
 				"storage": []interface{}{
 					map[string]interface{}{
-						"disk_size": 5001,
+						"disk_size":             5001,
+						"disk_thin_provisioned": true,
+						"disk_eagerly_scrub":    true,
 					},
 				},
 			},
@@ -93,10 +101,14 @@ func TestFixerVSphereNetwork_Fix(t *testing.T) {
 				},
 				"storage": []interface{}{
 					map[string]interface{}{
-						"disk_size": 5000,
+						"disk_size":             5000,
+						"disk_thin_provisioned": true,
+						"disk_eagerly_scrub":    true,
 					},
 					map[string]interface{}{
-						"disk_size": 5001,
+						"disk_size":             5001,
+						"disk_thin_provisioned": true,
+						"disk_eagerly_scrub":    true,
 					},
 				},
 			},

--- a/fix/fixer_vsphere_network_storage_test.go
+++ b/fix/fixer_vsphere_network_storage_test.go
@@ -1,0 +1,126 @@
+package fix
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFixerVSphereNetwork_impl(t *testing.T) {
+	var _ Fixer = new(FixerVSphereNetworkDisk)
+}
+
+func TestFixerVSphereNetwork_Fix(t *testing.T) {
+	cases := []struct {
+		Input    map[string]interface{}
+		Expected map[string]interface{}
+	}{
+		{
+			Input: map[string]interface{}{
+				"type":        "vsphere-iso",
+				"network":     "",
+				"networkCard": "vmxnet3",
+				"disk_size":   5000,
+			},
+
+			Expected: map[string]interface{}{
+				"type": "vsphere-iso",
+				"network_adapters": []interface{}{
+					map[string]interface{}{
+						"network":     "",
+						"networkCard": "vmxnet3",
+					},
+				},
+				"storage": []interface{}{
+					map[string]interface{}{
+						"disk_size": 5000,
+					},
+				},
+			},
+		},
+		{
+			Input: map[string]interface{}{
+				"type":        "vsphere-iso",
+				"network":     "myNetwork",
+				"networkCard": "vmxnet3",
+				"disk_size":   5000,
+			},
+
+			Expected: map[string]interface{}{
+				"type": "vsphere-iso",
+				"network_adapters": []interface{}{
+					map[string]interface{}{
+						"network":     "myNetwork",
+						"networkCard": "vmxnet3",
+					},
+				},
+				"storage": []interface{}{
+					map[string]interface{}{
+						"disk_size": 5000,
+					},
+				},
+			},
+		},
+		{
+			Input: map[string]interface{}{
+				"type":        "vsphere-iso",
+				"network":     "myNetwork",
+				"networkCard": "vmxnet3",
+				"disk_size":   5000,
+				"network_adapters": []interface{}{
+					map[string]interface{}{
+						"network":     "net1",
+						"networkCard": "vmxnet3",
+					},
+				},
+				"storage": []interface{}{
+					map[string]interface{}{
+						"disk_size": 5001,
+					},
+				},
+			},
+
+			Expected: map[string]interface{}{
+				"type": "vsphere-iso",
+				"network_adapters": []interface{}{
+					map[string]interface{}{
+						"network":     "myNetwork",
+						"networkCard": "vmxnet3",
+					},
+					map[string]interface{}{
+						"network":     "net1",
+						"networkCard": "vmxnet3",
+					},
+				},
+				"storage": []interface{}{
+					map[string]interface{}{
+						"disk_size": 5000,
+					},
+					map[string]interface{}{
+						"disk_size": 5001,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		var f FixerVSphereNetworkDisk
+
+		input := map[string]interface{}{
+			"builders": []map[string]interface{}{tc.Input},
+		}
+
+		expected := map[string]interface{}{
+			"builders": []map[string]interface{}{tc.Expected},
+		}
+
+		output, err := f.Fix(input)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if !reflect.DeepEqual(output, expected) {
+			t.Fatalf("unexpected: %#v\nexpected: %#v\n", output, expected)
+		}
+	}
+}

--- a/website/pages/partials/builder/vsphere/iso/CreateConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/iso/CreateConfig-not-required.mdx
@@ -13,17 +13,7 @@
     
 -   `disk_controller_type` (string) - Set VM disk controller type. Example `pvscsi`.
     
--   `disk_size` (int64) - The size of the disk in MB.
-    
--   `disk_thin_provisioned` (bool) - Enable VMDK thin provisioning for VM. Defaults to `false`.
-    
--   `disk_eagerly_scrub` (bool) - Enable VMDK eager scrubbing for VM. Defaults to `false`.
-    
 -   `storage` ([]DiskConfig) - A collection of one or more disks to be provisioned along with the VM.
-    
--   `network` (string) - Set network VM will be connected to.
-    
--   `network_card` (string) - Set VM network card type. Example `vmxnet3`.
     
 -   `network_adapters` ([]NIC) - Network adapters
     


### PR DESCRIPTION
removed the network and disk fields. added a fixer that creates the correct network adapter and storage adapters from the fields.