### PR TITLE
Update fix.mdx

### DIFF
--- a/website/pages/docs/commands/fix.mdx
+++ b/website/pages/docs/commands/fix.mdx
@@ -17,7 +17,7 @@ of Packer. After you update to a new Packer release, you should run the fix
 command to make sure your templates work with the new release.
 
 The fix command will output the changed template to standard out, so you should
-redirect standard using standard OS-specific techniques if you want to save it
+redirect standard out using standard OS-specific techniques if you want to save it
 to a file. For example, on Linux systems, you may want to do this:
 
 ```shell-session


### PR DESCRIPTION
trivially minor typo: omission of "out" when referring to "standard out"
