### PR TITLE
Fix typo in Ansible Provisioner Docs

### DIFF
--- a/website/pages/docs/provisioners/ansible.mdx
+++ b/website/pages/docs/provisioners/ansible.mdx
@@ -16,7 +16,7 @@ an Ansible inventory file configured to use SSH, runs an SSH server, executes
 `ansible-playbook`, and marshals Ansible plays through the SSH server to the
 machine being provisioned by Packer.
 
--> **Note:**: Any `remote_user` defined in tasks will be ignored. Packer
+-> **Note:** Any `remote_user` defined in tasks will be ignored. Packer
 will always connect with the user given in the json config for this
 provisioner.
 


### PR DESCRIPTION
Simple documentation fix, this removes the second ':' after 'Note:'
