### PR TITLE
make sure the no-op progress bar gets used for machine readable uis

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -170,11 +170,12 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	for i := range builds {
 		ui := c.Ui
 		if cla.Color {
-			ui = &packer.ColoredUi{
-				Color: colors[i%len(colors)],
-				Ui:    ui,
-			}
+			// Only set up UI colors if -machine-readable isn't set.
 			if _, ok := c.Ui.(*packer.MachineReadableUi); !ok {
+				ui = &packer.ColoredUi{
+					Color: colors[i%len(colors)],
+					Ui:    ui,
+				}
 				ui.Say(fmt.Sprintf("%s: output will be in this color.", builds[i].Name()))
 				if i+1 == len(builds) {
 					// Add a newline between the color output and the actual output

--- a/packer/ui.go
+++ b/packer/ui.go
@@ -131,7 +131,6 @@ func (u *ColoredUi) supportsColors() bool {
 type TargetedUI struct {
 	Target string
 	Ui     Ui
-	*uiProgressBar
 }
 
 var _ Ui = new(TargetedUI)
@@ -170,6 +169,10 @@ func (u *TargetedUI) prefixLines(arrow bool, message string) string {
 	}
 
 	return strings.TrimRightFunc(result.String(), unicode.IsSpace)
+}
+
+func (u *TargetedUI) TrackProgress(src string, currentSize, totalSize int64, stream io.ReadCloser) io.ReadCloser {
+	return u.Ui.TrackProgress(src, currentSize, totalSize, stream)
 }
 
 // The BasicUI is a UI that reads and writes from a standard Go reader


### PR DESCRIPTION
When a download occurred inside of a builder or other plugin (which is most of the time), the ProgressTracker for the rpc.ui implementation was being created from scratch as a default UI, which meant that the "machine readable" ui was getting obliterated and the progress tracker still ran, resulting in long spammy logs.

This fixes that by creating a ProgressTracker function on the TargetedUI that passes through to the underlying UI directly. It also fixes how uis are created in the build.go implementation so that machine readable uis stay as machine readable uis, not colored uis.

Closes #9440
