### PR TITLE
Bug: "file" provisioner only uses first entry from Sources if processing directories

### DIFF
--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -196,15 +196,16 @@ func (p *Provisioner) ProvisionUpload(ui packer.Ui, comm packer.Communicator) er
 			return err
 		}
 
+		filedst := dst
 		if strings.HasSuffix(dst, "/") {
-			dst = dst + filepath.Base(src)
+			filedst = dst + filepath.Base(src)
 		}
 
 		pf := ui.TrackProgress(filepath.Base(src), 0, info.Size(), f)
 		defer pf.Close()
 
 		// Upload the file
-		if err = comm.Upload(dst, pf, &fi); err != nil {
+		if err = comm.Upload(filedst, pf, &fi); err != nil {
 			if strings.Contains(err.Error(), "Error restoring file") {
 				ui.Error(fmt.Sprintf("Upload failed: %s; this can occur when "+
 					"your file destination is a folder without a trailing "+

--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -177,7 +177,11 @@ func (p *Provisioner) ProvisionUpload(ui packer.Ui, comm packer.Communicator) er
 
 		// If we're uploading a directory, short circuit and do that
 		if info.IsDir() {
-			return comm.UploadDir(dst, src, nil)
+			if err = comm.UploadDir(dst, src, nil); err != nil {
+				ui.Error(fmt.Sprintf("Upload failed: %s", err))
+				return err
+			}
+			continue
 		}
 
 		// We're uploading a file...

--- a/provisioner/file/provisioner_test.go
+++ b/provisioner/file/provisioner_test.go
@@ -172,7 +172,7 @@ func TestProvisionerProvision_SendsFileMultipleFiles(t *testing.T) {
 	}
 
 	config := map[string]interface{}{
-		"sources":      []string{tf1.Name(), tf2.Name()},
+		"sources":     []string{tf1.Name(), tf2.Name()},
 		"destination": "something",
 	}
 
@@ -241,7 +241,7 @@ func TestProvisionerProvision_SendsFileMultipleDirs(t *testing.T) {
 	// Run Provision
 
 	config := map[string]interface{}{
-		"sources":      []string{td1, td2},
+		"sources":     []string{td1, td2},
 		"destination": "something",
 	}
 


### PR DESCRIPTION
### Related bug https://github.com/hashicorp/packer/issues/4917
File provisioner supports `sources` property to copy a few entries. It works perfect for files but works incorrectly for directories. Provisioner stops copying after the first directory due to incorrect statement.

**Repro steps:**
```
{
  "type": "file",
  "sources": [
    "SetupDocker",
    "SetupComponentHost"
  ],
  "destination": "C:/Setup"
}
```

[return](https://github.com/hashicorp/packer/blob/v1.6.1/provisioner/file/provisioner.go#L181) statement finishes function execution on the first folder in the list. Correct behavior is just finishing the current iteration of loop and proceed with next one.
Fixing of this bug will allow to reduce and simplify templates significantly.

### Changes
- Replace `return` with `continue` and add error handling.
- Add tests to validate copying of multiple files and multiple directories (multiple directories test failed without my changes)

P.S. It is my first experience with Go, please let me know if something is incorrect with syntax / code.

### Update
Also fixed one more bug with overriding destination path when copying multiple files to folder:
```
{
  "type": "file",
  "sources": [
    "file_1.txt",
    "file_2.txt",
  ],
  "destination": "/something/"
}
```
![image](https://user-images.githubusercontent.com/16715858/89617133-528cb780-d892-11ea-8f81-6290f71058e5.png)
