### PR TITLE
core: Decode: when in HCL2 decoding mode; reset the whole struct before preparing it.

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -323,6 +323,38 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func Test_build_output(t *testing.T) {
+
+	tc := []struct {
+		command  []string
+		env      []string
+		expected string
+	}{
+		{[]string{"build", "--color=false", testFixture("hcl", "reprepare", "shell-local.pkr.hcl")}, nil,
+			`==> null.example: Running local shell script: ./test-fixtures/hcl/reprepare/hello.sh
+    null.example: hello from the NULL builder packeruser
+Build 'null.example' finished.
+
+==> Builds finished. The artifacts of successful builds are:
+--> null.example: Did not export anything. This is the null builder
+`},
+	}
+
+	for _, tc := range tc {
+		t.Run(fmt.Sprintf("packer %s", tc.command), func(t *testing.T) {
+			p := helperCommand(t, tc.command...)
+			p.Env = append(p.Env, tc.env...)
+			bs, err := p.Output()
+			if err != nil {
+				t.Fatalf("%v: %s", err, bs)
+			}
+			if diff := cmp.Diff(tc.expected, string(bs)); diff != "" {
+				t.Fatalf("unexpected output (+expected -actual): %s", diff)
+			}
+		})
+	}
+}
+
 func TestBuildOnlyFileCommaFlags(t *testing.T) {
 	c := &BuildCommand{
 		Meta: testMetaFile(t),

--- a/command/console_test.go
+++ b/command/console_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +13,10 @@ import (
 )
 
 func Test_console(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
 
 	tc := []struct {
 		piped    string
@@ -25,6 +30,8 @@ func Test_console(t *testing.T) {
 		{"upper(var.fruit)", []string{"console", filepath.Join(testFixture("var-arg"), "fruit_builder.pkr.hcl")}, []string{"PKR_VAR_fruit=potato"}, "POTATO\n"},
 		{"1 + 5", []string{"console", "--config-type=hcl2"}, nil, "6\n"},
 		{"var.images", []string{"console", filepath.Join(testFixture("var-arg"), "map.pkr.hcl")}, nil, "{\n" + `  "key" = "value"` + "\n}\n"},
+		{"path.cwd", []string{"console", filepath.Join(testFixture("var-arg"), "map.pkr.hcl")}, nil, strings.ReplaceAll(cwd, `\`, `/`) + "\n"},
+		{"path.root", []string{"console", filepath.Join(testFixture("var-arg"), "map.pkr.hcl")}, nil, strings.ReplaceAll(testFixture("var-arg"), `\`, `/`) + "\n"},
 	}
 
 	for _, tc := range tc {

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -87,6 +87,8 @@ func TestHelperProcess(*testing.T) {
 		os.Exit((&ConsoleCommand{Meta: commandMeta()}).Run(args))
 	case "inspect":
 		os.Exit((&InspectCommand{Meta: commandMeta()}).Run(args))
+	case "build":
+		os.Exit((&BuildCommand{Meta: commandMeta()}).Run(args))
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command %q\n", cmd)
 		os.Exit(2)

--- a/command/test-fixtures/hcl/reprepare/hello.sh
+++ b/command/test-fixtures/hcl/reprepare/hello.sh
@@ -1,0 +1,1 @@
+echo hello from the ${BUILDER} builder ${USER}

--- a/command/test-fixtures/hcl/reprepare/shell-local-windows.pkr.hcl
+++ b/command/test-fixtures/hcl/reprepare/shell-local-windows.pkr.hcl
@@ -1,0 +1,13 @@
+source "null" "example" {
+    communicator = "none"
+}
+
+build {
+	sources = [
+		"source.null.example"
+	]
+	provisioner "shell-local" {
+		script = "./${path.root}/test_cmd.cmd"
+		environment_vars = ["USER=packeruser", "BUILDER=${upper(build.ID)}"]
+	}
+}

--- a/command/test-fixtures/hcl/reprepare/shell-local.pkr.hcl
+++ b/command/test-fixtures/hcl/reprepare/shell-local.pkr.hcl
@@ -1,0 +1,13 @@
+source "null" "example" {
+    communicator = "none"
+}
+
+build {
+	sources = [
+		"source.null.example"
+	]
+	provisioner "shell-local" {
+		script = "./test-fixtures/hcl/reprepare/hello.sh"
+		environment_vars = ["USER=packeruser", "BUILDER=${upper(build.ID)}"]
+	}
+}

--- a/command/test-fixtures/hcl/reprepare/shell-local.pkr.hcl
+++ b/command/test-fixtures/hcl/reprepare/shell-local.pkr.hcl
@@ -7,7 +7,7 @@ build {
 		"source.null.example"
 	]
 	provisioner "shell-local" {
-		script = "./test-fixtures/hcl/reprepare/hello.sh"
+		script = "./${path.root}/hello.sh"
 		environment_vars = ["USER=packeruser", "BUILDER=${upper(build.ID)}"]
 	}
 }

--- a/command/test-fixtures/hcl/reprepare/test_cmd.cmd
+++ b/command/test-fixtures/hcl/reprepare/test_cmd.cmd
@@ -1,0 +1,1 @@
+echo hello from the %BUILDER% builder %USER%

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -77,6 +77,9 @@ func testParse(t *testing.T, tests []parseTest) {
 					ProvisionerBlock{},
 					PostProcessorBlock{},
 				),
+				cmpopts.IgnoreFields(PackerConfig{},
+					"Cwd", // Cwd will change for every computer
+				),
 				cmpopts.IgnoreTypes(HCL2Ref{}),
 				cmpopts.IgnoreTypes([]hcl.Range{}),
 				cmpopts.IgnoreTypes(hcl.Range{}),

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -70,7 +70,7 @@ func (p *Parser) Parse(filename string, varFiles []string, argVars map[string]st
 		hclFiles, jsonFiles, moreDiags := GetHCL2Files(filename, hcl2FileExt, hcl2JsonFileExt)
 		diags = append(diags, moreDiags...)
 		if len(hclFiles)+len(jsonFiles) == 0 {
-			diags = append(moreDiags, &hcl.Diagnostic{
+			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Could not find any config file in " + filename,
 				Detail: "A config file must be suffixed with `.pkr.hcl` or " +
@@ -96,8 +96,17 @@ func (p *Parser) Parse(filename string, varFiles []string, argVars map[string]st
 	if isDir, err := isDir(basedir); err == nil && !isDir {
 		basedir = filepath.Dir(basedir)
 	}
+	wd, err := os.Getwd()
+	if err != nil {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Could not find current working directory",
+			Detail:   err.Error(),
+		})
+	}
 	cfg := &PackerConfig{
 		Basedir:               basedir,
+		Cwd:                   wd,
 		builderSchemas:        p.BuilderSchemas,
 		provisionersSchemas:   p.ProvisionersSchemas,
 		postProcessorsSchemas: p.PostProcessorsSchemas,

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -16,6 +16,8 @@ import (
 type PackerConfig struct {
 	// Directory where the config files are defined
 	Basedir string
+	// directory Packer was called from
+	Cwd string
 
 	// Available Source blocks
 	Sources map[SourceRef]SourceBlock
@@ -49,6 +51,7 @@ type ValidationOptions struct {
 const (
 	inputVariablesAccessor = "var"
 	localsAccessor         = "local"
+	pathVariablesAccessor  = "path"
 	sourcesAccessor        = "source"
 	buildAccessor          = "build"
 )
@@ -69,6 +72,10 @@ func (cfg *PackerConfig) EvalContext(variables map[string]cty.Value) *hcl.EvalCo
 				"name": cty.UnknownVal(cty.String),
 			}),
 			buildAccessor: cty.UnknownVal(cty.EmptyObject),
+			pathVariablesAccessor: cty.ObjectVal(map[string]cty.Value{
+				"cwd":  cty.StringVal(strings.ReplaceAll(cfg.Cwd, `\`, `/`)),
+				"root": cty.StringVal(strings.ReplaceAll(cfg.Basedir, `\`, `/`)),
+			}),
 		},
 	}
 	for k, v := range variables {

--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -72,6 +72,18 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 			return err
 		}
 		raws[i] = raw
+		{
+			// reset target to zero.
+			// In HCL2, we need to prepare provisioners/post-processors after a
+			// builder has started in order to have build values correctly
+			// extrapolated. Packer plugins have never been prepared twice in
+			// the past and some of them set fields during their Validation
+			// steps; which end up in an invalid provisioner/post-processor,
+			// like in [GH-9596]. This ensures Packer plugin will be reset
+			// right before we Prepare them.
+			p := reflect.ValueOf(target).Elem()
+			p.Set(reflect.Zero(p.Type()))
+		}
 	}
 	if config == nil {
 		config = &DecodeOpts{Interpolate: true}

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -144,6 +144,7 @@ export default [
       'variables',
       'locals',
       'contextual-variables',
+      'path-variables',
       'syntax',
       'onlyexcept',
       'expressions',

--- a/website/pages/docs/from-1.5/path-variables.mdx
+++ b/website/pages/docs/from-1.5/path-variables.mdx
@@ -1,0 +1,14 @@
+---
+layout: docs
+page_title: Path Variables - HCL Configuration Language
+sidebar_title: Path Variables
+description: |-
+  Special variables provide directory information. This page covers all path
+  variables.
+---
+
+# Path variables
+
+- `path.cwd`: the directory from where Packer was started.
+
+- `path.root`: the directory of the input HCL file or the input folder.


### PR DESCRIPTION
[ HCL2 only ]

To allow provisioners and post-processors to access build variables we had to make provisioners re-prepare themselves after a build. The first prepare replaces variables with 'unknown' and then the second one uses the build values; but because provisioner and post-processors have never been prepared twice in the past this could expose us to errors like the one in #9596 where a Validation step sets a field from a field -- but those two fields are conflicting rendering the second prepare 'invalid'.

Internally a hcl2 flattened struct ( result from calling a `FlatMapstructure`) is always new making that part valid. But because we use JSON to transform it and then mapstructure to set it back on the actual target, the ‘not set’ fields are not reset to empty. A quick fix for #9596 could be to set the unset conflicting field `scripts` to it's null value in HCL2. 

This PR generalises this behaviour using reflection to reset a struct to it's basic -- every field unset -- state.


fix #9596