### PR TITLE
[WIP] Add SATA as a disk_interface for QEMU

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -41,6 +41,7 @@ var accels = map[string]struct{}{
 var diskInterface = map[string]bool{
 	"ide":         true,
 	"scsi":        true,
+	"sata":        true,
 	"virtio":      true,
 	"virtio-scsi": true,
 }


### PR DESCRIPTION
Closes #3983

EDIT: Turns out SATA is not a simple bus type. 