### PR TITLE
Proxmox NIC firewall flag

### DIFF
--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -71,7 +71,7 @@ type nicConfig struct {
 	MACAddress string `mapstructure:"mac_address"`
 	Bridge     string `mapstructure:"bridge"`
 	VLANTag    string `mapstructure:"vlan_tag"`
-	Firewall   *bool  `mapstructure:"firewall"`
+	Firewall   bool   `mapstructure:"firewall"`
 }
 type diskConfig struct {
 	Type            string `mapstructure:"type"`
@@ -159,11 +159,6 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		if c.NICs[idx].Model == "" {
 			log.Printf("NIC %d model not set, using default 'e1000'", idx)
 			c.NICs[idx].Model = "e1000"
-		}
-		if c.NICs[idx].Firewall == nil {
-			log.Printf("NIC %d firewall toggle not set, using default: 0", idx)
-			toggle := false
-			c.NICs[idx].Firewall = &toggle
 		}
 	}
 	for idx := range c.Disks {

--- a/builder/proxmox/config.go
+++ b/builder/proxmox/config.go
@@ -71,6 +71,7 @@ type nicConfig struct {
 	MACAddress string `mapstructure:"mac_address"`
 	Bridge     string `mapstructure:"bridge"`
 	VLANTag    string `mapstructure:"vlan_tag"`
+	Firewall   *bool  `mapstructure:"firewall"`
 }
 type diskConfig struct {
 	Type            string `mapstructure:"type"`
@@ -158,6 +159,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		if c.NICs[idx].Model == "" {
 			log.Printf("NIC %d model not set, using default 'e1000'", idx)
 			c.NICs[idx].Model = "e1000"
+		}
+		if c.NICs[idx].Firewall == nil {
+			log.Printf("NIC %d firewall toggle not set, using default: 0", idx)
+			toggle := false
+			c.NICs[idx].Firewall = &toggle
 		}
 	}
 	for idx := range c.Disks {

--- a/builder/proxmox/config.hcl2spec.go
+++ b/builder/proxmox/config.hcl2spec.go
@@ -247,6 +247,7 @@ type FlatnicConfig struct {
 	MACAddress *string `mapstructure:"mac_address" cty:"mac_address" hcl:"mac_address"`
 	Bridge     *string `mapstructure:"bridge" cty:"bridge" hcl:"bridge"`
 	VLANTag    *string `mapstructure:"vlan_tag" cty:"vlan_tag" hcl:"vlan_tag"`
+	Firewall   *bool   `mapstructure:"firewall" cty:"firewall" hcl:"firewall"`
 }
 
 // FlatMapstructure returns a new FlatnicConfig.
@@ -265,6 +266,7 @@ func (*FlatnicConfig) HCL2Spec() map[string]hcldec.Spec {
 		"mac_address": &hcldec.AttrSpec{Name: "mac_address", Type: cty.String, Required: false},
 		"bridge":      &hcldec.AttrSpec{Name: "bridge", Type: cty.String, Required: false},
 		"vlan_tag":    &hcldec.AttrSpec{Name: "vlan_tag", Type: cty.String, Required: false},
+		"firewall":    &hcldec.AttrSpec{Name: "firewall", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/proxmox/config_test.go
+++ b/builder/proxmox/config_test.go
@@ -97,6 +97,7 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	// Disk 0 cache mode not set, using default 'none'
 	// Agent not set, default is true
 	// SCSI controller not set, using default 'lsi'
+	// Firewall toggle not set, using default: 0
 
 	if b.config.Memory != 512 {
 		t.Errorf("Expected Memory to be 512, got %d", b.config.Memory)
@@ -115,6 +116,9 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	}
 	if b.config.NICs[0].Model != "e1000" {
 		t.Errorf("Expected NIC model to be 'e1000', got %s", b.config.NICs[0].Model)
+	}
+	if *b.config.NICs[0].Firewall != false {
+		t.Errorf("Expected NIC firewall to be false, got %t", *b.config.NICs[0].Firewall)
 	}
 	if b.config.Disks[0].CacheMode != "none" {
 		t.Errorf("Expected disk cache mode to be 'none', got %s", b.config.Disks[0].CacheMode)

--- a/builder/proxmox/config_test.go
+++ b/builder/proxmox/config_test.go
@@ -117,8 +117,8 @@ func TestBasicExampleFromDocsIsValid(t *testing.T) {
 	if b.config.NICs[0].Model != "e1000" {
 		t.Errorf("Expected NIC model to be 'e1000', got %s", b.config.NICs[0].Model)
 	}
-	if *b.config.NICs[0].Firewall != false {
-		t.Errorf("Expected NIC firewall to be false, got %t", *b.config.NICs[0].Firewall)
+	if b.config.NICs[0].Firewall != false {
+		t.Errorf("Expected NIC firewall to be false, got %t", b.config.NICs[0].Firewall)
 	}
 	if b.config.Disks[0].CacheMode != "none" {
 		t.Errorf("Expected disk cache mode to be 'none', got %s", b.config.Disks[0].CacheMode)

--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -104,7 +104,7 @@ func generateProxmoxNetworkAdapters(nics []nicConfig) proxmox.QemuDevices {
 		setDeviceParamIfDefined(devs[idx], "macaddr", nics[idx].MACAddress)
 		setDeviceParamIfDefined(devs[idx], "bridge", nics[idx].Bridge)
 		setDeviceParamIfDefined(devs[idx], "tag", nics[idx].VLANTag)
-		devs[idx]["firewall"] = *nics[idx].Firewall
+		devs[idx]["firewall"] = nics[idx].Firewall
 	}
 	return devs
 }

--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -104,7 +105,7 @@ func generateProxmoxNetworkAdapters(nics []nicConfig) proxmox.QemuDevices {
 		setDeviceParamIfDefined(devs[idx], "macaddr", nics[idx].MACAddress)
 		setDeviceParamIfDefined(devs[idx], "bridge", nics[idx].Bridge)
 		setDeviceParamIfDefined(devs[idx], "tag", nics[idx].VLANTag)
-		devs[idx]["firewall"] = nics[idx].Firewall
+		setDeviceParamIfDefined(devs[idx], "firewall", strconv.FormatBool(nics[idx].Firewall))
 	}
 	return devs
 }

--- a/builder/proxmox/step_start_vm.go
+++ b/builder/proxmox/step_start_vm.go
@@ -104,6 +104,7 @@ func generateProxmoxNetworkAdapters(nics []nicConfig) proxmox.QemuDevices {
 		setDeviceParamIfDefined(devs[idx], "macaddr", nics[idx].MACAddress)
 		setDeviceParamIfDefined(devs[idx], "bridge", nics[idx].Bridge)
 		setDeviceParamIfDefined(devs[idx], "tag", nics[idx].VLANTag)
+		devs[idx]["firewall"] = *nics[idx].Firewall
 	}
 	return devs
 }

--- a/website/pages/docs/builders/proxmox.mdx
+++ b/website/pages/docs/builders/proxmox.mdx
@@ -119,7 +119,8 @@ builder.
     {
       "model": "virtio",
       "bridge": "vmbr0",
-      "vlan_tag": "10"
+      "vlan_tag": "10",
+      "firewall": true
     }
   ]
   ```
@@ -137,6 +138,9 @@ builder.
 
   - `vlan_tag` (string) - If the adapter should tag packets. Defaults to
     no tagging.
+
+  - `firewall` (bool) - If the interface should be protected by the firewall.
+    Defaults to `false`.
 
 - `disks` (array of objects) - Disks attached to the virtual machine.
   Example:


### PR DESCRIPTION
This PR enables proxmox builder to toggle the firewall parameter for network interfaces. By default this parameter is omitted and thus not enabled.

Closes #9327 