### PR TITLE
add template option for templating the inventory file lines

### DIFF
--- a/provisioner/ansible/provisioner.hcl2spec.go
+++ b/provisioner/ansible/provisioner.hcl2spec.go
@@ -9,35 +9,36 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	PackerBuildName      *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
-	PackerBuilderType    *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
-	PackerDebug          *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
-	PackerForce          *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
-	PackerOnError        *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
-	PackerUserVars       map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
-	PackerSensitiveVars  []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	Command              *string           `cty:"command" hcl:"command"`
-	ExtraArguments       []string          `mapstructure:"extra_arguments" cty:"extra_arguments" hcl:"extra_arguments"`
-	AnsibleEnvVars       []string          `mapstructure:"ansible_env_vars" cty:"ansible_env_vars" hcl:"ansible_env_vars"`
-	PlaybookFile         *string           `mapstructure:"playbook_file" required:"true" cty:"playbook_file" hcl:"playbook_file"`
-	Groups               []string          `mapstructure:"groups" cty:"groups" hcl:"groups"`
-	EmptyGroups          []string          `mapstructure:"empty_groups" cty:"empty_groups" hcl:"empty_groups"`
-	HostAlias            *string           `mapstructure:"host_alias" cty:"host_alias" hcl:"host_alias"`
-	User                 *string           `mapstructure:"user" cty:"user" hcl:"user"`
-	LocalPort            *int              `mapstructure:"local_port" cty:"local_port" hcl:"local_port"`
-	SSHHostKeyFile       *string           `mapstructure:"ssh_host_key_file" cty:"ssh_host_key_file" hcl:"ssh_host_key_file"`
-	SSHAuthorizedKeyFile *string           `mapstructure:"ssh_authorized_key_file" cty:"ssh_authorized_key_file" hcl:"ssh_authorized_key_file"`
-	SFTPCmd              *string           `mapstructure:"sftp_command" cty:"sftp_command" hcl:"sftp_command"`
-	SkipVersionCheck     *bool             `mapstructure:"skip_version_check" cty:"skip_version_check" hcl:"skip_version_check"`
-	UseSFTP              *bool             `mapstructure:"use_sftp" cty:"use_sftp" hcl:"use_sftp"`
-	InventoryDirectory   *string           `mapstructure:"inventory_directory" cty:"inventory_directory" hcl:"inventory_directory"`
-	InventoryFile        *string           `mapstructure:"inventory_file" cty:"inventory_file" hcl:"inventory_file"`
-	KeepInventoryFile    *bool             `mapstructure:"keep_inventory_file" cty:"keep_inventory_file" hcl:"keep_inventory_file"`
-	GalaxyFile           *string           `mapstructure:"galaxy_file" cty:"galaxy_file" hcl:"galaxy_file"`
-	GalaxyCommand        *string           `mapstructure:"galaxy_command" cty:"galaxy_command" hcl:"galaxy_command"`
-	GalaxyForceInstall   *bool             `mapstructure:"galaxy_force_install" cty:"galaxy_force_install" hcl:"galaxy_force_install"`
-	RolesPath            *string           `mapstructure:"roles_path" cty:"roles_path" hcl:"roles_path"`
-	UseProxy             *bool             `mapstructure:"use_proxy" cty:"use_proxy" hcl:"use_proxy"`
+	PackerBuildName       *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
+	PackerBuilderType     *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerDebug           *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
+	PackerForce           *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
+	PackerOnError         *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
+	PackerUserVars        map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
+	PackerSensitiveVars   []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	Command               *string           `cty:"command" hcl:"command"`
+	ExtraArguments        []string          `mapstructure:"extra_arguments" cty:"extra_arguments" hcl:"extra_arguments"`
+	AnsibleEnvVars        []string          `mapstructure:"ansible_env_vars" cty:"ansible_env_vars" hcl:"ansible_env_vars"`
+	PlaybookFile          *string           `mapstructure:"playbook_file" required:"true" cty:"playbook_file" hcl:"playbook_file"`
+	Groups                []string          `mapstructure:"groups" cty:"groups" hcl:"groups"`
+	EmptyGroups           []string          `mapstructure:"empty_groups" cty:"empty_groups" hcl:"empty_groups"`
+	HostAlias             *string           `mapstructure:"host_alias" cty:"host_alias" hcl:"host_alias"`
+	User                  *string           `mapstructure:"user" cty:"user" hcl:"user"`
+	LocalPort             *int              `mapstructure:"local_port" cty:"local_port" hcl:"local_port"`
+	SSHHostKeyFile        *string           `mapstructure:"ssh_host_key_file" cty:"ssh_host_key_file" hcl:"ssh_host_key_file"`
+	SSHAuthorizedKeyFile  *string           `mapstructure:"ssh_authorized_key_file" cty:"ssh_authorized_key_file" hcl:"ssh_authorized_key_file"`
+	SFTPCmd               *string           `mapstructure:"sftp_command" cty:"sftp_command" hcl:"sftp_command"`
+	SkipVersionCheck      *bool             `mapstructure:"skip_version_check" cty:"skip_version_check" hcl:"skip_version_check"`
+	UseSFTP               *bool             `mapstructure:"use_sftp" cty:"use_sftp" hcl:"use_sftp"`
+	InventoryDirectory    *string           `mapstructure:"inventory_directory" cty:"inventory_directory" hcl:"inventory_directory"`
+	InventoryFileTemplate *string           `mapstructure:"inventory_file_template" cty:"inventory_file_template" hcl:"inventory_file_template"`
+	InventoryFile         *string           `mapstructure:"inventory_file" cty:"inventory_file" hcl:"inventory_file"`
+	KeepInventoryFile     *bool             `mapstructure:"keep_inventory_file" cty:"keep_inventory_file" hcl:"keep_inventory_file"`
+	GalaxyFile            *string           `mapstructure:"galaxy_file" cty:"galaxy_file" hcl:"galaxy_file"`
+	GalaxyCommand         *string           `mapstructure:"galaxy_command" cty:"galaxy_command" hcl:"galaxy_command"`
+	GalaxyForceInstall    *bool             `mapstructure:"galaxy_force_install" cty:"galaxy_force_install" hcl:"galaxy_force_install"`
+	RolesPath             *string           `mapstructure:"roles_path" cty:"roles_path" hcl:"roles_path"`
+	UseProxy              *bool             `mapstructure:"use_proxy" cty:"use_proxy" hcl:"use_proxy"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -74,6 +75,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"skip_version_check":         &hcldec.AttrSpec{Name: "skip_version_check", Type: cty.Bool, Required: false},
 		"use_sftp":                   &hcldec.AttrSpec{Name: "use_sftp", Type: cty.Bool, Required: false},
 		"inventory_directory":        &hcldec.AttrSpec{Name: "inventory_directory", Type: cty.String, Required: false},
+		"inventory_file_template":    &hcldec.AttrSpec{Name: "inventory_file_template", Type: cty.String, Required: false},
 		"inventory_file":             &hcldec.AttrSpec{Name: "inventory_file", Type: cty.String, Required: false},
 		"keep_inventory_file":        &hcldec.AttrSpec{Name: "keep_inventory_file", Type: cty.Bool, Required: false},
 		"galaxy_file":                &hcldec.AttrSpec{Name: "galaxy_file", Type: cty.String, Required: false},

--- a/website/pages/partials/provisioner/ansible/Config-not-required.mdx
+++ b/website/pages/partials/provisioner/ansible/Config-not-required.mdx
@@ -89,6 +89,15 @@
      inventory directory with `host_vars` `group_vars` that you would like to
      use in the playbook that this provisioner will run.
     
+-   `inventory_file_template` (string) - This template represents the format for the lines added to the temporary
+    inventory file that Packer will create to run Ansible against your image.
+    The default for recent versions of Ansible is:
+    "{{ .HostAlias }} ansible_host={{ .Host }} ansible_user={{ .User }} ansible_port={{ .Port }}\n"
+    Available template engines are: This option is a template engine;
+    variables available to you include the examples in the default (Host,
+    HostAlias, User, Port) as well as any variables available to you via the
+    "build" template engine.
+    
 -   `inventory_file` (string) - The inventory file to use during provisioning.
      When unspecified, Packer will create a temporary inventory file and will
      use the `host_alias`.


### PR DESCRIPTION
Adds a basic tempalting option so user can template the ansible inventory.

Closes #5493

This should be merged after #9439 is merged. I'll rebase and regenerate docs once that's in.