### PR TITLE
post-processor/vsphere: Fix password encoding in vsphere post-processor ovftool call

### DIFF
--- a/builder/vmware/common/driver_config.go
+++ b/builder/vmware/common/driver_config.go
@@ -99,10 +99,16 @@ func (c *DriverConfig) Validate(SkipExport bool) error {
 	// now, so that we don't fail for a simple mistake after a long
 	// build
 	ovftool := GetOVFTool()
-	ovfToolArgs := []string{"--noSSLVerify", "--verifyOnly", fmt.Sprintf("vi://%s:%s@%s",
-		url.QueryEscape(c.RemoteUser),
-		url.QueryEscape(c.RemotePassword),
-		c.RemoteHost)}
+
+	// Generate the uri of the host, with embedded credentials
+	ovftool_uri := fmt.Sprintf("vi://%s", c.RemoteHost)
+	u, err := url.Parse(ovftool_uri)
+	if err != nil {
+		return fmt.Errorf("Couldn't generate uri for ovftool: %s", err)
+	}
+	u.User = url.UserPassword(c.RemoteUser, c.RemotePassword)
+
+	ovfToolArgs := []string{"--noSSLVerify", "--verifyOnly", u.String()}
 
 	var out bytes.Buffer
 	cmdCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -133,11 +133,13 @@ func (p *PostProcessor) generateURI() (*url.URL, error) {
 	u.User = url.UserPassword(p.config.Username, p.config.Password)
 
 	if p.config.ESXiHost != "" {
+		q := u.Query()
 		if ipv4Regex.MatchString(p.config.ESXiHost) {
-			u.RawQuery = "ip=" + url.QueryEscape(p.config.ESXiHost)
+			q.Add("ip", p.config.ESXiHost)
 		} else if hostnameRegex.MatchString(p.config.ESXiHost) {
-			u.RawQuery = "dns=" + url.QueryEscape(p.config.ESXiHost)
+			q.Add("dns", p.config.ESXiHost)
 		}
+		u.RawQuery = q.Encode()
 	}
 	return u, nil
 }
@@ -191,7 +193,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 
 func filterLog(s string, u *url.URL) string {
 	password, passwordSet := u.User.Password()
-	if passwordSet {
+	if passwordSet && password != "" {
 		return strings.Replace(s, password, "<password>", -1)
 	}
 

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -7,19 +7,25 @@ import (
 	"testing"
 )
 
+func getTestConfig() Config {
+	return Config{
+		Username:   "me",
+		Password:   "notpassword",
+		Host:       "myhost",
+		Datacenter: "mydc",
+		Cluster:    "mycluster",
+		VMName:     "my vm",
+		Datastore:  "my datastore",
+		Insecure:   true,
+		DiskMode:   "thin",
+		VMFolder:   "my folder",
+	}
+}
+
 func TestArgs(t *testing.T) {
 	var p PostProcessor
 
-	p.config.Username = "me"
-	p.config.Password = "notpassword"
-	p.config.Host = "myhost"
-	p.config.Datacenter = "mydc"
-	p.config.Cluster = "mycluster"
-	p.config.VMName = "my vm"
-	p.config.Datastore = "my datastore"
-	p.config.Insecure = true
-	p.config.DiskMode = "thin"
-	p.config.VMFolder = "my folder"
+	p.config = getTestConfig()
 
 	source := "something.vmx"
 	ovftool_uri := fmt.Sprintf("vi://%s:%s@%s/%s/host/%s",
@@ -39,6 +45,55 @@ func TestArgs(t *testing.T) {
 	}
 
 	t.Logf("ovftool %s", strings.Join(args, " "))
+}
+
+func TestGenerateURI_Basic(t *testing.T) {
+	var p PostProcessor
+
+	p.config = getTestConfig()
+
+	uri := p.generateURI()
+	expected_uri := "vi://me:notpassword@myhost/mydc/host/mycluster"
+	if uri != expected_uri {
+		t.Fatalf("URI did not match. Recieved: %s. Expected: %s", uri, expected_uri)
+	}
+}
+
+func TestGenerateURI_PasswordEscapes(t *testing.T) {
+	type escapeCases struct {
+		Input    string
+		Expected string
+	}
+
+	cases := []escapeCases{
+		{`this has spaces`, `this%20has%20spaces`},
+		{`exclaimation_!`, `exclaimation_%21`},
+		{`hash_#_dollar_$`, `hash_%23_dollar_%24`},
+		{`ampersand_&awesome`, `ampersand_%26awesome`},
+		{`single_quote_'_and_another_'`, `single_quote_%27_and_another_%27`},
+		{`open_paren_(_close_paren_)`, `open_paren_%28_close_paren_%29`},
+		{`asterisk_*_plus_+`, `asterisk_%2A_plus_%2B`},
+		{`comma_,slash_/`, `comma_%2Cslash_%2F`},
+		{`colon_:semicolon_;`, `colon_%3Asemicolon_%3B`},
+		{`equal_=question_?`, `equal_%3Dquestion_%3F`},
+		{`at_@`, `at_%40`},
+		{`open_bracket_[closed_bracket]`, `open_bracket_%5Bclosed_bracket%5D`},
+		{`user:password with $paces@host/name.foo`, `user%3Apassword%20with%20%24paces%40host%2Fname.foo`},
+	}
+
+	for _, escapeCase := range cases {
+		var p PostProcessor
+
+		p.config = getTestConfig()
+		p.config.Password = escapeCase.Input
+
+		uri := p.generateURI()
+		expected_uri := fmt.Sprintf("vi://me:%s@myhost/mydc/host/mycluster", escapeCase.Expected)
+
+		if uri != expected_uri {
+			t.Fatalf("URI did not match. Recieved: %s. Expected: %s", uri, expected_uri)
+		}
+	}
 }
 
 func TestEscaping(t *testing.T) {

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -52,9 +52,12 @@ func TestGenerateURI_Basic(t *testing.T) {
 
 	p.config = getTestConfig()
 
-	uri := p.generateURI()
+	uri, err := p.generateURI()
+	if err != nil {
+		t.Fatalf("had error: %s", err)
+	}
 	expected_uri := "vi://me:notpassword@myhost/mydc/host/mycluster"
-	if uri != expected_uri {
+	if uri.String() != expected_uri {
 		t.Fatalf("URI did not match. Recieved: %s. Expected: %s", uri, expected_uri)
 	}
 }
@@ -68,17 +71,17 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 	cases := []escapeCases{
 		{`this has spaces`, `this%20has%20spaces`},
 		{`exclaimation_!`, `exclaimation_%21`},
-		{`hash_#_dollar_$`, `hash_%23_dollar_%24`},
-		{`ampersand_&awesome`, `ampersand_%26awesome`},
+		{`hash_#_dollar_$`, `hash_%23_dollar_$`},
+		{`ampersand_&awesome`, `ampersand_&awesome`},
 		{`single_quote_'_and_another_'`, `single_quote_%27_and_another_%27`},
 		{`open_paren_(_close_paren_)`, `open_paren_%28_close_paren_%29`},
-		{`asterisk_*_plus_+`, `asterisk_%2A_plus_%2B`},
-		{`comma_,slash_/`, `comma_%2Cslash_%2F`},
-		{`colon_:semicolon_;`, `colon_%3Asemicolon_%3B`},
-		{`equal_=question_?`, `equal_%3Dquestion_%3F`},
+		{`asterisk_*_plus_+`, `asterisk_%2A_plus_+`},
+		{`comma_,slash_/`, `comma_,slash_%2F`},
+		{`colon_:semicolon_;`, `colon_%3Asemicolon_;`},
+		{`equal_=question_?`, `equal_=question_%3F`},
 		{`at_@`, `at_%40`},
 		{`open_bracket_[closed_bracket]`, `open_bracket_%5Bclosed_bracket%5D`},
-		{`user:password with $paces@host/name.foo`, `user%3Apassword%20with%20%24paces%40host%2Fname.foo`},
+		{`user:password with $paces@host/name.foo`, `user%3Apassword%20with%20$paces%40host%2Fname.foo`},
 	}
 
 	for _, escapeCase := range cases {
@@ -87,42 +90,14 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 		p.config = getTestConfig()
 		p.config.Password = escapeCase.Input
 
-		uri := p.generateURI()
+		uri, err := p.generateURI()
+		if err != nil {
+			t.Fatalf("had error: %s", err)
+		}
 		expected_uri := fmt.Sprintf("vi://me:%s@myhost/mydc/host/mycluster", escapeCase.Expected)
 
-		if uri != expected_uri {
+		if uri.String() != expected_uri {
 			t.Fatalf("URI did not match. Recieved: %s. Expected: %s", uri, expected_uri)
 		}
 	}
-}
-
-func TestEscaping(t *testing.T) {
-	type escapeCases struct {
-		Input    string
-		Expected string
-	}
-
-	cases := []escapeCases{
-		{`this has spaces`, `this%20has%20spaces`},
-		{`exclaimation_!`, `exclaimation_%21`},
-		{`hash_#_dollar_$`, `hash_%23_dollar_%24`},
-		{`ampersand_&awesome`, `ampersand_%26awesome`},
-		{`single_quote_'_and_another_'`, `single_quote_%27_and_another_%27`},
-		{`open_paren_(_close_paren_)`, `open_paren_%28_close_paren_%29`},
-		{`asterisk_*_plus_+`, `asterisk_%2A_plus_%2B`},
-		{`comma_,slash_/`, `comma_%2Cslash_%2F`},
-		{`colon_:semicolon_;`, `colon_%3Asemicolon_%3B`},
-		{`equal_=question_?`, `equal_%3Dquestion_%3F`},
-		{`at_@`, `at_%40`},
-		{`open_bracket_[closed_bracket]`, `open_bracket_%5Bclosed_bracket%5D`},
-		{`user:password with $paces@host/name.foo`, `user%3Apassword%20with%20%24paces%40host%2Fname.foo`},
-	}
-	for _, escapeCase := range cases {
-		received := escapeWithSpaces(escapeCase.Input)
-
-		if escapeCase.Expected != received {
-			t.Errorf("Error escaping URL; expected %s got %s", escapeCase.Expected, received)
-		}
-	}
-
 }


### PR DESCRIPTION
Previously the vsphere post-processor code used QueryEscape to escape usernames and passwords, which is not entirely correct for special characters. Switch to using the URL struct, which encodes differently based on the part of URL that things are in. 

Still needs to be verified against issue #9184. Hasn't been tested yet. 

Closes #9184