### PR TITLE
create parent dirs of target

### DIFF
--- a/builder/file/builder.go
+++ b/builder/file/builder.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -38,6 +39,14 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 // Run is where the actual build should take place. It takes a Build and a Ui.
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
 	artifact := new(FileArtifact)
+
+	// Create all directories leading to target
+	dir := filepath.Dir(b.config.Target)
+	if dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, err
+		}
+	}
 
 	if b.config.Source != "" {
 		source, err := os.Open(b.config.Source)

--- a/website/pages/docs/builders/file.mdx
+++ b/website/pages/docs/builders/file.mdx
@@ -60,8 +60,8 @@ Any [communicator](/docs/templates/communicator) defined is ignored.
 
 ### Required:
 
-- `target` (string) - The path for a file which will be copied as the
-  artifact.
+- `target` (string) - The path for the artifact file that will be created. If
+  the path contains directories that don't exist, Packer will create them, too.
 
 ### Optional:
 


### PR DESCRIPTION
If Target contains directories that don't exist, file builder will create them.

Closes #9445