### PR TITLE
add microsoft daemon docs to hyperv docs

### DIFF
--- a/website/pages/docs/builders/hyperv/iso.mdx
+++ b/website/pages/docs/builders/hyperv/iso.mdx
@@ -849,3 +849,7 @@ Also note that while the operating system is still being installed by a preseed
 file, it is normal to see `Waiting for SSH/WinRM to be available` and
 `Error getting SSH/WinRM host: No ip address` error messages until the system
 is actually installed and ready to be connected to.
+
+For more information about the hyper-v daemons and supported distributions, see
+the Microsoft docs at
+https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/supported-linux-and-freebsd-virtual-machines-for-hyper-v-on-windows


### PR DESCRIPTION
Document that hyperv needs daemons installed to get the IP address of the guest. 

Closes #5049 
