### PR TITLE
.github/workflows/issues: Add milestone labeling action

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,13 @@
+name: Milestone Labeler
+on:
+  issues:
+    types: [milestoned]
+jobs:
+  apply_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add track-internal
+        uses: andymckay/labeler@1.0.2
+        with:
+          repo-token: ${{ secrets.Github_Token }}
+          add-labels: "track-internal"


### PR DESCRIPTION
This change adds a GitHub action that will automatically apply the `track-internal` label to any issue that is added to an existing Packer milestone.