### PR TITLE
Add force_bios_setup configuration option

### DIFF
--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -52,6 +52,7 @@ type FlatConfig struct {
 	VGPUProfile                     *string                                     `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
 	NestedHV                        *bool                                       `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
 	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
+	ForceBIOSSetup                  *bool                                       `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
 	ConfigParams                    map[string]string                           `mapstructure:"configuration_parameters" cty:"configuration_parameters" hcl:"configuration_parameters"`
 	ToolsSyncTime                   *bool                                       `mapstructure:"tools_sync_time" cty:"tools_sync_time" hcl:"tools_sync_time"`
 	ToolsUpgradePolicy              *bool                                       `mapstructure:"tools_upgrade_policy" cty:"tools_upgrade_policy" hcl:"tools_upgrade_policy"`
@@ -170,6 +171,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vgpu_profile":                   &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
 		"NestedHV":                       &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
 		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
+		"force_bios_setup":               &hcldec.AttrSpec{Name: "force_bios_setup", Type: cty.Bool, Required: false},
 		"configuration_parameters":       &hcldec.AttrSpec{Name: "configuration_parameters", Type: cty.Map(cty.String), Required: false},
 		"tools_sync_time":                &hcldec.AttrSpec{Name: "tools_sync_time", Type: cty.Bool, Required: false},
 		"tools_upgrade_policy":           &hcldec.AttrSpec{Name: "tools_upgrade_policy", Type: cty.Bool, Required: false},

--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -39,8 +39,10 @@ type HardwareConfig struct {
 	VGPUProfile string `mapstructure:"vgpu_profile"`
 	// Enable nested hardware virtualization for VM. Defaults to `false`.
 	NestedHV bool `mapstructure:"NestedHV"`
-	// Set the Firmware for virtual machine. Supported values: `bios`, `efi`, `efi-secure` or empty string to keep as in template. Defaults to empty string.
+	// Set the Firmware for virtual machine. Supported values: `bios`, `efi` or `efi-secure`. Defaults to `bios`.
 	Firmware string `mapstructure:"firmware"`
+	// During the boot, force entry into the BIOS setup screen. Defaults to `false`.
+	ForceBIOSSetup bool `mapstructure:"force_bios_setup"`
 }
 
 func (c *HardwareConfig) Prepare() []error {
@@ -82,6 +84,7 @@ func (s *StepConfigureHardware) Run(_ context.Context, state multistep.StateBag)
 			VideoRAM:            s.Config.VideoRAM,
 			VGPUProfile:         s.Config.VGPUProfile,
 			Firmware:            s.Config.Firmware,
+			ForceBIOSSetup:      s.Config.ForceBIOSSetup,
 		})
 		if err != nil {
 			state.Put("error", err)

--- a/builder/vsphere/common/step_hardware.hcl2spec.go
+++ b/builder/vsphere/common/step_hardware.hcl2spec.go
@@ -22,6 +22,7 @@ type FlatHardwareConfig struct {
 	VGPUProfile         *string `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
 	NestedHV            *bool   `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
 	Firmware            *string `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
+	ForceBIOSSetup      *bool   `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
 }
 
 // FlatMapstructure returns a new FlatHardwareConfig.
@@ -36,19 +37,20 @@ func (*HardwareConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hclde
 // The decoded values from this spec will then be applied to a FlatHardwareConfig.
 func (*FlatHardwareConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"CPUs":            &hcldec.AttrSpec{Name: "CPUs", Type: cty.Number, Required: false},
-		"cpu_cores":       &hcldec.AttrSpec{Name: "cpu_cores", Type: cty.Number, Required: false},
-		"CPU_reservation": &hcldec.AttrSpec{Name: "CPU_reservation", Type: cty.Number, Required: false},
-		"CPU_limit":       &hcldec.AttrSpec{Name: "CPU_limit", Type: cty.Number, Required: false},
-		"CPU_hot_plug":    &hcldec.AttrSpec{Name: "CPU_hot_plug", Type: cty.Bool, Required: false},
-		"RAM":             &hcldec.AttrSpec{Name: "RAM", Type: cty.Number, Required: false},
-		"RAM_reservation": &hcldec.AttrSpec{Name: "RAM_reservation", Type: cty.Number, Required: false},
-		"RAM_reserve_all": &hcldec.AttrSpec{Name: "RAM_reserve_all", Type: cty.Bool, Required: false},
-		"RAM_hot_plug":    &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
-		"video_ram":       &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
-		"vgpu_profile":    &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
-		"NestedHV":        &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
-		"firmware":        &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
+		"CPUs":             &hcldec.AttrSpec{Name: "CPUs", Type: cty.Number, Required: false},
+		"cpu_cores":        &hcldec.AttrSpec{Name: "cpu_cores", Type: cty.Number, Required: false},
+		"CPU_reservation":  &hcldec.AttrSpec{Name: "CPU_reservation", Type: cty.Number, Required: false},
+		"CPU_limit":        &hcldec.AttrSpec{Name: "CPU_limit", Type: cty.Number, Required: false},
+		"CPU_hot_plug":     &hcldec.AttrSpec{Name: "CPU_hot_plug", Type: cty.Bool, Required: false},
+		"RAM":              &hcldec.AttrSpec{Name: "RAM", Type: cty.Number, Required: false},
+		"RAM_reservation":  &hcldec.AttrSpec{Name: "RAM_reservation", Type: cty.Number, Required: false},
+		"RAM_reserve_all":  &hcldec.AttrSpec{Name: "RAM_reserve_all", Type: cty.Bool, Required: false},
+		"RAM_hot_plug":     &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
+		"video_ram":        &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
+		"vgpu_profile":     &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
+		"NestedHV":         &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
+		"firmware":         &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
+		"force_bios_setup": &hcldec.AttrSpec{Name: "force_bios_setup", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -60,11 +60,6 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		)
 	}
 
-	// default Firmware to "" since it is already configured by the CreateConfig.Firmware
-	if b.config.CreateConfig.Firmware != "" {
-		b.config.HardwareConfig.Firmware = ""
-	}
-
 	steps = append(steps,
 		&StepCreateVM{
 			Config:   &b.config.CreateConfig,

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -28,7 +28,6 @@ type FlatConfig struct {
 	Datacenter                      *string                                     `mapstructure:"datacenter" cty:"datacenter" hcl:"datacenter"`
 	Version                         *uint                                       `mapstructure:"vm_version" cty:"vm_version" hcl:"vm_version"`
 	GuestOSType                     *string                                     `mapstructure:"guest_os_type" cty:"guest_os_type" hcl:"guest_os_type"`
-	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
 	DiskControllerType              []string                                    `mapstructure:"disk_controller_type" cty:"disk_controller_type" hcl:"disk_controller_type"`
 	Storage                         []FlatDiskConfig                            `mapstructure:"storage" cty:"storage" hcl:"storage"`
 	NICs                            []FlatNIC                                   `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
@@ -53,6 +52,8 @@ type FlatConfig struct {
 	VideoRAM                        *int64                                      `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
 	VGPUProfile                     *string                                     `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
 	NestedHV                        *bool                                       `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
+	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
+	ForceBIOSSetup                  *bool                                       `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
 	ConfigParams                    map[string]string                           `mapstructure:"configuration_parameters" cty:"configuration_parameters" hcl:"configuration_parameters"`
 	ToolsSyncTime                   *bool                                       `mapstructure:"tools_sync_time" cty:"tools_sync_time" hcl:"tools_sync_time"`
 	ToolsUpgradePolicy              *bool                                       `mapstructure:"tools_upgrade_policy" cty:"tools_upgrade_policy" hcl:"tools_upgrade_policy"`
@@ -159,7 +160,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"datacenter":                     &hcldec.AttrSpec{Name: "datacenter", Type: cty.String, Required: false},
 		"vm_version":                     &hcldec.AttrSpec{Name: "vm_version", Type: cty.Number, Required: false},
 		"guest_os_type":                  &hcldec.AttrSpec{Name: "guest_os_type", Type: cty.String, Required: false},
-		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"disk_controller_type":           &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.List(cty.String), Required: false},
 		"storage":                        &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*FlatDiskConfig)(nil).HCL2Spec())},
 		"network_adapters":               &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},
