### PR TITLE
Validate host and network when looking for network

### DIFF
--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -21,7 +21,8 @@ type CloneConfig struct {
 	DiskSize int64 `mapstructure:"disk_size"`
 	// Create VM as a linked clone from latest snapshot. Defaults to `false`.
 	LinkedClone bool `mapstructure:"linked_clone"`
-	// Set network VM will be connected to.
+	// Set the network in which VM will be connected to. If no network is specified, `host`
+	// must be specified to allow Packer to look for the available network.
 	Network string `mapstructure:"network"`
 	// VM notes.
 	Notes string `mapstructure:"notes"`

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -21,7 +21,7 @@ type CloneConfig struct {
 	DiskSize int64 `mapstructure:"disk_size"`
 	// Create VM as a linked clone from latest snapshot. Defaults to `false`.
 	LinkedClone bool `mapstructure:"linked_clone"`
-	// Set the network in which VM will be connected to. If no network is specified, `host`
+	// Set the network in which the VM will be connected to. If no network is specified, `host`
 	// must be specified to allow Packer to look for the available network.
 	Network string `mapstructure:"network"`
 	// VM notes.

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -31,7 +31,8 @@ import (
 //   ],
 // ```
 type NIC struct {
-	// Set network VM will be connected to.
+	// Set the network in which VM will be connected to. If no network is specified, `host`
+	// must be specified to allow Packer to look for the available network.
 	Network string `mapstructure:"network"`
 	// Set VM network card type. Example `vmxnet3`.
 	NetworkCard string `mapstructure:"network_card" required:"true"`

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -31,7 +31,7 @@ import (
 //   ],
 // ```
 type NIC struct {
-	// Set the network in which VM will be connected to. If no network is specified, `host`
+	// Set the network in which the VM will be connected to. If no network is specified, `host`
 	// must be specified to allow Packer to look for the available network.
 	Network string `mapstructure:"network"`
 	// Set VM network card type. Example `vmxnet3`.

--- a/website/pages/partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -6,7 +6,8 @@
     
 -   `linked_clone` (bool) - Create VM as a linked clone from latest snapshot. Defaults to `false`.
     
--   `network` (string) - Set network VM will be connected to.
+-   `network` (string) - Set the network in which VM will be connected to. If no network is specified, `host`
+    must be specified to allow Packer to look for the available network.
     
 -   `notes` (string) - VM notes.
     

--- a/website/pages/partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -6,7 +6,7 @@
     
 -   `linked_clone` (bool) - Create VM as a linked clone from latest snapshot. Defaults to `false`.
     
--   `network` (string) - Set the network in which VM will be connected to. If no network is specified, `host`
+-   `network` (string) - Set the network in which the VM will be connected to. If no network is specified, `host`
     must be specified to allow Packer to look for the available network.
     
 -   `notes` (string) - VM notes.

--- a/website/pages/partials/builder/vsphere/iso/NIC-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/iso/NIC-not-required.mdx
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
--   `network` (string) - Set the network in which VM will be connected to. If no network is specified, `host`
+-   `network` (string) - Set the network in which the VM will be connected to. If no network is specified, `host`
     must be specified to allow Packer to look for the available network.
     
 -   `mac_address` (string) - Set network card MAC address

--- a/website/pages/partials/builder/vsphere/iso/NIC-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/iso/NIC-not-required.mdx
@@ -1,6 +1,7 @@
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
--   `network` (string) - Set network VM will be connected to.
+-   `network` (string) - Set the network in which VM will be connected to. If no network is specified, `host`
+    must be specified to allow Packer to look for the available network.
     
 -   `mac_address` (string) - Set network card MAC address
     


### PR DESCRIPTION
If `network` is not specified `host` must be specified in order to find an available network. This PR adds validation and returns an error whenever it couldn't find a Network because both configs are not set.

Closes https://github.com/hashicorp/packer/issues/9013
Closes https://github.com/hashicorp/packer/issues/8817