### PR TITLE
refactor initialisation out from packer configs + tests

### DIFF
--- a/builder/vmware/iso/step_create_vmx_test.go
+++ b/builder/vmware/iso/step_create_vmx_test.go
@@ -155,7 +155,8 @@ func setupVMwareBuild(t *testing.T, builderConfig map[string]string, provisioner
 	}
 
 	// create a core using our template
-	core, err := packer.NewCore(&config)
+	core := packer.NewCore(&config)
+	err = core.Initialize()
 	if err != nil {
 		t.Fatalf("Unable to create core: %s", err)
 	}

--- a/command/build.go
+++ b/command/build.go
@@ -109,7 +109,7 @@ func (m *Meta) GetConfig(cla *MetaArgs) (packer.Handler, int) {
 	}
 }
 
-func (m *Meta) GetConfigFromJSON(cla *MetaArgs) (*packer.Core, int) {
+func (m *Meta) GetConfigFromJSON(cla *MetaArgs) (packer.Handler, int) {
 	// Parse the template
 	var tpl *template.Template
 	var err error
@@ -133,11 +133,16 @@ func (m *Meta) GetConfigFromJSON(cla *MetaArgs) (*packer.Core, int) {
 		m.Ui.Error(err.Error())
 		ret = 1
 	}
-	return core, ret
+	return &CoreWrapper{core}, ret
 }
 
 func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int {
 	packerStarter, ret := c.GetConfig(&cla.MetaArgs)
+	if ret != 0 {
+		return ret
+	}
+	diags := packerStarter.Initialize()
+	ret = writeDiags(c.Ui, nil, diags)
 	if ret != 0 {
 		return ret
 	}

--- a/command/console.go
+++ b/command/console.go
@@ -60,6 +60,12 @@ func (c *ConsoleCommand) RunContext(ctx context.Context, cla *ConsoleArgs) int {
 		return ret
 	}
 
+	diags := packerStarter.Initialize()
+	ret = writeDiags(c.Ui, nil, diags)
+	if ret != 0 {
+		return ret
+	}
+
 	// Determine if stdin is a pipe. If so, we evaluate directly.
 	if c.StdinPiped() {
 		return c.modePiped(packerStarter)

--- a/command/core_wrapper.go
+++ b/command/core_wrapper.go
@@ -5,6 +5,8 @@ import (
 	"github.com/hashicorp/packer/packer"
 )
 
+// CoreWrapper wraps a packer.Core in order to have it's Initialize func return
+// a diagnostic.
 type CoreWrapper struct {
 	*packer.Core
 }

--- a/command/core_wrapper.go
+++ b/command/core_wrapper.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/packer/packer"
+)
+
+type CoreWrapper struct {
+	*packer.Core
+}
+
+func (c *CoreWrapper) Initialize() hcl.Diagnostics {
+	err := c.Core.Initialize()
+	if err != nil {
+		return hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Detail: err.Error(),
+			},
+		}
+	}
+	return nil
+}

--- a/command/core_wrapper.go
+++ b/command/core_wrapper.go
@@ -16,7 +16,8 @@ func (c *CoreWrapper) Initialize() hcl.Diagnostics {
 	if err != nil {
 		return hcl.Diagnostics{
 			&hcl.Diagnostic{
-				Detail: err.Error(),
+				Detail:   err.Error(),
+				Severity: hcl.DiagError,
 			},
 		}
 	}

--- a/command/inspect.go
+++ b/command/inspect.go
@@ -44,6 +44,11 @@ func (c *InspectCommand) RunContext(ctx context.Context, cla *InspectArgs) int {
 	if ret != 0 {
 		return ret
 	}
+	diags := packerStarter.Initialize()
+	ret = writeDiags(c.Ui, nil, diags)
+	if ret != 0 {
+		return ret
+	}
 	return packerStarter.InspectConfig(packer.InspectConfigOptions{
 		Ui: c.Ui,
 	})

--- a/command/meta.go
+++ b/command/meta.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bufio"
 	"flag"
-	"fmt"
 	"io"
 	"os"
 
@@ -59,13 +58,7 @@ func (m *Meta) Core(tpl *template.Template, cla *MetaArgs) (*packer.Core, error)
 	}
 	config.Variables = cla.Vars
 
-	// Init the core
 	core := packer.NewCore(&config)
-	err := core.Initialize()
-	if err != nil {
-		return nil, fmt.Errorf("Error initializing core: %s", err)
-	}
-
 	return core, nil
 }
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -60,7 +60,8 @@ func (m *Meta) Core(tpl *template.Template, cla *MetaArgs) (*packer.Core, error)
 	config.Variables = cla.Vars
 
 	// Init the core
