### PR TITLE
enable force, debug, and on-error for hcl2 builds

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -135,8 +135,11 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	}
 
 	builds, diags := packerStarter.GetBuilds(packer.GetBuildsOptions{
-		Only:   cla.Only,
-		Except: cla.Except,
+		Only:    cla.Only,
+		Except:  cla.Except,
+		Debug:   cla.Debug,
+		Force:   cla.Force,
+		OnError: cla.OnError,
 	})
 
 	// here, something could have gone wrong but we still want to run valid
@@ -186,6 +189,8 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	log.Printf("On error: %v", cla.OnError)
 
 	// Set the debug and force mode and prepare all the builds
+	// This is only affects json templates, because HCL2
+	// templates have already been prepared in GetBuilds() above.
 	for i := range builds {
 		b := builds[i]
 		log.Printf("Preparing build: %s", b.Name())

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -311,7 +311,7 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packer.Build
 				}
 			}
 
-			builder, moreDiags, generatedVars := cfg.startBuilder(src, cfg.EvalContext(nil))
+			builder, moreDiags, generatedVars := cfg.startBuilder(src, cfg.EvalContext(nil), opts)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue

--- a/main.go
+++ b/main.go
@@ -146,6 +146,11 @@ func wrappedMain() int {
 		runtime.Version(),
 		runtime.GOOS, runtime.GOARCH)
 
+	// The config being loaded here is the Packer config -- it defines
+	// the location of third party builder plugins, plugin ports to use, and
+	// whether to disable telemetry. It is a global config.
+	// Do not confuse this config with the .json Packer template which gets
+	// passed into commands like `packer build`
 	config, err := loadConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading configuration: \n\n%s\n", err)
@@ -328,6 +333,7 @@ func loadConfig() (*config, error) {
 	}
 	defer f.Close()
 
+	// This loads a json config, defined in packer/config.go
 	if err := decodeConfig(f, &config); err != nil {
 		return nil, err
 	}

--- a/packer/core.go
+++ b/packer/core.go
@@ -199,6 +199,8 @@ func (c *Core) generateCoreBuildProvisioner(rawP *template.Provisioner, rawName 
 	return cbp, nil
 }
 
+// This is used for json templates to launch the build plugins.
+// They will be prepared via b.Prepare() later.
 func (c *Core) GetBuilds(opts GetBuildsOptions) ([]Build, hcl.Diagnostics) {
 	buildNames := c.BuildNames(opts.Only, opts.Except)
 	builds := []Build{}
@@ -225,6 +227,12 @@ func (c *Core) Build(n string) (Build, error) {
 	if !ok {
 		return nil, fmt.Errorf("no such build found: %s", n)
 	}
+	// BuilderStore = config.Builders, gathered in loadConfig() in main.go
+	// For reference, the builtin BuilderStore is generated in
+	// packer/config.go in the Discover() func.
+
+	// the Start command launches the builder plugin of the given type without
+	// calling Prepare() or passing any build-specific details.
 	builder, err := c.components.BuilderStore.Start(configBuilder.Type)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -315,6 +323,8 @@ func (c *Core) Build(n string) (Build, error) {
 
 	// TODO hooks one day
 
+	// Return a structure that contains the plugins, their types, variables, and
+	// the raw builder config loaded from the json template
 	return &CoreBuild{
 		Type:               n,
 		Builder:            builder,

--- a/packer/run_interfaces.go
+++ b/packer/run_interfaces.go
@@ -6,6 +6,8 @@ type GetBuildsOptions struct {
 	// Get builds except the ones that match with except and with only the ones
 	// that match with Only. When those are empty everything matches.
 	Except, Only []string
+	Debug, Force bool
+	OnError      string
 }
 
 type BuildGetter interface {


### PR DESCRIPTION
HCL builds were being prepared before force and debug flags were being set. 

@azr I want your input on this solution before I write tests. In figuring out how to fix this I found it pretty surprising that HCL builds load the plugins and prepare them all in one step, when json builds do not. I feel pretty strongly that same-named functions should do the same general stuff regardless of whether they're operating on HCL or json. 

In this case, packerStarter.GetBuilds(...) should either just get or get and prepare for both, rather than having different behaviors for each. I want to discuss this with you outside the scope of this PR sometime soon.

I initially wanted to separate out the Prepare() call from the GetBuilds() flow for HCL2 but wanted to talk with you offline first about why you set things up this way.

Closes #9185
Closes #9223
