### PR TITLE
[azure-arm] Disable ssh password authentication unless password is explicitly specified

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -697,10 +697,10 @@ func setUserNamePassword(c *Config) error {
 	}
 	c.UserName = c.Comm.SSHUsername
 
-	if c.Comm.SSHPassword == "" {
-		c.Comm.SSHPassword = c.Password
+	// if user has an explicit wish to use an SSH password, we'll set it
+	if c.Comm.SSHPassword != "" {
+		c.Password = c.Comm.SSHPassword
 	}
-	c.Password = c.Comm.SSHPassword
 
 	if c.Comm.Type == "ssh" {
 		return nil

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -71,8 +71,8 @@ func TestConfigUserNameOverride(t *testing.T) {
 	if c.Password != c.tmpAdminPassword {
 		t.Errorf("Expected 'Password' to be set to generated password, but found %q!", c.Password)
 	}
-	if c.Comm.SSHPassword != c.tmpAdminPassword {
-		t.Errorf("Expected 'c.Comm.SSHPassword' to be set to generated password, but found %q!", c.Comm.SSHPassword)
+	if c.Comm.SSHPassword != "" {
+		t.Errorf("Expected 'c.Comm.SSHPassword' to be empty, but found %q!", c.Comm.SSHPassword)
 	}
 	if c.UserName != "override_username" {
 		t.Errorf("Expected 'UserName' to be set to 'override_username', but found %q!", c.UserName)
@@ -2088,6 +2088,14 @@ func getPackerCommunicatorConfiguration() map[string]string {
 	config := map[string]string{
 		"ssh_timeout":   "1h",
 		"winrm_timeout": "2h",
+	}
+
+	return config
+}
+
+func getPackerSSHPasswordCommunicatorConfiguration() map[string]string {
+	config := map[string]string{
+		"ssh_password": "superS3cret",
 	}
 
 	return config

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -55,7 +55,7 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 
 	switch config.OSType {
 	case constants.Target_Linux:
-		builder.BuildLinux(config.sshAuthorizedKey)
+		builder.BuildLinux(config.sshAuthorizedKey, config.Comm.SSHPassword == "") // if ssh password is not explicitly specified, disable password auth
 	case constants.Target_Windows:
 		osType = compute.Windows
 		builder.BuildWindows(config.tmpKeyVaultName, config.tmpWinRMCertificateUrl)

--- a/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
@@ -149,10 +149,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
@@ -153,10 +153,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
@@ -126,10 +126,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
@@ -141,10 +141,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
@@ -126,10 +126,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
@@ -104,10 +104,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
@@ -126,10 +126,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment14.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment14.approved.json
@@ -127,10 +127,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/arm/template_factory_test.go
+++ b/builder/azure/arm/template_factory_test.go
@@ -108,7 +108,10 @@ func TestVirtualMachineDeployment03(t *testing.T) {
 	m["image_version"] = "ImageVersion"
 
 	var c Config
-	c.Prepare(m, getPackerConfiguration())
+	_, err := c.Prepare(m, getPackerConfiguration(), getPackerSSHPasswordCommunicatorConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetVirtualMachineDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -168,7 +171,7 @@ func TestVirtualMachineDeployment05(t *testing.T) {
 	}
 
 	var c Config
-	_, err := c.Prepare(config, getPackerConfiguration())
+	_, err := c.Prepare(config, getPackerConfiguration(), getPackerSSHPasswordCommunicatorConfiguration())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +238,7 @@ func TestVirtualMachineDeployment07(t *testing.T) {
 	}
 
 	var c Config
-	_, err := c.Prepare(config, getPackerConfiguration())
+	_, err := c.Prepare(config, getPackerConfiguration(), getPackerSSHPasswordCommunicatorConfiguration())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +315,7 @@ func TestVirtualMachineDeployment09(t *testing.T) {
 	}
 
 	var c Config
-	_, err := c.Prepare(config, getPackerConfiguration())
+	_, err := c.Prepare(config, getPackerConfiguration(), getPackerSSHPasswordCommunicatorConfiguration())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +390,7 @@ func TestVirtualMachineDeployment11(t *testing.T) {
 	}
 
 	var c Config
-	_, err := c.Prepare(config, getPackerConfiguration())
+	_, err := c.Prepare(config, getPackerConfiguration(), getPackerSSHPasswordCommunicatorConfiguration())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -43,7 +43,7 @@ func NewTemplateBuilder(template string) (*TemplateBuilder, error) {
 	}, nil
 }
 
-func (s *TemplateBuilder) BuildLinux(sshAuthorizedKey string) error {
+func (s *TemplateBuilder) BuildLinux(sshAuthorizedKey string, disablePasswordAuthentication bool) error {
 	resource, err := s.getResourceByType(resourceVirtualMachine)
 	if err != nil {
 		return err
@@ -59,6 +59,11 @@ func (s *TemplateBuilder) BuildLinux(sshAuthorizedKey string) error {
 				},
 			},
 		},
+	}
+
+	if disablePasswordAuthentication {
+		profile.LinuxConfiguration.DisablePasswordAuthentication = to.BoolPtr(true)
+		profile.AdminPassword = nil
 	}
 
 	s.osType = compute.Linux

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux00.approved.json
@@ -126,10 +126,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
@@ -87,10 +87,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/common/template/template_builder_test.TestSetIdentity00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestSetIdentity00.approved.json
@@ -132,10 +132,10 @@
           ]
         },
         "osProfile": {
-          "adminPassword": "[parameters('adminPassword')]",
           "adminUsername": "[parameters('adminUsername')]",
           "computerName": "[parameters('vmName')]",
           "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {

--- a/builder/azure/common/template/template_builder_test.go
+++ b/builder/azure/common/template/template_builder_test.go
@@ -15,7 +15,7 @@ func TestBuildLinux00(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.BuildLinux("--test-ssh-authorized-key--")
+	err = testSubject.BuildLinux("--test-ssh-authorized-key--", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestBuildLinux01(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.BuildLinux("--test-ssh-authorized-key--")
+	err = testSubject.BuildLinux("--test-ssh-authorized-key--", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestBuildLinux02(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testSubject.BuildLinux("--test-ssh-authorized-key--")
+	testSubject.BuildLinux("--test-ssh-authorized-key--", true)
 	testSubject.SetImageUrl("http://azure/custom.vhd", compute.Linux, compute.CachingTypesReadWrite)
 	testSubject.SetOSDiskSizeGB(100)
 
@@ -189,7 +189,7 @@ func TestSharedImageGallery00(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.BuildLinux("--test-ssh-authorized-key--")
+	err = testSubject.BuildLinux("--test-ssh-authorized-key--", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestNetworkSecurityGroup00(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.BuildLinux("--test-ssh-authorized-key--")
+	err = testSubject.BuildLinux("--test-ssh-authorized-key--", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +251,7 @@ func TestSetIdentity00(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = testSubject.BuildLinux("--test-ssh-authorized-key--"); err != nil {
+	if err = testSubject.BuildLinux("--test-ssh-authorized-key--", true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/builder/azure/common/template/template_builder_test.go
+++ b/builder/azure/common/template/template_builder_test.go
@@ -71,9 +71,18 @@ func TestBuildLinux02(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testSubject.BuildLinux("--test-ssh-authorized-key--", true)
-	testSubject.SetImageUrl("http://azure/custom.vhd", compute.Linux, compute.CachingTypesReadWrite)
-	testSubject.SetOSDiskSizeGB(100)
+	err = testSubject.BuildLinux("--test-ssh-authorized-key--", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = testSubject.SetImageUrl("http://azure/custom.vhd", compute.Linux, compute.CachingTypesReadWrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = testSubject.SetOSDiskSizeGB(100)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = testSubject.SetVirtualNetwork("--virtual-network-resource-group--", "--virtual-network--", "--subnet-name--")
 	if err != nil {


### PR DESCRIPTION
Azure requires the caller to provide password and/or ssh keys when a VM is created. The `azure-arm` builder provides both `ssh_password` as well as a key pair (when using the ssh communicator) and both are sent to Azure.

Using a password is less secure and disallowed by some customer policies (enforced through ARM policy), this change only uses a password for SSH if the customer explicitly provides `ssh_password`. Otherwise, only an SSH key will be used and password authentication will be disabled.

I modified about half of the tests to use passwords and the other half uses key-only.