### PR TITLE
[gcp] Fixup for the deprecated Secure Boot guest OS feature

### DIFF
--- a/builder/googlecompute/image.go
+++ b/builder/googlecompute/image.go
@@ -27,7 +27,7 @@ func (i *Image) IsWindows() bool {
 
 func (i *Image) IsSecureBootCompatible() bool {
 	for _, osFeature := range i.GuestOsFeatures {
-		if osFeature.Type == "SECURE_BOOT" {
+		if osFeature.Type == "UEFI_COMPATIBLE" {
 			return true
 		}
 	}


### PR DESCRIPTION
Recently noticed that the SECURE_BOOT guest OS feature is missing
for the GCP managed compute images. This was an indication that the
image has Shielded VMs capabilities.

After raising this as an issue with GCP, they've informed us that the
SECURE_BOOT guest OS feature is deprecated internally and that they
are using UEFI_COMPATIBLE instead. This means, using an image with
'UEFI_COMPATIBLE' guest OS feature confirms the 'secureBoot' feature
compatibility. Because of this the Shielded VMs support in Packer is
currently not working as expected. This PR resolves the issue.

Closes #9353
