### PR TITLE
Fix vsphere boot command and check for context cancelation when waiting for ip

### DIFF
--- a/builder/vsphere/common/step_boot_command.go
+++ b/builder/vsphere/common/step_boot_command.go
@@ -87,11 +87,16 @@ func (s *StepBootCommand) Run(ctx context.Context, state multistep.StateBag) mul
 			keyShift = down
 		}
 
+		shift := down
+		if keyShift {
+			shift = keyShift
+		}
+
 		_, err := vm.TypeOnKeyboard(driver.KeyInput{
 			Scancode: code,
 			Ctrl:     keyCtrl,
 			Alt:      keyAlt,
-			Shift:    keyShift,
+			Shift:    shift,
 		})
 		if err != nil {
 			return fmt.Errorf("error typing a boot command (code, down) `%d, %t`: %w", code, down, err)

--- a/builder/vsphere/common/step_wait_for_ip.go
+++ b/builder/vsphere/common/step_wait_for_ip.go
@@ -140,6 +140,14 @@ loop:
 	if err != nil {
 		return "", err
 	}
+
+	// Check for ctx cancellation to avoid printing any IP logs at the timeout
+	select {
+	case <-ctx.Done():
+		return "", fmt.Errorf("IP wait cancelled")
+	default:
+	}
+
 	if prevIp == "" || prevIp != ip {
 		if prevIp == "" {
 			log.Printf("VM IP aquired: %s", ip)


### PR DESCRIPTION
This is fixing a regression from https://github.com/hashicorp/packer/pull/9702. At that time I didn't notice the bug it was introducing. This is a regression that is not released yet. 

This also adds a context check to avoid logs confusion like https://github.com/hashicorp/packer/issues/9694 where the IP is being printed after the timeout is reached. 