### PR TITLE
Clean up vsphere ui

### DIFF
--- a/builder/vmware/common/step_export.go
+++ b/builder/vmware/common/step_export.go
@@ -48,7 +48,7 @@ func (s *StepExport) generateArgs(c *DriverConfig, displayName string, hidePassw
 
 	password := c.RemotePassword
 	if hidePassword {
-		password = "<password_redacted>"
+		password = "<password>"
 	}
 	u.User = url.UserPassword(c.RemoteUser, password)
 

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -222,7 +222,10 @@ func (p *PostProcessor) ValidateOvfTool(args []string, ofvtool string) error {
 	// Need to manually close stdin or else the ofvtool call will hang
 	// forever in a situation where the user has provided an invalid
 	// password or username
-	stdin, _ := cmd.StdinPipe()
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		err
+	}
 	defer stdin.Close()
 
 	if err := cmd.Run(); err != nil {

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -224,7 +224,7 @@ func (p *PostProcessor) ValidateOvfTool(args []string, ofvtool string) error {
 	// password or username
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		err
+		return err
 	}
 	defer stdin.Close()
 

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -148,8 +148,7 @@ func getEncodedPassword(u *url.URL) (string, bool) {
 	// filter password from all logging
 	password, passwordSet := u.User.Password()
 	if passwordSet && password != "" {
-		encodedUserPassword := strings.Split(u.User.String(), ":")
-		encodedPassword := encodedUserPassword[len(encodedUserPassword)-1]
+		encodedPassword := strings.Split(u.User.String(), ":")[1]
 		return encodedPassword, true
 	}
 	return password, false

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -193,11 +193,13 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 
 func filterLog(s string, u *url.URL) string {
 	password, passwordSet := u.User.Password()
-	if passwordSet && password != "" {
-		return strings.Replace(s, password, "<password>", -1)
+	if !passwordSet || password == "" {
+		return s
 	}
+	encodedUserPassword := strings.Split(u.User.String(), ":")
+	encodedPassword := encodedUserPassword[len(encodedUserPassword)-1]
 
-	return s
+	return strings.Replace(s, encodedPassword, "<password>", -1)
 }
 
 func (p *PostProcessor) BuildArgs(source, ovftool_uri string) ([]string, error) {

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -101,3 +101,30 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterLogs(t *testing.T) {
+
+	// Password is encoded, and contains a colon
+	ovftool_uri := fmt.Sprintf("vi://hostname/Datacenter/host/cluster")
+
+	u, _ := url.Parse(ovftool_uri)
+	u.User = url.UserPassword("us:ername", "P@ssW:rd")
+
+	logstring := "vi://us%3Aername:P%40ssW%3Ard@hostname/Datacenter/host/cluster"
+	outstring := filterLog(logstring, u)
+	expected := "vi://us%3Aername:<password>@hostname/Datacenter/host/cluster"
+	if outstring != expected {
+		t.Fatalf("Should have successfully filtered encoded password. Expected: %s; recieved: %s", expected, outstring)
+	}
+
+	// There is no password
+	u.User = url.UserPassword("us:ername", "")
+
+	logstring = "vi://us%3Aername:@hostname/Datacenter/host/cluster"
+	outstring = filterLog(logstring, u)
+	expected = "vi://us%3Aername:@hostname/Datacenter/host/cluster"
+	if outstring != expected {
+		t.Fatalf("Should have ignored password filtering since it was not set. Expected: %s; recieved: %s", expected, outstring)
+	}
+
+}

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -102,7 +102,7 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 	}
 }
 
-func TestFilterLogs(t *testing.T) {
+func TestGetEncodedPassword(t *testing.T) {
 
 	// Password is encoded, and contains a colon
 	ovftool_uri := fmt.Sprintf("vi://hostname/Datacenter/host/cluster")
@@ -110,21 +110,21 @@ func TestFilterLogs(t *testing.T) {
 	u, _ := url.Parse(ovftool_uri)
 	u.User = url.UserPassword("us:ername", "P@ssW:rd")
 
-	logstring := "vi://us%3Aername:P%40ssW%3Ard@hostname/Datacenter/host/cluster"
-	outstring := filterLog(logstring, u)
-	expected := "vi://us%3Aername:<password>@hostname/Datacenter/host/cluster"
-	if outstring != expected {
-		t.Fatalf("Should have successfully filtered encoded password. Expected: %s; recieved: %s", expected, outstring)
+	encoded, isSet := getEncodedPassword(u)
+	expected := "P%40ssW%3Ard"
+	if !isSet {
+		t.Fatalf("Password is set but test said it is not")
+	}
+	if encoded != expected {
+		t.Fatalf("Should have successfully gotten encoded password. Expected: %s; recieved: %s", expected, encoded)
 	}
 
 	// There is no password
 	u.User = url.UserPassword("us:ername", "")
 
-	logstring = "vi://us%3Aername:@hostname/Datacenter/host/cluster"
-	outstring = filterLog(logstring, u)
-	expected = "vi://us%3Aername:@hostname/Datacenter/host/cluster"
-	if outstring != expected {
-		t.Fatalf("Should have ignored password filtering since it was not set. Expected: %s; recieved: %s", expected, outstring)
+	_, isSet = getEncodedPassword(u)
+	if isSet {
+		t.Fatalf("Should have determined that password was not set")
 	}
 
 }

--- a/website/pages/docs/post-processors/vsphere.mdx
+++ b/website/pages/docs/post-processors/vsphere.mdx
@@ -22,7 +22,9 @@ each category, the available configuration keys are alphabetized.
 
 Required:
 
-- `cluster` (string) - The cluster to upload the VM to.
+- `cluster` (string) - The cluster to upload the VM to. If you do not have a
+  cluster defined, you can instead provide the IP address of the esx host
+  that you want to upload to.
 
 - `datacenter` (string) - The name of the datacenter within vSphere to add
   the VM to.


### PR DESCRIPTION
This is a follow-on to #9589 

While I was working on this, I found that our call to ovftool will hang indefinitely without giving useful output if something goes wrong. For example, if the password is incorrect or if another required variable isn't set.

I've reworked the code to do two things -- first, perform a "dry-run" using the --verifyOnly flag, wrapped in a 15 second timeout. Only if it Passes will Packer invoke the actual upload, and otherwise it will return the error.

Second, Packer will now use the shell-local communicator to actually invoke the ovftool call, which means that stdout and stderr will get piped into the UI in real time instead of being shoved into a stdout variable and not read until the upload is complete. This will give users a clearer idea of what the tool is actually doing, and potentially how much longer it will take. 

Finally, this code modifies the password log sanitizing to use the LogSecretFilter that we implemented two years ago; the currently password handling is janky and predates that log filter. It also makes sure to sanitize not just the plaintext password, but the password as encoded for ovftool. 

Closes #4475
