### PR TITLE
replace AZR token with a CI one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: |
-          ghr -prerelease -t ${GITHUB_TOKEN_AZR} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./pkg/
+          ghr -prerelease -t ${CI_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./pkg/
   build-website-docker-image:
     docker:
       - image: circleci/buildpack-deps


### PR DESCRIPTION
I've created a new CI token with only permissions for public repos and saved it in our CircleCI config. We can rely on this user token to create the prerelease builds from here on out. Once this is merged, I will remove the `GITHUB_TOKEN_AZR` from CircleCI.