### PR TITLE
change default target to just make the dev binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export GOLDFLAGS
 .PHONY: bin checkversion ci ci-lint default install-build-deps install-gen-deps fmt fmt-docs fmt-examples generate install-lint-deps lint \
 	releasebin test testacc testrace
 
-default: install-build-deps install-gen-deps generate testrace dev releasebin package dev fmt fmt-check mode-check fmt-docs fmt-examples
+default: install-build-deps install-gen-deps generate bin
 
 ci: testrace ## Test in continuous integration
 


### PR DESCRIPTION
The default target does way more than it needs to, and some of the things it does are mutually incompatible. 

This changes the default target to just install deps and then generate and `make bin`, which will make it work for building if someone is pulling down a release tag of the Packer repo. 

Fixes #9690