### PR TITLE
aws: retry fetching blockdevicemapping if empty

### DIFF
--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -324,8 +324,10 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 		describeOutput, err = ec2conn.DescribeInstances(&ec2.DescribeInstancesInput{
 			InstanceIds: []*string{aws.String(instanceId)},
 		})
-		if len(describeOutput.Reservations) > 0 && len(describeOutput.Reservations[0].Instances) > 0 && len(describeOutput.Reservations[0].Instances[0].BlockDeviceMappings) == 0 {
-			return fmt.Errorf("Instance has no block devices")
+		if len(describeOutput.Reservations) > 0 && len(describeOutput.Reservations[0].Instances) > 0 {
+			if len(s.LaunchMappings.BuildEC2BlockDeviceMappings()) > 0 && len(describeOutput.Reservations[0].Instances[0].BlockDeviceMappings) == 0 {
+				return fmt.Errorf("Instance has no block devices")
+			}
 		}
 		return err
 	})

--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -324,6 +324,9 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 		describeOutput, err = ec2conn.DescribeInstances(&ec2.DescribeInstancesInput{
 			InstanceIds: []*string{aws.String(instanceId)},
 		})
+		if len(describeOutput.Reservations) > 0 && len(describeOutput.Reservations[0].Instances) > 0 && len(describeOutput.Reservations[0].Instances[0].BlockDeviceMappings) == 0 {
+			return fmt.Errorf("Instance has no block devices")
+		}
 		return err
 	})
 	if err != nil || len(describeOutput.Reservations) == 0 || len(describeOutput.Reservations[0].Instances) == 0 {


### PR DESCRIPTION
Closes #9476 
Closes #6420 

The PR does not include tests as I did not find any mocking utilities for the run_spot_instance step.

I have manually confirmed this seems to solve my issue (it retries a few seconds later and finds the mapping correctly).