### PR TITLE
command/validate: Add support for HCL2 config files

### DIFF
--- a/command/test-fixtures/validate-invalid/bad_provisioner.json
+++ b/command/test-fixtures/validate-invalid/bad_provisioner.json
@@ -1,0 +1,15 @@
+{
+  "builders":[
+    {
+      "type":"file",
+      "target":"chocolate.txt",
+      "content":"chocolate"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "comment": "unknown field"
+    }
+  ]
+}

--- a/command/test-fixtures/validate-invalid/broken.json
+++ b/command/test-fixtures/validate-invalid/broken.json
@@ -1,0 +1,10 @@
+{
+  "builders":[
+    {
+      "type":"file",
+      "target":"chocolate.txt",
+      "content":"chocolate"
+    }
+  ],
+  "provisioners": "not an array"
+}

--- a/command/test-fixtures/validate-invalid/missing_build_block.pkr.hcl
+++ b/command/test-fixtures/validate-invalid/missing_build_block.pkr.hcl
@@ -1,0 +1,9 @@
+source "file" "chocolate" {
+  target = "chocolate.txt"
+  content = "chocolate"
+}
+
+build {
+  sources = ["source.file.cho"]
+}
+

--- a/command/test-fixtures/validate/build.json
+++ b/command/test-fixtures/validate/build.json
@@ -1,0 +1,9 @@
+{
+  "builders":[
+    {
+      "type":"file",
+      "target":"chocolate.txt",
+      "content":"chocolate"
+    }
+  ]
+}

--- a/command/test-fixtures/validate/build.pkr.hcl
+++ b/command/test-fixtures/validate/build.pkr.hcl
@@ -1,0 +1,8 @@
+source "file" "chocolate" {
+  target = "chocolate.txt"
+  content = "chocolate"
+}
+
+build {
+  sources = ["source.file.chocolate"]
+}

--- a/command/test-fixtures/validate/build_with_vars.pkr.hcl
+++ b/command/test-fixtures/validate/build_with_vars.pkr.hcl
@@ -1,0 +1,13 @@
+variable "target" {
+  type = string
+  default = "chocolate.txt"
+}
+
+source "file" "chocolate" {
+  target = var.target
+  content = "chocolate"
+}
+
+build {
+  sources = ["source.file.chocolate"]
+}

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -450,3 +450,8 @@ func (p *PackerConfig) handleEval(line string) (out string, exit bool, diags hcl
 
 	return PrintableCtyValue(val), false, diags
 }
+
+func (p *PackerConfig) FixConfig(_ packer.FixConfigOptions) (diags hcl.Diagnostics) {
+	// No Fixers exist for HCL2 configs so there is nothing to do here for now.
+	return
+}

--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -159,7 +159,7 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 				if fixable {
 					unusedErr = fmt.Errorf("Deprecated configuration key: '%s'."+
 						" Please call `packer fix` against your template to "+
-						"update your template to be compatable with the current "+
+						"update your template to be compatible with the current "+
 						"version of Packer. Visit "+
 						"https://www.packer.io/docs/commands/fix/ for more detail.",
 						unused)

--- a/packer/core.go
+++ b/packer/core.go
@@ -1,6 +1,7 @@
 package packer
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -9,6 +10,7 @@ import (
 
 	ttmp "text/template"
 
+	"github.com/google/go-cmp/cmp"
 	multierror "github.com/hashicorp/go-multierror"
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -418,6 +420,66 @@ func (c *Core) EvaluateExpression(line string) (string, bool, hcl.Diagnostics) {
 		}
 		return rendered, false, diags
 	}
+}
+
+func (c *Core) FixConfig(opts FixConfigOptions) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	// Remove once we have support for the Inplace FixConfigMode
+	if opts.Mode != Diff {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("FixConfig only supports template diff; FixConfigMode %d not supported", opts.Mode),
+		})
+
+		return diags
+	}
+
+	var rawTemplateData map[string]interface{}
+	input := make(map[string]interface{})
+	templateData := make(map[string]interface{})
+	if err := json.Unmarshal(c.Template.RawContents, &rawTemplateData); err != nil {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("unable to read the contents of the JSON configuration file: %s", err),
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+	// Hold off on Diff for now - need to think about displaying to user.
+	// delete empty top-level keys since the fixers seem to add them
+	// willy-nilly
+	for k := range input {
+		ml, ok := input[k].([]map[string]interface{})
+		if !ok {
+			continue
+		}
+		if len(ml) == 0 {
+			delete(input, k)
+		}
+	}
+	// marshal/unmarshal to make comparable to templateData
+	var fixedData map[string]interface{}
+	// Guaranteed to be valid json, so we can ignore errors
+	j, _ := json.Marshal(input)
+	if err := json.Unmarshal(j, &fixedData); err != nil {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("unable to read the contents of the JSON configuration file: %s", err),
+			Detail:   err.Error(),
+		})
+
+		return diags
+	}
+
+	if diff := cmp.Diff(templateData, fixedData); diff != "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Fixable configuration found.\nPlease run `packer fix` to get your build to run correctly.\nSee debug log for more information.",
+			Detail:   diff,
+		})
+	}
+	return diags
 }
 
 // validate does a full validation of the template.

