### PR TITLE
Fix data disks URI

### DIFF
--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
@@ -149,7 +149,7 @@
               "lun": 0,
               "name": "[concat(parameters('dataDiskName'),'-1')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),parameters('dataDiskName'), '-1','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'), variables('vmStorageAccountContainerName'), '/', parameters('dataDiskName'), '-1','.vhd')]"
               }
             }
           ],

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
@@ -149,7 +149,7 @@
               "lun": 0,
               "name": "[concat(parameters('dataDiskName'),'-1')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'), '-1','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'),'-1','.vhd')]"
               }
             }
           ],

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
@@ -149,7 +149,7 @@
               "lun": 0,
               "name": "[concat(parameters('dataDiskName'),'-1')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'), variables('vmStorageAccountContainerName'), '/', parameters('dataDiskName'), '-1','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'), '-1','.vhd')]"
               }
             }
           ],

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -275,7 +275,7 @@ func (s *TemplateBuilder) SetAdditionalDisks(diskSizeGB []int32, dataDiskname st
 			dataDisks[i].ManagedDisk = profile.OsDisk.ManagedDisk
 		} else {
 			dataDisks[i].Vhd = &compute.VirtualHardDisk{
-				URI: to.StringPtr(fmt.Sprintf("[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),parameters('dataDiskName'), '-%d','.vhd')]", i+1)),
+				URI: to.StringPtr(fmt.Sprintf("[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'),'-%d','.vhd')]", i+1)),
 			}
 			dataDisks[i].ManagedDisk = nil
 		}

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
@@ -163,7 +163,7 @@
               "lun": 0,
               "name": "[concat(parameters('dataDiskName'),'-1')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),parameters('dataDiskName'), '-1','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'), variables('vmStorageAccountContainerName'), '/', parameters('dataDiskName'), '-1','.vhd')]"
               }
             },
             {
@@ -173,7 +173,7 @@
               "lun": 1,
               "name": "[concat(parameters('dataDiskName'),'-2')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),parameters('dataDiskName'), '-2','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'), variables('vmStorageAccountContainerName'), '/', parameters('dataDiskName'), '-2','.vhd')]"
               }
             }
           ],

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
@@ -163,7 +163,7 @@
               "lun": 0,
               "name": "[concat(parameters('dataDiskName'),'-1')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'), '-1','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'),'-1','.vhd')]"
               }
             },
             {
@@ -173,7 +173,7 @@
               "lun": 1,
               "name": "[concat(parameters('dataDiskName'),'-2')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'), '-2','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'),'-2','.vhd')]"
               }
             }
           ],

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
@@ -163,7 +163,7 @@
               "lun": 0,
               "name": "[concat(parameters('dataDiskName'),'-1')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'), variables('vmStorageAccountContainerName'), '/', parameters('dataDiskName'), '-1','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'), '-1','.vhd')]"
               }
             },
             {
@@ -173,7 +173,7 @@
               "lun": 1,
               "name": "[concat(parameters('dataDiskName'),'-2')]",
               "vhd": {
-                "uri": "[concat(parameters('storageAccountBlobEndpoint'), variables('vmStorageAccountContainerName'), '/', parameters('dataDiskName'), '-2','.vhd')]"
+                "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/',parameters('dataDiskName'), '-2','.vhd')]"
               }
             }
           ],


### PR DESCRIPTION
Closes #9420 

Hey, @sylviamoss, I was able to identify the issue. It seems it has been around for 3 months already!
As you can see from [this commit](https://github.com/hashicorp/packer/commit/0589f57d4d85ef28054d47049c346e53c1698205) the data disk name changed as following:
```diff
- to.StringPtr(fmt.Sprintf("[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/%s-', '%d','.vhd')]", dataDiskname, i+1))
+ to.StringPtr(fmt.Sprintf("[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),parameters('dataDiskName'), '-%d','.vhd')]", i+1))
```

The most interesting part is the following change: 
```diff
- '/%s-', '%d','.vhd')]", dataDiskname
+ `parameters('dataDiskName'), '-%d' 
```

As we can see from the code block above the slash sign is missing. To ensure that this slash sign is not introduced in `dataDiskName` parameter I'm providing the parameter's code block below:
```go
dataDisks[i].Name = to.StringPtr(fmt.Sprintf("[concat(parameters('dataDiskName'),'-%d'", i+1)). 
```

I think the commit author missed the slash sign when introducing this changes. My PR introduces really small change that fixes this bug. Could you please review? Thanks!


**P.S.** By the way, I just noticed another potential issue. Could you please take a look [here](https://github.com/hashicorp/packer/blob/master/builder/azure/common/template/template_builder.go#L645) and confirm that it doesn't matter what would be the `capture_container_name` variable, it would always use "images" as a container name? I think it is not a kind of intended behavior. I think I can introduce fix for this one as well.