### PR TITLE
Disables Codecov status config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,10 +10,8 @@ comment:
 
 coverage:
   status:
-    project:
-      default:
-        target: auto
-        threshold: "0.5%"
+    project: off
+    patch: off
 
 ignore:  # ignore hcl2spec generated code for coverage
   - "**/*.hcl2spec.go"


### PR DESCRIPTION
Disables the Codecov config that is making most of the PR fail in the checks when they don't meet a particular coverage threshold. 