### PR TITLE
increase resource size for sigkills

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ executors:
   golang:
     docker:
       - image: circleci/golang:1.13
+    resource_class: medium+
   darwin:
     macos:
       xcode: "9.0"


### PR DESCRIPTION
There are occasional failures on the `build_*` steps due to `/usr/local/go/pkg/tool/linux_amd64/compile: signal: killed`. This is due to not having enough RAM on the host image. Let's up the base image resources for building packages and see if these failures go away. Relevant Circle documentation [is here](https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes).
If we still see these failures we can up the size again.