### PR TITLE
actually run the fixer

### DIFF
--- a/fix/fixer.go
+++ b/fix/fixer.go
@@ -50,6 +50,7 @@ func init() {
 		"ssh-wait-timeout":           new(FixerSSHTimout),
 		"docker-tag-tags":            new(FixerDockerTagtoTags),
 		"vsphere-iso-net-disk":       new(FixerVSphereNetworkDisk),
+		"iso-checksum-type-and-url":  new(FixerISOChecksumTypeAndURL),
 	}
 
 	FixerOrder = []string{
@@ -83,5 +84,6 @@ func init() {
 		"comm-config",
 		"ssh-wait-timeout",
 		"vsphere-iso-net-disk",
+		"iso-checksum-type-and-url",
 	}
 }

--- a/fix/fixer_iso_checksum_type_and_url.go
+++ b/fix/fixer_iso_checksum_type_and_url.go
@@ -27,7 +27,9 @@ func (FixerISOChecksumTypeAndURL) Fix(input map[string]interface{}) (map[string]
 		checksum := stringValue(builder["iso_checksum"])
 		delete(builder, "iso_checksum_url")
 		delete(builder, "iso_checksum_type")
-
+		if checksum == "" && checksumUrl == "" {
+			continue
+		}
 		if checksumUrl != "" {
 			checksum = "file:" + checksumUrl
 		} else if checksumType != "" {


### PR DESCRIPTION
@azr wrote a great fixer but didn't actually implement it in the fix call. This runs it. I've tested it against both checksums and checksum files, and it appropriately fixed all templates including ones that use user variables for the checksum_type value.