### PR TITLE
move this to after the prepare() is successful so that we don't try t…

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -215,7 +215,6 @@ func (c *Core) GetBuilds(opts GetBuildsOptions) ([]Build, hcl.Diagnostics) {
 			})
 			continue
 		}
-		builds = append(builds, b)
 
 		// Now that build plugin has been launched, call Prepare()
 		log.Printf("Preparing build: %s", b.Name())
@@ -232,6 +231,9 @@ func (c *Core) GetBuilds(opts GetBuildsOptions) ([]Build, hcl.Diagnostics) {
 			})
 			continue
 		}
+
+		// Only append builds to list if the Prepare() is successful.
+		builds = append(builds, b)
 
 		if len(warnings) > 0 {
 			for _, warning := range warnings {


### PR DESCRIPTION
I noticed that my earlier PR to refactor the  build command allowed the build flow to try to run unsuccessfully prepared builds. This just moves the list of builds to run to _after_ the error check for the prepare()