### PR TITLE
Pretty print build durations

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -336,13 +336,11 @@ func Test_build_output(t *testing.T) {
 		{[]string{"build", "--color=false", testFixture("hcl", "reprepare", "shell-local.pkr.hcl")}, nil,
 			`
     null.example: hello from the NULL builder packeruser
-Build 'null.example' finished.
-`, "posix"},
+Build 'null.example' finished after`, "posix"},
 		{[]string{"build", "--color=false", testFixture("hcl", "reprepare", "shell-local-windows.pkr.hcl")}, nil,
 			`
     null.example: hello from the NULL  builder packeruser
-Build 'null.example' finished.
-`, "windows"},
+Build 'null.example' finished after`, "windows"},
 	}
 
 	for _, tc := range tc {
@@ -357,7 +355,7 @@ Build 'null.example' finished.
 				t.Fatalf("%v: %s", err, bs)
 			}
 			if !strings.Contains(string(bs), tc.expected) {
-				t.Fatalf("Should have given output %s.\nReceived: %s", tc.expected, string(bs))
+				t.Fatalf("Should contain output %s.\nReceived: %s", tc.expected, string(bs))
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/gorilla/websocket v0.0.0-20170319172727-a91eba7f9777 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
+	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026
 	github.com/hashicorp/consul/api v1.4.0
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,8 @@ github.com/gorilla/websocket v0.0.0-20170319172727-a91eba7f9777 h1:JIM+OacoOJRU3
 github.com/gorilla/websocket v0.0.0-20170319172727-a91eba7f9777/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 h1:THDBEeQ9xZ8JEaCLyLQqXMMdRqNr0QAUJTIkQAUtFjg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
+github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 h1:BpJ2o0OR5FV7vrkDYfXYVJQeMNWa8RhklZOpW2ITAIQ=
+github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026/go.mod h1:5Scbynm8dF1XAPwIwkGPqzkM/shndPm79Jd1003hTjE=
 github.com/hashicorp/consul/api v1.4.0 h1:jfESivXnO5uLdH650JU/6AnjRoHrLhULq0FnC3Kp9EY=
 github.com/hashicorp/consul/api v1.4.0/go.mod h1:xc8u05kyMa3Wjr9eEAsIAo3dg8+LywT5E/Cl7cNS5nU=
 github.com/hashicorp/consul/sdk v0.4.0 h1:zBtCfKJZcJDBvSCkQJch4ulp59m1rATFLKwNo/LYY30=

--- a/vendor/github.com/hako/durafmt/.gitignore
+++ b/vendor/github.com/hako/durafmt/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/hako/durafmt/.travis.yml
+++ b/vendor/github.com/hako/durafmt/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+
+go:
+  - 1.5
+  - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
+  - tip
+
+before_install:
+  - go get golang.org/x/tools/cmd/cover
+
+script:
+  - GOARCH=386 go test # test 32bit architectures.
+  - go test -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+sudo: false

--- a/vendor/github.com/hako/durafmt/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/hako/durafmt/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at wesley@hakobaito.co.uk. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/vendor/github.com/hako/durafmt/CONTRIBUTING.md
+++ b/vendor/github.com/hako/durafmt/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Contributions are welcome! Fork this repo and add your changes and submit a PR.
+
+If you would like to fix a bug, add a feature or provide feedback you can do so in the issues section.
+
+You can run tests by runnning `go test`. Running `go test; go vet; golint` is recommended.
+
+durafmt is also tested against `gometalinter`.

--- a/vendor/github.com/hako/durafmt/LICENSE
+++ b/vendor/github.com/hako/durafmt/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Wesley Hill
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/hako/durafmt/README.md
+++ b/vendor/github.com/hako/durafmt/README.md
@@ -1,0 +1,126 @@
+# durafmt
+
+[![Build Status](https://travis-ci.org/hako/durafmt.svg?branch=master)](https://travis-ci.org/hako/durafmt) [![Go Report Card](https://goreportcard.com/badge/github.com/hako/durafmt)](https://goreportcard.com/report/github.com/hako/durafmt) [![codecov](https://codecov.io/gh/hako/durafmt/branch/master/graph/badge.svg)](https://codecov.io/gh/hako/durafmt) [![GoDoc](https://godoc.org/github.com/hako/durafmt?status.svg)](https://godoc.org/github.com/hako/durafmt) 
+[![Open Source Helpers](https://www.codetriage.com/hako/durafmt/badges/users.svg)](https://www.codetriage.com/hako/durafmt)
+
+
+
+durafmt is a tiny Go library that formats `time.Duration` strings (and types) into a human readable format.
+
+```
+go get github.com/hako/durafmt
+```
+
+# Why
+
+If you've worked with `time.Duration` in Go, you most likely have come across this:
+
+```
+53m28.587093086s // :)
+```
+
+The above seems very easy to read, unless your duration looks like this:
+
+```
+354h22m3.24s // :S
+```
+
+# Usage
+
+### durafmt.ParseString()
+
+```go
+package main
+
+import (
+	"fmt"
+	
+	"github.com/hako/durafmt"
+)
+
+func main() {
+	duration, err := durafmt.ParseString("354h22m3.24s")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(duration) // 2 weeks 18 hours 22 minutes 3 seconds
+	// duration.String() // String representation. "2 weeks 18 hours 22 minutes 3 seconds"
+}
+```
+
+### durafmt.ParseStringShort()
+
+Version of `durafmt.ParseString()` that only returns the first part of the duration string.
+
+```go
+package main
+
+import (
+	"fmt"
+	
+	"github.com/hako/durafmt"
+)
+
+func main() {
+	duration, err := durafmt.ParseStringShort("354h22m3.24s")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(duration) // 2 weeks
+	// duration.String() // String short representation. "2 weeks"
+}
+```
+
+### durafmt.Parse()
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+	
+	"github.com/hako/durafmt"
+)
+
+func main() {
+	timeduration := (354 * time.Hour) + (22 * time.Minute) + (3 * time.Second)
+	duration := durafmt.Parse(timeduration).String()
+	fmt.Println(duration) // 2 weeks 18 hours 22 minutes 3 seconds
+}
+```
+
+#### LimitFirstN()
+
+Like `durafmt.ParseStringShort()` but for limiting the first N parts of the duration string.
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+	
+	"github.com/hako/durafmt"
+)
+
+func main() {
+	timeduration := (354 * time.Hour) + (22 * time.Minute) + (3 * time.Second)
+	duration := durafmt.Parse(timeduration).LimitFirstN(2) // // limit first two parts.
+	fmt.Println(duration) // 2 weeks 18 hours
+}
+```
+
+# Contributing
+
+Contributions are welcome! Fork this repo, add your changes and submit a PR.
+
+If you would like to fix a bug, add a feature or provide feedback you can do so in the issues section.
+
+durafmt is tested against `golangci-lint` and you can run tests with `go test`. 
+
+When contributing, running `go test; go vet; golint` or `golangci-lint` is recommended.
+
+# License
+
+MIT

--- a/vendor/github.com/hako/durafmt/durafmt.go
+++ b/vendor/github.com/hako/durafmt/durafmt.go
@@ -1,0 +1,205 @@
+// Package durafmt formats time.Duration into a human readable format.
+package durafmt
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	units      = []string{"years", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds"}
+	unitsShort = []string{"y", "w", "d", "h", "m", "s", "ms", "µs"}
+)
+
+// Durafmt holds the parsed duration and the original input duration.
+type Durafmt struct {
+	duration  time.Duration
+	input     string // Used as reference.
+	limitN    int    // Non-zero to limit only first N elements to output.
+	limitUnit string // Non-empty to limit max unit
+}
+
+// LimitToUnit sets the output format, you will not have unit bigger than the UNIT specified. UNIT = "" means no restriction.
+func (d *Durafmt) LimitToUnit(unit string) *Durafmt {
+	d.limitUnit = unit
+	return d
+}
+
+// LimitFirstN sets the output format, outputing only first N elements. n == 0 means no limit.
+func (d *Durafmt) LimitFirstN(n int) *Durafmt {
+	d.limitN = n
+	return d
+}
+
+func (d *Durafmt) Duration() time.Duration {
+	return d.duration
+}
+
+// Parse creates a new *Durafmt struct, returns error if input is invalid.
+func Parse(dinput time.Duration) *Durafmt {
+	input := dinput.String()
+	return &Durafmt{dinput, input, 0, ""}
+}
+
+// ParseShort creates a new *Durafmt struct, short form, returns error if input is invalid.
+// It's shortcut for `Parse(dur).LimitFirstN(1)`
+func ParseShort(dinput time.Duration) *Durafmt {
+	input := dinput.String()
+	return &Durafmt{dinput, input, 1, ""}
+}
+
+// ParseString creates a new *Durafmt struct from a string.
+// returns an error if input is invalid.
+func ParseString(input string) (*Durafmt, error) {
+	if input == "0" || input == "-0" {
+		return nil, errors.New("durafmt: missing unit in duration " + input)
+	}
+	duration, err := time.ParseDuration(input)
+	if err != nil {
+		return nil, err
+	}
+	return &Durafmt{duration, input, 0, ""}, nil
+}
+
+// ParseStringShort creates a new *Durafmt struct from a string, short form
+// returns an error if input is invalid.
+// It's shortcut for `ParseString(durStr)` and then calling `LimitFirstN(1)`
+func ParseStringShort(input string) (*Durafmt, error) {
+	if input == "0" || input == "-0" {
+		return nil, errors.New("durafmt: missing unit in duration " + input)
+	}
+	duration, err := time.ParseDuration(input)
+	if err != nil {
+		return nil, err
+	}
+	return &Durafmt{duration, input, 1, ""}, nil
+}
+
+// String parses d *Durafmt into a human readable duration.
+func (d *Durafmt) String() string {
+	var duration string
+
+	// Check for minus durations.
+	if string(d.input[0]) == "-" {
+		duration += "-"
+		d.duration = -d.duration
+	}
+
+	var microseconds int64
+	var milliseconds int64
+	var seconds int64
+	var minutes int64
+	var hours int64
+	var days int64
+	var weeks int64
+	var years int64
+	var shouldConvert = false
+
+	remainingSecondsToConvert := int64(d.duration / time.Microsecond)
+
+	// Convert duration.
+	if d.limitUnit == "" {
+		shouldConvert = true
+	}
+
+	if d.limitUnit == "years" || shouldConvert {
+		years = remainingSecondsToConvert / (365 * 24 * 3600 * 1000000)
+		remainingSecondsToConvert -= years * 365 * 24 * 3600 * 1000000
+		shouldConvert = true
+	}
+
+	if d.limitUnit == "weeks" || shouldConvert {
+		weeks = remainingSecondsToConvert / (7 * 24 * 3600 * 1000000)
+		remainingSecondsToConvert -= weeks * 7 * 24 * 3600 * 1000000
+		shouldConvert = true
+	}
+
+	if d.limitUnit == "days" || shouldConvert {
+		days = remainingSecondsToConvert / (24 * 3600 * 1000000)
+		remainingSecondsToConvert -= days * 24 * 3600 * 1000000
+		shouldConvert = true
+	}
+
+	if d.limitUnit == "hours" || shouldConvert {
+		hours = remainingSecondsToConvert / (3600 * 1000000)
+		remainingSecondsToConvert -= hours * 3600 * 1000000
+		shouldConvert = true
+	}
+
+	if d.limitUnit == "minutes" || shouldConvert {
+		minutes = remainingSecondsToConvert / (60 * 1000000)
+		remainingSecondsToConvert -= minutes * 60 * 1000000
+		shouldConvert = true
+	}
+
+	if d.limitUnit == "seconds" || shouldConvert {
+		seconds = remainingSecondsToConvert / 1000000
+		remainingSecondsToConvert -= seconds * 1000000
+		shouldConvert = true
+	}
+
+	if d.limitUnit == "milliseconds" || shouldConvert {
+		milliseconds = remainingSecondsToConvert / 1000
+		remainingSecondsToConvert -= milliseconds * 1000
+	}
+
+	microseconds = remainingSecondsToConvert
+
+	// Create a map of the converted duration time.
+	durationMap := map[string]int64{
+		"microseconds": microseconds,
+		"milliseconds": milliseconds,
+		"seconds":      seconds,
+		"minutes":      minutes,
+		"hours":        hours,
+		"days":         days,
+		"weeks":        weeks,
+		"years":        years,
+	}
+
+	// Construct duration string.
+	for i := range units {
+		u := units[i]
+		v := durationMap[u]
+		strval := strconv.FormatInt(v, 10)
+		switch {
+		// add to the duration string if v > 1.
+		case v > 1:
+			duration += strval + " " + u + " "
+		// remove the plural 's', if v is 1.
+		case v == 1:
+			duration += strval + " " + strings.TrimRight(u, "s") + " "
+		// omit any value with 0s or 0.
+		case d.duration.String() == "0" || d.duration.String() == "0s":
+			pattern := fmt.Sprintf("^-?0%s$", unitsShort[i])
+			isMatch, err := regexp.MatchString(pattern, d.input)
+			if err != nil {
+				return ""
+			}
+			if isMatch {
+				duration += strval + " " + u
+			}
+
+		// omit any value with 0.
+		case v == 0:
+			continue
+		}
+	}
+	// trim any remaining spaces.
+	duration = strings.TrimSpace(duration)
+
+	// if more than 2 spaces present return the first 2 strings
+	// if short version is requested
+	if d.limitN > 0 {
+		parts := strings.Split(duration, " ")
+		if len(parts) > d.limitN*2 {
+			duration = strings.Join(parts[:d.limitN*2], " ")
+		}
+	}
+
+	return duration
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,6 +297,8 @@ github.com/gophercloud/utils/openstack/compute/v2/flavors
 github.com/gorilla/websocket
 # github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 github.com/grpc-ecosystem/go-grpc-middleware
+# github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026
+github.com/hako/durafmt
 # github.com/hashicorp/consul/api v1.4.0
 github.com/hashicorp/consul/api
 # github.com/hashicorp/errwrap v1.0.0


### PR DESCRIPTION
This change adds additional output to the build command to pretty print the build durations from individual builds and for the entire build process. I have used this template to test:

```json
{
  "variables": {
    "access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
    "secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
    "token": "{{env `AWS_SESSION_TOKEN`}}"
  },
  "builders": [{
    "type": "amazon-ebs",
    "access_key": "{{user `access_key`}}",
    "secret_key": "{{user `secret_key`}}",
    "token": "{{user `token`}}",
    "region": "us-west-2",
    "source_ami": "ami-0a634ae95e11c6f91",
    "instance_type": "t2.micro",
    "ssh_username": "ubuntu",
    "ami_name": "packer-example {{timestamp}}"
  }]
}
```

This is the command used to test:

```sh
go run . build --timestamp-ui quick-start.json
```

When running this command for the first time you ought to see the output below. This includes grabbing the new dependency. I also used the `-timestamp-ui` flag while testing to see if the new output was consistent. 

```text
go: finding module for package github.com/hako/durafmt
go: found github.com/hako/durafmt in github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026
amazon-ebs: output will be in this color.

2020-08-11T11:10:53-07:00: ==> amazon-ebs: Prevalidating any provided VPC information
2020-08-11T11:10:53-07:00: ==> amazon-ebs: Prevalidating AMI Name: packer-example 1597169453
2020-08-11T11:10:55-07:00:     amazon-ebs: Found Image ID: ami-0a634ae95e11c6f91
2020-08-11T11:10:55-07:00: ==> amazon-ebs: Creating temporary keypair: packer_5f32df2d-9506-49b5-6964-98da715a6926
2020-08-11T11:10:55-07:00: ==> amazon-ebs: Creating temporary security group for this instance: packer_5f32df2f-29b9-ef71-755e-6a89cb197d19
2020-08-11T11:10:56-07:00: ==> amazon-ebs: Authorizing access to port 22 from [0.0.0.0/0] in the temporary security groups...
2020-08-11T11:10:56-07:00: ==> amazon-ebs: Launching a source AWS instance...
2020-08-11T11:10:56-07:00: ==> amazon-ebs: Adding tags to source instance
2020-08-11T11:10:56-07:00:     amazon-ebs: Adding tag: "Name": "Packer Builder"
2020-08-11T11:10:57-07:00:     amazon-ebs: Instance ID: i-0de359624f18437e1
2020-08-11T11:10:57-07:00: ==> amazon-ebs: Waiting for instance (i-0de359624f18437e1) to become ready...
2020-08-11T11:11:28-07:00: ==> amazon-ebs: Using ssh communicator to connect: 34.212.176.176
2020-08-11T11:11:28-07:00: ==> amazon-ebs: Waiting for SSH to become available...
2020-08-11T11:11:46-07:00: ==> amazon-ebs: Connected to SSH!
2020-08-11T11:11:46-07:00: ==> amazon-ebs: Stopping the source instance...
2020-08-11T11:11:46-07:00:     amazon-ebs: Stopping instance
2020-08-11T11:11:47-07:00: ==> amazon-ebs: Waiting for the instance to stop...
2020-08-11T11:12:18-07:00: ==> amazon-ebs: Creating AMI packer-example 1597169453 from instance i-0de359624f18437e1
2020-08-11T11:12:18-07:00:     amazon-ebs: AMI: ami-0c0efcbe2aed5c9bc
2020-08-11T11:12:18-07:00: ==> amazon-ebs: Waiting for AMI to become ready...
2020-08-11T11:13:05-07:00: ==> amazon-ebs: Terminating the source AWS instance...
2020-08-11T11:13:21-07:00: ==> amazon-ebs: Cleaning up any extra volumes...
2020-08-11T11:13:22-07:00: ==> amazon-ebs: No volumes to clean up, skipping
2020-08-11T11:13:22-07:00: ==> amazon-ebs: Deleting temporary security group...
2020-08-11T11:13:22-07:00: ==> amazon-ebs: Deleting temporary keypair...
2020-08-11T11:13:22-07:00: Build 'amazon-ebs' finished after 2 minutes 29 seconds.

==> Wait completed after 2 minutes 29 seconds

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs: AMIs were created:
us-west-2: ami-0c0efcbe2aed5c9bc
```

I did not find a place to add tests for the printed output but I'm happy to add them if you can direct me to the right place.

Closes https://github.com/hashicorp/packer/issues/7146