### PR TITLE
Fix build/validate -except flag for JSON and HCL2

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -379,23 +379,23 @@ func TestBuildExceptFileCommaFlags(t *testing.T) {
 			name: "JSON: except build and post-processor",
 			args: []string{
 				"-parallel-builds=1",
-				"-except=chocolate,vanilla,pear",
+				"-except=chocolate,vanilla,tomato",
 				filepath.Join(testFixture("build-only"), "template.json"),
 			},
 			expectedFiles:            []string{"apple.txt", "cherry.txt", "peach.txt"},
 			buildNotExpectedFiles:    []string{"chocolate.txt", "vanilla.txt", "tomato.txt", "unnamed.txt"},
-			postProcNotExpectedFiles: []string{"pear.txt"},
+			postProcNotExpectedFiles: []string{"pear.txt, banana.txt"},
 		},
 		{
 			name: "HCL2: except build and post-processor",
 			args: []string{
 				"-parallel-builds=1",
-				"-except=file.chocolate,file.vanilla,pear",
+				"-except=file.chocolate,file.vanilla,tomato",
 				filepath.Join(testFixture("build-only"), "template.pkr.hcl"),
 			},
 			expectedFiles:            []string{"apple.txt", "cherry.txt", "peach.txt"},
 			buildNotExpectedFiles:    []string{"chocolate.txt", "vanilla.txt", "tomato.txt", "unnamed.txt"},
-			postProcNotExpectedFiles: []string{"pear.txt"},
+			postProcNotExpectedFiles: []string{"pear.txt, banana.txt"},
 		},
 	}
 
