### PR TITLE
Add note for unmaintained community-supported plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,20 @@ See
 [CONTRIBUTING.md](https://github.com/hashicorp/packer/blob/master/.github/CONTRIBUTING.md)
 for best practices and instructions on setting up your development environment
 to work on Packer.
+
+## Unmaintained Plugins
+As contributors' circumstances change, development on a community-maintained
+plugins can slow. When this happens, the Packer team may mark a plugin as
+unmaintained, to clearly signal the plugin's status to users.
+
+What does **unmaintained** mean?
+
+1. The code repository and all commit history will still be available.
+1. Documentation will remain on the Packer website.
+1. Issues and pull requests are monitored as a best effort.
+1. No active development will be performed by the Packer team.
+
+If anyone from the community or an interested third party is willing to
+maintain a community supported plugin, they can fork the repository for
+their own uses. If you are interested in maintaining a plugin that has been
+marked as unmaintained, please reach out via [Packer's Issue Tracker](https://github.com/hashicorp/packer/issues/)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ What does **unmaintained** mean?
 1. Issues and pull requests are monitored as a best effort.
 1. No active development will be performed by the Packer team.
 
-If anyone from the community or an interested third party is willing to
-maintain a community supported plugin, they can fork the repository for
-their own uses. If you are interested in maintaining a plugin that has been
-marked as unmaintained, please reach out via [Packer's Issue Tracker](https://github.com/hashicorp/packer/issues/)
+If anyone form them community is interested in maintaining a community
+supported plugin, please feel free to submit contributions via a pull-
+request for review; reviews are generally prioritized over feature work
+when possible. For a list of open plugin issues and pending feature requests see the [Packer Issue Tracker](https://github.com/hashicorp/packer/issues/).

--- a/website/pages/docs/provisioners/salt-masterless.mdx
+++ b/website/pages/docs/provisioners/salt-masterless.mdx
@@ -9,11 +9,14 @@ sidebar_title: Salt Masterless
 
 # Salt Masterless Provisioner
 
+@include 'provisioners/unmaintained-plugin.mdx'
+
 Type: `salt-masterless`
 
 The `salt-masterless` Packer provisioner provisions machines built by Packer
 using [Salt](http://saltstack.com/) states, without connecting to a Salt
 master.
+
 
 ## Basic Example
 

--- a/website/pages/partials/provisioners/unmaintained-plugin.mdx
+++ b/website/pages/partials/provisioners/unmaintained-plugin.mdx
@@ -1,0 +1,2 @@
+
+~> **This community-supported provisioner is unmaintained**, read more details in the [README](https://github.com/hashicorp/packer/blob/master/README.md#unmaintained-plugins)


### PR DESCRIPTION
This change borrowed from Terraform's [archived provider documentation](https://www.terraform.io/docs/internals/archiving.html) adds a documentation partial that can be applied to any provisioner plugin that is not actively maintained by Packer or the community. A call to action for anyone interested in supporting the plugin has been added to the Packer README until a better location is made available.

* Mark the salt-masterless plugin as unmaintained

