### PR TITLE
provisioner/powershell: fix interpolation of execute_command in cleanup script call.

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -371,10 +371,11 @@ func (p *Provisioner) createRemoteCleanUpCommand(remoteFiles []string) (string, 
 		return "", fmt.Errorf("clean up script %q failed to upload: %s", remotePath, err)
 	}
 
-	data := map[string]string{
-		"Path": remotePath,
-		"Vars": p.config.RemoteEnvVarPath,
-	}
+	data := p.generatedData
+	data["Path"] = remotePath
+	data["Vars"] = p.config.RemoteEnvVarPath
+	p.config.ctx.Data = data
+
 	p.config.ctx.Data = data
 	return interpolate.Render(p.config.ExecuteCommand, &p.config.ctx)
 }


### PR DESCRIPTION
When testing something on AWS, I noticed an error message: 

```
2020/05/15 11:23:57 packer-provisioner-powershell plugin: failed to create a remote cleanup script: template: root:1:71: executing "root" at <build `Host`>: error calling build: loaded data, but couldnt find Host in it.
```
This turns out to be because we were re-interpolating the execute command for the cleanup script, but failing to include the generatedData. This PR fixes that, and removes this error message, fixing cleanup scripts for any execute_commands that depended on data from the `build` template function.