### PR TITLE
qemu: add support for using a network bridge

### DIFF
--- a/builder/qemu/builder.hcl2spec.go
+++ b/builder/qemu/builder.hcl2spec.go
@@ -96,6 +96,7 @@ type FlatConfig struct {
 	MachineType               *string           `mapstructure:"machine_type" required:"false" cty:"machine_type"`
 	MemorySize                *int              `mapstructure:"memory" required:"false" cty:"memory"`
 	NetDevice                 *string           `mapstructure:"net_device" required:"false" cty:"net_device"`
+	NetBridge                 *string           `mapstructure:"net_bridge" required:"false" cty:"net_bridge"`
 	OutputDir                 *string           `mapstructure:"output_directory" required:"false" cty:"output_directory"`
 	QemuArgs                  [][]string        `mapstructure:"qemuargs" required:"false" cty:"qemuargs"`
 	QemuBinary                *string           `mapstructure:"qemu_binary" required:"false" cty:"qemu_binary"`
@@ -212,6 +213,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"machine_type":                 &hcldec.AttrSpec{Name: "machine_type", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"net_device":                   &hcldec.AttrSpec{Name: "net_device", Type: cty.String, Required: false},
+		"net_bridge":                   &hcldec.AttrSpec{Name: "net_bridge", Type: cty.String, Required: false},
 		"output_directory":             &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
 		"qemuargs":                     &hcldec.AttrSpec{Name: "qemuargs", Type: cty.List(cty.List(cty.String)), Required: false},
 		"qemu_binary":                  &hcldec.AttrSpec{Name: "qemu_binary", Type: cty.String, Required: false},

--- a/builder/qemu/qmp.go
+++ b/builder/qemu/qmp.go
@@ -1,0 +1,135 @@
+package qemu
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/digitalocean/go-qemu/qmp"
+)
+
+type qomListRequest struct {
+	Execute   string                  `json:"execute"`
+	Arguments qomListRequestArguments `json:"arguments"`
+}
+
+type qomListRequestArguments struct {
+	Path string `json:"path"`
+}
+
+type qomListResponse struct {
+	Return []qomListReturn `json:"return"`
+}
+
+type qomListReturn struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+func qmpQomList(qmpMonitor *qmp.SocketMonitor, path string) ([]qomListReturn, error) {
+	request, _ := json.Marshal(qomListRequest{
+		Execute: "qom-list",
+		Arguments: qomListRequestArguments{
+			Path: path,
+		},
+	})
+	result, err := qmpMonitor.Run(request)
+	if err != nil {
+		return nil, err
+	}
+	var response qomListResponse
+	if err := json.Unmarshal(result, &response); err != nil {
+		return nil, err
+	}
+	return response.Return, nil
+}
+
+type qomGetRequest struct {
+	Execute   string                 `json:"execute"`
+	Arguments qomGetRequestArguments `json:"arguments"`
+}
+
+type qomGetRequestArguments struct {
+	Path     string `json:"path"`
+	Property string `json:"property"`
+}
+
+type qomGetResponse struct {
+	Return string `json:"return"`
+}
+
+func qmpQomGet(qmpMonitor *qmp.SocketMonitor, path string, property string) (string, error) {
+	request, _ := json.Marshal(qomGetRequest{
+		Execute: "qom-get",
+		Arguments: qomGetRequestArguments{
+			Path:     path,
+			Property: property,
+		},
+	})
+	result, err := qmpMonitor.Run(request)
+	if err != nil {
+		return "", err
+	}
+	var response qomGetResponse
+	if err := json.Unmarshal(result, &response); err != nil {
+		return "", err
+	}
+	return response.Return, nil
+}
+
+type netDevice struct {
+	Path       string
+	Name       string
+	Type       string
+	MacAddress string
+}
+
+func getNetDevices(qmpMonitor *qmp.SocketMonitor) ([]netDevice, error) {
+	devices := []netDevice{}
+	for _, parentPath := range []string{"/machine/peripheral", "/machine/peripheral-anon"} {
+		listResponse, err := qmpQomList(qmpMonitor, parentPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get qmp qom list %v: %w", parentPath, err)
+		}
+		for _, p := range listResponse {
+			if strings.HasPrefix(p.Type, "child<") {
+				path := fmt.Sprintf("%s/%s", parentPath, p.Name)
+				r, err := qmpQomList(qmpMonitor, path)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get qmp qom list %v: %w", path, err)
+				}
+				isNetdev := false
+				for _, d := range r {
+					if d.Name == "netdev" {
+						isNetdev = true
+						break
+					}
+				}
+				if isNetdev {
+					device := netDevice{
+						Path: path,
+					}
+					for _, d := range r {
+						if d.Name != "type" && d.Name != "netdev" && d.Name != "mac" {
+							continue
+						}
+						value, err := qmpQomGet(qmpMonitor, path, d.Name)
+						if err != nil {
+							return nil, fmt.Errorf("failed to get qmp qom property %v %v: %w", path, d.Name, err)
+						}
+						switch d.Name {
+						case "type":
+							device.Type = value
+						case "netdev":
+							device.Name = value
+						case "mac":
+							device.MacAddress = value
+						}
+					}
+					devices = append(devices, device)
+				}
+			}
+		}
+	}
+	return devices, nil
+}

