### PR TITLE
Don't use Packer context as vSphere driver context

### DIFF
--- a/builder/vsphere/common/step_connect.go
+++ b/builder/vsphere/common/step_connect.go
@@ -44,8 +44,8 @@ type StepConnect struct {
 	Config *ConnectConfig
 }
 
-func (s *StepConnect) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	d, err := driver.NewDriver(ctx, &driver.ConnectConfig{
+func (s *StepConnect) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	d, err := driver.NewDriver(&driver.ConnectConfig{
 		VCenterServer:      s.Config.VCenterServer,
 		Username:           s.Config.Username,
 		Password:           s.Config.Password,

--- a/builder/vsphere/common/testing/utility.go
+++ b/builder/vsphere/common/testing/utility.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -45,7 +44,7 @@ func TestConn(t *testing.T) *driver.Driver {
 		password = "jetbrains"
 	}
 
-	d, err := driver.NewDriver(context.TODO(), &driver.ConnectConfig{
+	d, err := driver.NewDriver(&driver.ConnectConfig{
 		VCenterServer:      "vcenter.vsphere65.test",
 		Username:           username,
 		Password:           password,

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -16,6 +16,7 @@ import (
 )
 
 type Driver struct {
+	// context that controls the authenticated sessions used to run the VM commands
 	ctx        context.Context
 	client     *govmomi.Client
 	restClient *rest.Client
@@ -33,6 +34,7 @@ type ConnectConfig struct {
 
 func NewDriver(config *ConnectConfig) (*Driver, error) {
 	ctx := context.TODO()
+
 	vcenterUrl, err := url.Parse(fmt.Sprintf("https://%v/sdk", config.VCenterServer))
 	if err != nil {
 		return nil, err

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -31,7 +31,8 @@ type ConnectConfig struct {
 	Datacenter         string
 }
 
-func NewDriver(ctx context.Context, config *ConnectConfig) (*Driver, error) {
+func NewDriver(config *ConnectConfig) (*Driver, error) {
+	ctx := context.TODO()
 	vcenterUrl, err := url.Parse(fmt.Sprintf("https://%v/sdk", config.VCenterServer))
 	if err != nil {
 		return nil, err

--- a/builder/vsphere/driver/driver_test.go
+++ b/builder/vsphere/driver/driver_test.go
@@ -1,7 +1,6 @@
 package driver
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -22,7 +21,7 @@ func newTestDriver(t *testing.T) *Driver {
 		password = "jetbrains"
 	}
 
-	d, err := NewDriver(context.TODO(), &ConnectConfig{
+	d, err := NewDriver(&ConnectConfig{
 		VCenterServer:      "vcenter.vsphere65.test",
 		Username:           username,
 		Password:           password,

--- a/builder/vsphere/examples/driver/main.go
+++ b/builder/vsphere/examples/driver/main.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/hashicorp/packer/builder/vsphere/driver"
 )
 
 func main() {
-	d, err := driver.NewDriver(context.TODO(), &driver.ConnectConfig{
+	d, err := driver.NewDriver(&driver.ConnectConfig{
 		VCenterServer:      "vcenter.vsphere65.test",
 		Username:           "root",
 		Password:           "jetbrains",


### PR DESCRIPTION
In https://github.com/hashicorp/packer/pull/9551 I made the vSphere driver use Packer's context, this is not possible because once this context is canceled the driver can't execute any VM command making it impossible to clean up resources after all.
This PR undo the changes regarding passing the Packer context to the driver.

Closes https://github.com/hashicorp/packer/issues/9575