### PR TITLE
Add template_dir() and pwd() functions to HCL

### DIFF
--- a/hcl2template/function/pwd.go
+++ b/hcl2template/function/pwd.go
@@ -1,0 +1,20 @@
+package function
+
+import (
+	"os"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// MakePwdFunc constructs a function that returns the working directory as a string.
+func MakePwdFunc() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{},
+		Type:   function.StaticReturnType(cty.String),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			dir, err := os.Getwd()
+			return cty.StringVal(dir), err
+		},
+	})
+}

--- a/hcl2template/function/templatedir.go
+++ b/hcl2template/function/templatedir.go
@@ -1,0 +1,18 @@
+package function
+
+import (
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// MakeTemplateDirFunc constructs a function that returns the directory
+// in which the configuration file is located.
+func MakeTemplateDirFunc(baseDir string) function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{},
+		Type:   function.StaticReturnType(cty.String),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			return cty.StringVal(baseDir), nil
+		},
+	})
+}

--- a/hcl2template/functions.go
+++ b/hcl2template/functions.go
@@ -76,6 +76,7 @@ func Functions(basedir string) map[string]function.Function {
 		"parseint":        stdlib.ParseIntFunc,
 		"pathexpand":      filesystem.PathExpandFunc,
 		"pow":             stdlib.PowFunc,
+		"pwd":             pkrfunction.MakePwdFunc(),
 		"range":           stdlib.RangeFunc,
 		"reverse":         stdlib.ReverseFunc,
 		"replace":         stdlib.ReplaceFunc,

--- a/hcl2template/functions.go
+++ b/hcl2template/functions.go
@@ -94,6 +94,7 @@ func Functions(basedir string) map[string]function.Function {
 		"split":           stdlib.SplitFunc,
 		"strrev":          stdlib.ReverseFunc,
 		"substr":          stdlib.SubstrFunc,
+		"template_dir":    pkrfunction.MakeTemplateDirFunc(basedir),
 		"timestamp":       pkrfunction.TimestampFunc,
 		"timeadd":         stdlib.TimeAddFunc,
 		"title":           stdlib.TitleFunc,

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -50,7 +50,7 @@ export default [
               'join',
               'lower',
               'replace',
-              'regexreplace',
+              'regex_replace',
               'split',
               'strrev',
               'substr',

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -113,6 +113,7 @@ export default [
               'fileset',
               'pathexpand',
               'pwd',
+              'template_dir',
             ],
           },
           {

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -112,6 +112,7 @@ export default [
               'fileexists',
               'fileset',
               'pathexpand',
+              'pwd',
             ],
           },
           {

--- a/website/pages/docs/from-1.5/functions/file/pwd.mdx
+++ b/website/pages/docs/from-1.5/functions/file/pwd.mdx
@@ -1,0 +1,21 @@
+---
+layout: docs
+page_title: pwd - Functions - Configuration Language
+sidebar_title: pwd
+description: The pwd function returns the working directory while executing Packer.
+---
+
+# `pwd` Function
+
+`pwd` returns the working directory while executing Packer.
+
+```hcl
+pwd()
+```
+
+## Examples
+
+```shell-session
+> pwd()
+/home/user/some/packer
+```

--- a/website/pages/docs/from-1.5/functions/file/template_dir.mdx
+++ b/website/pages/docs/from-1.5/functions/file/template_dir.mdx
@@ -1,0 +1,21 @@
+---
+layout: docs
+page_title: template_dir - Functions - Configuration Language
+sidebar_title: template_dir
+description: The template_dir function returns the directory in which the configuration file is located.
+---
+
+# `template_dir` Function
+
+`template_dir` returns the directory in which the configuration file is located.
+
+```hcl
+template_dir()
+```
+
+## Examples
+
+```shell-session
+> template_dir()
+packer
+```

--- a/website/pages/docs/from-1.5/functions/string/regex_replace.mdx
+++ b/website/pages/docs/from-1.5/functions/string/regex_replace.mdx
@@ -1,21 +1,21 @@
 ---
 layout: docs
-page_title: regexreplace - Functions - Configuration Language
-sidebar_title: regexreplace
+page_title: regex_replace - Functions - Configuration Language
+sidebar_title: regex_replace
 description: |-
-  The regexreplace function searches a given string for another given substring,
+  The regex_replace function searches a given string for another given substring,
   and replaces all occurrences with a given replacement string. The substring
   argument can be a valid regular expression or a string.
 ---
 
-# `regexreplace` Function
+# `regex_replace` Function
 
-`regexreplace` searches a given string for another given substring, and
+`regex_replace` searches a given string for another given substring, and
 replaces each occurrence with a given replacement string. The substring
 argument can be a valid regular expression or a string.
 
 ```hcl
-regexreplace(string, substring, replacement)
+regex_replace(string, substring, replacement)
 ```
 
 `substring` should not be wrapped in forward slashes, it is always treated as a
@@ -26,17 +26,17 @@ name of a capture group.
 ## Examples
 
 ```shell-session
-> regexreplace("hello world", "world", "everybody")
+> regex_replace("hello world", "world", "everybody")
 hello everybody
 
 
-> regexreplace("hello world", "w.*d", "everybody")
+> regex_replace("hello world", "w.*d", "everybody")
 hello everybody
 
-> regexreplace("-ab-axxb-", "a(x*)b", "$1W)
+> regex_replace("-ab-axxb-", "a(x*)b", "$1W)
 ---
 
-> regexreplace("-ab-axxb-", "a(x*)b", "${1}W")
+> regex_replace("-ab-axxb-", "a(x*)b", "${1}W")
 -W-xxW-
 ```
 

--- a/website/pages/docs/from-1.5/functions/string/replace.mdx
+++ b/website/pages/docs/from-1.5/functions/string/replace.mdx
@@ -28,5 +28,5 @@ hello everybody
 
 ## Related Functions
 
-- [`regexreplace`](/docs/from-1.5/functions/string/regexreplace) searches a given string for another given substring,
+- [`regex_replace`](/docs/from-1.5/functions/string/regex_replace) searches a given string for another given substring,
   and replaces each occurrence with a given replacement string.


### PR DESCRIPTION
Adding `template_dir()` and `pwd()` functions to HCL.

Let me know if the docs typo fix for `regex_replace()` should go in its own PR.