@@ -637,6 +637,7 @@ func cleanup(moreFiles ...string) {
 	os.RemoveAll("cherry.txt")
 	os.RemoveAll("apple.txt")
 	os.RemoveAll("peach.txt")
+	os.RemoveAll("banana.txt")
 	os.RemoveAll("pear.txt")
 	os.RemoveAll("tomato.txt")
 	os.RemoveAll("unnamed.txt")

--- a/command/test-fixtures/build-only/template.json
+++ b/command/test-fixtures/build-only/template.json
@@ -37,6 +37,11 @@
                 "name": "pear",
                 "type": "shell-local",
                 "inline": [ "echo pear > pear.txt" ]
+            },
+            {
+                "name": "banana",
+                "type": "shell-local",
+                "inline": [ "echo pear > banana.txt" ]
             }
         ],
         [

--- a/command/test-fixtures/build-only/template.pkr.hcl
+++ b/command/test-fixtures/build-only/template.pkr.hcl
@@ -1,0 +1,49 @@
+source "file" "chocolate" {
+  content = "chocolate"
+  target = "chocolate.txt"
+}
+
+source "file" "vanilla" {
+  content = "vanilla"
+  target = "vanilla.txt"
+}
+
+source "file" "cherry" {
+  content = "cherry"
+  target = "cherry.txt"
+}
+
+
+build {
+  sources = [
+    "sources.file.chocolate",
+    "sources.file.vanilla",
+    "sources.file.cherry",
+  ]
+
+  post-processor "shell-local" {
+    name = "apple"
+    inline = [ "echo apple > apple.txt" ]
+  }
+
+  post-processor "shell-local" {
+    name = "peach"
+    inline = [ "echo apple > peach.txt" ]
+  }
+
+  post-processor "shell-local" {
+    name = "pear"
+    inline = [ "echo apple > pear.txt" ]
+  }
+
+  post-processor "shell-local" {
+    only = ["vanilla"]
+    name = "tomato"
+    inline = [ "echo apple > tomato.txt" ]
+  }
+
+  post-processor "shell-local" {
+    only = ["chocolate"]
+    inline = [ "echo apple > unnamed.txt" ]
+  }
+}

--- a/command/test-fixtures/build-only/template.pkr.hcl
+++ b/command/test-fixtures/build-only/template.pkr.hcl
@@ -37,6 +37,11 @@ build {
   }
 
   post-processor "shell-local" {
+    name = "banana"
+    inline = [ "echo apple > banana.txt" ]
+  }
+
+  post-processor "shell-local" {
     only = ["vanilla"]
     name = "tomato"
     inline = [ "echo apple > tomato.txt" ]

--- a/command/test-fixtures/validate/validate_except.json
+++ b/command/test-fixtures/validate/validate_except.json
@@ -1,0 +1,26 @@
+{
+  "builders":[
+    {
+      "name": "chocolate",
+      "type":"file",
+      "target":"chocolate.txt",
+      "content":"chocolate"
+    },
+    {
+      "type":"file",
+      "name": "vanilla"
+    }
+  ],
+  "post-processors": [
+    {
+      "name": "apple",
+      "type": "shell-local",
+      "inline": [ "echo apple 'hello'" ]
+    },
+    {
+      "name": "pear",
+      "type": "shell-local"
+    }
+  ],
+  "min_packer_version":"101.0.0"
+}

--- a/command/test-fixtures/validate/validate_except.json
+++ b/command/test-fixtures/validate/validate_except.json
@@ -1,26 +1,39 @@
 {
-  "builders":[
+  "builders": [
     {
       "name": "chocolate",
-      "type":"file",
-      "target":"chocolate.txt",
-      "content":"chocolate"
+      "type": "file",
+      "target": "chocolate.txt",
+      "content": "chocolate"
     },
     {
-      "type":"file",
+      "type": "file",
       "name": "vanilla"
     }
   ],
   "post-processors": [
-    {
-      "name": "apple",
-      "type": "shell-local",
-      "inline": [ "echo apple 'hello'" ]
-    },
-    {
-      "name": "pear",
-      "type": "shell-local"
-    }
+    [
+      {
+        "name": "apple",
+        "type": "shell-local",
+        "inline": [
+          "echo apple 'apple'"
+        ]
+      }
+    ],
+    [
+      {
+        "name": "pear",
+        "type": "shell-local",
+        "inline": [
+          "echo apple 'pear'"
+        ]
+      },
+      {
+        "name": "banana",
+        "type": "shell-local"
+      }
+    ]
   ],
-  "min_packer_version":"101.0.0"
+  "min_packer_version": "101.0.0"
 }

--- a/command/test-fixtures/validate/validate_except.pkr.hcl
+++ b/command/test-fixtures/validate/validate_except.pkr.hcl
@@ -14,10 +14,15 @@ build {
 
   post-processor "shell-local" {
     name = "apple"
-    inline = [ "echo apple 'hello'" ]
+    inline = [ "echo apple 'apple'" ]
   }
 
   post-processor "shell-local" {
     name = "pear"
+    inline = [ "echo apple 'pear'" ]
+  }
+
+  post-processor "shell-local" {
+    name = "banana"
   }
 }

--- a/command/test-fixtures/validate/validate_except.pkr.hcl
+++ b/command/test-fixtures/validate/validate_except.pkr.hcl
@@ -1,0 +1,23 @@
+source "file" "chocolate" {
+  content = "chocolate"
+  target = "chocolate.txt"
+}
+source "file" "vanilla" {
+  content = "vanilla"
+}
+
+build {
+  sources = [
+    "source.file.chocolate",
+    "source.file.vanilla"
+  ]
+
+  post-processor "shell-local" {
+    name = "apple"
+    inline = [ "echo apple 'hello'" ]
+  }
+
+  post-processor "shell-local" {
+    name = "pear"
+  }
+}

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -144,6 +144,8 @@ func TestValidateCommandExcept(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			defer cleanup()
+
 			tc := tc
 			if code := c.Run(tc.args); code != tc.exitCode {
 				fatalCommand(t, c.Meta)

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -98,3 +98,56 @@ func TestValidateCommandBadVersion(t *testing.T) {
 	}
 	t.Log(stdout)
 }
+
+func TestValidateCommandExcept(t *testing.T) {
+	tt := []struct {
+		name     string
+		args     []string
+		exitCode int
+	}{
+		{
+			name: "JSON: validate except build and post-processor",
+			args: []string{
+				"-except=vanilla,pear",
+				filepath.Join(testFixture("validate"), "validate_except.json"),
+			},
+		},
+		{
+			name: "JSON: fail validate except build and post-processor",
+			args: []string{
+				"-except=chocolate,apple",
+				filepath.Join(testFixture("validate"), "validate_except.json"),
+			},
+			exitCode: 1,
+		},
+		{
+			name: "HCL2: validate except build and post-processor",
+			args: []string{
+				"-except=file.vanilla,pear",
+				filepath.Join(testFixture("validate"), "validate_except.pkr.hcl"),
+			},
+		},
+		{
+			name: "HCL2: fail validation except build and post-processor",
+			args: []string{
+				"-except=file.chocolate,apple",
+				filepath.Join(testFixture("validate"), "validate_except.pkr.hcl"),
+			},
+			exitCode: 1,
+		},
+	}
+
+	c := &ValidateCommand{
+		Meta: testMetaFile(t),
+	}
+	c.CoreConfig.Version = "102.0.0"
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			if code := c.Run(tc.args); code != tc.exitCode {
+				fatalCommand(t, c.Meta)
+			}
+		})
+	}
+}

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -2,9 +2,9 @@ package hcl2template
 
 import (
 	"fmt"
-	"github.com/gobwas/glob"
 	"strings"
 
+	"github.com/gobwas/glob"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/packer/helper/common"

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -262,7 +262,7 @@ func (cfg *PackerConfig) getCoreBuildPostProcessors(source SourceBlock, blocks [
 			}
 		}
 		if exclude {
-			continue
+			break
 		}
 
 		postProcessor, moreDiags := cfg.startPostProcessor(source, ppb, ectx, generatedVars)

--- a/packer/core.go
+++ b/packer/core.go
@@ -321,7 +321,7 @@ func (c *Core) Build(n string) (Build, error) {
 				}
 			}
 			if foundExcept {
-				continue
+				break
 			}
 
 			// Get the post-processor

--- a/packer/core.go
+++ b/packer/core.go
@@ -133,6 +133,8 @@ func (c *Core) BuildNames(only, except []string) []string {
 
 	sort.Strings(only)
 	sort.Strings(except)
+	c.except = except
+	c.only = only
 
 	r := make([]string, 0, len(c.builds))
 	for n := range c.builds {


### PR DESCRIPTION
This fixes a regression where the except/only flags lists weren't being set properly for the post-provisioners in JSON and HCL2.
  
Closes https://github.com/hashicorp/packer/issues/9377