### PR TITLE
HCL2: use source type and name as Name of a CoreBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * **New post-processor** Yandex Export [GH-9124]
 
 ### IMPROVEMENTS:
+* core: HCL logs now display source type and source name (`type.name`) in logs
+    to differentiate more easily who says what.
 * builder/amazon: Add SSM Session Manager as a SSH interface connection
     [GH-9082]
 * builder/google: Implement iap proxy for googlecompute [GH-9105]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### IMPROVEMENTS:
 * core: HCL logs now display source type and source name (`type.name`) in logs
-    to differentiate more easily who says what.
+    to differentiate more easily who says what. [GH-9257]
 * builder/amazon: Add SSM Session Manager as a SSH interface connection
     [GH-9082]
 * builder/google: Implement iap proxy for googlecompute [GH-9105]

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -353,7 +353,7 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packer.Build
 			}
 
 			pcb := &packer.CoreBuild{
-				Type:           src.Type,
+				Type:           src.Ref().String(),
 				Builder:        builder,
 				Provisioners:   provisioners,
 				PostProcessors: pps,

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -100,7 +100,7 @@ func TestParser_complete(t *testing.T) {
 			false, false,
 			[]packer.Build{
 				&packer.CoreBuild{
-					Type:     "virtualbox-iso",
+					Type:     "virtualbox-iso.ubuntu-1204",
 					Prepared: true,
 					Builder:  basicMockBuilder,
 					Provisioners: []packer.CoreBuildProvisioner{
@@ -199,7 +199,7 @@ func TestParser_complete(t *testing.T) {
 			false, false,
 			[]packer.Build{
 				&packer.CoreBuild{
-					Type:     "virtualbox-iso",
+					Type:     "virtualbox-iso.ubuntu-1204",
 					Prepared: true,
 					Builder:  emptyMockBuilder,
 					Provisioners: []packer.CoreBuildProvisioner{
@@ -242,7 +242,7 @@ func TestParser_complete(t *testing.T) {
 			false, false,
 			[]packer.Build{
 				&packer.CoreBuild{
-					Type:     "virtualbox-iso",
+					Type:     "virtualbox-iso.ubuntu-1204",
 					Prepared: true,
 					Builder:  emptyMockBuilder,
 					Provisioners: []packer.CoreBuildProvisioner{


### PR DESCRIPTION
With :
```hcl
source "null" "test" {
    communicator = "none"
}

source "null" "potato" {
    communicator = "none"
}

build {
    sources = [
        "sources.null.test",
        "sources.null.potato",
    ]
}
```

Before this PR:

```term
❯ go run . build ./.vscode/hcl2/null/does_nothing
null: output will be in this color.
null: output will be in this color.

Build 'null' finished.
Build 'null' finished.

==> Builds finished. The artifacts of successful builds are:
--> null: Did not export anything. This is the null builder
```

After this PR:

```term
❯ go run . build ./.vscode/hcl2/null/does_nothing
null.test: output will be in this color.
null.potato: output will be in this color.

Build 'null.potato' finished.
Build 'null.test' finished.

==> Builds finished. The artifacts of successful builds are:
--> null.test: Did not export anything. This is the null builder
--> null.potato: Did not export anything. This is the null builder

❯ go run . build -only "*.potato" ./.vscode/hcl2/null/does_nothing
null.potato: output will be in this color.

Build 'null.potato' finished.

==> Builds finished. The artifacts of successful builds are:
--> null.potato: Did not export anything. This is the null builder
```

Please note that if a source is used twice then it will be displayed twice.

A way to make this better would be to force users to name a build section:

```term
build "identifier-name" {
    sources = [
        "sources.null.test",
        "sources.null.potato",
    ]
}
```

Then we could name a build `identifier-name.null.test`. But I think https://github.com/hashicorp/packer/pull/9245 is the PR that should do this.