### PR TITLE
unset HardwareConfig.Firmware for vsphere-iso

### DIFF
--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -60,6 +60,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		)
 	}
 
+	// default Firmware to "" since it is already configured by the CreateConfig.Firmware
+	if b.config.CreateConfig.Firmware != "" {
+		b.config.HardwareConfig.Firmware = ""
+	}
+
 	steps = append(steps,
 		&StepCreateVM{
 			Config:   &b.config.CreateConfig,


### PR DESCRIPTION
HardwareConfig and CreateConfig both have the firmware field. We don't need to reconfigure the VM to use the same firmware after creating it.

Closes #9547
