### PR TITLE
Fix cty bool passing for post-processors

### DIFF
--- a/hcl2template/types.hcl_post-processor.go
+++ b/hcl2template/types.hcl_post-processor.go
@@ -39,6 +39,8 @@ func (p *HCL2PostProcessor) HCL2Prepare(buildVars map[string]interface{}) error 
 				buildValues[k] = cty.NumberIntVal(v)
 			case uint64:
 				buildValues[k] = cty.NumberUIntVal(v)
+			case bool:
+				buildValues[k] = cty.BoolVal(v)
 			default:
 				return fmt.Errorf("unhandled buildvar type: %T", v)
 			}


### PR DESCRIPTION
I was testing master with our build to have #9477 but then our build started failing before starting the post-processors, with `unhandled buildvar type: bool`.

Then saw https://github.com/hashicorp/packer/pull/9675 so just copied it for postprocessors and it fixed the issue.

Didn't get a full repro case stripped from our build (let me know if you need it and I can try to come up with one) but we only have those two post-processors so it seems it's either of them (or both):

```
  post-processor "googlecompute-export" {
    paths = [
      "gs://BUCKET/${var.image_name}-{{timestamp}}"
    ]
    keep_input_artifact = true
  }
  post-processor "manifest" {
    output     = "manifest.json"
    strip_path = true
  }

```