### PR TITLE
document issue with ansible macros

### DIFF
--- a/website/pages/docs/provisioners/ansible.mdx
+++ b/website/pages/docs/provisioners/ansible.mdx
@@ -20,6 +20,11 @@ machine being provisioned by Packer.
 will always connect with the user given in the json config for this
 provisioner.
 
+-> **Note:** Options below that use the Packer template engine won't be able to
+accept jinja2 `{{ function }}` macro syntax in a way that can be preserved to
+the Ansible run. If you need to set variables using Ansible macros, you need to
+do so inside your playbooks or inventory files.
+
 ## Basic Example
 
 This is a fully functional template that will provision an image on


### PR DESCRIPTION
Document the behavior discussed in #9125 to hopefully prevent users from wasting their time trying to figure out how to escape macros. This limitation is due to the way the packer templating engine works and probably isn't something we can work around without causing further issues. 

Closes #9125