### PR TITLE
send logs about floppy failure directly to UI not just logs

### DIFF
--- a/builder/virtualbox/common/step_attach_floppy.go
+++ b/builder/virtualbox/common/step_attach_floppy.go
@@ -88,6 +88,8 @@ func (s *StepAttachFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 }
 
 func (s *StepAttachFloppy) Cleanup(state multistep.StateBag) {
+	ui := state.Get("ui").(packer.Ui)
+	ui.Say("Cleaning up floppy disk...")
 	if s.floppyPath == "" {
 		return
 	}
@@ -107,7 +109,8 @@ func (s *StepAttachFloppy) Cleanup(state multistep.StateBag) {
 	}
 
 	if err := driver.VBoxManage(command...); err != nil {
-		log.Printf("Error unregistering floppy: %s", err)
+		ui.Error(fmt.Sprintf("Error unregistering floppy: %s. "+
+			"Not considering this a critical failure; build will continue.", err))
 	}
 }
 


### PR DESCRIPTION
Simple logging change. When looking at #9269 I realized errors with floppy detach only get sent to logs, not UI. This seems like an oversight. 