### PR TITLE
update docs for command and make sure they get generated properly so …

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -45,7 +45,10 @@ type Config struct {
 	//  `ansible-playbook`. If you would like to provide a more complex command,
 	//  for example, something that sets up a virtual environment before calling
 	//  ansible, take a look at the ansible wrapper guide below for inspiration.
-	Command string
+	//  Please note that Packer expects Command to be a path to an executable.
+	//  Arbitrary bash scripting will not work and needs to go inside an
+	//  executable script.
+	Command string `mapstructure:"command"`
 	// Extra arguments to pass to Ansible.
 	// These arguments _will not_ be passed through a shell and arguments should
 	// not be quoted. Usage example:

--- a/provisioner/ansible/provisioner.hcl2spec.go
+++ b/provisioner/ansible/provisioner.hcl2spec.go
@@ -16,7 +16,7 @@ type FlatConfig struct {
 	PackerOnError         *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars        map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars   []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	Command               *string           `cty:"command" hcl:"command"`
+	Command               *string           `mapstructure:"command" cty:"command" hcl:"command"`
 	ExtraArguments        []string          `mapstructure:"extra_arguments" cty:"extra_arguments" hcl:"extra_arguments"`
 	AnsibleEnvVars        []string          `mapstructure:"ansible_env_vars" cty:"ansible_env_vars" hcl:"ansible_env_vars"`
 	PlaybookFile          *string           `mapstructure:"playbook_file" required:"true" cty:"playbook_file" hcl:"playbook_file"`

--- a/website/pages/partials/provisioner/ansible/Config-not-required.mdx
+++ b/website/pages/partials/provisioner/ansible/Config-not-required.mdx
@@ -1,5 +1,13 @@
 <!-- Code generated from the comments of the Config struct in provisioner/ansible/provisioner.go; DO NOT EDIT MANUALLY -->
 
+- `command` (string) - The command to invoke ansible. Defaults to
+   `ansible-playbook`. If you would like to provide a more complex command,
+   for example, something that sets up a virtual environment before calling
+   ansible, take a look at the ansible wrapper guide below for inspiration.
+   Please note that Packer expects Command to be a path to an executable.
+   Arbitrary bash scripting will not work and needs to go inside an
+   executable script.
+
 - `extra_arguments` ([]string) - Extra arguments to pass to Ansible.
   These arguments _will not_ be passed through a shell and arguments should
   not be quoted. Usage example:


### PR DESCRIPTION
Ansible docs update to make sure the `command` string appears in the docs and that users know they can't use it the same way as one would call "execute_command" in a shell-style provisioner

Closes #9471