### PR TITLE
use ip_wait_address range to determine the default for the http server IP

### DIFF
--- a/builder/vsphere/common/step_http_ip_discover.go
+++ b/builder/vsphere/common/step_http_ip_discover.go
@@ -43,10 +43,21 @@ func getHostIP(s string, network *net.IPNet) (string, error) {
 		return "", err
 	}
 
+	// look for an IP that is contained in the ip_wait_address range
 	for _, a := range addrs {
 		ipnet, ok := a.(*net.IPNet)
 		if ok && !ipnet.IP.IsLoopback() {
 			if network.Contains(ipnet.IP) {
+				return ipnet.IP.String(), nil
+			}
+		}
+	}
+
+	// fallback to an ipv4 address if an IP is not found in the range
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
 				return ipnet.IP.String(), nil
 			}
 		}

--- a/builder/vsphere/common/step_http_ip_discover.go
+++ b/builder/vsphere/common/step_http_ip_discover.go
@@ -44,11 +44,13 @@ func getHostIP(s string, network *net.IPNet) (string, error) {
 	}
 
 	// look for an IP that is contained in the ip_wait_address range
-	for _, a := range addrs {
-		ipnet, ok := a.(*net.IPNet)
-		if ok && !ipnet.IP.IsLoopback() {
-			if network.Contains(ipnet.IP) {
-				return ipnet.IP.String(), nil
+	if network != nil {
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if ok && !ipnet.IP.IsLoopback() {
+				if network.Contains(ipnet.IP) {
+					return ipnet.IP.String(), nil
+				}
 			}
 		}
 	}

--- a/builder/vsphere/common/step_http_ip_discover_test.go
+++ b/builder/vsphere/common/step_http_ip_discover_test.go
@@ -43,7 +43,7 @@ func TestStepHTTPIPDiscover_Run(t *testing.T) {
 		t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, ip)
 	}
 
-	_, ipNet, err := net.ParseCIDR("0.0.0.0/24")
+	_, ipNet, err := net.ParseCIDR("0.0.0.0/0")
 	if err != nil {
 		t.Fatal("error getting ipNet", err)
 	}

--- a/builder/vsphere/common/step_http_ip_discover_test.go
+++ b/builder/vsphere/common/step_http_ip_discover_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/hashicorp/packer/helper/multistep"
@@ -35,6 +36,44 @@ func TestStepHTTPIPDiscover_Run(t *testing.T) {
 		t.Fatal("should NOT have error")
 	}
 	httpIp, ok := state.GetOk("http_ip")
+	if !ok {
+		t.Fatal("should have http_ip")
+	}
+	if httpIp != ip {
+		t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, ip)
+	}
+
+	_, ipNet, err := net.ParseCIDR("0.0.0.0/24")
+	if err != nil {
+		t.Fatal("error getting ipNet", err)
+	}
+	step = new(StepHTTPIPDiscover)
+	step.Network = ipNet
+
+	// without setting HTTPIP with Network
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+	_, ok = state.GetOk("http_ip")
+	if !ok {
+		t.Fatal("should have http_ip")
+	}
+
+	// setting HTTPIP with Network
+	step = &StepHTTPIPDiscover{
+		HTTPIP:  ip,
+		Network: ipNet,
+	}
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+	httpIp, ok = state.GetOk("http_ip")
 	if !ok {
 		t.Fatal("should have http_ip")
 	}

--- a/builder/vsphere/common/step_wait_for_ip.go
+++ b/builder/vsphere/common/step_wait_for_ip.go
@@ -32,8 +32,8 @@ type WaitIpConfig struct {
 	// this network range. Defaults to "0.0.0.0/0" for any ipv4 address. Examples include:
 	//
 	// * empty string ("") - remove all filters
-	// * "0:0:0:0:0:0:0:0/0" - allow only ipv6 addresses
-	// * "192.168.1.0/24 - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+	// * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
+	// * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
 	WaitAddress *string `mapstructure:"ip_wait_address"`
 	ipnet       *net.IPNet
 
@@ -67,6 +67,10 @@ func (c *WaitIpConfig) Prepare() []error {
 	}
 
 	return errs
+}
+
+func (c *WaitIpConfig) GetIPNet() *net.IPNet {
+	return c.ipnet
 }
 
 func (s *StepWaitForIp) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -91,7 +91,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 				SetHostForDatastoreUploads: b.config.SetHostForDatastoreUploads,
 			},
 			&common.StepHTTPIPDiscover{
-				HTTPIP: b.config.BootConfig.HTTPIP,
+				HTTPIP:  b.config.BootConfig.HTTPIP,
+				Network: b.config.WaitIpConfig.GetIPNet(),
 			},
 			&packerCommon.StepHTTPServer{
 				HTTPDir:     b.config.HTTPDir,

--- a/website/pages/partials/builder/vsphere/common/WaitIpConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/WaitIpConfig-not-required.mdx
@@ -16,6 +16,6 @@
     this network range. Defaults to "0.0.0.0/0" for any ipv4 address. Examples include:
     
     * empty string ("") - remove all filters
-    * "0:0:0:0:0:0:0:0/0" - allow only ipv6 addresses
-    * "192.168.1.0/24 - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+    * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
+    * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
     


### PR DESCRIPTION
since the ip_wait_address defaults to an ipv4 range, the default behavior should stay the same. This should make the HTTP address match the target IP range by default (may not always happen when the machine running packer has multiple NICs).