### PR TITLE
Fix aws_secretsmanager multiple keys support

### DIFF
--- a/template/interpolate/aws/secretsmanager/secretsmanager.go
+++ b/template/interpolate/aws/secretsmanager/secretsmanager.go
@@ -83,7 +83,11 @@ func getSecretValue(s *SecretString, spec *SecretSpec) (string, error) {
 		return "", err
 	}
 
-	// If key is not set then return first value stored in secret
+	// If key is not set and secret has multiple keys, return error
+	if spec.Key == "" && len(secretValue) > 1 {
+		return "", errors.New("Secret has multiple values and no key was set")
+	}
+
 	if spec.Key == "" {
 		for _, v := range secretValue {
 			return v, nil

--- a/template/interpolate/aws/secretsmanager/secretsmanager_test.go
+++ b/template/interpolate/aws/secretsmanager/secretsmanager_test.go
@@ -20,13 +20,15 @@ func (m mockedSecret) GetSecretValue(in *secretsmanager.GetSecretValueInput) (*s
 
 func TestGetSecret(t *testing.T) {
 	testCases := []struct {
-		arg  *SecretSpec
-		mock secretsmanager.GetSecretValueOutput
-		want string
-		ok   bool
+		description string
+		arg         *SecretSpec
+		mock        secretsmanager.GetSecretValueOutput
+		want        string
+		ok          bool
 	}{
 		{
-			arg: &SecretSpec{Name: "test/secret"},
+			description: "input has valid secret name, secret has single key",
+			arg:         &SecretSpec{Name: "test/secret"},
 			mock: secretsmanager.GetSecretValueOutput{
 				Name:         aws.String("test/secret"),
 				SecretString: aws.String(`{"key": "test"}`),
@@ -35,6 +37,7 @@ func TestGetSecret(t *testing.T) {
 			ok:   true,
 		},
 		{
+			description: "input has valid secret name and key, secret has single key",
 			arg: &SecretSpec{
 				Name: "test/secret",
 				Key:  "key",
@@ -47,6 +50,7 @@ func TestGetSecret(t *testing.T) {
 			ok:   true,
 		},
 		{
+			description: "input has valid secret name and key, secret has multiple keys",
 			arg: &SecretSpec{
 				Name: "test/secret",
 				Key:  "second_key",
@@ -59,6 +63,7 @@ func TestGetSecret(t *testing.T) {
 			ok:   true,
 		},
 		{
+			description: "input has valid secret name and no key, secret has multiple keys",
 			arg: &SecretSpec{
 				Name: "test/secret",
 			},
@@ -66,10 +71,10 @@ func TestGetSecret(t *testing.T) {
 				Name:         aws.String("test/secret"),
 				SecretString: aws.String(`{"first_key": "first_val", "second_key": "second_val"}`),
 			},
-			want: "first_val",
-			ok:   true,
+			ok: false,
 		},
 		{
+			description: "input has valid secret name and invalid key, secret has single key",
 			arg: &SecretSpec{
 				Name: "test/secret",
 				Key:  "nonexistent",
@@ -81,6 +86,7 @@ func TestGetSecret(t *testing.T) {
 			ok: false,
 		},
 		{
+			description: "input has valid secret name and invalid key, secret has multiple keys",
 			arg: &SecretSpec{
 				Name: "test/secret",
 				Key:  "nonexistent",
@@ -92,6 +98,7 @@ func TestGetSecret(t *testing.T) {
 			ok: false,
 		},
 		{
+			description: "input has secret and key, secret is empty",
 			arg: &SecretSpec{
 				Name: "test/secret",
 				Key:  "nonexistent",


### PR DESCRIPTION
As mentioned in here https://github.com/hashicorp/packer/pull/9273#issuecomment-632270587 current implementation of `aws_secretsmanager` function make a wrong assumption when no key is given and secret has multiple values making this feature inconsistent.

This PR fix this by throwing an error if no key is given when secret has mutliple values.

