### PR TITLE
Added SourceAMICreationDate

### DIFF
--- a/builder/amazon/common/interpolate_build_info.go
+++ b/builder/amazon/common/interpolate_build_info.go
@@ -8,12 +8,13 @@ import (
 )
 
 type BuildInfoTemplate struct {
-	BuildRegion        string
-	SourceAMI          string
-	SourceAMIName      string
-	SourceAMIOwner     string
-	SourceAMIOwnerName string
-	SourceAMITags      map[string]string
+	BuildRegion           string
+	SourceAMI             string
+	SourceAMICreationDate string
+	SourceAMIName         string
+	SourceAMIOwner        string
+	SourceAMIOwnerName    string
+	SourceAMITags         map[string]string
 }
 
 func extractBuildInfo(region string, state multistep.StateBag, generatedData *builder.GeneratedData) *BuildInfoTemplate {
@@ -31,12 +32,13 @@ func extractBuildInfo(region string, state multistep.StateBag, generatedData *bu
 	}
 
 	buildInfoTemplate := &BuildInfoTemplate{
-		BuildRegion:        region,
-		SourceAMI:          aws.StringValue(sourceAMI.ImageId),
-		SourceAMIName:      aws.StringValue(sourceAMI.Name),
-		SourceAMIOwner:     aws.StringValue(sourceAMI.OwnerId),
-		SourceAMIOwnerName: aws.StringValue(sourceAMI.ImageOwnerAlias),
-		SourceAMITags:      sourceAMITags,
+		BuildRegion:           region,
+		SourceAMI:             aws.StringValue(sourceAMI.ImageId),
+		SourceAMICreationDate: aws.StringValue(sourceAMI.CreationDate),
+		SourceAMIName:         aws.StringValue(sourceAMI.Name),
+		SourceAMIOwner:        aws.StringValue(sourceAMI.OwnerId),
+		SourceAMIOwnerName:    aws.StringValue(sourceAMI.ImageOwnerAlias),
+		SourceAMITags:         sourceAMITags,
 	}
 	generatedData.Put("SourceAMIName", buildInfoTemplate.SourceAMIName)
 	return buildInfoTemplate

--- a/builder/amazon/common/interpolate_build_info_test.go
+++ b/builder/amazon/common/interpolate_build_info_test.go
@@ -13,6 +13,7 @@ import (
 func testImage() *ec2.Image {
 	return &ec2.Image{
 		ImageId:         aws.String("ami-abcd1234"),
+		CreationDate:    aws.String("ami_test_creation_date"),
 		Name:            aws.String("ami_test_name"),
 		OwnerId:         aws.String("ami_test_owner_id"),
 		ImageOwnerAlias: aws.String("ami_test_owner_alias"),
@@ -59,11 +60,12 @@ func TestInterpolateBuildInfo_extractBuildInfo_withSourceImage(t *testing.T) {
 	buildInfo := extractBuildInfo("foo", state, &generatedData)
 
 	expected := BuildInfoTemplate{
-		BuildRegion:        "foo",
-		SourceAMI:          "ami-abcd1234",
-		SourceAMIName:      "ami_test_name",
-		SourceAMIOwner:     "ami_test_owner_id",
-		SourceAMIOwnerName: "ami_test_owner_alias",
+		BuildRegion:           "foo",
+		SourceAMI:             "ami-abcd1234",
+		SourceAMICreationDate: "ami_test_creation_date",
+		SourceAMIName:         "ami_test_name",
+		SourceAMIOwner:        "ami_test_owner_id",
+		SourceAMIOwnerName:    "ami_test_owner_alias",
 		SourceAMITags: map[string]string{
 			"key-1": "value-1",
 			"key-2": "value-2",

--- a/website/pages/docs/builders/amazon/chroot.mdx
+++ b/website/pages/docs/builders/amazon/chroot.mdx
@@ -289,6 +289,7 @@ variables are available:
   building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build
   the AMI.
+- `SourceAMICreationDate` - The source AMI creation date (for example `"2020-05-14T19:26:34.000Z"`).
 - `SourceAMIName` - The source AMI Name (for example
   `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
   build the AMI.

--- a/website/pages/docs/builders/amazon/ebs.mdx
+++ b/website/pages/docs/builders/amazon/ebs.mdx
@@ -193,6 +193,7 @@ variables are available:
   building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build
   the AMI.
+- `SourceAMICreationDate` - The source AMI creation date (for example `"2020-05-14T19:26:34.000Z"`).
 - `SourceAMIName` - The source AMI Name (for example
   `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
   build the AMI.

--- a/website/pages/docs/builders/amazon/ebssurrogate.mdx
+++ b/website/pages/docs/builders/amazon/ebssurrogate.mdx
@@ -155,6 +155,7 @@ variables are available:
   building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build
   the AMI.
+- `SourceAMICreationDate` - The source AMI creation date (for example `"2020-05-14T19:26:34.000Z"`).
 - `SourceAMIName` - The source AMI Name (for example
   `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
   build the AMI.

--- a/website/pages/docs/builders/amazon/ebsvolume.mdx
+++ b/website/pages/docs/builders/amazon/ebsvolume.mdx
@@ -176,6 +176,7 @@ variables are available:
   building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build
   the AMI.
+- `SourceAMICreationDate` - The source AMI creation date (for example `"2020-05-14T19:26:34.000Z"`).
 - `SourceAMIName` - The source AMI Name (for example
   `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
   build the AMI.

--- a/website/pages/docs/builders/amazon/instance.mdx
+++ b/website/pages/docs/builders/amazon/instance.mdx
@@ -161,6 +161,7 @@ variables are available:
   building the AMI.
 - `SourceAMI` - The source AMI ID (for example `ami-a2412fcd`) used to build
   the AMI.
+- `SourceAMICreationDate` - The source AMI creation date (for example `"2020-05-14T19:26:34.000Z"`).
 - `SourceAMIName` - The source AMI Name (for example
   `ubuntu/images/ebs-ssd/ubuntu-xenial-16.04-amd64-server-20180306`) used to
   build the AMI.


### PR DESCRIPTION
Added `SourceAMICreationDate` so the image's `CreationDate` can be used.

Modeled PR after https://github.com/hashicorp/packer/pull/8550

Closes https://github.com/hashicorp/packer/issues/9029
