### PR TITLE
improve validation and error handling around synced_folder

### DIFF
--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -242,6 +242,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		}
 	}
 
+	if _, err := os.Stat(b.config.SyncedFolder); err != nil {
+		errs = packer.MultiErrorAppend(errs,
+			fmt.Errorf("synced_folder \"%s\" does not exist on the Packer host.", b.config.SyncedFolder))
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warnings, errs
 	}

--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -151,13 +151,21 @@ func (d *Vagrant_2_2_Driver) SSHConfig(id string) (*VagrantSSHConfig, error) {
 	if id != "" {
 		args = append(args, id)
 	}
-	stdout, _, err := d.vagrantCmd(args...)
 	sshConf := &VagrantSSHConfig{}
 
+	stdout, stderr, err := d.vagrantCmd(args...)
+	if stderr != "" {
+		err := fmt.Errorf("ssh-config command returned error: %s", stderr)
+		return sshConf, err
+	}
 	lines := strings.Split(stdout, "\n")
 	sshConf.Hostname = parseSSHConfig(lines, "HostName ")
 	sshConf.User = parseSSHConfig(lines, "User ")
 	sshConf.Port = parseSSHConfig(lines, "Port ")
+	if sshConf.Port == "" {
+		err := fmt.Errorf("error: SSH Port was not properly retrieved from SSHConfig.")
+		return sshConf, err
+	}
 	sshConf.UserKnownHostsFile = parseSSHConfig(lines, "UserKnownHostsFile ")
 	sshConf.IdentityFile = parseSSHConfig(lines, "IdentityFile ")
 	sshConf.LogLevel = parseSSHConfig(lines, "LogLevel ")

--- a/website/pages/partials/builder/vagrant/Config-not-required.mdx
+++ b/website/pages/partials/builder/vagrant/Config-not-required.mdx
@@ -51,7 +51,8 @@
   `{{ .BoxName }}`, `{{ .SyncedFolder }}`, and `{{.InsertKey}}`, which
   correspond to the Packer options box_name, synced_folder, and insert_key.
 
-- `synced_folder` (string) - Synced Folder
+- `synced_folder` (string) - Path to the folder to be synced to the guest. The path can be absolute
+  or relative to the directory Packer is being run from.
 
 - `skip_add` (bool) - Don't call "vagrant add" to add the box to your local environment; this
   is necessary if you want to launch a box that is already added to your


### PR DESCRIPTION
Adds Prepare() validation that the synced_folder exists. Also checks stderr in vagrant driver's grabbing of ssh-config to make sure that there are no issues, to avoid the strconv.AtoI issue. 

Closes #9564
