### PR TITLE
Fix possible typo carried over from Terraform documentation.

### DIFF
--- a/website/pages/docs/commands/console.mdx
+++ b/website/pages/docs/commands/console.mdx
@@ -153,6 +153,6 @@ printed unless an error occurs earlier.
 For example:
 
 ```shell-session
-$ echo "1 + 5" | terraform console
+$ echo "1 + 5" | packer console
 6
 ```


### PR DESCRIPTION
This documentation page is talking about the packer console but in the last example, the command used it's piped into the terraform console. 

It might be a wrong example carried over from Terraform configuration.