### PR TITLE
[WIP] Run error-cleanup-provisioner on abort

### DIFF
--- a/common/multistep_runner.go
+++ b/common/multistep_runner.go
@@ -70,6 +70,12 @@ func (s abortStep) Run(ctx context.Context, state multistep.StateBag) multistep.
 }
 
 func (s abortStep) Cleanup(state multistep.StateBag) {
+	if s.InnerStepName() == "StepProvision" {
+		// call "error-cleanup-provisioner" if defined.
+		s.step.Cleanup(state)
+		return
+	}
+
 	shouldCleanup := handleAbortsAndInterupts(state, s.ui, typeName(s.step))
 	if !shouldCleanup {
 		return


### PR DESCRIPTION
If an `error-cleanup-provisioner` is defined, the cleanup provisioner will still happen when `-on-error=abort` is set. 


Closes https://github.com/hashicorp/packer/issues/8814

====
Still discussing if this is the best solution. 