### PR TITLE
add network_name option to vmware builder to make it match the networ…

### DIFF
--- a/builder/vmware/common/hw_config.go
+++ b/builder/vmware/common/hw_config.go
@@ -31,6 +31,8 @@ type HWConfig struct {
 	// machine](https://kb.vmware.com/s/article/1001805) for desktop VMware
 	// clients. For ESXi, refer to the proper ESXi documentation.
 	NetworkAdapterType string `mapstructure:"network_adapter_type" required:"false"`
+	// The custom name of the network. Sets the vmx value "ethernet0.networkName"
+	NetworkName string `mapstructure:"network_name" required:"false"`
 	// Specify whether to enable VMware's virtual soundcard device when
 	// building the VM. Defaults to false.
 	Sound bool `mapstructure:"sound" required:"false"`

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -50,6 +50,7 @@ type FlatConfig struct {
 	CoreCount                 *int              `mapstructure:"cores" required:"false" cty:"cores" hcl:"cores"`
 	Network                   *string           `mapstructure:"network" required:"false" cty:"network" hcl:"network"`
 	NetworkAdapterType        *string           `mapstructure:"network_adapter_type" required:"false" cty:"network_adapter_type" hcl:"network_adapter_type"`
+	NetworkName               *string           `mapstructure:"network_name" required:"false" cty:"network_name" hcl:"network_name"`
 	Sound                     *bool             `mapstructure:"sound" required:"false" cty:"sound" hcl:"sound"`
 	USB                       *bool             `mapstructure:"usb" required:"false" cty:"usb" hcl:"usb"`
 	Serial                    *string           `mapstructure:"serial" required:"false" cty:"serial" hcl:"serial"`
@@ -187,6 +188,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cores":                          &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
 		"network":                        &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
 		"network_adapter_type":           &hcldec.AttrSpec{Name: "network_adapter_type", Type: cty.String, Required: false},
+		"network_name":                   &hcldec.AttrSpec{Name: "network_name", Type: cty.String, Required: false},
 		"sound":                          &hcldec.AttrSpec{Name: "sound", Type: cty.Bool, Required: false},
 		"usb":                            &hcldec.AttrSpec{Name: "usb", Type: cty.Bool, Required: false},
 		"serial":                         &hcldec.AttrSpec{Name: "serial", Type: cty.String, Required: false},

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -38,6 +38,7 @@ type vmxTemplateData struct {
 	Network_Type    string
 	Network_Device  string
 	Network_Adapter string
+	Network_Name    string
 
 	Sound_Present string
 	Usb_Present   string
@@ -252,6 +253,9 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 
 	/// Check the network type that the user specified
 	network := config.HWConfig.Network
+	if config.HWConfig.NetworkName != "" {
+		templateData.Network_Name = config.HWConfig.NetworkName
+	}
 	driver := state.Get("driver").(vmwcommon.Driver).GetVmwareDriver()
 
 	// check to see if the driver implements a network mapper for mapping
@@ -542,6 +546,7 @@ ethernet0.pciSlotNumber = "33"
 ethernet0.present = "TRUE"
 ethernet0.virtualDev = "{{ .Network_Adapter }}"
 ethernet0.wakeOnPcktRcv = "FALSE"
+{{if .Network_Name }}ethernet0.networkName = "{{ .Network_Name }}"{{end}}
 
 // Hard disks
 scsi0.present = "{{ .SCSI_Present }}"

--- a/website/pages/partials/builder/vmware/common/HWConfig-not-required.mdx
+++ b/website/pages/partials/builder/vmware/common/HWConfig-not-required.mdx
@@ -19,6 +19,8 @@
   machine](https://kb.vmware.com/s/article/1001805) for desktop VMware
   clients. For ESXi, refer to the proper ESXi documentation.
 
+- `network_name` (string) - The custom name of the network. Sets the vmx value "ethernet0.networkName"
+
 - `sound` (bool) - Specify whether to enable VMware's virtual soundcard device when
   building the VM. Defaults to false.
 


### PR DESCRIPTION
This adds the network_name option to the vmware builder so that users can set a network without using vmx data 

Closes #9150
