### PR TITLE
only set up localhost port forwarding if skipnatmapping is false.

### DIFF
--- a/builder/qemu/comm_config.go
+++ b/builder/qemu/comm_config.go
@@ -46,7 +46,7 @@ func (c *CommConfig) Prepare(ctx *interpolate.Context) (warnings []string, errs 
 		c.HostPortMax = c.SSHHostPortMax
 	}
 
-	if c.Comm.SSHHost == "" {
+	if c.Comm.SSHHost == "" && c.SkipNatMapping {
 		c.Comm.SSHHost = "127.0.0.1"
 	}
 


### PR DESCRIPTION
Don't default to localhost if skipnatmapping is set, or we won't fall through to the nat mapping properly later. 

Closes #9475