### PR TITLE
make package_include match output_vagrantfile parsing and abspath cal…

### DIFF
--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -182,7 +182,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		}
 		if strings.HasSuffix(b.config.SourceBox, ".box") {
 			if _, err := os.Stat(b.config.SourceBox); err != nil {
-				packer.MultiErrorAppend(errs,
+				errs = packer.MultiErrorAppend(errs,
 					fmt.Errorf("Source box '%s' needs to exist at time of config validation! %v", b.config.SourceBox, err))
 			}
 		}
@@ -191,7 +191,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	if b.config.OutputVagrantfile != "" {
 		b.config.OutputVagrantfile, err = filepath.Abs(b.config.OutputVagrantfile)
 		if err != nil {
-			packer.MultiErrorAppend(errs,
+			errs = packer.MultiErrorAppend(errs,
 				fmt.Errorf("unable to determine absolute path for output vagrantfile: %s", err))
 		}
 	}
@@ -201,7 +201,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		for _, rawFile := range b.config.PackageInclude {
 			inclFile, err := filepath.Abs(rawFile)
 			if err != nil {
-				packer.MultiErrorAppend(errs,
+				errs = packer.MultiErrorAppend(errs,
 					fmt.Errorf("unable to determine absolute path for file to be included: %s", rawFile))
 			}
 			include = append(include, inclFile)

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -198,11 +198,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	if len(b.config.PackageInclude) > 0 {
 		include := []string{}
-		for i, inclFile := range b.config.PackageInclude {
-			b.config.PackageInclude, err = filepath.Abs(b.config.PackageInclude)
+		for _, rawFile := range b.config.PackageInclude {
+			inclFile, err := filepath.Abs(rawFile)
 			if err != nil {
 				packer.MultiErrorAppend(errs,
-					fmt.Errorf("unable to determine absolute path for file to be included: %s", inclFile))
+					fmt.Errorf("unable to determine absolute path for file to be included: %s", rawFile))
 			}
 			include = append(include, inclFile)
 		}

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -197,16 +197,14 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	}
 
 	if len(b.config.PackageInclude) > 0 {
-		include := []string{}
-		for _, rawFile := range b.config.PackageInclude {
+		for i, rawFile := range b.config.PackageInclude {
 			inclFile, err := filepath.Abs(rawFile)
 			if err != nil {
 				errs = packer.MultiErrorAppend(errs,
 					fmt.Errorf("unable to determine absolute path for file to be included: %s", rawFile))
 			}
-			include = append(include, inclFile)
+			b.config.PackageInclude[i] = inclFile
 		}
-		b.config.PackageInclude = include
 	}
 
 	if b.config.TeardownMethod == "" {

--- a/website/pages/partials/builder/vagrant/Config-not-required.mdx
+++ b/website/pages/partials/builder/vagrant/Config-not-required.mdx
@@ -70,4 +70,7 @@
     package your base box into its own standalone .box file.
     
 -   `output_vagrantfile` (string) - Output Vagrantfile
--   `package_include` ([]string) - Package Include
+-   `package_include` ([]string) - Equivalent to setting the
+    [`--include`](https://www.vagrantup.com/docs/cli/package.html#include-x-y-z) option
+    in `vagrant package`; defaults to unset
+    


### PR DESCRIPTION
use absolute path for package_include files to prevent them from having to be relative to the output vagrant directory. This makes them match the output_vagrantfile.

Closes #9256
