### PR TITLE
Add Communicator Configuration Reference to Hyper-v documentation

### DIFF
--- a/website/pages/docs/builders/hyperv/iso.mdx
+++ b/website/pages/docs/builders/hyperv/iso.mdx
@@ -106,6 +106,20 @@ builder.
 
 @include 'common/FloppyConfig-not-required.mdx'
 
+## Communicator configuration reference
+
+### Optional common fields:
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+### Optional SSH fields:
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+### Optional WinRM fields:
+
+@include 'helper/communicator/WinRM-not-required.mdx'
+
 ## Boot Configuration Reference
 
 @include 'common/bootcommand/BootConfig.mdx'

--- a/website/pages/docs/builders/hyperv/vmcx.mdx
+++ b/website/pages/docs/builders/hyperv/vmcx.mdx
@@ -103,6 +103,20 @@ builder.
 
 @include 'builder/hyperv/common/CommonConfig-not-required.mdx'
 
+## Communicator configuration reference
+
+### Optional common fields:
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+### Optional SSH fields:
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+### Optional WinRM fields:
+
+@include 'helper/communicator/WinRM-not-required.mdx'
+
 ## Boot Command
 
 The `boot_command` configuration is very important: it specifies the keys to


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/packer-tool/k44BAG_S7MU made me realize this information was missing in the Hyper-v docs.