### PR TITLE
Fix 8904

### DIFF
--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -325,7 +325,7 @@ func (d *VBox42Driver) LoadSnapshots(vmName string) (*VBoxSnapshot, error) {
 	var rootNode *VBoxSnapshot
 	stdoutString, err := d.VBoxManageWithOutput("snapshot", vmName, "list", "--machinereadable")
 	if stdoutString == "This machine does not have any snapshots" {
-		return rootNode, fmt.Errorf("VM %s does not have any snapshots.", vmName)
+		return rootNode, nil
 	}
 	if nil != err {
 		return nil, err


### PR DESCRIPTION
This reverts a change that would prevent the builder from running if it didn't have any snapshots. 

It also fixes the bug in 8904 where a setting target_snapshot on a build that ran against a VM with no current snapshots caused a crash. 

Closes #8904