### PR TITLE
builder/googlecompute: Update order of StepWaitStartupScript

### DIFF
--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -72,6 +72,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			AccountFile: b.config.AccountFile,
 			ProjectId:   b.config.ProjectId,
 		},
+		new(StepWaitStartupScript),
 		&communicator.StepConnect{
 			Config:      &b.config.Comm,
 			Host:        communicator.CommHost(b.config.Comm.Host(), "instance_ip"),
@@ -82,11 +83,9 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCleanupTempKeys{
 			Comm: &b.config.Comm,
 		},
+		new(StepTeardownInstance),
+		new(StepCreateImage),
 	}
-	if _, exists := b.config.Metadata[StartupScriptKey]; exists || b.config.StartupScriptFile != "" {
-		steps = append(steps, new(StepWaitStartupScript))
-	}
-	steps = append(steps, new(StepTeardownInstance), new(StepCreateImage))
 
 	// Run the steps.
 	b.runner = common.NewRunner(steps, b.config.PackerConfig, ui)

--- a/builder/googlecompute/step_wait_startup_script_test.go
+++ b/builder/googlecompute/step_wait_startup_script_test.go
@@ -17,6 +17,7 @@ func TestStepWaitStartupScript(t *testing.T) {
 	testZone := "test-zone"
 	testInstanceName := "test-instance-name"
 
+	c.StartupScriptFile = "startup.sh"
 	c.Zone = testZone
 	state.Put("instance_name", testInstanceName)
 


### PR DESCRIPTION
When running GCE with a startup script file Packer will wait for the script to finish executing before it can successfully provision an instance. This change moves up the step to wait for the completion of a supplied startup script file so that it completes before a valid connection is made to the instance and prior to the first provision step.

Closes #9121