### PR TITLE
post-processor/googlecompute-export: Remove IAP configuration from HCL schema

### DIFF
--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -23,7 +23,7 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	AccountFile string `mapstructure:"account_file"`
-	IAP         bool   `mapstructure:"iap"`
+	IAP         bool   `mapstructure-to-hcl2:",skip"`
 
 	DiskSizeGb          int64    `mapstructure:"disk_size"`
 	DiskType            string   `mapstructure:"disk_type"`
@@ -34,9 +34,8 @@ type Config struct {
 	VaultGCPOauthEngine string   `mapstructure:"vault_gcp_oauth_engine"`
 	Zone                string   `mapstructure:"zone"`
 	ServiceAccountEmail string   `mapstructure:"service_account_email"`
-
-	account *jwt.Config
-	ctx     interpolate.Context
+	account             *jwt.Config
+	ctx                 interpolate.Context
 }
 
 type PostProcessor struct {

--- a/post-processor/googlecompute-export/post-processor.hcl2spec.go
+++ b/post-processor/googlecompute-export/post-processor.hcl2spec.go
@@ -17,7 +17,6 @@ type FlatConfig struct {
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
 	AccountFile         *string           `mapstructure:"account_file" cty:"account_file" hcl:"account_file"`
-	IAP                 *bool             `mapstructure:"iap" cty:"iap" hcl:"iap"`
 	DiskSizeGb          *int64            `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	DiskType            *string           `mapstructure:"disk_type" cty:"disk_type" hcl:"disk_type"`
 	MachineType         *string           `mapstructure:"machine_type" cty:"machine_type" hcl:"machine_type"`
@@ -49,7 +48,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"account_file":               &hcldec.AttrSpec{Name: "account_file", Type: cty.String, Required: false},
-		"iap":                        &hcldec.AttrSpec{Name: "iap", Type: cty.Bool, Required: false},
 		"disk_size":                  &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"disk_type":                  &hcldec.AttrSpec{Name: "disk_type", Type: cty.String, Required: false},
 		"machine_type":               &hcldec.AttrSpec{Name: "machine_type", Type: cty.String, Required: false},


### PR DESCRIPTION
Build results before change
```
[go-1.14.2] [2] wilken@automaton in
~/Development/packer-templates/googlecompute/googlecompute-startup-scripts/
on master
⇶  packer build -var project=$GOOGLE_PROJECT_ID
googlecompute-ubuntu-startup-script-export.pkr.hcl
Error: Failed preparing post-processor-block "googlecompute-export" ""

  on googlecompute-ubuntu-startup-script-export.pkr.hcl line 28:
    (source code not available)

    1 error occurred:
            * unknown configuration key: '"iap"'

==> Builds finished but no artifacts were created.
```

Build results after change
```
⇶  packer build -var project=$GOOGLE_PROJECT_ID
googlecompute-ubuntu-startup-script-export.pkr.hcl
googlecompute.example: output will be in this color.

==> googlecompute.example: Checking image does not exist...
==> googlecompute.example: Creating temporary SSH key for instance...
```


**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer PR:

https://github.com/hashicorp/packer/blob/master/.github/CONTRIBUTING.md#opening-an-pull-request

Describe the change you are making here!

Please include tests. Check out these examples:

- https://github.com/hashicorp/packer/blob/master/builder/virtualbox/common/ssh_config_test.go#L19-L37
- https://github.com/hashicorp/packer/blob/master/post-processor/compress/post-processor_test.go#L153-L182

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx