### PR TITLE
Amazon hcl docs

### DIFF
--- a/website/pages/docs/builders/amazon/chroot.mdx
+++ b/website/pages/docs/builders/amazon/chroot.mdx
@@ -127,24 +127,35 @@ Here is a basic example. It is completely valid except for the access keys:
 <Tab heading="HCL2">
 
 ```hcl
+// To make Packer read these variables from the environment into the var object,
+// set the environment variables to have the same name as the declared
+// variables, with the prefix PKR_VAR_.
+
+// You could also hardcode them into the file, but we recommend against that.
+
+// export PKR_VAR_aws_access_key=$YOURKEY
 variable "aws_access_key" {
   type = string
+  // default = "hardcoded_key"
 }
 
+// export PKR_VAR_aws_secret_key=$YOURSECRETKEY
 variable "aws_secret_key" {
   type = string
+  // default = "hardcoded_secret_key"
 }
 
 source "amazon-chroot" "basic-example" {
   access_key = var.aws_access_key
   secret_key =  var.aws_secret_key
+  ami_name = "example-chroot"
   source_ami = "ami-e81d5881"
 }
 
 build {
-  source "sources.amazon-chroot.basic-example" {
-    ami_name = "packer-amazon-chroot {{timestamp}}"
-  }
+  sources = [
+    "source.amazon-chroot.basic-example"
+  ]
 }
 ```
 
@@ -163,19 +174,41 @@ chroot by Packer:
 - `/dev/pts` (devpts)
 - `/proc/sys/fs/binfmt_misc` (binfmt_misc)
 
-These default mounts are usually good enough for anyone and are sane defaults.
-However, if you want to change or add the mount points, you may using the
-`chroot_mounts` configuration. Here is an example configuration which only
+These default mounts are usually good enough for anyone and are reasonable
+defaults. However, if you want to change or add the mount points, you may using
+the `chroot_mounts` configuration. Here is an example configuration which only
 mounts `/proc` and `/dev`:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
