### PR TITLE
builder/scaleway: Remove mapstructure configuration for the UserAgent runtime-only field

### DIFF
--- a/builder/scaleway/builder_test.go
+++ b/builder/scaleway/builder_test.go
@@ -41,6 +41,19 @@ func TestBuilder_Prepare_BadType(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatal("should not have errors")
+	}
+}
+
 func TestBuilderPrepare_InvalidKey(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -67,7 +67,7 @@ type Config struct {
 
 	RemoveVolume bool `mapstructure:"remove_volume"`
 
-	UserAgent string `mapstructure:"user_agent"`
+	UserAgent string `mapstructure-to-hcl2:",skip"`
 	ctx       interpolate.Context
 }
 

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -67,7 +67,7 @@ type Config struct {
 
 	RemoveVolume bool `mapstructure:"remove_volume"`
 
-	UserAgent string
+	UserAgent string `mapstructure:"user_agent"`
 	ctx       interpolate.Context
 }
 

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -74,7 +74,7 @@ type FlatConfig struct {
 	Bootscript                *string           `mapstructure:"bootscript" required:"false" cty:"bootscript" hcl:"bootscript"`
 	BootType                  *string           `mapstructure:"boottype" required:"false" cty:"boottype" hcl:"boottype"`
 	RemoveVolume              *bool             `mapstructure:"remove_volume" cty:"remove_volume" hcl:"remove_volume"`
-	UserAgent                 *string           `cty:"user_agent" hcl:"user_agent"`
+	UserAgent                 *string           `mapstructure:"user_agent" cty:"user_agent" hcl:"user_agent"`
 }
 
 // FlatMapstructure returns a new FlatConfig.

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -74,7 +74,6 @@ type FlatConfig struct {
 	Bootscript                *string           `mapstructure:"bootscript" required:"false" cty:"bootscript" hcl:"bootscript"`
 	BootType                  *string           `mapstructure:"boottype" required:"false" cty:"boottype" hcl:"boottype"`
 	RemoveVolume              *bool             `mapstructure:"remove_volume" cty:"remove_volume" hcl:"remove_volume"`
-	UserAgent                 *string           `mapstructure:"user_agent" cty:"user_agent" hcl:"user_agent"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -154,7 +153,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"bootscript":                   &hcldec.AttrSpec{Name: "bootscript", Type: cty.String, Required: false},
 		"boottype":                     &hcldec.AttrSpec{Name: "boottype", Type: cty.String, Required: false},
 		"remove_volume":                &hcldec.AttrSpec{Name: "remove_volume", Type: cty.Bool, Required: false},
-		"user_agent":                   &hcldec.AttrSpec{Name: "user_agent", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/website/pages/partials/builder/scaleway/Config-not-required.mdx
+++ b/website/pages/partials/builder/scaleway/Config-not-required.mdx
@@ -16,5 +16,3 @@
   bootscript, Default bootscript
 
 - `remove_volume` (bool) - Remove Volume
-
-- `user_agent` (string) - User Agent

--- a/website/pages/partials/builder/scaleway/Config-not-required.mdx
+++ b/website/pages/partials/builder/scaleway/Config-not-required.mdx
@@ -16,3 +16,5 @@
   bootscript, Default bootscript
 
 - `remove_volume` (bool) - Remove Volume
+
+- `user_agent` (string) - User Agent


### PR DESCRIPTION
Closes: #9676

Results before change
```
⇶  packer build /tmp/minimal.pkr.hcl
Error: 1 error occurred:
* unknown configuration key: '"user_agent"'

on /tmp/minimal.pkr.hcl line 1:
(source code not available)

==> Builds finished but no artifacts were created.
```

Results after change
```
⇶  packer build /tmp/minimal.pkr.hcl
scaleway.required: output will be in this color.

==> scaleway.required: Creating temporary ssh key for server...
==> scaleway.required: Creating server...
```