### PR TITLE
post-processor/vagrant-cloud: missing vagrant_cloud_url in test

### DIFF
--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -173,6 +173,7 @@ func TestPostProcessor_Configure_checkAccessTokenIsRequiredByDefault(t *testing.
 	defer server.Close()
 
 	config := testNoAccessTokenProvidedConfig()
+	config["vagrant_cloud_url"] = server.URL
 	if err := p.Configure(config); err == nil {
 		t.Fatalf("Expected access token to be required.")
 	}


### PR DESCRIPTION
One test in post-processor_test.go forgets to set `vagrant_cloud_url`