--- a/packer/run_interfaces.go
+++ b/packer/run_interfaces.go
@@ -28,6 +28,7 @@ type Evaluator interface {
 type Handler interface {
 	Evaluator
 	BuildGetter
+	ConfigFixer
 }
 
 //go:generate enumer -type FixConfigMode
@@ -44,7 +45,7 @@ const (
 )
 
 type FixConfigOptions struct {
-	DiffOnly bool
+	Mode FixConfigMode
 }
 
 type ConfigFixer interface {

--- a/website/pages/docs/commands/validate.mdx
+++ b/website/pages/docs/commands/validate.mdx
@@ -33,13 +33,11 @@ Errors validating build 'vmware'. 1 error(s) occurred:
 - `-syntax-only` - Only the syntax of the template is checked. The
   configuration is not validated.
 
-- `-except=foo,bar,baz` - Builds all the builds and post-processors except
-  those with the given comma-separated names. Build and post-processor names
-  by default are the names of their builders, unless a specific `name`
-  attribute is specified within the configuration. A post-processor with an
-  empty name will be ignored.
+- `-except=foo,bar,baz` - Validates all the builds except those with the
+  comma-separated names. Build names by default are the names of their
+  builders, unless a specific `name` attribute is specified within the configuration.
 
-- `-only=foo,bar,baz` - Only build the builds with the given comma-separated
+- `-only=foo,bar,baz` - Only validate the builds with the given comma-separated
   names. Build names by default are the names of their builders, unless a
   specific `name` attribute is specified within the configuration.
 


### PR DESCRIPTION
This change updates the validate command so that it can properly validate HCL and JSON packer configuration files. Support for checking against available fixers only works for JSON files. 

- [x] Update validate command to read HCL2 config files
- [x] Add some basic unit tests for reading JSON and HCL2 configs
- [x]  Separate validation logic for JSON and HCL2 configs
- [x] Refactor fixer check logic for JSON configs
- [x] Add  SyntaxOnly tests
- [x] ~Add support for only and except for FixConfig check~ Fixing partial sections doesn't seem like a viable use case. Skipping this and leaving the command as it is. 
- [x] Test against some actual configs `packer validate ...`

I went back and forth on the command line output and eventually ended up removing all messaging that is not an error or a warning. See https://github.com/hashicorp/packer/pull/9346/commits/f672f5bd9b36012e3ba37377d3ea27f541cd589b

Single HCL2 config file
```
⇶  packer validate smaple.pkr.hcl
Error: Unset variable "AWS_REGION"

A used variable must be set or have a default value; see
https://packer.io/docs/configuration/from-1.5/syntax for details.

⇶  packer validate -var AWS_REGION=foo smaple.pkr.hcl
Template validated successfully.
```

Directory of HCL2 config files
```
⇶  packer validate .
Error: Duplicate variable

  on docker_centos_source_block.pkr.hcl line 3, in variables:
   3:     source_image = "centos:7.3.1611"

Duplicate source_image variable definition found.

Error: Duplicate variable

  on docker_centos_source_block.pkr.hcl line 4, in variables:
   4:     username = "blahblahuser"

Duplicate username variable definition found.

Error: Unset variable "AWS_REGION"

A used variable must be set or have a default value; see
https://packer.io/docs/configuration/from-1.5/syntax for details.

Error: Duplicate source block

  on docker_centos_source_block.pkr.hcl line 7, in source "docker" "base_setup":
   7: source "docker" "base_setup"{

This source block has the same builder type and name as a previous block
declared at docker_centos_shell_provisioner.pkr.hcl:7,1-29. Each source must
have a unique name per builder type.
```

Syntax only validation check
```
⇶  packer validate docker_test.pkr.hcl
Error: Failed preparing provisioner-block "ansible" ""
    
on docker_test.pkr.hcl line 11:
   (source code not available)
    
1 error(s) occurred:
    
* playbook_file: site.yml is invalid: stat site.yml: no such file or directory
    
Template validated successfully.
    
⇶  packer validate -syntax-only docker_test.pkr.hcl
Syntax-only check passed. Everything looks okay.
```

Including Fixer Check
HCL2 Configs
```
⇶  packer validate docker_centos_shell_provisioner.pkr.hcl
Template validated successfully.
Checking against known fixers for possible fixes
=> fix command no supported for this build configuration; skipping
```

JSON Configs
```
⇶  packer validate vmware-iso_ubuntu_minimal/vmware-iso_ubuntu_minimal.json
Template validated successfully.
Checking against known fixers for possible fixes
Error: Failed to prepare build: "vmware-iso"

1 error occurred:
        * Deprecated configuration key: 'iso_checksum_type'. Please call `packer fix`
against your template to update your template to be compatable with the current
version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more
detail.

Warning: Fixable configuration found.
You may need to run `packer fix` to get your build to run correctly.
See debug log for more information.

  map[string]interface{}{
        "builders": []interface{}{
                map[string]interface{}{
                        ... // 3 identical entries
                        "guest_os_type":     string("ubuntu-64"),
                        "http_directory":    string("http"),
-                       "iso_checksum":
string("946a6077af6f5f95a51f82fdc44051c7aa19f9cfc5f737954845a6050543d7c2"),
+                       "iso_checksum":
string("sha256:946a6077af6f5f95a51f82fdc44051c7aa19f9cfc5f737954845a6050543d7c2"),
-                       "iso_checksum_type": string("sha256"),
                        "iso_url":
string("http://old-releases.ubuntu.com/releases/14.04.1/ubuntu-14.04.1-server-amd64.iso"),
                        "shutdown_command":  string("echo 'vagrant' | sudo -S shutdown -P now"),
                        ... // 4 identical entries
                },
        },
  }
```

Relates to #8538 
