### PR TITLE
Add community supported post-processors

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -278,6 +278,7 @@ export default [
       'vsphere-template',
       'yandex-export',
       'yandex-import',
+      'community-supported',
     ],
   },
   '----------',

--- a/website/pages/community-tools/index.mdx
+++ b/website/pages/community-tools/index.mdx
@@ -30,6 +30,8 @@ contribution here!
 
 @include "provisioners/community_provisioners.mdx"
 
+@include "post-processors/community_post-processors.mdx"
+
 ## Templates
 
 - [bento](https://github.com/chef/bento) - Packer templates for building minimal

--- a/website/pages/docs/post-processors/community-supported.mdx
+++ b/website/pages/docs/post-processors/community-supported.mdx
@@ -1,0 +1,16 @@
+---
+description: |
+  Community-maintained post-processors are not part of the core Packer binary, but
+  can run alongside Packer with minimal extra effort.
+layout: docs
+page_title: Community - Post-Processors
+sidebar_title: Community-Supported
+---
+
+# Community Post-Processors
+
+The following post-processors are developed and maintained by various members of the
+Packer community, not by HashiCorp. For more information on how to use community
+post-processors, see our docs on [extending Packer](/docs/extending).
+
+@include 'post-processors/community_post-processors.mdx'

--- a/website/pages/partials/post-processors/community_post-processors.mdx
+++ b/website/pages/partials/post-processors/community_post-processors.mdx
@@ -1,0 +1,4 @@
+### Community Post-Processors
+
+- [Exoscale Import](https://github.com/exoscale/packer-post-processor-exoscale-import) -
+  Import a builder artifact as a new Exoscale Compute instance template.


### PR DESCRIPTION
Adding the community-supported post-processors page as a follow up to https://github.com/hashicorp/packer/pull/9733