### PR TITLE
remove spot_price_auto_product from docs

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -281,7 +281,7 @@ type RunConfig struct {
 	// best spot price. This must be one of: Linux/UNIX, SUSE Linux,
 	// Windows, Linux/UNIX (Amazon VPC), SUSE Linux (Amazon VPC),
 	// Windows (Amazon VPC)
-	SpotPriceAutoProduct string `mapstructure:"spot_price_auto_product" required:"false"`
+	SpotPriceAutoProduct string `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true"`
 	// Requires spot_price to be set. Key/value pair tags to apply tags to the
 	// spot request that is issued.
 	SpotTags map[string]string `mapstructure:"spot_tags" required:"false"`

--- a/builder/amazon/ebs/builder.hcl2spec.go
+++ b/builder/amazon/ebs/builder.hcl2spec.go
@@ -72,7 +72,7 @@ type FlatConfig struct {
 	SourceAmiFilter                           *common.FlatAmiFilterOptions           `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter"`
 	SpotInstanceTypes                         []string                               `mapstructure:"spot_instance_types" required:"false" cty:"spot_instance_types"`
 	SpotPrice                                 *string                                `mapstructure:"spot_price" required:"false" cty:"spot_price"`
-	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" cty:"spot_price_auto_product"`
+	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true" cty:"spot_price_auto_product"`
 	SpotTags                                  map[string]string                      `mapstructure:"spot_tags" required:"false" cty:"spot_tags"`
 	SpotTag                                   []hcl2template.FlatKeyValue            `mapstructure:"spot_tag" required:"false" cty:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter"`

--- a/builder/amazon/ebssurrogate/builder.hcl2spec.go
+++ b/builder/amazon/ebssurrogate/builder.hcl2spec.go
@@ -94,7 +94,7 @@ type FlatConfig struct {
 	SourceAmiFilter                           *common.FlatAmiFilterOptions           `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter"`
 	SpotInstanceTypes                         []string                               `mapstructure:"spot_instance_types" required:"false" cty:"spot_instance_types"`
 	SpotPrice                                 *string                                `mapstructure:"spot_price" required:"false" cty:"spot_price"`
-	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" cty:"spot_price_auto_product"`
+	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true" cty:"spot_price_auto_product"`
 	SpotTags                                  map[string]string                      `mapstructure:"spot_tags" required:"false" cty:"spot_tags"`
 	SpotTag                                   []hcl2template.FlatKeyValue            `mapstructure:"spot_tag" required:"false" cty:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter"`

--- a/builder/amazon/ebsvolume/builder.hcl2spec.go
+++ b/builder/amazon/ebsvolume/builder.hcl2spec.go
@@ -96,7 +96,7 @@ type FlatConfig struct {
 	SourceAmiFilter                           *common.FlatAmiFilterOptions           `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter"`
 	SpotInstanceTypes                         []string                               `mapstructure:"spot_instance_types" required:"false" cty:"spot_instance_types"`
 	SpotPrice                                 *string                                `mapstructure:"spot_price" required:"false" cty:"spot_price"`
-	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" cty:"spot_price_auto_product"`
+	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true" cty:"spot_price_auto_product"`
 	SpotTags                                  map[string]string                      `mapstructure:"spot_tags" required:"false" cty:"spot_tags"`
 	SpotTag                                   []hcl2template.FlatKeyValue            `mapstructure:"spot_tag" required:"false" cty:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter"`

--- a/builder/amazon/instance/builder.hcl2spec.go
+++ b/builder/amazon/instance/builder.hcl2spec.go
@@ -72,7 +72,7 @@ type FlatConfig struct {
 	SourceAmiFilter                           *common.FlatAmiFilterOptions           `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter"`
 	SpotInstanceTypes                         []string                               `mapstructure:"spot_instance_types" required:"false" cty:"spot_instance_types"`
 	SpotPrice                                 *string                                `mapstructure:"spot_price" required:"false" cty:"spot_price"`
-	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" cty:"spot_price_auto_product"`
+	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true" cty:"spot_price_auto_product"`
 	SpotTags                                  map[string]string                      `mapstructure:"spot_tags" required:"false" cty:"spot_tags"`
 	SpotTag                                   []hcl2template.FlatKeyValue            `mapstructure:"spot_tag" required:"false" cty:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter"`

--- a/website/pages/partials/builder/amazon/common/RunConfig-not-required.mdx
+++ b/website/pages/partials/builder/amazon/common/RunConfig-not-required.mdx
@@ -197,12 +197,6 @@
     For more information, see the Amazon docs on
     [spot pricing](https://aws.amazon.com/ec2/spot/pricing/).
     
--   `spot_price_auto_product` (string) - Required if spot_price is set to
-    auto. This tells Packer what sort of AMI you're launching to find the
-    best spot price. This must be one of: Linux/UNIX, SUSE Linux,
-    Windows, Linux/UNIX (Amazon VPC), SUSE Linux (Amazon VPC),
-    Windows (Amazon VPC)
-    
 -   `spot_tags` (map[string]string) - Requires spot_price to be set. Key/value pair tags to apply tags to the
     spot request that is issued.
     


### PR DESCRIPTION
Deprecated feature shouldn't be documented just because we haven't removed the template option for of backwards-compatability

Closes #9163 
