### PR TITLE
post-processor/digitalocean-import: replace deprecated oauth2.NoContext

### DIFF
--- a/post-processor/digitalocean-import/post-processor.go
+++ b/post-processor/digitalocean-import/post-processor.go
@@ -210,7 +210,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 	}
 	ui.Message(fmt.Sprintf("Completed upload of %s to spaces://%s/%s", source, p.config.SpaceName, p.config.ObjectName))
 
-	client := godo.NewClient(oauth2.NewClient(oauth2.NoContext, &apiTokenSource{
+	client := godo.NewClient(oauth2.NewClient(context.Background(), &apiTokenSource{
 		AccessToken: p.config.APIToken,
 	}))
 


### PR DESCRIPTION
This replaces a use of the deprecated `oauth2.NoContext` with `context.Background()`.