### PR TITLE
Json vs HCL2 parity refactor

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -188,31 +188,6 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	log.Printf("Force build: %v", cla.Force)
 	log.Printf("On error: %v", cla.OnError)
 
-	// Set the debug and force mode and prepare all the builds
-	// This is only affects json templates, because HCL2
-	// templates have already been prepared in GetBuilds() above.
-	for i := range builds {
-		b := builds[i]
-		log.Printf("Preparing build: %s", b.Name())
-		b.SetDebug(cla.Debug)
-		b.SetForce(cla.Force)
-		b.SetOnError(cla.OnError)
-
-		warnings, err := b.Prepare()
-		if err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
-		if len(warnings) > 0 {
-			ui := buildUis[b]
-			ui.Say(fmt.Sprintf("Warnings for build '%s':\n", b.Name()))
-			for _, warning := range warnings {
-				ui.Say(fmt.Sprintf("* %s", warning))
-			}
-			ui.Say("")
-		}
-	}
-
 	// Run all the builds in parallel and wait for them to complete
 	var wg sync.WaitGroup
 	var artifacts = struct {

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -363,6 +363,12 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packer.Build
 			// we did all the prep here.
 			_, err := pcb.Prepare()
 			if err != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  fmt.Sprintf("Preparing packer core build %s failed", src.Ref().String()),
+					Detail:   err.Error(),
+					Subject:  build.HCL2Ref.DefRange.Ptr(),
+				})
 				continue
 			}
 

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -359,6 +359,10 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packer.Build
 				PostProcessors: pps,
 				Prepared:       true,
 			}
+			// Prepare just sets the "prepareCalled" flag on CoreBuild, since
+			// we did all the prep here.
+			pcb.Prepare()
+
 			res = append(res, pcb)
 		}
 	}

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -361,7 +361,10 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packer.Build
 			}
 			// Prepare just sets the "prepareCalled" flag on CoreBuild, since
 			// we did all the prep here.
-			pcb.Prepare()
+			_, err := pcb.Prepare()
+			if err != nil {
+				continue
+			}
 
 			res = append(res, pcb)
 		}

--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -144,7 +144,7 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 		for _, unused := range md.Unused {
 			if unused != "type" && !strings.HasPrefix(unused, "packer_") {
 				err = multierror.Append(err, fmt.Errorf(
-					"unknown configuration key: %q; raws is %#v \n\n and ctx data is %#v", unused, raws, ctxData))
+					"unknown configuration key: %q", unused))
 			}
 		}
 		if err != nil {

--- a/packer/build.go
+++ b/packer/build.go
@@ -135,8 +135,8 @@ func (b *CoreBuild) Name() string {
 // and any hooks. This _must_ be called prior to Run. The parameter is the
 // overrides for the variables within the template (if any).
 func (b *CoreBuild) Prepare() (warn []string, err error) {
-	// For HCL2 templates, the builder and hooks are initialized when the template is parsed.
-	// Calling Prepare(...) is not necessary
+	// For HCL2 templates, the builder and hooks are initialized when the
+	// template is parsed. Calling Prepare(...) is not necessary
 	if b.Prepared {
 		b.prepareCalled = true
 		return
@@ -149,6 +149,8 @@ func (b *CoreBuild) Prepare() (warn []string, err error) {
 		panic("prepare already called")
 	}
 
+	// Templates loaded from HCL2 will never get here. TODO: move this code into
+	// a custom json area instead of just aborting early for HCL.
 	b.prepareCalled = true
 
 	packerConfig := map[string]interface{}{


### PR DESCRIPTION
refactor so that json and hcl2 templates are both prepared in the same place in the build call, to make code easier to reason about. 

Unrelated single line change to remove overly verbose error output which isn't useful in vast majority of cases