### PR TITLE
Make max_retries a string to allow variable interpolation

### DIFF
--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -61,7 +61,6 @@ const (
 // build; sources(builders)/provisioners/posts-processors will not be started
 // and their contents wont be verified; Most syntax errors will cause an error.
 func (p *Parser) Parse(filename string, varFiles []string, argVars map[string]string) (*PackerConfig, hcl.Diagnostics) {
-
 	var files []*hcl.File
 	var diags hcl.Diagnostics
 
@@ -225,7 +224,7 @@ func (p *Parser) decodeConfig(f *hcl.File, cfg *PackerConfig) hcl.Diagnostics {
 			cfg.Sources[ref] = source
 
 		case buildLabel:
-			build, moreDiags := p.decodeBuildConfig(block)
+			build, moreDiags := p.decodeBuildConfig(block, cfg)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue

--- a/hcl2template/testdata/variables/provisioner_variable_decoding.pkr.hcl
+++ b/hcl2template/testdata/variables/provisioner_variable_decoding.pkr.hcl
@@ -1,0 +1,21 @@
+variables {
+  max_retries = "1"
+  max_retries_int = 1
+}
+
+source "null" "null-builder" {
+  communicator = "none"
+}
+
+build {
+  sources = [
+    "source.null.null-builder",
+  ]
+
+  provisioner "shell" {
+    max_retries = var.max_retries_int
+  }
+  provisioner "shell" {
+    max_retries = var.max_retries
+  }
+}

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -70,7 +70,7 @@ type Builds []*BuildBlock
 
 // decodeBuildConfig is called when a 'build' block has been detected. It will
 // load the references to the contents of the build block.
-func (p *Parser) decodeBuildConfig(block *hcl.Block) (*BuildBlock, hcl.Diagnostics) {
+func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildBlock, hcl.Diagnostics) {
 	build := &BuildBlock{}
 
 	var b struct {
@@ -123,7 +123,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block) (*BuildBlock, hcl.Diagnosti
 			}
 			build.Sources = append(build.Sources, ref)
 		case buildProvisionerLabel:
-			p, moreDiags := p.decodeProvisioner(block)
+			p, moreDiags := p.decodeProvisioner(block, cfg)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -70,7 +70,7 @@ func (p *ProvisionerBlock) String() string {
 	return fmt.Sprintf(buildProvisionerLabel+"-block %q %q", p.PType, p.PName)
 }
 
-func (p *Parser) decodeProvisioner(block *hcl.Block) (*ProvisionerBlock, hcl.Diagnostics) {
+func (p *Parser) decodeProvisioner(block *hcl.Block, cfg *PackerConfig) (*ProvisionerBlock, hcl.Diagnostics) {
 	var b struct {
 		Name        string   `hcl:"name,optional"`
 		PauseBefore string   `hcl:"pause_before,optional"`
@@ -80,7 +80,7 @@ func (p *Parser) decodeProvisioner(block *hcl.Block) (*ProvisionerBlock, hcl.Dia
 		Except      []string `hcl:"except,optional"`
 		Rest        hcl.Body `hcl:",remain"`
 	}
-	diags := gohcl.DecodeBody(block.Body, nil, &b)
+	diags := gohcl.DecodeBody(block.Body, cfg.EvalContext(nil), &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/packer/core.go
+++ b/packer/core.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	ttmp "text/template"
@@ -191,9 +192,20 @@ func (c *Core) generateCoreBuildProvisioner(rawP *template.Provisioner, rawName 
 			Provisioner: provisioner,
 		}
 	}
-	if rawP.MaxRetries != 0 {
+	maxRetries := 0
+	if rawP.MaxRetries != "" {
+		renderedMaxRetries, err := interpolate.Render(rawP.MaxRetries, c.Context())
+		if err != nil {
+			return cbp, fmt.Errorf("failed to interpolate `max_retries`: %s", err.Error())
+		}
+		maxRetries, err = strconv.Atoi(renderedMaxRetries)
+		if err != nil {
+			return cbp, fmt.Errorf("`max_retries` must be a valid integer: %s", err.Error())
+		}
+	}
+	if maxRetries != 0 {
 		provisioner = &RetriedProvisioner{
-			MaxRetries:  rawP.MaxRetries,
+			MaxRetries:  maxRetries,
 			Provisioner: provisioner,
 		}
 	}

--- a/packer/test-fixtures/build-prov-retry.json
+++ b/packer/test-fixtures/build-prov-retry.json
@@ -3,8 +3,14 @@
         "type": "test"
     }],
 
-    "provisioners": [{
-        "type": "test",
-        "max_retries": 1
-    }]
+    "provisioners": [
+        {
+            "type": "test-integer",
+            "max_retries": 1
+        },
+        {
+            "type": "test-string",
+            "max_retries": "1"
+        }
+    ]
 }

--- a/template/parse.go
+++ b/template/parse.go
@@ -59,7 +59,7 @@ func (r *rawTemplate) MarshalJSON() ([]byte, error) {
 
 func (r *rawTemplate) decodeProvisioner(raw interface{}) (Provisioner, error) {
 	var p Provisioner
-	if err := r.decoder(&p, nil).Decode(raw); err != nil {
+	if err := r.weakDecoder(&p, nil).Decode(raw); err != nil {
 		return p, fmt.Errorf("Error decoding provisioner: %s", err)
 
 	}
@@ -277,6 +277,24 @@ func (r *rawTemplate) decoder(
 		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
 		Metadata:   md,
 		Result:     result,
+	})
+	if err != nil {
+		// This really shouldn't happen since we have firm control over
+		// all the arguments and they're all unit tested. So we use a
+		// panic here to note this would definitely be a bug.
+		panic(err)
+	}
+	return d
+}
+
+func (r *rawTemplate) weakDecoder(
+	result interface{},
+	md *mapstructure.Metadata) *mapstructure.Decoder {
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+		Metadata:         md,
+		Result:           result,
 	})
 	if err != nil {
 		// This really shouldn't happen since we have firm control over

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -112,7 +112,7 @@ func TestParse(t *testing.T) {
 				Provisioners: []*Provisioner{
 					{
 						Type:       "something",
-						MaxRetries: 5,
+						MaxRetries: "5",
 					},
 				},
 			},

--- a/template/template.go
+++ b/template/template.go
@@ -141,7 +141,7 @@ type Provisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty"`
 	Override    map[string]interface{} `json:"override,omitempty"`
 	PauseBefore time.Duration          `mapstructure:"pause_before" json:"pause_before,omitempty"`
-	MaxRetries  int                    `mapstructure:"max_retries" json:"max_retries,omitempty"`
+	MaxRetries  string                 `mapstructure:"max_retries" json:"max_retries,omitempty"`
 	Timeout     time.Duration          `mapstructure:"timeout" json:"timeout,omitempty"`
 }
 

--- a/template/template.hcl2spec.go
+++ b/template/template.hcl2spec.go
@@ -15,7 +15,7 @@ type FlatProvisioner struct {
 	Config      map[string]interface{} `json:"config,omitempty" cty:"config" hcl:"config"`
 	Override    map[string]interface{} `json:"override,omitempty" cty:"override" hcl:"override"`
 	PauseBefore *string                `mapstructure:"pause_before" json:"pause_before,omitempty" cty:"pause_before" hcl:"pause_before"`
-	MaxRetries  *int                   `mapstructure:"max_retries" json:"max_retries,omitempty" cty:"max_retries" hcl:"max_retries"`
+	MaxRetries  *string                `mapstructure:"max_retries" json:"max_retries,omitempty" cty:"max_retries" hcl:"max_retries"`
 	Timeout     *string                `mapstructure:"timeout" json:"timeout,omitempty" cty:"timeout" hcl:"timeout"`
 }
 
@@ -37,7 +37,7 @@ func (*FlatProvisioner) HCL2Spec() map[string]hcldec.Spec {
 		"config":       &hcldec.AttrSpec{Name: "config", Type: cty.Map(cty.String), Required: false},
 		"override":     &hcldec.AttrSpec{Name: "override", Type: cty.Map(cty.String), Required: false},
 		"pause_before": &hcldec.AttrSpec{Name: "pause_before", Type: cty.String, Required: false},
-		"max_retries":  &hcldec.AttrSpec{Name: "max_retries", Type: cty.Number, Required: false},
+		"max_retries":  &hcldec.AttrSpec{Name: "max_retries", Type: cty.String, Required: false},
 		"timeout":      &hcldec.AttrSpec{Name: "timeout", Type: cty.String, Required: false},
 	}
 	return s


### PR DESCRIPTION
This is to allow variable interpolation in the `max_retries` option for JSON and HCL2. For backward compatibility, I've changed the provisioners decode to a weak decode. 


Closes https://github.com/hashicorp/packer/issues/9651