### PR TITLE
Add 'cdrom_interface' option to QEMU builder

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -316,6 +316,11 @@ type Config struct {
 	// "BUILDNAME" is the name of the build. Currently, no file extension will be
 	// used unless it is specified in this option.
 	VMName string `mapstructure:"vm_name" required:"false"`
+	// The interface to use for the CDROM device which contains the ISO image.
+	// Allowed values include any of `ide`, `scsi`, `virtio` or
+	// `virtio-scsi`. The Qemu builder uses `virtio` by default.
+	// Some ARM64 images require `virtio-scsi`.
+	CDROMInterface string `mapstructure:"cdrom_interface" required:"false"`
 
 	// TODO(mitchellh): deprecate
 	RunOnce bool `mapstructure:"run_once"`

--- a/builder/qemu/builder.hcl2spec.go
+++ b/builder/qemu/builder.hcl2spec.go
@@ -115,6 +115,7 @@ type FlatConfig struct {
 	VNCPortMin                *int              `mapstructure:"vnc_port_min" required:"false" cty:"vnc_port_min" hcl:"vnc_port_min"`
 	VNCPortMax                *int              `mapstructure:"vnc_port_max" cty:"vnc_port_max" hcl:"vnc_port_max"`
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name" hcl:"vm_name"`
+	CDROMInterface            *string           `mapstructure:"cdrom_interface" required:"false" cty:"cdrom_interface" hcl:"cdrom_interface"`
 	RunOnce                   *bool             `mapstructure:"run_once" cty:"run_once" hcl:"run_once"`
 }
 
@@ -236,6 +237,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vnc_port_min":                 &hcldec.AttrSpec{Name: "vnc_port_min", Type: cty.Number, Required: false},
 		"vnc_port_max":                 &hcldec.AttrSpec{Name: "vnc_port_max", Type: cty.Number, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
+		"cdrom_interface":              &hcldec.AttrSpec{Name: "cdrom_interface", Type: cty.String, Required: false},
 		"run_once":                     &hcldec.AttrSpec{Name: "run_once", Type: cty.Bool, Required: false},
 	}
 	return s

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -191,12 +191,20 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 		}
 	}
 
+	if !config.DiskImage {
+		if config.CDROMInterface == "" {
+			defaultArgs["-cdrom"] = isoPath
+		} else if config.CDROMInterface == "virtio-scsi" {
+			driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=none,id=cdrom,media=cdrom", isoPath))
+			deviceArgs = append(deviceArgs, "virtio-scsi-device", "scsi-cd,drive=cdrom")
+		} else {
+			driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=%s,id=cdrom,media=cdrom", isoPath, config.CDROMInterface))
+		}
+	}
+
 	defaultArgs["-device"] = deviceArgs
 	defaultArgs["-drive"] = driveArgs
 
-	if !config.DiskImage {
-		defaultArgs["-cdrom"] = isoPath
-	}
 	defaultArgs["-boot"] = bootDrive
 	defaultArgs["-m"] = fmt.Sprintf("%dM", config.MemorySize)
 	if config.CpuCount > 1 {

--- a/website/pages/partials/builder/qemu/Config-not-required.mdx
+++ b/website/pages/partials/builder/qemu/Config-not-required.mdx
@@ -239,3 +239,8 @@
     "BUILDNAME" is the name of the build. Currently, no file extension will be
     used unless it is specified in this option.
     
+-   `cdrom_interface` (string) - The interface to use for the CDROM device which contains the ISO image.
+    Allowed values include any of `ide`, `scsi`, `virtio` or
+    `virtio-scsi`. The Qemu builder uses `virtio` by default.
+    Some ARM64 images require `virtio-scsi`.
+    


### PR DESCRIPTION
- This option allows the user to select the interface type for the CDROM
  drive, e.g. `virtio-scsi`, rather than the default `virtio`
- Background: Installation of Ubuntu 20.04 on ARM64 fails as it can't mount the
  installation CDROM. While the default `virtio` CDROM fails, setting
  `cdrom_interface: virtio-scsi` with this PR succeeds. Some links:
  - ISO link: http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04-legacy-server-arm64.iso
  - https://bugs.launchpad.net/ubuntu/+source/debian-installer/+bug/1605407
  - https://superuser.com/a/1376628/230508
- Didn't see any existing tests in this area but let me know if there are some QEMU tests I should extend to cover this functionality
