### PR TITLE
Fix configuration_parameters

### DIFF
--- a/builder/vsphere/common/step_config_params.go
+++ b/builder/vsphere/common/step_config_params.go
@@ -51,12 +51,12 @@ func (s *StepConfigParams) Run(_ context.Context, state multistep.StateBag) mult
 		if s.Config.ToolsUpgradePolicy {
 			info.ToolsUpgradePolicy = "UpgradeAtPowerCycle"
 		}
+	}
 
-		ui.Say("Adding configuration parameters...")
-		if err := vm.AddConfigParams(configParams, info); err != nil {
-			state.Put("error", fmt.Errorf("error adding configuration parameters: %v", err))
-			return multistep.ActionHalt
-		}
+	ui.Say("Adding configuration parameters...")
+	if err := vm.AddConfigParams(configParams, info); err != nil {
+		state.Put("error", fmt.Errorf("error adding configuration parameters: %v", err))
+		return multistep.ActionHalt
 	}
 
 	return multistep.ActionContinue


### PR DESCRIPTION
This moves the configuration of the `configuration_parameters` option outside an if statement that was avoiding this to be called.

Closes https://github.com/hashicorp/packer/issues/9684