-	core, err := packer.NewCore(&config)
+	core := packer.NewCore(&config)
+	err := core.Initialize()
 	if err != nil {
 		return nil, fmt.Errorf("Error initializing core: %s", err)
 	}

--- a/command/test-fixtures/validate/null_var.json
+++ b/command/test-fixtures/validate/null_var.json
@@ -1,0 +1,15 @@
+{
+    "variables": {
+        "null_var": null
+    },
+    "builders": [{
+        "type": "null",
+        "communicator": "none"
+    }],
+    "provisioners": [
+        {
+            "type": "shell-local",
+            "inline": "echo yop"
+        }
+    ]
+}

--- a/command/test-fixtures/validate/var_foo_with_no_default.pkr.hcl
+++ b/command/test-fixtures/validate/var_foo_with_no_default.pkr.hcl
@@ -1,0 +1,3 @@
+
+variable "foo" {
+}

--- a/command/validate.go
+++ b/command/validate.go
@@ -52,6 +52,7 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 
 	// If we're only checking syntax, then we're done already
 	if cla.SyntaxOnly {
+		c.Ui.Say("Syntax-only check passed. Everything looks okay.")
 		return 0
 	}
 

--- a/command/validate.go
+++ b/command/validate.go
@@ -55,7 +55,13 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 		return 0
 	}
 
