### PR TITLE
Get full hostname, instead of just the NetBIOS name

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -23,7 +23,7 @@ import (
 )
 
 var DefaultRestartCommand = `shutdown /r /f /t 0 /c "packer restart"`
-var DefaultRestartCheckCommand = winrm.Powershell(`echo "${env:COMPUTERNAME} restarted."`)
+var DefaultRestartCheckCommand = winrm.Powershell(`echo ("{0} restarted." -f [System.Net.Dns]::GetHostName())`)
 var retryableSleep = 5 * time.Second
 var TryCheckReboot = `shutdown /r /f /t 60 /c "packer restart test"`
 var AbortReboot = `shutdown /a`


### PR DESCRIPTION
`$env:COMPUTERNAME` give you the first 15 characters of the machine name (the NetBIOS name). But normally its pretty nice to get the full DNS name in the output, if your machine names is long.

**Example:**

The computer name on build: `my-packer-build-12345`
 
👎  Right now it will output: `MY-PACKER-BUILD restarted.`
👍  After my fix it will output: `my-packer-build-12345 restarted.`

**Its my time contributing to Packer, so please feel free to provide your feedback** 😄