### PR TITLE
provisioner/salt-masterless: ignore the CmdArgs field in hcl2

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -67,7 +67,7 @@ type Config struct {
 	SaltBinDir string `mapstructure:"salt_bin_dir"`
 
 	// Command line args passed onto salt-call
-	CmdArgs string ""
+	CmdArgs string `mapstructure-to-hcl2:",skip"`
 
 	// The Guest OS Type (unix or windows)
 	GuestOSType string `mapstructure:"guest_os_type"`

--- a/provisioner/salt-masterless/provisioner.hcl2spec.go
+++ b/provisioner/salt-masterless/provisioner.hcl2spec.go
@@ -31,7 +31,6 @@ type FlatConfig struct {
 	LogLevel            *string           `mapstructure:"log_level" cty:"log_level"`
 	SaltCallArgs        *string           `mapstructure:"salt_call_args" cty:"salt_call_args"`
 	SaltBinDir          *string           `mapstructure:"salt_bin_dir" cty:"salt_bin_dir"`
-	CmdArgs             *string           `cty:"cmd_args"`
 	GuestOSType         *string           `mapstructure:"guest_os_type" cty:"guest_os_type"`
 }
 
@@ -69,7 +68,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"log_level":                  &hcldec.AttrSpec{Name: "log_level", Type: cty.String, Required: false},
 		"salt_call_args":             &hcldec.AttrSpec{Name: "salt_call_args", Type: cty.String, Required: false},
 		"salt_bin_dir":               &hcldec.AttrSpec{Name: "salt_bin_dir", Type: cty.String, Required: false},
-		"cmd_args":                   &hcldec.AttrSpec{Name: "cmd_args", Type: cty.String, Required: false},
 		"guest_os_type":              &hcldec.AttrSpec{Name: "guest_os_type", Type: cty.String, Required: false},
 	}
 	return s


### PR DESCRIPTION
fix #9233

The CmdArgs field is public but the value is always overwritten so I just ignored the field in HCL2

https://github.com/hashicorp/packer/blob/ec88415fbbad4629a2f17376060ceeb5eddaf5ec/provisioner/salt-masterless/provisioner.go#L175-L219