### PR TITLE
alt, ctrl, and shift should be outside variables

### DIFF
--- a/builder/vsphere/common/step_boot_command.go
+++ b/builder/vsphere/common/step_boot_command.go
@@ -76,9 +76,8 @@ func (s *StepBootCommand) Run(ctx context.Context, state multistep.StateBag) mul
 		ui.Say(fmt.Sprintf("HTTP server is working at http://%v:%v/", ip, port))
 	}
 
+	var keyAlt, keyCtrl, keyShift bool
 	sendCodes := func(code key.Code, down bool) error {
-		var keyAlt, keyCtrl, keyShift bool
-
 		switch code {
 		case key.CodeLeftAlt:
 			keyAlt = down

--- a/builder/vsphere/common/step_boot_command.go
+++ b/builder/vsphere/common/step_boot_command.go
@@ -83,7 +83,7 @@ func (s *StepBootCommand) Run(ctx context.Context, state multistep.StateBag) mul
 			keyAlt = down
 		case key.CodeLeftControl:
 			keyCtrl = down
-		default:
+		case key.CodeLeftShift:
 			keyShift = down
 		}
 


### PR DESCRIPTION
This should enable the alt, ctrl, and shift modifiers.

Closes #9701
