### PR TITLE
Windows restart check registry run with ui

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -263,7 +263,7 @@ var waitForCommunicator = func(ctx context.Context, p *Provisioner) error {
 				cmdKeyCheck.Stdout = &buf
 				cmdKeyCheck.Stdout = io.MultiWriter(cmdKeyCheck.Stdout, &buf2)
 
-				err := p.comm.Start(ctx, cmdKeyCheck)
+				err := cmdKeyCheck.RunWithUi(ctx, p.comm, p.ui)
 				if err != nil {
 					log.Printf("Communication connection err: %s", err)
 					shouldContinue = true

--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -268,7 +268,6 @@ var waitForCommunicator = func(ctx context.Context, p *Provisioner) error {
 					log.Printf("Communication connection err: %s", err)
 					shouldContinue = true
 				}
-				cmdKeyCheck.Wait()
 
 				stdoutToRead := buf2.String()
 				if strings.Contains(stdoutToRead, "True") {


### PR DESCRIPTION
Duplicate of #7983 as I'm finally able to sign the CLA

The WinRM communicator requires that stderr is not nil, the previous implementation calls comm.Start() without configuring a stderr writer. cmd.RunWithUi() will set a default stderr buffer if none is specified in the command. This approach is consistent with how other commands in this and other provisioners are ran.

The existing unit tests do not exercise the check_registry functionality, so I have neither added or modified any tests.

Closes #7901 (which is already closed but had this issue added afterwards)