### PR TITLE
don't error if metadata can't be set. Old versions of openstack don't…

### DIFF
--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -63,7 +63,6 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 			}).ExtractErr()
 			if err != nil {
 				err := fmt.Errorf("Error setting image metadata: %s", err)
-				state.Put("error", err)
 				ui.Error(err.Error())
 			}
 		}

--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -65,7 +65,6 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 				err := fmt.Errorf("Error setting image metadata: %s", err)
 				state.Put("error", err)
 				ui.Error(err.Error())
-				return multistep.ActionHalt
 			}
 		}
 


### PR DESCRIPTION
Don't fail the whole build if we can't set metadata on the blockstorage image. 
Closes #9190