-{
+...
+"builders": [{
+  "type": "amazon-chroot"
+  ...
   "chroot_mounts": [
+    ["proc", "proc", "/proc"],
+    ["bind", "/dev", "/dev"]
+  ]
+}]
+```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-chroot" "basic-example" {
+  // ... other builder options
+  chroot_mounts = [
     ["proc", "proc", "/proc"],
     ["bind", "/dev", "/dev"]
   ]
 }
 ```
+
+</Tab>
+</Tabs>
 
 `chroot_mounts` is a list of a 3-tuples of strings. The three components of the
 3-tuple, in order, are:
@@ -210,22 +243,55 @@ For debian based distributions you can setup a
 file which will prevent packages installed by your provisioners from starting
 services:
 
-```json
-({
-  "type": "shell",
-  "inline": [
-    "echo '#!/bin/sh' > /usr/sbin/policy-rc.d",
-    "echo 'exit 101' >> /usr/sbin/policy-rc.d",
-    "chmod a+x /usr/sbin/policy-rc.d"
-  ]
-},
-// ...
 
-{
-  "type": "shell",
-  "inline": ["rm -f /usr/sbin/policy-rc.d"]
-})
+<Tabs>
+<Tab heading="JSON">
+
+```json
+"provisioners": [
+  {
+    "type": "shell",
+    "inline": [
+      "echo '#!/bin/sh' > /usr/sbin/policy-rc.d",
+      "echo 'exit 101' >> /usr/sbin/policy-rc.d",
+      "chmod a+x /usr/sbin/policy-rc.d"
+    ]
+  },
+  {
+    "type": "shell",
+    "inline": ["rm -f /usr/sbin/policy-rc.d"]
+  }
+]
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+// ...
+build {
+  sources = [
+    "source.amazon-chroot.basic-example"
+  ]
+
+  // Set policy
+  provisioner "shell" {
+    inline = [
+        "echo '#!/bin/sh' > /usr/sbin/policy-rc.d",
+        "echo 'exit 101' >> /usr/sbin/policy-rc.d",
+        "chmod a+x /usr/sbin/policy-rc.d"
+    ]
+  }
+
+  // Un-set policy
+  provisioner "shell" {
+    inline = ["rm -f /usr/sbin/policy-rc.d"]
+  }
+}
+```
+
+</Tab>
+</Tabs>
 
 ### Ansible provisioner
 
@@ -241,6 +307,9 @@ In order to correctly mount these devices, you have to do some extra legwork,
 involving the `nvme_device_path` option above. Read that for more information.
 
 A working example for mounting an NVMe device is below:
+
+<Tabs>
+<Tab heading="JSON">
 
 ```json
 {
@@ -276,6 +345,60 @@ A working example for mounting an NVMe device is below:
 }
 ```
 
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+// export PKR_VAR_aws_access_key=$YOURKEY
+variable "aws_access_key" {
+  type = string
+}
+
+// export PKR_VAR_aws_secret_key=$YOURSECRETKEY
+variable "aws_secret_key" {
+  type = string
+}
+
+source "amazon-chroot" "basic-example" {
+  access_key = var.aws_access_key
+  secret_key =  var.aws_secret_key
+  region = "us-east-1"
+  source_ami_filter {
+    filter {
+      key = "virtualization-type"
+      value = "hvm"
+    }
+    filter {
+      key = "name"
+      value = "amzn-ami-hvm-*"
+    }
+    filter {
+      key = "root-device-type"
+      value = "ebs"
+    }
+    owners = ["137112412989"]
+    most_recent = true
+  }
+  ena_support = true
+  ami_name = "amazon-chroot-test-{{timestamp}}"
+  nvme_device_path = "/dev/nvme1n1p"
+  device_path = "/dev/sdf"
+}
+
+build {
+  sources = [
+    "source.amazon-chroot.basic-example"
+  ]
+
+  provisioner "shell" {
+    inline = ["echo Test > /tmp/test.txt"]
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
 Note that in the `nvme_device_path` you must end with the `p`; if you try to
 define the partition in this path (e.g. `nvme_device_path`: `/dev/nvme1n1p1`)
 and haven't also set the `"mount_partition": 0`, a `1` will be appended to the
@@ -288,6 +411,9 @@ This example demonstrates the essentials of building an image from scratch. A
 The device setup commands partition the device with one partition for use as an
 HVM image and format it ext4. This builder block should be followed by
 provisioning commands to install the os and bootloader.
+
+<Tabs>
+<Tab heading="JSON">
 
 ```json
 {
@@ -310,6 +436,53 @@ provisioning commands to install the os and bootloader.
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+// This example assumes that AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID are
+// set in your environment, or a ~/.aws/credentials file is configured.
+source "amazon-chroot" "basic-example" {
+  region = "us-east-1"
+  ami_name = "packer-from-scratch {{timestamp}}"
+  from_scratch = true
+  ami_virtualization_type = "hvm"
+  pre_mount_commands = [
+    "parted {{.Device}} mklabel msdos mkpart primary 1M 100% set 1 boot on print",
+    "mkfs.ext4 {{.Device}}1"
+  ]
+  root_volume_size = 15
+  root_device_name = "xvda"
+  ami_block_device_mappings {
+    device_name = "xvda"
+    delete_on_termination = true
+    volume_type = "gp2"
+  }
+
+}
+
+build {
+  sources = [
+    "source.amazon-chroot.basic-example"
+  ]
+
+  provisioner "shell" {
+    inline = [
+        "echo '#!/bin/sh' > /usr/sbin/policy-rc.d",
+        "echo 'exit 101' >> /usr/sbin/policy-rc.d",
+        "chmod a+x /usr/sbin/policy-rc.d"
+    ]
+  }
+
+  provisioner "shell" {
+    inline = ["rm -f /usr/sbin/policy-rc.d"]
+  }
+}
+```
+
+</Tab>
+</Tabs>
 
 ## Build template data
 

--- a/website/pages/docs/builders/amazon/chroot.mdx
+++ b/website/pages/docs/builders/amazon/chroot.mdx
@@ -136,7 +136,7 @@ Here is a basic example. It is completely valid except for the access keys:
 // export PKR_VAR_aws_access_key=$YOURKEY
 variable "aws_access_key" {
   type = string
-  // default = "hardcoded_key"
+  // default = "hardcoded_key" // Not recommended !
 }
 
 // export PKR_VAR_aws_secret_key=$YOURSECRETKEY

--- a/website/pages/docs/builders/amazon/chroot.mdx
+++ b/website/pages/docs/builders/amazon/chroot.mdx
@@ -361,8 +361,8 @@ variable "aws_secret_key" {
 
 source "amazon-chroot" "basic-example" {
   access_key = var.aws_access_key
-  secret_key =  var.aws_secret_key
-  region = "us-east-1"
+  secret_key = var.aws_secret_key
+  region     = "us-east-1"
   source_ami_filter {
     filter {
       key = "virtualization-type"

--- a/website/pages/docs/builders/amazon/chroot.mdx
+++ b/website/pages/docs/builders/amazon/chroot.mdx
@@ -142,7 +142,7 @@ variable "aws_access_key" {
 // export PKR_VAR_aws_secret_key=$YOURSECRETKEY
 variable "aws_secret_key" {
   type = string
-  // default = "hardcoded_secret_key"
+  // default = "hardcoded_secret_key" // Not recommended !
 }
 
 source "amazon-chroot" "basic-example" {

--- a/website/pages/docs/builders/amazon/ebs.mdx
+++ b/website/pages/docs/builders/amazon/ebs.mdx
@@ -248,27 +248,27 @@ configuration of `launch_block_device_mappings` will expand the root volume
 
 ```hcl
 source "amazon-ebs" "basic-example" {
-  region =  "us-east-1"
-  source_ami =  "ami-fce3c696"
+  region        =  "us-east-1"
+  source_ami    =  "ami-fce3c696"
   instance_type =  "t2.micro"
-  ssh_username =  "ubuntu"
-  ami_name =  "packer_AWS_example_{{timestamp}}"
+  ssh_username  =  "ubuntu"
+  ami_name      =  "packer_AWS_example_{{timestamp}}"
   launch_block_device_mappings {
-      device_name = "/dev/sda1"
-      volume_size = 40
-      volume_type = "gp2"
-      delete_on_termination = true
-    }
+    device_name = "/dev/sda1"
+    volume_size = 40
+    volume_type = "gp2"
+    delete_on_termination = true
+  }
   // Notice that instead of providing a list of mappings, you are just providing
   // multiple mappings in a row. This diverges from the JSON template format.
   ami_block_device_mappings {
-      device_name = "/dev/sdb"
-      virtual_name = "ephemeral0"
-    }
+    device_name  = "/dev/sdb"
+    virtual_name = "ephemeral0"
+  }
   ami_block_device_mappings {
-      device_name = "/dev/sdc"
-      virtual_name = "ephemeral1"
-    }
+    device_name  = "/dev/sdc"
+    virtual_name = "ephemeral1"
+  }
 }
 
 build {

--- a/website/pages/docs/builders/amazon/ebs.mdx
+++ b/website/pages/docs/builders/amazon/ebs.mdx
@@ -289,7 +289,7 @@ These source AMIs may include volumes that are not flagged to be destroyed on
 termination of the instance building the new image. Packer will attempt to
 clean up all residual volumes that are not designated by the user to remain
 after termination. If you need to preserve those source volumes, you can
-overwrite the termination setting by specifying `delete_on_termination=false`
+overwrite the termination setting by setting `delete_on_termination` to `false`
 in the `launch_block_device_mappings` block for the device.
 
 ## Build template data

--- a/website/pages/docs/builders/amazon/ebs.mdx
+++ b/website/pages/docs/builders/amazon/ebs.mdx
@@ -143,12 +143,22 @@ run:
 <Tab heading="HCL2">
 
 ```hcl
+// To make Packer read these variables from the environment into the var object,
+// set the environment variables to have the same name as the declared
+// variables, with the prefix PKR_VAR_.
+
+// You could also hardcode them into the file, but we recommend against that.
+
+// export PKR_VAR_aws_access_key=$YOURKEY
 variable "aws_access_key" {
   type = string
+  // default = "hardcoded_key"
 }
 
+// export PKR_VAR_aws_secret_key=$YOURSECRETKEY
 variable "aws_secret_key" {
   type = string
+  // default = "hardcoded_secret_key"
 }
 
 source "amazon-ebs" "basic-example" {
@@ -158,21 +168,23 @@ source "amazon-ebs" "basic-example" {
   source_ami =  "ami-fce3c696"
   instance_type =  "t2.micro"
   ssh_username =  "ubuntu"
+  ami_name =  "packer_AWS {{timestamp}}"
 }
 
 build {
-  source "sources.amazon-ebs.basic-example" {
-    ami_name =  "packer_AWS {{timestamp}}"
-  }
+  sources = [
+    "source.amazon-ebs.basic-example"
+  ]
 }
 ```
 
 </Tab>
 </Tabs>
 
--> **Note:** Packer can also read the access key and secret access key from
-environmental variables. See the configuration reference in the section above
-for more information on what environmental variables Packer will look for.
+-> **Note:** Packer can also read the access key and secret access key directly
+from environmental variables instead of being set as user variables. See the
+configuration reference in the section above for more information on what
+environmental variables Packer will look for.
 
 Further information on locating AMI IDs and their relationship to instance
 types and regions can be found in the AWS EC2 Documentation [for
@@ -195,36 +207,90 @@ configuration of `launch_block_device_mappings` will expand the root volume
 `ami_block_device_mappings` AWS will attach additional volumes `/dev/sdb` and
 `/dev/sdc` when we boot a new instance of our AMI.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
-  "type": "amazon-ebs",
-  "access_key": "YOUR KEY HERE",
-  "secret_key": "YOUR SECRET KEY HERE",
-  "region": "us-east-1",
-  "source_ami": "ami-fce3c696",
-  "instance_type": "t2.micro",
-  "ssh_username": "ubuntu",
-  "ami_name": "packer-quick-start {{timestamp}}",
-  "launch_block_device_mappings": [
-    {
-      "device_name": "/dev/sda1",
-      "volume_size": 40,
-      "volume_type": "gp2",
-      "delete_on_termination": true
-    }
-  ],
-  "ami_block_device_mappings": [
-    {
-      "device_name": "/dev/sdb",
-      "virtual_name": "ephemeral0"
-    },
-    {
-      "device_name": "/dev/sdc",
-      "virtual_name": "ephemeral1"
+  "builders": [
+      {
+      "type": "amazon-ebs",
+      "region": "us-east-1",
+      "source_ami": "ami-fce3c696",
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "ami_name": "packer-quick-start {{timestamp}}",
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_size": 40,
+          "volume_type": "gp2",
+          "delete_on_termination": true
+        }
+      ],
+      "ami_block_device_mappings": [
+        {
+          "device_name": "/dev/sdb",
+          "virtual_name": "ephemeral0"
+        },
+        {
+          "device_name": "/dev/sdc",
+          "virtual_name": "ephemeral1"
+        }
+      ]
     }
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-ebs" "basic-example" {
+  region =  "us-east-1"
+  source_ami =  "ami-fce3c696"
+  instance_type =  "t2.micro"
+  ssh_username =  "ubuntu"
+  ami_name =  "packer_AWS_example_{{timestamp}}"
+  launch_block_device_mappings {
+      device_name = "/dev/sda1"
+      volume_size = 40
+      volume_type = "gp2"
+      delete_on_termination = true
+    }
+  // Notice that instead of providing a list of mappings, you are just providing
+  // multiple mappings in a row. This diverges from the JSON template format.
+  ami_block_device_mappings {
+      device_name = "/dev/sdb"
+      virtual_name = "ephemeral0"
+    }
+  ami_block_device_mappings {
+      device_name = "/dev/sdc"
+      virtual_name = "ephemeral1"
+    }
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.basic-example"
+  ]
+}
+```
+
+</Tab>
+</Tabs>
+
+The above build template is functional assuming you have set the environment
+variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+
+-> **Note:** Packer uses pre-built AMIs as the source for building images.
+These source AMIs may include volumes that are not flagged to be destroyed on
+termination of the instance building the new image. Packer will attempt to
+clean up all residual volumes that are not designated by the user to remain
+after termination. If you need to preserve those source volumes, you can
+overwrite the termination setting by specifying `delete_on_termination=false`
+in the `launch_block_device_mappings` block for the device.
 
 ## Build template data
 
@@ -294,32 +360,57 @@ Here is an example using the optional AMI tags. This will add the tags
 provide your access keys, and may need to change the source AMI ID based on
 what images exist when this template is run:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
-  "type": "amazon-ebs",
-  "access_key": "YOUR KEY HERE",
-  "secret_key": "YOUR SECRET KEY HERE",
-  "region": "us-east-1",
-  "source_ami": "ami-fce3c696",
-  "instance_type": "t2.micro",
-  "ssh_username": "ubuntu",
-  "ami_name": "packer-quick-start {{timestamp}}",
-  "tags": {
-    "OS_Version": "Ubuntu",
-    "Release": "Latest",
-    "Base_AMI_Name": "{{ .SourceAMIName }}",
-    "Extra": "{{ .SourceAMITags.TagName }}"
-  }
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "us-east-1",
+      "source_ami": "ami-fce3c696",
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "ami_name": "packer-tag-example {{timestamp}}",
+      "tags": {
+        "OS_Version": "Ubuntu",
+        "Release": "Latest",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "Extra": "{{ .SourceAMITags.TagName }}"
+      }
+    }
+  ]
 }
 ```
 
--> **Note:** Packer uses pre-built AMIs as the source for building images.
-These source AMIs may include volumes that are not flagged to be destroyed on
-termination of the instance building the new image. Packer will attempt to
-clean up all residual volumes that are not designated by the user to remain
-after termination. If you need to preserve those source volumes, you can
-overwrite the termination setting by specifying `delete_on_termination=false`
-in the `launch_block_device_mappings` block for the device.
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-ebs" "basic-example" {
+  region =  "us-east-1"
+  source_ami =  "ami-fce3c696"
+  instance_type =  "t2.micro"
+  ssh_username =  "ubuntu"
+  ami_name =  "packer_tag_example {{timestamp}}"
+  tags = {
+      OS_Version = "Ubuntu"
+      Release = "Latest"
+      Base_AMI_Name = "{{ .SourceAMIName }}"
+      Extra = "{{ .SourceAMITags.TagName }}"
+  }
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.basic-example"
+  ]
+}
+```
+
+</Tab>
+</Tabs>
 
 ## Connecting to Windows instances using WinRM
 
@@ -387,6 +478,9 @@ You'll notice that this config does not define a user or password; instead,
 Packer will ask AWS to provide a random password that it generates
 automatically. The following config will work with the above template:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "builders": [
@@ -404,7 +498,7 @@ automatically. The following config will work with the above template:
         "owners": "amazon"
       },
       "ami_name": "default-packer",
-      "user_data_file": "winrm_bootstrap.txt",
+      "user_data_file": "./boot_config/winrm_bootstrap.txt",
       "communicator": "winrm",
       "force_deregister": true,
       "winrm_insecure": true,
@@ -415,10 +509,62 @@ automatically. The following config will work with the above template:
 }
 ```
 
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-ebs" "winrm-example" {
+  region =  "us-east-1"
+  // This example uses a source_ami_filter rather than a specific AMI.
+  // this allows us to use the same filter regardless of what region we're in,
+  // among other benefits.
+  source_ami_filter {
+    filter {
+      key = "virtualization-type"
+      value = "hvm"
+    }
+    filter {
+      key = "name"
+      value = "*Windows_Server-2012*English-64Bit-Base*"
+    }
+    filter {
+      key = "root-device-type"
+      value = "ebs"
+    }
+    most_recent = true
+    owners = ["amazon"]
+  }
+  instance_type =  "t2.micro"
+  ami_name =  "packer_winrm_example {{timestamp}}"
+  // This user data file sets up winrm and configures it so that the connection
+  // from Packer is allowed. Without this file being set, Packer will not
+  // connect to the instance.
+  user_data_file = "../boot_config/winrm_bootstrap.txt"
+  communicator = "winrm"
+  force_deregister = true
+  winrm_insecure = true
+  winrm_username = "Administrator"
+  winrm_use_ssl = true
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.winrm-example"
+  ]
+}
+```
+
+</Tab>
+</Tabs>
+
+
 ## Windows 2016 Sysprep Commands - For Amazon Windows AMIs Only
 
 For Amazon Windows 2016 AMIs it is necessary to run Sysprep commands which can
 be easily added to the provisioner section.
+
+<Tabs>
+<Tab heading="JSON">
 
 ```json
 {
@@ -429,5 +575,21 @@ be easily added to the provisioner section.
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+provisioner "powershell" {
+  inline = [
+    "C:/ProgramData/Amazon/EC2-Windows/Launch/Scripts/InitializeInstance.ps1 -Schedule",
+    "C:/ProgramData/Amazon/EC2-Windows/Launch/Scripts/SysprepInstance.ps1 -NoShutdown"
+  ]
+}
+```
+
+</Tab>
+</Tabs>
+
 
 @include 'builders/aws-ssh-differentiation-table.mdx'

--- a/website/pages/docs/builders/amazon/index.mdx
+++ b/website/pages/docs/builders/amazon/index.mdx
@@ -85,8 +85,8 @@ These look like:
 ```hcl
 source "amazon-ebs" "basic-example" {
   access_key = "AKIAIOSFODNN7EXAMPLE"
-  secret_key =  "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-  region = "us-east-1"
+  secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  region         = "us-east-1"
 }
 ```
 

--- a/website/pages/docs/builders/amazon/index.mdx
+++ b/website/pages/docs/builders/amazon/index.mdx
@@ -67,14 +67,31 @@ explained below:
 Static credentials can be provided in the form of an access key id and secret.
 These look like:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
-{
+"builders": {
+  "type": "amazon-ebs"
   "access_key": "AKIAIOSFODNN7EXAMPLE",
   "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
   "region": "us-east-1",
-  "type": "amazon-ebs"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-ebs" "basic-example" {
+  access_key = "AKIAIOSFODNN7EXAMPLE"
+  secret_key =  "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  region = "us-east-1"
+}
+```
+
+</Tab>
+</Tabs>
 
 ### Environment variables
 
@@ -110,13 +127,30 @@ The format for the credentials file is like so
 You may also configure the profile to use by setting the `profile`
 configuration option, or setting the `AWS_PROFILE` environment variable:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
-{
+"builders": {
+  "type": "amazon-ebs"
   "profile": "customprofile",
   "region": "us-east-1",
-  "type": "amazon-ebs"
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "amazon-ebs" "basic-example" {
+  profile = "customprofile"
+  region = "us-east-1"
+}
+```
+
+</Tab>
+</Tabs>
+
 
 ### IAM Task or Instance Role
 


### PR DESCRIPTION
Add HCL examples to all the standalone examples in amazon docs. HCL examples in the struct --> markdown code will come in a separate PR.