### PR TITLE
add note about versioning to vsphere builder docs

### DIFF
--- a/website/pages/docs/builders/vmware/vsphere-clone.mdx
+++ b/website/pages/docs/builders/vmware/vsphere-clone.mdx
@@ -17,6 +17,9 @@ This builder clones VMs from existing templates.
 
 - VMware Player is not required.
 - It uses the official vCenter API, and does not require ESXi host [modification](https://www.packer.io/docs/builders/vmware-iso.html#building-on-a-remote-vsphere-hypervisor)
+- This builder is supported for vSphere version 6.5 and greater. Builds on lower
+versions may work, but some configuration options may throw errors because they
+do not exist in the older versions of the vSphere API.
 
 ## Examples
 

--- a/website/pages/docs/builders/vmware/vsphere-iso.mdx
+++ b/website/pages/docs/builders/vmware/vsphere-iso.mdx
@@ -18,6 +18,9 @@ starts from an ISO file and creates new VMs from scratch.
 
 - VMware Player is not required.
 - It uses the official vCenter API, and does not require ESXi host [modification](/docs/builders/vmware-iso#building-on-a-remote-vsphere-hypervisor)
+- This builder is supported for vSphere version 6.5 and greater. Builds on lower
+versions may work, but some configuration options may throw errors because they
+do not exist in the older versions of the vSphere API.
 
 ## Examples
 


### PR DESCRIPTION
Document that Packer doesn't support older versions of vSphere. This is because govmomi, our upstream vSphere library, does not support older versions. 

Closes #9547
