### PR TITLE
fix vsphere ToolsSyncTime and ToolsUpgradePolicy

### DIFF
--- a/builder/vsphere/common/step_config_params.go
+++ b/builder/vsphere/common/step_config_params.go
@@ -51,9 +51,7 @@ func (s *StepConfigParams) Run(_ context.Context, state multistep.StateBag) mult
 		if s.Config.ToolsUpgradePolicy {
 			info.ToolsUpgradePolicy = "UpgradeAtPowerCycle"
 		}
-	}
 
-	if len(configParams) > 0 || info != nil {
 		ui.Say("Adding configuration parameters...")
 		if err := vm.AddConfigParams(configParams, info); err != nil {
 			state.Put("error", fmt.Errorf("error adding configuration parameters: %v", err))

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -802,7 +802,6 @@ func (vm *VirtualMachine) addDevice(device types.BaseVirtualDevice) error {
 
 func (vm *VirtualMachine) AddConfigParams(params map[string]string, info *types.ToolsConfigInfo) error {
 	var confSpec types.VirtualMachineConfigSpec
-	var err error
 
 	var ov []types.BaseOptionValue
 	for k, v := range params {
@@ -823,9 +822,10 @@ func (vm *VirtualMachine) AddConfigParams(params map[string]string, info *types.
 		}
 
 		_, err = task.WaitForResult(vm.driver.ctx, nil)
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func (vm *VirtualMachine) Export() (*nfc.Lease, error) {

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -802,29 +802,29 @@ func (vm *VirtualMachine) addDevice(device types.BaseVirtualDevice) error {
 
 func (vm *VirtualMachine) AddConfigParams(params map[string]string, info *types.ToolsConfigInfo) error {
 	var confSpec types.VirtualMachineConfigSpec
+	var err error
 
-	if len(params) > 0 {
-		var ov []types.BaseOptionValue
-		for k, v := range params {
-			o := types.OptionValue{
-				Key:   k,
-				Value: v,
-			}
-			ov = append(ov, &o)
+	var ov []types.BaseOptionValue
+	for k, v := range params {
+		o := types.OptionValue{
+			Key:   k,
+			Value: v,
 		}
-		confSpec.ExtraConfig = ov
+		ov = append(ov, &o)
+	}
+	confSpec.ExtraConfig = ov
+
+	confSpec.Tools = info
+
+	if len(confSpec.ExtraConfig) > 0 || confSpec.Tools != nil {
+		task, err := vm.vm.Reconfigure(vm.driver.ctx, confSpec)
+		if err != nil {
+			return err
+		}
+
+		_, err = task.WaitForResult(vm.driver.ctx, nil)
 	}
 
-	if info != nil {
-		confSpec.Tools = info
-	}
-
-	task, err := vm.vm.Reconfigure(vm.driver.ctx, confSpec)
-	if err != nil {
-		return err
-	}
-
-	_, err = task.WaitForResult(vm.driver.ctx, nil)
 	return err
 }
 

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -800,18 +800,24 @@ func (vm *VirtualMachine) addDevice(device types.BaseVirtualDevice) error {
 	return err
 }
 
-func (vm *VirtualMachine) AddConfigParams(params map[string]string) error {
+func (vm *VirtualMachine) AddConfigParams(params map[string]string, info *types.ToolsConfigInfo) error {
 	var confSpec types.VirtualMachineConfigSpec
 
-	var ov []types.BaseOptionValue
-	for k, v := range params {
-		o := types.OptionValue{
-			Key:   k,
-			Value: v,
+	if len(params) > 0 {
+		var ov []types.BaseOptionValue
+		for k, v := range params {
+			o := types.OptionValue{
+				Key:   k,
+				Value: v,
+			}
+			ov = append(ov, &o)
 		}
-		ov = append(ov, &o)
+		confSpec.ExtraConfig = ov
 	}
-	confSpec.ExtraConfig = ov
+
+	if info != nil {
+		confSpec.Tools = info
+	}
 
 	task, err := vm.vm.Reconfigure(vm.driver.ctx, confSpec)
 	if err != nil {

--- a/website/pages/partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
@@ -3,8 +3,7 @@
 -   `configuration_parameters` (map[string]string) - configuration_parameters is a direct passthrough to the VSphere API's
     ConfigSpec: https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.ConfigSpec.html
     
--   `tools_sync_time` (bool) - Enables time synchronization with the host. If set to true will set `tools.syncTime` to `TRUE`.
-    Defaults to FALSE.
+-   `tools_sync_time` (bool) - Enables time synchronization with the host. Defaults to false.
     
 -   `tools_upgrade_policy` (bool) - If sets to true, vSphere will automatically check and upgrade VMware Tools upon a system power cycle.
     If not set, defaults to manual upgrade.


### PR DESCRIPTION
setting config params on the vm did not update the ToolsSyncTime and ToolsUpgradePolicy. Using the types.ToolsConfigInfo does.