### PR TITLE
fix generator to work even in nested packer/packer dirs

### DIFF
--- a/cmd/generate-fixer-deprecations/main.go
+++ b/cmd/generate-fixer-deprecations/main.go
@@ -40,7 +40,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	paths := strings.SplitAfter(absFilePath, "packer"+string(os.PathSeparator))
+	paths := strings.Split(absFilePath, "cmd"+string(os.PathSeparator)+
+		"generate-fixer-deprecations"+string(os.PathSeparator)+"main.go")
 	packerDir := paths[0]
 
 	// Load all deprecated options from all active fixers


### PR DESCRIPTION
Make directory search for Packer root smarter so it doesn't break when there are multiple dirs named packer. 
Closes #9722