### PR TITLE
fix cty bool passing for provisioners, too

### DIFF
--- a/hcl2template/types.hcl_provisioner.go
+++ b/hcl2template/types.hcl_provisioner.go
@@ -39,6 +39,8 @@ func (p *HCL2Provisioner) HCL2Prepare(buildVars map[string]interface{}) error {
 				buildValues[k] = cty.NumberIntVal(v)
 			case uint64:
 				buildValues[k] = cty.NumberUIntVal(v)
+			case bool:
+				buildValues[k] = cty.BoolVal(v)
 			default:
 				return fmt.Errorf("unhandled buildvar type: %T", v)
 			}


### PR DESCRIPTION
fixes cty value handling for provisioners. 

repro case: 

```
source "amazon-ebs" "basic-example" {
  region =  "us-east-1"
  source_ami_filter {
    filters = {
       virtualization-type = "hvm"
       name = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
       root-device-type = "ebs"
    }
    owners = ["099720109477"]
    most_recent = true
  }
  instance_type =  "t2.small"
  ssh_username =  "ubuntu"
  ami_name =  "packer_AWS {{timestamp}}"
}

build {
  sources = [
    "source.amazon-ebs.basic-example"
  ]

  provisioner "shell-local"{
    inline = ["echo '${build.Host}'"]
    environment_vars = ["HELLO_USER=packeruser", "UUID=${build.Host}"]
    execute_command = ["/bin/sh", "-c", "echo '${build.Host}'", "{{.Vars}} {{.Script}}"]
  }

}
```

Formerly failed with "Build 'amazon-ebs.basic-example' errored: unhandled buildvar type: bool"
