### PR TITLE
builder/azure-arm: Update runtime constants with a valid DataDiskName

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -394,7 +394,7 @@ type Config struct {
 	// see [here](https://docs.microsoft.com/en-us/azure/virtual-machines/troubleshooting/boot-diagnostics) for more info
 	BootDiagSTGAccount string `mapstructure:"boot_diag_storage_account" required:"false"`
 
-	// specify custom azure resource names during build limited to max 10 charcters
+	// specify custom azure resource names during build limited to max 10 characters
 	// this will set the prefix for the resources. The actuall resource names will be
 	// `custom_resource_build_prefix` + resourcetype + 5 character random alphanumeric string
 	CustomResourcePrefix string `mapstructure:"custom_resource_build_prefix" required:"false"`
@@ -668,7 +668,7 @@ func setRuntimeValues(c *Config) {
 	c.tmpNicName = tempName.NicName
 	c.tmpPublicIPAddressName = tempName.PublicIPAddressName
 	c.tmpOSDiskName = tempName.OSDiskName
-	c.tmpDataDiskName = tempName.DataDiskname
+	c.tmpDataDiskName = tempName.DataDiskName
 	c.tmpSubnetName = tempName.SubnetName
 	c.tmpVirtualNetworkName = tempName.VirtualNetworkName
 	c.tmpNsgName = tempName.NsgName

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -596,6 +596,10 @@ func TestSystemShouldDefineRuntimeValues(t *testing.T) {
 		t.Errorf("Expected tmpOSDiskName to not be empty, but it was '%s'!", c.tmpOSDiskName)
 	}
 
+	if c.tmpDataDiskName == "" {
+		t.Errorf("Expected tmpDataDiskName to not be empty, but it was '%s'!", c.tmpDataDiskName)
+	}
+
 	if c.tmpNsgName == "" {
 		t.Errorf("Expected tmpNsgName to not be empty, but it was '%s'!", c.tmpNsgName)
 	}

--- a/builder/azure/arm/tempname.go
+++ b/builder/azure/arm/tempname.go
@@ -15,7 +15,7 @@ type TempName struct {
 	KeyVaultName        string
 	ResourceGroupName   string
 	OSDiskName          string
-	DataDiskname        string
+	DataDiskName        string
 	NicName             string
 	SubnetName          string
 	PublicIPAddressName string
@@ -36,6 +36,7 @@ func NewTempName(p string) *TempName {
 	tempName.DeploymentName = fmt.Sprintf("%sdp%s", p, suffix)
 	tempName.KeyVaultName = fmt.Sprintf("%skv%s", p, suffix)
 	tempName.OSDiskName = fmt.Sprintf("%sos%s", p, suffix)
+	tempName.DataDiskName = fmt.Sprintf("%sdd%s", p, suffix)
 	tempName.NicName = fmt.Sprintf("%sni%s", p, suffix)
 	tempName.PublicIPAddressName = fmt.Sprintf("%sip%s", p, suffix)
 	tempName.SubnetName = fmt.Sprintf("%ssn%s", p, suffix)

--- a/website/pages/docs/builders/azure/arm.mdx
+++ b/website/pages/docs/builders/azure/arm.mdx
@@ -367,6 +367,7 @@ The Azure builder creates the following random values at runtime.
 - NIC Name: a random 15-character name prefixed with pkrni.
 - Public IP Name: a random 15-character name prefixed with pkrip.
 - OS Disk Name: a random 15-character name prefixed with pkros.
+- Data Disk Name: a random 15-character name prefixed with pkrdd.
 - Resource Group Name: a random 33-character name prefixed with
   packer-Resource-Group-.
 - Subnet Name: a random 15-character name prefixed with pkrsn.

--- a/website/pages/partials/builder/azure/arm/Config-not-required.mdx
+++ b/website/pages/partials/builder/azure/arm/Config-not-required.mdx
@@ -243,7 +243,7 @@
     once the build is completed, it has to be removed manually.
     see [here](https://docs.microsoft.com/en-us/azure/virtual-machines/troubleshooting/boot-diagnostics) for more info
     
--   `custom_resource_build_prefix` (string) - specify custom azure resource names during build limited to max 10 charcters
+-   `custom_resource_build_prefix` (string) - specify custom azure resource names during build limited to max 10 characters
     this will set the prefix for the resources. The actuall resource names will be
     `custom_resource_build_prefix` + resourcetype + 5 character random alphanumeric string
     


### PR DESCRIPTION
This change fixes an issue where using the `disk_additional_size` configuration option would cause builds to fail.

Build results before the change
```
==> Builds finished but no artifacts were created.
Build 'azure-arm' errored: Code="DeploymentFailed" Message="At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/DeployOperations for usage details." Details=[{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code
\": \"InvalidParameter\",\r\n    \"message\": \"The entity name 'dataDisk.name' is invalid according to its validation rule: ^[^_\\\\W][\\\\w-._]{0,79}(?\u003c![-.])$.\",\r\n    \"target\": \"dataDisk.name\"\r\n  }\r\n}"}]

```

Build results after change
```
Build 'azure-arm' finished.

==> Builds finished. The artifacts of successful builds are:
--> azure-arm: Azure.ResourceManagement.VMImage:
```

Closes #9249