### PR TITLE
add hcl2 basic examples under tabs

### DIFF
--- a/website/pages/docs/builders/alicloud-ecs.mdx
+++ b/website/pages/docs/builders/alicloud-ecs.mdx
@@ -49,6 +49,9 @@ builder.
 
 Here is a basic example for Alicloud.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "variables": {
@@ -78,6 +81,45 @@ Here is a basic example for Alicloud.
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+variable "access_key" {
+  type = string
+}
+
+variable "secret_key" {
+  type = string
+}
+
+source "alicloud-ecs" "basic-example" {
+      access_key = var.access_key
+      secret_key = var.secret_key
+      region = "cn-beijing"
+      image_name = "packer_test2"
+      source_image = "centos_7_04_64_20G_alibase_201701015.vhd"
+      ssh_username = "root"
+      instance_type = "ecs.n1.tiny"
+      io_optimized = true
+      internet_charge_type = "PayByTraffic"
+      image_force_delete = true
+}
+
+build {
+  sources = ["sources.alicloud-ecs.basic-example"]
+
+  provisioner "shell" {
+    inline = [
+      "sleep 30", "yum install redis.x86_64 -y",
+    ]
+  }
+}
+```
+
+</Tab>
+</Tabs>
 
 ~> Note: Images can become deprecated after a while; run
 `aliyun ecs DescribeImages` to find one that exists.

--- a/website/pages/docs/builders/amazon/chroot.mdx
+++ b/website/pages/docs/builders/amazon/chroot.mdx
@@ -110,8 +110,6 @@ Block devices can be nested in the
 
 Here is a basic example. It is completely valid except for the access keys:
 
-
-
 <Tabs>
 <Tab heading="JSON">
 

--- a/website/pages/docs/builders/amazon/chroot.mdx
+++ b/website/pages/docs/builders/amazon/chroot.mdx
@@ -110,6 +110,11 @@ Block devices can be nested in the
 
 Here is a basic example. It is completely valid except for the access keys:
 
+
+
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "amazon-chroot",
@@ -119,6 +124,34 @@ Here is a basic example. It is completely valid except for the access keys:
   "ami_name": "packer-amazon-chroot {{timestamp}}"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+variable "aws_access_key" {
+  type = string
+}
+
+variable "aws_secret_key" {
+  type = string
+}
+
+source "amazon-chroot" "basic-example" {
+  access_key = var.aws_access_key
+  secret_key =  var.aws_secret_key
+  source_ami = "ami-e81d5881"
+}
+
+build {
+  source "sources.amazon-chroot.basic-example" {
+    ami_name = "packer-amazon-chroot {{timestamp}}"
+  }
+}
+```
+
+</Tab>
+</Tabs>
 
 ## Chroot Mounts
 

--- a/website/pages/docs/builders/amazon/ebs.mdx
+++ b/website/pages/docs/builders/amazon/ebs.mdx
@@ -107,6 +107,9 @@ Here is a basic example. You will need to provide access keys, and may need to
 change the AMI IDs according to what images exist at the time the template is
 run:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "variables": {
@@ -127,6 +130,37 @@ run:
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+variable "aws_access_key" {
+  type = string
+}
+
+variable "aws_secret_key" {
+  type = string
+}
+
+source "amazon-ebs" "basic-example" {
+  access_key = var.aws_access_key
+  secret_key =  var.aws_secret_key
+  region =  "us-east-1"
+  source_ami =  "ami-fce3c696"
+  instance_type =  "t2.micro"
+  ssh_username =  "ubuntu"
+}
+
+build {
+  source "sources.amazon-ebs.basic-example" {
+    ami_name =  "packer_AWS {{timestamp}}"
+  }
+}
+```
+
+</Tab>
+</Tabs>
 
 -> **Note:** Packer can also read the access key and secret access key from
 environmental variables. See the configuration reference in the section above

--- a/website/pages/docs/builders/amazon/ebssurrogate.mdx
+++ b/website/pages/docs/builders/amazon/ebssurrogate.mdx
@@ -102,6 +102,10 @@ Block devices can be nested in the
 
 ## Basic Example
 
+
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "amazon-ebssurrogate",
@@ -128,6 +132,46 @@ Block devices can be nested in the
   }
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-ebssurrogate" "basic-example" {
+  region = "us-east-1"
+  ssh_username = "ubuntu"
+  instance_type = "t2.medium"
+  source_ami = "ami-40d28157"
+  ami_name = "packer-test-adrien"
+  ami_virtualization_type = "paravirtual"
+
+  launch_block_device_mappings {
+      volume_type = "gp2"
+      device_name = "/dev/xvdf"
+      delete_on_termination = false
+      volume_size = 10
+  }
+
+  ami_root_device {
+    source_device_name = "/dev/xvdf"
+    device_name = "/dev/xvda"
+    delete_on_termination = true
+    volume_size = 16
+    volume_type = "gp2"
+  }
+}
+
+build {
+  sources = ["sources.amazon-ebssurrogate.basic-example"]
+
+  provisioner "shell" {
+      inline = ["..."]
+  }
+}
+```
+
+</Tab>
+</Tabs>
 
 -> **Note:** Packer can also read the access key and secret access key from
 environmental variables. See the configuration reference in the section above

--- a/website/pages/docs/builders/amazon/ebsvolume.mdx
+++ b/website/pages/docs/builders/amazon/ebsvolume.mdx
@@ -106,11 +106,12 @@ Block devices can be nested in the
 
 ## Basic Example
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "amazon-ebsvolume",
-  "secret_key": "YOUR SECRET KEY HERE",
-  "access_key": "YOUR KEY HERE",
   "region": "us-east-1",
   "ssh_username": "ubuntu",
   "instance_type": "t2.medium",
@@ -149,6 +150,58 @@ Block devices can be nested in the
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-ebsvolume" "basic-example" {
+  region = "us-east-1"
+  ssh_username = "ubuntu"
+  instance_type = "t2.medium"
+  source_ami = "ami-40d28157"
+
+  ebs_volumes {
+      volume_type = "gp2"
+      device_name = "/dev/xvdf"
+      delete_on_termination = false
+      tags = {
+        zpool = "data"
+        Name = "Data1"
+      }
+      volume_size = 10
+  }
+
+  ebs_volumes {
+      volume_type = "gp2"
+      device_name = "/dev/xvdg"
+      tags = {
+        zpool = "data"
+        Name = "Data2"
+      }
+      delete_on_termination = false
+      volume_size = 10
+  }
+
+  ebs_volumes {
+      volume_size = 10
+      tags = {
+        zpool = "data"
+        Name = "Data3"
+      }
+      delete_on_termination = false
+      device_name = "/dev/xvdh"
+      volume_type = "gp2"
+  }
+}
+
+build {
+  sources = ["sources.amazon-ebsvolume.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
 
 -> **Note:** Packer can also read the access key and secret access key from
 environmental variables. See the configuration reference in the section above

--- a/website/pages/docs/builders/amazon/instance.mdx
+++ b/website/pages/docs/builders/amazon/instance.mdx
@@ -121,6 +121,9 @@ Block devices can be nested in the
 
 Here is a basic example. It is completely valid except for the access keys:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "amazon-instance",
@@ -140,6 +143,33 @@ Here is a basic example. It is completely valid except for the access keys:
   "ami_name": "packer-quick-start {{timestamp}}"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-instance" "basic-example" {
+  region = "us-east-1"
+  source_ami = "ami-d9d6a6b0"
+  instance_type = "m1.small"
+  ssh_username = "ubuntu"
+
+  account_id = "0123-4567-0890"
+  s3_bucket = "packer-images"
+  x509_cert_path = "x509.cert"
+  x509_key_path = "x509.key"
+  x509_upload_path = "/tmp"
+}
+
+build {
+  source "sources.amazon-instance.basic-example" {
+    ami_name = "packer-quick-start {{timestamp}}"
+  }
+}
+```
+
+</Tab>
+</Tabs>
 
 -> **Note:** Packer can also read the access key and secret access key from
 environmental variables. See the configuration reference in the section above

--- a/website/pages/docs/builders/azure/arm.mdx
+++ b/website/pages/docs/builders/azure/arm.mdx
@@ -165,6 +165,9 @@ Providing `temp_resource_group_name` or `location` in combination with
 
 Here is a basic example for Azure.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "azure-arm",
@@ -192,6 +195,42 @@ Here is a basic example for Azure.
   "vm_size": "Standard_A2"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "azure-arm" "basic-example" {
+  client_id = "fe354398-d7sf-4dc9-87fd-c432cd8a7e09"
+  client_secret = "keepitsecret&#*$"
+  resource_group_name = "packerdemo"
+  storage_account = "virtualmachines"
+  subscription_id = "44cae533-4247-4093-42cf-897ded6e7823"
+  tenant_id = "de39842a-caba-497e-a798-7896aea43218"
+
+  capture_container_name = "images"
+  capture_name_prefix = "packer"
+
+  os_type = "Linux"
+  image_publisher = "Canonical"
+  image_offer = "UbuntuServer"
+  image_sku = "14.04.4-LTS"
+
+  azure_tags = {
+    dept = "engineering"
+  }
+
+  location = "West US"
+  vm_size = "Standard_A2"
+}
+
+build {
+  sources = ["sources.azure-arm.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
 
 ## Deprovision
 

--- a/website/pages/docs/builders/azure/chroot.mdx
+++ b/website/pages/docs/builders/azure/chroot.mdx
@@ -194,6 +194,9 @@ to update your VM.
 Set the `ARM_IMAGE_RESOURCEGROUP_ID` variable to an existing resource group in the
 subscription where the resulting image will be created.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "variables": {
@@ -224,3 +227,43 @@ subscription where the resulting image will be created.
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+variable "client_id" {
+  type = string
+}
+variable "client_secret" {
+  type = string
+}
+variable "subscription_id" {
+  type = string
+}
+variable "resource_group" {
+  type = string
+}
+
+source "azure-chroot" "basic-example" {
+  client_id = var.client_id
+  client_secret = var.client_secret
+  subscription_id = var.subscription_id
+
+  image_resource_id = "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group}/providers/Microsoft.Compute/images/MyDebianOSImage-{{timestamp}}"
+
+  source = "credativ:Debian:9:latest"
+}
+
+build {
+  sources = ["sources.azure-chroot.basic-example"]
+
+  provisioner "shell" {
+    inline = ["apt-get update", "apt-get upgrade -y"]
+    inline_shebang = "/bin/sh -x"
+  }
+}
+```
+
+</Tab>
+</Tabs>

--- a/website/pages/docs/builders/file.mdx
+++ b/website/pages/docs/builders/file.mdx
@@ -21,6 +21,9 @@ wait times.
 Below is a fully functioning example. It create a file at `target` with the
 specified `content`.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "file",
@@ -28,6 +31,24 @@ specified `content`.
   "target": "dummy_artifact"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "file" "basic-example" {
+  content =  "Lorem ipsum dolor sit amet"
+  target =  "dummy_artifact"
+}
+
+build {
+  sources = ["sources.file.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
+
 
 ## Configuration Reference
 

--- a/website/pages/docs/builders/googlecompute.mdx
+++ b/website/pages/docs/builders/googlecompute.mdx
@@ -119,6 +119,9 @@ repackage an existing GCE image. The account_file is obtained in the previous
 section. If it parses as JSON it is assumed to be the file itself, otherwise,
 it is assumed to be the path to the file containing the JSON.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "builders": [
@@ -133,6 +136,26 @@ it is assumed to be the path to the file containing the JSON.
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "googlecompute" "basic-example" {
+  account_file = "account.json"
+  project_id = "my project"
+  source_image = "debian-7-wheezy-v20150127"
+  ssh_username = "packer"
+  zone = "us-central1-a"
+}
+
+build {
+  sources = ["sources.googlecompute.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
 
 ### Windows Example
 

--- a/website/pages/docs/builders/null.mdx
+++ b/website/pages/docs/builders/null.mdx
@@ -23,6 +23,9 @@ artifact.
 Below is a fully functioning example. It doesn't do anything useful, since no
 provisioners are defined, but it will connect to the specified host via ssh.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "null",
@@ -31,6 +34,25 @@ provisioners are defined, but it will connect to the specified host via ssh.
   "ssh_password": "bar"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "null" "basic-example" {
+  ssh_host = "127.0.0.1"
+  ssh_username = "foo"
+  ssh_password = "bar"
+}
+
+build {
+  sources = ["sources.null.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
+
 
 ## Configuration Reference
 

--- a/website/pages/docs/builders/virtualbox/iso.mdx
+++ b/website/pages/docs/builders/virtualbox/iso.mdx
@@ -28,6 +28,9 @@ Here is a basic example. This example is not functional. It will start the OS
 installer but then fail because we don't provide the preseed file for Ubuntu to
 self-install. Still, the example serves to show the basic configuration:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "virtualbox-iso",
@@ -40,6 +43,29 @@ self-install. Still, the example serves to show the basic configuration:
   "shutdown_command": "echo 'packer' | sudo -S shutdown -P now"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+
+source "virtualbox-iso" "basic-example" {
+  guest_os_type = "Ubuntu_64"
+  iso_url = "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso"
+  iso_checksum = "769474248a3897f4865817446f9a4a53"
+  iso_checksum_type = "md5"
+  ssh_username = "packer"
+  ssh_password = "packer"
+  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+}
+
+build {
+  sources = ["sources.virtualbox-iso.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
 
 It is important to add a `shutdown_command`. By default Packer halts the virtual
 machine and the file system may not be sync'd. Thus, changes made in a

--- a/website/pages/docs/builders/virtualbox/ovf.mdx
+++ b/website/pages/docs/builders/virtualbox/ovf.mdx
@@ -40,6 +40,9 @@ build.
 Here is a basic example. This example is functional if you have an OVF matching
 the settings here.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "virtualbox-ovf",
@@ -49,6 +52,25 @@ the settings here.
   "shutdown_command": "echo 'packer' | sudo -S shutdown -P now"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "virtualbox-ovf" "basic-example" {
+  source_path = "source.ovf"
+  ssh_username = "packer"
+  ssh_password = "packer"
+  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+}
+
+build {
+  sources = ["sources.virtualbox-ovf.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
 
 It is important to add a `shutdown_command`. By default Packer halts the virtual
 machine and the file system may not be sync'd. Thus, changes made in a

--- a/website/pages/docs/builders/virtualbox/vm.mdx
+++ b/website/pages/docs/builders/virtualbox/vm.mdx
@@ -29,6 +29,9 @@ from the applied provisioners.
 
 Here is a basic example. which serves to show the basic configuration:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "virtualbox-vm",
@@ -48,6 +51,35 @@ Here is a basic example. which serves to show the basic configuration:
   "skip_export": "false"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "virtualbox-vm" "basic-example" {
+  communicator = "winrm"
+  headless = "{{user `headless`}}"
+  winrm_username = "vagrant"
+  winrm_password = "vagrant"
+  winrm_timeout = "2h"
+  shutdown_command = "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\""
+  guest_additions_mode = "disable"
+  output_directory = "./builds-vm"
+  vm_name = "target-vm"
+  attach_snapshot = "Snapshot"
+  target_snapshot = "Target-Snapshot"
+  force_delete_snapshot = true
+  keep_registered = false
+  skip_export = false
+}
+
+build {
+  sources = ["sources.virtualbox-vm.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
 
 It is important to add a `shutdown_command`. By default Packer halts the virtual
 machine and the file system may not be sync'd. Thus, changes made in a

--- a/website/pages/docs/builders/vmware/iso.mdx
+++ b/website/pages/docs/builders/vmware/iso.mdx
@@ -37,17 +37,39 @@ Here is a basic example. This example is not functional. It will start the OS
 installer but then fail because we don't provide the preseed file for Ubuntu to
 self-install. Still, the example serves to show the basic configuration:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "vmware-iso",
   "iso_url": "http://old-releases.ubuntu.com/releases/precise/ubuntu-12.04.2-server-amd64.iso",
-  "iso_checksum": "af5f788aee1b32c4b2634734309cc9e9",
-  "iso_checksum_type": "md5",
+  "iso_checksum": "md5:af5f788aee1b32c4b2634734309cc9e9",
   "ssh_username": "packer",
   "ssh_password": "packer",
   "shutdown_command": "shutdown -P now"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "vmware-iso" "basic-example" {
+  iso_url = "http://old-releases.ubuntu.com/releases/precise/ubuntu-12.04.2-server-amd64.iso"
+  iso_checksum = "md5:af5f788aee1b32c4b2634734309cc9e9"
+  ssh_username = "packer"
+  ssh_password = "packer"
+  shutdown_command = "shutdown -P now"
+}
+
+build {
+  sources = ["sources.vmware-iso.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
 
 ## VMware-ISO Builder Configuration Reference
 

--- a/website/pages/docs/builders/vmware/vmx.mdx
+++ b/website/pages/docs/builders/vmware/vmx.mdx
@@ -34,6 +34,9 @@ VMware virtual machine.
 Here is an example. This example is fully functional as long as the source path
 points to a real VMX file with the proper settings:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "vmware-vmx",
@@ -43,6 +46,25 @@ points to a real VMX file with the proper settings:
   "shutdown_command": "shutdown -P now"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "vmware-vmx" "basic-example" {
+  source_path = "/path/to/a/vm.vmx"
+  ssh_username = "root"
+  ssh_password = "root"
+  shutdown_command = "shutdown -P now"
+}
+
+build {
+  sources = ["sources.vmware-vmx.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
 
 ## Configuration Reference
 


### PR DESCRIPTION
This adds HCL2 examples next to JSON examples; behind a tab

![Screenshot 2020-06-16 at 18 15 17](https://user-images.githubusercontent.com/1024852/84799977-5b34e000-affd-11ea-817f-06b933612825.png)

This will probably be a continuous effort to get all examples swappable, I will continue working on this and this can be merged already, or not. Same thing 🙂 
