### PR TITLE
Fix ReregisterVM to default to true instead of false. 

### DIFF
--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -33,16 +33,16 @@ var builtins = map[string]string{
 
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
-	Host                string `mapstructure:"host"`
-	Insecure            bool   `mapstructure:"insecure"`
-	Username            string `mapstructure:"username"`
-	Password            string `mapstructure:"password"`
-	Datacenter          string `mapstructure:"datacenter"`
-	Folder              string `mapstructure:"folder"`
-	SnapshotEnable      bool   `mapstructure:"snapshot_enable"`
-	SnapshotName        string `mapstructure:"snapshot_name"`
-	SnapshotDescription string `mapstructure:"snapshot_description"`
-	ReregisterVM        bool   `mapstructure:"reregister_vm" default:"true"`
+	Host                string         `mapstructure:"host"`
+	Insecure            bool           `mapstructure:"insecure"`
+	Username            string         `mapstructure:"username"`
+	Password            string         `mapstructure:"password"`
+	Datacenter          string         `mapstructure:"datacenter"`
+	Folder              string         `mapstructure:"folder"`
+	SnapshotEnable      bool           `mapstructure:"snapshot_enable"`
+	SnapshotName        string         `mapstructure:"snapshot_name"`
+	SnapshotDescription string         `mapstructure:"snapshot_description"`
+	ReregisterVM        config.Trilean `mapstructure:"reregister_vm"`
 
 	ctx interpolate.Context
 }

--- a/post-processor/vsphere-template/post-processor.hcl2spec.go
+++ b/post-processor/vsphere-template/post-processor.hcl2spec.go
@@ -25,7 +25,7 @@ type FlatConfig struct {
 	SnapshotEnable      *bool             `mapstructure:"snapshot_enable" cty:"snapshot_enable" hcl:"snapshot_enable"`
 	SnapshotName        *string           `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
 	SnapshotDescription *string           `mapstructure:"snapshot_description" cty:"snapshot_description" hcl:"snapshot_description"`
-	ReregisterVM        *bool             `mapstructure:"reregister_vm" default:"true" cty:"reregister_vm" hcl:"reregister_vm"`
+	ReregisterVM        *bool             `mapstructure:"reregister_vm" cty:"reregister_vm" hcl:"reregister_vm"`
 }
 
 // FlatMapstructure returns a new FlatConfig.

--- a/post-processor/vsphere-template/post-processor_test.go
+++ b/post-processor/vsphere-template/post-processor_test.go
@@ -1,0 +1,39 @@
+package vsphere_template
+
+import (
+	"testing"
+)
+
+func getTestConfig() Config {
+	return Config{
+		Username: "me",
+		Password: "notpassword",
+		Host:     "myhost",
+	}
+}
+
+func TestConfigure_Good(t *testing.T) {
+	var p PostProcessor
+
+	config := getTestConfig()
+
+	err := p.Configure(config)
+	if err != nil {
+		t.Errorf("Error: %s", err)
+	}
+}
+
+func TestConfigure_ReRegisterVM(t *testing.T) {
+	var p PostProcessor
+
+	config := getTestConfig()
+
+	err := p.Configure(config)
+	if err != nil {
+		t.Errorf("Error: %s", err)
+	}
+
+	if p.config.ReregisterVM.False() {
+		t.Errorf("This should default to unset, not false.")
+	}
+}

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/post-processor/vsphere"
@@ -18,7 +19,7 @@ import (
 type stepMarkAsTemplate struct {
 	VMName       string
 	RemoteFolder string
-	ReregisterVM bool
+	ReregisterVM config.Trilean
 }
 
 func NewStepMarkAsTemplate(artifact packer.Artifact, p *PostProcessor) *stepMarkAsTemplate {
@@ -52,7 +53,7 @@ func (s *stepMarkAsTemplate) Run(ctx context.Context, state multistep.StateBag) 
 	}
 
 	// Use a simple "MarkAsTemplate" method unless `reregister_vm` is true
-	if !s.ReregisterVM {
+	if s.ReregisterVM.False() {
 		ui.Message("Marking as a template...")
 
 		if err := vm.MarkAsTemplate(context.Background()); err != nil {


### PR DESCRIPTION
I think this will fix 9719 and even if it doesn't this produces the originally intended behavior for #8511.  The defaulting on this was messed up so it made a backwards-incompatible change. This changes the template to know the difference between "false" and "unset" so we can be certain the user wants "reregister = false"

closes #9719
