### PR TITLE
builder/googlecompute: Make IAP tunnel timeout configurable.

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -425,6 +425,9 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 			c.IAPConfig.IAPExt = ".cmd"
 		}
 	}
+	if c.IAPConfig.IAPTunnelLaunchTimeout == 0 {
+		c.IAPConfig.IAPTunnelLaunchTimeout = 30
+	}
 
 	// Configure IAP: Update SSH config to use localhost proxy instead
 	if c.IAPConfig.IAP {

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -425,8 +425,8 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 			c.IAPConfig.IAPExt = ".cmd"
 		}
 	}
-	if c.IAPConfig.IAPTunnelLaunchTimeout == 0 {
-		c.IAPConfig.IAPTunnelLaunchTimeout = 30
+	if c.IAPConfig.IAPTunnelLaunchWait == 0 {
+		c.IAPConfig.IAPTunnelLaunchWait = 30
 	}
 
 	// Configure IAP: Update SSH config to use localhost proxy instead

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -78,6 +78,7 @@ type FlatConfig struct {
 	IAPLocalhostPort             *int                       `mapstructure:"iap_localhost_port" cty:"iap_localhost_port" hcl:"iap_localhost_port"`
 	IAPHashBang                  *string                    `mapstructure:"iap_hashbang" required:"false" cty:"iap_hashbang" hcl:"iap_hashbang"`
 	IAPExt                       *string                    `mapstructure:"iap_ext" required:"false" cty:"iap_ext" hcl:"iap_ext"`
+	IAPTunnelLaunchTimeout       *int                       `mapstructure:"iap_tunnel_launch_timeout" required:"false" cty:"iap_tunnel_launch_timeout" hcl:"iap_tunnel_launch_timeout"`
 	ImageName                    *string                    `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
 	ImageDescription             *string                    `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageEncryptionKey           *FlatCustomerEncryptionKey `mapstructure:"image_encryption_key" required:"false" cty:"image_encryption_key" hcl:"image_encryption_key"`
@@ -194,6 +195,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"iap_localhost_port":              &hcldec.AttrSpec{Name: "iap_localhost_port", Type: cty.Number, Required: false},
 		"iap_hashbang":                    &hcldec.AttrSpec{Name: "iap_hashbang", Type: cty.String, Required: false},
 		"iap_ext":                         &hcldec.AttrSpec{Name: "iap_ext", Type: cty.String, Required: false},
+		"iap_tunnel_launch_timeout":       &hcldec.AttrSpec{Name: "iap_tunnel_launch_timeout", Type: cty.Number, Required: false},
 		"image_name":                      &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"image_description":               &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_encryption_key":            &hcldec.BlockSpec{TypeName: "image_encryption_key", Nested: hcldec.ObjectSpec((*FlatCustomerEncryptionKey)(nil).HCL2Spec())},

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -78,7 +78,7 @@ type FlatConfig struct {
 	IAPLocalhostPort             *int                       `mapstructure:"iap_localhost_port" cty:"iap_localhost_port" hcl:"iap_localhost_port"`
 	IAPHashBang                  *string                    `mapstructure:"iap_hashbang" required:"false" cty:"iap_hashbang" hcl:"iap_hashbang"`
 	IAPExt                       *string                    `mapstructure:"iap_ext" required:"false" cty:"iap_ext" hcl:"iap_ext"`
-	IAPTunnelLaunchTimeout       *int                       `mapstructure:"iap_tunnel_launch_timeout" required:"false" cty:"iap_tunnel_launch_timeout" hcl:"iap_tunnel_launch_timeout"`
+	IAPTunnelLaunchWait          *int                       `mapstructure:"iap_tunnel_launch_wait" required:"false" cty:"iap_tunnel_launch_wait" hcl:"iap_tunnel_launch_wait"`
 	ImageName                    *string                    `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
 	ImageDescription             *string                    `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageEncryptionKey           *FlatCustomerEncryptionKey `mapstructure:"image_encryption_key" required:"false" cty:"image_encryption_key" hcl:"image_encryption_key"`
@@ -195,7 +195,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"iap_localhost_port":              &hcldec.AttrSpec{Name: "iap_localhost_port", Type: cty.Number, Required: false},
 		"iap_hashbang":                    &hcldec.AttrSpec{Name: "iap_hashbang", Type: cty.String, Required: false},
 		"iap_ext":                         &hcldec.AttrSpec{Name: "iap_ext", Type: cty.String, Required: false},
-		"iap_tunnel_launch_timeout":       &hcldec.AttrSpec{Name: "iap_tunnel_launch_timeout", Type: cty.Number, Required: false},
+		"iap_tunnel_launch_wait":          &hcldec.AttrSpec{Name: "iap_tunnel_launch_wait", Type: cty.Number, Required: false},
 		"image_name":                      &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"image_description":               &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_encryption_key":            &hcldec.BlockSpec{TypeName: "image_encryption_key", Nested: hcldec.ObjectSpec((*FlatCustomerEncryptionKey)(nil).HCL2Spec())},

--- a/builder/googlecompute/step_start_tunnel.go
+++ b/builder/googlecompute/step_start_tunnel.go
@@ -53,7 +53,7 @@ type IAPConfig struct {
 	IAPExt string `mapstructure:"iap_ext" required:"false"`
 	// How long to wait, in seconds, before assuming a tunnel launch was
 	// successful. Defaults to 30 seconds.
-	IAPTunnelLaunchTimeout int `mapstructure:"iap_tunnel_launch_timeout" required:"false"`
+	IAPTunnelLaunchWait int `mapstructure:"iap_tunnel_launch_wait" required:"false"`
 }
 
 type TunnelDriver interface {
@@ -311,7 +311,7 @@ func (s *StepStartTunnel) Run(ctx context.Context, state multistep.StateBag) mul
 		RetryDelay: (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 	}.Run(ctx, func(ctx context.Context) error {
 		// tunnel launcher/destroyer has to be different on windows vs. unix.
-		err := s.tunnelDriver.StartTunnel(ctx, tempScriptFileName, s.IAPConf.IAPTunnelLaunchTimeout)
+		err := s.tunnelDriver.StartTunnel(ctx, tempScriptFileName, s.IAPConf.IAPTunnelLaunchWait)
 		return err
 	})
 	if err != nil {

--- a/builder/googlecompute/step_start_tunnel.hcl2spec.go
+++ b/builder/googlecompute/step_start_tunnel.hcl2spec.go
@@ -9,10 +9,11 @@ import (
 // FlatIAPConfig is an auto-generated flat version of IAPConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatIAPConfig struct {
-	IAP              *bool   `mapstructure:"use_iap" required:"false" cty:"use_iap" hcl:"use_iap"`
-	IAPLocalhostPort *int    `mapstructure:"iap_localhost_port" cty:"iap_localhost_port" hcl:"iap_localhost_port"`
-	IAPHashBang      *string `mapstructure:"iap_hashbang" required:"false" cty:"iap_hashbang" hcl:"iap_hashbang"`
-	IAPExt           *string `mapstructure:"iap_ext" required:"false" cty:"iap_ext" hcl:"iap_ext"`
+	IAP                    *bool   `mapstructure:"use_iap" required:"false" cty:"use_iap" hcl:"use_iap"`
+	IAPLocalhostPort       *int    `mapstructure:"iap_localhost_port" cty:"iap_localhost_port" hcl:"iap_localhost_port"`
+	IAPHashBang            *string `mapstructure:"iap_hashbang" required:"false" cty:"iap_hashbang" hcl:"iap_hashbang"`
+	IAPExt                 *string `mapstructure:"iap_ext" required:"false" cty:"iap_ext" hcl:"iap_ext"`
+	IAPTunnelLaunchTimeout *int    `mapstructure:"iap_tunnel_launch_timeout" required:"false" cty:"iap_tunnel_launch_timeout" hcl:"iap_tunnel_launch_timeout"`
 }
 
 // FlatMapstructure returns a new FlatIAPConfig.
@@ -27,10 +28,11 @@ func (*IAPConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spe
 // The decoded values from this spec will then be applied to a FlatIAPConfig.
 func (*FlatIAPConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"use_iap":            &hcldec.AttrSpec{Name: "use_iap", Type: cty.Bool, Required: false},
-		"iap_localhost_port": &hcldec.AttrSpec{Name: "iap_localhost_port", Type: cty.Number, Required: false},
-		"iap_hashbang":       &hcldec.AttrSpec{Name: "iap_hashbang", Type: cty.String, Required: false},
-		"iap_ext":            &hcldec.AttrSpec{Name: "iap_ext", Type: cty.String, Required: false},
+		"use_iap":                   &hcldec.AttrSpec{Name: "use_iap", Type: cty.Bool, Required: false},
+		"iap_localhost_port":        &hcldec.AttrSpec{Name: "iap_localhost_port", Type: cty.Number, Required: false},
+		"iap_hashbang":              &hcldec.AttrSpec{Name: "iap_hashbang", Type: cty.String, Required: false},
+		"iap_ext":                   &hcldec.AttrSpec{Name: "iap_ext", Type: cty.String, Required: false},
+		"iap_tunnel_launch_timeout": &hcldec.AttrSpec{Name: "iap_tunnel_launch_timeout", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/googlecompute/step_start_tunnel.hcl2spec.go
+++ b/builder/googlecompute/step_start_tunnel.hcl2spec.go
@@ -9,11 +9,11 @@ import (
 // FlatIAPConfig is an auto-generated flat version of IAPConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatIAPConfig struct {
-	IAP                    *bool   `mapstructure:"use_iap" required:"false" cty:"use_iap" hcl:"use_iap"`
-	IAPLocalhostPort       *int    `mapstructure:"iap_localhost_port" cty:"iap_localhost_port" hcl:"iap_localhost_port"`
-	IAPHashBang            *string `mapstructure:"iap_hashbang" required:"false" cty:"iap_hashbang" hcl:"iap_hashbang"`
-	IAPExt                 *string `mapstructure:"iap_ext" required:"false" cty:"iap_ext" hcl:"iap_ext"`
-	IAPTunnelLaunchTimeout *int    `mapstructure:"iap_tunnel_launch_timeout" required:"false" cty:"iap_tunnel_launch_timeout" hcl:"iap_tunnel_launch_timeout"`
+	IAP                 *bool   `mapstructure:"use_iap" required:"false" cty:"use_iap" hcl:"use_iap"`
+	IAPLocalhostPort    *int    `mapstructure:"iap_localhost_port" cty:"iap_localhost_port" hcl:"iap_localhost_port"`
+	IAPHashBang         *string `mapstructure:"iap_hashbang" required:"false" cty:"iap_hashbang" hcl:"iap_hashbang"`
+	IAPExt              *string `mapstructure:"iap_ext" required:"false" cty:"iap_ext" hcl:"iap_ext"`
+	IAPTunnelLaunchWait *int    `mapstructure:"iap_tunnel_launch_wait" required:"false" cty:"iap_tunnel_launch_wait" hcl:"iap_tunnel_launch_wait"`
 }
 
 // FlatMapstructure returns a new FlatIAPConfig.
@@ -28,11 +28,11 @@ func (*IAPConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spe
 // The decoded values from this spec will then be applied to a FlatIAPConfig.
 func (*FlatIAPConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"use_iap":                   &hcldec.AttrSpec{Name: "use_iap", Type: cty.Bool, Required: false},
-		"iap_localhost_port":        &hcldec.AttrSpec{Name: "iap_localhost_port", Type: cty.Number, Required: false},
-		"iap_hashbang":              &hcldec.AttrSpec{Name: "iap_hashbang", Type: cty.String, Required: false},
-		"iap_ext":                   &hcldec.AttrSpec{Name: "iap_ext", Type: cty.String, Required: false},
-		"iap_tunnel_launch_timeout": &hcldec.AttrSpec{Name: "iap_tunnel_launch_timeout", Type: cty.Number, Required: false},
+		"use_iap":                &hcldec.AttrSpec{Name: "use_iap", Type: cty.Bool, Required: false},
+		"iap_localhost_port":     &hcldec.AttrSpec{Name: "iap_localhost_port", Type: cty.Number, Required: false},
+		"iap_hashbang":           &hcldec.AttrSpec{Name: "iap_hashbang", Type: cty.String, Required: false},
+		"iap_ext":                &hcldec.AttrSpec{Name: "iap_ext", Type: cty.String, Required: false},
+		"iap_tunnel_launch_wait": &hcldec.AttrSpec{Name: "iap_tunnel_launch_wait", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/googlecompute/step_start_tunnel_test.go
+++ b/builder/googlecompute/step_start_tunnel_test.go
@@ -12,16 +12,18 @@ import (
 )
 
 type MockTunnelDriver struct {
-	StopTunnelCalled  bool
-	StartTunnelCalled bool
+	StopTunnelCalled   bool
+	StartTunnelCalled  bool
+	StartTunnelTimeout int
 }
 
 func (m *MockTunnelDriver) StopTunnel() {
 	m.StopTunnelCalled = true
 }
 
-func (m *MockTunnelDriver) StartTunnel(context.Context, string) error {
+func (m *MockTunnelDriver) StartTunnel(_ context.Context, _ string, timeout int) error {
 	m.StartTunnelCalled = true
+	m.StartTunnelTimeout = timeout
 	return nil
 }
 

--- a/builder/googlecompute/tunnel_driver.go
+++ b/builder/googlecompute/tunnel_driver.go
@@ -17,11 +17,11 @@ type TunnelDriverLinux struct {
 	cmd *exec.Cmd
 }
 
-func (t *TunnelDriverLinux) StartTunnel(cancelCtx context.Context, tempScriptFileName string) error {
+func (t *TunnelDriverLinux) StartTunnel(cancelCtx context.Context, tempScriptFileName string, timeout int) error {
 	cmd := exec.CommandContext(cancelCtx, tempScriptFileName)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	err := RunTunnelCommand(cmd)
+	err := RunTunnelCommand(cmd, timeout)
 	if err != nil {
 		return err
 	}

--- a/builder/googlecompute/tunnel_driver_windows.go
+++ b/builder/googlecompute/tunnel_driver_windows.go
@@ -16,10 +16,10 @@ type TunnelDriverWindows struct {
 	cmd *exec.Cmd
 }
 
-func (t *TunnelDriverWindows) StartTunnel(cancelCtx context.Context, tempScriptFileName string) error {
+func (t *TunnelDriverWindows) StartTunnel(cancelCtx context.Context, tempScriptFileName string, timeout int) error {
 	args := []string{"/C", "call", tempScriptFileName}
 	cmd := exec.CommandContext(cancelCtx, "cmd", args...)
-	err := RunTunnelCommand(cmd)
+	err := RunTunnelCommand(cmd, timeout)
 	if err != nil {
 		return err
 	}

--- a/website/pages/partials/builder/googlecompute/IAPConfig-not-required.mdx
+++ b/website/pages/partials/builder/googlecompute/IAPConfig-not-required.mdx
@@ -23,5 +23,5 @@
 - `iap_ext` (string) - What file extension to use for script that sets up gcloud.
   Default: ".sh"
 
-- `iap_tunnel_launch_timeout` (int) - How long to wait, in seconds, before assuming a tunnel launch was
+- `iap_tunnel_launch_wait` (int) - How long to wait, in seconds, before assuming a tunnel launch was
   successful. Defaults to 30 seconds.

--- a/website/pages/partials/builder/googlecompute/IAPConfig-not-required.mdx
+++ b/website/pages/partials/builder/googlecompute/IAPConfig-not-required.mdx
@@ -22,3 +22,6 @@
 
 - `iap_ext` (string) - What file extension to use for script that sets up gcloud.
   Default: ".sh"
+
+- `iap_tunnel_launch_timeout` (int) - How long to wait, in seconds, before assuming a tunnel launch was
+  successful. Defaults to 30 seconds.


### PR DESCRIPTION
Add config option to change timeout in case tunnel takes longer than 30s to fail. 
Closes #9528 

