### PR TITLE
Add `directory_permission` config option to `vsphere` builder

### DIFF
--- a/builder/vsphere/common/output_config.go
+++ b/builder/vsphere/common/output_config.go
@@ -21,11 +21,21 @@ type OutputConfig struct {
 	// created, must be empty prior to running the builder. By default this is
 	// "output-BUILDNAME" where "BUILDNAME" is the name of the build.
 	OutputDir string `mapstructure:"output_directory" required:"false"`
+	// The permission of the directories newly created to store artifacts,
+	// possibly including the directory speified by "output_directory" and its
+	// ancestor directories. By default this is "0750". You should express the
+	// permission as quoted string with a leading zero such as "0755" in JSON
+	// file, because JSON does not support octal value. In Unix-like OS, the
+	// actual permission may differ from this value because of umask.
+	DirPerm os.FileMode `mapstructure:"directory_permission" required:"false"`
 }
 
 func (c *OutputConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig) []error {
 	if c.OutputDir == "" {
 		c.OutputDir = fmt.Sprintf("output-%s", pc.PackerBuildName)
+	}
+	if c.DirPerm == 0 {
+		c.DirPerm = 0750
 	}
 
 	return nil

--- a/builder/vsphere/common/output_config.go
+++ b/builder/vsphere/common/output_config.go
@@ -21,12 +21,12 @@ type OutputConfig struct {
 	// created, must be empty prior to running the builder. By default this is
 	// "output-BUILDNAME" where "BUILDNAME" is the name of the build.
 	OutputDir string `mapstructure:"output_directory" required:"false"`
-	// The permission of the directories newly created to store artifacts,
-	// possibly including the directory speified by "output_directory" and its
-	// ancestor directories. By default this is "0750". You should express the
-	// permission as quoted string with a leading zero such as "0755" in JSON
-	// file, because JSON does not support octal value. In Unix-like OS, the
-	// actual permission may differ from this value because of umask.
+	// The permissions to apply to the "output_directory", and to any parent
+	// directories that get created for output_directory.  By default this is
+	// "0750". You should express the permission as quoted string with a
+	// leading zero such as "0755" in JSON file, because JSON does not support
+	// octal value. In Unix-like OS, the actual permission may differ from
+	// this value because of umask.
 	DirPerm os.FileMode `mapstructure:"directory_permission" required:"false"`
 }
 

--- a/builder/vsphere/common/output_config.hcl2spec.go
+++ b/builder/vsphere/common/output_config.hcl2spec.go
@@ -2,6 +2,8 @@
 package common
 
 import (
+	"os"
+
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -9,7 +11,8 @@ import (
 // FlatOutputConfig is an auto-generated flat version of OutputConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatOutputConfig struct {
-	OutputDir *string `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
+	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
+	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 }
 
 // FlatMapstructure returns a new FlatOutputConfig.
@@ -24,7 +27,8 @@ func (*OutputConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.
 // The decoded values from this spec will then be applied to a FlatOutputConfig.
 func (*FlatOutputConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"output_directory": &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
+		"output_directory":     &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
+		"directory_permission": &hcldec.AttrSpec{Name: "directory_permission", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_export.go
+++ b/builder/vsphere/common/step_export.go
@@ -105,7 +105,7 @@ func (c *ExportConfig) Prepare(ctx *interpolate.Context, lc *LocationConfig, pc 
 		}
 	}
 
-	if err := os.MkdirAll(c.OutputDir.OutputDir, 0750); err != nil {
+	if err := os.MkdirAll(c.OutputDir.OutputDir, c.OutputDir.DirPerm); err != nil {
 		errs = packer.MultiErrorAppend(errs, errors.Wrap(err, "unable to make directory for export"))
 	}
 

--- a/builder/vsphere/common/step_export.hcl2spec.go
+++ b/builder/vsphere/common/step_export.hcl2spec.go
@@ -2,6 +2,8 @@
 package common
 
 import (
+	"os"
+
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -9,12 +11,13 @@ import (
 // FlatExportConfig is an auto-generated flat version of ExportConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatExportConfig struct {
-	Name      *string  `mapstructure:"name" cty:"name" hcl:"name"`
-	Force     *bool    `mapstructure:"force" cty:"force" hcl:"force"`
-	Images    *bool    `mapstructure:"images" cty:"images" hcl:"images"`
-	Manifest  *string  `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
-	OutputDir *string  `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	Options   []string `mapstructure:"options" cty:"options" hcl:"options"`
+	Name      *string      `mapstructure:"name" cty:"name" hcl:"name"`
+	Force     *bool        `mapstructure:"force" cty:"force" hcl:"force"`
+	Images    *bool        `mapstructure:"images" cty:"images" hcl:"images"`
+	Manifest  *string      `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
+	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
+	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	Options   []string     `mapstructure:"options" cty:"options" hcl:"options"`
 }
 
 // FlatMapstructure returns a new FlatExportConfig.
@@ -29,12 +32,13 @@ func (*ExportConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.
 // The decoded values from this spec will then be applied to a FlatExportConfig.
 func (*FlatExportConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"name":             &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
-		"force":            &hcldec.AttrSpec{Name: "force", Type: cty.Bool, Required: false},
-		"images":           &hcldec.AttrSpec{Name: "images", Type: cty.Bool, Required: false},
-		"manifest":         &hcldec.AttrSpec{Name: "manifest", Type: cty.String, Required: false},
-		"output_directory": &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
-		"options":          &hcldec.AttrSpec{Name: "options", Type: cty.List(cty.String), Required: false},
+		"name":                 &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
+		"force":                &hcldec.AttrSpec{Name: "force", Type: cty.Bool, Required: false},
+		"images":               &hcldec.AttrSpec{Name: "images", Type: cty.Bool, Required: false},
+		"manifest":             &hcldec.AttrSpec{Name: "manifest", Type: cty.String, Required: false},
+		"output_directory":     &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
+		"directory_permission": &hcldec.AttrSpec{Name: "directory_permission", Type: cty.Number, Required: false},
+		"options":              &hcldec.AttrSpec{Name: "options", Type: cty.List(cty.String), Required: false},
 	}
 	return s
 }

--- a/website/pages/partials/builder/vsphere/common/OutputConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/OutputConfig-not-required.mdx
@@ -7,3 +7,10 @@
   packer is executed from. This directory must not exist or, if
   created, must be empty prior to running the builder. By default this is
   "output-BUILDNAME" where "BUILDNAME" is the name of the build.
+
+- `directory_permission` (os.FileMode) - The permission of the directories newly created to store artifacts,
+  possibly including the directory speified by "output_directory" and its
+  ancestor directories. By default this is "0750". You should express the
+  permission as quoted string with a leading zero such as "0755" in JSON
+  file, because JSON does not support octal value. In Unix-like OS, the
+  actual permission may differ from this value because of umask.

--- a/website/pages/partials/builder/vsphere/common/OutputConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/OutputConfig-not-required.mdx
@@ -8,9 +8,9 @@
   created, must be empty prior to running the builder. By default this is
   "output-BUILDNAME" where "BUILDNAME" is the name of the build.
 
-- `directory_permission` (os.FileMode) - The permission of the directories newly created to store artifacts,
-  possibly including the directory speified by "output_directory" and its
-  ancestor directories. By default this is "0750". You should express the
-  permission as quoted string with a leading zero such as "0755" in JSON
-  file, because JSON does not support octal value. In Unix-like OS, the
-  actual permission may differ from this value because of umask.
+- `directory_permission` (os.FileMode) - The permissions to apply to the "output_directory", and to any parent
+  directories that get created for output_directory.  By default this is
+  "0750". You should express the permission as quoted string with a
+  leading zero such as "0755" in JSON file, because JSON does not support
+  octal value. In Unix-like OS, the actual permission may differ from
+  this value because of umask.


### PR DESCRIPTION
`directory_permission` is added to `export` config of `vsphere` builder.

Currently, permission of directories created to store artifacts are "0750".
This PR allows users to specify the permission of the created directories.

### Example

1. In Unix-like OS, `umask 000` to avoid the effect of umask
2. Run `packer build` with a config file like the following
   ```json
   { 
     "builders": [  
       {  
         "type": "vsphere-clone", 
         "vcenter_server": "vcenter.example.org", 
         "username": "******", 
         "password": "******", 
         "insecure_connection": "true", 
         "template": "test", 
         "vm_name": "packer-test-{{timestamp}}", 
         "host": "esxi-001.example.org", 
         "communicator": "none", 
         "export": {  
           "output_directory": "./output/{{timestamp}}", 
           "directory_permission": "0775" 
         }                                                                                                                               
       }  
     ]  
   } 
   ```
3. Make sure the permission is set as intended
    ```
    $ ls -lgod --time-style=iso output output/* output/*/*
    drwxrwxr-x 3      4096 08-02 15:13 output
    drwxrwxr-x 2      4096 08-02 15:13 output/1596348799
    -rw-rw-rw- 1 242085888 08-02 15:13 output/1596348799/packer-test-1596348799-disk-0.vmdk
    -rw-rw-rw- 1       210 08-02 15:13 output/1596348799/packer-test-1596348799.mf
    -rw-rw-rw- 1      8840 08-02 15:13 output/1596348799/packer-test-1596348799.ovf
    ```

### Note

* JSON does not support octal numbers. Instead, permission specified in JSON file should be string type and have a leading zero, because when [`WeaklyTypedInput` is enabled](https://github.com/hashicorp/packer/blob/a28edbaa0b93d761d09638a7e8e04dbb81c54950/helper/config/decode.go#L135) `mapstructure` automatically converts types with prefix for octal number considered.