### PR TITLE
builder/digitalocean: Use correct image type for Droplet creates.

### DIFF
--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -26,10 +26,11 @@ const testBuilderAccBasic = `
 	"builders": [{
 		"type": "test",
 		"region": "nyc2",
-		"size": "512mb",
-		"image": "ubuntu-12-04-x64",
-		"user_date": "",
-		"user_date_file": ""
+		"size": "s-1vcpu-1gb",
+		"image": "ubuntu-20-04-x64",
+		"ssh_username": "root",
+		"user_data": "",
+		"user_data_file": ""
 	}]
 }
 `

--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -1,17 +1,29 @@
 package digitalocean
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/digitalocean/godo"
 	builderT "github.com/hashicorp/packer/helper/builder/testing"
+	"golang.org/x/oauth2"
 )
 
 func TestBuilderAcc_basic(t *testing.T) {
 	builderT.Test(t, builderT.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Builder:  &Builder{},
-		Template: testBuilderAccBasic,
+		Template: fmt.Sprintf(testBuilderAccBasic, "ubuntu-20-04-x64"),
+	})
+}
+
+func TestBuilderAcc_imageId(t *testing.T) {
+	builderT.Test(t, builderT.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Builder:  &Builder{},
+		Template: makeTemplateWithImageId(t),
 	})
 }
 
@@ -21,13 +33,26 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func makeTemplateWithImageId(t *testing.T) string {
+	token := os.Getenv("DIGITALOCEAN_API_TOKEN")
+	client := godo.NewClient(oauth2.NewClient(context.TODO(), &apiTokenSource{
+		AccessToken: token,
+	}))
+	image, _, err := client.Images.GetBySlug(context.TODO(), "ubuntu-20-04-x64")
+	if err != nil {
+		t.Fatalf("failed to retrieve image ID: %s", err)
+	}
+
+	return fmt.Sprintf(testBuilderAccBasic, image.ID)
+}
+
 const testBuilderAccBasic = `
 {
 	"builders": [{
 		"type": "test",
 		"region": "nyc2",
 		"size": "s-1vcpu-1gb",
-		"image": "ubuntu-20-04-x64",
+		"image": "%v",
 		"ssh_username": "root",
 		"user_data": "",
 		"user_data_file": ""

--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -20,10 +20,6 @@ func TestBuilderAcc_basic(t *testing.T) {
 }
 
 func TestBuilderAcc_imageId(t *testing.T) {
-	if os.Getenv("PACKER_ACC") == "" {
-		t.Skip("Acceptance tests skipped unless env 'PACKER_ACC' set")
-	}
-
 	builderT.Test(t, builderT.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Builder:  &Builder{},
@@ -38,16 +34,20 @@ func testAccPreCheck(t *testing.T) {
 }
 
 func makeTemplateWithImageId(t *testing.T) string {
-	token := os.Getenv("DIGITALOCEAN_API_TOKEN")
-	client := godo.NewClient(oauth2.NewClient(context.TODO(), &apiTokenSource{
-		AccessToken: token,
-	}))
-	image, _, err := client.Images.GetBySlug(context.TODO(), "ubuntu-20-04-x64")
-	if err != nil {
-		t.Fatalf("failed to retrieve image ID: %s", err)
+	if os.Getenv(builderT.TestEnvVar) != "" {
+		token := os.Getenv("DIGITALOCEAN_API_TOKEN")
+		client := godo.NewClient(oauth2.NewClient(context.TODO(), &apiTokenSource{
+			AccessToken: token,
+		}))
+		image, _, err := client.Images.GetBySlug(context.TODO(), "ubuntu-20-04-x64")
+		if err != nil {
+			t.Fatalf("failed to retrieve image ID: %s", err)
+		}
+
+		return fmt.Sprintf(testBuilderAccBasic, image.ID)
 	}
 
-	return fmt.Sprintf(testBuilderAccBasic, image.ID)
+	return ""
 }
 
 const testBuilderAccBasic = `

--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -20,6 +20,10 @@ func TestBuilderAcc_basic(t *testing.T) {
 }
 
 func TestBuilderAcc_imageId(t *testing.T) {
+	if os.Getenv("PACKER_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'PACKER_ACC' set")
+	}
+
 	builderT.Test(t, builderT.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Builder:  &Builder{},

--- a/builder/digitalocean/step_create_droplet.go
+++ b/builder/digitalocean/step_create_droplet.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"io/ioutil"
 
@@ -35,13 +36,18 @@ func (s *stepCreateDroplet) Run(ctx context.Context, state multistep.StateBag) m
 		userData = string(contents)
 	}
 
