### PR TITLE
[amazon-ebs] Add a prevaliate step for KMS keys

### DIFF
--- a/builder/amazon/common/step_pre_validate.go
+++ b/builder/amazon/common/step_pre_validate.go
@@ -85,7 +85,7 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 	// Note: Per docs, if region-specific keys are set they override and we
 	// silently ignore the default kms_key_id options.
 	// FIXME: Assume the user wants to use the default KMS key, by setting kms_key_id="".
-	// Do we still need permissions to encrypt with it? In other words, should we 
+	// Do we still need permissions to encrypt with it? In other words, should we
 	// expect we can perform a kms.DescribeKey(`alias/aws/ebs`) operation successfully?
 	if len(s.AMIRegionKMSKeyIDs) != 0 {
 		// Check each key and region exists.v

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -206,12 +206,15 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepPreValidate{
-			DestAmiName:        b.config.AMIName,
-			ForceDeregister:    b.config.AMIForceDeregister,
-			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
-			VpcId:              b.config.VpcId,
-			SubnetId:           b.config.SubnetId,
-			HasSubnetFilter:    !b.config.SubnetFilter.Empty(),
+			DestAmiName:          b.config.AMIName,
+			ForceDeregister:      b.config.AMIForceDeregister,
+			AMISkipBuildRegion:   b.config.AMISkipBuildRegion,
+			VpcId:                b.config.VpcId,
+			SubnetId:             b.config.SubnetId,
+			HasSubnetFilter:      !b.config.SubnetFilter.Empty(),
+			AMIEncryptBootVolume: b.config.AMIEncryptBootVolume.True(),
+			AMIKmsKeyId:          b.config.AMIKmsKeyId,
+			AMIRegionKMSKeyIDs:   b.config.AMIRegionKMSKeyIDs,
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,


### PR DESCRIPTION
This change introduces a check on the KMS key id or alias early in
start-up to make sure it exists in the given regions. This eliminates a
possible condition that can cause the opaque ResourceNotFound at the end
of the build.

If encryption parameters are not set, the check is not performed so we
shouldn't run afoul of IAM permission issues.
