### PR TITLE
fix network card fixer

### DIFF
--- a/fix/fixer_vsphere_network_storage.go
+++ b/fix/fixer_vsphere_network_storage.go
@@ -46,10 +46,19 @@ func (FixerVSphereNetworkDisk) Fix(input map[string]interface{}) (map[string]int
 			hasNetwork = true
 		}
 
+		// legacy syntax from when VSphere was 3rd party
 		networkCardRaw, ok := builder["networkCard"]
 		if ok {
-			nic["networkCard"] = networkCardRaw
+			nic["network_card"] = networkCardRaw
 			delete(builder, "networkCard")
+			hasNetwork = true
+		}
+
+		// underscored syntax used when Packer merged vSphere
+		networkCardRaw, ok = builder["network_card"]
+		if ok {
+			nic["network_card"] = networkCardRaw
+			delete(builder, "network_card")
 			hasNetwork = true
 		}
 

--- a/fix/fixer_vsphere_network_storage_test.go
+++ b/fix/fixer_vsphere_network_storage_test.go
@@ -26,8 +26,31 @@ func TestFixerVSphereNetwork_Fix(t *testing.T) {
 				"type": "vsphere-iso",
 				"network_adapters": []interface{}{
 					map[string]interface{}{
-						"network":     "",
-						"networkCard": "vmxnet3",
+						"network":      "",
+						"network_card": "vmxnet3",
+					},
+				},
+				"storage": []interface{}{
+					map[string]interface{}{
+						"disk_size": 5000,
+					},
+				},
+			},
+		},
+		{
+			Input: map[string]interface{}{
+				"type":         "vsphere-iso",
+				"network":      "",
+				"network_card": "vmxnet3",
+				"disk_size":    5000,
+			},
+
+			Expected: map[string]interface{}{
+				"type": "vsphere-iso",
+				"network_adapters": []interface{}{
+					map[string]interface{}{
+						"network":      "",
+						"network_card": "vmxnet3",
 					},
 				},
 				"storage": []interface{}{
@@ -51,8 +74,8 @@ func TestFixerVSphereNetwork_Fix(t *testing.T) {
 				"type": "vsphere-iso",
 				"network_adapters": []interface{}{
 					map[string]interface{}{
-						"network":     "myNetwork",
-						"networkCard": "vmxnet3",
+						"network":      "myNetwork",
+						"network_card": "vmxnet3",
 					},
 				},
 				"storage": []interface{}{
@@ -74,8 +97,8 @@ func TestFixerVSphereNetwork_Fix(t *testing.T) {
 				"disk_eagerly_scrub":    true,
 				"network_adapters": []interface{}{
 					map[string]interface{}{
-						"network":     "net1",
-						"networkCard": "vmxnet3",
+						"network":      "net1",
+						"network_card": "vmxnet3",
 					},
 				},
 				"storage": []interface{}{
@@ -91,12 +114,12 @@ func TestFixerVSphereNetwork_Fix(t *testing.T) {
 				"type": "vsphere-iso",
 				"network_adapters": []interface{}{
 					map[string]interface{}{
-						"network":     "myNetwork",
-						"networkCard": "vmxnet3",
+						"network":      "myNetwork",
+						"network_card": "vmxnet3",
 					},
 					map[string]interface{}{
-						"network":     "net1",
-						"networkCard": "vmxnet3",
+						"network":      "net1",
+						"network_card": "vmxnet3",
 					},
 				},
 				"storage": []interface{}{


### PR DESCRIPTION
Noticed when performing some vSphere acceptance testing that the fixer didn't correctly set network cards into the new nic struct. 
