### PR TITLE
Fix typo in VSphere Docs

### DIFF
--- a/builder/vsphere/common/step_config_params.go
+++ b/builder/vsphere/common/step_config_params.go
@@ -18,7 +18,7 @@ type ConfigParamsConfig struct {
 	ConfigParams map[string]string `mapstructure:"configuration_parameters"`
 
 	// Enables time synchronization with the host. If set to true will set `tools.syncTime` to `TRUE`.
-	// Defaults fo FALSE.
+	// Defaults to FALSE.
 	ToolsSyncTime bool `mapstructure:"tools_sync_time"`
 
 	// If sets to true, vSphere will automatically check and upgrade VMware Tools upon a system power cycle.

--- a/website/pages/partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
@@ -4,7 +4,7 @@
     ConfigSpec: https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.ConfigSpec.html
     
 -   `tools_sync_time` (bool) - Enables time synchronization with the host. If set to true will set `tools.syncTime` to `TRUE`.
-    Defaults fo FALSE.
+    Defaults to FALSE.
     
 -   `tools_upgrade_policy` (bool) - If sets to true, vSphere will automatically check and upgrade VMware Tools upon a system power cycle.
     If not set, defaults to manual upgrade.


### PR DESCRIPTION
Fixes a typo in the VSphere docs (`fo` -> `to`).