### PR TITLE
(vsphere-iso) use the Datacenter's VmFolder

### DIFF
--- a/builder/vsphere/driver/folder.go
+++ b/builder/vsphere/driver/folder.go
@@ -21,7 +21,12 @@ func (d *Driver) NewFolder(ref *types.ManagedObjectReference) *Folder {
 }
 
 func (d *Driver) FindFolder(name string) (*Folder, error) {
-	f, err := d.finder.Folder(d.ctx, fmt.Sprintf("/%v/vm/%v", d.datacenter.Name(), name))
+	folders, err := d.datacenter.Folders(d.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := d.finder.Folder(d.ctx, fmt.Sprintf("%v/%v", folders.VmFolder.InventoryPath, name))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use the datacenter VmFolder instead of hand generating it. This should fix the issue when there are multiple data centers and the datacenter path is located inside a folder.

Closes #9328
