### PR TITLE
builder/docker: runner support for --cap-add, --cap-drop, --tmpfs, --device

### DIFF
--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -43,6 +43,10 @@ type Config struct {
 	// the [artifice
 	// post-processor](/docs/post-processors/artifice).
 	Discard bool `mapstructure:"discard" required:"true"`
+	// An array of additional Linux capabilities to grant to the container.
+	CapAdd []string `mapstructure:"cap_add" required:"false"`
+	// An array of Linux capabilities to drop from the container.
+	CapDrop []string `mapstructure:"cap_drop" required:"false"`
 	// Username (UID) to run remote commands with. You can also set the group
 	// name/ID if you want: (UID or UID:GID). You may need this if you get
 	// permission errors trying to run the shell or other provisioners.
@@ -75,6 +79,8 @@ type Config struct {
 	// docker image embeds a binary intended to be run often, you should
 	// consider changing the default entrypoint to point to it.
 	RunCommand []string `mapstructure:"run_command" required:"false"`
+	// An array of additional tmpfs volumes to mount into this container.
+	TmpFs []string `mapstructure:"tmpfs" required:"false"`
 	// A mapping of additional volumes to mount into this container. The key of
 	// the object is the host path, the value is the container path.
 	Volumes map[string]string `mapstructure:"volumes" required:"false"`

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -39,6 +39,9 @@ type Config struct {
 	// for work [file provisioner](/docs/provisioners/file). This defaults
 	// to c:/packer-files on windows and /packer-files on other systems.
 	ContainerDir string `mapstructure:"container_dir" required:"false"`
+	// An array of devices which will be accessible in container when it's run
+	// without `--privileged` flag.
+	Device []string `mapstructure:"device" required:"false"`
 	// Throw away the container when the build is complete. This is useful for
 	// the [artifice
 	// post-processor](/docs/post-processors/artifice).

--- a/builder/docker/config.go
+++ b/builder/docker/config.go
@@ -46,9 +46,13 @@ type Config struct {
 	// the [artifice
 	// post-processor](/docs/post-processors/artifice).
 	Discard bool `mapstructure:"discard" required:"true"`
-	// An array of additional Linux capabilities to grant to the container.
+	// An array of additional [Linux
+	// capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
+	// to grant to the container.
 	CapAdd []string `mapstructure:"cap_add" required:"false"`
-	// An array of Linux capabilities to drop from the container.
+	// An array of [Linux
+	// capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
+	// to drop from the container.
 	CapDrop []string `mapstructure:"cap_drop" required:"false"`
 	// Username (UID) to run remote commands with. You can also set the group
 	// name/ID if you want: (UID or UID:GID). You may need this if you get

--- a/builder/docker/config.hcl2spec.go
+++ b/builder/docker/config.hcl2spec.go
@@ -66,6 +66,7 @@ type FlatConfig struct {
 	Changes                   []string          `mapstructure:"changes" cty:"changes" hcl:"changes"`
 	Commit                    *bool             `mapstructure:"commit" required:"true" cty:"commit" hcl:"commit"`
 	ContainerDir              *string           `mapstructure:"container_dir" required:"false" cty:"container_dir" hcl:"container_dir"`
+	Device                    []string          `mapstructure:"device" required:"false" cty:"device" hcl:"device"`
 	Discard                   *bool             `mapstructure:"discard" required:"true" cty:"discard" hcl:"discard"`
 	CapAdd                    []string          `mapstructure:"cap_add" required:"false" cty:"cap_add" hcl:"cap_add"`
 	CapDrop                   []string          `mapstructure:"cap_drop" required:"false" cty:"cap_drop" hcl:"cap_drop"`
@@ -161,6 +162,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"changes":                      &hcldec.AttrSpec{Name: "changes", Type: cty.List(cty.String), Required: false},
 		"commit":                       &hcldec.AttrSpec{Name: "commit", Type: cty.Bool, Required: false},
 		"container_dir":                &hcldec.AttrSpec{Name: "container_dir", Type: cty.String, Required: false},
+		"device":                       &hcldec.AttrSpec{Name: "device", Type: cty.List(cty.String), Required: false},
 		"discard":                      &hcldec.AttrSpec{Name: "discard", Type: cty.Bool, Required: false},
 		"cap_add":                      &hcldec.AttrSpec{Name: "cap_add", Type: cty.List(cty.String), Required: false},
 		"cap_drop":                     &hcldec.AttrSpec{Name: "cap_drop", Type: cty.List(cty.String), Required: false},

--- a/builder/docker/config.hcl2spec.go
+++ b/builder/docker/config.hcl2spec.go
@@ -67,6 +67,8 @@ type FlatConfig struct {
 	Commit                    *bool             `mapstructure:"commit" required:"true" cty:"commit" hcl:"commit"`
 	ContainerDir              *string           `mapstructure:"container_dir" required:"false" cty:"container_dir" hcl:"container_dir"`
 	Discard                   *bool             `mapstructure:"discard" required:"true" cty:"discard" hcl:"discard"`
+	CapAdd                    []string          `mapstructure:"cap_add" required:"false" cty:"cap_add" hcl:"cap_add"`
+	CapDrop                   []string          `mapstructure:"cap_drop" required:"false" cty:"cap_drop" hcl:"cap_drop"`
 	ExecUser                  *string           `mapstructure:"exec_user" required:"false" cty:"exec_user" hcl:"exec_user"`
 	ExportPath                *string           `mapstructure:"export_path" required:"true" cty:"export_path" hcl:"export_path"`
 	Image                     *string           `mapstructure:"image" required:"true" cty:"image" hcl:"image"`
@@ -75,6 +77,7 @@ type FlatConfig struct {
 	Pty                       *bool             `cty:"pty" hcl:"pty"`
 	Pull                      *bool             `mapstructure:"pull" required:"false" cty:"pull" hcl:"pull"`
 	RunCommand                []string          `mapstructure:"run_command" required:"false" cty:"run_command" hcl:"run_command"`
+	TmpFs                     []string          `mapstructure:"tmpfs" required:"false" cty:"tmpfs" hcl:"tmpfs"`
 	Volumes                   map[string]string `mapstructure:"volumes" required:"false" cty:"volumes" hcl:"volumes"`
 	FixUploadOwner            *bool             `mapstructure:"fix_upload_owner" required:"false" cty:"fix_upload_owner" hcl:"fix_upload_owner"`
 	WindowsContainer          *bool             `mapstructure:"windows_container" required:"false" cty:"windows_container" hcl:"windows_container"`
@@ -159,6 +162,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"commit":                       &hcldec.AttrSpec{Name: "commit", Type: cty.Bool, Required: false},
 		"container_dir":                &hcldec.AttrSpec{Name: "container_dir", Type: cty.String, Required: false},
 		"discard":                      &hcldec.AttrSpec{Name: "discard", Type: cty.Bool, Required: false},
+		"cap_add":                      &hcldec.AttrSpec{Name: "cap_add", Type: cty.List(cty.String), Required: false},
+		"cap_drop":                     &hcldec.AttrSpec{Name: "cap_drop", Type: cty.List(cty.String), Required: false},
 		"exec_user":                    &hcldec.AttrSpec{Name: "exec_user", Type: cty.String, Required: false},
 		"export_path":                  &hcldec.AttrSpec{Name: "export_path", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
@@ -167,6 +172,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"pty":                          &hcldec.AttrSpec{Name: "pty", Type: cty.Bool, Required: false},
 		"pull":                         &hcldec.AttrSpec{Name: "pull", Type: cty.Bool, Required: false},
 		"run_command":                  &hcldec.AttrSpec{Name: "run_command", Type: cty.List(cty.String), Required: false},
+		"tmpfs":                        &hcldec.AttrSpec{Name: "tmpfs", Type: cty.List(cty.String), Required: false},
 		"volumes":                      &hcldec.AttrSpec{Name: "volumes", Type: cty.Map(cty.String), Required: false},
 		"fix_upload_owner":             &hcldec.AttrSpec{Name: "fix_upload_owner", Type: cty.Bool, Required: false},
 		"windows_container":            &hcldec.AttrSpec{Name: "windows_container", Type: cty.Bool, Required: false},

--- a/builder/docker/driver.go
+++ b/builder/docker/driver.go
@@ -66,7 +66,10 @@ type Driver interface {
 type ContainerConfig struct {
 	Image      string
 	RunCommand []string
+	CapAdd     []string
+	CapDrop    []string
 	Volumes    map[string]string
+	TmpFs      []string
 	Privileged bool
 }
 

--- a/builder/docker/driver.go
+++ b/builder/docker/driver.go
@@ -66,6 +66,7 @@ type Driver interface {
 type ContainerConfig struct {
 	Image      string
 	RunCommand []string
+	Device     []string
 	CapAdd     []string
 	CapDrop    []string
 	Volumes    map[string]string

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -265,6 +265,9 @@ func (d *DockerDriver) StartContainer(config *ContainerConfig) (string, error) {
 
 	// Args that we're going to pass to Docker
 	args := []string{"run"}
+	for _, v := range config.Device {
+		args = append(args, "--device", v)
+	}
 	for _, v := range config.CapAdd {
 		args = append(args, "--cap-add", v)
 	}

--- a/builder/docker/driver_docker.go
+++ b/builder/docker/driver_docker.go
@@ -265,8 +265,17 @@ func (d *DockerDriver) StartContainer(config *ContainerConfig) (string, error) {
 
 	// Args that we're going to pass to Docker
 	args := []string{"run"}
+	for _, v := range config.CapAdd {
+		args = append(args, "--cap-add", v)
+	}
+	for _, v := range config.CapDrop {
+		args = append(args, "--cap-drop", v)
+	}
 	if config.Privileged {
 		args = append(args, "--privileged")
+	}
+	for _, v := range config.TmpFs {
+		args = append(args, "--tmpfs", v)
 	}
 	for host, guest := range config.Volumes {
 		args = append(args, "-v", fmt.Sprintf("%s:%s", host, guest))

--- a/builder/docker/step_run.go
+++ b/builder/docker/step_run.go
@@ -25,6 +25,7 @@ func (s *StepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 	runConfig := ContainerConfig{
 		Image:      config.Image,
 		RunCommand: config.RunCommand,
+		Device:     config.Device,
 		TmpFs:      config.TmpFs,
 		Volumes:    make(map[string]string),
 		CapAdd:     config.CapAdd,

--- a/builder/docker/step_run.go
+++ b/builder/docker/step_run.go
@@ -25,7 +25,10 @@ func (s *StepRun) Run(ctx context.Context, state multistep.StateBag) multistep.S
 	runConfig := ContainerConfig{
 		Image:      config.Image,
 		RunCommand: config.RunCommand,
+		TmpFs:      config.TmpFs,
 		Volumes:    make(map[string]string),
+		CapAdd:     config.CapAdd,
+		CapDrop:    config.CapDrop,
 		Privileged: config.Privileged,
 	}
 

--- a/website/pages/partials/builder/docker/Config-not-required.mdx
+++ b/website/pages/partials/builder/docker/Config-not-required.mdx
@@ -13,9 +13,13 @@
 - `device` ([]string) - An array of devices which will be accessible in container when it's run
   without `--privileged` flag.
 
-- `cap_add` ([]string) - An array of additional Linux capabilities to grant to the container.
+- `cap_add` ([]string) - An array of additional [Linux
+  capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
+  to grant to the container.
 
-- `cap_drop` ([]string) - An array of Linux capabilities to drop from the container.
+- `cap_drop` ([]string) - An array of [Linux
+  capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
+  to drop from the container.
 
 - `exec_user` (string) - Username (UID) to run remote commands with. You can also set the group
   name/ID if you want: (UID or UID:GID). You may need this if you get

--- a/website/pages/partials/builder/docker/Config-not-required.mdx
+++ b/website/pages/partials/builder/docker/Config-not-required.mdx
@@ -10,6 +10,9 @@
   for work [file provisioner](/docs/provisioners/file). This defaults
   to c:/packer-files on windows and /packer-files on other systems.
 
+- `device` ([]string) - An array of devices which will be accessible in container when it's run
+  without `--privileged` flag.
+
 - `cap_add` ([]string) - An array of additional Linux capabilities to grant to the container.
 
 - `cap_drop` ([]string) - An array of Linux capabilities to drop from the container.

--- a/website/pages/partials/builder/docker/Config-not-required.mdx
+++ b/website/pages/partials/builder/docker/Config-not-required.mdx
@@ -10,6 +10,10 @@
   for work [file provisioner](/docs/provisioners/file). This defaults
   to c:/packer-files on windows and /packer-files on other systems.
 
+- `cap_add` ([]string) - An array of additional Linux capabilities to grant to the container.
+
+- `cap_drop` ([]string) - An array of Linux capabilities to drop from the container.
+
 - `exec_user` (string) - Username (UID) to run remote commands with. You can also set the group
   name/ID if you want: (UID or UID:GID). You may need this if you get
   permission errors trying to run the shell or other provisioners.
@@ -33,6 +37,8 @@
   or another shell by running docker run -it --rm  -c /bin/bash. If your
   docker image embeds a binary intended to be run often, you should
   consider changing the default entrypoint to point to it.
+
+- `tmpfs` ([]string) - An array of additional tmpfs volumes to mount into this container.
 
 - `volumes` (map[string]string) - A mapping of additional volumes to mount into this container. The key of
   the object is the host path, the value is the container path.


### PR DESCRIPTION
Containers with PID1 systemd require additional capabilities. Instead of running them as privileged, SYS_ADMIN capability could be granted, with additional tmpfs mounts. This PR allows to specify additional parameters to pass to docker runner.

```json
{
    "type": "docker",
    "device": ["/dev/fuse"],
    "tmpfs": ["/run", "/run/lock"],
    "cap_add": ["SYS_ADMIN"],
    "volumes": {
        "/sys/fs/cgroup": "/sys/fs/cgroup:ro",
    }
}
```