### PR TITLE
builder/hyperone: Allow skip chroot device discovery

### DIFF
--- a/builder/hyperone/config.go
+++ b/builder/hyperone/config.go
@@ -100,6 +100,7 @@ type Config struct {
 	// Can be useful when using custom api_url. Defaults to public.
 	PublicNetAdpService string `mapstructure:"public_netadp_service" required:"false"`
 
+	ChrootDevice    string     `mapstructure:"chroot_device"`
 	ChrootDisk      bool       `mapstructure:"chroot_disk"`
 	ChrootDiskSize  float32    `mapstructure:"chroot_disk_size"`
 	ChrootDiskType  string     `mapstructure:"chroot_disk_type"`

--- a/builder/hyperone/config.hcl2spec.go
+++ b/builder/hyperone/config.hcl2spec.go
@@ -83,6 +83,7 @@ type FlatConfig struct {
 	PrivateIP                 *string                      `mapstructure:"private_ip" required:"false" cty:"private_ip" hcl:"private_ip"`
 	PublicIP                  *string                      `mapstructure:"public_ip" required:"false" cty:"public_ip" hcl:"public_ip"`
 	PublicNetAdpService       *string                      `mapstructure:"public_netadp_service" required:"false" cty:"public_netadp_service" hcl:"public_netadp_service"`
+	ChrootDevice              *string                      `mapstructure:"chroot_device" cty:"chroot_device" hcl:"chroot_device"`
 	ChrootDisk                *bool                        `mapstructure:"chroot_disk" cty:"chroot_disk" hcl:"chroot_disk"`
 	ChrootDiskSize            *float32                     `mapstructure:"chroot_disk_size" cty:"chroot_disk_size" hcl:"chroot_disk_size"`
 	ChrootDiskType            *string                      `mapstructure:"chroot_disk_type" cty:"chroot_disk_type" hcl:"chroot_disk_type"`
@@ -183,6 +184,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"private_ip":                   &hcldec.AttrSpec{Name: "private_ip", Type: cty.String, Required: false},
 		"public_ip":                    &hcldec.AttrSpec{Name: "public_ip", Type: cty.String, Required: false},
 		"public_netadp_service":        &hcldec.AttrSpec{Name: "public_netadp_service", Type: cty.String, Required: false},
+		"chroot_device":                &hcldec.AttrSpec{Name: "chroot_device", Type: cty.String, Required: false},
 		"chroot_disk":                  &hcldec.AttrSpec{Name: "chroot_disk", Type: cty.Bool, Required: false},
 		"chroot_disk_size":             &hcldec.AttrSpec{Name: "chroot_disk_size", Type: cty.Number, Required: false},
 		"chroot_disk_type":             &hcldec.AttrSpec{Name: "chroot_disk_type", Type: cty.String, Required: false},

--- a/builder/hyperone/step_prepare_device.go
+++ b/builder/hyperone/step_prepare_device.go
@@ -17,6 +17,13 @@ type stepPrepareDevice struct{}
 
 func (s *stepPrepareDevice) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("config").(*Config)
+
+	if config.ChrootDevice != "" {
+		state.Put("device", config.ChrootDevice)
+		return multistep.ActionContinue
+	}
+
 	controllerNumber := state.Get("chroot_controller_number").(string)
 	controllerLocation := state.Get("chroot_controller_location").(int)
 

--- a/website/pages/docs/builders/hyperone.mdx
+++ b/website/pages/docs/builders/hyperone.mdx
@@ -181,6 +181,9 @@ builder.
   that will be copied into the chroot environment before provisioning.
   Defaults to `/etc/resolv.conf` so that DNS lookups work.
 
+- `chroot_device` (string) - The path of chroot device. Defaults an attempt is
+  made to identify it based on the attach location. 
+
 - `chroot_disk_size` (float) - The size of the chroot disk in GiB. Defaults
   to `disk_size`.
 

--- a/website/pages/partials/builder/hyperone/Config-not-required.mdx
+++ b/website/pages/partials/builder/hyperone/Config-not-required.mdx
@@ -49,6 +49,7 @@
 -   `public_netadp_service` (string) - Custom service of public network adapter.
     Can be useful when using custom api_url. Defaults to public.
     
+-   `chroot_device` (string) - Chroot Device
 -   `chroot_disk` (bool) - Chroot Disk
 -   `chroot_disk_size` (float32) - Chroot Disk Size
 -   `chroot_disk_type` (string) - Chroot Disk Type


### PR DESCRIPTION
Currently, Hashicorp Packer in the HyperOne builder using chroot creates a virtual machine with two disks and chroot to second disk for purpose of installation. In the case of the Linux environment - from our observations - the disk path is not fully deterministic, so a mechanism for their automatic detection based on the known attach location using `/sys/bus/mbus/devices` has been implemented. 

We are currently working on providing FreeBSD, which, however, does not have `/sys/bus/mbus/devices`, but the paths of the drives in GEOM are predictable. For this reason, the change is necessary for the builder to work with the FreeBSD environment.

We plan to publish FreeBSD on the Platform in the near future. We will then add an integration test that uses this functionality to install FreeBSD (similar to the current Debootstrap installation – https://github.com/hashicorp/packer/blob/master/test/fixtures/builder-hyperone/chroot.json ).

The FreeBSD installation must start using the FreeBSD image, and the first image must be manually created, so we must wait for the image to be published as the recommended image on the Platform to add the appropriate E2E tests.

The change has been manually verified and is part of the internal work of continuous delivery of current FreeBSD as recommended image.