### PR TITLE
CI/tech-debt: Virtualbox acceptance tests: Fix minimal json example to use new checksumming

### DIFF
--- a/builder/virtualbox/iso/testdata/minimal.json
+++ b/builder/virtualbox/iso/testdata/minimal.json
@@ -2,8 +2,7 @@
   "builders": [
         {
           "type": "test",
-          "iso_checksum": "946a6077af6f5f95a51f82fdc44051c7aa19f9cfc5f737954845a6050543d7c2",
-          "iso_checksum_type": "sha256",
+          "iso_checksum": "sha256:946a6077af6f5f95a51f82fdc44051c7aa19f9cfc5f737954845a6050543d7c2",
           "iso_url": "http://old-releases.ubuntu.com/releases/14.04.1/ubuntu-14.04.1-server-amd64.iso",
           "disk_size": "40960",
           "guest_os_type": "Ubuntu_64",
@@ -38,9 +37,9 @@
             " -- <wait>",
             "<enter><wait>"
           ],
-      
+
           "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
           "post_shutdown_delay": "60s"
-        }    
+        }
   ]
 }


### PR DESCRIPTION
Title says it all. Acceptance tests were failing because of the old style checksum.