### PR TITLE
Support using WinRM over an IAP tunnel

### DIFF
--- a/website/pages/partials/builder/googlecompute/IAPConfig-not-required.mdx
+++ b/website/pages/partials/builder/googlecompute/IAPConfig-not-required.mdx
@@ -6,8 +6,6 @@
   - You must have the gcloud sdk installed on the computer running Packer.
   - You must be using a Service Account with a credentials file (using the
   	 account_file option in the Packer template)
-  - This is currently only implemented for the SSH communicator, not the
-    WinRM Communicator.
   - You must add the given service account to project level IAP permissions
     in https://console.cloud.google.com/security/iap. To do so, click
     "project" > "SSH and TCP resoures" > "All Tunnel Resources" >
@@ -24,4 +22,4 @@
   Default: ".sh"
 
 - `iap_tunnel_launch_wait` (int) - How long to wait, in seconds, before assuming a tunnel launch was
-  successful. Defaults to 30 seconds.
+  successful. Defaults to 30 seconds for SSH or 40 seconds for WinRM.


### PR DESCRIPTION
This avoids the need to expose WinRM ports on the internet and allows using instances with only an internal private IP address.

When using a WinRM tunnel there is a race condition between the tunnel connection attempt timing out and packer assuming the connection was successful. To allow for this, when using WinRM the default success time out is increased to 40 seconds.

I wanted to handle all the connection updating in `ApplyIAPTunnel` but that caused issues with `StepConnect`. The method call to `communicator.CommHost(b.config.Comm.Host(), "instance_ip")` binds quite early to the host value. One way to solve that would be to change that to `communicator.CommHost(b.config.Comm "instance_ip")`, and defer reading `Host()` until checking the state. However, I suspect this will have a high impact on all the other builders as well.

The `SupportsIAPTunnel` and `ApplyIAPTunnel` methods are deliberately located next to each other because they are highly coupled and need to be kept in sync with each other. I considered putting this methods on the communicator config, but that feels like the wrong place as this only applies to the googlecompute builder.
