### PR TITLE
HCL2: Make the `build`.`sources` argument list optional

### DIFF
--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -56,7 +56,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block) (*BuildBlock, hcl.Diagnosti
 	build := &BuildBlock{}
 
 	var b struct {
-		FromSources []string `hcl:"sources"`
+		FromSources []string `hcl:"sources,optional"`
 		Config      hcl.Body `hcl:",remain"`
 	}
 	diags := gohcl.DecodeBody(block.Body, nil, &b)


### PR DESCRIPTION
after incorporating #9291 `sources` is now an optional field.