### PR TITLE
builder/hyperone: Add support for custom username in vm create

### DIFF
--- a/builder/hyperone/step_create_vm.go
+++ b/builder/hyperone/step_create_vm.go
@@ -55,6 +55,7 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 		Netadp:       []openapi.VmCreateNetadp{netAdapter},
 		UserMetadata: config.UserData,
 		Tag:          config.VmTags,
+		Username:     config.Comm.SSHUsername,
 	}
 
 	vm, _, err := client.VmApi.VmCreate(ctx, options)


### PR DESCRIPTION
The Hyperone platform allows you to choose your own username on vm create. If you use your own user image with a custom username - you may need to upload it to the Platform. I decided not to introduce a separate parameter since parameter similar (in practice both should match) currently exists in Packer.