### PR TITLE
hcl work on only/except 

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -515,14 +515,19 @@ func TestBuildCommand_HCLOnlyExceptOptions(t *testing.T) {
 			[]string{"chocolate.txt", "vanilla.txt"},
 		},
 		{
-			[]string{"-only=file.chocolate"},
+			[]string{"-only=my_build.file.chocolate"},
 			[]string{"chocolate.txt"},
 			[]string{"vanilla.txt", "cherry.txt"},
 		},
 		{
-			[]string{"-except=file.chocolate"},
+			[]string{"-except=my_build.file.chocolate"},
 			[]string{"vanilla.txt", "cherry.txt"},
 			[]string{"chocolate.txt"},
+		},
+		{
+			[]string{"-only=file.cherry"},
+			[]string{"cherry.txt"},
+			[]string{"vanilla.txt", "chocolate.txt"},
 		},
 	}
 

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -220,6 +220,18 @@ func TestBuild(t *testing.T) {
 				notExpected: []string{"chocolate.txt", "vanilla.txt"},
 			},
 		},
+
+		{
+			name: "hcl - 'except' a build block",
+			args: []string{
+				"-only=my_build.*",
+				testFixture("hcl-only-except"),
+			},
+			fileCheck: fileCheck{
+				notExpected: []string{"cherry.txt"},
+				expected:    []string{"chocolate.txt", "vanilla.txt"},
+			},
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -222,7 +222,7 @@ func TestBuild(t *testing.T) {
 		},
 
 		{
-			name: "hcl - 'except' a build block",
+			name: "hcl - 'only' a build block",
 			args: []string{
 				"-only=my_build.*",
 				testFixture("hcl-only-except"),

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -207,6 +207,19 @@ func TestBuild(t *testing.T) {
 				},
 			},
 		},
+
+		// only / except HCL2
+		{
+			name: "hcl - 'except' a build block",
+			args: []string{
+				"-except=my_build.*",
+				testFixture("hcl-only-except"),
+			},
+			fileCheck: fileCheck{
+				expected:    []string{"cherry.txt"},
+				notExpected: []string{"chocolate.txt", "vanilla.txt"},
+			},
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/test-fixtures/hcl-only-except/build.pkr.hcl
+++ b/command/test-fixtures/hcl-only-except/build.pkr.hcl
@@ -15,8 +15,14 @@ source "file" "cherry" {
 
 build {
   sources = [
+    "file.cherry",
+  ]
+}
+
+build {
+  name = "my_build"
+  sources = [
     "file.chocolate",
     "file.vanilla",
-    "file.cherry",
   ]
 }

--- a/command/test-fixtures/hcl-only-except/build.pkr.hcl
+++ b/command/test-fixtures/hcl-only-except/build.pkr.hcl
@@ -14,9 +14,9 @@ source "file" "cherry" {
 }
 
 build {
-  sources = [
-    "file.cherry",
-  ]
+  source "file.cherry" {
+
+  }
 }
 
 build {

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -301,9 +301,13 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packer.Build
 			}
 			src.addition = from.addition
 
-			// Apply the -only and -except command-line options to exclude matching builds.
-			buildName := fmt.Sprintf("%s.%s", src.Type, src.Name)
+			pcb := &packer.CoreBuild{
+				BuildName: build.Name,
+				Type:      src.Ref().String(),
+			}
 
+			// Apply the -only and -except command-line options to exclude matching builds.
+			buildName := pcb.Name()
 			// -only
 			if len(opts.Only) > 0 {
 				onlyGlobs, diags := convertFilterOption(opts.Only, "only")
@@ -383,14 +387,11 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packer.Build
 				continue
 			}
 
-			pcb := &packer.CoreBuild{
-				BuildName:      build.Name,
-				Type:           src.Ref().String(),
-				Builder:        builder,
-				Provisioners:   provisioners,
-				PostProcessors: pps,
-				Prepared:       true,
-			}
+			pcb.Builder = builder
+			pcb.Provisioners = provisioners
+			pcb.PostProcessors = pps
+			pcb.Prepared = true
+
 			// Prepare just sets the "prepareCalled" flag on CoreBuild, since
 			// we did all the prep here.
 			_, err := pcb.Prepare()

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -11,12 +11,12 @@ export default [
     content: [
       {
         category: 'blocks',
-        content: [ 
+        content: [
           {
             category: 'build',
-            content: [ 'source', 'provisioner', 'post-processor' ],
+            content: ['source', 'provisioner', 'post-processor'],
           },
-          'locals', 'source', 'variable' ],
+          'locals', 'source', 'variable'],
       },
       {
         category: 'functions',
@@ -141,6 +141,7 @@ export default [
       'variables',
       'locals',
       'syntax',
+      'onlyexcept',
       'expressions',
       'syntax-json',
     ],

--- a/website/pages/docs/commands/build.mdx
+++ b/website/pages/docs/commands/build.mdx
@@ -26,13 +26,7 @@ artifacts that are created will be outputted at the end of the build.
   will stop between each step, waiting for keyboard input before continuing.
   This will allow the user to inspect state and so on.
 
-- `-except=foo,bar,baz` - Run all the builds and post-processors except those
-  with the given comma-separated names. Build and post-processor names by
-  default are their type, unless a specific `name` attribute is specified
-  within the configuration. Any post-processor following a skipped
-  post-processor will not run. Because post-processors can be nested in
-  arrays a different post-processor chain can still run. A post-processor
-  with an empty name will be ignored.
+`@include 'commands/except.mdx'`
 
 - `-force` - Forces a builder to run when artifacts from a previous build
   prevent a build from running. The exact behavior of a forced build is left
@@ -53,6 +47,8 @@ artifacts that are created will be outputted at the end of the build.
   names. Build names by default are their type, unless a specific `name`
   attribute is specified within the configuration. `-only` does not apply to
   post-processors.
+
+`@include 'commands/only.mdx'`
 
 - `-parallel-builds=N` - Limit the number of builds to run in parallel, 0
   means no limit (defaults to 0).

--- a/website/pages/docs/from-1.5/onlyexcept.mdx
+++ b/website/pages/docs/from-1.5/onlyexcept.mdx
@@ -1,0 +1,64 @@
+---
+layout: docs
+page_title: Only Except - HCL Configuration Language
+sidebar_title: Only Except
+description: >-
+  Only and Except can be used as a command line argument to selectively run
+  builds. Only and Except can also be used in a provisioner to not run it for a
+  source.
+---
+
+# Only and Except
+
+`only` and `except` are keywords used to filter what runs in your Packer build,
+they can be seen as a command line argument:
+
+`@include 'commands/except.mdx'`
+
+`@include 'commands/only.mdx'`
+
+They can also be seen in a template:
+
+```hcl
+build {
+  name = "my_build"
+  sources [
+    "source.amazon-ebs.first-example",
+    "source.amazon-ebs.second-example",
+  ]
+
+  provisioner "shell-local" {
+    only = ["source.amazon-ebs.second-example"]
+    inline = ["echo I will only run for the second example source"]
+  }
+
+  provisioner "shell-local" {
+    except = ["source.amazon-ebs.second-example"]
+    inline = ["echo I will never run for the second example source"]
+  }
+}
+
+build {
+  sources [
+    "source.amazon-ebs.third-example",
+  ]
+}
+
+# this file will result in Packer creating three builds named:
+#  my_build.amazon-ebs.first-example
+#  my_build.amazon-ebs.second-example
+#  amazon-ebs.third-example
+```
+
+Note that cli arguments can be used with a glob operator, using the previous
+configuration:
+
+* `packer build -only 'my_build.*' dir`: will only run the builds in blocks
+  named `my_build`.
+
+* `packer build -only '*.amazon-ebs.*' dir`: will only run the builds with a
+source of type `amazon-ebs`.
+
+-> Note: In the cli `only` and `except` will match agains **build names** (for
+  example:`my_build.amazon-ebs.first-example`) but in a provisioner they will
+  match on the **source type** (for example:`source.amazon-ebs.third-example`).

--- a/website/pages/docs/from-1.5/onlyexcept.mdx
+++ b/website/pages/docs/from-1.5/onlyexcept.mdx
@@ -17,7 +17,8 @@ they can be seen as a command line argument:
 
 `@include 'commands/only.mdx'`
 
-They can also be seen in a template:
+They can also be seen in a template to run or skip provisioners and/or
+post-processors for a specific source:
 
 ```hcl
 build {

--- a/website/pages/partials/commands/except.mdx
+++ b/website/pages/partials/commands/except.mdx
@@ -1,0 +1,7 @@
+- `-except=foo,bar,baz` - Run all the builds and post-processors except those
+  with the given comma-separated names. Build and post-processor names by
+  default are their type, unless a specific `name` attribute is specified
+  within the configuration. Any post-processor following a skipped
+  post-processor will not run. Because post-processors can be nested in
+  arrays a different post-processor chain can still run. A post-processor
+  with an empty name will be ignored.

--- a/website/pages/partials/commands/only.mdx
+++ b/website/pages/partials/commands/only.mdx
@@ -1,0 +1,4 @@
+- `-only=foo,bar,baz` - Only run the builds with the given comma-separated
+  names. Build names by default are their type, unless a specific `name`
+  attribute is specified within the configuration. `-only` does not apply to
+  post-processors.


### PR DESCRIPTION
This adds:
* cli: make -only/-except match build names too
* specific docs to avoid confusion for matches between a build and a source.
* add some tests

close #9399