### PR TITLE
buidler/vsphere-iso: ISOUrl Fix

### DIFF
--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -63,9 +63,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	warnings := make([]string, 0)
 	errs := new(packer.MultiError)
 
-	isoWarnings, isoErrs := c.ISOConfig.Prepare(&c.ctx)
-	warnings = append(warnings, isoWarnings...)
-	errs = packer.MultiErrorAppend(errs, isoErrs...)
+	if (c.ISOUrls != nil || c.RawSingleISOUrl != "") {
+		isoWarnings, isoErrs := c.ISOConfig.Prepare(&c.ctx)
+		warnings = append(warnings, isoWarnings...)
+		errs = packer.MultiErrorAppend(errs, isoErrs...)
+	}
 
 	errs = packer.MultiErrorAppend(errs, c.ConnectConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.CreateConfig.Prepare()...)

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -63,7 +63,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	warnings := make([]string, 0)
 	errs := new(packer.MultiError)
 
-	if (c.ISOUrls != nil || c.RawSingleISOUrl != "") {
+	if c.ISOUrls != nil || c.RawSingleISOUrl != "" {
 		isoWarnings, isoErrs := c.ISOConfig.Prepare(&c.ctx)
 		warnings = append(warnings, isoWarnings...)
 		errs = packer.MultiErrorAppend(errs, isoErrs...)


### PR DESCRIPTION
Added the check for ISOUrls back in addition to a check for RawSingleISOUrl. This should allow both ISOUrls[] or ISOUrl to work while not requiring them all the time. This change is to address issue hashicorp#9281. By adding the if block back and checking for both ISOUrls and RawSingleISOUrl, this should resolve the issue mentioned in hashicorp#9281 while still resolving the original issue of hashicorp#9186 that pull request hashicorp#9197 was created for.

Closes hashicorp#9281