### PR TITLE
Update Proxmox storagePoolTypes

### DIFF
--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -173,10 +173,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 			log.Printf("Disk %d cache mode not set, using default 'none'", idx)
 			c.Disks[idx].CacheMode = "none"
 		}
-		// For any storage pool types which aren't in rxStorageTypes in proxmox-api/proxmox/config_qemu.go:651
-		// (currently zfspool and lvm), the format parameter is mandatory. Make sure this is still up to date
+		// For any storage pool types which aren't in rxStorageTypes in proxmox-api/proxmox/config_qemu.go:890
+		// (currently zfspool|lvm|rbd|cephfs), the format parameter is mandatory. Make sure this is still up to date
 		// when updating the vendored code!
-		if !contains([]string{"zfspool", "lvm"}, c.Disks[idx].StoragePoolType) && c.Disks[idx].DiskFormat == "" {
+		if !contains([]string{"zfspool", "lvm", "rbd", "cephfs"}, c.Disks[idx].StoragePoolType) && c.Disks[idx].DiskFormat == "" {
 			errs = packer.MultiErrorAppend(errs, errors.New(fmt.Sprintf("disk format must be specified for pool type %q", c.Disks[idx].StoragePoolType)))
 		}
 	}

--- a/website/pages/docs/builders/proxmox.mdx
+++ b/website/pages/docs/builders/proxmox.mdx
@@ -157,7 +157,7 @@ builder.
     by the installer, for example.
 
   - `storage_pool_type` (string) - Required. The type of the pool, can
-    be `lvm`, `lvm-thin`, `zfspool` or `directory`.
+    be `lvm`, `lvm-thin`, `zfspool`, `cephfs`, `rbd` or `directory`.
 
   - `type` (string) - The type of disk. Can be `scsi`, `sata`, `virtio` or
     `ide`. Defaults to `scsi`.


### PR DESCRIPTION
This PR brings the supported `storagePoolTypes` in line with the API client, thus adding support for RBD and CephFS pools

Closes #8710
