### PR TITLE
builder/amazon: Fix skip_save_build_region in the ebssurrogate builder.

### DIFF
--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -238,11 +238,12 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	// Build the steps
 	steps := []multistep.Step{
 		&awscommon.StepPreValidate{
-			DestAmiName:     b.config.AMIName,
-			ForceDeregister: b.config.AMIForceDeregister,
-			VpcId:           b.config.VpcId,
-			SubnetId:        b.config.SubnetId,
-			HasSubnetFilter: !b.config.SubnetFilter.Empty(),
+			DestAmiName:        b.config.AMIName,
+			ForceDeregister:    b.config.AMIForceDeregister,
+			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
+			VpcId:              b.config.VpcId,
+			SubnetId:           b.config.SubnetId,
+			HasSubnetFilter:    !b.config.SubnetFilter.Empty(),
 		},
 		&awscommon.StepSourceAMIInfo{
 			SourceAmi:                b.config.SourceAmi,
@@ -342,13 +343,14 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			AMISkipBuildRegion:       b.config.AMISkipBuildRegion,
 		},
 		&awscommon.StepAMIRegionCopy{
-			AccessConfig:      &b.config.AccessConfig,
-			Regions:           b.config.AMIRegions,
-			AMIKmsKeyId:       b.config.AMIKmsKeyId,
-			RegionKeyIds:      b.config.AMIRegionKMSKeyIDs,
-			EncryptBootVolume: b.config.AMIEncryptBootVolume,
-			Name:              b.config.AMIName,
-			OriginalRegion:    *ec2conn.Config.Region,
+			AccessConfig:       &b.config.AccessConfig,
+			Regions:            b.config.AMIRegions,
+			AMIKmsKeyId:        b.config.AMIKmsKeyId,
+			RegionKeyIds:       b.config.AMIRegionKMSKeyIDs,
+			EncryptBootVolume:  b.config.AMIEncryptBootVolume,
+			Name:               b.config.AMIName,
+			OriginalRegion:     *ec2conn.Config.Region,
+			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,


### PR DESCRIPTION
This fixes the skip_save_build_region flag for the amazon-ebssurrogate builder. It just needed to be passed through to a few extra steps.