@@ -184,6 +184,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"video_ram":                      &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
 		"vgpu_profile":                   &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
 		"NestedHV":                       &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
+		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
+		"force_bios_setup":               &hcldec.AttrSpec{Name: "force_bios_setup", Type: cty.Bool, Required: false},
 		"configuration_parameters":       &hcldec.AttrSpec{Name: "configuration_parameters", Type: cty.Map(cty.String), Required: false},
 		"tools_sync_time":                &hcldec.AttrSpec{Name: "tools_sync_time", Type: cty.Bool, Required: false},
 		"tools_upgrade_policy":           &hcldec.AttrSpec{Name: "tools_upgrade_policy", Type: cty.Bool, Required: false},

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -101,8 +101,6 @@ type CreateConfig struct {
 	// here](https://code.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
 	// for a full list of possible values.
 	GuestOSType string `mapstructure:"guest_os_type"`
-	// Set the Firmware at machine creation. Supported values: `bios`, `efi` or `efi-secure`. Defaults to `bios`.
-	Firmware string `mapstructure:"firmware"`
 	// Set VM disk controller type. Example `lsilogic`, pvscsi`, or `scsi`. Use a list to define additional controllers. Defaults to `lsilogic`
 	DiskControllerType []string `mapstructure:"disk_controller_type"`
 	// A collection of one or more disks to be provisioned along with the VM.
@@ -136,10 +134,6 @@ func (c *CreateConfig) Prepare() []error {
 
 	if c.GuestOSType == "" {
 		c.GuestOSType = "otherGuest"
-	}
-
-	if c.Firmware != "" && c.Firmware != "bios" && c.Firmware != "efi" && c.Firmware != "efi-secure" {
-		errs = append(errs, fmt.Errorf("'firmware' must be 'bios', 'efi' or 'efi-secure'"))
 	}
 
 	return errs
@@ -200,7 +194,6 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 		NICs:               networkCards,
 		USBController:      s.Config.USBController,
 		Version:            s.Config.Version,
-		Firmware:           s.Config.Firmware,
 	})
 	if err != nil {
 		state.Put("error", fmt.Errorf("error creating vm: %v", err))

--- a/builder/vsphere/iso/step_create.hcl2spec.go
+++ b/builder/vsphere/iso/step_create.hcl2spec.go
@@ -11,7 +11,6 @@ import (
 type FlatCreateConfig struct {
 	Version            *uint            `mapstructure:"vm_version" cty:"vm_version" hcl:"vm_version"`
 	GuestOSType        *string          `mapstructure:"guest_os_type" cty:"guest_os_type" hcl:"guest_os_type"`
-	Firmware           *string          `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
 	DiskControllerType []string         `mapstructure:"disk_controller_type" cty:"disk_controller_type" hcl:"disk_controller_type"`
 	Storage            []FlatDiskConfig `mapstructure:"storage" cty:"storage" hcl:"storage"`
 	NICs               []FlatNIC        `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
@@ -33,7 +32,6 @@ func (*FlatCreateConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"vm_version":           &hcldec.AttrSpec{Name: "vm_version", Type: cty.Number, Required: false},
 		"guest_os_type":        &hcldec.AttrSpec{Name: "guest_os_type", Type: cty.String, Required: false},
-		"firmware":             &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"disk_controller_type": &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.List(cty.String), Required: false},
 		"storage":              &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*FlatDiskConfig)(nil).HCL2Spec())},
 		"network_adapters":     &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},

