### PR TITLE
Add @hashicorp/react-tabs css styles

### DIFF
--- a/website/pages/style.css
+++ b/website/pages/style.css
@@ -12,15 +12,16 @@
 
 @import '~@hashicorp/react-button/dist/style.css';
 @import '~@hashicorp/react-consent-manager/dist/style.css';
-@import '~@hashicorp/react-toggle/dist/style.css';
-@import '~@hashicorp/react-section-header/dist/style.css';
-@import '~@hashicorp/react-product-downloader/dist/style.css';
-@import '~@hashicorp/react-vertical-text-block-list/dist/style.css';
-@import '~@hashicorp/react-docs-sidenav/dist/style.css';
 @import '~@hashicorp/react-content/dist/style.css';
-@import '~@hashicorp/react-subnav/dist/style.css';
-@import '~@hashicorp/react-mega-nav/style.css';
 @import '~@hashicorp/react-docs-page/style.css';
+@import '~@hashicorp/react-docs-sidenav/dist/style.css';
+@import '~@hashicorp/react-mega-nav/style.css';
+@import '~@hashicorp/react-product-downloader/dist/style.css';
+@import '~@hashicorp/react-section-header/dist/style.css';
+@import '~@hashicorp/react-subnav/dist/style.css';
+@import '~@hashicorp/react-tabs/dist/style.css';
+@import '~@hashicorp/react-toggle/dist/style.css';
+@import '~@hashicorp/react-vertical-text-block-list/dist/style.css';
 
 /* Local Components */
 @import '../components/footer/style.css';
@@ -96,16 +97,16 @@
 .g-section-block section {
   padding-top: 96px;
   padding-bottom: 96px;
-}
 
-.g-section-block section > .g-section-header + *,
-.g-section-block section > .g-container > .g-section-header + * {
+& > .g-section-header + *,
+& > .g-container > .g-section-header + * {
   margin-top: 72px;
 }
 
-.g-section-block section > * + *,
-.g-section-block section > .g-container > * + * {
+& > * + *,
+& > .g-container > * + * {
   margin-top: 96px;
+}
 }
 
 .g-section-block .button-container {


### PR DESCRIPTION
This PR adds a `.css` import to correctly style the `<Tabs>` component that is available in our `.mdx` pages (specifically `@import '~@hashicorp/react-tabs/dist/style.css'`)

**Before**

![Screenshot 2020-06-15 at 10 32 00](https://user-images.githubusercontent.com/794809/84700243-d83e5780-af20-11ea-9e0c-2d1c68e41c8c.png)

**After**

![Screen Shot 2020-06-15 at 3 55 25 PM](https://user-images.githubusercontent.com/794809/84700122-a3ca9b80-af20-11ea-8308-fb5e3784ca9c.png)


