### PR TITLE
Remove prerelease publish and tag-specific filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,15 +150,6 @@ jobs:
       - store_artifacts:
           path: ./pkg/
           destination: /
-  publish-github-tag-release:
-    docker:
-      - image: cibuilds/github:0.10
-    working_directory: /go/src/github.com/hashicorp/packer
-    steps:
-      - attach_workspace:
-          at: .
-      - run: |
-          ghr -prerelease -t ${CI_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./pkg/
   build-website-docker-image:
     docker:
       - image: circleci/buildpack-deps
@@ -196,30 +187,12 @@ workflows:
       - check-generate
   build_packer_binaries:
     jobs:
-      - build_linux:
-          filters:
-            tags:
-              only: /.*/
-      - build_darwin:
-          filters:
-            tags:
-              only: /.*/
-      - build_windows:
-          filters:
-            tags:
-              only: /.*/
-      - build_freebsd:
-          filters:
-            tags:
-              only: /.*/
-      - build_openbsd:
-          filters:
-            tags:
-              only: /.*/
-      - build_solaris:
-          filters:
-            tags:
-              only: /.*/
+      - build_linux
+      - build_darwin
+      - build_windows
+      - build_freebsd
+      - build_openbsd
+      - build_solaris
       - store_artifacts:
           requires:
             - build_linux
@@ -228,19 +201,6 @@ workflows:
             - build_freebsd
             - build_openbsd
             - build_solaris
-      - publish-github-tag-release:
-          requires:
-            - build_linux
-            - build_darwin
-            - build_windows
-            - build_freebsd
-            - build_openbsd
-            - build_solaris
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: nightly
   build_website_docker_image:
     jobs:
       - build-website-docker-image:


### PR DESCRIPTION
The publishing of prereleases (currently called `nightly`) can now be handled in a separate CI/CD pipeline. This new setup results in signed builds, as are currently part of the `nightly` release [here](https://github.com/hashicorp/packer/releases/tag/nightly).
If we'd like to move forward with this updated method of publishing prereleases, we should remove the check here to avoid collisions.
As part of this update, I also removed the tag filters for the other build steps, as they should no longer be necessary without the opposite filter for the `nightly` tags.