### PR TITLE
post-processor/docker-import: more informative error message when artifact is wrong type

### DIFF
--- a/post-processor/docker-import/post-processor.go
+++ b/post-processor/docker-import/post-processor.go
@@ -55,7 +55,11 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 		break
 	default:
 		err := fmt.Errorf(
-			"Unknown artifact type: %s\nCan only import from Docker builder and Artifice post-processor artifacts.",
+			"Unknown artifact type: %s\nCan only import from Docker builder "+
+				"and Artifice post-processor artifacts. If you are getting this "+
+				"error after having run the docker builder, it may be because you "+
+				"set commit: true in your Docker builder, so the image is "+
+				"already imported. ",
 			artifact.BuilderId())
 		return nil, false, false, err
 	}


### PR DESCRIPTION
While testing the examples for the docker-import postprocessor I hit this error and was confused until I introspected the code. Let's change this to make it friendlier for people who may not want to crack open Packer to see what's going on. 