### PR TITLE
fix docker-import postprocessor.

### DIFF
--- a/hcl2template/types.hcl_post-processor.go
+++ b/hcl2template/types.hcl_post-processor.go
@@ -39,6 +39,8 @@ func (p *HCL2PostProcessor) HCL2Prepare(buildVars map[string]interface{}) error 
 				buildValues[k] = cty.NumberIntVal(v)
 			case uint64:
 				buildValues[k] = cty.NumberUIntVal(v)
+			case bool:
+				buildValues[k] = cty.BoolVal(v)
 			default:
 				return fmt.Errorf("unhandled buildvar type: %T", v)
 			}


### PR DESCRIPTION
When calling the docker-import postprocessor in hcl, I'd get a failure: 

```
* Post-processor failed: unhandled buildvar type: bool
```

This fixes that. 

Repro: 

```

source "docker" "example" {
    image = "ubuntu"
    export_path = "dockerparty"
}

build {
  sources = [
    "source.docker.example"
  ]
  post-processors {
    post-processor "docker-import" {
        repository = "local/ubuntu"
        tag = "0.7"
      }
  }
}
```