### PR TITLE
Added fuzzer

### DIFF
--- a/command/fuzz.go
+++ b/command/fuzz.go
@@ -1,0 +1,33 @@
+package command
+
+import (
+    "os"
+    "github.com/hashicorp/packer/packer"
+    "bytes"
+)
+
+func FuzzBuild(data []byte) int {
+	var out, errui bytes.Buffer
+	f, err := os.Create("data.json")
+	if err != nil {
+		return -1
+	}
+	defer os.Remove("data.json")
+	_, err = f.Write(data)
+	if err != nil {
+		return -1
+	}
+	c := &BuildCommand{
+		Meta: Meta{
+			Ui: &packer.BasicUi{
+				Writer:      &out,
+				ErrorWriter: &errui,
+			},
+		},
+	}
+	args := []string{"data.json"}
+	if code := c.Run(args); code != 0 {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer for the build command. It tests the build command by creating "data.json" , creates a BuildCommand and passes "data.json" as argument.

Local tests of fuzzing reveal no crashes, however it may be an idea to setup continuous fuzzing for Packer to keep looking for bugs. I managed to get the fuzzer running on oss-fuzz's infrastructure, and integrating Packer there will allow Google to run this fuzzer and future fuzzers continuously. If a bug is found, all maintainers on the contact list get a detailed bug report.
It is a free service that is offered with an implied expectation that found bugs are fixed, so that the resources spent on fuzzing Packer are put to good use.

I will be happy to integrate Packer into oss-fuzz. All I need are the email addresses for the bug reports. Please note that this is a public list that can be modified at any time.

If there is interest in fuzzing Packer, it will be my pleasure to work more on it by increasing coverage and the effectiveness of the fuzzers.