### PR TITLE
output_filename virtualbox option.

### DIFF
--- a/builder/virtualbox/common/output_config.go
+++ b/builder/virtualbox/common/output_config.go
@@ -17,6 +17,10 @@ type OutputConfig struct {
 	// the builder. By default this is output-BUILDNAME where "BUILDNAME" is the
 	// name of the build.
 	OutputDir string `mapstructure:"output_directory" required:"false"`
+	// This is the base name of the file (excluding the file extension) where
+	// the resulting virtual machine will be created. By default this is the
+	// `vm_name`.
+	OutputFilename string `mapstructure:"output_filename" required:"false"`
 }
 
 func (c *OutputConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig) []error {

--- a/builder/virtualbox/common/step_export.go
+++ b/builder/virtualbox/common/step_export.go
@@ -19,6 +19,7 @@ import (
 type StepExport struct {
 	Format         string
 	OutputDir      string
+	OutputFilename string
 	ExportOpts     []string
 	Bundling       VBoxBundleConfig
 	SkipNatMapping bool
@@ -37,6 +38,9 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packer.Ui)
 	vmName := state.Get("vmName").(string)
+	if s.OutputFilename == "" {
+		s.OutputFilename = vmName
+	}
 
 	// Skip export if requested
 	if s.SkipExport {
@@ -61,7 +65,7 @@ func (s *StepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 	}
 
 	// Export the VM to an OVF
-	outputPath := filepath.Join(s.OutputDir, vmName+"."+s.Format)
+	outputPath := filepath.Join(s.OutputDir, s.OutputFilename+"."+s.Format)
 
 	command := []string{
 		"export",

--- a/builder/virtualbox/common/step_export_test.go
+++ b/builder/virtualbox/common/step_export_test.go
@@ -43,3 +43,71 @@ func TestStepExport(t *testing.T) {
 		t.Fatal("bad")
 	}
 }
+
+func TestStepExport_OutputPath(t *testing.T) {
+	type testCase struct {
+		Step     *StepExport
+		Expected string
+		Reason   string
+	}
+	tcs := []testCase{
+		{
+			Step: &StepExport{
+				Format:         "ova",
+				OutputDir:      "output-dir",
+				OutputFilename: "output-filename",
+			},
+			Expected: "output-dir/output-filename.ova",
+			Reason:   "output_filename should not be vmName if set.",
+		},
+		{
+			Step: &StepExport{
+				Format:         "ovf",
+				OutputDir:      "output-dir",
+				OutputFilename: "",
+			},
+			Expected: "output-dir/foo.ovf",
+			Reason:   "output_filename should default to vmName.",
+		},
+	}
+	for _, tc := range tcs {
+		state := testState(t)
+		state.Put("vmName", "foo")
+
+		// Test the run
+		if action := tc.Step.Run(context.Background(), state); action != multistep.ActionContinue {
+			t.Fatalf("bad action: %#v", action)
+		}
+
+		// Test output state
+		path, ok := state.GetOk("exportPath")
+		if !ok {
+			t.Fatal("should set exportPath")
+		}
+		if path != tc.Expected {
+			t.Fatalf("Expected %s didn't match received %s: %s", tc.Expected, path, tc.Reason)
+		}
+	}
+}
+
+func TestStepExport_SkipExport(t *testing.T) {
+	state := testState(t)
+	step := StepExport{SkipExport: true}
+
+	state.Put("vmName", "foo")
+
+	driver := state.Get("driver").(*DriverMock)
+
+	// Test the run
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+	// Test driver
+	if len(driver.VBoxManageCalls) != 0 {
+		t.Fatal("shouldn't have called vboxmanage; skip_export was set.")
+	}
+
+}

--- a/builder/virtualbox/common/step_export_test.go
+++ b/builder/virtualbox/common/step_export_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -57,7 +58,7 @@ func TestStepExport_OutputPath(t *testing.T) {
 				OutputDir:      "output-dir",
 				OutputFilename: "output-filename",
 			},
-			Expected: "output-dir/output-filename.ova",
+			Expected: filepath.Join("output-dir", "output-filename.ova"),
 			Reason:   "output_filename should not be vmName if set.",
 		},
 		{
@@ -66,7 +67,7 @@ func TestStepExport_OutputPath(t *testing.T) {
 				OutputDir:      "output-dir",
 				OutputFilename: "",
 			},
-			Expected: "output-dir/foo.ovf",
+			Expected: filepath.Join("output-dir", "foo.ovf"),
 			Reason:   "output_filename should default to vmName.",
 		},
 	}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -396,6 +396,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&vboxcommon.StepExport{
 			Format:         b.config.Format,
 			OutputDir:      b.config.OutputDir,
+			OutputFilename: b.config.OutputFilename,
 			ExportOpts:     b.config.ExportConfig.ExportOpts,
 			Bundling:       b.config.VBoxBundleConfig,
 			SkipNatMapping: b.config.SkipNatMapping,

--- a/builder/virtualbox/iso/builder.hcl2spec.go
+++ b/builder/virtualbox/iso/builder.hcl2spec.go
@@ -35,6 +35,7 @@ type FlatConfig struct {
 	Format                    *string           `mapstructure:"format" required:"false" cty:"format"`
 	ExportOpts                []string          `mapstructure:"export_opts" required:"false" cty:"export_opts"`
 	OutputDir                 *string           `mapstructure:"output_directory" required:"false" cty:"output_directory"`
+	OutputFilename            *string           `mapstructure:"output_filename" required:"false" cty:"output_filename"`
 	Headless                  *bool             `mapstructure:"headless" required:"false" cty:"headless"`
 	VRDPBindAddress           *string           `mapstructure:"vrdp_bind_address" required:"false" cty:"vrdp_bind_address"`
 	VRDPPortMin               *int              `mapstructure:"vrdp_port_min" required:"false" cty:"vrdp_port_min"`
@@ -156,6 +157,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"format":                       &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
 		"export_opts":                  &hcldec.AttrSpec{Name: "export_opts", Type: cty.List(cty.String), Required: false},
 		"output_directory":             &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
+		"output_filename":              &hcldec.AttrSpec{Name: "output_filename", Type: cty.String, Required: false},
 		"headless":                     &hcldec.AttrSpec{Name: "headless", Type: cty.Bool, Required: false},
 		"vrdp_bind_address":            &hcldec.AttrSpec{Name: "vrdp_bind_address", Type: cty.String, Required: false},
 		"vrdp_port_min":                &hcldec.AttrSpec{Name: "vrdp_port_min", Type: cty.Number, Required: false},

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -158,6 +158,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&vboxcommon.StepExport{
 			Format:         b.config.Format,
 			OutputDir:      b.config.OutputDir,
+			OutputFilename: b.config.OutputFilename,
 			ExportOpts:     b.config.ExportConfig.ExportOpts,
 			SkipNatMapping: b.config.SkipNatMapping,
 			SkipExport:     b.config.SkipExport,

--- a/builder/virtualbox/ovf/config.hcl2spec.go
+++ b/builder/virtualbox/ovf/config.hcl2spec.go
@@ -28,6 +28,7 @@ type FlatConfig struct {
 	Format                    *string           `mapstructure:"format" required:"false" cty:"format"`
 	ExportOpts                []string          `mapstructure:"export_opts" required:"false" cty:"export_opts"`
 	OutputDir                 *string           `mapstructure:"output_directory" required:"false" cty:"output_directory"`
+	OutputFilename            *string           `mapstructure:"output_filename" required:"false" cty:"output_filename"`
 	Headless                  *bool             `mapstructure:"headless" required:"false" cty:"headless"`
 	VRDPBindAddress           *string           `mapstructure:"vrdp_bind_address" required:"false" cty:"vrdp_bind_address"`
 	VRDPPortMin               *int              `mapstructure:"vrdp_port_min" required:"false" cty:"vrdp_port_min"`
@@ -135,6 +136,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"format":                       &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
 		"export_opts":                  &hcldec.AttrSpec{Name: "export_opts", Type: cty.List(cty.String), Required: false},
 		"output_directory":             &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
+		"output_filename":              &hcldec.AttrSpec{Name: "output_filename", Type: cty.String, Required: false},
 		"headless":                     &hcldec.AttrSpec{Name: "headless", Type: cty.Bool, Required: false},
 		"vrdp_bind_address":            &hcldec.AttrSpec{Name: "vrdp_bind_address", Type: cty.String, Required: false},
 		"vrdp_port_min":                &hcldec.AttrSpec{Name: "vrdp_port_min", Type: cty.Number, Required: false},

--- a/builder/virtualbox/vm/builder.go
+++ b/builder/virtualbox/vm/builder.go
@@ -141,6 +141,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&vboxcommon.StepExport{
 			Format:         b.config.Format,
 			OutputDir:      b.config.OutputDir,
+			OutputFilename: b.config.OutputFilename,
 			ExportOpts:     b.config.ExportOpts,
 			SkipNatMapping: b.config.SkipNatMapping,
 			SkipExport:     b.config.SkipExport,

--- a/builder/virtualbox/vm/config.hcl2spec.go
+++ b/builder/virtualbox/vm/config.hcl2spec.go
@@ -28,6 +28,7 @@ type FlatConfig struct {
 	Format                    *string           `mapstructure:"format" required:"false" cty:"format"`
 	ExportOpts                []string          `mapstructure:"export_opts" required:"false" cty:"export_opts"`
 	OutputDir                 *string           `mapstructure:"output_directory" required:"false" cty:"output_directory"`
+	OutputFilename            *string           `mapstructure:"output_filename" required:"false" cty:"output_filename"`
 	Headless                  *bool             `mapstructure:"headless" required:"false" cty:"headless"`
 	VRDPBindAddress           *string           `mapstructure:"vrdp_bind_address" required:"false" cty:"vrdp_bind_address"`
 	VRDPPortMin               *int              `mapstructure:"vrdp_port_min" required:"false" cty:"vrdp_port_min"`
@@ -131,6 +132,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"format":                       &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
 		"export_opts":                  &hcldec.AttrSpec{Name: "export_opts", Type: cty.List(cty.String), Required: false},
 		"output_directory":             &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
+		"output_filename":              &hcldec.AttrSpec{Name: "output_filename", Type: cty.String, Required: false},
 		"headless":                     &hcldec.AttrSpec{Name: "headless", Type: cty.Bool, Required: false},
 		"vrdp_bind_address":            &hcldec.AttrSpec{Name: "vrdp_bind_address", Type: cty.String, Required: false},
 		"vrdp_port_min":                &hcldec.AttrSpec{Name: "vrdp_port_min", Type: cty.Number, Required: false},

--- a/website/pages/partials/builder/virtualbox/common/OutputConfig-not-required.mdx
+++ b/website/pages/partials/builder/virtualbox/common/OutputConfig-not-required.mdx
@@ -7,3 +7,7 @@
     the builder. By default this is output-BUILDNAME where "BUILDNAME" is the
     name of the build.
     
+-   `output_filename` (string) - This is the base name of the file (excluding the file extension) where
+    the resulting virtual machine will be created. By default this is the
+    `vm_name`.
+    


### PR DESCRIPTION
Allow users to set the output filename instead of forcing the filename to be the same as the vm_name. 

Closes #9145