### PR TITLE
fix agent auth in ssh communicator for ansible provisioner (#9488)

### DIFF
--- a/common/step_provision.go
+++ b/common/step_provision.go
@@ -85,6 +85,7 @@ func PopulateProvisionHookData(state multistep.StateBag) map[string]interface{} 
 	hookData["SSHPublicKey"] = string(commConf.SSHPublicKey)
 	hookData["SSHPrivateKey"] = string(commConf.SSHPrivateKey)
 	hookData["SSHPrivateKeyFile"] = commConf.SSHPrivateKeyFile
+	hookData["SSHAgentAuth"] = commConf.SSHAgentAuth
 
 	// Backwards compatibility; in practice, WinRMPassword is fulfilled by
 	// Password.

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -561,7 +561,8 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 			// In this situation, we need to make sure we have the
 			// private key we actually use to access the instance.
 			SSHPrivateKeyFile := generatedData["SSHPrivateKeyFile"].(string)
-			if SSHPrivateKeyFile != "" {
+			SSHAgentAuth := generatedData["SSHAgentAuth"].(bool)
+			if SSHPrivateKeyFile != "" || SSHAgentAuth {
 				privKeyFile = SSHPrivateKeyFile
 			} else {
 				// See if we can get a private key and write that to a tmpfile
@@ -695,7 +696,7 @@ func (p *Provisioner) createCmdArgs(httpAddr, inventory, playbook, privKeyFile s
 		args = append(args, "-e", fmt.Sprintf("packer_http_addr=%s", httpAddr))
 	}
 
-	if p.generatedData["ConnType"] == "ssh" {
+	if p.generatedData["ConnType"] == "ssh" && len(privKeyFile) > 0 {
 		// Add ssh extra args to set IdentitiesOnly
 		args = append(args, "--ssh-extra-args", "'-o IdentitiesOnly=yes'")
 	}

--- a/provisioner/ansible/provisioner_test.go
+++ b/provisioner/ansible/provisioner_test.go
@@ -473,6 +473,7 @@ func basicGenData(input map[string]interface{}) map[string]interface{} {
 		"ConnType":          "ssh",
 		"SSHPrivateKeyFile": "",
 		"SSHPrivateKey":     "asdf",
+		"SSHAgentAuth":      false,
 		"User":              "PartyPacker",
 		"PackerHTTPAddr":    common.HttpAddrNotImplemented,
 		"PackerHTTPIP":      common.HttpIPNotImplemented,
@@ -544,7 +545,7 @@ func TestCreateCmdArgs(t *testing.T) {
 				"PackerHTTPAddr": "123.45.67.89",
 			}),
 			callArgs:        []string{"123.45.67.89", "/var/inventory", "test-playbook.yml", ""},
-			ExpectedArgs:    []string{"-e", "packer_build_name=\"packerparty\"", "-e", "packer_builder_type=fakebuilder", "-e", "packer_http_addr=123.45.67.89", "--ssh-extra-args", "'-o IdentitiesOnly=yes'", "-e", "hello-world", "-i", "/var/inventory", "test-playbook.yml"},
+			ExpectedArgs:    []string{"-e", "packer_build_name=\"packerparty\"", "-e", "packer_builder_type=fakebuilder", "-e", "packer_http_addr=123.45.67.89", "-e", "hello-world", "-i", "/var/inventory", "test-playbook.yml"},
 			ExpectedEnvVars: []string{},
 		},
 		{
@@ -600,7 +601,7 @@ func TestCreateCmdArgs(t *testing.T) {
 			ExtraArguments:  []string{"-e", "hello-world", "-e", "ansible_password=ilovebananapancakes"},
 			AnsibleEnvVars:  []string{"ENV_1=pancakes", "ENV_2=bananas"},
 			callArgs:        []string{"123.45.67.89", "/var/inventory", "test-playbook.yml", ""},
-			ExpectedArgs:    []string{"-e", "packer_builder_type=fakebuilder", "-e", "packer_http_addr=123.45.67.89", "--ssh-extra-args", "'-o IdentitiesOnly=yes'", "-e", "hello-world", "-e", "ansible_password=ilovebananapancakes", "-e", "ansible_host_key_checking=False", "-i", "/var/inventory", "test-playbook.yml"},
+			ExpectedArgs:    []string{"-e", "packer_builder_type=fakebuilder", "-e", "packer_http_addr=123.45.67.89", "-e", "hello-world", "-e", "ansible_password=ilovebananapancakes", "-e", "ansible_host_key_checking=False", "-i", "/var/inventory", "test-playbook.yml"},
 			ExpectedEnvVars: []string{"ENV_1=pancakes", "ENV_2=bananas"},
 		},
 		{
@@ -614,7 +615,7 @@ func TestCreateCmdArgs(t *testing.T) {
 			ExtraArguments:  []string{"-e", "hello-world", "-e", "ansible_password=ilovebananapancakes"},
 			AnsibleEnvVars:  []string{"ENV_1=pancakes", "ENV_2=bananas", "ANSIBLE_HOST_KEY_CHECKING=False"},
 			callArgs:        []string{"123.45.67.89", "/var/inventory", "test-playbook.yml", ""},
-			ExpectedArgs:    []string{"-e", "packer_builder_type=fakebuilder", "-e", "packer_http_addr=123.45.67.89", "--ssh-extra-args", "'-o IdentitiesOnly=yes'", "-e", "hello-world", "-e", "ansible_password=ilovebananapancakes", "-i", "/var/inventory", "test-playbook.yml"},
+			ExpectedArgs:    []string{"-e", "packer_builder_type=fakebuilder", "-e", "packer_http_addr=123.45.67.89", "-e", "hello-world", "-e", "ansible_password=ilovebananapancakes", "-i", "/var/inventory", "test-playbook.yml"},
 			ExpectedEnvVars: []string{"ENV_1=pancakes", "ENV_2=bananas", "ANSIBLE_HOST_KEY_CHECKING=False"},
 		},
 		{
@@ -628,11 +629,19 @@ func TestCreateCmdArgs(t *testing.T) {
 			ExpectedEnvVars: []string{},
 		},
 		{
+			TestName:        "Use SSH Agent",
+			UseProxy:        confighelper.TriTrue,
+			generatedData:   basicGenData(nil),
+			callArgs:        []string{common.HttpAddrNotImplemented, "/var/inventory", "test-playbook.yml", ""},
+			ExpectedArgs:    []string{"-e", "packer_builder_type=fakebuilder", "-i", "/var/inventory", "test-playbook.yml"},
+			ExpectedEnvVars: []string{},
+		},
+		{
 			// No builder name. This shouldn't cause an error, it just shouldn't be set. HCL, yo.
 			TestName:        "No builder name. This shouldn't cause an error, it just shouldn't be set. HCL, yo.",
 			generatedData:   basicGenData(nil),
 			callArgs:        []string{common.HttpAddrNotImplemented, "/var/inventory", "test-playbook.yml", ""},
-			ExpectedArgs:    []string{"-e", "packer_builder_type=fakebuilder", "--ssh-extra-args", "'-o IdentitiesOnly=yes'", "-i", "/var/inventory", "test-playbook.yml"},
+			ExpectedArgs:    []string{"-e", "packer_builder_type=fakebuilder", "-i", "/var/inventory", "test-playbook.yml"},
 			ExpectedEnvVars: []string{},
 		},
 	}


### PR DESCRIPTION
Fix agent auth in ssh communicator for ansible provisioner
Closes #9488 