### PR TITLE
website: add urls to homepage buttons

### DIFF
--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -8,13 +8,18 @@ export default function Homepage() {
         <img src="/img/logo-hashicorp.svg" alt="HashiCorp Packer Logo" />
         <h1 className="g-type-display-3">Build Automated Machine Images</h1>
         <div className="buttons">
-          <Button title="Get Started" theme={{ brand: 'packer' }} />
+          <Button
+            title="Get Started"
+            theme={{ brand: 'packer' }}
+            url="/intro"
+          />
           <Button
             title={`Download ${VERSION}`}
             theme={{
               variant: 'secondary',
               background: 'light',
             }}
+            url="/downloads"
           />
         </div>
       </section>


### PR DESCRIPTION
this PR fixes an issue where the CTA links on the homepage were not hooked up to any particular URL 