--- a/builder/qemu/ssh.go
+++ b/builder/qemu/ssh.go
@@ -13,11 +13,18 @@ func commHost(host string) func(multistep.StateBag) (string, error) {
 			return host, nil
 		}
 
+		if guestAddress, ok := state.Get("guestAddress").(string); ok {
+			return guestAddress, nil
+		}
+
 		return "127.0.0.1", nil
 	}
 }
 
 func commPort(state multistep.StateBag) (int, error) {
-	sshHostPort := state.Get("sshHostPort").(int)
+	sshHostPort, ok := state.Get("sshHostPort").(int)
+	if !ok {
+		sshHostPort = 22
+	}
 	return int(sshHostPort), nil
 }

--- a/builder/qemu/step_http_ip_discover_test.go
+++ b/builder/qemu/step_http_ip_discover_test.go
@@ -1,14 +1,22 @@
 package qemu
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
 )
 
 func TestStepHTTPIPDiscover_Run(t *testing.T) {
 	state := new(multistep.BasicStateBag)
+	state.Put("ui", &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	config := &Config{}
+	state.Put("config", config)
 	step := new(stepHTTPIPDiscover)
 	hostIp := "10.0.2.2"
 

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -224,7 +223,7 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 	if len(config.QemuArgs) > 0 {
 		ui.Say("Overriding defaults Qemu arguments with QemuArgs...")
 
-		httpIp := common.GetHTTPIP()
+		httpIp := state.Get("http_ip").(string)
 		httpPort := state.Get("http_port").(int)
 		ictx := config.ctx
 		if config.Comm.Type != "none" {

--- a/builder/qemu/step_wait_guest_address.go
+++ b/builder/qemu/step_wait_guest_address.go
@@ -1,0 +1,122 @@
+package qemu
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+
+	"github.com/digitalocean/go-qemu/qmp"
+)
+
+// This step waits for the guest address to become available in the network
+// bridge, then it sets the guestAddress state property.
+type stepWaitGuestAddress struct{}
+
+func (s *stepWaitGuestAddress) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*Config)
+	ui := state.Get("ui").(packer.Ui)
+	qmpMonitor := state.Get("qmp_monitor").(*qmp.SocketMonitor)
+
+	ui.Say(fmt.Sprintf("Waiting for the guest address to become available in the %s network bridge...", config.NetBridge))
+	for {
+		guestAddress := getGuestAddress(qmpMonitor, config.NetBridge, "user.0")
+		if guestAddress != "" {
+			log.Printf("Found guest address %s", guestAddress)
+			state.Put("guestAddress", guestAddress)
+			break
+		}
+		select {
+		case <-time.After(10 * time.Second):
+			continue
+		case <-ctx.Done():
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepWaitGuestAddress) Cleanup(state multistep.StateBag) {
+}
+
+func getGuestAddress(qmpMonitor *qmp.SocketMonitor, bridgeName string, deviceName string) string {
+	devices, err := getNetDevices(qmpMonitor)
+	if err != nil {
+		log.Printf("Could not retrieve QEMU QMP network device list: %v", err)
+		return ""
+	}
+
+	for _, device := range devices {
+		if device.Name == deviceName {
+			ipAddress, _ := getDeviceIPAddress(bridgeName, device.MacAddress)
+			return ipAddress
+		}
+	}
+
+	log.Printf("QEMU QMP network device %s was not found", deviceName)
+	return ""
+}
+
+func getDeviceIPAddress(device string, macAddress string) (string, error) {
+	// this parses /proc/net/arp to retrieve the given device IP address.
+	//
+	// /proc/net/arp is normally someting alike:
+	//
+	// 		IP address       HW type     Flags       HW address            Mask     Device
+	// 		192.168.121.111  0x1         0x2         52:54:00:12:34:56     *        virbr0
+	//
+
+	const (
+		IPAddressIndex int = iota
+		HWTypeIndex
+		FlagsIndex
+		HWAddressIndex
+		MaskIndex
+		DeviceIndex
+	)
+
+	// see ARP flags at https://github.com/torvalds/linux/blob/v5.4/include/uapi/linux/if_arp.h#L132
+	const (
+		AtfCom int = 0x02 // ATF_COM (complete)
+	)
+
+	f, err := os.Open("/proc/net/arp")
+	if err != nil {
+		return "", fmt.Errorf("failed to open /proc/net/arp: %w", err)
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	s.Scan()
+
+	for s.Scan() {
+		fields := strings.Fields(s.Text())
+
+		if device != "" && fields[DeviceIndex] != device {
+			continue
+		}
+
+		if fields[HWAddressIndex] != macAddress {
+			continue
+		}
+
+		flags, err := strconv.ParseInt(fields[FlagsIndex], 0, 32)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse /proc/net/arp flags field %s: %w", fields[FlagsIndex], err)
+		}
+
+		if int(flags)&AtfCom == AtfCom {
+			return fields[IPAddressIndex], nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find %s", macAddress)
+}

--- a/website/pages/partials/builder/qemu/Config-not-required.mdx
+++ b/website/pages/partials/builder/qemu/Config-not-required.mdx
@@ -108,6 +108,16 @@
     `vmxnet3`, `i82558a` or `i82558b`. The Qemu builder uses `virtio-net` by
     default.
     
+-   `net_bridge` (string) - Connects the network to this bridge instead of using the user mode
+    networking.
+    
+    **NB** This bridge must already exist. You can use the `virbr0` bridge
+    as created by vagrant-libvirt.
+    
+    **NB** This will automatically enable the QMP socket (see QMPEnable).
+    
+    **NB** This only works in Linux based OSes.
+    
 -   `output_directory` (string) - This is the path to the directory where the
     resulting virtual machine will be created. This may be relative or absolute.
     If relative, the path is relative to the working directory when packer


### PR DESCRIPTION
I've just found out about [0xef53/go-qmp](https://github.com/0xef53/go-qmp) which provides a nicer interface to QMP (e.g. we do not need to manually (un)marshal the structs), what do you think in switching over to that library too?

But please note that the digitalocean repo also seems to support libvirt; the go-qmp is only for QMP.

I also want to make the network device easier to find using QMP, but that will introduce a couple of backward incompatible changes:

1. instead of the netdev being called `user.0` I want to change it to `net0` (because it can now be a `user` or `bridge` netdev).
2. add the `id=nic0` parameter to the qemu `-device` argument. that way, that device is easier to find using QMP. That is, instead of `-device vmxnet3,netdev=net0` it will be `-device vmxnet3,id=nic0,netdev=net0`.
    * this way instead of trying to find the device in the qmp paths `/machine/peripheral/*` and `/machine/peripheral-anon/*` I can directly access it at `/machine/peripheral/nic0`, which simplifies to code a lot.
      * hummm or maybe this should be used anyways just in case the user forgets the `id=nic0`?

This closes #9156.
