### PR TITLE
(vsphere) add ability to add a xhci/usb3 controller

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -75,7 +75,7 @@ type CreateConfig struct {
 	Datastore     string
 	GuestOS       string // example: otherGuest
 	NICs          []NIC
-	USBController bool
+	USBController []string
 	Version       uint // example: 10
 	Storage       []Disk
 }
@@ -175,11 +175,21 @@ func (d *Driver) CreateVM(config *CreateConfig) (*VirtualMachine, error) {
 		return nil, err
 	}
 
-	if config.USBController {
-		t := true
-		usb := &types.VirtualUSBController{
-			EhciEnabled: &t,
+	t := true
+	for _, usbType := range config.USBController {
+		var usb types.BaseVirtualDevice
+		switch usbType {
+		// handle "true" and "1" for backwards compatibility
+		case "usb", "true", "1":
+			usb = &types.VirtualUSBController{
+				EhciEnabled: &t,
+			}
+		case "xhci":
+			usb = new(types.VirtualUSBXHCIController)
+		default:
+			continue
 		}
+
 		devices = append(devices, usb)
 	}
 

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -31,7 +31,7 @@ type FlatConfig struct {
 	DiskControllerType              []string                                    `mapstructure:"disk_controller_type" cty:"disk_controller_type" hcl:"disk_controller_type"`
 	Storage                         []FlatDiskConfig                            `mapstructure:"storage" cty:"storage" hcl:"storage"`
 	NICs                            []FlatNIC                                   `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
-	USBController                   *bool                                       `mapstructure:"usb_controller" cty:"usb_controller" hcl:"usb_controller"`
+	USBController                   []string                                    `mapstructure:"usb_controller" cty:"usb_controller" hcl:"usb_controller"`
 	Notes                           *string                                     `mapstructure:"notes" cty:"notes" hcl:"notes"`
 	VMName                          *string                                     `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	Folder                          *string                                     `mapstructure:"folder" cty:"folder" hcl:"folder"`
@@ -165,7 +165,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_controller_type":           &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.List(cty.String), Required: false},
 		"storage":                        &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*FlatDiskConfig)(nil).HCL2Spec())},
 		"network_adapters":               &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},
-		"usb_controller":                 &hcldec.AttrSpec{Name: "usb_controller", Type: cty.Bool, Required: false},
+		"usb_controller":                 &hcldec.AttrSpec{Name: "usb_controller", Type: cty.List(cty.String), Required: false},
 		"notes":                          &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
 		"vm_name":                        &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"folder":                         &hcldec.AttrSpec{Name: "folder", Type: cty.String, Required: false},

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -146,6 +146,9 @@ func (c *CreateConfig) Prepare() []error {
 			usbCount++
 		case "xhci":
 			xhciCount++
+		// 0 and false for backwards compatibility
+		case "false", "0":
+			continue
 		default:
 			errs = append(errs, fmt.Errorf("usb_controller[%d] references an unknown usb controller", i))
 		}

--- a/builder/vsphere/iso/step_create.hcl2spec.go
+++ b/builder/vsphere/iso/step_create.hcl2spec.go
@@ -14,7 +14,7 @@ type FlatCreateConfig struct {
 	DiskControllerType []string         `mapstructure:"disk_controller_type" cty:"disk_controller_type" hcl:"disk_controller_type"`
 	Storage            []FlatDiskConfig `mapstructure:"storage" cty:"storage" hcl:"storage"`
 	NICs               []FlatNIC        `mapstructure:"network_adapters" cty:"network_adapters" hcl:"network_adapters"`
-	USBController      *bool            `mapstructure:"usb_controller" cty:"usb_controller" hcl:"usb_controller"`
+	USBController      []string         `mapstructure:"usb_controller" cty:"usb_controller" hcl:"usb_controller"`
 	Notes              *string          `mapstructure:"notes" cty:"notes" hcl:"notes"`
 }
 
@@ -35,7 +35,7 @@ func (*FlatCreateConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_controller_type": &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.List(cty.String), Required: false},
 		"storage":              &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*FlatDiskConfig)(nil).HCL2Spec())},
 		"network_adapters":     &hcldec.BlockListSpec{TypeName: "network_adapters", Nested: hcldec.ObjectSpec((*FlatNIC)(nil).HCL2Spec())},
-		"usb_controller":       &hcldec.AttrSpec{Name: "usb_controller", Type: cty.Bool, Required: false},
+		"usb_controller":       &hcldec.AttrSpec{Name: "usb_controller", Type: cty.List(cty.String), Required: false},
 		"notes":                &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
 	}
 	return s

--- a/website/pages/partials/builder/vsphere/iso/CreateConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/iso/CreateConfig-not-required.mdx
@@ -15,6 +15,6 @@
 
 - `network_adapters` ([]NIC) - Network adapters
 
-- `usb_controller` (bool) - Create USB controller for virtual machine. Defaults to `false`.
+- `usb_controller` ([]string) - Create USB controllers for the virtual machine. "usb" for a usb 2.0 controller. "xhci" for a usb 3.0 controller. There can only be at most one of each.
 
 - `notes` (string) - VM notes.


### PR DESCRIPTION
Converted the "usb_controller" field to a list of strings so that you can define both a usb and a usb xhci controller ("usb" and "xhci). Added validation logic. 

For backwards compatibility, I put in support for "1" and "true" in case someone has already defined "usb_controller": true or "usb_controller": "true"

Closes #8874