### PR TITLE
floppy_label Parameter for vsphere-iso Builder

### DIFF
--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -81,6 +81,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			&packerCommon.StepCreateFloppy{
 				Files:       b.config.FloppyFiles,
 				Directories: b.config.FloppyDirectories,
+				Label:       b.config.FloppyLabel,
 			},
 			&StepAddFloppy{
 				Config:    &b.config.FloppyConfig,

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -70,6 +70,7 @@ type FlatConfig struct {
 	FloppyIMGPath             *string                  `mapstructure:"floppy_img_path" cty:"floppy_img_path"`
 	FloppyFiles               []string                 `mapstructure:"floppy_files" cty:"floppy_files"`
 	FloppyDirectories         []string                 `mapstructure:"floppy_dirs" cty:"floppy_dirs"`
+	FloppyLabel               *string                  `mapstructure:"floppy_label" cty:"floppy_label"`
 	BootOrder                 *string                  `mapstructure:"boot_order" cty:"boot_order"`
 	BootCommand               []string                 `mapstructure:"boot_command" cty:"boot_command"`
 	BootWait                  *string                  `mapstructure:"boot_wait" cty:"boot_wait"`
@@ -198,6 +199,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"floppy_img_path":              &hcldec.AttrSpec{Name: "floppy_img_path", Type: cty.String, Required: false},
 		"floppy_files":                 &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":                  &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},
+		"floppy_label":                 &hcldec.AttrSpec{Name: "floppy_label", Type: cty.String, Required: false},
 		"boot_order":                   &hcldec.AttrSpec{Name: "boot_order", Type: cty.String, Required: false},
 		"boot_command":                 &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},
 		"boot_wait":                    &hcldec.AttrSpec{Name: "boot_wait", Type: cty.String, Required: false},

--- a/builder/vsphere/iso/step_add_floppy.go
+++ b/builder/vsphere/iso/step_add_floppy.go
@@ -21,6 +21,11 @@ type FloppyConfig struct {
 	FloppyFiles []string `mapstructure:"floppy_files"`
 	// List of directories to copy files from.
 	FloppyDirectories []string `mapstructure:"floppy_dirs"`
+	// The label to use for the floppy disk that
+	// is attached when the VM is booted. This is most useful for cloud-init,
+	// Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+	// By default, the floppy label will be 'packer'.
+	FloppyLabel string `mapstructure:"floppy_label"`
 }
 
 type StepAddFloppy struct {

--- a/builder/vsphere/iso/step_add_floppy.hcl2spec.go
+++ b/builder/vsphere/iso/step_add_floppy.hcl2spec.go
@@ -12,6 +12,7 @@ type FlatFloppyConfig struct {
 	FloppyIMGPath     *string  `mapstructure:"floppy_img_path" cty:"floppy_img_path"`
 	FloppyFiles       []string `mapstructure:"floppy_files" cty:"floppy_files"`
 	FloppyDirectories []string `mapstructure:"floppy_dirs" cty:"floppy_dirs"`
+	FloppyLabel       *string  `mapstructure:"floppy_label" cty:"floppy_label"`
 }
 
 // FlatMapstructure returns a new FlatFloppyConfig.
@@ -29,6 +30,7 @@ func (*FlatFloppyConfig) HCL2Spec() map[string]hcldec.Spec {
 		"floppy_img_path": &hcldec.AttrSpec{Name: "floppy_img_path", Type: cty.String, Required: false},
 		"floppy_files":    &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":     &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},
+		"floppy_label":    &hcldec.AttrSpec{Name: "floppy_label", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/website/pages/partials/builder/vsphere/iso/FloppyConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/iso/FloppyConfig-not-required.mdx
@@ -8,3 +8,8 @@
     
 -   `floppy_dirs` ([]string) - List of directories to copy files from.
     
+-   `floppy_label` (string) - The label to use for the floppy disk that
+    is attached when the VM is booted. This is most useful for cloud-init,
+    Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
+    By default, the floppy label will be 'packer'.
+    


### PR DESCRIPTION
Add ability to specify `floppy_label` parameter for `vsphere-iso`
builder, which would be especially beneficial when someone wants to pass
information to cloud-init via floppy disk images.

Related: #8099

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>