### PR TITLE
Fix shelllocal validation

### DIFF
--- a/provisioner/shell-local/provisioner.go
+++ b/provisioner/shell-local/provisioner.go
@@ -9,12 +9,23 @@ import (
 )
 
 type Provisioner struct {
-	config sl.Config
+	config        sl.Config
+	prepareCalled bool
 }
 
 func (p *Provisioner) ConfigSpec() hcldec.ObjectSpec { return p.config.FlatMapstructure().HCL2Spec() }
 
 func (p *Provisioner) Prepare(raws ...interface{}) error {
+	if p.prepareCalled {
+		err := sl.Decode(&p.config, raws...)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	p.prepareCalled = true
+
 	err := sl.Decode(&p.config, raws...)
 	if err != nil {
 		return err


### PR DESCRIPTION
Splits internal processing into a decode and validate section so that we can re-decode for hcl2 vars without re-validating and causing potential super weirdness. 