### PR TITLE
Update vagrant.mdx

### DIFF
--- a/website/pages/docs/builders/vagrant.mdx
+++ b/website/pages/docs/builders/vagrant.mdx
@@ -61,7 +61,7 @@ the Compress post-processor will not work with this builder.
 
 - `output_dir` (string) - The directory to create that will contain
   your output box. We always create this directory and run from inside of it to
-  prevent Vagrant init collisions. If unset, it will be set to `packer-` plus
+  prevent Vagrant init collisions. If unset, it will be set to `output-` plus
   your buildname.
 
 - `box_name` (string) - if your source_box is a boxfile that we need to add


### PR DESCRIPTION
Fix the incorrect folder prefix if the `output_dir` is not set. If `output_dir` is not set, the folder will be set to `output-` plus buildname instead of `packer-`