### PR TITLE
Add on-error flag option to run error-cleanup-provisioner

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -361,7 +361,7 @@ Options:
   -only=foo,bar,baz             Build only the specified builds.
   -force                        Force a build to continue if artifacts exist, deletes existing artifacts.
   -machine-readable             Produce machine-readable output.
-  -on-error=[cleanup|abort|ask] If the build fails do: clean up (default), abort, or ask.
+  -on-error=[cleanup|abort|ask|run-cleanup-provisioner] If the build fails do: clean up (default), abort, ask, or run-cleanup-provisioner.
   -parallel-builds=1            Number of builds to run in parallel. 1 disables parallelization. 0 means no limit (Default: 0)
   -timestamp-ui                 Enable prefixing of each ui output with an RFC3339 timestamp.
   -var 'key=value'              Variable for templates, can be used multiple times.

--- a/command/cli.go
+++ b/command/cli.go
@@ -79,7 +79,7 @@ func (ba *BuildArgs) AddFlagSets(flags *flag.FlagSet) {
 
 	flags.Int64Var(&ba.ParallelBuilds, "parallel-builds", 0, "")
 
-	flagOnError := enumflag.New(&ba.OnError, "cleanup", "abort", "ask")
+	flagOnError := enumflag.New(&ba.OnError, "cleanup", "abort", "ask", "run-cleanup-provisioner")
 	flags.Var(flagOnError, "on-error", "")
 
 	ba.MetaArgs.AddFlagSets(flags)

--- a/website/pages/docs/commands/build.mdx
+++ b/website/pages/docs/commands/build.mdx
@@ -40,12 +40,14 @@ artifacts that are created will be outputted at the end of the build.
   remove the artifacts from the previous build. This will allow the user to
   repeat a build without having to manually clean these artifacts beforehand.
 
-- `-on-error=cleanup` (default), `-on-error=abort`, `-on-error=ask` - Selects
-  what to do when the build fails. `cleanup` cleans up after the previous
-  steps, deleting temporary files and virtual machines. `abort` exits without
-  any cleanup, which might require the next build to use `-force`. `ask`
-  presents a prompt and waits for you to decide to clean up, abort, or retry
+- `-on-error=cleanup` (default), `-on-error=abort`, `-on-error=ask`, `-on-error=run-cleanup-provisioner` -
+  Selects what to do when the build fails.
+  - `cleanup` cleans up after the previous steps, deleting temporary files and virtual machines.
+  - `abort` exits without any cleanup, which might require the next build to use `-force`.
+  - `ask` presents a prompt and waits for you to decide to clean up, abort, or retry
   the failed step.
+  - `run-cleanup-provisioner` aborts and exits without any cleanup besides
+  the [error-cleanup-provisioner](/docs/templates/provisioners#on-error-provisioner) if one is defined.
 
 - `-only=foo,bar,baz` - Only run the builds with the given comma-separated
   names. Build names by default are their type, unless a specific `name`


### PR DESCRIPTION
With `-on-error=run-cleanup-provisioner` Packer will abort and run the cleanup provisioner script if one is defined. 

Closes https://github.com/hashicorp/packer/issues/8814