### PR TITLE
Interpolate generatedData in the Inspec provisioner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           file: coverage.txt
   check-lint:
     executor: golang
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - run: git fetch --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
     supported builders [GH-9238]
 * post-processor/vsphere-template: Add VSphere builder's artifact to vsphere-
     template's supported types [GH-9146]
+* provisioner/inspec: Fix build variables interpolation [GH-9262]
 * provisioner/powershell: Fix long-wait retry loop caused by cleanup logic
     [GH-9226]
 

--- a/provisioner/inspec/provisioner.go
+++ b/provisioner/inspec/provisioner.go
@@ -347,11 +347,14 @@ func (p *Provisioner) executeInspec(ui packer.Ui, comm packer.Communicator, priv
 	args = append(args, "--backend", p.config.Backend)
 	args = append(args, "--host", p.config.Host)
 
+	if p.config.User != "" {
+		args = append(args, "--user", p.config.User)
+	}
+
 	if p.config.Backend == "ssh" {
 		if len(privKeyFile) > 0 {
 			args = append(args, "--key-files", privKeyFile)
 		}
-		args = append(args, "--user", p.config.User)
 		args = append(args, "--port", strconv.Itoa(p.config.LocalPort))
 	}
 

--- a/provisioner/inspec/provisioner.go
+++ b/provisioner/inspec/provisioner.go
@@ -189,8 +189,21 @@ func (p *Provisioner) getVersion() error {
 	return nil
 }
 
-func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.Communicator, _ map[string]interface{}) error {
+func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.Communicator, generateData map[string]interface{}) error {
 	ui.Say("Provisioning with Inspec...")
+	p.config.ctx.Data = generateData
+
+	userp, err := interpolate.Render(p.config.User, &p.config.ctx)
+	if err != nil {
+		return fmt.Errorf("Could not interpolate inspec user: %s", err)
+	}
+	p.config.User = userp
+
+	host, err := interpolate.Render(p.config.Host, &p.config.ctx)
+	if err != nil {
+		return fmt.Errorf("Could not interpolate inspec user: %s", err)
+	}
+	p.config.Host = host
 
 	for i, envVar := range p.config.InspecEnvVars {
 		envVar, err := interpolate.Render(envVar, &p.config.ctx)

--- a/provisioner/inspec/provisioner.go
+++ b/provisioner/inspec/provisioner.go
@@ -191,7 +191,7 @@ func (p *Provisioner) getVersion() error {
 
 func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.Communicator, generatedData map[string]interface{}) error {
 	ui.Say("Provisioning with Inspec...")
-	p.config.ctx.Data = generateData
+	p.config.ctx.Data = generatedData
 
 	userp, err := interpolate.Render(p.config.User, &p.config.ctx)
 	if err != nil {

--- a/provisioner/inspec/provisioner.go
+++ b/provisioner/inspec/provisioner.go
@@ -189,7 +189,7 @@ func (p *Provisioner) getVersion() error {
 	return nil
 }
 
-func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.Communicator, generateData map[string]interface{}) error {
+func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.Communicator, generatedData map[string]interface{}) error {
 	ui.Say("Provisioning with Inspec...")
 	p.config.ctx.Data = generateData
 

--- a/website/pages/docs/provisioners/inspec.mdx
+++ b/website/pages/docs/provisioners/inspec.mdx
@@ -106,6 +106,23 @@ Optional Parameters:
 
 @include 'provisioners/common-config.mdx'
 
+## Accepting the InSpec license
+
+Chef InSpec requires accepting the license before starting to use the tool.
+This can be done via `inspec_env_vars` in the template:
+
+```
+"provisioners": [
+    {
+      "type": "inspec",
+      "inspec_env_vars": [ "CHEF_LICENSE=accept"],
+      "profile": "https://github.com/dev-sec/linux-baseline"
+    }
+  ],
+```
+
+See their [official docs](https://docs.chef.io/chef_license_accept/) to learn other ways to accept the license.
+
 ## Default Extra Variables
 
 In addition to being able to specify extra arguments using the


### PR DESCRIPTION
Interpolate generatedData in the Inspec provisioner and add doc section to mention accepting Chef InSpec licenses. (idea from https://github.com/hashicorp/packer/issues/8147#issue-497684898)


Closes https://github.com/hashicorp/packer/issues/9075