### PR TITLE
Add option to destroy VM after deploying to Content Library

### DIFF
--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -44,6 +44,8 @@ type ContentLibraryDestinationConfig struct {
 	// The datastore for the virtual machine template's configuration and log files.
 	// Defaults to the storage backing associated with the library specified by library.
 	Datastore string `mapstructure:"datastore"`
+	// If set to true, the VM will be destroyed after deploying the template to the Content Library. Defaults to `false`.
+	Destroy bool `mapstructure:"destroy"`
 }
 
 func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
@@ -118,6 +120,10 @@ func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.Stat
 		ui.Error(fmt.Sprintf("Failed to import VM template %s: %s", s.ContentLibConfig.Name, err.Error()))
 		state.Put("error", err)
 		return multistep.ActionHalt
+	}
+
+	if s.ContentLibConfig.Destroy {
+		state.Put("destroy_vm", s.ContentLibConfig.Destroy)
 	}
 
 	return multistep.ActionContinue

--- a/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
+++ b/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
@@ -17,6 +17,7 @@ type FlatContentLibraryDestinationConfig struct {
 	Host         *string `mapstructure:"host" cty:"host" hcl:"host"`
 	ResourcePool *string `mapstructure:"resource_pool" cty:"resource_pool" hcl:"resource_pool"`
 	Datastore    *string `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
+	Destroy      *bool   `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
 }
 
 // FlatMapstructure returns a new FlatContentLibraryDestinationConfig.
@@ -39,6 +40,7 @@ func (*FlatContentLibraryDestinationConfig) HCL2Spec() map[string]hcldec.Spec {
 		"host":          &hcldec.AttrSpec{Name: "host", Type: cty.String, Required: false},
 		"resource_pool": &hcldec.AttrSpec{Name: "resource_pool", Type: cty.String, Required: false},
 		"datastore":     &hcldec.AttrSpec{Name: "datastore", Type: cty.String, Required: false},
+		"destroy":       &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -207,7 +207,8 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 func (s *StepCreateVM) Cleanup(state multistep.StateBag) {
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)
-	if !cancelled && !halted {
+	_, destroy := state.GetOk("destroy_vm")
+	if !cancelled && !halted && !destroy {
 		return
 	}
 

--- a/website/pages/partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -27,3 +27,5 @@
 
 - `datastore` (string) - The datastore for the virtual machine template's configuration and log files.
   Defaults to the storage backing associated with the library specified by library.
+
+- `destroy` (bool) - If set to true, the VM will be destroyed after deploying the template to the Content Library. Defaults to `false`.


### PR DESCRIPTION
Adding an extra config to allow to destroy the source VM after deploying its template to the Content Library