### PR TITLE
Document 9294

### DIFF
--- a/website/pages/guides/packer-on-cicd/build-image-in-cicd.mdx
+++ b/website/pages/guides/packer-on-cicd/build-image-in-cicd.mdx
@@ -19,7 +19,7 @@ a container or VM, a common model used by most CI/CD services. However, the
 [Xen](https://www.xenproject.org/) virtual machine images, [VirtualBox
 builder](/docs/builders/virtualbox) for OVA or OVF virtual machines and
 [VMware builder](/docs/builders/vmware) for use with VMware products
-require running on a bare-metal machine.
+require running on a bare-metal machine or nested virtualization.
 
 The [Building a VirtualBox Image with Packer in
 TeamCity](/guides/packer-on-cicd/build-virtualbox-image) guide shows


### PR DESCRIPTION
#9294 rightfully points out that we say you MUST do vmware/vbox builds on bare metal, but nested virtualization is another option, if a bit harder to configure. While our guide shows how to do the builds on bare metal, for correctness we should indicate that it is possible to do nested virtualization instead. 

Closes #9294