### PR TITLE
support pushing multiple tags

### DIFF
--- a/builder/docker/artifact_import.go
+++ b/builder/docker/artifact_import.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"strings"
 )
 
 // ImportArtifact is an Artifact implementation for when a container is
@@ -29,7 +30,20 @@ func (a *ImportArtifact) Id() string {
 }
 
 func (a *ImportArtifact) String() string {
-	return fmt.Sprintf("Imported Docker image: %s", a.Id())
+	tags := a.StateData["docker_tags"]
+	if tags == nil {
+		return fmt.Sprintf("Imported Docker image: %s", a.Id())
+	} else {
+		cast := tags.([]interface{})
+		names := []string{}
+		for _, name := range cast {
+			if n, ok := name.(string); ok {
+				names = append(names, n)
+			}
+		}
+		return fmt.Sprintf("Imported Docker image: %s with tags %s",
+			a.Id(), strings.Join(names, " "))
+	}
 }
 
 func (a *ImportArtifact) State(name string) interface{} {

--- a/builder/docker/artifact_import.go
+++ b/builder/docker/artifact_import.go
@@ -33,17 +33,16 @@ func (a *ImportArtifact) String() string {
 	tags := a.StateData["docker_tags"]
 	if tags == nil {
 		return fmt.Sprintf("Imported Docker image: %s", a.Id())
-	} else {
-		cast := tags.([]interface{})
-		names := []string{}
-		for _, name := range cast {
-			if n, ok := name.(string); ok {
-				names = append(names, n)
-			}
-		}
-		return fmt.Sprintf("Imported Docker image: %s with tags %s",
-			a.Id(), strings.Join(names, " "))
 	}
+	cast := tags.([]interface{})
+	names := []string{}
+	for _, name := range cast {
+		if n, ok := name.(string); ok {
+			names = append(names, n)
+		}
+	}
+	return fmt.Sprintf("Imported Docker image: %s with tags %s",
+		a.Id(), strings.Join(names, " "))
 }
 
 func (a *ImportArtifact) State(name string) interface{} {

--- a/post-processor/docker-push/post-processor.go
+++ b/post-processor/docker-push/post-processor.go
@@ -5,7 +5,6 @@ package dockerpush
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/builder/docker"

--- a/post-processor/docker-tag/post-processor.go
+++ b/post-processor/docker-tag/post-processor.go
@@ -5,7 +5,6 @@ package dockertag
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/builder/docker"

--- a/post-processor/docker-tag/post-processor.go
+++ b/post-processor/docker-tag/post-processor.go
@@ -5,6 +5,7 @@ package dockertag
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/builder/docker"
@@ -68,6 +69,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 
 	importRepo := p.config.Repository
 	var lastTaggedRepo = importRepo
+	RepoTags := []string{}
 	if len(p.config.Tag) > 0 {
 		for _, tag := range p.config.Tag {
 			local := importRepo + ":" + tag
@@ -79,6 +81,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 				return nil, false, true, err
 			}
 
+			RepoTags = append(RepoTags, local)
 			lastTaggedRepo = local
 		}
 	} else {
@@ -95,6 +98,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 		BuilderIdValue: BuilderId,
 		Driver:         driver,
 		IdValue:        lastTaggedRepo,
+		StateData:      map[string]interface{}{"docker_tags": RepoTags},
 	}
 
 	// If we tag an image and then delete it, there was no point in creating the


### PR DESCRIPTION
Add list of tags to the docker artifact so that docker-push can properly push all tags, not just the last tag assigned. 

Closes #9131 
