### PR TITLE
un-bypass secretsmanager tests

### DIFF
--- a/template/interpolate/aws/secretsmanager/secretsmanager_test.go
+++ b/template/interpolate/aws/secretsmanager/secretsmanager_test.go
@@ -115,12 +115,12 @@ func TestGetSecret(t *testing.T) {
 		got, err := c.GetSecret(test.arg)
 		if test.ok {
 			if got != test.want {
-				t.Logf("want %v, got %v, error %v, using arg %v", test.want, got, err, test.arg)
+				t.Fatalf("want %v, got %v, error %v, using arg %v", test.want, got, err, test.arg)
 			}
 		}
 		if !test.ok {
 			if err == nil {
-				t.Logf("error expected but got %q, using arg %v", err, test.arg)
+				t.Fatalf("error expected but got %q, using arg %v", err, test.arg)
 			}
 		}
 		t.Logf("arg (%v), want %v, got %v, err %v", test.arg, test.want, got, err)


### PR DESCRIPTION
Aws secretsmanager tests were flaking, so I turned them off on master. this PR re-enables them, but let's not merge until I know they aren't flaking anymore.
