### PR TITLE
HCL compliance for HyperOne builder

### DIFF
--- a/examples/hyperone/new-syntax.pkr.hcl
+++ b/examples/hyperone/new-syntax.pkr.hcl
@@ -1,0 +1,32 @@
+variable "token" {
+  type = string
+}
+
+variable "project" {
+  type = string
+}
+
+source "hyperone" "new-syntax" {
+  token = var.token
+  project = var.project
+  source_image = "debian"
+  disk_size = 10
+  vm_type = "a1.nano"
+  image_name = "packerbats-hcl-{{timestamp}}"
+  image_tags = {
+      key="value"
+  }
+}
+
+build {
+  sources = [
+    "source.hyperone.new-syntax"
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "apt-get update",
+      "apt-get upgrade -y"
+    ]
+  }
+}

--- a/test/builder_hyperone.bats
+++ b/test/builder_hyperone.bats
@@ -18,7 +18,7 @@ USER_VARS="${USER_VARS} -var token=${HYPERONE_TOKEN}"
 USER_VARS="${USER_VARS} -var project=${HYPERONE_PROJECT}"
 
 hyperone_has_image() {
-    h1 image list --project-select=${HYPERONE_PROJECT} --query "[?tag.${2}=='${3}']"  --output=tsv | grep $1 | wc -l
+    h1 image list --project-select=${HYPERONE_PROJECT} --query "[?tag.${2}=='${3}']"  --output=tsv | grep $1 -c
 }
 
 teardown() {
@@ -33,6 +33,13 @@ teardown() {
     [ "$status" -eq 0 ]
     [ "$(hyperone_has_image "packerbats-minimal" "key" "value")" -eq 1 ]
 }
+
+@test "hyperone: build new-syntax.pkr.hcl" {
+    run packer build ${USER_VARS} $FIXTURE_ROOT/new-syntax.pkr.hcl
+    [ "$status" -eq 0 ]
+    [ "$(hyperone_has_image "packerbats-hcl" "key" "value")" -eq 1 ]
+}
+
 
 @test "hyperone: build chroot.json" {
     run packer build ${USER_VARS} $FIXTURE_ROOT/chroot.json

--- a/test/fixtures/builder-hyperone/new-syntax.pkr.hcl
+++ b/test/fixtures/builder-hyperone/new-syntax.pkr.hcl
@@ -1,0 +1,29 @@
+variable "token" {
+  type = string
+}
+
+variable "project" {
+  type = string
+}
+
+source "hyperone" "new-syntax" {
+  token = var.token
+  project = var.project
+  source_image = "debian"
+  disk_size = 10
+  vm_type = "a1.nano"
+  image_name = "packerbats-hcl-{{timestamp}}"
+  image_tags = {
+      key="value"
+  }
+}
+
+build {
+  sources = [
+    "source.hyperone.new-syntax"
+  ]
+
+  provisioner "shell" {
+    inline = ["sleep 5"]
+  }
+}

--- a/website/pages/docs/builders/hyperone.mdx
+++ b/website/pages/docs/builders/hyperone.mdx
@@ -243,3 +243,40 @@ token.
   ]
 }
 ```
+
+## HCL Example
+
+```hcl
+variable "token" {
+  type = string
+}
+
+variable "project" {
+  type = string
+}
+
+source "hyperone" "new-syntax" {
+  token = var.token
+  project = var.project
+  source_image = "debian"
+  disk_size = 10
+  vm_type = "a1.nano"
+  image_name = "packerbats-hcl-{{timestamp}}"
+  image_tags = {
+      key="value"
+  }
+}
+
+build {
+  sources = [
+    "source.hyperone.new-syntax"
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "apt-get update",
+      "apt-get upgrade -y"
+    ]
+  }
+}
+```


### PR DESCRIPTION
According https://www.packer.io/guides/hcl/component-object-spec/ special operations are required to ensure proper HCL support in the plugin.

HyperOne Builder - based on manually conducted tests - works correctly with HCL. No change in the builder's behavior is required.

However, it is advisable to change the documentation confirm this fact for the world, as well and add tests to periodically verify. 

I would like notice that this builder is periodically tested in open-source repository ( https://github.com/hyperonecom/h1-packer-e2e ). After merges these changes into the master branch - new tests will be performed as part of periodic verification, which will allow the cloud provider to respond appropriately in the event of incompatibility to HCL syntax and other problems.

Changes were made in places where this is appropriate based on the current project structure. However, there is some redundancy and repetition in the structure of project already.

Is it possible to load full or part of ".hcl" files, e.g. from tests, under "* .mdx" files?  Ideally, the documentation should only have fragments that are somehow tested. I love how Apache Airflow organized it (example https://github.com/apache/airflow/pull/8883/files ).