### PR TITLE
Remove double-quoted in variable type

### DIFF
--- a/website/pages/guides/hcl/variables.mdx
+++ b/website/pages/guides/hcl/variables.mdx
@@ -216,7 +216,7 @@ Lists are defined either explicitly or implicitly
 variable "cidrs" { default = [] }
 
 # explicitly
-variable "cidrs" { type = "list" }
+variable "cidrs" { type = list }
 ```
 
 You can specify lists in a `variables.pkrvars.hcl` file:
@@ -233,7 +233,7 @@ support for the `us-west-2` region as well:
 
 ```hcl
 variable "amis" {
-  type = "map"
+  type = map
   default = {
     "us-east-1" = "ami-b374d5a5"
     "us-west-2" = "ami-4b32be2b"
@@ -278,7 +278,7 @@ variable definitions:
 ```hcl
 variable "region" {}
 variable "amis" {
-  type = "map"
+  type = map
 }
 ```
 


### PR DESCRIPTION
The type parameter in a variable definition can't be double-quoted as it is a primitive type keyword or a complex type constructor. Using double-quoted for the type keyword (bool, number, string) in packer 1.6.1 produces the following error.

Example:

```hcl
variable "command" {
  type = "string"
  default = "default value"
}
```
Error:

```bash
type = "string"

A type specification is either a primitive type keyword (bool, number, string)
or a complex type constructor call, like list(string).
```