### PR TITLE
Set project via project flag, not setting in the config

### DIFF
--- a/builder/googlecompute/step_start_tunnel.go
+++ b/builder/googlecompute/step_start_tunnel.go
@@ -196,13 +196,11 @@ func (s *StepStartTunnel) createTempGcloudScript(args []string) (string, error) 
 
 	launchTemplate := `
 gcloud auth activate-service-account --key-file='{{.AccountFile}}'
-gcloud config set project {{.ProjectID}}
 {{.Args}}
 `
 	if runtime.GOOS == "windows" {
 		launchTemplate = `
 call gcloud auth activate-service-account --key-file "{{.AccountFile}}"
-call gcloud config set project {{.ProjectID}}
 call {{.Args}}
 `
 	}
@@ -215,7 +213,6 @@ call {{.Args}}
 
 	opts := map[string]string{
 		"AccountFile": s.AccountFile,
-		"ProjectID":   s.ProjectId,
 		"Args":        argString,
 	}
 
@@ -276,7 +273,7 @@ func (s *StepStartTunnel) Run(ctx context.Context, state multistep.StateBag) mul
 	args := []string{"compute", "start-iap-tunnel", instanceName,
 		strconv.Itoa(s.CommConf.Port()),
 		fmt.Sprintf("--local-host-port=localhost:%d", s.IAPConf.IAPLocalhostPort),
-		"--zone", c.Zone,
+		"--zone", c.Zone, "--project", s.ProjectId,
 	}
 
 	// This is the port the IAP tunnel listens on, on localhost.

--- a/builder/googlecompute/step_start_tunnel_test.go
+++ b/builder/googlecompute/step_start_tunnel_test.go
@@ -49,7 +49,8 @@ func TestStepStartTunnel_CreateTempScript(t *testing.T) {
 	s := getTestStepStartTunnel()
 
 	args := []string{"compute", "start-iap-tunnel", "fakeinstance-12345",
-		"1234", "--local-host-port=localhost:8774", "--zone", "us-central-b"}
+		"1234", "--local-host-port=localhost:8774", "--zone", "us-central-b",
+		"--project", "fake-project-123"}
 
 	scriptPath, err := s.createTempGcloudScript(args)
 	if err != nil {
@@ -65,16 +66,14 @@ func TestStepStartTunnel_CreateTempScript(t *testing.T) {
 	expected := `#!/bin/bash
 
 gcloud auth activate-service-account --key-file='/path/to/account_file.json'
-gcloud config set project fake-project-123
-gcloud compute start-iap-tunnel fakeinstance-12345 1234 --local-host-port=localhost:8774 --zone us-central-b
+gcloud compute start-iap-tunnel fakeinstance-12345 1234 --local-host-port=localhost:8774 --zone us-central-b --project fake-project-123
 `
 	if runtime.GOOS == "windows" {
 		// in real life you'd not be passing a HashBang here, but GIGO.
 		expected = `#!/bin/bash
 
 call gcloud auth activate-service-account --key-file "/path/to/account_file.json"
-call gcloud config set project fake-project-123
-call gcloud compute start-iap-tunnel fakeinstance-12345 1234 --local-host-port=localhost:8774 --zone us-central-b
+call gcloud compute start-iap-tunnel fakeinstance-12345 1234 --local-host-port=localhost:8774 --zone us-central-b --project fake-project-123
 `
 	}
 	if fmt.Sprintf("%s", f) != expected {


### PR DESCRIPTION
Rather than using gcloud config call to set the project, do so using the --project flag. This reduces the scope of the call so that it no longer makes global changes.

Closes #9527