### PR TITLE
provisioner/powershell: Update cleanup logic

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -335,10 +335,10 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		return nil
 	}
 
-	err := retry.Config{StartTimeout: p.config.StartRetryTimeout}.Run(ctx, func(ctx context.Context) error {
+	err := retry.Config{StartTimeout: time.Minute, RetryDelay: func() time.Duration { return 10 * time.Second }}.Run(ctx, func(ctx context.Context) error {
 		command, err := p.createRemoteCleanUpCommand(uploadedScripts)
 		if err != nil {
-			log.Printf("failed to create a remote cleanup script: %s", err)
+			log.Printf("failed to upload the remote cleanup script: %q", err)
 			return err
 		}
 
@@ -346,7 +346,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		return cmd.RunWithUi(ctx, comm, ui)
 	})
 	if err != nil {
-		log.Printf("failed to clean up temporary files: %s", strings.Join(uploadedScripts, ","))
+		log.Printf("remote cleanup script failed to upload; skipping the removal of temporary files: %s; ", strings.Join(uploadedScripts, ","))
 	}
 
 	return nil
@@ -364,7 +364,7 @@ func (p *Provisioner) createRemoteCleanUpCommand(remoteFiles []string) (string, 
 	remotePath := p.config.remoteCleanUpScriptPath
 	remoteFiles = append(remoteFiles, remotePath)
 	for _, filename := range remoteFiles {
-		fmt.Fprintf(&b, "Remove-Item %s\n", filename)
+		fmt.Fprintf(&b, "if (Test-Path %[1]s) {Remove-Item %[1]s}\n", filename)
 	}
 
 	if err := p.communicator.Upload(remotePath, strings.NewReader(b.String()), nil); err != nil {


### PR DESCRIPTION
This change reduces the retry timeout from 5m to 1m, and sets the RetryDelay to 10s for a total of 6 retries. In additional to the retry time reduction the cleanup script will now check to see if the provisioner script created by Packer exists before trying to delete to prevent any file not found issues.

Closes #9181
Closes #9189