--- a/website/pages/partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -26,5 +26,7 @@
     
 -   `NestedHV` (bool) - Enable nested hardware virtualization for VM. Defaults to `false`.
     
--   `firmware` (string) - Set the Firmware for virtual machine. Supported values: `bios`, `efi`, `efi-secure` or empty string to keep as in template. Defaults to empty string.
+-   `firmware` (string) - Set the Firmware for virtual machine. Supported values: `bios`, `efi` or `efi-secure`. Defaults to `bios`.
+    
+-   `force_bios_setup` (bool) - During the boot, force entry into the BIOS setup screen. Defaults to `false`.
     

--- a/website/pages/partials/builder/vsphere/iso/CreateConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/iso/CreateConfig-not-required.mdx
@@ -9,8 +9,6 @@
     here](https://code.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
     for a full list of possible values.
     
--   `firmware` (string) - Set the Firmware at machine creation. Supported values: `bios`, `efi` or `efi-secure`. Defaults to `bios`.
-    
 -   `disk_controller_type` ([]string) - Set VM disk controller type. Example `lsilogic`, pvscsi`, or `scsi`. Use a list to define additional controllers. Defaults to `lsilogic`
     
 -   `storage` ([]DiskConfig) - A collection of one or more disks to be provisioned along with the VM.


### PR DESCRIPTION
This allows to force the machine to enter into the BIOS setup screen on boot. Also, it removes the duplicated firmware config from `CreateConfig` and moves any logic to `HardwareConfig`

Closes https://github.com/hashicorp/packer/issues/9025