### PR TITLE
Do not require 'gpu-standard-v1' platform_id for any GPU-based config.

### DIFF
--- a/builder/yandex/config.go
+++ b/builder/yandex/config.go
@@ -248,11 +248,6 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.FolderID = os.Getenv("YC_FOLDER_ID")
 	}
 
-	if c.PlatformID != defaultGpuPlatformID && c.InstanceGpus != 0 {
-		errs = packer.MultiErrorAppend(
-			errs, fmt.Errorf("for instances with gpu platform_id must be specified as `%s`", defaultGpuPlatformID))
-	}
-
 	if c.Token == "" && c.ServiceAccountKeyFile == "" {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("a token or service account key file must be specified"))

--- a/builder/yandex/config_test.go
+++ b/builder/yandex/config_test.go
@@ -231,7 +231,7 @@ func TestGpuDefaultPlatformID(t *testing.T) {
 	var c Config
 	c.Prepare(raw)
 	if c.PlatformID != "gpu-standard-v1" {
-		t.Fatalf("expected 'gpu-standard-v1', but got '%s'", c.PlatformID)
+		t.Fatalf("expected 'gpu-standard-v1' as default platform_id for instance with GPU(s), but got '%s'", c.PlatformID)
 	}
 }
 

--- a/builder/yandex/config_test.go
+++ b/builder/yandex/config_test.go
@@ -235,16 +235,6 @@ func TestGpuDefaultPlatformID(t *testing.T) {
 	}
 }
 
-func TestGpuWrongPlatformID(t *testing.T) {
-	raw := testConfig(t)
-	raw["instance_gpus"] = 1
-	raw["platform_id"] = "standard-v1"
-
-	var c Config
-	warns, errs := c.Prepare(raw)
-	testConfigErr(t, warns, errs, "incompatible GPU platform_id")
-}
-
 // Helper stuff below
 
 func testConfig(t *testing.T) (config map[string]interface{}) {


### PR DESCRIPTION
Support use another kind of GPU platforms.