-	_, diags := packerStarter.GetBuilds(packer.GetBuildsOptions{
+	diags := packerStarter.Initialize()
+	ret = writeDiags(c.Ui, nil, diags)
+	if ret != 0 {
+		return ret
+	}
+
+	_, diags = packerStarter.GetBuilds(packer.GetBuildsOptions{
 		Only:   cla.Only,
 		Except: cla.Except,
 	})

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -16,6 +16,7 @@ func TestValidateCommand(t *testing.T) {
 		{path: filepath.Join(testFixture("validate-invalid"), "bad_provisioner.json"), exitCode: 1},
 		{path: filepath.Join(testFixture("validate-invalid"), "missing_build_block.pkr.hcl"), exitCode: 1},
 		{path: filepath.Join(testFixture("validate"), "null_var.json"), exitCode: 1},
+		{path: filepath.Join(testFixture("validate"), "var_foo_with_no_default.pkr.hcl"), exitCode: 1},
 	}
 
 	for _, tc := range tt {
@@ -44,6 +45,7 @@ func TestValidateCommand_SyntaxOnly(t *testing.T) {
 		{path: filepath.Join(testFixture("validate-invalid"), "missing_build_block.pkr.hcl")},
 		{path: filepath.Join(testFixture("validate-invalid"), "broken.json"), exitCode: 1},
 		{path: filepath.Join(testFixture("validate"), "null_var.json")},
+		{path: filepath.Join(testFixture("validate"), "var_foo_with_no_default.pkr.hcl")},
 	}
 
 	for _, tc := range tt {

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -15,6 +15,7 @@ func TestValidateCommand(t *testing.T) {
 		{path: filepath.Join(testFixture("validate"), "build_with_vars.pkr.hcl")},
 		{path: filepath.Join(testFixture("validate-invalid"), "bad_provisioner.json"), exitCode: 1},
 		{path: filepath.Join(testFixture("validate-invalid"), "missing_build_block.pkr.hcl"), exitCode: 1},
+		{path: filepath.Join(testFixture("validate"), "null_var.json"), exitCode: 1},
 	}
 
 	for _, tc := range tt {

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -17,12 +17,11 @@ func TestValidateCommand(t *testing.T) {
 		{path: filepath.Join(testFixture("validate-invalid"), "missing_build_block.pkr.hcl"), exitCode: 1},
 	}
 
-	c := &ValidateCommand{
-		Meta: testMetaFile(t),
-	}
-
 	for _, tc := range tt {
 		t.Run(tc.path, func(t *testing.T) {
+			c := &ValidateCommand{
+				Meta: testMetaFile(t),
+			}
 			tc := tc
 			args := []string{tc.path}
 			if code := c.Run(args); code != tc.exitCode {
@@ -45,13 +44,12 @@ func TestValidateCommand_SyntaxOnly(t *testing.T) {
 		{path: filepath.Join(testFixture("validate-invalid"), "broken.json"), exitCode: 1},
 	}
 
-	c := &ValidateCommand{
-		Meta: testMetaFile(t),
-	}
-	c.CoreConfig.Version = "102.0.0"
-
 	for _, tc := range tt {
 		t.Run(tc.path, func(t *testing.T) {
+			c := &ValidateCommand{
+				Meta: testMetaFile(t),
+			}
+			c.CoreConfig.Version = "102.0.0"
 			tc := tc
 			args := []string{"-syntax-only", tc.path}
 			if code := c.Run(args); code != tc.exitCode {

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -3,6 +3,8 @@ package command
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestValidateCommand(t *testing.T) {
@@ -93,10 +95,15 @@ func TestValidateCommandBadVersion(t *testing.T) {
 	}
 
 	stdout, stderr := outputCommand(t, c.Meta)
-	expected := `Error initializing core: This template requires Packer version 101.0.0 or higher; using 100.0.0
+	expected := `Error: 
+
+This template requires Packer version 101.0.0 or higher; using 100.0.0
+
+
 `
-	if stderr != expected {
-		t.Fatalf("Expected:\n%s\nFound:\n%s\n", expected, stderr)
+
+	if diff := cmp.Diff(expected, stderr); diff != "" {
+		t.Errorf("Unexpected output: %s", diff)
 	}
 	t.Log(stdout)
 }

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -42,6 +42,7 @@ func TestValidateCommand_SyntaxOnly(t *testing.T) {
 		{path: filepath.Join(testFixture("validate-invalid"), "bad_provisioner.json")},
 		{path: filepath.Join(testFixture("validate-invalid"), "missing_build_block.pkr.hcl")},
 		{path: filepath.Join(testFixture("validate-invalid"), "broken.json"), exitCode: 1},
+		{path: filepath.Join(testFixture("validate"), "null_var.json")},
 	}
 
 	for _, tc := range tt {

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -61,6 +61,8 @@ func testParse(t *testing.T, tests []parseTest) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotCfg, gotDiags := tt.parser.Parse(tt.args.filename, tt.args.varFiles, tt.args.vars)
+			moreDiags := gotCfg.Initialize()
+			gotDiags = append(gotDiags, moreDiags...)
 			if tt.parseWantDiags == (gotDiags == nil) {
 				t.Fatalf("Parser.parse() unexpected %q diagnostics.", gotDiags)
 			}
@@ -78,6 +80,7 @@ func testParse(t *testing.T, tests []parseTest) {
 					PostProcessorBlock{},
 				),
 				cmpopts.IgnoreTypes(HCL2Ref{}),
+				cmpopts.IgnoreTypes([]*LocalBlock{}),
 				cmpopts.IgnoreTypes([]hcl.Range{}),
 				cmpopts.IgnoreTypes(hcl.Range{}),
 				cmpopts.IgnoreInterfaces(struct{ hcl.Expression }{}),

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -27,6 +27,8 @@ type PackerConfig struct {
 	InputVariables Variables
 	LocalVariables Variables
 
+	LocalBlocks []*LocalBlock
+
 	ValidationOptions
 
 	// Builds is the list of Build blocks defined in the config files.
@@ -40,6 +42,9 @@ type PackerConfig struct {
 
 	except []glob.Glob
 	only   []glob.Glob
+
+	parser *Parser
+	files  []*hcl.File
 }
 
 type ValidationOptions struct {
@@ -106,12 +111,12 @@ func (c *PackerConfig) decodeInputVariables(f *hcl.File) hcl.Diagnostics {
 // parseLocalVariables looks in the found blocks for 'locals' blocks. It
 // should be called after parsing input variables so that they can be
 // referenced.
-func (c *PackerConfig) parseLocalVariables(f *hcl.File) ([]*Local, hcl.Diagnostics) {
+func (c *PackerConfig) parseLocalVariables(f *hcl.File) ([]*LocalBlock, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	content, moreDiags := f.Body.Content(configSchema)
 	diags = append(diags, moreDiags...)
-	var locals []*Local
+	var locals []*LocalBlock
 
 	for _, block := range content.Blocks {
 		switch block.Type {
@@ -129,7 +134,7 @@ func (c *PackerConfig) parseLocalVariables(f *hcl.File) ([]*Local, hcl.Diagnosti
 					})
 					return nil, diags
 				}
-				locals = append(locals, &Local{
+				locals = append(locals, &LocalBlock{
 					Name: name,
 					Expr: attr.Expr,
 				})
@@ -140,7 +145,7 @@ func (c *PackerConfig) parseLocalVariables(f *hcl.File) ([]*Local, hcl.Diagnosti
 	return locals, diags
 }
 
-func (c *PackerConfig) evaluateLocalVariables(locals []*Local) hcl.Diagnostics {
+func (c *PackerConfig) evaluateLocalVariables(locals []*LocalBlock) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
 	if len(locals) > 0 && c.LocalVariables == nil {
@@ -180,7 +185,7 @@ func (c *PackerConfig) evaluateLocalVariables(locals []*Local) hcl.Diagnostics {
 	return diags
 }
 
-func (c *PackerConfig) evaluateLocalVariable(local *Local) hcl.Diagnostics {
+func (c *PackerConfig) evaluateLocalVariable(local *LocalBlock) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
 	value, moreDiags := local.Expr.Value(c.EvalContext(nil))

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -15,7 +15,7 @@ import (
 // Local represents a single entry from a "locals" block in a module or file.
 // The "locals" block itself is not represented, because it serves only to
 // provide context for us to interpret its contents.
-type Local struct {
+type LocalBlock struct {
 	Name string
 	Expr hcl.Expression
 }

--- a/helper/builder/testing/testing.go
+++ b/helper/builder/testing/testing.go
@@ -125,7 +125,7 @@ func Test(t TestT, c TestCase) {
 		},
 		Template: tpl,
 	})
-	err := core.Initialize()
+	err = core.Initialize()
 	if err != nil {
 		t.Fatal(fmt.Sprintf("Failed to init core: %s", err))
 		return

--- a/helper/builder/testing/testing.go
+++ b/helper/builder/testing/testing.go
@@ -111,7 +111,7 @@ func Test(t TestT, c TestCase) {
 
 	// Build the core
 	log.Printf("[DEBUG] Initializing core...")
-	core, err := packer.NewCore(&packer.CoreConfig{
+	core := packer.NewCore(&packer.CoreConfig{
 		Components: packer.ComponentFinder{
 			BuilderStore: TestBuilderStore{
 				StartFn: func(n string) (packer.Builder, error) {
@@ -125,6 +125,7 @@ func Test(t TestT, c TestCase) {
 		},
 		Template: tpl,
 	})
+	err := core.Initialize()
 	if err != nil {
 		t.Fatal(fmt.Sprintf("Failed to init core: %s", err))
 		return

--- a/packer/core.go
+++ b/packer/core.go
@@ -92,7 +92,7 @@ type ComponentFinder struct {
 }
 
 // NewCore creates a new Core.
-func NewCore(c *CoreConfig) (*Core, error) {
+func NewCore(c *CoreConfig) *Core {
 	core := &Core{
 		Template:   c.Template,
 		components: c.Components,
@@ -101,12 +101,15 @@ func NewCore(c *CoreConfig) (*Core, error) {
 		only:       c.Only,
 		except:     c.Except,
 	}
+	return core
+}
 
+func (core *Core) Initialize() error {
 	if err := core.validate(); err != nil {
-		return nil, err
+		return err
 	}
 	if err := core.init(); err != nil {
-		return nil, err
+		return err
 	}
 	for _, secret := range core.secrets {
 		LogSecretFilter.Set(secret)
@@ -115,17 +118,17 @@ func NewCore(c *CoreConfig) (*Core, error) {
 	// Go through and interpolate all the build names. We should be able
 	// to do this at this point with the variables.
 	core.builds = make(map[string]*template.Builder)
-	for _, b := range c.Template.Builders {
+	for _, b := range core.Template.Builders {
 		v, err := interpolate.Render(b.Name, core.Context())
 		if err != nil {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"Error interpolating builder '%s': %s",
 				b.Name, err)
 		}
 
 		core.builds[v] = b
 	}
-	return core, nil
+	return nil
 }
 
 // BuildNames returns the builds that are available in this configured core.

--- a/packer/core.go
+++ b/packer/core.go
@@ -93,7 +93,7 @@ type ComponentFinder struct {
 
 // NewCore creates a new Core.
 func NewCore(c *CoreConfig) (*Core, error) {
-	result := &Core{
+	core := &Core{
 		Template:   c.Template,
 		components: c.Components,
 		variables:  c.Variables,
@@ -102,30 +102,30 @@ func NewCore(c *CoreConfig) (*Core, error) {
 		except:     c.Except,
 	}
 
-	if err := result.validate(); err != nil {
+	if err := core.validate(); err != nil {
 		return nil, err
 	}
-	if err := result.init(); err != nil {
+	if err := core.init(); err != nil {
 		return nil, err
 	}
-	for _, secret := range result.secrets {
+	for _, secret := range core.secrets {
 		LogSecretFilter.Set(secret)
 	}
 
 	// Go through and interpolate all the build names. We should be able
 	// to do this at this point with the variables.
-	result.builds = make(map[string]*template.Builder)
+	core.builds = make(map[string]*template.Builder)
 	for _, b := range c.Template.Builders {
-		v, err := interpolate.Render(b.Name, result.Context())
+		v, err := interpolate.Render(b.Name, core.Context())
 		if err != nil {
 			return nil, fmt.Errorf(
 				"Error interpolating builder '%s': %s",
 				b.Name, err)
 		}
 
-		result.builds[v] = b
+		core.builds[v] = b
 	}
-	return result, nil
+	return core, nil
 }
 
 // BuildNames returns the builds that are available in this configured core.

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -37,10 +37,11 @@ func TestCoreBuildNames(t *testing.T) {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
 		}
 
-		core, err := NewCore(&CoreConfig{
+		core := NewCore(&CoreConfig{
 			Template:  tpl,
 			Variables: tc.Vars,
 		})
+		err = core.Initialize()
 		if err != nil {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
 		}
@@ -487,11 +488,12 @@ func TestCoreValidate(t *testing.T) {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
 		}
 
-		_, err = NewCore(&CoreConfig{
+		core := NewCore(&CoreConfig{
 			Template:  tpl,
 			Variables: tc.Vars,
 			Version:   "1.0.0",
 		})
+		err = core.Initialize()
 
 		if (err != nil) != tc.Err {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
@@ -535,10 +537,11 @@ func TestCore_InterpolateUserVars(t *testing.T) {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
 		}
 
-		ccf, err := NewCore(&CoreConfig{
+		ccf := NewCore(&CoreConfig{
 			Template: tpl,
 			Version:  "1.0.0",
 		})
+		err = ccf.Initialize()
 
 		if (err != nil) != tc.Err {
 			if tc.Err == false {
@@ -606,11 +609,12 @@ func TestCore_InterpolateUserVars_VarFile(t *testing.T) {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
 		}
 
-		ccf, err := NewCore(&CoreConfig{
+		ccf := NewCore(&CoreConfig{
 			Template:  tpl,
 			Version:   "1.0.0",
 			Variables: tc.Variables,
 		})
+		err = ccf.Initialize()
 
 		if (err != nil) != tc.Err {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
@@ -665,11 +669,12 @@ func TestSensitiveVars(t *testing.T) {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
 		}
 
-		_, err = NewCore(&CoreConfig{
+		ccf = NewCore(&CoreConfig{
 			Template:  tpl,
 			Variables: tc.Vars,
 			Version:   "1.0.0",
 		})
+		err = ccf.Initialize()
 
 		if (err != nil) != tc.Err {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
@@ -744,7 +749,7 @@ func TestEnvAndFileVars(t *testing.T) {
 		t.Fatalf("err: %s\n\n%s", "complex-recursed-env-user-var-file.json", err)
 	}
 
-	ccf, err := NewCore(&CoreConfig{
+	ccf := NewCore(&CoreConfig{
 		Template: tpl,
 		Version:  "1.0.0",
 		Variables: map[string]string{
@@ -753,6 +758,8 @@ func TestEnvAndFileVars(t *testing.T) {
 			"final_var": "{{user `env_1`}}/{{user `env_2`}}/{{user `env_4`}}{{user `env_3`}}-{{user `var_1`}}/vmware/{{user `var_2`}}.vmx",
 		},
 	})
+	err = ccf.Initialize()
+
 	expected := map[string]string{
 		"var_1":     "partyparrot",
 		"var_2":     "bulbasaur-5/path/to/nowhere-partyparrot",

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -669,7 +669,7 @@ func TestSensitiveVars(t *testing.T) {
 			t.Fatalf("err: %s\n\n%s", tc.File, err)
 		}
 
-		ccf = NewCore(&CoreConfig{
+		ccf := NewCore(&CoreConfig{
 			Template:  tpl,
 			Variables: tc.Vars,
 			Version:   "1.0.0",

--- a/packer/run_interfaces.go
+++ b/packer/run_interfaces.go
@@ -26,6 +26,7 @@ type Evaluator interface {
 
 // The packer.Handler handles all Packer things.
 type Handler interface {
+	Initialize() hcl.Diagnostics
 	Evaluator
 	BuildGetter
 	ConfigFixer

--- a/packer/testing.go
+++ b/packer/testing.go
@@ -20,7 +20,8 @@ func TestCoreConfig(t *testing.T) *CoreConfig {
 }
 
 func TestCore(t *testing.T, c *CoreConfig) *Core {
-	core, err := NewCore(c)
+	core := NewCore(c)
+	err := core.Initialize()
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
This refactors initialisation out of packer configs: JSON config and HCL2 config.

This fixes #9478