+	createImage := godo.DropletCreateImage{Slug: c.Image}
+
+	imageId, err := strconv.Atoi(c.Image)
+	if err == nil {
+		createImage = godo.DropletCreateImage{ID: imageId}
+	}
+
 	droplet, _, err := client.Droplets.Create(context.TODO(), &godo.DropletCreateRequest{
 		Name:   c.DropletName,
 		Region: c.Region,
 		Size:   c.Size,
-		Image: godo.DropletCreateImage{
-			Slug: c.Image,
-		},
+		Image:  createImage,
 		SSHKeys: []godo.DropletCreateSSHKey{
 			{ID: sshKeyId},
 		},

--- a/builder/digitalocean/step_create_droplet.go
+++ b/builder/digitalocean/step_create_droplet.go
@@ -37,12 +37,7 @@ func (s *stepCreateDroplet) Run(ctx context.Context, state multistep.StateBag) m
 		userData = string(contents)
 	}
 
-	createImage := godo.DropletCreateImage{Slug: c.Image}
-
-	imageId, err := strconv.Atoi(c.Image)
-	if err == nil {
-		createImage = godo.DropletCreateImage{ID: imageId}
-	}
+	createImage := getImageType(c.Image)
 
 	dropletCreateReq := &godo.DropletCreateRequest{
 		Name:   c.DropletName,
@@ -97,4 +92,15 @@ func (s *stepCreateDroplet) Cleanup(state multistep.StateBag) {
 		ui.Error(fmt.Sprintf(
 			"Error destroying droplet. Please destroy it manually: %s", err))
 	}
+}
+
+func getImageType(image string) godo.DropletCreateImage {
+	createImage := godo.DropletCreateImage{Slug: image}
+
+	imageId, err := strconv.Atoi(image)
+	if err == nil {
+		createImage = godo.DropletCreateImage{ID: imageId}
+	}
+
+	return createImage
 }

--- a/builder/digitalocean/step_create_droplet.go
+++ b/builder/digitalocean/step_create_droplet.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 
 	"io/ioutil"
@@ -43,7 +44,7 @@ func (s *stepCreateDroplet) Run(ctx context.Context, state multistep.StateBag) m
 		createImage = godo.DropletCreateImage{ID: imageId}
 	}
 
-	droplet, _, err := client.Droplets.Create(context.TODO(), &godo.DropletCreateRequest{
+	dropletCreateReq := &godo.DropletCreateRequest{
 		Name:   c.DropletName,
 		Region: c.Region,
 		Size:   c.Size,
@@ -56,7 +57,11 @@ func (s *stepCreateDroplet) Run(ctx context.Context, state multistep.StateBag) m
 		IPv6:              c.IPv6,
 		UserData:          userData,
 		Tags:              c.Tags,
-	})
+	}
+
+	log.Printf("[DEBUG] Droplet create paramaters: %s", godo.Stringify(dropletCreateReq))
+
+	droplet, _, err := client.Droplets.Create(context.TODO(), dropletCreateReq)
 	if err != nil {
 		err := fmt.Errorf("Error creating droplet: %s", err)
 		state.Put("error", err)

--- a/builder/digitalocean/step_create_droplet_test.go
+++ b/builder/digitalocean/step_create_droplet_test.go
@@ -1,0 +1,26 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/digitalocean/godo"
+)
+
+func TestBuilder_GetImageType(t *testing.T) {
+	imageTypeTests := []struct {
+		in  string
+		out godo.DropletCreateImage
+	}{
+		{"ubuntu-20-04-x64", godo.DropletCreateImage{Slug: "ubuntu-20-04-x64"}},
+		{"123456", godo.DropletCreateImage{ID: 123456}},
+	}
+
+	for _, tt := range imageTypeTests {
+		t.Run(tt.in, func(t *testing.T) {
+			i := getImageType(tt.in)
+			if i != tt.out {
+				t.Errorf("got %q, want %q", godo.Stringify(i), godo.Stringify(tt.out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The main purpose of this PR is to correct the type used when building a new DigitalOcean snapshot when the base image is specified as an integer ID rather than a string. It also adds a new acceptance test for this case. In order to do so, I had to first fix the existing acceptance test which was failing for multiple reasons.

It also adds debug logging for the attributes used to create the Droplet in order to help better understand reported issues. See: https://github.com/hashicorp/packer/issues/8141