### PR TITLE
Add option to also import OVF templates to the Content Library

### DIFF
--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -36,8 +36,8 @@ type Config struct {
 	// Configuration for exporting VM to an ovf file.
 	// The VM will not be exported if no [Export Configuration](#export-configuration) is specified.
 	Export *common.ExportConfig `mapstructure:"export"`
-	// Configuration for importing the VM template to a Content Library.
-	// The VM template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
+	// Configuration for importing a VM template or OVF template to a Content Library.
+	// The template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
 	// The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
 	ContentLibraryDestinationConfig *common.ContentLibraryDestinationConfig `mapstructure:"content_library_destination"`
 	// Customize the cloned VM to configure host, network, or licensing settings. See the [customization options](#customization).

--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -5,6 +5,8 @@ package common
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/hashicorp/packer/builder/vsphere/driver"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -20,7 +22,13 @@ type ContentLibraryDestinationConfig struct {
 	// The Content Library should be of type Local to allow deploying virtual machines.
 	Library string `mapstructure:"library"`
 	// Name of the library item that will be created. The name of the item should be different from [vm_name](#vm_name).
-	// Defaults to [vm_name](#vm_name) + timestamp.
+	// Defaults to [vm_name](#vm_name) + timestamp. If the item already exists, then it will be updated
+	// with the new template if the operation is compatible with the vSphere API version.
+	//
+	// ~> **Note**: Updating an existing library item is an operation added in vSphere API 6.9.1. Lower
+	// versions will fail to update an existing library item, and therefore, a non-existing name
+	// should be given in order to create a new library item.
+	//
 	Name string `mapstructure:"name"`
 	// Description of the library item that will be created. Defaults to "Packer imported [vm_name](#vm_name) VM template".
 	Description string `mapstructure:"description"`
@@ -46,6 +54,8 @@ type ContentLibraryDestinationConfig struct {
 	Datastore string `mapstructure:"datastore"`
 	// If set to true, the VM will be destroyed after deploying the template to the Content Library. Defaults to `false`.
 	Destroy bool `mapstructure:"destroy"`
+	// TODO
+	Ovf bool `mapstructure:"ovf"`
 }
 
 func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
@@ -96,30 +106,56 @@ func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.Stat
 	ui := state.Get("ui").(packer.Ui)
 	vm := state.Get("vm").(*driver.VirtualMachine)
 
-	template := vcenter.Template{
-		Name:        s.ContentLibConfig.Name,
-		Description: s.ContentLibConfig.Description,
-		Library:     s.ContentLibConfig.Library,
-		Placement: &vcenter.Placement{
-			Cluster:      s.ContentLibConfig.Cluster,
-			Folder:       s.ContentLibConfig.Folder,
-			Host:         s.ContentLibConfig.Host,
-			ResourcePool: s.ContentLibConfig.ResourcePool,
-		},
-	}
-
-	if s.ContentLibConfig.Datastore != "" {
-		template.VMHomeStorage = &vcenter.DiskStorage{
-			Datastore: s.ContentLibConfig.Datastore,
+	if s.ContentLibConfig.Ovf {
+		ovf := driver.OVF{
+			Spec: driver.CreateSpec{
+				Name: s.ContentLibConfig.Name,
+			},
+			Target: driver.LibraryTarget{
+				LibraryID: s.ContentLibConfig.Library,
+			},
 		}
-	}
 
-	ui.Say(fmt.Sprintf("Importing VM template %s to Content Library...", s.ContentLibConfig.Name))
-	err := vm.ImportToContentLibrary(template)
-	if err != nil {
-		ui.Error(fmt.Sprintf("Failed to import VM template %s: %s", s.ContentLibConfig.Name, err.Error()))
-		state.Put("error", err)
-		return multistep.ActionHalt
+		ui.Say(fmt.Sprintf("Importing VM OVF template %s to Content Library...", s.ContentLibConfig.Name))
+		err := vm.ImportOvfToContentLibrary(ovf)
+		if err != nil {
+			if strings.Contains(err.Error(), http.StatusText(404)) {
+				err = fmt.Errorf("%s. Please, verify if the vSphere API version is compatible with this operation.", err.Error())
+			}
+			ui.Error(fmt.Sprintf("Failed to import VM template %s: %s", s.ContentLibConfig.Name, err.Error()))
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
+
+	} else {
+		template := vcenter.Template{
+			Name:        s.ContentLibConfig.Name,
+			Description: s.ContentLibConfig.Description,
+			Library:     s.ContentLibConfig.Library,
+			Placement: &vcenter.Placement{
+				Cluster:      s.ContentLibConfig.Cluster,
+				Folder:       s.ContentLibConfig.Folder,
+				Host:         s.ContentLibConfig.Host,
+				ResourcePool: s.ContentLibConfig.ResourcePool,
+			},
+		}
+
+		if s.ContentLibConfig.Datastore != "" {
+			template.VMHomeStorage = &vcenter.DiskStorage{
+				Datastore: s.ContentLibConfig.Datastore,
+			}
+		}
+
+		ui.Say(fmt.Sprintf("Importing VM template %s to Content Library...", s.ContentLibConfig.Name))
+		err := vm.ImportToContentLibrary(template)
+		if err != nil {
+			if strings.Contains(err.Error(), http.StatusText(404)) {
+				err = fmt.Errorf("%s. Please, verify if the vSphere API version is compatible with this operation.", err.Error())
+			}
+			ui.Error(fmt.Sprintf("Failed to import VM template %s: %s", s.ContentLibConfig.Name, err.Error()))
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
 	}
 
 	if s.ContentLibConfig.Destroy {

--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -5,8 +5,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"strings"
 
 	"github.com/hashicorp/packer/builder/vsphere/driver"
 	"github.com/hashicorp/packer/helper/multistep"
@@ -15,34 +13,41 @@ import (
 	"github.com/vmware/govmomi/vapi/vcenter"
 )
 
-// With this configuration Packer creates a library item in a content library whose content is a virtual machine template created from the just built VM.
-// The virtual machine template is stored in a newly created library item.
+// With this configuration Packer creates a library item in a content library whose content is a VM template
+// or an OVF template created from the just built VM.
+// The template is stored in a existing or newly created library item.
 type ContentLibraryDestinationConfig struct {
-	// Name of the library in which the new library item containing the VM template should be created.
+	// Name of the library in which the new library item containing the template should be created/updated.
 	// The Content Library should be of type Local to allow deploying virtual machines.
 	Library string `mapstructure:"library"`
-	// Name of the library item that will be created. The name of the item should be different from [vm_name](#vm_name).
-	// Defaults to [vm_name](#vm_name) + timestamp. If the item already exists, then it will be updated
-	// with the new template if the operation is compatible with the vSphere API version.
+	// Name of the library item that will be created or updated.
+	// For VM templates, the name of the item should be different from [vm_name](#vm_name) and
+	// the default is [vm_name](#vm_name) + timestamp when not set. VM templates will be always imported to a new library item.
+	// For OVF templates, the name defaults to [vm_name](#vm_name) when not set, and if an item with the same name already
+	// exists it will be then updated with the new OVF template, otherwise a new item will be created.
 	//
-	// ~> **Note**: Updating an existing library item is an operation added in vSphere API 6.9.1. Lower
-	// versions will fail to update an existing library item, and therefore, a non-existing name
-	// should be given in order to create a new library item.
+	// ~> **Note**: It's not possible to update existing library items with a new VM template. If updating an existing library
+	// item is necessary, use an OVF template instead by setting the [ovf](#ovf) option as `true`.
 	//
 	Name string `mapstructure:"name"`
-	// Description of the library item that will be created. Defaults to "Packer imported [vm_name](#vm_name) VM template".
+	// Description of the library item that will be created.
+	// This option is not used when importing OVF templates.
+	// Defaults to "Packer imported [vm_name](#vm_name) VM template".
 	Description string `mapstructure:"description"`
 	// Cluster onto which the virtual machine template should be placed.
 	// If cluster and resource_pool are both specified, resource_pool must belong to cluster.
 	// If cluster and host are both specified, host must be a member of cluster.
+	// This option is not used when importing OVF templates.
 	// Defaults to [cluster](#cluster).
 	Cluster string `mapstructure:"cluster"`
 	// Virtual machine folder into which the virtual machine template should be placed.
+	// This option is not used when importing OVF templates.
 	// Defaults to the same folder as the source virtual machine.
 	Folder string `mapstructure:"folder"`
 	// Host onto which the virtual machine template should be placed.
 	// If host and resource_pool are both specified, resource_pool must belong to host.
 	// If host and cluster are both specified, host must be a member of cluster.
+	// This option is not used when importing OVF templates.
 	// Defaults to [host](#host).
 	Host string `mapstructure:"host"`
 	// Resource pool into which the virtual machine template should be placed.
@@ -50,11 +55,13 @@ type ContentLibraryDestinationConfig struct {
 	// the system will attempt to choose a suitable resource pool for the virtual machine template.
 	ResourcePool string `mapstructure:"resource_pool"`
 	// The datastore for the virtual machine template's configuration and log files.
+	// This option is not used when importing OVF templates.
 	// Defaults to the storage backing associated with the library specified by library.
 	Datastore string `mapstructure:"datastore"`
-	// If set to true, the VM will be destroyed after deploying the template to the Content Library. Defaults to `false`.
+	// If set to true, the VM will be destroyed after deploying the template to the Content Library.
+	// Defaults to `false`.
 	Destroy bool `mapstructure:"destroy"`
-	// TODO
+	// When set to true, Packer will import and OVF template to the content library item. Defaults to `false`.
 	Ovf bool `mapstructure:"ovf"`
 }
 
@@ -64,31 +71,38 @@ func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
 	if c.Library == "" {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("a library name must be provided"))
 	}
-	if c.Name == lc.VMName {
-		errs = packer.MultiErrorAppend(errs, fmt.Errorf("the content library destination name must be different from the VM name"))
-	}
 
-	if c.Name == "" {
-		// Add timestamp to the the name to differentiate from the original VM
-		// otherwise vSphere won't be able to create the template which will be imported
-		name, err := interpolate.Render(lc.VMName+"{{timestamp}}", nil)
-		if err != nil {
-			errs = packer.MultiErrorAppend(errs,
-				fmt.Errorf("unable to parse content library VM template name: %s", err))
+	if c.Ovf {
+		if c.Name == "" {
+			c.Name = lc.VMName
 		}
-		c.Name = name
-	}
-	if c.Cluster == "" {
-		c.Cluster = lc.Cluster
-	}
-	if c.Host == "" {
-		c.Host = lc.Host
-	}
-	if c.ResourcePool == "" {
-		c.ResourcePool = lc.ResourcePool
-	}
-	if c.Description == "" {
-		c.Description = fmt.Sprintf("Packer imported %s VM template", lc.VMName)
+	} else {
+		if c.Name == lc.VMName {
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("the content library destination name must be different from the VM name"))
+		}
+
+		if c.Name == "" {
+			// Add timestamp to the name to differentiate from the original VM
+			// otherwise vSphere won't be able to create the template which will be imported
+			name, err := interpolate.Render(lc.VMName+"{{timestamp}}", nil)
+			if err != nil {
+				errs = packer.MultiErrorAppend(errs,
+					fmt.Errorf("unable to parse content library VM template name: %s", err))
+			}
+			c.Name = name
+		}
+		if c.Cluster == "" {
+			c.Cluster = lc.Cluster
+		}
+		if c.Host == "" {
+			c.Host = lc.Host
+		}
+		if c.ResourcePool == "" {
+			c.ResourcePool = lc.ResourcePool
+		}
+		if c.Description == "" {
+			c.Description = fmt.Sprintf("Packer imported %s VM template", lc.VMName)
+		}
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {
@@ -105,57 +119,20 @@ type StepImportToContentLibrary struct {
 func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	vm := state.Get("vm").(*driver.VirtualMachine)
+	var err error
 
 	if s.ContentLibConfig.Ovf {
-		ovf := driver.OVF{
-			Spec: driver.CreateSpec{
-				Name: s.ContentLibConfig.Name,
-			},
-			Target: driver.LibraryTarget{
-				LibraryID: s.ContentLibConfig.Library,
-			},
-		}
-
 		ui.Say(fmt.Sprintf("Importing VM OVF template %s to Content Library...", s.ContentLibConfig.Name))
-		err := vm.ImportOvfToContentLibrary(ovf)
-		if err != nil {
-			if strings.Contains(err.Error(), http.StatusText(404)) {
-				err = fmt.Errorf("%s. Please, verify if the vSphere API version is compatible with this operation.", err.Error())
-			}
-			ui.Error(fmt.Sprintf("Failed to import VM template %s: %s", s.ContentLibConfig.Name, err.Error()))
-			state.Put("error", err)
-			return multistep.ActionHalt
-		}
-
+		err = s.importOvfTemplate(vm)
 	} else {
-		template := vcenter.Template{
-			Name:        s.ContentLibConfig.Name,
-			Description: s.ContentLibConfig.Description,
-			Library:     s.ContentLibConfig.Library,
-			Placement: &vcenter.Placement{
-				Cluster:      s.ContentLibConfig.Cluster,
-				Folder:       s.ContentLibConfig.Folder,
-				Host:         s.ContentLibConfig.Host,
-				ResourcePool: s.ContentLibConfig.ResourcePool,
-			},
-		}
-
-		if s.ContentLibConfig.Datastore != "" {
-			template.VMHomeStorage = &vcenter.DiskStorage{
-				Datastore: s.ContentLibConfig.Datastore,
-			}
-		}
-
 		ui.Say(fmt.Sprintf("Importing VM template %s to Content Library...", s.ContentLibConfig.Name))
-		err := vm.ImportToContentLibrary(template)
-		if err != nil {
-			if strings.Contains(err.Error(), http.StatusText(404)) {
-				err = fmt.Errorf("%s. Please, verify if the vSphere API version is compatible with this operation.", err.Error())
-			}
-			ui.Error(fmt.Sprintf("Failed to import VM template %s: %s", s.ContentLibConfig.Name, err.Error()))
-			state.Put("error", err)
-			return multistep.ActionHalt
-		}
+		err = s.importVmTemplate(vm)
+	}
+
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to import template %s: %s", s.ContentLibConfig.Name, err.Error()))
+		state.Put("error", err)
+		return multistep.ActionHalt
 	}
 
 	if s.ContentLibConfig.Destroy {
@@ -163,6 +140,40 @@ func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.Stat
 	}
 
 	return multistep.ActionContinue
+}
+
+func (s *StepImportToContentLibrary) importOvfTemplate(vm *driver.VirtualMachine) error {
+	ovf := vcenter.OVF{
+		Spec: vcenter.CreateSpec{
+			Name: s.ContentLibConfig.Name,
+		},
+		Target: vcenter.LibraryTarget{
+			LibraryID: s.ContentLibConfig.Library,
+		},
+	}
+	return vm.ImportOvfToContentLibrary(ovf)
+}
+
+func (s *StepImportToContentLibrary) importVmTemplate(vm *driver.VirtualMachine) error {
+	template := vcenter.Template{
+		Name:        s.ContentLibConfig.Name,
+		Description: s.ContentLibConfig.Description,
+		Library:     s.ContentLibConfig.Library,
+		Placement: &vcenter.Placement{
+			Cluster:      s.ContentLibConfig.Cluster,
+			Folder:       s.ContentLibConfig.Folder,
+			Host:         s.ContentLibConfig.Host,
+			ResourcePool: s.ContentLibConfig.ResourcePool,
+		},
+	}
+
+	if s.ContentLibConfig.Datastore != "" {
+		template.VMHomeStorage = &vcenter.DiskStorage{
+			Datastore: s.ContentLibConfig.Datastore,
+		}
+	}
+
+	return vm.ImportToContentLibrary(template)
 }
 
 func (s *StepImportToContentLibrary) Cleanup(multistep.StateBag) {

--- a/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
+++ b/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
@@ -18,6 +18,7 @@ type FlatContentLibraryDestinationConfig struct {
 	ResourcePool *string `mapstructure:"resource_pool" cty:"resource_pool" hcl:"resource_pool"`
 	Datastore    *string `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
 	Destroy      *bool   `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
+	Ovf          *bool   `mapstructure:"ovf" cty:"ovf" hcl:"ovf"`
 }
 
 // FlatMapstructure returns a new FlatContentLibraryDestinationConfig.
@@ -41,6 +42,7 @@ func (*FlatContentLibraryDestinationConfig) HCL2Spec() map[string]hcldec.Spec {
 		"resource_pool": &hcldec.AttrSpec{Name: "resource_pool", Type: cty.String, Required: false},
 		"datastore":     &hcldec.AttrSpec{Name: "datastore", Type: cty.String, Required: false},
 		"destroy":       &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
+		"ovf":           &hcldec.AttrSpec{Name: "ovf", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -1,6 +1,9 @@
 package driver
 
-import "github.com/vmware/govmomi/vapi/library"
+import (
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/vcenter"
+)
 
 type Library struct {
 	driver  *Driver
@@ -17,4 +20,45 @@ func (d *Driver) FindContentLibrary(name string) (*Library, error) {
 		library: l,
 		driver:  d,
 	}, nil
+}
+
+func (d *Driver) FindContentLibraryItem(libraryId string, name string) (*library.Item, error) {
+	lm := library.NewManager(d.restClient)
+	items, err := lm.GetLibraryItems(d.ctx, libraryId)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, nil
+}
+
+// LibraryTarget specifies a Library or Library item
+type LibraryTarget struct {
+	LibraryID     string `json:"library_id,omitempty"`
+	LibraryItemID string `json:"library_item_id,omitempty"`
+}
+
+// CreateSpec info used to create an OVF package from a VM
+type CreateSpec struct {
+	Description string   `json:"description,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Flags       []string `json:"flags,omitempty"`
+}
+
+// OVF data used by CreateOVF
+type OVF struct {
+	Spec   CreateSpec         `json:"create_spec"`
+	Source vcenter.ResourceID `json:"source"`
+	Target LibraryTarget      `json:"target"`
+}
+
+// CreateResult used for decoded a CreateOVF response
+type CreateResult struct {
+	Succeeded bool                     `json:"succeeded,omitempty"`
+	ID        string                   `json:"ovf_library_item_id,omitempty"`
+	Error     *vcenter.DeploymentError `json:"error,omitempty"`
 }

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"github.com/vmware/govmomi/vapi/library"
-	"github.com/vmware/govmomi/vapi/vcenter"
 )
 
 type Library struct {
@@ -34,31 +33,4 @@ func (d *Driver) FindContentLibraryItem(libraryId string, name string) (*library
 		}
 	}
 	return nil, nil
-}
-
-// LibraryTarget specifies a Library or Library item
-type LibraryTarget struct {
-	LibraryID     string `json:"library_id,omitempty"`
-	LibraryItemID string `json:"library_item_id,omitempty"`
-}
-
-// CreateSpec info used to create an OVF package from a VM
-type CreateSpec struct {
-	Description string   `json:"description,omitempty"`
-	Name        string   `json:"name,omitempty"`
-	Flags       []string `json:"flags,omitempty"`
-}
-
-// OVF data used by CreateOVF
-type OVF struct {
-	Spec   CreateSpec         `json:"create_spec"`
-	Source vcenter.ResourceID `json:"source"`
-	Target LibraryTarget      `json:"target"`
-}
-
-// CreateResult used for decoded a CreateOVF response
-type CreateResult struct {
-	Succeeded bool                     `json:"succeeded,omitempty"`
-	ID        string                   `json:"ovf_library_item_id,omitempty"`
-	Error     *vcenter.DeploymentError `json:"error,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/ufilesdk-dev/ufile-gosdk v0.0.0-20190830075812-b4dbc4ef43a6
 	github.com/ugorji/go v0.0.0-20151218193438-646ae4a518c1
 	github.com/ulikunitz/xz v0.5.5
-	github.com/vmware/govmomi v0.22.2
+	github.com/vmware/govmomi v0.23.1
 	github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0
 	github.com/yandex-cloud/go-genproto v0.0.0-20200608085315-d6e7ef5ceb97
 	github.com/yandex-cloud/go-sdk v0.0.0-20200610100221-ae86895efb97

--- a/go.sum
+++ b/go.sum
@@ -610,6 +610,9 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmware/govmomi v0.22.2 h1:hmLv4f+RMTTseqtJRijjOWzwELiaLMIoHv2D6H3bF4I=
 github.com/vmware/govmomi v0.22.2/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.23.0/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
+github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0 h1:NJrcIkdzq0C3I8ypAZwFE9RHtGbfp+mJvqIcoFATZuk=
 github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0/go.mod h1:sBh287mCRwCz6zyXHMmw7sSZGPohVpnx+o+OY4M+i3A=

--- a/vendor/github.com/vmware/govmomi/.mailmap
+++ b/vendor/github.com/vmware/govmomi/.mailmap
@@ -1,12 +1,16 @@
-Amanda H. L. de Andrade <amanda.andrade@serpro.gov.br> amandahla <amanda.andrade@serpro.gov.br>
 Amanda H. L. de Andrade <amanda.andrade@serpro.gov.br> Amanda Hager Lopes de Andrade Katz <amanda.katz@serpro.gov.br>
+Amanda H. L. de Andrade <amanda.andrade@serpro.gov.br> amandahla <amanda.andrade@serpro.gov.br>
 Amit Bathla <abathla@.vmware.com> <abathla@promb-1s-dhcp216.eng.vmware.com>
-Andrew Kutz <akutz@vmware.com> akutz <akutz@vmware.com>
 Andrew Kutz <akutz@vmware.com> <sakutz@gmail.com>
 Andrew Kutz <akutz@vmware.com> Andrew Kutz <101085+akutz@users.noreply.github.com>
+Andrew Kutz <akutz@vmware.com> akutz <akutz@vmware.com>
+Anfernee Yongkun Gui <agui@vmware.com> <anfernee.gui@gmail.com>
+Anfernee Yongkun Gui <agui@vmware.com> Yongkun Anfernee Gui <agui@vmware.com>
+Anna Carrigan <anna.carrigan@hpe.com> Anna <anna.carrigan@outlook.com>
+Balu Dontu <bdontu@vmware.com> BaluDontu <bdontu@vmware.com>
 Bruce Downs <bruceadowns@gmail.com> <bdowns@vmware.com>
-Bruce Downs <bruceadowns@gmail.com> <bruce.downs@jivesoftware.com>
 Bruce Downs <bruceadowns@gmail.com> <bruce.downs@autodesk.com>
+Bruce Downs <bruceadowns@gmail.com> <bruce.downs@jivesoftware.com>
 Clint Greenwood <cgreenwood@vmware.com> <clint.greenwood@gmail.com>
 Cédric Blomart <cblomart@gmail.com> <cedric.blomart@minfin.fed.be>
 Cédric Blomart <cblomart@gmail.com> cedric <cblomart@gmail.com>
@@ -14,17 +18,18 @@ David Stark <dave@davidstark.name> <david.stark@bskyb.com>
 Eric Gray <egray@vmware.com> <ericgray@users.noreply.github.com>
 Eric Yutao <eric.yutao@gmail.com> eric <eric.yutao@gmail.com>
 Fabio Rapposelli <fabio@vmware.com> <fabio@rapposelli.org>
+Faiyaz Ahmed <faiyaza@vmware.com> Faiyaz Ahmed <ahmedf@vmware.com>
+Faiyaz Ahmed <faiyaza@vmware.com> Faiyaz Ahmed <faiyaza@gmail.com>
+Faiyaz Ahmed <faiyaza@vmware.com> Faiyaz Ahmed <fdawg4l@users.noreply.github.com>
 Henrik Hodne <henrik@travis-ci.com> <henrik@hodne.io>
 Jeremy Canady <jcanady@jackhenry.com> <jcanady@gmail.com>
+Jiatong Wang <wjiatong@vmware.com> jiatongw <wjiatong@vmware.com>
+Lintong Jiang <lintongj@vmware.com> lintongj <55512168+lintongj@users.noreply.github.com>
 Pieter Noordhuis <pnoordhuis@vmware.com> <pcnoordhuis@gmail.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com> takaaki.furukawa <takaaki.furukawa@mail.rakuten.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com> tkak <takaaki.frkw@gmail.com>
-Vadim Egorov <vegorov@vmware.com> <egorovv@gmail.com>
-Anfernee Yongkun Gui <agui@vmware.com> <anfernee.gui@gmail.com>
-Anfernee Yongkun Gui <agui@vmware.com> Yongkun Anfernee Gui <agui@vmware.com>
-Zach Tucker <ztucker@vmware.com> <jzt@users.noreply.github.com>
-Zee Yang <zeey@vmware.com> <zee.yang@gmail.com>
-Jiatong Wang <wjiatong@vmware.com> jiatongw <wjiatong@vmware.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de> Uwe Bessle <u.bessle.extern@eos-ts.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de> Uwe Bessle <uwe.bessle@web.de>
-Lintong Jiang <lintongj@vmware.com> lintongj <55512168+lintongj@users.noreply.github.com>
+Vadim Egorov <vegorov@vmware.com> <egorovv@gmail.com>
+Zach Tucker <ztucker@vmware.com> <jzt@users.noreply.github.com>
+Zee Yang <zeey@vmware.com> <zee.yang@gmail.com>

--- a/vendor/github.com/vmware/govmomi/.travis.yml
+++ b/vendor/github.com/vmware/govmomi/.travis.yml
@@ -12,7 +12,7 @@ services:       false
 
 # Set the version of Go.
 language:       go
-go:             1.13
+go:             1.14
 
 # Always set the project's Go import path to ensure that forked
 # builds get cloned to the correct location.

--- a/vendor/github.com/vmware/govmomi/CHANGELOG.md
+++ b/vendor/github.com/vmware/govmomi/CHANGELOG.md
@@ -1,5 +1,27 @@
 # changelog
 
+### 0.23.0 (2020-06-11)
+
+* Finder: support DistributedVirtualSwitch traversal
+
+* Update to vSphere 7 APIs
+
+* Avoid possible nil pointer dereference in guest TransferURL
+
+* Refactor govc session persistence into session/cache package
+
+* Add SetTaskState SetTaskDescription UpdateProgress to object package
+
+* Add Content Library subscriptions support
+
+* Add Content Library item copy support
+
+* Sync vim25/xml with golang 1.13 encoding/xml
+
+* vapi: Add cluster modules client and simulator
+
+* Expose soap client default transport
+
 ### 0.22.1 (2020-01-13)
 
 * Fix SAML token auth using Holder-of-Key with delegated Bearer identity against 6.7 U3b+

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTING.md
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTING.md
@@ -96,6 +96,9 @@ We follow the conventions on [How to Write a Git Commit Message](http://chris.be
 
 Be sure to include any related GitHub issue references in the commit message.
 
+### Running CI checks and tests
+You can run both `make check` and `make test` from the top level of the repository. While `make check` will catch formatting and import errors, it will not apply any fixes. The developer is expected to do that.
+
 ## Reporting Bugs and Creating Issues
 
 When opening a new issue, try to roughly follow the commit message format conventions above.

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTORS
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTORS
@@ -6,6 +6,7 @@
 Abhijeet Kasurde <akasurde@redhat.com>
 abrarshivani <abrarshivani@users.noreply.github.com>
 Adam Shannon <adamkshannon@gmail.com>
+Al Biheiri <abiheiri@apple.com>
 Alessandro Cortiana <alessandro.cortiana@gmail.com>
 Alex Bozhenko <alexbozhenko@fb.com>
 Alex Ellis (VMware) <alexellis2@gmail.com>
@@ -21,6 +22,8 @@ Andrey Klimentyev <andrey.klimentyev@flant.com>
 Anfernee Yongkun Gui <agui@vmware.com>
 angystardust <angystardust@users.noreply.github.com>
 aniketGslab <aniket.shinde@gslab.com>
+Ankit Vaidya <vaidyaa@vmware.com>
+Anna Carrigan <anna.carrigan@hpe.com>
 Arran Walker <arran.walker@zopa.com>
 Artem Anisimov <aanisimov@inbox.ru>
 Aryeh Weinreb <aryehweinreb@gmail.com>
@@ -28,26 +31,33 @@ Austin Parker <aparker@apprenda.com>
 Balu Dontu <bdontu@vmware.com>
 bastienbc <bastien.barbe.creuly@gmail.com>
 Ben Corrie <bcorrie@vmware.com>
+Benjamin Davini <davinib@vmware.com>
 Benjamin Peterson <benjamin@python.org>
 Bob Killen <killen.bob@gmail.com>
 Brad Fitzpatrick <bradfitz@golang.org>
 Bruce Downs <bruceadowns@gmail.com>
 Cédric Blomart <cblomart@gmail.com>
+Cheng Cheng <chengch@vmware.com>
+Chethan Venkatesh <chethanv@vmware.com>
 Chris Marchesi <chrism@vancluevertech.com>
 Christian Höltje <docwhat@gerf.org>
 Clint Greenwood <cgreenwood@vmware.com>
 CuiHaozhi <cuihaozhi@chinacloud.com.cn>
 Daniel Mueller <deso@posteo.net>
+Dan Ilan <danilan@google.com>
 Danny Lockard <danny.lockard@banno.com>
 Dave Gress <gressd@vmware.com>
 Dave Smith-Uchida <dsmithuchida@vmware.com>
 Dave Tucker <dave@dtucker.co.uk>
 Davide Agnello <dagnello@hp.com>
+David Gress <gressd@vmware.com>
 David Stark <dave@davidstark.name>
 Davinder Kumar <davinderk@vmware.com>
+demarey <christophe.demarey@inria.fr>
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Deric Crago <deric.crago@gmail.com>
 Divyen Patel <divyenp@vmware.com>
+Dnyanesh Gate <dnyanesh.gate@druva.com>
 Doug MacEachern <dougm@vmware.com>
 Eloy Coto <eloy.coto@gmail.com>
 Eric Edens <ericedens@google.com>
@@ -56,8 +66,10 @@ Eric Gray <egray@vmware.com>
 Eric Yutao <eric.yutao@gmail.com>
 Erik Hollensbe <github@hollensbe.org>
 Ethan Kaley <ethan.kaley@emc.com>
+Evan Chu <echu@vmware.com>
 Fabio Rapposelli <fabio@vmware.com>
-Faiyaz Ahmed <ahmedf@vmware.com>
+Faiyaz Ahmed <faiyaza@vmware.com>
+Federico Pellegatta <12744504+federico-pellegatta@users.noreply.github.com>
 forkbomber <forkbomber@users.noreply.github.com>
 François Rigault <rigault.francois@gmail.com>
 freebsdly <qinhuajun@outlook.com>
@@ -86,6 +98,7 @@ kayrus <kay.diam@gmail.com>
 Kevin George <georgek@vmware.com>
 leslie-qiwa <leslie.qiwa@gmail.com>
 Lintong Jiang <lintongj@vmware.com>
+Liping Xue <lipingx@vmware.com>
 Louie Jiang <jiangl@vmware.com>
 Luther Monson <luther.monson@gmail.com>
 maplain <fangyuanl@vmware.com>
@@ -97,6 +110,7 @@ Mario Trangoni <mjtrangoni@gmail.com>
 Mark Peek <markpeek@vmware.com>
 Matt Clay <matt@mystile.com>
 Matthew Cosgrove <matthew.cosgrove@dell.com>
+Matt Moore <mattmoor@vmware.com>
 Matt Moriarity <matt@mattmoriarity.com>
 Mevan Samaratunga <mevansam@gmail.com>
 Michal Jankowski <mjankowski@vmware.com>
@@ -109,15 +123,20 @@ Pieter Noordhuis <pnoordhuis@vmware.com>
 prydin <prydin@vmware.com>
 rHermes <teodor_spaeren@riseup.net>
 Rowan Jacobs <rojacobs@pivotal.io>
+rsikdar <rsikdar@berkeley.edu>
 runner.mei <runner.mei@gmail.com>
+Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>
 S.Çağlar Onur <conur@vmware.com>
 Sergey Ignatov <sergey.ignatov@jetbrains.com>
 serokles <timbo.alexander@gmail.com>
+Shalini Bhaskara <sbhaskara@vmware.com>
 Shawn Neal <sneal@sneal.net>
+shylasrinivas <sshyla@vmware.com>
 sky-joker <sky.jokerxx@gmail.com>
 Sten Feldman <exile@chamber.ee>
 Stepan Mazurov <smazurov@gmail.com>
 Steve Purcell <steve@sanityinc.com>
+SUMIT AGRAWAL <asumit@vmware.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com>
 Tamas Eger <tamas.eger@bitrise.io>
 tanishi <tanishi503@gmail.com>
@@ -128,13 +147,19 @@ Tim McNamara <tim.mcnamara@canonical.com>
 Tjeu Kayim <15987676+TjeuKayim@users.noreply.github.com>
 Toomas Pelberg <toomas.pelberg@playtech.com>
 Trevor Dawe <trevor.dawe@gmail.com>
+tshihad <tshihad9@gmail.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de>
 Vadim Egorov <vegorov@vmware.com>
 Vikram Krishnamurthy <vikramkrishnamu@vmware.com>
+volanja <volaaanja@gmail.com>
 Volodymyr Bobyr <pupsua@gmail.com>
+Waldek Maleska <w.maleska@gmail.com>
 William Lam <info.virtuallyghetto@gmail.com>
 Witold Krecicki <wpk@culm.net>
+xing-yang <xingyang105@gmail.com>
+yangxi <yangxi@vmware.com>
 Yang Yang <yangy@vmware.com>
+Yann Hodique <yhodique@google.com>
 ykakarap <yuva2811@gmail.com>
 Yuya Kusakabe <yuya.kusakabe@gmail.com>
 Zacharias Taubert <zacharias.taubert@gmail.com>

--- a/vendor/github.com/vmware/govmomi/Makefile
+++ b/vendor/github.com/vmware/govmomi/Makefile
@@ -9,6 +9,7 @@ goimports:
 	@echo checking go imports...
 	@command -v goimports >/dev/null 2>&1 || $(GO) get golang.org/x/tools/cmd/goimports
 	@! goimports -d . 2>&1 | egrep -v '^$$'
+	@! TERM=xterm git grep encoding/xml -- '*.go' ':!vim25/xml/*.go'
 
 govet:
 	@echo checking go vet...

--- a/vendor/github.com/vmware/govmomi/README.md
+++ b/vendor/github.com/vmware/govmomi/README.md
@@ -15,9 +15,9 @@ In addition to the vSphere API client, this repository includes:
 
 ## Compatibility
 
-This library is built for and tested against ESXi and vCenter 6.0, 6.5 and 6.7.
+This library is built for and tested against ESXi and vCenter 6.5, 6.7 and 7.0.
 
-It may work with versions 5.5 and 5.1, but neither are officially supported.
+It may work with versions 5.1, 5.5 and 6.0, but neither are officially supported.
 
 ## Documentation
 
@@ -28,7 +28,7 @@ The code in the `govmomi` package is a wrapper for the code that is generated fr
 It primarily provides convenience functions for working with the vSphere API.
 See [godoc.org][godoc] for documentation.
 
-[apiref]:https://code.vmware.com/apis/196/vsphere
+[apiref]:https://code.vmware.com/apis/968/vsphere
 [godoc]:http://godoc.org/github.com/vmware/govmomi
 
 ## Installation
@@ -85,12 +85,24 @@ Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
 
 * [Juju](https://github.com/juju/juju)
 
+* [vSphere 7.0](https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-7-vsphere-with-kubernetes-release-notes.html)
+
+* [OPS](https://github.com/nanovms/ops)
+
 ## Related projects
 
 * [rbvmomi](https://github.com/vmware/rbvmomi)
 
 * [pyvmomi](https://github.com/vmware/pyvmomi)
 
+* [go-vmware-nsxt](https://github.com/vmware/go-vmware-nsxt)
+
 ## License
 
 govmomi is available under the [Apache 2 license](LICENSE.txt).
+
+## Name
+
+Pronounced "go-v-mom-ie"
+
+Follows pyvmomi and rbvmomi: language prefix + the vSphere acronym "VM Object Management Infrastructure".

--- a/vendor/github.com/vmware/govmomi/object/network.go
+++ b/vendor/github.com/vmware/govmomi/object/network.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/vmware/govmomi/vim25"
-	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -40,19 +39,14 @@ func (n Network) GetInventoryPath() string {
 
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network
 func (n Network) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
-	var e mo.Network
-
-	// Use Network.Name rather than Common.Name as the latter does not return the complete name if it contains a '/'
-	// We can't use Common.ObjectName here either as we need the ManagedEntity.Name field is not set since mo.Network
-	// has its own Name field.
-	err := n.Properties(ctx, n.Reference(), []string{"name"}, &e)
+	name, err := n.ObjectName(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	backing := &types.VirtualEthernetCardNetworkBackingInfo{
 		VirtualDeviceDeviceBackingInfo: types.VirtualDeviceDeviceBackingInfo{
-			DeviceName: e.Name,
+			DeviceName: name,
 		},
 	}
 

--- a/vendor/github.com/vmware/govmomi/object/opaque_network.go
+++ b/vendor/github.com/vmware/govmomi/object/opaque_network.go
@@ -41,15 +41,9 @@ func (n OpaqueNetwork) GetInventoryPath() string {
 
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network
 func (n OpaqueNetwork) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
-	var net mo.OpaqueNetwork
-
-	if err := n.Properties(ctx, n.Reference(), []string{"summary"}, &net); err != nil {
+	summary, err := n.Summary(ctx)
+	if err != nil {
 		return nil, err
-	}
-
-	summary, ok := net.Summary.(*types.OpaqueNetworkSummary)
-	if !ok {
-		return nil, fmt.Errorf("%s unsupported network type: %T", n, net.Summary)
 	}
 
 	backing := &types.VirtualEthernetCardOpaqueNetworkBackingInfo{
@@ -58,4 +52,21 @@ func (n OpaqueNetwork) EthernetCardBackingInfo(ctx context.Context) (types.BaseV
 	}
 
 	return backing, nil
+}
+
+// Summary returns the mo.OpaqueNetwork.Summary property
+func (n OpaqueNetwork) Summary(ctx context.Context) (*types.OpaqueNetworkSummary, error) {
+	var props mo.OpaqueNetwork
+
+	err := n.Properties(ctx, n.Reference(), []string{"summary"}, &props)
+	if err != nil {
+		return nil, err
+	}
+
+	summary, ok := props.Summary.(*types.OpaqueNetworkSummary)
+	if !ok {
+		return nil, fmt.Errorf("%s unsupported network summary type: %T", n, props.Summary)
+	}
+
+	return summary, nil
 }

--- a/vendor/github.com/vmware/govmomi/object/task.go
+++ b/vendor/github.com/vmware/govmomi/object/task.go
@@ -64,3 +64,37 @@ func (t *Task) Cancel(ctx context.Context) error {
 
 	return err
 }
+
+// SetState sets task state and optionally sets results or fault, as appropriate for state.
+func (t *Task) SetState(ctx context.Context, state types.TaskInfoState, result types.AnyType, fault *types.LocalizedMethodFault) error {
+	req := types.SetTaskState{
+		This:   t.Reference(),
+		State:  state,
+		Result: result,
+		Fault:  fault,
+	}
+	_, err := methods.SetTaskState(ctx, t.Common.Client(), &req)
+	return err
+}
+
+// SetDescription updates task description to describe the current phase of the task.
+func (t *Task) SetDescription(ctx context.Context, description types.LocalizableMessage) error {
+	req := types.SetTaskDescription{
+		This:        t.Reference(),
+		Description: description,
+	}
+	_, err := methods.SetTaskDescription(ctx, t.Common.Client(), &req)
+	return err
+}
+
+// UpdateProgress Sets percentage done for this task and recalculates overall percentage done.
+// If a percentDone value of less than zero or greater than 100 is specified,
+// a value of zero or 100 respectively is used.
+func (t *Task) UpdateProgress(ctx context.Context, percentDone int) error {
+	req := types.UpdateProgress{
+		This:        t.Reference(),
+		PercentDone: int32(percentDone),
+	}
+	_, err := methods.UpdateProgress(ctx, t.Common.Client(), &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/object/virtual_machine.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_machine.go
@@ -855,8 +855,10 @@ func (v VirtualMachine) UUID(ctx context.Context) string {
 	if err != nil {
 		return ""
 	}
-
-	return o.Config.Uuid
+	if o.Config != nil {
+		return o.Config.Uuid
+	}
+	return ""
 }
 
 func (v VirtualMachine) QueryChangedDiskAreas(ctx context.Context, baseSnapshot, curSnapshot *types.ManagedObjectReference, disk *types.VirtualDisk, offset int64) (types.DiskChangeInfo, error) {

--- a/vendor/github.com/vmware/govmomi/property/collector.go
+++ b/vendor/github.com/vmware/govmomi/property/collector.go
@@ -143,7 +143,7 @@ func (p *Collector) Retrieve(ctx context.Context, objs []types.ManagedObjectRefe
 			spec := types.PropertySpec{
 				Type: obj.Type,
 			}
-			if ps == nil {
+			if len(ps) == 0 {
 				spec.All = types.NewBool(true)
 			} else {
 				spec.PathSet = ps

--- a/vendor/github.com/vmware/govmomi/property/filter.go
+++ b/vendor/github.com/vmware/govmomi/property/filter.go
@@ -42,6 +42,9 @@ func (f Filter) Keys() []string {
 
 // MatchProperty returns true if a Filter entry matches the given prop.
 func (f Filter) MatchProperty(prop types.DynamicProperty) bool {
+	if prop.Val == nil {
+		return false
+	}
 	match, ok := f[prop.Name]
 	if !ok {
 		return false
@@ -74,7 +77,7 @@ func (f Filter) MatchProperty(prop types.DynamicProperty) bool {
 		}
 
 		// convert if we can
-		switch prop.Val.(type) {
+		switch val := prop.Val.(type) {
 		case bool:
 			match, _ = strconv.ParseBool(s)
 		case int16:
@@ -91,7 +94,9 @@ func (f Filter) MatchProperty(prop types.DynamicProperty) bool {
 		case float64:
 			match, _ = strconv.ParseFloat(s, 64)
 		case fmt.Stringer:
-			prop.Val = prop.Val.(fmt.Stringer).String()
+			prop.Val = val.String()
+		case *types.CustomFieldStringValue:
+			prop.Val = fmt.Sprintf("%d:%s", val.Key, val.Value)
 		default:
 			if ptype.Kind() != reflect.String {
 				return false

--- a/vendor/github.com/vmware/govmomi/property/wait.go
+++ b/vendor/github.com/vmware/govmomi/property/wait.go
@@ -29,6 +29,7 @@ type WaitFilter struct {
 	types.CreateFilter
 	Options          *types.WaitOptions
 	PropagateMissing bool
+	Truncated        bool
 }
 
 // Add a new ObjectSpec and PropertySpec to the WaitFilter
@@ -127,6 +128,10 @@ func WaitForUpdates(ctx context.Context, c *Collector, filter *WaitFilter, f fun
 		}
 
 		req.Version = set.Version
+		filter.Truncated = false
+		if set.Truncated != nil {
+			filter.Truncated = *set.Truncated
+		}
 
 		for _, fs := range set.FilterSet {
 			if filter.PropagateMissing {

--- a/vendor/github.com/vmware/govmomi/session/keep_alive.go
+++ b/vendor/github.com/vmware/govmomi/session/keep_alive.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015,2019 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2020 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,115 +17,24 @@ limitations under the License.
 package session
 
 import (
-	"context"
-	"sync"
 	"time"
 
-	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
-type keepAlive struct {
-	sync.Mutex
-
-	roundTripper    soap.RoundTripper
-	idleTime        time.Duration
-	notifyRequest   chan struct{}
-	notifyStop      chan struct{}
-	notifyWaitGroup sync.WaitGroup
-
-	// keepAlive executes a request in the background with the purpose of
-	// keeping the session active. The response for this request is discarded.
-	keepAlive func(soap.RoundTripper) error
-}
-
-func defaultKeepAlive(roundTripper soap.RoundTripper) error {
-	_, err := methods.GetCurrentTime(context.Background(), roundTripper)
-	return err
-}
-
-// KeepAlive wraps the specified soap.RoundTripper and executes a meaningless
-// API request in the background after the RoundTripper has been idle for the
-// specified amount of idle time. The keep alive process only starts once a
-// user logs in and runs until the user logs out again.
+// KeepAlive is a backward compatible wrapper around KeepAliveHandler.
 func KeepAlive(roundTripper soap.RoundTripper, idleTime time.Duration) soap.RoundTripper {
-	return KeepAliveHandler(roundTripper, idleTime, defaultKeepAlive)
+	return KeepAliveHandler(roundTripper, idleTime, nil)
 }
 
-// KeepAliveHandler works as KeepAlive() does, but the handler param can decide how to handle errors.
-// For example, if connectivity to ESX/VC is down long enough for a session to expire, a handler can choose to
-// Login() on a types.NotAuthenticated error.  If handler returns non-nil, the keep alive go routine will be stopped.
+// KeepAliveHandler is a backward compatible wrapper around keepalive.NewHandlerSOAP.
 func KeepAliveHandler(roundTripper soap.RoundTripper, idleTime time.Duration, handler func(soap.RoundTripper) error) soap.RoundTripper {
-	k := &keepAlive{
-		roundTripper:  roundTripper,
-		idleTime:      idleTime,
-		notifyRequest: make(chan struct{}),
-	}
-
-	k.keepAlive = handler
-
-	return k
-}
-
-func (k *keepAlive) start() {
-	k.Lock()
-	defer k.Unlock()
-
-	if k.notifyStop != nil {
-		return
-	}
-
-	// This channel must be closed to terminate idle timer.
-	k.notifyStop = make(chan struct{})
-	k.notifyWaitGroup.Add(1)
-
-	go func() {
-		for t := time.NewTimer(k.idleTime); ; {
-			select {
-			case <-k.notifyStop:
-				k.notifyWaitGroup.Done()
-				return
-			case <-k.notifyRequest:
-				t.Reset(k.idleTime)
-			case <-t.C:
-				if err := k.keepAlive(k.roundTripper); err != nil {
-					k.notifyWaitGroup.Done()
-					k.stop()
-					return
-				}
-				t = time.NewTimer(k.idleTime)
-			}
+	var f func() error
+	if handler != nil {
+		f = func() error {
+			return handler(roundTripper)
 		}
-	}()
-}
-
-func (k *keepAlive) stop() {
-	k.Lock()
-	defer k.Unlock()
-
-	if k.notifyStop != nil {
-		close(k.notifyStop)
-		k.notifyWaitGroup.Wait()
-		k.notifyStop = nil
 	}
-}
-
-func (k *keepAlive) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
-	// Stop ticker on logout.
-	switch req.(type) {
-	case *methods.LogoutBody:
-		k.stop()
-	}
-
-	err := k.roundTripper.RoundTrip(ctx, req, res)
-	if err != nil {
-		return err
-	}
-	// Start ticker on login.
-	switch req.(type) {
-	case *methods.LoginBody, *methods.LoginExtensionByCertificateBody, *methods.LoginByTokenBody:
-		k.start()
-	}
-
-	return nil
+	return keepalive.NewHandlerSOAP(roundTripper, idleTime, f)
 }

--- a/vendor/github.com/vmware/govmomi/session/keepalive/handler.go
+++ b/vendor/github.com/vmware/govmomi/session/keepalive/handler.go
@@ -1,0 +1,204 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepalive
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// handler contains the generic keep alive settings and logic
+type handler struct {
+	mu              sync.Mutex
+	notifyStop      chan struct{}
+	notifyWaitGroup sync.WaitGroup
+
+	idle time.Duration
+	send func() error
+}
+
+// NewHandlerSOAP returns a soap.RoundTripper for use with a vim25.Client
+// The idle time specifies the interval in between send() requests. Defaults to 10 minutes.
+// The send func is used to keep a session alive. Defaults to calling vim25 GetCurrentTime().
+// The keep alive goroutine starts when a Login method is called and runs until Logout is called or send returns an error.
+func NewHandlerSOAP(c soap.RoundTripper, idle time.Duration, send func() error) *HandlerSOAP {
+	h := &handler{
+		idle: idle,
+		send: send,
+	}
+
+	if send == nil {
+		h.send = func() error {
+			return h.keepAliveSOAP(c)
+		}
+	}
+
+	return &HandlerSOAP{h, c}
+}
+
+// NewHandlerREST returns an http.RoundTripper for use with a rest.Client
+// The idle time specifies the interval in between send() requests. Defaults to 10 minutes.
+// The send func is used to keep a session alive. Defaults to calling the rest.Client.Session() method
+// The keep alive goroutine starts when a Login method is called and runs until Logout is called or send returns an error.
+func NewHandlerREST(c *rest.Client, idle time.Duration, send func() error) *HandlerREST {
+	h := &handler{
+		idle: idle,
+		send: send,
+	}
+
+	if send == nil {
+		h.send = func() error {
+			return h.keepAliveREST(c)
+		}
+	}
+
+	return &HandlerREST{h, c.Transport}
+}
+
+func (h *handler) keepAliveSOAP(rt soap.RoundTripper) error {
+	ctx := context.Background()
+	_, err := methods.GetCurrentTime(ctx, rt)
+	return err
+}
+
+func (h *handler) keepAliveREST(c *rest.Client) error {
+	ctx := context.Background()
+
+	s, err := c.Session(ctx)
+	if err != nil {
+		return err
+	}
+	if s != nil {
+		return nil
+	}
+	return errors.New(http.StatusText(http.StatusUnauthorized))
+}
+
+// Start explicitly starts the keep alive go routine.
+// For use with session cache.Client, as cached sessions may not involve Login/Logout via RoundTripper.
+func (h *handler) Start() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.notifyStop != nil {
+		return
+	}
+
+	if h.idle == 0 {
+		h.idle = time.Minute * 10
+	}
+
+	// This channel must be closed to terminate idle timer.
+	h.notifyStop = make(chan struct{})
+	h.notifyWaitGroup.Add(1)
+
+	go func() {
+		for t := time.NewTimer(h.idle); ; {
+			select {
+			case <-h.notifyStop:
+				h.notifyWaitGroup.Done()
+				t.Stop()
+				return
+			case <-t.C:
+				if err := h.send(); err != nil {
+					h.notifyWaitGroup.Done()
+					h.Stop()
+					return
+				}
+				t.Reset(h.idle)
+			}
+		}
+	}()
+}
+
+// Stop explicitly stops the keep alive go routine.
+// For use with session cache.Client, as cached sessions may not involve Login/Logout via RoundTripper.
+func (h *handler) Stop() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.notifyStop != nil {
+		close(h.notifyStop)
+		h.notifyWaitGroup.Wait()
+		h.notifyStop = nil
+	}
+}
+
+// HandlerSOAP is a keep alive implementation for use with vim25.Client
+type HandlerSOAP struct {
+	*handler
+
+	roundTripper soap.RoundTripper
+}
+
+// RoundTrip implements soap.RoundTripper
+func (h *HandlerSOAP) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
+	// Stop ticker on logout.
+	switch req.(type) {
+	case *methods.LogoutBody:
+		h.Stop()
+	}
+
+	err := h.roundTripper.RoundTrip(ctx, req, res)
+	if err != nil {
+		return err
+	}
+
+	// Start ticker on login.
+	switch req.(type) {
+	case *methods.LoginBody, *methods.LoginExtensionByCertificateBody, *methods.LoginByTokenBody:
+		h.Start()
+	}
+
+	return nil
+}
+
+// HandlerREST is a keep alive implementation for use with rest.Client
+type HandlerREST struct {
+	*handler
+
+	roundTripper http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper
+func (h *HandlerREST) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path != "/rest/com/vmware/cis/session" {
+		return h.roundTripper.RoundTrip(req)
+	}
+
+	if req.Method == http.MethodDelete { // Logout
+		h.Stop()
+	}
+
+	res, err := h.roundTripper.RoundTrip(req)
+	if err != nil {
+		return res, err
+	}
+
+	if req.Method == http.MethodPost { // Login
+		h.Start()
+	}
+
+	return res, err
+}

--- a/vendor/github.com/vmware/govmomi/session/manager.go
+++ b/vendor/github.com/vmware/govmomi/session/manager.go
@@ -19,7 +19,6 @@ package session
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -124,7 +123,7 @@ func (sm *Manager) LoginExtensionByCertificate(ctx context.Context, key string) 
 		// "Post https://sdkTunnel:8089/sdk: x509: certificate is valid for $vcenter_hostname, not sdkTunnel"
 		// The only easy way around this is to disable verification for the call to LoginExtensionByCertificate().
 		// TODO: find a way to avoid disabling InsecureSkipVerify.
-		c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+		c.DefaultTransport().TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	req := types.LoginExtensionByCertificate{

--- a/vendor/github.com/vmware/govmomi/vapi/internal/internal.go
+++ b/vendor/github.com/vmware/govmomi/vapi/internal/internal.go
@@ -38,10 +38,12 @@ const (
 	LocalLibraryPath               = "/com/vmware/content/local-library"
 	SubscribedLibraryPath          = "/com/vmware/content/subscribed-library"
 	SubscribedLibraryItem          = "/com/vmware/content/library/subscribed-item"
+	Subscriptions                  = "/com/vmware/content/library/subscriptions"
 	VCenterOVFLibraryItem          = "/com/vmware/vcenter/ovf/library-item"
 	VCenterVMTXLibraryItem         = "/vcenter/vm-template/library-items"
 	VCenterVM                      = "/vcenter/vm"
 	SessionCookieName              = "vmware-api-session-id"
+	UseHeaderAuthn                 = "vmware-use-header-authn"
 )
 
 // AssociatedObject is the same structure as types.ManagedObjectReference,
@@ -68,4 +70,17 @@ func NewAssociation(ref mo.Reference) Association {
 	return Association{
 		ObjectID: &obj,
 	}
+}
+
+type SubscriptionDestination struct {
+	ID string `json:"subscription"`
+}
+
+type SubscriptionDestinationSpec struct {
+	Subscriptions []SubscriptionDestination `json:"subscriptions,omitempty"`
+}
+
+type SubscriptionItemDestinationSpec struct {
+	Force         bool                      `json:"force_sync_content"`
+	Subscriptions []SubscriptionDestination `json:"subscriptions,omitempty"`
 }

--- a/vendor/github.com/vmware/govmomi/vapi/library/library_item.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/library_item.go
@@ -88,12 +88,35 @@ func (c *Manager) CreateLibraryItem(ctx context.Context, item Item) (string, err
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }
 
+// CopyLibraryItem copies a library item
+func (c *Manager) CopyLibraryItem(ctx context.Context, src *Item, dst Item) (string, error) {
+	body := struct {
+		Item `json:"destination_create_spec"`
+	}{dst}
+	url := c.Resource(internal.LibraryItemPath).WithID(src.ID).WithAction("copy")
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, body), &res)
+}
+
 // SyncLibraryItem syncs a subscribed library item
 func (c *Manager) SyncLibraryItem(ctx context.Context, item *Item, force bool) error {
 	body := struct {
 		Force bool `json:"force_sync_content"`
 	}{force}
 	url := c.Resource(internal.SubscribedLibraryItem).WithID(item.ID).WithAction("sync")
+	return c.Do(ctx, url.Request(http.MethodPost, body), nil)
+}
+
+// PublishLibraryItem publishes a library item to specified subscriptions.
+// If no subscriptions are specified, then publishes the library item to all subscriptions.
+func (c *Manager) PublishLibraryItem(ctx context.Context, item *Item, force bool, subscriptions []string) error {
+	body := internal.SubscriptionItemDestinationSpec{
+		Force: force,
+	}
+	for i := range subscriptions {
+		body.Subscriptions = append(body.Subscriptions, internal.SubscriptionDestination{ID: subscriptions[i]})
+	}
+	url := c.Resource(internal.LibraryItemPath).WithID(item.ID).WithAction("publish")
 	return c.Do(ctx, url.Request(http.MethodPost, body), nil)
 }
 

--- a/vendor/github.com/vmware/govmomi/vapi/library/library_item_updatesession_file.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/library_item_updatesession_file.go
@@ -116,7 +116,7 @@ func (c *Manager) getContentLengthAndFingerprint(
 	}
 	fingerprint := c.Thumbprint(resp.Request.URL.Host)
 	if fingerprint == "" {
-		if c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify {
+		if c.DefaultTransport().TLSClientConfig.InsecureSkipVerify {
 			fingerprint = soap.ThumbprintSHA1(resp.TLS.PeerCertificates[0])
 		}
 	}

--- a/vendor/github.com/vmware/govmomi/vapi/rest/client.go
+++ b/vendor/github.com/vmware/govmomi/vapi/rest/client.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/vmware/govmomi/vapi/internal"
@@ -34,7 +35,10 @@ import (
 
 // Client extends soap.Client to support JSON encoding, while inheriting security features, debug tracing and session persistence.
 type Client struct {
+	mu sync.Mutex
+
 	*soap.Client
+	sessionID string
 }
 
 // Session information
@@ -59,7 +63,47 @@ func (m *LocalizableMessage) Error() string {
 func NewClient(c *vim25.Client) *Client {
 	sc := c.Client.NewServiceClient(Path, "")
 
-	return &Client{sc}
+	return &Client{Client: sc}
+}
+
+// SessionID is set by calling Login() or optionally with the given id param
+func (c *Client) SessionID(id ...string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(id) != 0 {
+		c.sessionID = id[0]
+	}
+	return c.sessionID
+}
+
+type marshaledClient struct {
+	SoapClient *soap.Client
+	SessionID  string
+}
+
+func (c *Client) MarshalJSON() ([]byte, error) {
+	m := marshaledClient{
+		SoapClient: c.Client,
+		SessionID:  c.sessionID,
+	}
+
+	return json.Marshal(m)
+}
+
+func (c *Client) UnmarshalJSON(b []byte) error {
+	var m marshaledClient
+
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+
+	*c = Client{
+		Client:    m.SoapClient,
+		sessionID: m.SessionID,
+	}
+
+	return nil
 }
 
 // Resource helper for the given path.
@@ -96,6 +140,10 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 
 	req.Header.Set("Accept", "application/json")
 
+	if id := c.SessionID(); id != "" {
+		req.Header.Set(internal.SessionCookieName, id)
+	}
+
 	if s, ok := ctx.Value(signerContext{}).(Signer); ok {
 		if err := s.SignRequest(req); err != nil {
 			return err
@@ -105,6 +153,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 	return c.Client.Do(ctx, req, func(res *http.Response) error {
 		switch res.StatusCode {
 		case http.StatusOK:
+		case http.StatusNoContent:
 		case http.StatusBadRequest:
 			// TODO: structured error types
 			detail, err := ioutil.ReadAll(res.Body)
@@ -135,9 +184,46 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 	})
 }
 
+// authHeaders ensures the given map contains a REST auth header
+func (c *Client) authHeaders(h map[string]string) map[string]string {
+	if _, exists := h[internal.SessionCookieName]; exists {
+		return h
+	}
+	if h == nil {
+		h = make(map[string]string)
+	}
+
+	h[internal.SessionCookieName] = c.SessionID()
+
+	return h
+}
+
+// Download wraps soap.Client.Download, adding the REST authentication header
+func (c *Client) Download(ctx context.Context, u *url.URL, param *soap.Download) (io.ReadCloser, int64, error) {
+	p := *param
+	p.Headers = c.authHeaders(p.Headers)
+	return c.Client.Download(ctx, u, &p)
+}
+
+// DownloadFile wraps soap.Client.DownloadFile, adding the REST authentication header
+func (c *Client) DownloadFile(ctx context.Context, file string, u *url.URL, param *soap.Download) error {
+	p := *param
+	p.Headers = c.authHeaders(p.Headers)
+	return c.Client.DownloadFile(ctx, file, u, &p)
+}
+
+// Upload wraps soap.Client.Upload, adding the REST authentication header
+func (c *Client) Upload(ctx context.Context, f io.Reader, u *url.URL, param *soap.Upload) error {
+	p := *param
+	p.Headers = c.authHeaders(p.Headers)
+	return c.Client.Upload(ctx, f, u, &p)
+}
+
 // Login creates a new session via Basic Authentication with the given url.Userinfo.
 func (c *Client) Login(ctx context.Context, user *url.Userinfo) error {
 	req := c.Resource(internal.SessionPath).Request(http.MethodPost)
+
+	req.Header.Set(internal.UseHeaderAuthn, "true")
 
 	if user != nil {
 		if password, ok := user.Password(); ok {
@@ -145,7 +231,15 @@ func (c *Client) Login(ctx context.Context, user *url.Userinfo) error {
 		}
 	}
 
-	return c.Do(ctx, req, nil)
+	var id string
+	err := c.Do(ctx, req, &id)
+	if err != nil {
+		return err
+	}
+
+	c.SessionID(id)
+
+	return nil
 }
 
 func (c *Client) LoginByToken(ctx context.Context) error {
@@ -173,4 +267,23 @@ func (c *Client) Session(ctx context.Context) (*Session, error) {
 func (c *Client) Logout(ctx context.Context) error {
 	req := c.Resource(internal.SessionPath).Request(http.MethodDelete)
 	return c.Do(ctx, req, nil)
+}
+
+// Valid returns whether or not the client is valid and ready for use.
+// This should be called after unmarshalling the client.
+func (c *Client) Valid() bool {
+	if c == nil {
+		return false
+	}
+
+	if c.Client == nil {
+		return false
+	}
+
+	return true
+}
+
+// Path returns rest.Path (see cache.Client)
+func (c *Client) Path() string {
+	return Path
 }

--- a/vendor/github.com/vmware/govmomi/vapi/vcenter/vcenter_ovf.go
+++ b/vendor/github.com/vmware/govmomi/vapi/vcenter/vcenter_ovf.go
@@ -60,14 +60,13 @@ type AdditionalParams struct {
 }
 
 const (
-	ClassOvfParams             = "com.vmware.vcenter.ovf.ovf_params"
-	ClassPropertyParams        = "com.vmware.vcenter.ovf.property_params"
-	TypeDeploymentOptionParams = "DeploymentOptionParams"
-	TypeExtraConfigParams      = "ExtraConfigParams"
-	TypeExtraConfigs           = "ExtraConfigs"
-	TypeIPAllocationParams     = "IpAllocationParams"
-	TypePropertyParams         = "PropertyParams"
-	TypeSizeParams             = "SizeParams"
+	ClassDeploymentOptionParams = "com.vmware.vcenter.ovf.deployment_option_params"
+	ClassPropertyParams         = "com.vmware.vcenter.ovf.property_params"
+	TypeDeploymentOptionParams  = "DeploymentOptionParams"
+	TypeExtraConfigParams       = "ExtraConfigParams"
+	TypeIPAllocationParams      = "IpAllocationParams"
+	TypePropertyParams          = "PropertyParams"
+	TypeSizeParams              = "SizeParams"
 )
 
 // DeploymentOption contains the information about a deployment option as defined in the OVF specification
@@ -204,6 +203,33 @@ func (e *DeploymentError) Error() string {
 	return "deploy error: " + msg
 }
 
+// LibraryTarget specifies a Library or Library item
+type LibraryTarget struct {
+	LibraryID     string `json:"library_id,omitempty"`
+	LibraryItemID string `json:"library_item_id,omitempty"`
+}
+
+// CreateSpec info used to create an OVF package from a VM
+type CreateSpec struct {
+	Description string   `json:"description,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Flags       []string `json:"flags,omitempty"`
+}
+
+// OVF data used by CreateOVF
+type OVF struct {
+	Spec   CreateSpec    `json:"create_spec"`
+	Source ResourceID    `json:"source"`
+	Target LibraryTarget `json:"target"`
+}
+
+// CreateResult used for decoded a CreateOVF response
+type CreateResult struct {
+	Succeeded bool             `json:"succeeded,omitempty"`
+	ID        string           `json:"ovf_library_item_id,omitempty"`
+	Error     *DeploymentError `json:"error,omitempty"`
+}
+
 // Deployment is the results from issuing a library OVF deployment
 type Deployment struct {
 	Succeeded  bool             `json:"succeeded,omitempty"`
@@ -236,6 +262,23 @@ func NewManager(client *rest.Client) *Manager {
 	return &Manager{
 		Client: client,
 	}
+}
+
+// CreateOVF creates a library OVF item in content library from an existing VM
+func (c *Manager) CreateOVF(ctx context.Context, ovf OVF) (string, error) {
+	if ovf.Source.Type == "" {
+		ovf.Source.Type = "VirtualMachine"
+	}
+	url := c.Resource(internal.VCenterOVFLibraryItem)
+	var res CreateResult
+	err := c.Do(ctx, url.Request(http.MethodPost, ovf), &res)
+	if err != nil {
+		return "", err
+	}
+	if res.Succeeded {
+		return res.ID, nil
+	}
+	return "", res.Error
 }
 
 // DeployLibraryItem deploys a library OVF

--- a/vendor/github.com/vmware/govmomi/vapi/vcenter/vcenter_vmtx.go
+++ b/vendor/github.com/vmware/govmomi/vapi/vcenter/vcenter_vmtx.go
@@ -53,12 +53,7 @@ type TemplateInfo struct {
 }
 
 // Placement information used to place the virtual machine template
-type Placement struct {
-	ResourcePool string `json:"resource_pool,omitempty"`
-	Host         string `json:"host,omitempty"`
-	Folder       string `json:"folder,omitempty"`
-	Cluster      string `json:"cluster,omitempty"`
-}
+type Placement = library.Placement
 
 // StoragePolicy for DiskStorage
 type StoragePolicy struct {
@@ -113,7 +108,7 @@ type CheckIn struct {
 	Message string `json:"message"`
 }
 
-// CreateTemplate creates a library item in content library from an existing VM
+// CreateTemplate creates a library VMTX item in content library from an existing VM
 func (c *Manager) CreateTemplate(ctx context.Context, vmtx Template) (string, error) {
 	url := c.Resource(internal.VCenterVMTXLibraryItem)
 	var res string

--- a/vendor/github.com/vmware/govmomi/vim25/methods/methods.go
+++ b/vendor/github.com/vmware/govmomi/vim25/methods/methods.go
@@ -63,6 +63,26 @@ func AbdicateDomOwnership(ctx context.Context, r soap.RoundTripper, req *types.A
 	return resBody.Res, nil
 }
 
+type AbortCustomization_TaskBody struct {
+	Req    *types.AbortCustomization_Task         `xml:"urn:vim25 AbortCustomization_Task,omitempty"`
+	Res    *types.AbortCustomization_TaskResponse `xml:"AbortCustomization_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AbortCustomization_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AbortCustomization_Task(ctx context.Context, r soap.RoundTripper, req *types.AbortCustomization_Task) (*types.AbortCustomization_TaskResponse, error) {
+	var reqBody, resBody AbortCustomization_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type AcknowledgeAlarmBody struct {
 	Req    *types.AcknowledgeAlarm         `xml:"urn:vim25 AcknowledgeAlarm,omitempty"`
 	Res    *types.AcknowledgeAlarmResponse `xml:"AcknowledgeAlarmResponse,omitempty"`
@@ -2263,6 +2283,26 @@ func ConfigureVFlashResourceEx_Task(ctx context.Context, r soap.RoundTripper, re
 	return resBody.Res, nil
 }
 
+type ConnectNvmeControllerBody struct {
+	Req    *types.ConnectNvmeController         `xml:"urn:vim25 ConnectNvmeController,omitempty"`
+	Res    *types.ConnectNvmeControllerResponse `xml:"ConnectNvmeControllerResponse,omitempty"`
+	Fault_ *soap.Fault                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ConnectNvmeControllerBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ConnectNvmeController(ctx context.Context, r soap.RoundTripper, req *types.ConnectNvmeController) (*types.ConnectNvmeControllerResponse, error) {
+	var reqBody, resBody ConnectNvmeControllerBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type ConsolidateVMDisks_TaskBody struct {
 	Req    *types.ConsolidateVMDisks_Task         `xml:"urn:vim25 ConsolidateVMDisks_Task,omitempty"`
 	Res    *types.ConsolidateVMDisks_TaskResponse `xml:"ConsolidateVMDisks_TaskResponse,omitempty"`
@@ -2943,6 +2983,26 @@ func CreateNvdimmPMemNamespace_Task(ctx context.Context, r soap.RoundTripper, re
 	return resBody.Res, nil
 }
 
+type CreateNvmeOverRdmaAdapterBody struct {
+	Req    *types.CreateNvmeOverRdmaAdapter         `xml:"urn:vim25 CreateNvmeOverRdmaAdapter,omitempty"`
+	Res    *types.CreateNvmeOverRdmaAdapterResponse `xml:"CreateNvmeOverRdmaAdapterResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CreateNvmeOverRdmaAdapterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CreateNvmeOverRdmaAdapter(ctx context.Context, r soap.RoundTripper, req *types.CreateNvmeOverRdmaAdapter) (*types.CreateNvmeOverRdmaAdapterResponse, error) {
+	var reqBody, resBody CreateNvmeOverRdmaAdapterBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type CreateObjectScheduledTaskBody struct {
 	Req    *types.CreateObjectScheduledTask         `xml:"urn:vim25 CreateObjectScheduledTask,omitempty"`
 	Res    *types.CreateObjectScheduledTaskResponse `xml:"CreateObjectScheduledTaskResponse,omitempty"`
@@ -3383,6 +3443,26 @@ func CreateVvolDatastore(ctx context.Context, r soap.RoundTripper, req *types.Cr
 	return resBody.Res, nil
 }
 
+type CryptoManagerHostDisableBody struct {
+	Req    *types.CryptoManagerHostDisable         `xml:"urn:vim25 CryptoManagerHostDisable,omitempty"`
+	Res    *types.CryptoManagerHostDisableResponse `xml:"CryptoManagerHostDisableResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CryptoManagerHostDisableBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CryptoManagerHostDisable(ctx context.Context, r soap.RoundTripper, req *types.CryptoManagerHostDisable) (*types.CryptoManagerHostDisableResponse, error) {
+	var reqBody, resBody CryptoManagerHostDisableBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type CryptoManagerHostEnableBody struct {
 	Req    *types.CryptoManagerHostEnable         `xml:"urn:vim25 CryptoManagerHostEnable,omitempty"`
 	Res    *types.CryptoManagerHostEnableResponse `xml:"CryptoManagerHostEnableResponse,omitempty"`
@@ -3473,6 +3553,26 @@ func (b *CustomizationSpecItemToXmlBody) Fault() *soap.Fault { return b.Fault_ }
 
 func CustomizationSpecItemToXml(ctx context.Context, r soap.RoundTripper, req *types.CustomizationSpecItemToXml) (*types.CustomizationSpecItemToXmlResponse, error) {
 	var reqBody, resBody CustomizationSpecItemToXmlBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CustomizeGuest_TaskBody struct {
+	Req    *types.CustomizeGuest_Task         `xml:"urn:vim25 CustomizeGuest_Task,omitempty"`
+	Res    *types.CustomizeGuest_TaskResponse `xml:"CustomizeGuest_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CustomizeGuest_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CustomizeGuest_Task(ctx context.Context, r soap.RoundTripper, req *types.CustomizeGuest_Task) (*types.CustomizeGuest_TaskResponse, error) {
+	var reqBody, resBody CustomizeGuest_TaskBody
 
 	reqBody.Req = req
 
@@ -4423,6 +4523,46 @@ func DetachTagFromVStorageObject(ctx context.Context, r soap.RoundTripper, req *
 	return resBody.Res, nil
 }
 
+type DisableAlarmBody struct {
+	Req    *types.DisableAlarm         `xml:"urn:vim25 DisableAlarm,omitempty"`
+	Res    *types.DisableAlarmResponse `xml:"DisableAlarmResponse,omitempty"`
+	Fault_ *soap.Fault                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DisableAlarmBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DisableAlarm(ctx context.Context, r soap.RoundTripper, req *types.DisableAlarm) (*types.DisableAlarmResponse, error) {
+	var reqBody, resBody DisableAlarmBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DisableClusteredVmdkSupportBody struct {
+	Req    *types.DisableClusteredVmdkSupport         `xml:"urn:vim25 DisableClusteredVmdkSupport,omitempty"`
+	Res    *types.DisableClusteredVmdkSupportResponse `xml:"DisableClusteredVmdkSupportResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DisableClusteredVmdkSupportBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DisableClusteredVmdkSupport(ctx context.Context, r soap.RoundTripper, req *types.DisableClusteredVmdkSupport) (*types.DisableClusteredVmdkSupportResponse, error) {
+	var reqBody, resBody DisableClusteredVmdkSupportBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type DisableEvcMode_TaskBody struct {
 	Req    *types.DisableEvcMode_Task         `xml:"urn:vim25 DisableEvcMode_Task,omitempty"`
 	Res    *types.DisableEvcMode_TaskResponse `xml:"DisableEvcMode_TaskResponse,omitempty"`
@@ -4583,6 +4723,26 @@ func DisconnectHost_Task(ctx context.Context, r soap.RoundTripper, req *types.Di
 	return resBody.Res, nil
 }
 
+type DisconnectNvmeControllerBody struct {
+	Req    *types.DisconnectNvmeController         `xml:"urn:vim25 DisconnectNvmeController,omitempty"`
+	Res    *types.DisconnectNvmeControllerResponse `xml:"DisconnectNvmeControllerResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DisconnectNvmeControllerBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DisconnectNvmeController(ctx context.Context, r soap.RoundTripper, req *types.DisconnectNvmeController) (*types.DisconnectNvmeControllerResponse, error) {
+	var reqBody, resBody DisconnectNvmeControllerBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type DiscoverFcoeHbasBody struct {
 	Req    *types.DiscoverFcoeHbas         `xml:"urn:vim25 DiscoverFcoeHbas,omitempty"`
 	Res    *types.DiscoverFcoeHbasResponse `xml:"DiscoverFcoeHbasResponse,omitempty"`
@@ -4593,6 +4753,26 @@ func (b *DiscoverFcoeHbasBody) Fault() *soap.Fault { return b.Fault_ }
 
 func DiscoverFcoeHbas(ctx context.Context, r soap.RoundTripper, req *types.DiscoverFcoeHbas) (*types.DiscoverFcoeHbasResponse, error) {
 	var reqBody, resBody DiscoverFcoeHbasBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DiscoverNvmeControllersBody struct {
+	Req    *types.DiscoverNvmeControllers         `xml:"urn:vim25 DiscoverNvmeControllers,omitempty"`
+	Res    *types.DiscoverNvmeControllersResponse `xml:"DiscoverNvmeControllersResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DiscoverNvmeControllersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DiscoverNvmeControllers(ctx context.Context, r soap.RoundTripper, req *types.DiscoverNvmeControllers) (*types.DiscoverNvmeControllersResponse, error) {
+	var reqBody, resBody DiscoverNvmeControllersBody
 
 	reqBody.Req = req
 
@@ -4633,6 +4813,26 @@ func (b *DoesCustomizationSpecExistBody) Fault() *soap.Fault { return b.Fault_ }
 
 func DoesCustomizationSpecExist(ctx context.Context, r soap.RoundTripper, req *types.DoesCustomizationSpecExist) (*types.DoesCustomizationSpecExistResponse, error) {
 	var reqBody, resBody DoesCustomizationSpecExistBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DownloadDescriptionTreeBody struct {
+	Req    *types.DownloadDescriptionTree         `xml:"urn:vim25 DownloadDescriptionTree,omitempty"`
+	Res    *types.DownloadDescriptionTreeResponse `xml:"DownloadDescriptionTreeResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DownloadDescriptionTreeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DownloadDescriptionTree(ctx context.Context, r soap.RoundTripper, req *types.DownloadDescriptionTree) (*types.DownloadDescriptionTreeResponse, error) {
+	var reqBody, resBody DownloadDescriptionTreeBody
 
 	reqBody.Req = req
 
@@ -4703,6 +4903,26 @@ func EagerZeroVirtualDisk_Task(ctx context.Context, r soap.RoundTripper, req *ty
 	return resBody.Res, nil
 }
 
+type EnableAlarmBody struct {
+	Req    *types.EnableAlarm         `xml:"urn:vim25 EnableAlarm,omitempty"`
+	Res    *types.EnableAlarmResponse `xml:"EnableAlarmResponse,omitempty"`
+	Fault_ *soap.Fault                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *EnableAlarmBody) Fault() *soap.Fault { return b.Fault_ }
+
+func EnableAlarm(ctx context.Context, r soap.RoundTripper, req *types.EnableAlarm) (*types.EnableAlarmResponse, error) {
+	var reqBody, resBody EnableAlarmBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type EnableAlarmActionsBody struct {
 	Req    *types.EnableAlarmActions         `xml:"urn:vim25 EnableAlarmActions,omitempty"`
 	Res    *types.EnableAlarmActionsResponse `xml:"EnableAlarmActionsResponse,omitempty"`
@@ -4713,6 +4933,26 @@ func (b *EnableAlarmActionsBody) Fault() *soap.Fault { return b.Fault_ }
 
 func EnableAlarmActions(ctx context.Context, r soap.RoundTripper, req *types.EnableAlarmActions) (*types.EnableAlarmActionsResponse, error) {
 	var reqBody, resBody EnableAlarmActionsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type EnableClusteredVmdkSupportBody struct {
+	Req    *types.EnableClusteredVmdkSupport         `xml:"urn:vim25 EnableClusteredVmdkSupport,omitempty"`
+	Res    *types.EnableClusteredVmdkSupportResponse `xml:"EnableClusteredVmdkSupportResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *EnableClusteredVmdkSupportBody) Fault() *soap.Fault { return b.Fault_ }
+
+func EnableClusteredVmdkSupport(ctx context.Context, r soap.RoundTripper, req *types.EnableClusteredVmdkSupport) (*types.EnableClusteredVmdkSupportResponse, error) {
+	var reqBody, resBody EnableClusteredVmdkSupportBody
 
 	reqBody.Req = req
 
@@ -5963,6 +6203,26 @@ func GetCustomizationSpec(ctx context.Context, r soap.RoundTripper, req *types.G
 	return resBody.Res, nil
 }
 
+type GetDefaultKmsClusterBody struct {
+	Req    *types.GetDefaultKmsCluster         `xml:"urn:vim25 GetDefaultKmsCluster,omitempty"`
+	Res    *types.GetDefaultKmsClusterResponse `xml:"GetDefaultKmsClusterResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetDefaultKmsClusterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetDefaultKmsCluster(ctx context.Context, r soap.RoundTripper, req *types.GetDefaultKmsCluster) (*types.GetDefaultKmsClusterResponse, error) {
+	var reqBody, resBody GetDefaultKmsClusterBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type GetPublicKeyBody struct {
 	Req    *types.GetPublicKey         `xml:"urn:vim25 GetPublicKey,omitempty"`
 	Res    *types.GetPublicKeyResponse `xml:"GetPublicKeyResponse,omitempty"`
@@ -5993,6 +6253,26 @@ func (b *GetResourceUsageBody) Fault() *soap.Fault { return b.Fault_ }
 
 func GetResourceUsage(ctx context.Context, r soap.RoundTripper, req *types.GetResourceUsage) (*types.GetResourceUsageResponse, error) {
 	var reqBody, resBody GetResourceUsageBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GetSiteInfoBody struct {
+	Req    *types.GetSiteInfo         `xml:"urn:vim25 GetSiteInfo,omitempty"`
+	Res    *types.GetSiteInfoResponse `xml:"GetSiteInfoResponse,omitempty"`
+	Fault_ *soap.Fault                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetSiteInfoBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetSiteInfo(ctx context.Context, r soap.RoundTripper, req *types.GetSiteInfo) (*types.GetSiteInfoResponse, error) {
+	var reqBody, resBody GetSiteInfoBody
 
 	reqBody.Req = req
 
@@ -7203,6 +7483,26 @@ func InstantClone_Task(ctx context.Context, r soap.RoundTripper, req *types.Inst
 	return resBody.Res, nil
 }
 
+type IsKmsClusterActiveBody struct {
+	Req    *types.IsKmsClusterActive         `xml:"urn:vim25 IsKmsClusterActive,omitempty"`
+	Res    *types.IsKmsClusterActiveResponse `xml:"IsKmsClusterActiveResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *IsKmsClusterActiveBody) Fault() *soap.Fault { return b.Fault_ }
+
+func IsKmsClusterActive(ctx context.Context, r soap.RoundTripper, req *types.IsKmsClusterActive) (*types.IsKmsClusterActiveResponse, error) {
+	var reqBody, resBody IsKmsClusterActiveBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type IsSharedGraphicsActiveBody struct {
 	Req    *types.IsSharedGraphicsActive         `xml:"urn:vim25 IsSharedGraphicsActive,omitempty"`
 	Res    *types.IsSharedGraphicsActiveResponse `xml:"IsSharedGraphicsActiveResponse,omitempty"`
@@ -7413,6 +7713,26 @@ func (b *ListKmipServersBody) Fault() *soap.Fault { return b.Fault_ }
 
 func ListKmipServers(ctx context.Context, r soap.RoundTripper, req *types.ListKmipServers) (*types.ListKmipServersResponse, error) {
 	var reqBody, resBody ListKmipServersBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ListKmsClustersBody struct {
+	Req    *types.ListKmsClusters         `xml:"urn:vim25 ListKmsClusters,omitempty"`
+	Res    *types.ListKmsClustersResponse `xml:"ListKmsClustersResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ListKmsClustersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ListKmsClusters(ctx context.Context, r soap.RoundTripper, req *types.ListKmsClusters) (*types.ListKmsClustersResponse, error) {
+	var reqBody, resBody ListKmsClustersBody
 
 	reqBody.Req = req
 
@@ -7993,6 +8313,26 @@ func (b *MarkPerenniallyReservedEx_TaskBody) Fault() *soap.Fault { return b.Faul
 
 func MarkPerenniallyReservedEx_Task(ctx context.Context, r soap.RoundTripper, req *types.MarkPerenniallyReservedEx_Task) (*types.MarkPerenniallyReservedEx_TaskResponse, error) {
 	var reqBody, resBody MarkPerenniallyReservedEx_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type MarkServiceProviderEntitiesBody struct {
+	Req    *types.MarkServiceProviderEntities         `xml:"urn:vim25 MarkServiceProviderEntities,omitempty"`
+	Res    *types.MarkServiceProviderEntitiesResponse `xml:"MarkServiceProviderEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *MarkServiceProviderEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func MarkServiceProviderEntities(ctx context.Context, r soap.RoundTripper, req *types.MarkServiceProviderEntities) (*types.MarkServiceProviderEntitiesResponse, error) {
+	var reqBody, resBody MarkServiceProviderEntitiesBody
 
 	reqBody.Req = req
 
@@ -11983,6 +12323,26 @@ func RegisterKmipServer(ctx context.Context, r soap.RoundTripper, req *types.Reg
 	return resBody.Res, nil
 }
 
+type RegisterKmsClusterBody struct {
+	Req    *types.RegisterKmsCluster         `xml:"urn:vim25 RegisterKmsCluster,omitempty"`
+	Res    *types.RegisterKmsClusterResponse `xml:"RegisterKmsClusterResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RegisterKmsClusterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RegisterKmsCluster(ctx context.Context, r soap.RoundTripper, req *types.RegisterKmsCluster) (*types.RegisterKmsClusterResponse, error) {
+	var reqBody, resBody RegisterKmsClusterBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RegisterVM_TaskBody struct {
 	Req    *types.RegisterVM_Task         `xml:"urn:vim25 RegisterVM_Task,omitempty"`
 	Res    *types.RegisterVM_TaskResponse `xml:"RegisterVM_TaskResponse,omitempty"`
@@ -12593,6 +12953,26 @@ func (b *RemoveNetworkResourcePoolBody) Fault() *soap.Fault { return b.Fault_ }
 
 func RemoveNetworkResourcePool(ctx context.Context, r soap.RoundTripper, req *types.RemoveNetworkResourcePool) (*types.RemoveNetworkResourcePoolResponse, error) {
 	var reqBody, resBody RemoveNetworkResourcePoolBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RemoveNvmeOverRdmaAdapterBody struct {
+	Req    *types.RemoveNvmeOverRdmaAdapter         `xml:"urn:vim25 RemoveNvmeOverRdmaAdapter,omitempty"`
+	Res    *types.RemoveNvmeOverRdmaAdapterResponse `xml:"RemoveNvmeOverRdmaAdapterResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemoveNvmeOverRdmaAdapterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemoveNvmeOverRdmaAdapter(ctx context.Context, r soap.RoundTripper, req *types.RemoveNvmeOverRdmaAdapter) (*types.RemoveNvmeOverRdmaAdapterResponse, error) {
+	var reqBody, resBody RemoveNvmeOverRdmaAdapterBody
 
 	reqBody.Req = req
 
@@ -13563,6 +13943,26 @@ func RetrieveDiskPartitionInfo(ctx context.Context, r soap.RoundTripper, req *ty
 	return resBody.Res, nil
 }
 
+type RetrieveDynamicPassthroughInfoBody struct {
+	Req    *types.RetrieveDynamicPassthroughInfo         `xml:"urn:vim25 RetrieveDynamicPassthroughInfo,omitempty"`
+	Res    *types.RetrieveDynamicPassthroughInfoResponse `xml:"RetrieveDynamicPassthroughInfoResponse,omitempty"`
+	Fault_ *soap.Fault                                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveDynamicPassthroughInfoBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveDynamicPassthroughInfo(ctx context.Context, r soap.RoundTripper, req *types.RetrieveDynamicPassthroughInfo) (*types.RetrieveDynamicPassthroughInfoResponse, error) {
+	var reqBody, resBody RetrieveDynamicPassthroughInfoBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RetrieveEntityPermissionsBody struct {
 	Req    *types.RetrieveEntityPermissions         `xml:"urn:vim25 RetrieveEntityPermissions,omitempty"`
 	Res    *types.RetrieveEntityPermissionsResponse `xml:"RetrieveEntityPermissionsResponse,omitempty"`
@@ -13593,6 +13993,26 @@ func (b *RetrieveEntityScheduledTaskBody) Fault() *soap.Fault { return b.Fault_ 
 
 func RetrieveEntityScheduledTask(ctx context.Context, r soap.RoundTripper, req *types.RetrieveEntityScheduledTask) (*types.RetrieveEntityScheduledTaskResponse, error) {
 	var reqBody, resBody RetrieveEntityScheduledTaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveFreeEpcMemoryBody struct {
+	Req    *types.RetrieveFreeEpcMemory         `xml:"urn:vim25 RetrieveFreeEpcMemory,omitempty"`
+	Res    *types.RetrieveFreeEpcMemoryResponse `xml:"RetrieveFreeEpcMemoryResponse,omitempty"`
+	Fault_ *soap.Fault                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveFreeEpcMemoryBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveFreeEpcMemory(ctx context.Context, r soap.RoundTripper, req *types.RetrieveFreeEpcMemory) (*types.RetrieveFreeEpcMemoryResponse, error) {
+	var reqBody, resBody RetrieveFreeEpcMemoryBody
 
 	reqBody.Req = req
 
@@ -13873,6 +14293,46 @@ func (b *RetrieveServiceContentBody) Fault() *soap.Fault { return b.Fault_ }
 
 func RetrieveServiceContent(ctx context.Context, r soap.RoundTripper, req *types.RetrieveServiceContent) (*types.RetrieveServiceContentResponse, error) {
 	var reqBody, resBody RetrieveServiceContentBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveServiceProviderEntitiesBody struct {
+	Req    *types.RetrieveServiceProviderEntities         `xml:"urn:vim25 RetrieveServiceProviderEntities,omitempty"`
+	Res    *types.RetrieveServiceProviderEntitiesResponse `xml:"RetrieveServiceProviderEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveServiceProviderEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveServiceProviderEntities(ctx context.Context, r soap.RoundTripper, req *types.RetrieveServiceProviderEntities) (*types.RetrieveServiceProviderEntitiesResponse, error) {
+	var reqBody, resBody RetrieveServiceProviderEntitiesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveSnapshotDetailsBody struct {
+	Req    *types.RetrieveSnapshotDetails         `xml:"urn:vim25 RetrieveSnapshotDetails,omitempty"`
+	Res    *types.RetrieveSnapshotDetailsResponse `xml:"RetrieveSnapshotDetailsResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveSnapshotDetailsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveSnapshotDetails(ctx context.Context, r soap.RoundTripper, req *types.RetrieveSnapshotDetails) (*types.RetrieveSnapshotDetailsResponse, error) {
+	var reqBody, resBody RetrieveSnapshotDetailsBody
 
 	reqBody.Req = req
 
@@ -14363,6 +14823,46 @@ func SetCollectorPageSize(ctx context.Context, r soap.RoundTripper, req *types.S
 	return resBody.Res, nil
 }
 
+type SetCryptoModeBody struct {
+	Req    *types.SetCryptoMode         `xml:"urn:vim25 SetCryptoMode,omitempty"`
+	Res    *types.SetCryptoModeResponse `xml:"SetCryptoModeResponse,omitempty"`
+	Fault_ *soap.Fault                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetCryptoModeBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetCryptoMode(ctx context.Context, r soap.RoundTripper, req *types.SetCryptoMode) (*types.SetCryptoModeResponse, error) {
+	var reqBody, resBody SetCryptoModeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type SetDefaultKmsClusterBody struct {
+	Req    *types.SetDefaultKmsCluster         `xml:"urn:vim25 SetDefaultKmsCluster,omitempty"`
+	Res    *types.SetDefaultKmsClusterResponse `xml:"SetDefaultKmsClusterResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *SetDefaultKmsClusterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func SetDefaultKmsCluster(ctx context.Context, r soap.RoundTripper, req *types.SetDefaultKmsCluster) (*types.SetDefaultKmsClusterResponse, error) {
+	var reqBody, resBody SetDefaultKmsClusterBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type SetDisplayTopologyBody struct {
 	Req    *types.SetDisplayTopology         `xml:"urn:vim25 SetDisplayTopology,omitempty"`
 	Res    *types.SetDisplayTopologyResponse `xml:"SetDisplayTopologyResponse,omitempty"`
@@ -14773,6 +15273,26 @@ func (b *StandbyGuestBody) Fault() *soap.Fault { return b.Fault_ }
 
 func StandbyGuest(ctx context.Context, r soap.RoundTripper, req *types.StandbyGuest) (*types.StandbyGuestResponse, error) {
 	var reqBody, resBody StandbyGuestBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type StartGuestNetwork_TaskBody struct {
+	Req    *types.StartGuestNetwork_Task         `xml:"urn:vim25 StartGuestNetwork_Task,omitempty"`
+	Res    *types.StartGuestNetwork_TaskResponse `xml:"StartGuestNetwork_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *StartGuestNetwork_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func StartGuestNetwork_Task(ctx context.Context, r soap.RoundTripper, req *types.StartGuestNetwork_Task) (*types.StartGuestNetwork_TaskResponse, error) {
+	var reqBody, resBody StartGuestNetwork_TaskBody
 
 	reqBody.Req = req
 
@@ -15223,6 +15743,26 @@ func UnmapVmfsVolumeEx_Task(ctx context.Context, r soap.RoundTripper, req *types
 	return resBody.Res, nil
 }
 
+type UnmarkServiceProviderEntitiesBody struct {
+	Req    *types.UnmarkServiceProviderEntities         `xml:"urn:vim25 UnmarkServiceProviderEntities,omitempty"`
+	Res    *types.UnmarkServiceProviderEntitiesResponse `xml:"UnmarkServiceProviderEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UnmarkServiceProviderEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UnmarkServiceProviderEntities(ctx context.Context, r soap.RoundTripper, req *types.UnmarkServiceProviderEntities) (*types.UnmarkServiceProviderEntitiesResponse, error) {
+	var reqBody, resBody UnmarkServiceProviderEntitiesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type UnmountDiskMapping_TaskBody struct {
 	Req    *types.UnmountDiskMapping_Task         `xml:"urn:vim25 UnmountDiskMapping_Task,omitempty"`
 	Res    *types.UnmountDiskMapping_TaskResponse `xml:"UnmountDiskMapping_TaskResponse,omitempty"`
@@ -15403,6 +15943,26 @@ func UnregisterHealthUpdateProvider(ctx context.Context, r soap.RoundTripper, re
 	return resBody.Res, nil
 }
 
+type UnregisterKmsClusterBody struct {
+	Req    *types.UnregisterKmsCluster         `xml:"urn:vim25 UnregisterKmsCluster,omitempty"`
+	Res    *types.UnregisterKmsClusterResponse `xml:"UnregisterKmsClusterResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UnregisterKmsClusterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UnregisterKmsCluster(ctx context.Context, r soap.RoundTripper, req *types.UnregisterKmsCluster) (*types.UnregisterKmsClusterResponse, error) {
+	var reqBody, resBody UnregisterKmsClusterBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type UnregisterVMBody struct {
 	Req    *types.UnregisterVM         `xml:"urn:vim25 UnregisterVM,omitempty"`
 	Res    *types.UnregisterVMResponse `xml:"UnregisterVMResponse,omitempty"`
@@ -15433,6 +15993,26 @@ func (b *UpdateAnswerFile_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func UpdateAnswerFile_Task(ctx context.Context, r soap.RoundTripper, req *types.UpdateAnswerFile_Task) (*types.UpdateAnswerFile_TaskResponse, error) {
 	var reqBody, resBody UpdateAnswerFile_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateAssignableHardwareConfigBody struct {
+	Req    *types.UpdateAssignableHardwareConfig         `xml:"urn:vim25 UpdateAssignableHardwareConfig,omitempty"`
+	Res    *types.UpdateAssignableHardwareConfigResponse `xml:"UpdateAssignableHardwareConfigResponse,omitempty"`
+	Fault_ *soap.Fault                                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateAssignableHardwareConfigBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateAssignableHardwareConfig(ctx context.Context, r soap.RoundTripper, req *types.UpdateAssignableHardwareConfig) (*types.UpdateAssignableHardwareConfigResponse, error) {
+	var reqBody, resBody UpdateAssignableHardwareConfigBody
 
 	reqBody.Req = req
 
@@ -15913,6 +16493,26 @@ func (b *UpdateHostSubSpecificationBody) Fault() *soap.Fault { return b.Fault_ }
 
 func UpdateHostSubSpecification(ctx context.Context, r soap.RoundTripper, req *types.UpdateHostSubSpecification) (*types.UpdateHostSubSpecificationResponse, error) {
 	var reqBody, resBody UpdateHostSubSpecificationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateHppMultipathLunPolicyBody struct {
+	Req    *types.UpdateHppMultipathLunPolicy         `xml:"urn:vim25 UpdateHppMultipathLunPolicy,omitempty"`
+	Res    *types.UpdateHppMultipathLunPolicyResponse `xml:"UpdateHppMultipathLunPolicyResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateHppMultipathLunPolicyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateHppMultipathLunPolicy(ctx context.Context, r soap.RoundTripper, req *types.UpdateHppMultipathLunPolicy) (*types.UpdateHppMultipathLunPolicyResponse, error) {
+	var reqBody, resBody UpdateHppMultipathLunPolicyBody
 
 	reqBody.Req = req
 
@@ -16783,6 +17383,26 @@ func UpdateVStorageInfrastructureObjectPolicy_Task(ctx context.Context, r soap.R
 	return resBody.Res, nil
 }
 
+type UpdateVStorageObjectCrypto_TaskBody struct {
+	Req    *types.UpdateVStorageObjectCrypto_Task         `xml:"urn:vim25 UpdateVStorageObjectCrypto_Task,omitempty"`
+	Res    *types.UpdateVStorageObjectCrypto_TaskResponse `xml:"UpdateVStorageObjectCrypto_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateVStorageObjectCrypto_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateVStorageObjectCrypto_Task(ctx context.Context, r soap.RoundTripper, req *types.UpdateVStorageObjectCrypto_Task) (*types.UpdateVStorageObjectCrypto_TaskResponse, error) {
+	var reqBody, resBody UpdateVStorageObjectCrypto_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type UpdateVStorageObjectPolicy_TaskBody struct {
 	Req    *types.UpdateVStorageObjectPolicy_Task         `xml:"urn:vim25 UpdateVStorageObjectPolicy_Task,omitempty"`
 	Res    *types.UpdateVStorageObjectPolicy_TaskResponse `xml:"UpdateVStorageObjectPolicy_TaskResponse,omitempty"`
@@ -17233,6 +17853,26 @@ func (b *ValidateStoragePodConfigBody) Fault() *soap.Fault { return b.Fault_ }
 
 func ValidateStoragePodConfig(ctx context.Context, r soap.RoundTripper, req *types.ValidateStoragePodConfig) (*types.ValidateStoragePodConfigResponse, error) {
 	var reqBody, resBody ValidateStoragePodConfigBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type VstorageObjectVCenterQueryChangedDiskAreasBody struct {
+	Req    *types.VstorageObjectVCenterQueryChangedDiskAreas         `xml:"urn:vim25 VstorageObjectVCenterQueryChangedDiskAreas,omitempty"`
+	Res    *types.VstorageObjectVCenterQueryChangedDiskAreasResponse `xml:"VstorageObjectVCenterQueryChangedDiskAreasResponse,omitempty"`
+	Fault_ *soap.Fault                                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *VstorageObjectVCenterQueryChangedDiskAreasBody) Fault() *soap.Fault { return b.Fault_ }
+
+func VstorageObjectVCenterQueryChangedDiskAreas(ctx context.Context, r soap.RoundTripper, req *types.VstorageObjectVCenterQueryChangedDiskAreas) (*types.VstorageObjectVCenterQueryChangedDiskAreasResponse, error) {
+	var reqBody, resBody VstorageObjectVCenterQueryChangedDiskAreasBody
 
 	reqBody.Req = req
 

--- a/vendor/github.com/vmware/govmomi/vim25/mo/mo.go
+++ b/vendor/github.com/vmware/govmomi/vim25/mo/mo.go
@@ -129,6 +129,7 @@ type ComputeResource struct {
 	Summary            types.BaseComputeResourceSummary    `mo:"summary"`
 	EnvironmentBrowser *types.ManagedObjectReference       `mo:"environmentBrowser"`
 	ConfigurationEx    types.BaseComputeResourceConfigInfo `mo:"configurationEx"`
+	LifecycleManaged   *bool                               `mo:"lifecycleManaged"`
 }
 
 func (m *ComputeResource) Entity() *ManagedEntity {
@@ -442,6 +443,7 @@ type Folder struct {
 
 	ChildType   []string                       `mo:"childType"`
 	ChildEntity []types.ManagedObjectReference `mo:"childEntity"`
+	Namespace   *string                        `mo:"namespace"`
 }
 
 func (m *Folder) Entity() *ManagedEntity {
@@ -576,6 +578,21 @@ type HostActiveDirectoryAuthentication struct {
 
 func init() {
 	t["HostActiveDirectoryAuthentication"] = reflect.TypeOf((*HostActiveDirectoryAuthentication)(nil)).Elem()
+}
+
+type HostAssignableHardwareManager struct {
+	Self types.ManagedObjectReference
+
+	Binding []types.HostAssignableHardwareBinding `mo:"binding"`
+	Config  types.HostAssignableHardwareConfig    `mo:"config"`
+}
+
+func (m HostAssignableHardwareManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["HostAssignableHardwareManager"] = reflect.TypeOf((*HostAssignableHardwareManager)(nil)).Elem()
 }
 
 type HostAuthenticationManager struct {
@@ -1266,10 +1283,10 @@ func init() {
 type Network struct {
 	ManagedEntity
 
-	Name    string                         `mo:"name"`
 	Summary types.BaseNetworkSummary       `mo:"summary"`
 	Host    []types.ManagedObjectReference `mo:"host"`
 	Vm      []types.ManagedObjectReference `mo:"vm"`
+	Name    string                         `mo:"name"`
 }
 
 func (m *Network) Entity() *ManagedEntity {
@@ -1445,6 +1462,7 @@ type ResourcePool struct {
 	ResourcePool       []types.ManagedObjectReference `mo:"resourcePool"`
 	Vm                 []types.ManagedObjectReference `mo:"vm"`
 	Config             types.ResourceConfigSpec       `mo:"config"`
+	Namespace          *string                        `mo:"namespace"`
 	ChildConfiguration []types.ResourceConfigSpec     `mo:"childConfiguration"`
 }
 
@@ -1557,6 +1575,18 @@ func init() {
 	t["SimpleCommand"] = reflect.TypeOf((*SimpleCommand)(nil)).Elem()
 }
 
+type SiteInfoManager struct {
+	Self types.ManagedObjectReference
+}
+
+func (m SiteInfoManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["SiteInfoManager"] = reflect.TypeOf((*SiteInfoManager)(nil)).Elem()
+}
+
 type StoragePod struct {
 	Folder
 
@@ -1566,6 +1596,18 @@ type StoragePod struct {
 
 func init() {
 	t["StoragePod"] = reflect.TypeOf((*StoragePod)(nil)).Elem()
+}
+
+type StorageQueryManager struct {
+	Self types.ManagedObjectReference
+}
+
+func (m StorageQueryManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["StorageQueryManager"] = reflect.TypeOf((*StorageQueryManager)(nil)).Elem()
 }
 
 type StorageResourceManager struct {
@@ -1614,6 +1656,18 @@ func (m TaskManager) Reference() types.ManagedObjectReference {
 
 func init() {
 	t["TaskManager"] = reflect.TypeOf((*TaskManager)(nil)).Elem()
+}
+
+type TenantTenantManager struct {
+	Self types.ManagedObjectReference
+}
+
+func (m TenantTenantManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["TenantTenantManager"] = reflect.TypeOf((*TenantTenantManager)(nil)).Elem()
 }
 
 type UserDirectory struct {
@@ -1743,6 +1797,18 @@ func (m VirtualMachineCompatibilityChecker) Reference() types.ManagedObjectRefer
 
 func init() {
 	t["VirtualMachineCompatibilityChecker"] = reflect.TypeOf((*VirtualMachineCompatibilityChecker)(nil)).Elem()
+}
+
+type VirtualMachineGuestCustomizationManager struct {
+	Self types.ManagedObjectReference
+}
+
+func (m VirtualMachineGuestCustomizationManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["VirtualMachineGuestCustomizationManager"] = reflect.TypeOf((*VirtualMachineGuestCustomizationManager)(nil)).Elem()
 }
 
 type VirtualMachineProvisioningChecker struct {

--- a/vendor/github.com/vmware/govmomi/vim25/soap/client.go
+++ b/vendor/github.com/vmware/govmomi/vim25/soap/client.go
@@ -159,6 +159,10 @@ func NewClient(u *url.URL, insecure bool) *Client {
 	return &c
 }
 
+func (c *Client) DefaultTransport() *http.Transport {
+	return c.t
+}
+
 // NewServiceClient creates a NewClient with the given URL.Path and namespace.
 func (c *Client) NewServiceClient(path string, namespace string) *Client {
 	vc := c.URL()
@@ -173,7 +177,7 @@ func (c *Client) NewServiceClient(path string, namespace string) *Client {
 
 	client := NewClient(u, c.k)
 	client.Namespace = "urn:" + namespace
-	client.Transport.(*http.Transport).TLSClientConfig = c.Transport.(*http.Transport).TLSClientConfig
+	client.DefaultTransport().TLSClientConfig = c.DefaultTransport().TLSClientConfig
 	if cert := c.Certificate(); cert != nil {
 		client.SetCertificate(*cert)
 	}

--- a/vendor/github.com/vmware/govmomi/vim25/types/enum.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/enum.go
@@ -200,8 +200,7 @@ func init() {
 type CannotEnableVmcpForClusterReason string
 
 const (
-	CannotEnableVmcpForClusterReasonAPDTimeoutDisabled      = CannotEnableVmcpForClusterReason("APDTimeoutDisabled")
-	CannotEnableVmcpForClusterReasonIncompatibleHostVersion = CannotEnableVmcpForClusterReason("IncompatibleHostVersion")
+	CannotEnableVmcpForClusterReasonAPDTimeoutDisabled = CannotEnableVmcpForClusterReason("APDTimeoutDisabled")
 )
 
 func init() {
@@ -239,6 +238,8 @@ const (
 	CannotUseNetworkReasonMismatchedNetworkPolicies       = CannotUseNetworkReason("MismatchedNetworkPolicies")
 	CannotUseNetworkReasonMismatchedDvsVersionOrVendor    = CannotUseNetworkReason("MismatchedDvsVersionOrVendor")
 	CannotUseNetworkReasonVMotionToUnsupportedNetworkType = CannotUseNetworkReason("VMotionToUnsupportedNetworkType")
+	CannotUseNetworkReasonNetworkUnderMaintenance         = CannotUseNetworkReason("NetworkUnderMaintenance")
+	CannotUseNetworkReasonMismatchedEnsMode               = CannotUseNetworkReason("MismatchedEnsMode")
 )
 
 func init() {
@@ -269,6 +270,17 @@ const (
 
 func init() {
 	t["ClusterComputeResourceHCIWorkflowState"] = reflect.TypeOf((*ClusterComputeResourceHCIWorkflowState)(nil)).Elem()
+}
+
+type ClusterCryptoConfigInfoCryptoMode string
+
+const (
+	ClusterCryptoConfigInfoCryptoModeOnDemand    = ClusterCryptoConfigInfoCryptoMode("onDemand")
+	ClusterCryptoConfigInfoCryptoModeForceEnable = ClusterCryptoConfigInfoCryptoMode("forceEnable")
+)
+
+func init() {
+	t["ClusterCryptoConfigInfoCryptoMode"] = reflect.TypeOf((*ClusterCryptoConfigInfoCryptoMode)(nil)).Elem()
 }
 
 type ClusterDasAamNodeStateDasState string
@@ -509,15 +521,26 @@ func init() {
 type CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason string
 
 const (
-	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateMissingInCache     = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateMissingInCache")
-	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateClusterInvalid     = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateClusterInvalid")
-	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateClusterUnreachable = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateClusterUnreachable")
-	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateMissingInKMS       = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateMissingInKMS")
-	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateNotActiveOrEnabled = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateNotActiveOrEnabled")
+	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateMissingInCache          = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateMissingInCache")
+	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateClusterInvalid          = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateClusterInvalid")
+	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateClusterUnreachable      = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateClusterUnreachable")
+	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateMissingInKMS            = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateMissingInKMS")
+	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateNotActiveOrEnabled      = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateNotActiveOrEnabled")
+	CryptoManagerKmipCryptoKeyStatusKeyUnavailableReasonKeyStateManagedByTrustAuthority = CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason("KeyStateManagedByTrustAuthority")
 )
 
 func init() {
 	t["CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason"] = reflect.TypeOf((*CryptoManagerKmipCryptoKeyStatusKeyUnavailableReason)(nil)).Elem()
+}
+
+type CustomizationFailedReasonCode string
+
+const (
+	CustomizationFailedReasonCodeUserDefinedScriptDisabled = CustomizationFailedReasonCode("userDefinedScriptDisabled")
+)
+
+func init() {
+	t["CustomizationFailedReasonCode"] = reflect.TypeOf((*CustomizationFailedReasonCode)(nil)).Elem()
 }
 
 type CustomizationLicenseDataMode string
@@ -602,6 +625,8 @@ const (
 	DasConfigFaultDasConfigFaultReasonCreateConfigVvolFailed      = DasConfigFaultDasConfigFaultReason("CreateConfigVvolFailed")
 	DasConfigFaultDasConfigFaultReasonVSanNotSupportedOnHost      = DasConfigFaultDasConfigFaultReason("VSanNotSupportedOnHost")
 	DasConfigFaultDasConfigFaultReasonDasNetworkMisconfiguration  = DasConfigFaultDasConfigFaultReason("DasNetworkMisconfiguration")
+	DasConfigFaultDasConfigFaultReasonSetDesiredImageSpecFailed   = DasConfigFaultDasConfigFaultReason("SetDesiredImageSpecFailed")
+	DasConfigFaultDasConfigFaultReasonApplyHAVibsOnClusterFailed  = DasConfigFaultDasConfigFaultReason("ApplyHAVibsOnClusterFailed")
 )
 
 func init() {
@@ -729,6 +754,17 @@ func init() {
 	t["DisallowedChangeByServiceDisallowedChange"] = reflect.TypeOf((*DisallowedChangeByServiceDisallowedChange)(nil)).Elem()
 }
 
+type DistributedVirtualPortgroupBackingType string
+
+const (
+	DistributedVirtualPortgroupBackingTypeStandard = DistributedVirtualPortgroupBackingType("standard")
+	DistributedVirtualPortgroupBackingTypeNsx      = DistributedVirtualPortgroupBackingType("nsx")
+)
+
+func init() {
+	t["DistributedVirtualPortgroupBackingType"] = reflect.TypeOf((*DistributedVirtualPortgroupBackingType)(nil)).Elem()
+}
+
 type DistributedVirtualPortgroupMetaTagName string
 
 const (
@@ -784,6 +820,17 @@ const (
 
 func init() {
 	t["DistributedVirtualSwitchHostMemberHostComponentState"] = reflect.TypeOf((*DistributedVirtualSwitchHostMemberHostComponentState)(nil)).Elem()
+}
+
+type DistributedVirtualSwitchHostMemberTransportZoneType string
+
+const (
+	DistributedVirtualSwitchHostMemberTransportZoneTypeVlan    = DistributedVirtualSwitchHostMemberTransportZoneType("vlan")
+	DistributedVirtualSwitchHostMemberTransportZoneTypeOverlay = DistributedVirtualSwitchHostMemberTransportZoneType("overlay")
+)
+
+func init() {
+	t["DistributedVirtualSwitchHostMemberTransportZoneType"] = reflect.TypeOf((*DistributedVirtualSwitchHostMemberTransportZoneType)(nil)).Elem()
 }
 
 type DistributedVirtualSwitchNetworkResourceControlVersion string
@@ -1272,9 +1319,10 @@ func init() {
 type HostCryptoState string
 
 const (
-	HostCryptoStateIncapable = HostCryptoState("incapable")
-	HostCryptoStatePrepared  = HostCryptoState("prepared")
-	HostCryptoStateSafe      = HostCryptoState("safe")
+	HostCryptoStateIncapable        = HostCryptoState("incapable")
+	HostCryptoStatePrepared         = HostCryptoState("prepared")
+	HostCryptoStateSafe             = HostCryptoState("safe")
+	HostCryptoStatePendingIncapable = HostCryptoState("pendingIncapable")
 )
 
 func init() {
@@ -1296,6 +1344,17 @@ const (
 
 func init() {
 	t["HostDasErrorEventHostDasErrorReason"] = reflect.TypeOf((*HostDasErrorEventHostDasErrorReason)(nil)).Elem()
+}
+
+type HostDateTimeInfoProtocol string
+
+const (
+	HostDateTimeInfoProtocolNtp = HostDateTimeInfoProtocol("ntp")
+	HostDateTimeInfoProtocolPtp = HostDateTimeInfoProtocol("ptp")
+)
+
+func init() {
+	t["HostDateTimeInfoProtocol"] = reflect.TypeOf((*HostDateTimeInfoProtocol)(nil)).Elem()
 }
 
 type HostDigestInfoDigestMethodType string
@@ -1670,6 +1729,16 @@ func init() {
 	t["HostLowLevelProvisioningManagerReloadTarget"] = reflect.TypeOf((*HostLowLevelProvisioningManagerReloadTarget)(nil)).Elem()
 }
 
+type HostMaintenanceSpecPurpose string
+
+const (
+	HostMaintenanceSpecPurposeHostUpgrade = HostMaintenanceSpecPurpose("hostUpgrade")
+)
+
+func init() {
+	t["HostMaintenanceSpecPurpose"] = reflect.TypeOf((*HostMaintenanceSpecPurpose)(nil)).Elem()
+}
+
 type HostMountInfoInaccessibleReason string
 
 const (
@@ -1763,12 +1832,65 @@ func init() {
 	t["HostNumericSensorType"] = reflect.TypeOf((*HostNumericSensorType)(nil)).Elem()
 }
 
+type HostNvmeDiscoveryLogSubsystemType string
+
+const (
+	HostNvmeDiscoveryLogSubsystemTypeDiscovery = HostNvmeDiscoveryLogSubsystemType("discovery")
+	HostNvmeDiscoveryLogSubsystemTypeNvm       = HostNvmeDiscoveryLogSubsystemType("nvm")
+)
+
+func init() {
+	t["HostNvmeDiscoveryLogSubsystemType"] = reflect.TypeOf((*HostNvmeDiscoveryLogSubsystemType)(nil)).Elem()
+}
+
+type HostNvmeDiscoveryLogTransportRequirements string
+
+const (
+	HostNvmeDiscoveryLogTransportRequirementsSecureChannelRequired    = HostNvmeDiscoveryLogTransportRequirements("secureChannelRequired")
+	HostNvmeDiscoveryLogTransportRequirementsSecureChannelNotRequired = HostNvmeDiscoveryLogTransportRequirements("secureChannelNotRequired")
+	HostNvmeDiscoveryLogTransportRequirementsRequirementsNotSpecified = HostNvmeDiscoveryLogTransportRequirements("requirementsNotSpecified")
+)
+
+func init() {
+	t["HostNvmeDiscoveryLogTransportRequirements"] = reflect.TypeOf((*HostNvmeDiscoveryLogTransportRequirements)(nil)).Elem()
+}
+
+type HostNvmeTransportParametersNvmeAddressFamily string
+
+const (
+	HostNvmeTransportParametersNvmeAddressFamilyIpv4       = HostNvmeTransportParametersNvmeAddressFamily("ipv4")
+	HostNvmeTransportParametersNvmeAddressFamilyIpv6       = HostNvmeTransportParametersNvmeAddressFamily("ipv6")
+	HostNvmeTransportParametersNvmeAddressFamilyInfiniBand = HostNvmeTransportParametersNvmeAddressFamily("infiniBand")
+	HostNvmeTransportParametersNvmeAddressFamilyFc         = HostNvmeTransportParametersNvmeAddressFamily("fc")
+	HostNvmeTransportParametersNvmeAddressFamilyLoopback   = HostNvmeTransportParametersNvmeAddressFamily("loopback")
+	HostNvmeTransportParametersNvmeAddressFamilyUnknown    = HostNvmeTransportParametersNvmeAddressFamily("unknown")
+)
+
+func init() {
+	t["HostNvmeTransportParametersNvmeAddressFamily"] = reflect.TypeOf((*HostNvmeTransportParametersNvmeAddressFamily)(nil)).Elem()
+}
+
+type HostNvmeTransportType string
+
+const (
+	HostNvmeTransportTypePcie         = HostNvmeTransportType("pcie")
+	HostNvmeTransportTypeFibreChannel = HostNvmeTransportType("fibreChannel")
+	HostNvmeTransportTypeRdma         = HostNvmeTransportType("rdma")
+	HostNvmeTransportTypeLoopback     = HostNvmeTransportType("loopback")
+	HostNvmeTransportTypeUnsupported  = HostNvmeTransportType("unsupported")
+)
+
+func init() {
+	t["HostNvmeTransportType"] = reflect.TypeOf((*HostNvmeTransportType)(nil)).Elem()
+}
+
 type HostOpaqueSwitchOpaqueSwitchState string
 
 const (
-	HostOpaqueSwitchOpaqueSwitchStateUp      = HostOpaqueSwitchOpaqueSwitchState("up")
-	HostOpaqueSwitchOpaqueSwitchStateWarning = HostOpaqueSwitchOpaqueSwitchState("warning")
-	HostOpaqueSwitchOpaqueSwitchStateDown    = HostOpaqueSwitchOpaqueSwitchState("down")
+	HostOpaqueSwitchOpaqueSwitchStateUp          = HostOpaqueSwitchOpaqueSwitchState("up")
+	HostOpaqueSwitchOpaqueSwitchStateWarning     = HostOpaqueSwitchOpaqueSwitchState("warning")
+	HostOpaqueSwitchOpaqueSwitchStateDown        = HostOpaqueSwitchOpaqueSwitchState("down")
+	HostOpaqueSwitchOpaqueSwitchStateMaintenance = HostOpaqueSwitchOpaqueSwitchState("maintenance")
 )
 
 func init() {
@@ -1921,6 +2043,21 @@ func init() {
 	t["HostProtocolEndpointProtocolEndpointType"] = reflect.TypeOf((*HostProtocolEndpointProtocolEndpointType)(nil)).Elem()
 }
 
+type HostRdmaDeviceConnectionState string
+
+const (
+	HostRdmaDeviceConnectionStateUnknown     = HostRdmaDeviceConnectionState("unknown")
+	HostRdmaDeviceConnectionStateDown        = HostRdmaDeviceConnectionState("down")
+	HostRdmaDeviceConnectionStateInit        = HostRdmaDeviceConnectionState("init")
+	HostRdmaDeviceConnectionStateArmed       = HostRdmaDeviceConnectionState("armed")
+	HostRdmaDeviceConnectionStateActive      = HostRdmaDeviceConnectionState("active")
+	HostRdmaDeviceConnectionStateActiveDefer = HostRdmaDeviceConnectionState("activeDefer")
+)
+
+func init() {
+	t["HostRdmaDeviceConnectionState"] = reflect.TypeOf((*HostRdmaDeviceConnectionState)(nil)).Elem()
+}
+
 type HostReplayUnsupportedReason string
 
 const (
@@ -1961,6 +2098,35 @@ func init() {
 	t["HostServicePolicy"] = reflect.TypeOf((*HostServicePolicy)(nil)).Elem()
 }
 
+type HostSgxInfoFlcModes string
+
+const (
+	HostSgxInfoFlcModesOff      = HostSgxInfoFlcModes("off")
+	HostSgxInfoFlcModesLocked   = HostSgxInfoFlcModes("locked")
+	HostSgxInfoFlcModesUnlocked = HostSgxInfoFlcModes("unlocked")
+)
+
+func init() {
+	t["HostSgxInfoFlcModes"] = reflect.TypeOf((*HostSgxInfoFlcModes)(nil)).Elem()
+}
+
+type HostSgxInfoSgxStates string
+
+const (
+	HostSgxInfoSgxStatesNotPresent          = HostSgxInfoSgxStates("notPresent")
+	HostSgxInfoSgxStatesDisabledBIOS        = HostSgxInfoSgxStates("disabledBIOS")
+	HostSgxInfoSgxStatesDisabledCFW101      = HostSgxInfoSgxStates("disabledCFW101")
+	HostSgxInfoSgxStatesDisabledCPUMismatch = HostSgxInfoSgxStates("disabledCPUMismatch")
+	HostSgxInfoSgxStatesDisabledNoFLC       = HostSgxInfoSgxStates("disabledNoFLC")
+	HostSgxInfoSgxStatesDisabledNUMAUnsup   = HostSgxInfoSgxStates("disabledNUMAUnsup")
+	HostSgxInfoSgxStatesDisabledMaxEPCRegs  = HostSgxInfoSgxStates("disabledMaxEPCRegs")
+	HostSgxInfoSgxStatesEnabled             = HostSgxInfoSgxStates("enabled")
+)
+
+func init() {
+	t["HostSgxInfoSgxStates"] = reflect.TypeOf((*HostSgxInfoSgxStates)(nil)).Elem()
+}
+
 type HostSnmpAgentCapability string
 
 const (
@@ -1984,6 +2150,17 @@ const (
 
 func init() {
 	t["HostStandbyMode"] = reflect.TypeOf((*HostStandbyMode)(nil)).Elem()
+}
+
+type HostStorageProtocol string
+
+const (
+	HostStorageProtocolScsi = HostStorageProtocol("scsi")
+	HostStorageProtocolNvme = HostStorageProtocol("nvme")
+)
+
+func init() {
+	t["HostStorageProtocol"] = reflect.TypeOf((*HostStorageProtocol)(nil)).Elem()
 }
 
 type HostSystemConnectionState string
@@ -2084,6 +2261,8 @@ const (
 	HostVirtualNicManagerNicTypeVsan                  = HostVirtualNicManagerNicType("vsan")
 	HostVirtualNicManagerNicTypeVSphereProvisioning   = HostVirtualNicManagerNicType("vSphereProvisioning")
 	HostVirtualNicManagerNicTypeVsanWitness           = HostVirtualNicManagerNicType("vsanWitness")
+	HostVirtualNicManagerNicTypeVSphereBackupNFC      = HostVirtualNicManagerNicType("vSphereBackupNFC")
+	HostVirtualNicManagerNicTypePtp                   = HostVirtualNicManagerNicType("ptp")
 )
 
 func init() {
@@ -2244,6 +2423,18 @@ const (
 
 func init() {
 	t["IscsiPortInfoPathStatus"] = reflect.TypeOf((*IscsiPortInfoPathStatus)(nil)).Elem()
+}
+
+type KmipClusterInfoKmsManagementType string
+
+const (
+	KmipClusterInfoKmsManagementTypeUnknown        = KmipClusterInfoKmsManagementType("unknown")
+	KmipClusterInfoKmsManagementTypeVCenter        = KmipClusterInfoKmsManagementType("vCenter")
+	KmipClusterInfoKmsManagementTypeTrustAuthority = KmipClusterInfoKmsManagementType("trustAuthority")
+)
+
+func init() {
+	t["KmipClusterInfoKmsManagementType"] = reflect.TypeOf((*KmipClusterInfoKmsManagementType)(nil)).Elem()
 }
 
 type LatencySensitivitySensitivityLevel string
@@ -2717,6 +2908,7 @@ const (
 	PerformanceManagerUnitWatt               = PerformanceManagerUnit("watt")
 	PerformanceManagerUnitJoule              = PerformanceManagerUnit("joule")
 	PerformanceManagerUnitTeraBytes          = PerformanceManagerUnit("teraBytes")
+	PerformanceManagerUnitCelsius            = PerformanceManagerUnit("celsius")
 )
 
 func init() {
@@ -2907,6 +3099,9 @@ const (
 	RecommendationReasonCodeHostExitDegradation             = RecommendationReasonCode("hostExitDegradation")
 	RecommendationReasonCodeMaxVmsConstraint                = RecommendationReasonCode("maxVmsConstraint")
 	RecommendationReasonCodeFtConstraints                   = RecommendationReasonCode("ftConstraints")
+	RecommendationReasonCodeVmHostAffinityPolicy            = RecommendationReasonCode("vmHostAffinityPolicy")
+	RecommendationReasonCodeVmHostAntiAffinityPolicy        = RecommendationReasonCode("vmHostAntiAffinityPolicy")
+	RecommendationReasonCodeVmAntiAffinityPolicy            = RecommendationReasonCode("vmAntiAffinityPolicy")
 )
 
 func init() {
@@ -3007,6 +3202,17 @@ const (
 
 func init() {
 	t["ReplicationVmState"] = reflect.TypeOf((*ReplicationVmState)(nil)).Elem()
+}
+
+type ResourceConfigSpecScaleSharesBehavior string
+
+const (
+	ResourceConfigSpecScaleSharesBehaviorDisabled                = ResourceConfigSpecScaleSharesBehavior("disabled")
+	ResourceConfigSpecScaleSharesBehaviorScaleCpuAndMemoryShares = ResourceConfigSpecScaleSharesBehavior("scaleCpuAndMemoryShares")
+)
+
+func init() {
+	t["ResourceConfigSpecScaleSharesBehavior"] = reflect.TypeOf((*ResourceConfigSpecScaleSharesBehavior)(nil)).Elem()
 }
 
 type ScheduledHardwareUpgradeInfoHardwareUpgradePolicy string
@@ -4108,6 +4314,7 @@ const (
 	VirtualMachineGuestOsIdentifierWindows9_64Guest        = VirtualMachineGuestOsIdentifier("windows9_64Guest")
 	VirtualMachineGuestOsIdentifierWindows9Server64Guest   = VirtualMachineGuestOsIdentifier("windows9Server64Guest")
 	VirtualMachineGuestOsIdentifierWindowsHyperVGuest      = VirtualMachineGuestOsIdentifier("windowsHyperVGuest")
+	VirtualMachineGuestOsIdentifierWindows2019srv_64Guest  = VirtualMachineGuestOsIdentifier("windows2019srv_64Guest")
 	VirtualMachineGuestOsIdentifierFreebsdGuest            = VirtualMachineGuestOsIdentifier("freebsdGuest")
 	VirtualMachineGuestOsIdentifierFreebsd64Guest          = VirtualMachineGuestOsIdentifier("freebsd64Guest")
 	VirtualMachineGuestOsIdentifierFreebsd11Guest          = VirtualMachineGuestOsIdentifier("freebsd11Guest")
@@ -4176,6 +4383,8 @@ const (
 	VirtualMachineGuestOsIdentifierDebian9_64Guest         = VirtualMachineGuestOsIdentifier("debian9_64Guest")
 	VirtualMachineGuestOsIdentifierDebian10Guest           = VirtualMachineGuestOsIdentifier("debian10Guest")
 	VirtualMachineGuestOsIdentifierDebian10_64Guest        = VirtualMachineGuestOsIdentifier("debian10_64Guest")
+	VirtualMachineGuestOsIdentifierDebian11Guest           = VirtualMachineGuestOsIdentifier("debian11Guest")
+	VirtualMachineGuestOsIdentifierDebian11_64Guest        = VirtualMachineGuestOsIdentifier("debian11_64Guest")
 	VirtualMachineGuestOsIdentifierAsianux3Guest           = VirtualMachineGuestOsIdentifier("asianux3Guest")
 	VirtualMachineGuestOsIdentifierAsianux3_64Guest        = VirtualMachineGuestOsIdentifier("asianux3_64Guest")
 	VirtualMachineGuestOsIdentifierAsianux4Guest           = VirtualMachineGuestOsIdentifier("asianux4Guest")
@@ -4229,11 +4438,14 @@ const (
 	VirtualMachineGuestOsIdentifierDarwin16_64Guest        = VirtualMachineGuestOsIdentifier("darwin16_64Guest")
 	VirtualMachineGuestOsIdentifierDarwin17_64Guest        = VirtualMachineGuestOsIdentifier("darwin17_64Guest")
 	VirtualMachineGuestOsIdentifierDarwin18_64Guest        = VirtualMachineGuestOsIdentifier("darwin18_64Guest")
+	VirtualMachineGuestOsIdentifierDarwin19_64Guest        = VirtualMachineGuestOsIdentifier("darwin19_64Guest")
 	VirtualMachineGuestOsIdentifierVmkernelGuest           = VirtualMachineGuestOsIdentifier("vmkernelGuest")
 	VirtualMachineGuestOsIdentifierVmkernel5Guest          = VirtualMachineGuestOsIdentifier("vmkernel5Guest")
 	VirtualMachineGuestOsIdentifierVmkernel6Guest          = VirtualMachineGuestOsIdentifier("vmkernel6Guest")
 	VirtualMachineGuestOsIdentifierVmkernel65Guest         = VirtualMachineGuestOsIdentifier("vmkernel65Guest")
+	VirtualMachineGuestOsIdentifierVmkernel7Guest          = VirtualMachineGuestOsIdentifier("vmkernel7Guest")
 	VirtualMachineGuestOsIdentifierAmazonlinux2_64Guest    = VirtualMachineGuestOsIdentifier("amazonlinux2_64Guest")
+	VirtualMachineGuestOsIdentifierCrxPod1Guest            = VirtualMachineGuestOsIdentifier("crxPod1Guest")
 	VirtualMachineGuestOsIdentifierOtherGuest              = VirtualMachineGuestOsIdentifier("otherGuest")
 	VirtualMachineGuestOsIdentifierOtherGuest64            = VirtualMachineGuestOsIdentifier("otherGuest64")
 )
@@ -4425,6 +4637,17 @@ func init() {
 	t["VirtualMachineScsiPassthroughType"] = reflect.TypeOf((*VirtualMachineScsiPassthroughType)(nil)).Elem()
 }
 
+type VirtualMachineSgxInfoFlcModes string
+
+const (
+	VirtualMachineSgxInfoFlcModesLocked   = VirtualMachineSgxInfoFlcModes("locked")
+	VirtualMachineSgxInfoFlcModesUnlocked = VirtualMachineSgxInfoFlcModes("unlocked")
+)
+
+func init() {
+	t["VirtualMachineSgxInfoFlcModes"] = reflect.TypeOf((*VirtualMachineSgxInfoFlcModes)(nil)).Elem()
+}
+
 type VirtualMachineStandbyActionType string
 
 const (
@@ -4450,11 +4673,12 @@ func init() {
 type VirtualMachineTicketType string
 
 const (
-	VirtualMachineTicketTypeMks            = VirtualMachineTicketType("mks")
-	VirtualMachineTicketTypeDevice         = VirtualMachineTicketType("device")
-	VirtualMachineTicketTypeGuestControl   = VirtualMachineTicketType("guestControl")
-	VirtualMachineTicketTypeWebmks         = VirtualMachineTicketType("webmks")
-	VirtualMachineTicketTypeGuestIntegrity = VirtualMachineTicketType("guestIntegrity")
+	VirtualMachineTicketTypeMks             = VirtualMachineTicketType("mks")
+	VirtualMachineTicketTypeDevice          = VirtualMachineTicketType("device")
+	VirtualMachineTicketTypeGuestControl    = VirtualMachineTicketType("guestControl")
+	VirtualMachineTicketTypeWebmks          = VirtualMachineTicketType("webmks")
+	VirtualMachineTicketTypeGuestIntegrity  = VirtualMachineTicketType("guestIntegrity")
+	VirtualMachineTicketTypeWebRemoteDevice = VirtualMachineTicketType("webRemoteDevice")
 )
 
 func init() {
@@ -4549,11 +4773,12 @@ func init() {
 type VirtualMachineUsbInfoSpeed string
 
 const (
-	VirtualMachineUsbInfoSpeedLow          = VirtualMachineUsbInfoSpeed("low")
-	VirtualMachineUsbInfoSpeedFull         = VirtualMachineUsbInfoSpeed("full")
-	VirtualMachineUsbInfoSpeedHigh         = VirtualMachineUsbInfoSpeed("high")
-	VirtualMachineUsbInfoSpeedSuperSpeed   = VirtualMachineUsbInfoSpeed("superSpeed")
-	VirtualMachineUsbInfoSpeedUnknownSpeed = VirtualMachineUsbInfoSpeed("unknownSpeed")
+	VirtualMachineUsbInfoSpeedLow            = VirtualMachineUsbInfoSpeed("low")
+	VirtualMachineUsbInfoSpeedFull           = VirtualMachineUsbInfoSpeed("full")
+	VirtualMachineUsbInfoSpeedHigh           = VirtualMachineUsbInfoSpeed("high")
+	VirtualMachineUsbInfoSpeedSuperSpeed     = VirtualMachineUsbInfoSpeed("superSpeed")
+	VirtualMachineUsbInfoSpeedSuperSpeedPlus = VirtualMachineUsbInfoSpeed("superSpeedPlus")
+	VirtualMachineUsbInfoSpeedUnknownSpeed   = VirtualMachineUsbInfoSpeed("unknownSpeed")
 )
 
 func init() {

--- a/vendor/github.com/vmware/govmomi/vim25/types/if.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/if.go
@@ -1424,6 +1424,28 @@ func init() {
 	t["BaseHostMultipathInfoLogicalUnitPolicy"] = reflect.TypeOf((*HostMultipathInfoLogicalUnitPolicy)(nil)).Elem()
 }
 
+func (b *HostNvmeSpec) GetHostNvmeSpec() *HostNvmeSpec { return b }
+
+type BaseHostNvmeSpec interface {
+	GetHostNvmeSpec() *HostNvmeSpec
+}
+
+func init() {
+	t["BaseHostNvmeSpec"] = reflect.TypeOf((*HostNvmeSpec)(nil)).Elem()
+}
+
+func (b *HostNvmeTransportParameters) GetHostNvmeTransportParameters() *HostNvmeTransportParameters {
+	return b
+}
+
+type BaseHostNvmeTransportParameters interface {
+	GetHostNvmeTransportParameters() *HostNvmeTransportParameters
+}
+
+func init() {
+	t["BaseHostNvmeTransportParameters"] = reflect.TypeOf((*HostNvmeTransportParameters)(nil)).Elem()
+}
+
 func (b *HostPciPassthruConfig) GetHostPciPassthruConfig() *HostPciPassthruConfig { return b }
 
 type BaseHostPciPassthruConfig interface {
@@ -1474,6 +1496,16 @@ type BaseHostProfilesEntityCustomizations interface {
 
 func init() {
 	t["BaseHostProfilesEntityCustomizations"] = reflect.TypeOf((*HostProfilesEntityCustomizations)(nil)).Elem()
+}
+
+func (b *HostRdmaDeviceBacking) GetHostRdmaDeviceBacking() *HostRdmaDeviceBacking { return b }
+
+type BaseHostRdmaDeviceBacking interface {
+	GetHostRdmaDeviceBacking() *HostRdmaDeviceBacking
+}
+
+func init() {
+	t["BaseHostRdmaDeviceBacking"] = reflect.TypeOf((*HostRdmaDeviceBacking)(nil)).Elem()
 }
 
 func (b *HostSriovDevicePoolInfo) GetHostSriovDevicePoolInfo() *HostSriovDevicePoolInfo { return b }

--- a/vendor/github.com/vmware/govmomi/vim25/types/types.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/types.go
@@ -57,6 +57,26 @@ type AbdicateDomOwnershipResponse struct {
 	Returnval []string `xml:"returnval,omitempty"`
 }
 
+type AbortCustomizationRequestType struct {
+	This ManagedObjectReference  `xml:"_this"`
+	Vm   ManagedObjectReference  `xml:"vm"`
+	Auth BaseGuestAuthentication `xml:"auth,typeattr"`
+}
+
+func init() {
+	t["AbortCustomizationRequestType"] = reflect.TypeOf((*AbortCustomizationRequestType)(nil)).Elem()
+}
+
+type AbortCustomization_Task AbortCustomizationRequestType
+
+func init() {
+	t["AbortCustomization_Task"] = reflect.TypeOf((*AbortCustomization_Task)(nil)).Elem()
+}
+
+type AbortCustomization_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type AboutInfo struct {
 	DynamicData
 
@@ -1045,6 +1065,7 @@ type AlarmState struct {
 	AcknowledgedByUser string                 `xml:"acknowledgedByUser,omitempty"`
 	AcknowledgedTime   *time.Time             `xml:"acknowledgedTime"`
 	EventKey           int32                  `xml:"eventKey,omitempty"`
+	Disabled           *bool                  `xml:"disabled"`
 }
 
 func init() {
@@ -2254,6 +2275,14 @@ func init() {
 	t["ArrayOfDistributedVirtualPortgroupInfo"] = reflect.TypeOf((*ArrayOfDistributedVirtualPortgroupInfo)(nil)).Elem()
 }
 
+type ArrayOfDistributedVirtualPortgroupProblem struct {
+	DistributedVirtualPortgroupProblem []DistributedVirtualPortgroupProblem `xml:"DistributedVirtualPortgroupProblem,omitempty"`
+}
+
+func init() {
+	t["ArrayOfDistributedVirtualPortgroupProblem"] = reflect.TypeOf((*ArrayOfDistributedVirtualPortgroupProblem)(nil)).Elem()
+}
+
 type ArrayOfDistributedVirtualSwitchHostMember struct {
 	DistributedVirtualSwitchHostMember []DistributedVirtualSwitchHostMember `xml:"DistributedVirtualSwitchHostMember,omitempty"`
 }
@@ -2276,6 +2305,14 @@ type ArrayOfDistributedVirtualSwitchHostMemberPnicSpec struct {
 
 func init() {
 	t["ArrayOfDistributedVirtualSwitchHostMemberPnicSpec"] = reflect.TypeOf((*ArrayOfDistributedVirtualSwitchHostMemberPnicSpec)(nil)).Elem()
+}
+
+type ArrayOfDistributedVirtualSwitchHostMemberTransportZoneInfo struct {
+	DistributedVirtualSwitchHostMemberTransportZoneInfo []DistributedVirtualSwitchHostMemberTransportZoneInfo `xml:"DistributedVirtualSwitchHostMemberTransportZoneInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfDistributedVirtualSwitchHostMemberTransportZoneInfo"] = reflect.TypeOf((*ArrayOfDistributedVirtualSwitchHostMemberTransportZoneInfo)(nil)).Elem()
 }
 
 type ArrayOfDistributedVirtualSwitchHostProductSpec struct {
@@ -2734,6 +2771,14 @@ func init() {
 	t["ArrayOfGuestInfoNamespaceGenerationInfo"] = reflect.TypeOf((*ArrayOfGuestInfoNamespaceGenerationInfo)(nil)).Elem()
 }
 
+type ArrayOfGuestInfoVirtualDiskMapping struct {
+	GuestInfoVirtualDiskMapping []GuestInfoVirtualDiskMapping `xml:"GuestInfoVirtualDiskMapping,omitempty"`
+}
+
+func init() {
+	t["ArrayOfGuestInfoVirtualDiskMapping"] = reflect.TypeOf((*ArrayOfGuestInfoVirtualDiskMapping)(nil)).Elem()
+}
+
 type ArrayOfGuestMappedAliases struct {
 	GuestMappedAliases []GuestMappedAliases `xml:"GuestMappedAliases,omitempty"`
 }
@@ -2836,6 +2881,22 @@ type ArrayOfHostActiveDirectory struct {
 
 func init() {
 	t["ArrayOfHostActiveDirectory"] = reflect.TypeOf((*ArrayOfHostActiveDirectory)(nil)).Elem()
+}
+
+type ArrayOfHostAssignableHardwareBinding struct {
+	HostAssignableHardwareBinding []HostAssignableHardwareBinding `xml:"HostAssignableHardwareBinding,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostAssignableHardwareBinding"] = reflect.TypeOf((*ArrayOfHostAssignableHardwareBinding)(nil)).Elem()
+}
+
+type ArrayOfHostAssignableHardwareConfigAttributeOverride struct {
+	HostAssignableHardwareConfigAttributeOverride []HostAssignableHardwareConfigAttributeOverride `xml:"HostAssignableHardwareConfigAttributeOverride,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostAssignableHardwareConfigAttributeOverride"] = reflect.TypeOf((*ArrayOfHostAssignableHardwareConfigAttributeOverride)(nil)).Elem()
 }
 
 type ArrayOfHostAuthenticationStoreInfo struct {
@@ -3318,6 +3379,38 @@ func init() {
 	t["ArrayOfHostNumericSensorInfo"] = reflect.TypeOf((*ArrayOfHostNumericSensorInfo)(nil)).Elem()
 }
 
+type ArrayOfHostNvmeController struct {
+	HostNvmeController []HostNvmeController `xml:"HostNvmeController,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostNvmeController"] = reflect.TypeOf((*ArrayOfHostNvmeController)(nil)).Elem()
+}
+
+type ArrayOfHostNvmeDiscoveryLogEntry struct {
+	HostNvmeDiscoveryLogEntry []HostNvmeDiscoveryLogEntry `xml:"HostNvmeDiscoveryLogEntry,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostNvmeDiscoveryLogEntry"] = reflect.TypeOf((*ArrayOfHostNvmeDiscoveryLogEntry)(nil)).Elem()
+}
+
+type ArrayOfHostNvmeNamespace struct {
+	HostNvmeNamespace []HostNvmeNamespace `xml:"HostNvmeNamespace,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostNvmeNamespace"] = reflect.TypeOf((*ArrayOfHostNvmeNamespace)(nil)).Elem()
+}
+
+type ArrayOfHostNvmeTopologyInterface struct {
+	HostNvmeTopologyInterface []HostNvmeTopologyInterface `xml:"HostNvmeTopologyInterface,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostNvmeTopologyInterface"] = reflect.TypeOf((*ArrayOfHostNvmeTopologyInterface)(nil)).Elem()
+}
+
 type ArrayOfHostOpaqueNetworkInfo struct {
 	HostOpaqueNetworkInfo []HostOpaqueNetworkInfo `xml:"HostOpaqueNetworkInfo,omitempty"`
 }
@@ -3548,6 +3641,14 @@ type ArrayOfHostProxySwitchHostLagConfig struct {
 
 func init() {
 	t["ArrayOfHostProxySwitchHostLagConfig"] = reflect.TypeOf((*ArrayOfHostProxySwitchHostLagConfig)(nil)).Elem()
+}
+
+type ArrayOfHostRdmaDevice struct {
+	HostRdmaDevice []HostRdmaDevice `xml:"HostRdmaDevice,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostRdmaDevice"] = reflect.TypeOf((*ArrayOfHostRdmaDevice)(nil)).Elem()
 }
 
 type ArrayOfHostRuntimeInfoNetStackInstanceRuntimeInfo struct {
@@ -5030,6 +5131,14 @@ func init() {
 	t["ArrayOfUpdateVirtualMachineFilesResultFailedVmFileInfo"] = reflect.TypeOf((*ArrayOfUpdateVirtualMachineFilesResultFailedVmFileInfo)(nil)).Elem()
 }
 
+type ArrayOfUri struct {
+	Uri []string `xml:"uri,omitempty"`
+}
+
+func init() {
+	t["ArrayOfUri"] = reflect.TypeOf((*ArrayOfUri)(nil)).Elem()
+}
+
 type ArrayOfUsbScanCodeSpecKeyEvent struct {
 	UsbScanCodeSpecKeyEvent []UsbScanCodeSpecKeyEvent `xml:"UsbScanCodeSpecKeyEvent,omitempty"`
 }
@@ -5374,6 +5483,14 @@ func init() {
 	t["ArrayOfVirtualMachineConfigOptionDescriptor"] = reflect.TypeOf((*ArrayOfVirtualMachineConfigOptionDescriptor)(nil)).Elem()
 }
 
+type ArrayOfVirtualMachineConfigSpec struct {
+	VirtualMachineConfigSpec []VirtualMachineConfigSpec `xml:"VirtualMachineConfigSpec,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVirtualMachineConfigSpec"] = reflect.TypeOf((*ArrayOfVirtualMachineConfigSpec)(nil)).Elem()
+}
+
 type ArrayOfVirtualMachineCpuIdInfoSpec struct {
 	VirtualMachineCpuIdInfoSpec []VirtualMachineCpuIdInfoSpec `xml:"VirtualMachineCpuIdInfoSpec,omitempty"`
 }
@@ -5412,6 +5529,14 @@ type ArrayOfVirtualMachineDisplayTopology struct {
 
 func init() {
 	t["ArrayOfVirtualMachineDisplayTopology"] = reflect.TypeOf((*ArrayOfVirtualMachineDisplayTopology)(nil)).Elem()
+}
+
+type ArrayOfVirtualMachineDynamicPassthroughInfo struct {
+	VirtualMachineDynamicPassthroughInfo []VirtualMachineDynamicPassthroughInfo `xml:"VirtualMachineDynamicPassthroughInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVirtualMachineDynamicPassthroughInfo"] = reflect.TypeOf((*ArrayOfVirtualMachineDynamicPassthroughInfo)(nil)).Elem()
 }
 
 type ArrayOfVirtualMachineFeatureRequirement struct {
@@ -5558,6 +5683,14 @@ func init() {
 	t["ArrayOfVirtualMachinePciSharedGpuPassthroughInfo"] = reflect.TypeOf((*ArrayOfVirtualMachinePciSharedGpuPassthroughInfo)(nil)).Elem()
 }
 
+type ArrayOfVirtualMachinePrecisionClockInfo struct {
+	VirtualMachinePrecisionClockInfo []VirtualMachinePrecisionClockInfo `xml:"VirtualMachinePrecisionClockInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVirtualMachinePrecisionClockInfo"] = reflect.TypeOf((*ArrayOfVirtualMachinePrecisionClockInfo)(nil)).Elem()
+}
+
 type ArrayOfVirtualMachineProfileDetailsDiskProfileDetails struct {
 	VirtualMachineProfileDetailsDiskProfileDetails []VirtualMachineProfileDetailsDiskProfileDetails `xml:"VirtualMachineProfileDetailsDiskProfileDetails,omitempty"`
 }
@@ -5678,12 +5811,28 @@ func init() {
 	t["ArrayOfVirtualMachineVMCIDeviceFilterSpec"] = reflect.TypeOf((*ArrayOfVirtualMachineVMCIDeviceFilterSpec)(nil)).Elem()
 }
 
+type ArrayOfVirtualMachineVcpuConfig struct {
+	VirtualMachineVcpuConfig []VirtualMachineVcpuConfig `xml:"VirtualMachineVcpuConfig,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVirtualMachineVcpuConfig"] = reflect.TypeOf((*ArrayOfVirtualMachineVcpuConfig)(nil)).Elem()
+}
+
 type ArrayOfVirtualNicManagerNetConfig struct {
 	VirtualNicManagerNetConfig []VirtualNicManagerNetConfig `xml:"VirtualNicManagerNetConfig,omitempty"`
 }
 
 func init() {
 	t["ArrayOfVirtualNicManagerNetConfig"] = reflect.TypeOf((*ArrayOfVirtualNicManagerNetConfig)(nil)).Elem()
+}
+
+type ArrayOfVirtualPCIPassthroughAllowedDevice struct {
+	VirtualPCIPassthroughAllowedDevice []VirtualPCIPassthroughAllowedDevice `xml:"VirtualPCIPassthroughAllowedDevice,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVirtualPCIPassthroughAllowedDevice"] = reflect.TypeOf((*ArrayOfVirtualPCIPassthroughAllowedDevice)(nil)).Elem()
 }
 
 type ArrayOfVirtualSCSISharing struct {
@@ -6267,6 +6416,7 @@ type BaseConfigInfoFileBackingInfo struct {
 	BackingObjectId string                            `xml:"backingObjectId,omitempty"`
 	Parent          BaseBaseConfigInfoFileBackingInfo `xml:"parent,omitempty,typeattr"`
 	DeltaSizeInMB   int64                             `xml:"deltaSizeInMB,omitempty"`
+	KeyId           *CryptoKeyId                      `xml:"keyId,omitempty"`
 }
 
 func init() {
@@ -7064,6 +7214,10 @@ type Capability struct {
 	NetworkBackupAndRestoreSupported *bool     `xml:"networkBackupAndRestoreSupported"`
 	FtDrsWithoutEvcSupported         *bool     `xml:"ftDrsWithoutEvcSupported"`
 	HciWorkflowSupported             *bool     `xml:"hciWorkflowSupported"`
+	ComputePolicyVersion             int32     `xml:"computePolicyVersion,omitempty"`
+	ClusterPlacementSupported        *bool     `xml:"clusterPlacementSupported"`
+	LifecycleManagementSupported     *bool     `xml:"lifecycleManagementSupported"`
+	ScalableSharesSupported          *bool     `xml:"scalableSharesSupported"`
 }
 
 func init() {
@@ -8076,14 +8230,16 @@ func init() {
 type ClusterComputeResourceSummary struct {
 	ComputeResourceSummary
 
-	CurrentFailoverLevel int32                              `xml:"currentFailoverLevel"`
-	AdmissionControlInfo BaseClusterDasAdmissionControlInfo `xml:"admissionControlInfo,omitempty,typeattr"`
-	NumVmotions          int32                              `xml:"numVmotions"`
-	TargetBalance        int32                              `xml:"targetBalance,omitempty"`
-	CurrentBalance       int32                              `xml:"currentBalance,omitempty"`
-	UsageSummary         *ClusterUsageSummary               `xml:"usageSummary,omitempty"`
-	CurrentEVCModeKey    string                             `xml:"currentEVCModeKey,omitempty"`
-	DasData              BaseClusterDasData                 `xml:"dasData,omitempty,typeattr"`
+	CurrentFailoverLevel    int32                              `xml:"currentFailoverLevel"`
+	AdmissionControlInfo    BaseClusterDasAdmissionControlInfo `xml:"admissionControlInfo,omitempty,typeattr"`
+	NumVmotions             int32                              `xml:"numVmotions"`
+	TargetBalance           int32                              `xml:"targetBalance,omitempty"`
+	CurrentBalance          int32                              `xml:"currentBalance,omitempty"`
+	DrsScore                int32                              `xml:"drsScore,omitempty"`
+	NumVmsPerDrsScoreBucket []int32                            `xml:"numVmsPerDrsScoreBucket,omitempty"`
+	UsageSummary            *ClusterUsageSummary               `xml:"usageSummary,omitempty"`
+	CurrentEVCModeKey       string                             `xml:"currentEVCModeKey,omitempty"`
+	DasData                 BaseClusterDasData                 `xml:"dasData,omitempty,typeattr"`
 }
 
 func init() {
@@ -8142,6 +8298,7 @@ type ClusterConfigInfoEx struct {
 	Group               []BaseClusterGroupInfo          `xml:"group,omitempty,typeattr"`
 	InfraUpdateHaConfig *ClusterInfraUpdateHaConfigInfo `xml:"infraUpdateHaConfig,omitempty"`
 	ProactiveDrsConfig  *ClusterProactiveDrsConfigInfo  `xml:"proactiveDrsConfig,omitempty"`
+	CryptoConfig        *ClusterCryptoConfigInfo        `xml:"cryptoConfig,omitempty"`
 }
 
 func init() {
@@ -8180,6 +8337,7 @@ type ClusterConfigSpecEx struct {
 	InfraUpdateHaConfig *ClusterInfraUpdateHaConfigInfo `xml:"infraUpdateHaConfig,omitempty"`
 	ProactiveDrsConfig  *ClusterProactiveDrsConfigInfo  `xml:"proactiveDrsConfig,omitempty"`
 	InHciWorkflow       *bool                           `xml:"inHciWorkflow"`
+	CryptoConfig        *ClusterCryptoConfigInfo        `xml:"cryptoConfig,omitempty"`
 }
 
 func init() {
@@ -8194,6 +8352,16 @@ type ClusterCreatedEvent struct {
 
 func init() {
 	t["ClusterCreatedEvent"] = reflect.TypeOf((*ClusterCreatedEvent)(nil)).Elem()
+}
+
+type ClusterCryptoConfigInfo struct {
+	DynamicData
+
+	CryptoMode string `xml:"cryptoMode,omitempty"`
+}
+
+func init() {
+	t["ClusterCryptoConfigInfo"] = reflect.TypeOf((*ClusterCryptoConfigInfo)(nil)).Elem()
 }
 
 type ClusterDasAamHostInfo struct {
@@ -8481,6 +8649,7 @@ type ClusterDrsConfigInfo struct {
 	EnableVmBehaviorOverrides *bool             `xml:"enableVmBehaviorOverrides"`
 	DefaultVmBehavior         DrsBehavior       `xml:"defaultVmBehavior,omitempty"`
 	VmotionRate               int32             `xml:"vmotionRate,omitempty"`
+	ScaleDescendantsShares    string            `xml:"scaleDescendantsShares,omitempty"`
 	Option                    []BaseOptionValue `xml:"option,omitempty,typeattr"`
 }
 
@@ -9316,9 +9485,10 @@ func init() {
 type ComputeResourceConfigSpec struct {
 	DynamicData
 
-	VmSwapPlacement           string `xml:"vmSwapPlacement,omitempty"`
-	SpbmEnabled               *bool  `xml:"spbmEnabled"`
-	DefaultHardwareVersionKey string `xml:"defaultHardwareVersionKey,omitempty"`
+	VmSwapPlacement           string               `xml:"vmSwapPlacement,omitempty"`
+	SpbmEnabled               *bool                `xml:"spbmEnabled"`
+	DefaultHardwareVersionKey string               `xml:"defaultHardwareVersionKey,omitempty"`
+	DesiredSoftwareSpec       *DesiredSoftwareSpec `xml:"desiredSoftwareSpec,omitempty"`
 }
 
 func init() {
@@ -9384,6 +9554,7 @@ type ConfigTarget struct {
 	NumCpus                                int32                                       `xml:"numCpus"`
 	NumCpuCores                            int32                                       `xml:"numCpuCores"`
 	NumNumaNodes                           int32                                       `xml:"numNumaNodes"`
+	MaxCpusPerHost                         int32                                       `xml:"maxCpusPerHost,omitempty"`
 	SmcPresent                             *bool                                       `xml:"smcPresent"`
 	Datastore                              []VirtualMachineDatastoreInfo               `xml:"datastore,omitempty"`
 	Network                                []VirtualMachineNetworkInfo                 `xml:"network,omitempty"`
@@ -9401,6 +9572,7 @@ type ConfigTarget struct {
 	ScsiDisk                               []VirtualMachineScsiDiskDeviceInfo          `xml:"scsiDisk,omitempty"`
 	IdeDisk                                []VirtualMachineIdeDiskDeviceInfo           `xml:"ideDisk,omitempty"`
 	MaxMemMBOptimalPerf                    int32                                       `xml:"maxMemMBOptimalPerf"`
+	SupportedMaxMemMB                      int32                                       `xml:"supportedMaxMemMB,omitempty"`
 	ResourcePool                           *ResourcePoolRuntimeInfo                    `xml:"resourcePool,omitempty"`
 	AutoVmotion                            *bool                                       `xml:"autoVmotion"`
 	PciPassthrough                         []BaseVirtualMachinePciPassthroughInfo      `xml:"pciPassthrough,omitempty,typeattr"`
@@ -9408,6 +9580,9 @@ type ConfigTarget struct {
 	VFlashModule                           []VirtualMachineVFlashModuleInfo            `xml:"vFlashModule,omitempty"`
 	SharedGpuPassthroughTypes              []VirtualMachinePciSharedGpuPassthroughInfo `xml:"sharedGpuPassthroughTypes,omitempty"`
 	AvailablePersistentMemoryReservationMB int64                                       `xml:"availablePersistentMemoryReservationMB,omitempty"`
+	DynamicPassthrough                     []VirtualMachineDynamicPassthroughInfo      `xml:"dynamicPassthrough,omitempty"`
+	SgxTargetInfo                          *VirtualMachineSgxTargetInfo                `xml:"sgxTargetInfo,omitempty"`
+	PrecisionClockInfo                     []VirtualMachinePrecisionClockInfo          `xml:"precisionClockInfo,omitempty"`
 }
 
 func init() {
@@ -9648,6 +9823,24 @@ type ConflictingDatastoreFoundFault ConflictingDatastoreFound
 
 func init() {
 	t["ConflictingDatastoreFoundFault"] = reflect.TypeOf((*ConflictingDatastoreFoundFault)(nil)).Elem()
+}
+
+type ConnectNvmeController ConnectNvmeControllerRequestType
+
+func init() {
+	t["ConnectNvmeController"] = reflect.TypeOf((*ConnectNvmeController)(nil)).Elem()
+}
+
+type ConnectNvmeControllerRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	ConnectSpec HostNvmeConnectSpec    `xml:"connectSpec"`
+}
+
+func init() {
+	t["ConnectNvmeControllerRequestType"] = reflect.TypeOf((*ConnectNvmeControllerRequestType)(nil)).Elem()
+}
+
+type ConnectNvmeControllerResponse struct {
 }
 
 type ConnectedIso struct {
@@ -10433,6 +10626,24 @@ type CreateNvdimmPMemNamespace_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type CreateNvmeOverRdmaAdapter CreateNvmeOverRdmaAdapterRequestType
+
+func init() {
+	t["CreateNvmeOverRdmaAdapter"] = reflect.TypeOf((*CreateNvmeOverRdmaAdapter)(nil)).Elem()
+}
+
+type CreateNvmeOverRdmaAdapterRequestType struct {
+	This           ManagedObjectReference `xml:"_this"`
+	RdmaDeviceName string                 `xml:"rdmaDeviceName"`
+}
+
+func init() {
+	t["CreateNvmeOverRdmaAdapterRequestType"] = reflect.TypeOf((*CreateNvmeOverRdmaAdapterRequestType)(nil)).Elem()
+}
+
+type CreateNvmeOverRdmaAdapterResponse struct {
+}
+
 type CreateObjectScheduledTask CreateObjectScheduledTaskRequestType
 
 func init() {
@@ -10926,6 +11137,23 @@ func init() {
 	t["CryptoKeyResult"] = reflect.TypeOf((*CryptoKeyResult)(nil)).Elem()
 }
 
+type CryptoManagerHostDisable CryptoManagerHostDisableRequestType
+
+func init() {
+	t["CryptoManagerHostDisable"] = reflect.TypeOf((*CryptoManagerHostDisable)(nil)).Elem()
+}
+
+type CryptoManagerHostDisableRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["CryptoManagerHostDisableRequestType"] = reflect.TypeOf((*CryptoManagerHostDisableRequestType)(nil)).Elem()
+}
+
+type CryptoManagerHostDisableResponse struct {
+}
+
 type CryptoManagerHostEnable CryptoManagerHostEnableRequestType
 
 func init() {
@@ -10983,6 +11211,8 @@ type CryptoManagerKmipClusterStatus struct {
 	DynamicData
 
 	ClusterId      KeyProviderId                     `xml:"clusterId"`
+	OverallStatus  ManagedEntityStatus               `xml:"overallStatus,omitempty"`
+	ManagementType string                            `xml:"managementType,omitempty"`
 	Servers        []CryptoManagerKmipServerStatus   `xml:"servers"`
 	ClientCertInfo *CryptoManagerKmipCertificateInfo `xml:"clientCertInfo,omitempty"`
 }
@@ -11304,6 +11534,8 @@ func init() {
 
 type CustomizationFailed struct {
 	CustomizationEvent
+
+	Reason string `xml:"reason,omitempty"`
 }
 
 func init() {
@@ -11489,6 +11721,7 @@ type CustomizationLinuxPrep struct {
 	Domain     string                `xml:"domain"`
 	TimeZone   string                `xml:"timeZone,omitempty"`
 	HwClockUTC *bool                 `xml:"hwClockUTC"`
+	ScriptText string                `xml:"scriptText,omitempty"`
 }
 
 func init() {
@@ -11736,6 +11969,28 @@ func init() {
 	t["CustomizationWinOptions"] = reflect.TypeOf((*CustomizationWinOptions)(nil)).Elem()
 }
 
+type CustomizeGuestRequestType struct {
+	This         ManagedObjectReference  `xml:"_this"`
+	Vm           ManagedObjectReference  `xml:"vm"`
+	Auth         BaseGuestAuthentication `xml:"auth,typeattr"`
+	Spec         CustomizationSpec       `xml:"spec"`
+	ConfigParams []BaseOptionValue       `xml:"configParams,omitempty,typeattr"`
+}
+
+func init() {
+	t["CustomizeGuestRequestType"] = reflect.TypeOf((*CustomizeGuestRequestType)(nil)).Elem()
+}
+
+type CustomizeGuest_Task CustomizeGuestRequestType
+
+func init() {
+	t["CustomizeGuest_Task"] = reflect.TypeOf((*CustomizeGuest_Task)(nil)).Elem()
+}
+
+type CustomizeGuest_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type CustomizeVMRequestType struct {
 	This ManagedObjectReference `xml:"_this"`
 	Spec CustomizationSpec      `xml:"spec"`
@@ -11858,6 +12113,7 @@ type DVPortgroupConfigInfo struct {
 	DefaultPortConfig            BaseDVPortSetting                         `xml:"defaultPortConfig,omitempty,typeattr"`
 	Description                  string                                    `xml:"description,omitempty"`
 	Type                         string                                    `xml:"type"`
+	BackingType                  string                                    `xml:"backingType,omitempty"`
 	Policy                       BaseDVPortgroupPolicy                     `xml:"policy,typeattr"`
 	PortNameFormat               string                                    `xml:"portNameFormat,omitempty"`
 	Scope                        []ManagedObjectReference                  `xml:"scope,omitempty"`
@@ -11866,6 +12122,10 @@ type DVPortgroupConfigInfo struct {
 	AutoExpand                   *bool                                     `xml:"autoExpand"`
 	VmVnicNetworkResourcePoolKey string                                    `xml:"vmVnicNetworkResourcePoolKey,omitempty"`
 	Uplink                       *bool                                     `xml:"uplink"`
+	TransportZoneUuid            string                                    `xml:"transportZoneUuid,omitempty"`
+	TransportZoneName            string                                    `xml:"transportZoneName,omitempty"`
+	LogicalSwitchUuid            string                                    `xml:"logicalSwitchUuid,omitempty"`
+	SegmentId                    string                                    `xml:"segmentId,omitempty"`
 }
 
 func init() {
@@ -11882,11 +12142,16 @@ type DVPortgroupConfigSpec struct {
 	DefaultPortConfig            BaseDVPortSetting                         `xml:"defaultPortConfig,omitempty,typeattr"`
 	Description                  string                                    `xml:"description,omitempty"`
 	Type                         string                                    `xml:"type,omitempty"`
+	BackingType                  string                                    `xml:"backingType,omitempty"`
 	Scope                        []ManagedObjectReference                  `xml:"scope,omitempty"`
 	Policy                       BaseDVPortgroupPolicy                     `xml:"policy,omitempty,typeattr"`
 	VendorSpecificConfig         []DistributedVirtualSwitchKeyedOpaqueBlob `xml:"vendorSpecificConfig,omitempty"`
 	AutoExpand                   *bool                                     `xml:"autoExpand"`
 	VmVnicNetworkResourcePoolKey string                                    `xml:"vmVnicNetworkResourcePoolKey,omitempty"`
+	TransportZoneUuid            string                                    `xml:"transportZoneUuid,omitempty"`
+	TransportZoneName            string                                    `xml:"transportZoneName,omitempty"`
+	LogicalSwitchUuid            string                                    `xml:"logicalSwitchUuid,omitempty"`
+	SegmentId                    string                                    `xml:"segmentId,omitempty"`
 }
 
 func init() {
@@ -12730,6 +12995,7 @@ type DatastoreCapability struct {
 	VsanSparseSupported              *bool `xml:"vsanSparseSupported"`
 	UpitSupported                    *bool `xml:"upitSupported"`
 	VmdkExpandSupported              *bool `xml:"vmdkExpandSupported"`
+	ClusteredVmdkSupported           *bool `xml:"clusteredVmdkSupported"`
 }
 
 func init() {
@@ -13512,6 +13778,38 @@ func init() {
 type DeselectVnicResponse struct {
 }
 
+type DesiredSoftwareSpec struct {
+	DynamicData
+
+	BaseImageSpec   DesiredSoftwareSpecBaseImageSpec    `xml:"baseImageSpec"`
+	VendorAddOnSpec *DesiredSoftwareSpecVendorAddOnSpec `xml:"vendorAddOnSpec,omitempty"`
+}
+
+func init() {
+	t["DesiredSoftwareSpec"] = reflect.TypeOf((*DesiredSoftwareSpec)(nil)).Elem()
+}
+
+type DesiredSoftwareSpecBaseImageSpec struct {
+	DynamicData
+
+	Version string `xml:"version"`
+}
+
+func init() {
+	t["DesiredSoftwareSpecBaseImageSpec"] = reflect.TypeOf((*DesiredSoftwareSpecBaseImageSpec)(nil)).Elem()
+}
+
+type DesiredSoftwareSpecVendorAddOnSpec struct {
+	DynamicData
+
+	Name    string `xml:"name"`
+	Version string `xml:"version"`
+}
+
+func init() {
+	t["DesiredSoftwareSpecVendorAddOnSpec"] = reflect.TypeOf((*DesiredSoftwareSpecVendorAddOnSpec)(nil)).Elem()
+}
+
 type DestinationSwitchFull struct {
 	CannotAccessNetwork
 }
@@ -14018,6 +14316,43 @@ func init() {
 	t["DisableAdminNotSupportedFault"] = reflect.TypeOf((*DisableAdminNotSupportedFault)(nil)).Elem()
 }
 
+type DisableAlarm DisableAlarmRequestType
+
+func init() {
+	t["DisableAlarm"] = reflect.TypeOf((*DisableAlarm)(nil)).Elem()
+}
+
+type DisableAlarmRequestType struct {
+	This   ManagedObjectReference `xml:"_this"`
+	Alarm  ManagedObjectReference `xml:"alarm"`
+	Entity ManagedObjectReference `xml:"entity"`
+}
+
+func init() {
+	t["DisableAlarmRequestType"] = reflect.TypeOf((*DisableAlarmRequestType)(nil)).Elem()
+}
+
+type DisableAlarmResponse struct {
+}
+
+type DisableClusteredVmdkSupport DisableClusteredVmdkSupportRequestType
+
+func init() {
+	t["DisableClusteredVmdkSupport"] = reflect.TypeOf((*DisableClusteredVmdkSupport)(nil)).Elem()
+}
+
+type DisableClusteredVmdkSupportRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["DisableClusteredVmdkSupportRequestType"] = reflect.TypeOf((*DisableClusteredVmdkSupportRequestType)(nil)).Elem()
+}
+
+type DisableClusteredVmdkSupportResponse struct {
+}
+
 type DisableEvcModeRequestType struct {
 	This ManagedObjectReference `xml:"_this"`
 }
@@ -14227,6 +14562,24 @@ type DisconnectHost_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type DisconnectNvmeController DisconnectNvmeControllerRequestType
+
+func init() {
+	t["DisconnectNvmeController"] = reflect.TypeOf((*DisconnectNvmeController)(nil)).Elem()
+}
+
+type DisconnectNvmeControllerRequestType struct {
+	This           ManagedObjectReference `xml:"_this"`
+	DisconnectSpec HostNvmeDisconnectSpec `xml:"disconnectSpec"`
+}
+
+func init() {
+	t["DisconnectNvmeControllerRequestType"] = reflect.TypeOf((*DisconnectNvmeControllerRequestType)(nil)).Elem()
+}
+
+type DisconnectNvmeControllerResponse struct {
+}
+
 type DisconnectedHostsBlockingEVC struct {
 	EVCConfigFault
 }
@@ -14259,6 +14612,25 @@ func init() {
 type DiscoverFcoeHbasResponse struct {
 }
 
+type DiscoverNvmeControllers DiscoverNvmeControllersRequestType
+
+func init() {
+	t["DiscoverNvmeControllers"] = reflect.TypeOf((*DiscoverNvmeControllers)(nil)).Elem()
+}
+
+type DiscoverNvmeControllersRequestType struct {
+	This         ManagedObjectReference `xml:"_this"`
+	DiscoverSpec HostNvmeDiscoverSpec   `xml:"discoverSpec"`
+}
+
+func init() {
+	t["DiscoverNvmeControllersRequestType"] = reflect.TypeOf((*DiscoverNvmeControllersRequestType)(nil)).Elem()
+}
+
+type DiscoverNvmeControllersResponse struct {
+	Returnval HostNvmeDiscoveryLog `xml:"returnval"`
+}
+
 type DiskChangeExtent struct {
 	DynamicData
 
@@ -14280,6 +14652,17 @@ type DiskChangeInfo struct {
 
 func init() {
 	t["DiskChangeInfo"] = reflect.TypeOf((*DiskChangeInfo)(nil)).Elem()
+}
+
+type DiskCryptoSpec struct {
+	DynamicData
+
+	Parent *DiskCryptoSpec `xml:"parent,omitempty"`
+	Crypto BaseCryptoSpec  `xml:"crypto,typeattr"`
+}
+
+func init() {
+	t["DiskCryptoSpec"] = reflect.TypeOf((*DiskCryptoSpec)(nil)).Elem()
 }
 
 type DiskHasPartitions struct {
@@ -14415,6 +14798,8 @@ type DistributedVirtualPort struct {
 	ConnectionCookie int32                                  `xml:"connectionCookie,omitempty"`
 	LastStatusChange time.Time                              `xml:"lastStatusChange"`
 	HostLocalPort    *bool                                  `xml:"hostLocalPort"`
+	ExternalId       string                                 `xml:"externalId,omitempty"`
+	SegmentPortId    string                                 `xml:"segmentPortId,omitempty"`
 }
 
 func init() {
@@ -14432,10 +14817,35 @@ type DistributedVirtualPortgroupInfo struct {
 	UplinkPortgroup             bool                   `xml:"uplinkPortgroup"`
 	Portgroup                   ManagedObjectReference `xml:"portgroup"`
 	NetworkReservationSupported *bool                  `xml:"networkReservationSupported"`
+	BackingType                 string                 `xml:"backingType,omitempty"`
+	LogicalSwitchUuid           string                 `xml:"logicalSwitchUuid,omitempty"`
+	SegmentId                   string                 `xml:"segmentId,omitempty"`
 }
 
 func init() {
 	t["DistributedVirtualPortgroupInfo"] = reflect.TypeOf((*DistributedVirtualPortgroupInfo)(nil)).Elem()
+}
+
+type DistributedVirtualPortgroupNsxPortgroupOperationResult struct {
+	DynamicData
+
+	Portgroups []ManagedObjectReference             `xml:"portgroups,omitempty"`
+	Problems   []DistributedVirtualPortgroupProblem `xml:"problems,omitempty"`
+}
+
+func init() {
+	t["DistributedVirtualPortgroupNsxPortgroupOperationResult"] = reflect.TypeOf((*DistributedVirtualPortgroupNsxPortgroupOperationResult)(nil)).Elem()
+}
+
+type DistributedVirtualPortgroupProblem struct {
+	DynamicData
+
+	LogicalSwitchUuid string               `xml:"logicalSwitchUuid"`
+	Fault             LocalizedMethodFault `xml:"fault"`
+}
+
+func init() {
+	t["DistributedVirtualPortgroupProblem"] = reflect.TypeOf((*DistributedVirtualPortgroupProblem)(nil)).Elem()
 }
 
 type DistributedVirtualSwitchHostMember struct {
@@ -14464,10 +14874,15 @@ func init() {
 type DistributedVirtualSwitchHostMemberConfigInfo struct {
 	DynamicData
 
-	Host                 *ManagedObjectReference                       `xml:"host,omitempty"`
-	MaxProxySwitchPorts  int32                                         `xml:"maxProxySwitchPorts"`
-	VendorSpecificConfig []DistributedVirtualSwitchKeyedOpaqueBlob     `xml:"vendorSpecificConfig,omitempty"`
-	Backing              BaseDistributedVirtualSwitchHostMemberBacking `xml:"backing,typeattr"`
+	Host                 *ManagedObjectReference                               `xml:"host,omitempty"`
+	MaxProxySwitchPorts  int32                                                 `xml:"maxProxySwitchPorts"`
+	VendorSpecificConfig []DistributedVirtualSwitchKeyedOpaqueBlob             `xml:"vendorSpecificConfig,omitempty"`
+	Backing              BaseDistributedVirtualSwitchHostMemberBacking         `xml:"backing,typeattr"`
+	NsxSwitch            *bool                                                 `xml:"nsxSwitch"`
+	EnsEnabled           *bool                                                 `xml:"ensEnabled"`
+	EnsInterruptEnabled  *bool                                                 `xml:"ensInterruptEnabled"`
+	TransportZones       []DistributedVirtualSwitchHostMemberTransportZoneInfo `xml:"transportZones,omitempty"`
+	NsxtUsedUplinkNames  []string                                              `xml:"nsxtUsedUplinkNames,omitempty"`
 }
 
 func init() {
@@ -14519,6 +14934,17 @@ type DistributedVirtualSwitchHostMemberRuntimeState struct {
 
 func init() {
 	t["DistributedVirtualSwitchHostMemberRuntimeState"] = reflect.TypeOf((*DistributedVirtualSwitchHostMemberRuntimeState)(nil)).Elem()
+}
+
+type DistributedVirtualSwitchHostMemberTransportZoneInfo struct {
+	DynamicData
+
+	Uuid string `xml:"uuid"`
+	Type string `xml:"type"`
+}
+
+func init() {
+	t["DistributedVirtualSwitchHostMemberTransportZoneInfo"] = reflect.TypeOf((*DistributedVirtualSwitchHostMemberTransportZoneInfo)(nil)).Elem()
 }
 
 type DistributedVirtualSwitchHostProductSpec struct {
@@ -14673,6 +15099,7 @@ type DistributedVirtualSwitchPortCriteria struct {
 	Connected    *bool                    `xml:"connected"`
 	Active       *bool                    `xml:"active"`
 	UplinkPort   *bool                    `xml:"uplinkPort"`
+	NsxPort      *bool                    `xml:"nsxPort"`
 	Scope        *ManagedObjectReference  `xml:"scope,omitempty"`
 	PortgroupKey []string                 `xml:"portgroupKey,omitempty"`
 	Inside       *bool                    `xml:"inside"`
@@ -14760,6 +15187,24 @@ type DomainNotFoundFault DomainNotFound
 
 func init() {
 	t["DomainNotFoundFault"] = reflect.TypeOf((*DomainNotFoundFault)(nil)).Elem()
+}
+
+type DownloadDescriptionTree DownloadDescriptionTreeRequestType
+
+func init() {
+	t["DownloadDescriptionTree"] = reflect.TypeOf((*DownloadDescriptionTree)(nil)).Elem()
+}
+
+type DownloadDescriptionTreeRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["DownloadDescriptionTreeRequestType"] = reflect.TypeOf((*DownloadDescriptionTreeRequestType)(nil)).Elem()
+}
+
+type DownloadDescriptionTreeResponse struct {
+	Returnval []byte `xml:"returnval"`
 }
 
 type DrsDisabledEvent struct {
@@ -16217,6 +16662,12 @@ func init() {
 	t["ElementDescription"] = reflect.TypeOf((*ElementDescription)(nil)).Elem()
 }
 
+type EnableAlarm EnableAlarmRequestType
+
+func init() {
+	t["EnableAlarm"] = reflect.TypeOf((*EnableAlarm)(nil)).Elem()
+}
+
 type EnableAlarmActions EnableAlarmActionsRequestType
 
 func init() {
@@ -16234,6 +16685,37 @@ func init() {
 }
 
 type EnableAlarmActionsResponse struct {
+}
+
+type EnableAlarmRequestType struct {
+	This   ManagedObjectReference `xml:"_this"`
+	Alarm  ManagedObjectReference `xml:"alarm"`
+	Entity ManagedObjectReference `xml:"entity"`
+}
+
+func init() {
+	t["EnableAlarmRequestType"] = reflect.TypeOf((*EnableAlarmRequestType)(nil)).Elem()
+}
+
+type EnableAlarmResponse struct {
+}
+
+type EnableClusteredVmdkSupport EnableClusteredVmdkSupportRequestType
+
+func init() {
+	t["EnableClusteredVmdkSupport"] = reflect.TypeOf((*EnableClusteredVmdkSupport)(nil)).Elem()
+}
+
+type EnableClusteredVmdkSupportRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["EnableClusteredVmdkSupportRequestType"] = reflect.TypeOf((*EnableClusteredVmdkSupportRequestType)(nil)).Elem()
+}
+
+type EnableClusteredVmdkSupportResponse struct {
 }
 
 type EnableCrypto EnableCryptoRequestType
@@ -19056,6 +19538,26 @@ type GetCustomizationSpecResponse struct {
 	Returnval CustomizationSpecItem `xml:"returnval"`
 }
 
+type GetDefaultKmsCluster GetDefaultKmsClusterRequestType
+
+func init() {
+	t["GetDefaultKmsCluster"] = reflect.TypeOf((*GetDefaultKmsCluster)(nil)).Elem()
+}
+
+type GetDefaultKmsClusterRequestType struct {
+	This             ManagedObjectReference  `xml:"_this"`
+	Entity           *ManagedObjectReference `xml:"entity,omitempty"`
+	DefaultsToParent *bool                   `xml:"defaultsToParent"`
+}
+
+func init() {
+	t["GetDefaultKmsClusterRequestType"] = reflect.TypeOf((*GetDefaultKmsClusterRequestType)(nil)).Elem()
+}
+
+type GetDefaultKmsClusterResponse struct {
+	Returnval *KeyProviderId `xml:"returnval,omitempty"`
+}
+
 type GetPublicKey GetPublicKeyRequestType
 
 func init() {
@@ -19090,6 +19592,24 @@ func init() {
 
 type GetResourceUsageResponse struct {
 	Returnval ClusterResourceUsageSummary `xml:"returnval"`
+}
+
+type GetSiteInfo GetSiteInfoRequestType
+
+func init() {
+	t["GetSiteInfo"] = reflect.TypeOf((*GetSiteInfo)(nil)).Elem()
+}
+
+type GetSiteInfoRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["GetSiteInfoRequestType"] = reflect.TypeOf((*GetSiteInfoRequestType)(nil)).Elem()
+}
+
+type GetSiteInfoResponse struct {
+	Returnval SiteInfo `xml:"returnval"`
 }
 
 type GetVchaClusterHealth GetVchaClusterHealthRequestType
@@ -19262,9 +19782,11 @@ func init() {
 type GuestDiskInfo struct {
 	DynamicData
 
-	DiskPath  string `xml:"diskPath,omitempty"`
-	Capacity  int64  `xml:"capacity,omitempty"`
-	FreeSpace int64  `xml:"freeSpace,omitempty"`
+	DiskPath       string                        `xml:"diskPath,omitempty"`
+	Capacity       int64                         `xml:"capacity,omitempty"`
+	FreeSpace      int64                         `xml:"freeSpace,omitempty"`
+	FilesystemType string                        `xml:"filesystemType,omitempty"`
+	Mappings       []GuestInfoVirtualDiskMapping `xml:"mappings,omitempty"`
 }
 
 func init() {
@@ -19322,6 +19844,7 @@ type GuestInfo struct {
 	InteractiveGuestOperationsReady *bool                              `xml:"interactiveGuestOperationsReady"`
 	GuestStateChangeSupported       *bool                              `xml:"guestStateChangeSupported"`
 	GenerationInfo                  []GuestInfoNamespaceGenerationInfo `xml:"generationInfo,omitempty"`
+	HwVersion                       string                             `xml:"hwVersion,omitempty"`
 }
 
 func init() {
@@ -19337,6 +19860,16 @@ type GuestInfoNamespaceGenerationInfo struct {
 
 func init() {
 	t["GuestInfoNamespaceGenerationInfo"] = reflect.TypeOf((*GuestInfoNamespaceGenerationInfo)(nil)).Elem()
+}
+
+type GuestInfoVirtualDiskMapping struct {
+	DynamicData
+
+	Key int32 `xml:"key"`
+}
+
+func init() {
+	t["GuestInfoVirtualDiskMapping"] = reflect.TypeOf((*GuestInfoVirtualDiskMapping)(nil)).Elem()
 }
 
 type GuestListFileInfo struct {
@@ -19483,7 +20016,9 @@ type GuestOsDescriptor struct {
 	NumRecommendedCoresPerSocket            int32           `xml:"numRecommendedCoresPerSocket,omitempty"`
 	VvtdSupported                           *BoolOption     `xml:"vvtdSupported,omitempty"`
 	VbsSupported                            *BoolOption     `xml:"vbsSupported,omitempty"`
+	VsgxSupported                           *BoolOption     `xml:"vsgxSupported,omitempty"`
 	SupportsTPM20                           *bool           `xml:"supportsTPM20"`
+	VwdtSupported                           *bool           `xml:"vwdtSupported"`
 }
 
 func init() {
@@ -20214,6 +20749,39 @@ func init() {
 	t["HostApplyProfile"] = reflect.TypeOf((*HostApplyProfile)(nil)).Elem()
 }
 
+type HostAssignableHardwareBinding struct {
+	DynamicData
+
+	InstanceId string                 `xml:"instanceId"`
+	Vm         ManagedObjectReference `xml:"vm"`
+}
+
+func init() {
+	t["HostAssignableHardwareBinding"] = reflect.TypeOf((*HostAssignableHardwareBinding)(nil)).Elem()
+}
+
+type HostAssignableHardwareConfig struct {
+	DynamicData
+
+	AttributeOverride []HostAssignableHardwareConfigAttributeOverride `xml:"attributeOverride,omitempty"`
+}
+
+func init() {
+	t["HostAssignableHardwareConfig"] = reflect.TypeOf((*HostAssignableHardwareConfig)(nil)).Elem()
+}
+
+type HostAssignableHardwareConfigAttributeOverride struct {
+	DynamicData
+
+	InstanceId string  `xml:"instanceId"`
+	Name       string  `xml:"name"`
+	Value      AnyType `xml:"value,typeattr"`
+}
+
+func init() {
+	t["HostAssignableHardwareConfigAttributeOverride"] = reflect.TypeOf((*HostAssignableHardwareConfigAttributeOverride)(nil)).Elem()
+}
+
 type HostAuthenticationManagerInfo struct {
 	DynamicData
 
@@ -20436,7 +21004,15 @@ type HostCapability struct {
 	Vmfs3EOLSupported                         *bool           `xml:"vmfs3EOLSupported"`
 	FtVmcpSupported                           *bool           `xml:"ftVmcpSupported"`
 	QuickBootSupported                        *bool           `xml:"quickBootSupported"`
+	AssignableHardwareSupported               *bool           `xml:"assignableHardwareSupported"`
+	UseFeatureReqsForOldHWv                   *bool           `xml:"useFeatureReqsForOldHWv"`
 	MarkPerenniallyReservedSupported          *bool           `xml:"markPerenniallyReservedSupported"`
+	HppPspSupported                           *bool           `xml:"hppPspSupported"`
+	DeviceRebindWithoutRebootSupported        *bool           `xml:"deviceRebindWithoutRebootSupported"`
+	StoragePolicyChangeSupported              *bool           `xml:"storagePolicyChangeSupported"`
+	PrecisionTimeProtocolSupported            *bool           `xml:"precisionTimeProtocolSupported"`
+	RemoteDeviceVMotionSupported              *bool           `xml:"remoteDeviceVMotionSupported"`
+	MaxSupportedVmMemory                      int32           `xml:"maxSupportedVmMemory,omitempty"`
 }
 
 func init() {
@@ -20733,12 +21309,15 @@ type HostConfigInfo struct {
 	DomainList                []string                             `xml:"domainList,omitempty"`
 	ScriptCheckSum            []byte                               `xml:"scriptCheckSum,omitempty"`
 	HostConfigCheckSum        []byte                               `xml:"hostConfigCheckSum,omitempty"`
+	DescriptionTreeCheckSum   []byte                               `xml:"descriptionTreeCheckSum,omitempty"`
 	GraphicsInfo              []HostGraphicsInfo                   `xml:"graphicsInfo,omitempty"`
 	SharedPassthruGpuTypes    []string                             `xml:"sharedPassthruGpuTypes,omitempty"`
 	GraphicsConfig            *HostGraphicsConfig                  `xml:"graphicsConfig,omitempty"`
 	SharedGpuCapabilities     []HostSharedGpuCapabilities          `xml:"sharedGpuCapabilities,omitempty"`
 	IoFilterInfo              []HostIoFilterInfo                   `xml:"ioFilterInfo,omitempty"`
 	SriovDevicePool           []BaseHostSriovDevicePoolInfo        `xml:"sriovDevicePool,omitempty,typeattr"`
+	AssignableHardwareBinding []HostAssignableHardwareBinding      `xml:"assignableHardwareBinding,omitempty"`
+	AssignableHardwareConfig  *HostAssignableHardwareConfig        `xml:"assignableHardwareConfig,omitempty"`
 }
 
 func init() {
@@ -20786,6 +21365,7 @@ type HostConfigManager struct {
 	CertificateManager        *ManagedObjectReference `xml:"certificateManager,omitempty"`
 	CryptoManager             *ManagedObjectReference `xml:"cryptoManager,omitempty"`
 	NvdimmSystem              *ManagedObjectReference `xml:"nvdimmSystem,omitempty"`
+	AssignableHardwareManager *ManagedObjectReference `xml:"assignableHardwareManager,omitempty"`
 }
 
 func init() {
@@ -20813,6 +21393,7 @@ type HostConfigSpec struct {
 	ActiveDirectory          []HostActiveDirectory                   `xml:"activeDirectory,omitempty"`
 	GenericConfig            []KeyAnyValue                           `xml:"genericConfig,omitempty"`
 	GraphicsConfig           *HostGraphicsConfig                     `xml:"graphicsConfig,omitempty"`
+	AssignableHardwareConfig *HostAssignableHardwareConfig           `xml:"assignableHardwareConfig,omitempty"`
 }
 
 func init() {
@@ -21191,8 +21772,9 @@ func init() {
 type HostDateTimeInfo struct {
 	DynamicData
 
-	TimeZone  HostDateTimeSystemTimeZone `xml:"timeZone"`
-	NtpConfig *HostNtpConfig             `xml:"ntpConfig,omitempty"`
+	TimeZone            HostDateTimeSystemTimeZone `xml:"timeZone"`
+	SystemClockProtocol string                     `xml:"systemClockProtocol,omitempty"`
+	NtpConfig           *HostNtpConfig             `xml:"ntpConfig,omitempty"`
 }
 
 func init() {
@@ -22024,6 +22606,7 @@ type HostHardwareInfo struct {
 	BiosInfo               *HostBIOSInfo               `xml:"biosInfo,omitempty"`
 	ReliableMemoryInfo     *HostReliableMemoryInfo     `xml:"reliableMemoryInfo,omitempty"`
 	PersistentMemoryInfo   *HostPersistentMemoryInfo   `xml:"persistentMemoryInfo,omitempty"`
+	SgxInfo                *HostSgxInfo                `xml:"sgxInfo,omitempty"`
 }
 
 func init() {
@@ -22084,13 +22667,14 @@ func init() {
 type HostHostBusAdapter struct {
 	DynamicData
 
-	Key    string `xml:"key,omitempty"`
-	Device string `xml:"device"`
-	Bus    int32  `xml:"bus"`
-	Status string `xml:"status"`
-	Model  string `xml:"model"`
-	Driver string `xml:"driver,omitempty"`
-	Pci    string `xml:"pci,omitempty"`
+	Key             string `xml:"key,omitempty"`
+	Device          string `xml:"device"`
+	Bus             int32  `xml:"bus"`
+	Status          string `xml:"status"`
+	Model           string `xml:"model"`
+	Driver          string `xml:"driver,omitempty"`
+	Pci             string `xml:"pci,omitempty"`
+	StorageProtocol string `xml:"storageProtocol,omitempty"`
 }
 
 func init() {
@@ -22958,6 +23542,7 @@ type HostMaintenanceSpec struct {
 	DynamicData
 
 	VsanMode *VsanHostDecommissionMode `xml:"vsanMode,omitempty"`
+	Purpose  string                    `xml:"purpose,omitempty"`
 }
 
 func init() {
@@ -22980,6 +23565,8 @@ type HostMemberRuntimeInfo struct {
 	Host              ManagedObjectReference            `xml:"host"`
 	Status            string                            `xml:"status,omitempty"`
 	StatusDetail      string                            `xml:"statusDetail,omitempty"`
+	NsxtStatus        string                            `xml:"nsxtStatus,omitempty"`
+	NsxtStatusDetail  string                            `xml:"nsxtStatusDetail,omitempty"`
 	HealthCheckResult []BaseHostMemberHealthCheckResult `xml:"healthCheckResult,omitempty,typeattr"`
 }
 
@@ -23068,6 +23655,20 @@ type HostMultipathInfoFixedLogicalUnitPolicy struct {
 
 func init() {
 	t["HostMultipathInfoFixedLogicalUnitPolicy"] = reflect.TypeOf((*HostMultipathInfoFixedLogicalUnitPolicy)(nil)).Elem()
+}
+
+type HostMultipathInfoHppLogicalUnitPolicy struct {
+	HostMultipathInfoLogicalUnitPolicy
+
+	Bytes              int64  `xml:"bytes,omitempty"`
+	Iops               int64  `xml:"iops,omitempty"`
+	Path               string `xml:"path,omitempty"`
+	LatencyEvalTime    int64  `xml:"latencyEvalTime,omitempty"`
+	SamplingIosPerPath int64  `xml:"samplingIosPerPath,omitempty"`
+}
+
+func init() {
+	t["HostMultipathInfoHppLogicalUnitPolicy"] = reflect.TypeOf((*HostMultipathInfoHppLogicalUnitPolicy)(nil)).Elem()
 }
 
 type HostMultipathInfoLogicalUnit struct {
@@ -23371,6 +23972,7 @@ type HostNetworkInfo struct {
 	ProxySwitch          []HostProxySwitch       `xml:"proxySwitch,omitempty"`
 	Portgroup            []HostPortGroup         `xml:"portgroup,omitempty"`
 	Pnic                 []PhysicalNic           `xml:"pnic,omitempty"`
+	RdmaDevice           []HostRdmaDevice        `xml:"rdmaDevice,omitempty"`
 	Vnic                 []HostVirtualNic        `xml:"vnic,omitempty"`
 	ConsoleVnic          []HostVirtualNic        `xml:"consoleVnic,omitempty"`
 	DnsConfig            BaseHostDnsConfig       `xml:"dnsConfig,omitempty,typeattr"`
@@ -23384,6 +23986,7 @@ type HostNetworkInfo struct {
 	NetStackInstance     []HostNetStackInstance  `xml:"netStackInstance,omitempty"`
 	OpaqueSwitch         []HostOpaqueSwitch      `xml:"opaqueSwitch,omitempty"`
 	OpaqueNetwork        []HostOpaqueNetworkInfo `xml:"opaqueNetwork,omitempty"`
+	NsxTransportNodeId   string                  `xml:"nsxTransportNodeId,omitempty"`
 }
 
 func init() {
@@ -23613,6 +24216,184 @@ func init() {
 	t["HostNumericSensorInfo"] = reflect.TypeOf((*HostNumericSensorInfo)(nil)).Elem()
 }
 
+type HostNvmeConnectSpec struct {
+	HostNvmeSpec
+
+	Subnqn           string `xml:"subnqn"`
+	ControllerId     int32  `xml:"controllerId,omitempty"`
+	AdminQueueSize   int32  `xml:"adminQueueSize,omitempty"`
+	KeepAliveTimeout int32  `xml:"keepAliveTimeout,omitempty"`
+}
+
+func init() {
+	t["HostNvmeConnectSpec"] = reflect.TypeOf((*HostNvmeConnectSpec)(nil)).Elem()
+}
+
+type HostNvmeController struct {
+	DynamicData
+
+	Key                     string              `xml:"key"`
+	ControllerNumber        int32               `xml:"controllerNumber"`
+	Subnqn                  string              `xml:"subnqn"`
+	Name                    string              `xml:"name"`
+	AssociatedAdapter       string              `xml:"associatedAdapter"`
+	TransportType           string              `xml:"transportType"`
+	FusedOperationSupported bool                `xml:"fusedOperationSupported"`
+	NumberOfQueues          int32               `xml:"numberOfQueues"`
+	QueueSize               int32               `xml:"queueSize"`
+	AttachedNamespace       []HostNvmeNamespace `xml:"attachedNamespace,omitempty"`
+	VendorId                string              `xml:"vendorId,omitempty"`
+	Model                   string              `xml:"model,omitempty"`
+	SerialNumber            string              `xml:"serialNumber,omitempty"`
+	FirmwareVersion         string              `xml:"firmwareVersion,omitempty"`
+}
+
+func init() {
+	t["HostNvmeController"] = reflect.TypeOf((*HostNvmeController)(nil)).Elem()
+}
+
+type HostNvmeDisconnectSpec struct {
+	DynamicData
+
+	HbaName          string `xml:"hbaName"`
+	Subnqn           string `xml:"subnqn,omitempty"`
+	ControllerNumber int32  `xml:"controllerNumber,omitempty"`
+}
+
+func init() {
+	t["HostNvmeDisconnectSpec"] = reflect.TypeOf((*HostNvmeDisconnectSpec)(nil)).Elem()
+}
+
+type HostNvmeDiscoverSpec struct {
+	HostNvmeSpec
+
+	AutoConnect *bool `xml:"autoConnect"`
+}
+
+func init() {
+	t["HostNvmeDiscoverSpec"] = reflect.TypeOf((*HostNvmeDiscoverSpec)(nil)).Elem()
+}
+
+type HostNvmeDiscoveryLog struct {
+	DynamicData
+
+	Entry    []HostNvmeDiscoveryLogEntry `xml:"entry,omitempty"`
+	Complete bool                        `xml:"complete"`
+}
+
+func init() {
+	t["HostNvmeDiscoveryLog"] = reflect.TypeOf((*HostNvmeDiscoveryLog)(nil)).Elem()
+}
+
+type HostNvmeDiscoveryLogEntry struct {
+	DynamicData
+
+	Subnqn                string                          `xml:"subnqn"`
+	SubsystemType         string                          `xml:"subsystemType"`
+	SubsystemPortId       int32                           `xml:"subsystemPortId"`
+	ControllerId          int32                           `xml:"controllerId"`
+	AdminQueueMaxSize     int32                           `xml:"adminQueueMaxSize"`
+	TransportParameters   BaseHostNvmeTransportParameters `xml:"transportParameters,typeattr"`
+	TransportRequirements string                          `xml:"transportRequirements"`
+	Connected             bool                            `xml:"connected"`
+}
+
+func init() {
+	t["HostNvmeDiscoveryLogEntry"] = reflect.TypeOf((*HostNvmeDiscoveryLogEntry)(nil)).Elem()
+}
+
+type HostNvmeNamespace struct {
+	DynamicData
+
+	Key              string `xml:"key"`
+	Name             string `xml:"name"`
+	Id               int32  `xml:"id"`
+	BlockSize        int32  `xml:"blockSize"`
+	CapacityInBlocks int64  `xml:"capacityInBlocks"`
+}
+
+func init() {
+	t["HostNvmeNamespace"] = reflect.TypeOf((*HostNvmeNamespace)(nil)).Elem()
+}
+
+type HostNvmeOpaqueTransportParameters struct {
+	HostNvmeTransportParameters
+
+	Trtype  string `xml:"trtype"`
+	Traddr  string `xml:"traddr"`
+	Adrfam  string `xml:"adrfam"`
+	Trsvcid string `xml:"trsvcid"`
+	Tsas    []byte `xml:"tsas"`
+}
+
+func init() {
+	t["HostNvmeOpaqueTransportParameters"] = reflect.TypeOf((*HostNvmeOpaqueTransportParameters)(nil)).Elem()
+}
+
+type HostNvmeOverFibreChannelParameters struct {
+	HostNvmeTransportParameters
+
+	NodeWorldWideName int64 `xml:"nodeWorldWideName"`
+	PortWorldWideName int64 `xml:"portWorldWideName"`
+}
+
+func init() {
+	t["HostNvmeOverFibreChannelParameters"] = reflect.TypeOf((*HostNvmeOverFibreChannelParameters)(nil)).Elem()
+}
+
+type HostNvmeOverRdmaParameters struct {
+	HostNvmeTransportParameters
+
+	Address       string `xml:"address"`
+	AddressFamily string `xml:"addressFamily,omitempty"`
+	PortNumber    int32  `xml:"portNumber,omitempty"`
+}
+
+func init() {
+	t["HostNvmeOverRdmaParameters"] = reflect.TypeOf((*HostNvmeOverRdmaParameters)(nil)).Elem()
+}
+
+type HostNvmeSpec struct {
+	DynamicData
+
+	HbaName             string                          `xml:"hbaName"`
+	TransportParameters BaseHostNvmeTransportParameters `xml:"transportParameters,typeattr"`
+}
+
+func init() {
+	t["HostNvmeSpec"] = reflect.TypeOf((*HostNvmeSpec)(nil)).Elem()
+}
+
+type HostNvmeTopology struct {
+	DynamicData
+
+	Adapter []HostNvmeTopologyInterface `xml:"adapter,omitempty"`
+}
+
+func init() {
+	t["HostNvmeTopology"] = reflect.TypeOf((*HostNvmeTopology)(nil)).Elem()
+}
+
+type HostNvmeTopologyInterface struct {
+	DynamicData
+
+	Key                 string               `xml:"key"`
+	Adapter             string               `xml:"adapter"`
+	ConnectedController []HostNvmeController `xml:"connectedController,omitempty"`
+}
+
+func init() {
+	t["HostNvmeTopologyInterface"] = reflect.TypeOf((*HostNvmeTopologyInterface)(nil)).Elem()
+}
+
+type HostNvmeTransportParameters struct {
+	DynamicData
+}
+
+func init() {
+	t["HostNvmeTransportParameters"] = reflect.TypeOf((*HostNvmeTransportParameters)(nil)).Elem()
+}
+
 type HostOpaqueNetworkInfo struct {
 	DynamicData
 
@@ -23795,6 +24576,7 @@ type HostPciPassthruConfig struct {
 
 	Id              string `xml:"id"`
 	PassthruEnabled bool   `xml:"passthruEnabled"`
+	ApplyNow        *bool  `xml:"applyNow"`
 }
 
 func init() {
@@ -23813,6 +24595,22 @@ type HostPciPassthruInfo struct {
 
 func init() {
 	t["HostPciPassthruInfo"] = reflect.TypeOf((*HostPciPassthruInfo)(nil)).Elem()
+}
+
+type HostPcieHba struct {
+	HostHostBusAdapter
+}
+
+func init() {
+	t["HostPcieHba"] = reflect.TypeOf((*HostPcieHba)(nil)).Elem()
+}
+
+type HostPcieTargetTransport struct {
+	HostTargetTransport
+}
+
+func init() {
+	t["HostPcieTargetTransport"] = reflect.TypeOf((*HostPcieTargetTransport)(nil)).Elem()
 }
 
 type HostPersistentMemoryInfo struct {
@@ -24250,18 +25048,25 @@ func init() {
 type HostProxySwitch struct {
 	DynamicData
 
-	DvsUuid                     string                         `xml:"dvsUuid"`
-	DvsName                     string                         `xml:"dvsName"`
-	Key                         string                         `xml:"key"`
-	NumPorts                    int32                          `xml:"numPorts"`
-	ConfigNumPorts              int32                          `xml:"configNumPorts,omitempty"`
-	NumPortsAvailable           int32                          `xml:"numPortsAvailable"`
-	UplinkPort                  []KeyValue                     `xml:"uplinkPort,omitempty"`
-	Mtu                         int32                          `xml:"mtu,omitempty"`
-	Pnic                        []string                       `xml:"pnic,omitempty"`
-	Spec                        HostProxySwitchSpec            `xml:"spec"`
-	HostLag                     []HostProxySwitchHostLagConfig `xml:"hostLag,omitempty"`
-	NetworkReservationSupported *bool                          `xml:"networkReservationSupported"`
+	DvsUuid                     string                                                `xml:"dvsUuid"`
+	DvsName                     string                                                `xml:"dvsName"`
+	Key                         string                                                `xml:"key"`
+	NumPorts                    int32                                                 `xml:"numPorts"`
+	ConfigNumPorts              int32                                                 `xml:"configNumPorts,omitempty"`
+	NumPortsAvailable           int32                                                 `xml:"numPortsAvailable"`
+	UplinkPort                  []KeyValue                                            `xml:"uplinkPort,omitempty"`
+	Mtu                         int32                                                 `xml:"mtu,omitempty"`
+	Pnic                        []string                                              `xml:"pnic,omitempty"`
+	Spec                        HostProxySwitchSpec                                   `xml:"spec"`
+	HostLag                     []HostProxySwitchHostLagConfig                        `xml:"hostLag,omitempty"`
+	NetworkReservationSupported *bool                                                 `xml:"networkReservationSupported"`
+	NsxtEnabled                 *bool                                                 `xml:"nsxtEnabled"`
+	EnsEnabled                  *bool                                                 `xml:"ensEnabled"`
+	EnsInterruptEnabled         *bool                                                 `xml:"ensInterruptEnabled"`
+	TransportZones              []DistributedVirtualSwitchHostMemberTransportZoneInfo `xml:"transportZones,omitempty"`
+	NsxUsedUplinkPort           []string                                              `xml:"nsxUsedUplinkPort,omitempty"`
+	NsxtStatus                  string                                                `xml:"nsxtStatus,omitempty"`
+	NsxtStatusDetail            string                                                `xml:"nsxtStatusDetail,omitempty"`
 }
 
 func init() {
@@ -24300,6 +25105,82 @@ type HostProxySwitchSpec struct {
 
 func init() {
 	t["HostProxySwitchSpec"] = reflect.TypeOf((*HostProxySwitchSpec)(nil)).Elem()
+}
+
+type HostRdmaDevice struct {
+	DynamicData
+
+	Key            string                       `xml:"key"`
+	Device         string                       `xml:"device"`
+	Driver         string                       `xml:"driver,omitempty"`
+	Description    string                       `xml:"description,omitempty"`
+	Backing        BaseHostRdmaDeviceBacking    `xml:"backing,omitempty,typeattr"`
+	ConnectionInfo HostRdmaDeviceConnectionInfo `xml:"connectionInfo"`
+	Capability     HostRdmaDeviceCapability     `xml:"capability"`
+}
+
+func init() {
+	t["HostRdmaDevice"] = reflect.TypeOf((*HostRdmaDevice)(nil)).Elem()
+}
+
+type HostRdmaDeviceBacking struct {
+	DynamicData
+}
+
+func init() {
+	t["HostRdmaDeviceBacking"] = reflect.TypeOf((*HostRdmaDeviceBacking)(nil)).Elem()
+}
+
+type HostRdmaDeviceCapability struct {
+	DynamicData
+
+	RoceV1Capable bool `xml:"roceV1Capable"`
+	RoceV2Capable bool `xml:"roceV2Capable"`
+	IWarpCapable  bool `xml:"iWarpCapable"`
+}
+
+func init() {
+	t["HostRdmaDeviceCapability"] = reflect.TypeOf((*HostRdmaDeviceCapability)(nil)).Elem()
+}
+
+type HostRdmaDeviceConnectionInfo struct {
+	DynamicData
+
+	State       string `xml:"state"`
+	Mtu         int32  `xml:"mtu"`
+	SpeedInMbps int32  `xml:"speedInMbps"`
+}
+
+func init() {
+	t["HostRdmaDeviceConnectionInfo"] = reflect.TypeOf((*HostRdmaDeviceConnectionInfo)(nil)).Elem()
+}
+
+type HostRdmaDevicePnicBacking struct {
+	HostRdmaDeviceBacking
+
+	PairedUplink string `xml:"pairedUplink"`
+}
+
+func init() {
+	t["HostRdmaDevicePnicBacking"] = reflect.TypeOf((*HostRdmaDevicePnicBacking)(nil)).Elem()
+}
+
+type HostRdmaHba struct {
+	HostHostBusAdapter
+
+	AssociatedRdmaDevice string `xml:"associatedRdmaDevice,omitempty"`
+}
+
+func init() {
+	t["HostRdmaHba"] = reflect.TypeOf((*HostRdmaHba)(nil)).Elem()
+}
+
+type HostRdmaTargetTransport struct {
+	HostTargetTransport
+}
+
+func init() {
+	t["HostRdmaTargetTransport"] = reflect.TypeOf((*HostRdmaTargetTransport)(nil)).Elem()
 }
 
 type HostReconcileDatastoreInventoryRequestType struct {
@@ -24795,6 +25676,19 @@ func init() {
 type HostSetVStorageObjectControlFlagsResponse struct {
 }
 
+type HostSgxInfo struct {
+	DynamicData
+
+	SgxState       string `xml:"sgxState"`
+	TotalEpcMemory int64  `xml:"totalEpcMemory"`
+	FlcMode        string `xml:"flcMode"`
+	LePubKeyHash   string `xml:"lePubKeyHash,omitempty"`
+}
+
+func init() {
+	t["HostSgxInfo"] = reflect.TypeOf((*HostSgxInfo)(nil)).Elem()
+}
+
 type HostSharedGpuCapabilities struct {
 	DynamicData
 
@@ -25040,6 +25934,7 @@ type HostStorageDeviceInfo struct {
 	HostBusAdapter              []BaseHostHostBusAdapter `xml:"hostBusAdapter,omitempty,typeattr"`
 	ScsiLun                     []BaseScsiLun            `xml:"scsiLun,omitempty,typeattr"`
 	ScsiTopology                *HostScsiTopology        `xml:"scsiTopology,omitempty"`
+	NvmeTopology                *HostNvmeTopology        `xml:"nvmeTopology,omitempty"`
 	MultipathInfo               *HostMultipathInfo       `xml:"multipathInfo,omitempty"`
 	PlugStoreTopology           *HostPlugStoreTopology   `xml:"plugStoreTopology,omitempty"`
 	SoftwareInternetScsiEnabled bool                     `xml:"softwareInternetScsiEnabled"`
@@ -25632,6 +26527,39 @@ func init() {
 	t["HostVMotionInfo"] = reflect.TypeOf((*HostVMotionInfo)(nil)).Elem()
 }
 
+type HostVMotionManagerDstInstantCloneResult struct {
+	DynamicData
+
+	DstVmId              int32 `xml:"dstVmId,omitempty"`
+	StartTime            int64 `xml:"startTime,omitempty"`
+	CptLoadTime          int64 `xml:"cptLoadTime,omitempty"`
+	CptLoadDoneTime      int64 `xml:"cptLoadDoneTime,omitempty"`
+	ReplicateMemDoneTime int64 `xml:"replicateMemDoneTime,omitempty"`
+	EndTime              int64 `xml:"endTime,omitempty"`
+	CptXferTime          int64 `xml:"cptXferTime,omitempty"`
+	CptCacheUsed         int64 `xml:"cptCacheUsed,omitempty"`
+	DevCptStreamSize     int64 `xml:"devCptStreamSize,omitempty"`
+	DevCptStreamTime     int64 `xml:"devCptStreamTime,omitempty"`
+}
+
+func init() {
+	t["HostVMotionManagerDstInstantCloneResult"] = reflect.TypeOf((*HostVMotionManagerDstInstantCloneResult)(nil)).Elem()
+}
+
+type HostVMotionManagerSrcInstantCloneResult struct {
+	DynamicData
+
+	StartTime       int64 `xml:"startTime,omitempty"`
+	QuiesceTime     int64 `xml:"quiesceTime,omitempty"`
+	QuiesceDoneTime int64 `xml:"quiesceDoneTime,omitempty"`
+	ResumeDoneTime  int64 `xml:"resumeDoneTime,omitempty"`
+	EndTime         int64 `xml:"endTime,omitempty"`
+}
+
+func init() {
+	t["HostVMotionManagerSrcInstantCloneResult"] = reflect.TypeOf((*HostVMotionManagerSrcInstantCloneResult)(nil)).Elem()
+}
+
 type HostVMotionNetConfig struct {
 	DynamicData
 
@@ -25880,6 +26808,7 @@ type HostVirtualNicSpec struct {
 	ExternalId             string                                  `xml:"externalId,omitempty"`
 	PinnedPnic             string                                  `xml:"pinnedPnic,omitempty"`
 	IpRouteSpec            *HostVirtualNicIpRouteSpec              `xml:"ipRouteSpec,omitempty"`
+	SystemOwned            *bool                                   `xml:"systemOwned"`
 }
 
 func init() {
@@ -27943,7 +28872,7 @@ func init() {
 type InvalidOperationOnSecondaryVm struct {
 	VmFaultToleranceIssue
 
-	InstanceUuid string `xml:"instanceUuid,omitempty"`
+	InstanceUuid string `xml:"instanceUuid"`
 }
 
 func init() {
@@ -28338,6 +29267,25 @@ type IpRouteProfile struct {
 
 func init() {
 	t["IpRouteProfile"] = reflect.TypeOf((*IpRouteProfile)(nil)).Elem()
+}
+
+type IsKmsClusterActive IsKmsClusterActiveRequestType
+
+func init() {
+	t["IsKmsClusterActive"] = reflect.TypeOf((*IsKmsClusterActive)(nil)).Elem()
+}
+
+type IsKmsClusterActiveRequestType struct {
+	This    ManagedObjectReference `xml:"_this"`
+	Cluster *KeyProviderId         `xml:"cluster,omitempty"`
+}
+
+func init() {
+	t["IsKmsClusterActiveRequestType"] = reflect.TypeOf((*IsKmsClusterActiveRequestType)(nil)).Elem()
+}
+
+type IsKmsClusterActiveResponse struct {
+	Returnval bool `xml:"returnval"`
 }
 
 type IsSharedGraphicsActive IsSharedGraphicsActiveRequestType
@@ -28747,9 +29695,11 @@ func init() {
 type KmipClusterInfo struct {
 	DynamicData
 
-	ClusterId    KeyProviderId    `xml:"clusterId"`
-	Servers      []KmipServerInfo `xml:"servers,omitempty"`
-	UseAsDefault bool             `xml:"useAsDefault"`
+	ClusterId          KeyProviderId            `xml:"clusterId"`
+	Servers            []KmipServerInfo         `xml:"servers,omitempty"`
+	UseAsDefault       bool                     `xml:"useAsDefault"`
+	ManagementType     string                   `xml:"managementType,omitempty"`
+	UseAsEntityDefault []ManagedObjectReference `xml:"useAsEntityDefault,omitempty"`
 }
 
 func init() {
@@ -29391,6 +30341,27 @@ func init() {
 }
 
 type ListKmipServersResponse struct {
+	Returnval []KmipClusterInfo `xml:"returnval,omitempty"`
+}
+
+type ListKmsClusters ListKmsClustersRequestType
+
+func init() {
+	t["ListKmsClusters"] = reflect.TypeOf((*ListKmsClusters)(nil)).Elem()
+}
+
+type ListKmsClustersRequestType struct {
+	This                 ManagedObjectReference `xml:"_this"`
+	IncludeKmsServers    *bool                  `xml:"includeKmsServers"`
+	ManagementTypeFilter int32                  `xml:"managementTypeFilter,omitempty"`
+	StatusFilter         int32                  `xml:"statusFilter,omitempty"`
+}
+
+func init() {
+	t["ListKmsClustersRequestType"] = reflect.TypeOf((*ListKmsClustersRequestType)(nil)).Elem()
+}
+
+type ListKmsClustersResponse struct {
 	Returnval []KmipClusterInfo `xml:"returnval,omitempty"`
 }
 
@@ -30172,6 +31143,24 @@ func init() {
 }
 
 type MarkPerenniallyReservedResponse struct {
+}
+
+type MarkServiceProviderEntities MarkServiceProviderEntitiesRequestType
+
+func init() {
+	t["MarkServiceProviderEntities"] = reflect.TypeOf((*MarkServiceProviderEntities)(nil)).Elem()
+}
+
+type MarkServiceProviderEntitiesRequestType struct {
+	This   ManagedObjectReference   `xml:"_this"`
+	Entity []ManagedObjectReference `xml:"entity,omitempty"`
+}
+
+func init() {
+	t["MarkServiceProviderEntitiesRequestType"] = reflect.TypeOf((*MarkServiceProviderEntitiesRequestType)(nil)).Elem()
+}
+
+type MarkServiceProviderEntitiesResponse struct {
 }
 
 type MemoryFileFormatNotSupportedByDatastore struct {
@@ -31685,6 +32674,7 @@ type NetworkProfile struct {
 	DvsHostNic              []DvsHostVNicProfile             `xml:"dvsHostNic,omitempty"`
 	NsxHostNic              []NsxHostVNicProfile             `xml:"nsxHostNic,omitempty"`
 	NetStackInstance        []NetStackInstanceProfile        `xml:"netStackInstance,omitempty"`
+	OpaqueSwitch            *OpaqueSwitchProfile             `xml:"opaqueSwitch,omitempty"`
 }
 
 func init() {
@@ -32951,6 +33941,14 @@ type OpaqueNetworkTargetInfo struct {
 
 func init() {
 	t["OpaqueNetworkTargetInfo"] = reflect.TypeOf((*OpaqueNetworkTargetInfo)(nil)).Elem()
+}
+
+type OpaqueSwitchProfile struct {
+	ApplyProfile
+}
+
+func init() {
+	t["OpaqueSwitchProfile"] = reflect.TypeOf((*OpaqueSwitchProfile)(nil)).Elem()
 }
 
 type OpenInventoryViewFolder OpenInventoryViewFolderRequestType
@@ -35213,6 +36211,8 @@ type PhysicalNic struct {
 	ResourcePoolSchedulerDisallowedReason []string              `xml:"resourcePoolSchedulerDisallowedReason,omitempty"`
 	AutoNegotiateSupported                *bool                 `xml:"autoNegotiateSupported"`
 	EnhancedNetworkingStackSupported      *bool                 `xml:"enhancedNetworkingStackSupported"`
+	EnsInterruptSupported                 *bool                 `xml:"ensInterruptSupported"`
+	RdmaDevice                            string                `xml:"rdmaDevice,omitempty"`
 }
 
 func init() {
@@ -35345,6 +36345,7 @@ type PhysicalNicSpec struct {
 	Ip                            *HostIpConfig        `xml:"ip,omitempty"`
 	LinkSpeed                     *PhysicalNicLinkInfo `xml:"linkSpeed,omitempty"`
 	EnableEnhancedNetworkingStack *bool                `xml:"enableEnhancedNetworkingStack"`
+	EnsInterruptEnabled           *bool                `xml:"ensInterruptEnabled"`
 }
 
 func init() {
@@ -39639,6 +40640,25 @@ func init() {
 type RegisterKmipServerResponse struct {
 }
 
+type RegisterKmsCluster RegisterKmsClusterRequestType
+
+func init() {
+	t["RegisterKmsCluster"] = reflect.TypeOf((*RegisterKmsCluster)(nil)).Elem()
+}
+
+type RegisterKmsClusterRequestType struct {
+	This           ManagedObjectReference `xml:"_this"`
+	ClusterId      KeyProviderId          `xml:"clusterId"`
+	ManagementType string                 `xml:"managementType,omitempty"`
+}
+
+func init() {
+	t["RegisterKmsClusterRequestType"] = reflect.TypeOf((*RegisterKmsClusterRequestType)(nil)).Elem()
+}
+
+type RegisterKmsClusterResponse struct {
+}
+
 type RegisterVMRequestType struct {
 	This       ManagedObjectReference  `xml:"_this"`
 	Path       string                  `xml:"path"`
@@ -40284,6 +41304,24 @@ func init() {
 type RemoveNetworkResourcePoolResponse struct {
 }
 
+type RemoveNvmeOverRdmaAdapter RemoveNvmeOverRdmaAdapterRequestType
+
+func init() {
+	t["RemoveNvmeOverRdmaAdapter"] = reflect.TypeOf((*RemoveNvmeOverRdmaAdapter)(nil)).Elem()
+}
+
+type RemoveNvmeOverRdmaAdapterRequestType struct {
+	This          ManagedObjectReference `xml:"_this"`
+	HbaDeviceName string                 `xml:"hbaDeviceName"`
+}
+
+func init() {
+	t["RemoveNvmeOverRdmaAdapterRequestType"] = reflect.TypeOf((*RemoveNvmeOverRdmaAdapterRequestType)(nil)).Elem()
+}
+
+type RemoveNvmeOverRdmaAdapterResponse struct {
+}
+
 type RemovePerfInterval RemovePerfIntervalRequestType
 
 func init() {
@@ -40784,10 +41822,10 @@ func init() {
 type ReplicationVmFault struct {
 	ReplicationFault
 
-	Reason     string                  `xml:"reason,omitempty"`
-	State      string                  `xml:"state,omitempty"`
-	InstanceId string                  `xml:"instanceId,omitempty"`
-	Vm         *ManagedObjectReference `xml:"vm,omitempty"`
+	Reason     string                 `xml:"reason"`
+	State      string                 `xml:"state,omitempty"`
+	InstanceId string                 `xml:"instanceId,omitempty"`
+	Vm         ManagedObjectReference `xml:"vm"`
 }
 
 func init() {
@@ -41209,11 +42247,12 @@ func init() {
 type ResourceConfigSpec struct {
 	DynamicData
 
-	Entity           *ManagedObjectReference `xml:"entity,omitempty"`
-	ChangeVersion    string                  `xml:"changeVersion,omitempty"`
-	LastModified     *time.Time              `xml:"lastModified"`
-	CpuAllocation    ResourceAllocationInfo  `xml:"cpuAllocation"`
-	MemoryAllocation ResourceAllocationInfo  `xml:"memoryAllocation"`
+	Entity                 *ManagedObjectReference `xml:"entity,omitempty"`
+	ChangeVersion          string                  `xml:"changeVersion,omitempty"`
+	LastModified           *time.Time              `xml:"lastModified"`
+	CpuAllocation          ResourceAllocationInfo  `xml:"cpuAllocation"`
+	MemoryAllocation       ResourceAllocationInfo  `xml:"memoryAllocation"`
+	ScaleDescendantsShares string                  `xml:"scaleDescendantsShares,omitempty"`
 }
 
 func init() {
@@ -41356,9 +42395,10 @@ func init() {
 type ResourcePoolRuntimeInfo struct {
 	DynamicData
 
-	Memory        ResourcePoolResourceUsage `xml:"memory"`
-	Cpu           ResourcePoolResourceUsage `xml:"cpu"`
-	OverallStatus ManagedEntityStatus       `xml:"overallStatus"`
+	Memory         ResourcePoolResourceUsage `xml:"memory"`
+	Cpu            ResourcePoolResourceUsage `xml:"cpu"`
+	OverallStatus  ManagedEntityStatus       `xml:"overallStatus"`
+	SharesScalable string                    `xml:"sharesScalable,omitempty"`
 }
 
 func init() {
@@ -41640,6 +42680,24 @@ type RetrieveDiskPartitionInfoResponse struct {
 	Returnval []HostDiskPartitionInfo `xml:"returnval,omitempty"`
 }
 
+type RetrieveDynamicPassthroughInfo RetrieveDynamicPassthroughInfoRequestType
+
+func init() {
+	t["RetrieveDynamicPassthroughInfo"] = reflect.TypeOf((*RetrieveDynamicPassthroughInfo)(nil)).Elem()
+}
+
+type RetrieveDynamicPassthroughInfoRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["RetrieveDynamicPassthroughInfoRequestType"] = reflect.TypeOf((*RetrieveDynamicPassthroughInfoRequestType)(nil)).Elem()
+}
+
+type RetrieveDynamicPassthroughInfoResponse struct {
+	Returnval []VirtualMachineDynamicPassthroughInfo `xml:"returnval,omitempty"`
+}
+
 type RetrieveEntityPermissions RetrieveEntityPermissionsRequestType
 
 func init() {
@@ -41677,6 +42735,24 @@ func init() {
 
 type RetrieveEntityScheduledTaskResponse struct {
 	Returnval []ManagedObjectReference `xml:"returnval,omitempty"`
+}
+
+type RetrieveFreeEpcMemory RetrieveFreeEpcMemoryRequestType
+
+func init() {
+	t["RetrieveFreeEpcMemory"] = reflect.TypeOf((*RetrieveFreeEpcMemory)(nil)).Elem()
+}
+
+type RetrieveFreeEpcMemoryRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["RetrieveFreeEpcMemoryRequestType"] = reflect.TypeOf((*RetrieveFreeEpcMemoryRequestType)(nil)).Elem()
+}
+
+type RetrieveFreeEpcMemoryResponse struct {
+	Returnval int64 `xml:"returnval"`
 }
 
 type RetrieveHardwareUptime RetrieveHardwareUptimeRequestType
@@ -41964,6 +43040,45 @@ func init() {
 
 type RetrieveServiceContentResponse struct {
 	Returnval ServiceContent `xml:"returnval"`
+}
+
+type RetrieveServiceProviderEntities RetrieveServiceProviderEntitiesRequestType
+
+func init() {
+	t["RetrieveServiceProviderEntities"] = reflect.TypeOf((*RetrieveServiceProviderEntities)(nil)).Elem()
+}
+
+type RetrieveServiceProviderEntitiesRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["RetrieveServiceProviderEntitiesRequestType"] = reflect.TypeOf((*RetrieveServiceProviderEntitiesRequestType)(nil)).Elem()
+}
+
+type RetrieveServiceProviderEntitiesResponse struct {
+	Returnval []ManagedObjectReference `xml:"returnval,omitempty"`
+}
+
+type RetrieveSnapshotDetails RetrieveSnapshotDetailsRequestType
+
+func init() {
+	t["RetrieveSnapshotDetails"] = reflect.TypeOf((*RetrieveSnapshotDetails)(nil)).Elem()
+}
+
+type RetrieveSnapshotDetailsRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	Id         ID                     `xml:"id"`
+	Datastore  ManagedObjectReference `xml:"datastore"`
+	SnapshotId ID                     `xml:"snapshotId"`
+}
+
+func init() {
+	t["RetrieveSnapshotDetailsRequestType"] = reflect.TypeOf((*RetrieveSnapshotDetailsRequestType)(nil)).Elem()
+}
+
+type RetrieveSnapshotDetailsResponse struct {
+	Returnval VStorageObjectSnapshotDetails `xml:"returnval"`
 }
 
 type RetrieveSnapshotInfo RetrieveSnapshotInfoRequestType
@@ -42640,26 +43755,27 @@ func init() {
 type ScsiLun struct {
 	HostDevice
 
-	Key                 string               `xml:"key,omitempty"`
-	Uuid                string               `xml:"uuid"`
-	Descriptor          []ScsiLunDescriptor  `xml:"descriptor,omitempty"`
-	CanonicalName       string               `xml:"canonicalName,omitempty"`
-	DisplayName         string               `xml:"displayName,omitempty"`
-	LunType             string               `xml:"lunType"`
-	Vendor              string               `xml:"vendor,omitempty"`
-	Model               string               `xml:"model,omitempty"`
-	Revision            string               `xml:"revision,omitempty"`
-	ScsiLevel           int32                `xml:"scsiLevel,omitempty"`
-	SerialNumber        string               `xml:"serialNumber,omitempty"`
-	DurableName         *ScsiLunDurableName  `xml:"durableName,omitempty"`
-	AlternateName       []ScsiLunDurableName `xml:"alternateName,omitempty"`
-	StandardInquiry     []byte               `xml:"standardInquiry,omitempty"`
-	QueueDepth          int32                `xml:"queueDepth,omitempty"`
-	OperationalState    []string             `xml:"operationalState"`
-	Capabilities        *ScsiLunCapabilities `xml:"capabilities,omitempty"`
-	VStorageSupport     string               `xml:"vStorageSupport,omitempty"`
-	ProtocolEndpoint    *bool                `xml:"protocolEndpoint"`
-	PerenniallyReserved *bool                `xml:"perenniallyReserved"`
+	Key                    string               `xml:"key,omitempty"`
+	Uuid                   string               `xml:"uuid"`
+	Descriptor             []ScsiLunDescriptor  `xml:"descriptor,omitempty"`
+	CanonicalName          string               `xml:"canonicalName,omitempty"`
+	DisplayName            string               `xml:"displayName,omitempty"`
+	LunType                string               `xml:"lunType"`
+	Vendor                 string               `xml:"vendor,omitempty"`
+	Model                  string               `xml:"model,omitempty"`
+	Revision               string               `xml:"revision,omitempty"`
+	ScsiLevel              int32                `xml:"scsiLevel,omitempty"`
+	SerialNumber           string               `xml:"serialNumber,omitempty"`
+	DurableName            *ScsiLunDurableName  `xml:"durableName,omitempty"`
+	AlternateName          []ScsiLunDurableName `xml:"alternateName,omitempty"`
+	StandardInquiry        []byte               `xml:"standardInquiry,omitempty"`
+	QueueDepth             int32                `xml:"queueDepth,omitempty"`
+	OperationalState       []string             `xml:"operationalState"`
+	Capabilities           *ScsiLunCapabilities `xml:"capabilities,omitempty"`
+	VStorageSupport        string               `xml:"vStorageSupport,omitempty"`
+	ProtocolEndpoint       *bool                `xml:"protocolEndpoint"`
+	PerenniallyReserved    *bool                `xml:"perenniallyReserved"`
+	ClusteredVmdkSupported *bool                `xml:"clusteredVmdkSupported"`
 }
 
 func init() {
@@ -42784,7 +43900,7 @@ func init() {
 type SecondaryVmAlreadyRegistered struct {
 	VmFaultToleranceIssue
 
-	InstanceUuid string `xml:"instanceUuid,omitempty"`
+	InstanceUuid string `xml:"instanceUuid"`
 }
 
 func init() {
@@ -42800,7 +43916,7 @@ func init() {
 type SecondaryVmNotRegistered struct {
 	VmFaultToleranceIssue
 
-	InstanceUuid string `xml:"instanceUuid,omitempty"`
+	InstanceUuid string `xml:"instanceUuid"`
 }
 
 func init() {
@@ -43024,6 +44140,7 @@ type ServiceContent struct {
 	TaskManager                 *ManagedObjectReference `xml:"taskManager,omitempty"`
 	ExtensionManager            *ManagedObjectReference `xml:"extensionManager,omitempty"`
 	CustomizationSpecManager    *ManagedObjectReference `xml:"customizationSpecManager,omitempty"`
+	GuestCustomizationManager   *ManagedObjectReference `xml:"guestCustomizationManager,omitempty"`
 	CustomFieldsManager         *ManagedObjectReference `xml:"customFieldsManager,omitempty"`
 	AccountManager              *ManagedObjectReference `xml:"accountManager,omitempty"`
 	DiagnosticManager           *ManagedObjectReference `xml:"diagnosticManager,omitempty"`
@@ -43054,6 +44171,8 @@ type ServiceContent struct {
 	HealthUpdateManager         *ManagedObjectReference `xml:"healthUpdateManager,omitempty"`
 	FailoverClusterConfigurator *ManagedObjectReference `xml:"failoverClusterConfigurator,omitempty"`
 	FailoverClusterManager      *ManagedObjectReference `xml:"failoverClusterManager,omitempty"`
+	TenantManager               *ManagedObjectReference `xml:"tenantManager,omitempty"`
+	SiteInfoManager             *ManagedObjectReference `xml:"siteInfoManager,omitempty"`
 	StorageQueryManager         *ManagedObjectReference `xml:"storageQueryManager,omitempty"`
 }
 
@@ -43233,6 +44352,43 @@ func init() {
 }
 
 type SetCollectorPageSizeResponse struct {
+}
+
+type SetCryptoMode SetCryptoModeRequestType
+
+func init() {
+	t["SetCryptoMode"] = reflect.TypeOf((*SetCryptoMode)(nil)).Elem()
+}
+
+type SetCryptoModeRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	CryptoMode string                 `xml:"cryptoMode"`
+}
+
+func init() {
+	t["SetCryptoModeRequestType"] = reflect.TypeOf((*SetCryptoModeRequestType)(nil)).Elem()
+}
+
+type SetCryptoModeResponse struct {
+}
+
+type SetDefaultKmsCluster SetDefaultKmsClusterRequestType
+
+func init() {
+	t["SetDefaultKmsCluster"] = reflect.TypeOf((*SetDefaultKmsCluster)(nil)).Elem()
+}
+
+type SetDefaultKmsClusterRequestType struct {
+	This      ManagedObjectReference  `xml:"_this"`
+	Entity    *ManagedObjectReference `xml:"entity,omitempty"`
+	ClusterId *KeyProviderId          `xml:"clusterId,omitempty"`
+}
+
+func init() {
+	t["SetDefaultKmsClusterRequestType"] = reflect.TypeOf((*SetDefaultKmsClusterRequestType)(nil)).Elem()
+}
+
+type SetDefaultKmsClusterResponse struct {
 }
 
 type SetDisplayTopology SetDisplayTopologyRequestType
@@ -43651,6 +44807,14 @@ func init() {
 	t["SingleMac"] = reflect.TypeOf((*SingleMac)(nil)).Elem()
 }
 
+type SiteInfo struct {
+	DynamicData
+}
+
+func init() {
+	t["SiteInfo"] = reflect.TypeOf((*SiteInfo)(nil)).Elem()
+}
+
 type SnapshotCloneNotSupported struct {
 	SnapshotCopyNotSupported
 }
@@ -43883,6 +45047,20 @@ func init() {
 	t["SoftwarePackageCapability"] = reflect.TypeOf((*SoftwarePackageCapability)(nil)).Elem()
 }
 
+type SolutionUserRequired struct {
+	SecurityError
+}
+
+func init() {
+	t["SolutionUserRequired"] = reflect.TypeOf((*SolutionUserRequired)(nil)).Elem()
+}
+
+type SolutionUserRequiredFault SolutionUserRequired
+
+func init() {
+	t["SolutionUserRequiredFault"] = reflect.TypeOf((*SolutionUserRequiredFault)(nil)).Elem()
+}
+
 type SourceNodeSpec struct {
 	DynamicData
 
@@ -43965,6 +45143,26 @@ func init() {
 }
 
 type StandbyGuestResponse struct {
+}
+
+type StartGuestNetworkRequestType struct {
+	This ManagedObjectReference  `xml:"_this"`
+	Vm   ManagedObjectReference  `xml:"vm"`
+	Auth BaseGuestAuthentication `xml:"auth,typeattr"`
+}
+
+func init() {
+	t["StartGuestNetworkRequestType"] = reflect.TypeOf((*StartGuestNetworkRequestType)(nil)).Elem()
+}
+
+type StartGuestNetwork_Task StartGuestNetworkRequestType
+
+func init() {
+	t["StartGuestNetwork_Task"] = reflect.TypeOf((*StartGuestNetwork_Task)(nil)).Elem()
+}
+
+type StartGuestNetwork_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type StartProgramInGuest StartProgramInGuestRequestType
@@ -45950,6 +47148,24 @@ type UnmapVmfsVolumeEx_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type UnmarkServiceProviderEntities UnmarkServiceProviderEntitiesRequestType
+
+func init() {
+	t["UnmarkServiceProviderEntities"] = reflect.TypeOf((*UnmarkServiceProviderEntities)(nil)).Elem()
+}
+
+type UnmarkServiceProviderEntitiesRequestType struct {
+	This   ManagedObjectReference   `xml:"_this"`
+	Entity []ManagedObjectReference `xml:"entity,omitempty"`
+}
+
+func init() {
+	t["UnmarkServiceProviderEntitiesRequestType"] = reflect.TypeOf((*UnmarkServiceProviderEntitiesRequestType)(nil)).Elem()
+}
+
+type UnmarkServiceProviderEntitiesResponse struct {
+}
+
 type UnmountDiskMappingRequestType struct {
 	This    ManagedObjectReference `xml:"_this"`
 	Mapping []VsanHostDiskMapping  `xml:"mapping"`
@@ -46129,6 +47345,24 @@ func init() {
 type UnregisterHealthUpdateProviderResponse struct {
 }
 
+type UnregisterKmsCluster UnregisterKmsClusterRequestType
+
+func init() {
+	t["UnregisterKmsCluster"] = reflect.TypeOf((*UnregisterKmsCluster)(nil)).Elem()
+}
+
+type UnregisterKmsClusterRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	ClusterId KeyProviderId          `xml:"clusterId"`
+}
+
+func init() {
+	t["UnregisterKmsClusterRequestType"] = reflect.TypeOf((*UnregisterKmsClusterRequestType)(nil)).Elem()
+}
+
+type UnregisterKmsClusterResponse struct {
+}
+
 type UnregisterVM UnregisterVMRequestType
 
 func init() {
@@ -46254,6 +47488,24 @@ func init() {
 
 type UpdateAnswerFile_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type UpdateAssignableHardwareConfig UpdateAssignableHardwareConfigRequestType
+
+func init() {
+	t["UpdateAssignableHardwareConfig"] = reflect.TypeOf((*UpdateAssignableHardwareConfig)(nil)).Elem()
+}
+
+type UpdateAssignableHardwareConfigRequestType struct {
+	This   ManagedObjectReference       `xml:"_this"`
+	Config HostAssignableHardwareConfig `xml:"config"`
+}
+
+func init() {
+	t["UpdateAssignableHardwareConfigRequestType"] = reflect.TypeOf((*UpdateAssignableHardwareConfigRequestType)(nil)).Elem()
+}
+
+type UpdateAssignableHardwareConfigResponse struct {
 }
 
 type UpdateAssignedLicense UpdateAssignedLicenseRequestType
@@ -46698,6 +47950,25 @@ func init() {
 }
 
 type UpdateHostSubSpecificationResponse struct {
+}
+
+type UpdateHppMultipathLunPolicy UpdateHppMultipathLunPolicyRequestType
+
+func init() {
+	t["UpdateHppMultipathLunPolicy"] = reflect.TypeOf((*UpdateHppMultipathLunPolicy)(nil)).Elem()
+}
+
+type UpdateHppMultipathLunPolicyRequestType struct {
+	This   ManagedObjectReference                `xml:"_this"`
+	LunId  string                                `xml:"lunId"`
+	Policy HostMultipathInfoHppLogicalUnitPolicy `xml:"policy"`
+}
+
+func init() {
+	t["UpdateHppMultipathLunPolicyRequestType"] = reflect.TypeOf((*UpdateHppMultipathLunPolicyRequestType)(nil)).Elem()
+}
+
+type UpdateHppMultipathLunPolicyResponse struct {
 }
 
 type UpdateInternetScsiAdvancedOptions UpdateInternetScsiAdvancedOptionsRequestType
@@ -47512,6 +48783,28 @@ func init() {
 }
 
 type UpdateVStorageInfrastructureObjectPolicy_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type UpdateVStorageObjectCryptoRequestType struct {
+	This        ManagedObjectReference          `xml:"_this"`
+	Id          ID                              `xml:"id"`
+	Datastore   ManagedObjectReference          `xml:"datastore"`
+	Profile     []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+	DisksCrypto *DiskCryptoSpec                 `xml:"disksCrypto,omitempty"`
+}
+
+func init() {
+	t["UpdateVStorageObjectCryptoRequestType"] = reflect.TypeOf((*UpdateVStorageObjectCryptoRequestType)(nil)).Elem()
+}
+
+type UpdateVStorageObjectCrypto_Task UpdateVStorageObjectCryptoRequestType
+
+func init() {
+	t["UpdateVStorageObjectCrypto_Task"] = reflect.TypeOf((*UpdateVStorageObjectCrypto_Task)(nil)).Elem()
+}
+
+type UpdateVStorageObjectCrypto_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
@@ -48655,6 +49948,7 @@ type VMwareDVSFeatureCapability struct {
 	MulticastSnoopingSupported *bool                     `xml:"multicastSnoopingSupported"`
 	VspanCapability            *VMwareDVSVspanCapability `xml:"vspanCapability,omitempty"`
 	LacpCapability             *VMwareDvsLacpCapability  `xml:"lacpCapability,omitempty"`
+	NsxSupported               *bool                     `xml:"nsxSupported"`
 }
 
 func init() {
@@ -48703,6 +49997,7 @@ type VMwareDVSPortSetting struct {
 	TxUplink            *BoolPolicy                                `xml:"txUplink,omitempty"`
 	LacpPolicy          *VMwareUplinkLacpPolicy                    `xml:"lacpPolicy,omitempty"`
 	MacManagementPolicy *DVSMacManagementPolicy                    `xml:"macManagementPolicy,omitempty"`
+	VNI                 *IntPolicy                                 `xml:"VNI,omitempty"`
 }
 
 func init() {
@@ -49097,6 +50392,7 @@ type VVolVmConfigFileUpdateResultFailedVmConfigFileInfo struct {
 	DynamicData
 
 	TargetConfigVVolId string               `xml:"targetConfigVVolId"`
+	DsPath             string               `xml:"dsPath,omitempty"`
 	Fault              LocalizedMethodFault `xml:"fault"`
 }
 
@@ -50543,25 +51839,28 @@ func init() {
 type VirtualHardwareOption struct {
 	DynamicData
 
-	HwVersion             int32                     `xml:"hwVersion"`
-	VirtualDeviceOption   []BaseVirtualDeviceOption `xml:"virtualDeviceOption,typeattr"`
-	DeviceListReadonly    bool                      `xml:"deviceListReadonly"`
-	NumCPU                []int32                   `xml:"numCPU"`
-	NumCoresPerSocket     *IntOption                `xml:"numCoresPerSocket,omitempty"`
-	NumCpuReadonly        bool                      `xml:"numCpuReadonly"`
-	MemoryMB              LongOption                `xml:"memoryMB"`
-	NumPCIControllers     IntOption                 `xml:"numPCIControllers"`
-	NumIDEControllers     IntOption                 `xml:"numIDEControllers"`
-	NumUSBControllers     IntOption                 `xml:"numUSBControllers"`
-	NumUSBXHCIControllers *IntOption                `xml:"numUSBXHCIControllers,omitempty"`
-	NumSIOControllers     IntOption                 `xml:"numSIOControllers"`
-	NumPS2Controllers     IntOption                 `xml:"numPS2Controllers"`
-	LicensingLimit        []string                  `xml:"licensingLimit,omitempty"`
-	NumSupportedWwnPorts  *IntOption                `xml:"numSupportedWwnPorts,omitempty"`
-	NumSupportedWwnNodes  *IntOption                `xml:"numSupportedWwnNodes,omitempty"`
-	ResourceConfigOption  *ResourceConfigOption     `xml:"resourceConfigOption,omitempty"`
-	NumNVDIMMControllers  *IntOption                `xml:"numNVDIMMControllers,omitempty"`
-	NumTPMDevices         *IntOption                `xml:"numTPMDevices,omitempty"`
+	HwVersion                int32                     `xml:"hwVersion"`
+	VirtualDeviceOption      []BaseVirtualDeviceOption `xml:"virtualDeviceOption,typeattr"`
+	DeviceListReadonly       bool                      `xml:"deviceListReadonly"`
+	NumCPU                   []int32                   `xml:"numCPU"`
+	NumCoresPerSocket        *IntOption                `xml:"numCoresPerSocket,omitempty"`
+	NumCpuReadonly           bool                      `xml:"numCpuReadonly"`
+	MemoryMB                 LongOption                `xml:"memoryMB"`
+	NumPCIControllers        IntOption                 `xml:"numPCIControllers"`
+	NumIDEControllers        IntOption                 `xml:"numIDEControllers"`
+	NumUSBControllers        IntOption                 `xml:"numUSBControllers"`
+	NumUSBXHCIControllers    *IntOption                `xml:"numUSBXHCIControllers,omitempty"`
+	NumSIOControllers        IntOption                 `xml:"numSIOControllers"`
+	NumPS2Controllers        IntOption                 `xml:"numPS2Controllers"`
+	LicensingLimit           []string                  `xml:"licensingLimit,omitempty"`
+	NumSupportedWwnPorts     *IntOption                `xml:"numSupportedWwnPorts,omitempty"`
+	NumSupportedWwnNodes     *IntOption                `xml:"numSupportedWwnNodes,omitempty"`
+	ResourceConfigOption     *ResourceConfigOption     `xml:"resourceConfigOption,omitempty"`
+	NumNVDIMMControllers     *IntOption                `xml:"numNVDIMMControllers,omitempty"`
+	NumTPMDevices            *IntOption                `xml:"numTPMDevices,omitempty"`
+	NumWDTDevices            *IntOption                `xml:"numWDTDevices,omitempty"`
+	NumPrecisionClockDevices *IntOption                `xml:"numPrecisionClockDevices,omitempty"`
+	EpcMemoryMB              *LongOption               `xml:"epcMemoryMB,omitempty"`
 }
 
 func init() {
@@ -50844,6 +52143,7 @@ type VirtualMachineConfigInfo struct {
 	ConsolePreferences           *VirtualMachineConsolePreferences          `xml:"consolePreferences,omitempty"`
 	DefaultPowerOps              VirtualMachineDefaultPowerOpInfo           `xml:"defaultPowerOps"`
 	Hardware                     VirtualHardware                            `xml:"hardware"`
+	VcpuConfig                   []VirtualMachineVcpuConfig                 `xml:"vcpuConfig,omitempty"`
 	CpuAllocation                *ResourceAllocationInfo                    `xml:"cpuAllocation,omitempty"`
 	MemoryAllocation             *ResourceAllocationInfo                    `xml:"memoryAllocation,omitempty"`
 	LatencySensitivity           *LatencySensitivity                        `xml:"latencySensitivity,omitempty"`
@@ -50883,6 +52183,9 @@ type VirtualMachineConfigInfo struct {
 	KeyId                        *CryptoKeyId                               `xml:"keyId,omitempty"`
 	GuestIntegrityInfo           *VirtualMachineGuestIntegrityInfo          `xml:"guestIntegrityInfo,omitempty"`
 	MigrateEncryption            string                                     `xml:"migrateEncryption,omitempty"`
+	SgxInfo                      *VirtualMachineSgxInfo                     `xml:"sgxInfo,omitempty"`
+	ContentLibItemInfo           *VirtualMachineContentLibraryItemInfo      `xml:"contentLibItemInfo,omitempty"`
+	GuestMonitoringModeInfo      *VirtualMachineGuestMonitoringModeInfo     `xml:"guestMonitoringModeInfo,omitempty"`
 }
 
 func init() {
@@ -50951,66 +52254,69 @@ func init() {
 type VirtualMachineConfigSpec struct {
 	DynamicData
 
-	ChangeVersion                string                            `xml:"changeVersion,omitempty"`
-	Name                         string                            `xml:"name,omitempty"`
-	Version                      string                            `xml:"version,omitempty"`
-	CreateDate                   *time.Time                        `xml:"createDate"`
-	Uuid                         string                            `xml:"uuid,omitempty"`
-	InstanceUuid                 string                            `xml:"instanceUuid,omitempty"`
-	NpivNodeWorldWideName        []int64                           `xml:"npivNodeWorldWideName,omitempty"`
-	NpivPortWorldWideName        []int64                           `xml:"npivPortWorldWideName,omitempty"`
-	NpivWorldWideNameType        string                            `xml:"npivWorldWideNameType,omitempty"`
-	NpivDesiredNodeWwns          int16                             `xml:"npivDesiredNodeWwns,omitempty"`
-	NpivDesiredPortWwns          int16                             `xml:"npivDesiredPortWwns,omitempty"`
-	NpivTemporaryDisabled        *bool                             `xml:"npivTemporaryDisabled"`
-	NpivOnNonRdmDisks            *bool                             `xml:"npivOnNonRdmDisks"`
-	NpivWorldWideNameOp          string                            `xml:"npivWorldWideNameOp,omitempty"`
-	LocationId                   string                            `xml:"locationId,omitempty"`
-	GuestId                      string                            `xml:"guestId,omitempty"`
-	AlternateGuestName           string                            `xml:"alternateGuestName,omitempty"`
-	Annotation                   string                            `xml:"annotation,omitempty"`
-	Files                        *VirtualMachineFileInfo           `xml:"files,omitempty"`
-	Tools                        *ToolsConfigInfo                  `xml:"tools,omitempty"`
-	Flags                        *VirtualMachineFlagInfo           `xml:"flags,omitempty"`
-	ConsolePreferences           *VirtualMachineConsolePreferences `xml:"consolePreferences,omitempty"`
-	PowerOpInfo                  *VirtualMachineDefaultPowerOpInfo `xml:"powerOpInfo,omitempty"`
-	NumCPUs                      int32                             `xml:"numCPUs,omitempty"`
-	NumCoresPerSocket            int32                             `xml:"numCoresPerSocket,omitempty"`
-	MemoryMB                     int64                             `xml:"memoryMB,omitempty"`
-	MemoryHotAddEnabled          *bool                             `xml:"memoryHotAddEnabled"`
-	CpuHotAddEnabled             *bool                             `xml:"cpuHotAddEnabled"`
-	CpuHotRemoveEnabled          *bool                             `xml:"cpuHotRemoveEnabled"`
-	VirtualICH7MPresent          *bool                             `xml:"virtualICH7MPresent"`
-	VirtualSMCPresent            *bool                             `xml:"virtualSMCPresent"`
-	DeviceChange                 []BaseVirtualDeviceConfigSpec     `xml:"deviceChange,omitempty,typeattr"`
-	CpuAllocation                *ResourceAllocationInfo           `xml:"cpuAllocation,omitempty"`
-	MemoryAllocation             *ResourceAllocationInfo           `xml:"memoryAllocation,omitempty"`
-	LatencySensitivity           *LatencySensitivity               `xml:"latencySensitivity,omitempty"`
-	CpuAffinity                  *VirtualMachineAffinityInfo       `xml:"cpuAffinity,omitempty"`
-	MemoryAffinity               *VirtualMachineAffinityInfo       `xml:"memoryAffinity,omitempty"`
-	NetworkShaper                *VirtualMachineNetworkShaperInfo  `xml:"networkShaper,omitempty"`
-	CpuFeatureMask               []VirtualMachineCpuIdInfoSpec     `xml:"cpuFeatureMask,omitempty"`
-	ExtraConfig                  []BaseOptionValue                 `xml:"extraConfig,omitempty,typeattr"`
-	SwapPlacement                string                            `xml:"swapPlacement,omitempty"`
-	BootOptions                  *VirtualMachineBootOptions        `xml:"bootOptions,omitempty"`
-	VAppConfig                   BaseVmConfigSpec                  `xml:"vAppConfig,omitempty,typeattr"`
-	FtInfo                       BaseFaultToleranceConfigInfo      `xml:"ftInfo,omitempty,typeattr"`
-	RepConfig                    *ReplicationConfigSpec            `xml:"repConfig,omitempty"`
-	VAppConfigRemoved            *bool                             `xml:"vAppConfigRemoved"`
-	VAssertsEnabled              *bool                             `xml:"vAssertsEnabled"`
-	ChangeTrackingEnabled        *bool                             `xml:"changeTrackingEnabled"`
-	Firmware                     string                            `xml:"firmware,omitempty"`
-	MaxMksConnections            int32                             `xml:"maxMksConnections,omitempty"`
-	GuestAutoLockEnabled         *bool                             `xml:"guestAutoLockEnabled"`
-	ManagedBy                    *ManagedByInfo                    `xml:"managedBy,omitempty"`
-	MemoryReservationLockedToMax *bool                             `xml:"memoryReservationLockedToMax"`
-	NestedHVEnabled              *bool                             `xml:"nestedHVEnabled"`
-	VPMCEnabled                  *bool                             `xml:"vPMCEnabled"`
-	ScheduledHardwareUpgradeInfo *ScheduledHardwareUpgradeInfo     `xml:"scheduledHardwareUpgradeInfo,omitempty"`
-	VmProfile                    []BaseVirtualMachineProfileSpec   `xml:"vmProfile,omitempty,typeattr"`
-	MessageBusTunnelEnabled      *bool                             `xml:"messageBusTunnelEnabled"`
-	Crypto                       BaseCryptoSpec                    `xml:"crypto,omitempty,typeattr"`
-	MigrateEncryption            string                            `xml:"migrateEncryption,omitempty"`
+	ChangeVersion                string                                 `xml:"changeVersion,omitempty"`
+	Name                         string                                 `xml:"name,omitempty"`
+	Version                      string                                 `xml:"version,omitempty"`
+	CreateDate                   *time.Time                             `xml:"createDate"`
+	Uuid                         string                                 `xml:"uuid,omitempty"`
+	InstanceUuid                 string                                 `xml:"instanceUuid,omitempty"`
+	NpivNodeWorldWideName        []int64                                `xml:"npivNodeWorldWideName,omitempty"`
+	NpivPortWorldWideName        []int64                                `xml:"npivPortWorldWideName,omitempty"`
+	NpivWorldWideNameType        string                                 `xml:"npivWorldWideNameType,omitempty"`
+	NpivDesiredNodeWwns          int16                                  `xml:"npivDesiredNodeWwns,omitempty"`
+	NpivDesiredPortWwns          int16                                  `xml:"npivDesiredPortWwns,omitempty"`
+	NpivTemporaryDisabled        *bool                                  `xml:"npivTemporaryDisabled"`
+	NpivOnNonRdmDisks            *bool                                  `xml:"npivOnNonRdmDisks"`
+	NpivWorldWideNameOp          string                                 `xml:"npivWorldWideNameOp,omitempty"`
+	LocationId                   string                                 `xml:"locationId,omitempty"`
+	GuestId                      string                                 `xml:"guestId,omitempty"`
+	AlternateGuestName           string                                 `xml:"alternateGuestName,omitempty"`
+	Annotation                   string                                 `xml:"annotation,omitempty"`
+	Files                        *VirtualMachineFileInfo                `xml:"files,omitempty"`
+	Tools                        *ToolsConfigInfo                       `xml:"tools,omitempty"`
+	Flags                        *VirtualMachineFlagInfo                `xml:"flags,omitempty"`
+	ConsolePreferences           *VirtualMachineConsolePreferences      `xml:"consolePreferences,omitempty"`
+	PowerOpInfo                  *VirtualMachineDefaultPowerOpInfo      `xml:"powerOpInfo,omitempty"`
+	NumCPUs                      int32                                  `xml:"numCPUs,omitempty"`
+	VcpuConfig                   []VirtualMachineVcpuConfig             `xml:"vcpuConfig,omitempty"`
+	NumCoresPerSocket            int32                                  `xml:"numCoresPerSocket,omitempty"`
+	MemoryMB                     int64                                  `xml:"memoryMB,omitempty"`
+	MemoryHotAddEnabled          *bool                                  `xml:"memoryHotAddEnabled"`
+	CpuHotAddEnabled             *bool                                  `xml:"cpuHotAddEnabled"`
+	CpuHotRemoveEnabled          *bool                                  `xml:"cpuHotRemoveEnabled"`
+	VirtualICH7MPresent          *bool                                  `xml:"virtualICH7MPresent"`
+	VirtualSMCPresent            *bool                                  `xml:"virtualSMCPresent"`
+	DeviceChange                 []BaseVirtualDeviceConfigSpec          `xml:"deviceChange,omitempty,typeattr"`
+	CpuAllocation                *ResourceAllocationInfo                `xml:"cpuAllocation,omitempty"`
+	MemoryAllocation             *ResourceAllocationInfo                `xml:"memoryAllocation,omitempty"`
+	LatencySensitivity           *LatencySensitivity                    `xml:"latencySensitivity,omitempty"`
+	CpuAffinity                  *VirtualMachineAffinityInfo            `xml:"cpuAffinity,omitempty"`
+	MemoryAffinity               *VirtualMachineAffinityInfo            `xml:"memoryAffinity,omitempty"`
+	NetworkShaper                *VirtualMachineNetworkShaperInfo       `xml:"networkShaper,omitempty"`
+	CpuFeatureMask               []VirtualMachineCpuIdInfoSpec          `xml:"cpuFeatureMask,omitempty"`
+	ExtraConfig                  []BaseOptionValue                      `xml:"extraConfig,omitempty,typeattr"`
+	SwapPlacement                string                                 `xml:"swapPlacement,omitempty"`
+	BootOptions                  *VirtualMachineBootOptions             `xml:"bootOptions,omitempty"`
+	VAppConfig                   BaseVmConfigSpec                       `xml:"vAppConfig,omitempty,typeattr"`
+	FtInfo                       BaseFaultToleranceConfigInfo           `xml:"ftInfo,omitempty,typeattr"`
+	RepConfig                    *ReplicationConfigSpec                 `xml:"repConfig,omitempty"`
+	VAppConfigRemoved            *bool                                  `xml:"vAppConfigRemoved"`
+	VAssertsEnabled              *bool                                  `xml:"vAssertsEnabled"`
+	ChangeTrackingEnabled        *bool                                  `xml:"changeTrackingEnabled"`
+	Firmware                     string                                 `xml:"firmware,omitempty"`
+	MaxMksConnections            int32                                  `xml:"maxMksConnections,omitempty"`
+	GuestAutoLockEnabled         *bool                                  `xml:"guestAutoLockEnabled"`
+	ManagedBy                    *ManagedByInfo                         `xml:"managedBy,omitempty"`
+	MemoryReservationLockedToMax *bool                                  `xml:"memoryReservationLockedToMax"`
+	NestedHVEnabled              *bool                                  `xml:"nestedHVEnabled"`
+	VPMCEnabled                  *bool                                  `xml:"vPMCEnabled"`
+	ScheduledHardwareUpgradeInfo *ScheduledHardwareUpgradeInfo          `xml:"scheduledHardwareUpgradeInfo,omitempty"`
+	VmProfile                    []BaseVirtualMachineProfileSpec        `xml:"vmProfile,omitempty,typeattr"`
+	MessageBusTunnelEnabled      *bool                                  `xml:"messageBusTunnelEnabled"`
+	Crypto                       BaseCryptoSpec                         `xml:"crypto,omitempty,typeattr"`
+	MigrateEncryption            string                                 `xml:"migrateEncryption,omitempty"`
+	SgxInfo                      *VirtualMachineSgxInfo                 `xml:"sgxInfo,omitempty"`
+	GuestMonitoringModeInfo      *VirtualMachineGuestMonitoringModeInfo `xml:"guestMonitoringModeInfo,omitempty"`
 }
 
 func init() {
@@ -51040,6 +52346,7 @@ type VirtualMachineConfigSummary struct {
 	ManagedBy           *ManagedByInfo               `xml:"managedBy,omitempty"`
 	TpmPresent          *bool                        `xml:"tpmPresent"`
 	NumVmiopBackings    int32                        `xml:"numVmiopBackings,omitempty"`
+	HwVersion           string                       `xml:"hwVersion,omitempty"`
 }
 
 func init() {
@@ -51056,6 +52363,17 @@ type VirtualMachineConsolePreferences struct {
 
 func init() {
 	t["VirtualMachineConsolePreferences"] = reflect.TypeOf((*VirtualMachineConsolePreferences)(nil)).Elem()
+}
+
+type VirtualMachineContentLibraryItemInfo struct {
+	DynamicData
+
+	ContentLibraryItemUuid    string `xml:"contentLibraryItemUuid"`
+	ContentLibraryItemVersion string `xml:"contentLibraryItemVersion,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineContentLibraryItemInfo"] = reflect.TypeOf((*VirtualMachineContentLibraryItemInfo)(nil)).Elem()
 }
 
 type VirtualMachineCpuIdInfoSpec struct {
@@ -51190,6 +52508,20 @@ type VirtualMachineDisplayTopology struct {
 
 func init() {
 	t["VirtualMachineDisplayTopology"] = reflect.TypeOf((*VirtualMachineDisplayTopology)(nil)).Elem()
+}
+
+type VirtualMachineDynamicPassthroughInfo struct {
+	VirtualMachineTargetInfo
+
+	VendorName  string `xml:"vendorName"`
+	DeviceName  string `xml:"deviceName"`
+	CustomLabel string `xml:"customLabel,omitempty"`
+	VendorId    int32  `xml:"vendorId"`
+	DeviceId    int32  `xml:"deviceId"`
+}
+
+func init() {
+	t["VirtualMachineDynamicPassthroughInfo"] = reflect.TypeOf((*VirtualMachineDynamicPassthroughInfo)(nil)).Elem()
 }
 
 type VirtualMachineEmptyProfileSpec struct {
@@ -51382,6 +52714,17 @@ func init() {
 	t["VirtualMachineGuestIntegrityInfo"] = reflect.TypeOf((*VirtualMachineGuestIntegrityInfo)(nil)).Elem()
 }
 
+type VirtualMachineGuestMonitoringModeInfo struct {
+	DynamicData
+
+	GmmFile      string `xml:"gmmFile,omitempty"`
+	GmmAppliance string `xml:"gmmAppliance,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineGuestMonitoringModeInfo"] = reflect.TypeOf((*VirtualMachineGuestMonitoringModeInfo)(nil)).Elem()
+}
+
 type VirtualMachineGuestQuiesceSpec struct {
 	DynamicData
 
@@ -51403,6 +52746,7 @@ type VirtualMachineGuestSummary struct {
 	ToolsRunningStatus  string                    `xml:"toolsRunningStatus,omitempty"`
 	HostName            string                    `xml:"hostName,omitempty"`
 	IpAddress           string                    `xml:"ipAddress,omitempty"`
+	HwVersion           string                    `xml:"hwVersion,omitempty"`
 }
 
 func init() {
@@ -51610,6 +52954,16 @@ func init() {
 	t["VirtualMachinePciSharedGpuPassthroughInfo"] = reflect.TypeOf((*VirtualMachinePciSharedGpuPassthroughInfo)(nil)).Elem()
 }
 
+type VirtualMachinePrecisionClockInfo struct {
+	VirtualMachineTargetInfo
+
+	SystemClockProtocol string `xml:"systemClockProtocol,omitempty"`
+}
+
+func init() {
+	t["VirtualMachinePrecisionClockInfo"] = reflect.TypeOf((*VirtualMachinePrecisionClockInfo)(nil)).Elem()
+}
+
 type VirtualMachineProfileDetails struct {
 	DynamicData
 
@@ -51680,6 +53034,7 @@ type VirtualMachineQuickStats struct {
 
 	OverallCpuUsage              int32               `xml:"overallCpuUsage,omitempty"`
 	OverallCpuDemand             int32               `xml:"overallCpuDemand,omitempty"`
+	OverallCpuReadiness          int32               `xml:"overallCpuReadiness,omitempty"`
 	GuestMemoryUsage             int32               `xml:"guestMemoryUsage,omitempty"`
 	HostMemoryUsage              int32               `xml:"hostMemoryUsage,omitempty"`
 	GuestHeartbeatStatus         ManagedEntityStatus `xml:"guestHeartbeatStatus"`
@@ -51687,6 +53042,7 @@ type VirtualMachineQuickStats struct {
 	DistributedMemoryEntitlement int32               `xml:"distributedMemoryEntitlement,omitempty"`
 	StaticCpuEntitlement         int32               `xml:"staticCpuEntitlement,omitempty"`
 	StaticMemoryEntitlement      int32               `xml:"staticMemoryEntitlement,omitempty"`
+	GrantedMemory                int32               `xml:"grantedMemory,omitempty"`
 	PrivateMemory                int32               `xml:"privateMemory,omitempty"`
 	SharedMemory                 int32               `xml:"sharedMemory,omitempty"`
 	SwappedMemory                int32               `xml:"swappedMemory,omitempty"`
@@ -51717,6 +53073,7 @@ type VirtualMachineRelocateSpec struct {
 	Transform    VirtualMachineRelocateTransformation    `xml:"transform,omitempty"`
 	DeviceChange []BaseVirtualDeviceConfigSpec           `xml:"deviceChange,omitempty,typeattr"`
 	Profile      []BaseVirtualMachineProfileSpec         `xml:"profile,omitempty,typeattr"`
+	CryptoSpec   BaseCryptoSpec                          `xml:"cryptoSpec,omitempty,typeattr"`
 }
 
 func init() {
@@ -51726,15 +53083,27 @@ func init() {
 type VirtualMachineRelocateSpecDiskLocator struct {
 	DynamicData
 
-	DiskId          int32                           `xml:"diskId"`
-	Datastore       ManagedObjectReference          `xml:"datastore"`
-	DiskMoveType    string                          `xml:"diskMoveType,omitempty"`
-	DiskBackingInfo BaseVirtualDeviceBackingInfo    `xml:"diskBackingInfo,omitempty,typeattr"`
-	Profile         []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+	DiskId          int32                                             `xml:"diskId"`
+	Datastore       ManagedObjectReference                            `xml:"datastore"`
+	DiskMoveType    string                                            `xml:"diskMoveType,omitempty"`
+	DiskBackingInfo BaseVirtualDeviceBackingInfo                      `xml:"diskBackingInfo,omitempty,typeattr"`
+	Profile         []BaseVirtualMachineProfileSpec                   `xml:"profile,omitempty,typeattr"`
+	Backing         *VirtualMachineRelocateSpecDiskLocatorBackingSpec `xml:"backing,omitempty"`
 }
 
 func init() {
 	t["VirtualMachineRelocateSpecDiskLocator"] = reflect.TypeOf((*VirtualMachineRelocateSpecDiskLocator)(nil)).Elem()
+}
+
+type VirtualMachineRelocateSpecDiskLocatorBackingSpec struct {
+	DynamicData
+
+	Parent *VirtualMachineRelocateSpecDiskLocatorBackingSpec `xml:"parent,omitempty"`
+	Crypto BaseCryptoSpec                                    `xml:"crypto,omitempty,typeattr"`
+}
+
+func init() {
+	t["VirtualMachineRelocateSpecDiskLocatorBackingSpec"] = reflect.TypeOf((*VirtualMachineRelocateSpecDiskLocatorBackingSpec)(nil)).Elem()
 }
 
 type VirtualMachineRuntimeInfo struct {
@@ -51816,6 +53185,30 @@ type VirtualMachineSerialInfo struct {
 
 func init() {
 	t["VirtualMachineSerialInfo"] = reflect.TypeOf((*VirtualMachineSerialInfo)(nil)).Elem()
+}
+
+type VirtualMachineSgxInfo struct {
+	DynamicData
+
+	EpcSize      int64  `xml:"epcSize"`
+	FlcMode      string `xml:"flcMode,omitempty"`
+	LePubKeyHash string `xml:"lePubKeyHash,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineSgxInfo"] = reflect.TypeOf((*VirtualMachineSgxInfo)(nil)).Elem()
+}
+
+type VirtualMachineSgxTargetInfo struct {
+	VirtualMachineTargetInfo
+
+	MaxEpcSize     int64    `xml:"maxEpcSize"`
+	FlcModes       []string `xml:"flcModes,omitempty"`
+	LePubKeyHashes []string `xml:"lePubKeyHashes,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineSgxTargetInfo"] = reflect.TypeOf((*VirtualMachineSgxTargetInfo)(nil)).Elem()
 }
 
 type VirtualMachineSnapshotInfo struct {
@@ -51950,6 +53343,7 @@ type VirtualMachineTicket struct {
 	Host          string `xml:"host,omitempty"`
 	Port          int32  `xml:"port,omitempty"`
 	SslThumbprint string `xml:"sslThumbprint,omitempty"`
+	Url           string `xml:"url,omitempty"`
 }
 
 func init() {
@@ -52065,6 +53459,16 @@ type VirtualMachineVMIROM struct {
 
 func init() {
 	t["VirtualMachineVMIROM"] = reflect.TypeOf((*VirtualMachineVMIROM)(nil)).Elem()
+}
+
+type VirtualMachineVcpuConfig struct {
+	DynamicData
+
+	LatencySensitivity *LatencySensitivity `xml:"latencySensitivity,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineVcpuConfig"] = reflect.TypeOf((*VirtualMachineVcpuConfig)(nil)).Elem()
 }
 
 type VirtualMachineVideoCard struct {
@@ -52227,6 +53631,20 @@ func init() {
 	t["VirtualPCIPassthrough"] = reflect.TypeOf((*VirtualPCIPassthrough)(nil)).Elem()
 }
 
+type VirtualPCIPassthroughAllowedDevice struct {
+	DynamicData
+
+	VendorId    int32 `xml:"vendorId"`
+	DeviceId    int32 `xml:"deviceId"`
+	SubVendorId int32 `xml:"subVendorId,omitempty"`
+	SubDeviceId int32 `xml:"subDeviceId,omitempty"`
+	RevisionId  int16 `xml:"revisionId,omitempty"`
+}
+
+func init() {
+	t["VirtualPCIPassthroughAllowedDevice"] = reflect.TypeOf((*VirtualPCIPassthroughAllowedDevice)(nil)).Elem()
+}
+
 type VirtualPCIPassthroughDeviceBackingInfo struct {
 	VirtualDeviceDeviceBackingInfo
 
@@ -52246,6 +53664,26 @@ type VirtualPCIPassthroughDeviceBackingOption struct {
 
 func init() {
 	t["VirtualPCIPassthroughDeviceBackingOption"] = reflect.TypeOf((*VirtualPCIPassthroughDeviceBackingOption)(nil)).Elem()
+}
+
+type VirtualPCIPassthroughDynamicBackingInfo struct {
+	VirtualDeviceDeviceBackingInfo
+
+	AllowedDevice []VirtualPCIPassthroughAllowedDevice `xml:"allowedDevice,omitempty"`
+	CustomLabel   string                               `xml:"customLabel,omitempty"`
+	AssignedId    string                               `xml:"assignedId,omitempty"`
+}
+
+func init() {
+	t["VirtualPCIPassthroughDynamicBackingInfo"] = reflect.TypeOf((*VirtualPCIPassthroughDynamicBackingInfo)(nil)).Elem()
+}
+
+type VirtualPCIPassthroughDynamicBackingOption struct {
+	VirtualDeviceDeviceBackingOption
+}
+
+func init() {
+	t["VirtualPCIPassthroughDynamicBackingOption"] = reflect.TypeOf((*VirtualPCIPassthroughDynamicBackingOption)(nil)).Elem()
 }
 
 type VirtualPCIPassthroughOption struct {
@@ -52412,6 +53850,42 @@ type VirtualPointingDeviceOption struct {
 
 func init() {
 	t["VirtualPointingDeviceOption"] = reflect.TypeOf((*VirtualPointingDeviceOption)(nil)).Elem()
+}
+
+type VirtualPrecisionClock struct {
+	VirtualDevice
+}
+
+func init() {
+	t["VirtualPrecisionClock"] = reflect.TypeOf((*VirtualPrecisionClock)(nil)).Elem()
+}
+
+type VirtualPrecisionClockOption struct {
+	VirtualDeviceOption
+}
+
+func init() {
+	t["VirtualPrecisionClockOption"] = reflect.TypeOf((*VirtualPrecisionClockOption)(nil)).Elem()
+}
+
+type VirtualPrecisionClockSystemClockBackingInfo struct {
+	VirtualDeviceBackingInfo
+
+	Protocol string `xml:"protocol,omitempty"`
+}
+
+func init() {
+	t["VirtualPrecisionClockSystemClockBackingInfo"] = reflect.TypeOf((*VirtualPrecisionClockSystemClockBackingInfo)(nil)).Elem()
+}
+
+type VirtualPrecisionClockSystemClockBackingOption struct {
+	VirtualDeviceBackingOption
+
+	Protocol ChoiceOption `xml:"protocol"`
+}
+
+func init() {
+	t["VirtualPrecisionClockSystemClockBackingOption"] = reflect.TypeOf((*VirtualPrecisionClockSystemClockBackingOption)(nil)).Elem()
 }
 
 type VirtualSATAController struct {
@@ -52967,6 +54441,27 @@ type VirtualVmxnetOption struct {
 
 func init() {
 	t["VirtualVmxnetOption"] = reflect.TypeOf((*VirtualVmxnetOption)(nil)).Elem()
+}
+
+type VirtualWDT struct {
+	VirtualDevice
+
+	RunOnBoot bool `xml:"runOnBoot"`
+	Running   bool `xml:"running"`
+}
+
+func init() {
+	t["VirtualWDT"] = reflect.TypeOf((*VirtualWDT)(nil)).Elem()
+}
+
+type VirtualWDTOption struct {
+	VirtualDeviceOption
+
+	RunOnBoot BoolOption `xml:"runOnBoot"`
+}
+
+func init() {
+	t["VirtualWDTOption"] = reflect.TypeOf((*VirtualWDTOption)(nil)).Elem()
 }
 
 type VlanProfile struct {
@@ -55500,6 +56995,7 @@ type VslmCreateSpec struct {
 	BackingSpec       BaseVslmCreateSpecBackingSpec   `xml:"backingSpec,typeattr"`
 	CapacityInMB      int64                           `xml:"capacityInMB"`
 	Profile           []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+	Crypto            BaseCryptoSpec                  `xml:"crypto,omitempty,typeattr"`
 	Metadata          []KeyValue                      `xml:"metadata,omitempty"`
 }
 
@@ -55545,6 +57041,7 @@ type VslmMigrateSpec struct {
 	BackingSpec BaseVslmCreateSpecBackingSpec   `xml:"backingSpec,typeattr"`
 	Profile     []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
 	Consolidate *bool                           `xml:"consolidate"`
+	DisksCrypto *DiskCryptoSpec                 `xml:"disksCrypto,omitempty"`
 }
 
 func init() {
@@ -55704,6 +57201,29 @@ type VspanSameSessionPortConflictFault VspanSameSessionPortConflict
 
 func init() {
 	t["VspanSameSessionPortConflictFault"] = reflect.TypeOf((*VspanSameSessionPortConflictFault)(nil)).Elem()
+}
+
+type VstorageObjectVCenterQueryChangedDiskAreas VstorageObjectVCenterQueryChangedDiskAreasRequestType
+
+func init() {
+	t["VstorageObjectVCenterQueryChangedDiskAreas"] = reflect.TypeOf((*VstorageObjectVCenterQueryChangedDiskAreas)(nil)).Elem()
+}
+
+type VstorageObjectVCenterQueryChangedDiskAreasRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	Id          ID                     `xml:"id"`
+	Datastore   ManagedObjectReference `xml:"datastore"`
+	SnapshotId  ID                     `xml:"snapshotId"`
+	StartOffset int64                  `xml:"startOffset"`
+	ChangeId    string                 `xml:"changeId"`
+}
+
+func init() {
+	t["VstorageObjectVCenterQueryChangedDiskAreasRequestType"] = reflect.TypeOf((*VstorageObjectVCenterQueryChangedDiskAreasRequestType)(nil)).Elem()
+}
+
+type VstorageObjectVCenterQueryChangedDiskAreasResponse struct {
+	Returnval DiskChangeInfo `xml:"returnval"`
 }
 
 type VvolDatastoreInfo struct {

--- a/vendor/github.com/vmware/govmomi/vim25/xml/LICENSE
+++ b/vendor/github.com/vmware/govmomi/vim25/xml/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/vendor/github.com/vmware/govmomi/vim25/xml/marshal.go
+++ b/vendor/github.com/vmware/govmomi/vim25/xml/marshal.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// A generic XML header suitable for use with the output of Marshal.
+	// Header is a generic XML header suitable for use with the output of Marshal.
 	// This is not automatically added to any output of this package,
 	// it is provided as a convenience.
 	Header = `<?xml version="1.0" encoding="UTF-8"?>` + "\n"
@@ -24,21 +24,21 @@ const (
 
 // Marshal returns the XML encoding of v.
 //
-// Marshal handles an array or slice by marshalling each of the elements.
-// Marshal handles a pointer by marshalling the value it points at or, if the
-// pointer is nil, by writing nothing.  Marshal handles an interface value by
-// marshalling the value it contains or, if the interface value is nil, by
-// writing nothing.  Marshal handles all other data by writing one or more XML
+// Marshal handles an array or slice by marshaling each of the elements.
+// Marshal handles a pointer by marshaling the value it points at or, if the
+// pointer is nil, by writing nothing. Marshal handles an interface value by
+// marshaling the value it contains or, if the interface value is nil, by
+// writing nothing. Marshal handles all other data by writing one or more XML
 // elements containing the data.
 //
 // The name for the XML elements is taken from, in order of preference:
 //     - the tag on the XMLName field, if the data is a struct
-//     - the value of the XMLName field of type xml.Name
+//     - the value of the XMLName field of type Name
 //     - the tag of the struct field used to obtain the data
 //     - the name of the struct field used to obtain the data
-//     - the name of the marshalled type
+//     - the name of the marshaled type
 //
-// The XML element for a struct contains marshalled elements for each of the
+// The XML element for a struct contains marshaled elements for each of the
 // exported fields of the struct, with these exceptions:
 //     - the XMLName field, described above, is omitted.
 //     - a field with tag "-" is omitted.
@@ -48,10 +48,12 @@ const (
 //       field name in the XML element.
 //     - a field with tag ",chardata" is written as character data,
 //       not as an XML element.
+//     - a field with tag ",cdata" is written as character data
+//       wrapped in one or more <![CDATA[ ... ]]> tags, not as an XML element.
 //     - a field with tag ",innerxml" is written verbatim, not subject
-//       to the usual marshalling procedure.
+//       to the usual marshaling procedure.
 //     - a field with tag ",comment" is written as an XML comment, not
-//       subject to the usual marshalling procedure. It must not contain
+//       subject to the usual marshaling procedure. It must not contain
 //       the "--" string within it.
 //     - a field with a tag including the "omitempty" option is omitted
 //       if the field value is empty. The empty values are false, 0, any
@@ -59,10 +61,17 @@ const (
 //       string of length zero.
 //     - an anonymous struct field is handled as if the fields of its
 //       value were part of the outer struct.
+//     - a field implementing Marshaler is written by calling its MarshalXML
+//       method.
+//     - a field implementing encoding.TextMarshaler is written by encoding the
+//       result of its MarshalText method as text.
 //
 // If a field uses a tag "a>b>c", then the element c will be nested inside
-// parent elements a and b.  Fields that appear next to each other that name
+// parent elements a and b. Fields that appear next to each other that name
 // the same parent will be enclosed in one XML element.
+//
+// If the XML name for a struct field is defined by both the field tag and the
+// struct's XMLName field, the names must match.
 //
 // See MarshalIndent for an example.
 //
@@ -173,9 +182,9 @@ func (enc *Encoder) EncodeElement(v interface{}, start StartElement) error {
 }
 
 var (
-	endComment   = []byte("-->")
-	endProcInst  = []byte("?>")
-	endDirective = []byte(">")
+	begComment  = []byte("<!--")
+	endComment  = []byte("-->")
+	endProcInst = []byte("?>")
 )
 
 // EncodeToken writes the given XML token to the stream.
@@ -191,6 +200,7 @@ var (
 // EncodeToken allows writing a ProcInst with Target set to "xml" only as the first token
 // in the stream.
 func (enc *Encoder) EncodeToken(t Token) error {
+
 	p := &enc.p
 	switch t := t.(type) {
 	case StartElement:
@@ -202,7 +212,7 @@ func (enc *Encoder) EncodeToken(t Token) error {
 			return err
 		}
 	case CharData:
-		EscapeText(p, t)
+		escapeText(p, t, false)
 	case Comment:
 		if bytes.Contains(t, endComment) {
 			return fmt.Errorf("xml: EncodeToken of Comment containing --> marker")
@@ -213,7 +223,7 @@ func (enc *Encoder) EncodeToken(t Token) error {
 		return p.cachedWriteError()
 	case ProcInst:
 		// First token to be encoded which is also a ProcInst with target of xml
-		// is the xml declaration.  The only ProcInst where target of xml is allowed.
+		// is the xml declaration. The only ProcInst where target of xml is allowed.
 		if t.Target == "xml" && p.Buffered() != 0 {
 			return fmt.Errorf("xml: EncodeToken of ProcInst xml target only valid for xml declaration, first token encoded")
 		}
@@ -231,14 +241,57 @@ func (enc *Encoder) EncodeToken(t Token) error {
 		}
 		p.WriteString("?>")
 	case Directive:
-		if bytes.Contains(t, endDirective) {
-			return fmt.Errorf("xml: EncodeToken of Directive containing > marker")
+		if !isValidDirective(t) {
+			return fmt.Errorf("xml: EncodeToken of Directive containing wrong < or > markers")
 		}
 		p.WriteString("<!")
 		p.Write(t)
 		p.WriteString(">")
+	default:
+		return fmt.Errorf("xml: EncodeToken of invalid token type")
+
 	}
 	return p.cachedWriteError()
+}
+
+// isValidDirective reports whether dir is a valid directive text,
+// meaning angle brackets are matched, ignoring comments and strings.
+func isValidDirective(dir Directive) bool {
+	var (
+		depth     int
+		inquote   uint8
+		incomment bool
+	)
+	for i, c := range dir {
+		switch {
+		case incomment:
+			if c == '>' {
+				if n := 1 + i - len(endComment); n >= 0 && bytes.Equal(dir[n:i+1], endComment) {
+					incomment = false
+				}
+			}
+			// Just ignore anything in comment
+		case inquote != 0:
+			if c == inquote {
+				inquote = 0
+			}
+			// Just ignore anything within quotes
+		case c == '\'' || c == '"':
+			inquote = c
+		case c == '<':
+			if i+len(begComment) < len(dir) && bytes.Equal(dir[i:i+len(begComment)], begComment) {
+				incomment = true
+			} else {
+				depth++
+			}
+		case c == '>':
+			if depth == 0 {
+				return false
+			}
+			depth--
+		}
+	}
+	return depth == 0 && inquote == 0 && !incomment
 }
 
 // Flush flushes any buffered XML to the underlying writer.
@@ -274,7 +327,7 @@ func (p *printer) createAttrPrefix(url string) string {
 	// (The "http://www.w3.org/2000/xmlns/" name space is also predefined as "xmlns",
 	// but users should not be trying to use that one directly - that's our job.)
 	if url == xmlURL {
-		return "xml"
+		return xmlPrefix
 	}
 
 	// Need to define a new name space.
@@ -453,7 +506,6 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 			continue
 		}
 		fv := finfo.value(val)
-		name := Name{Space: finfo.xmlns, Local: finfo.name}
 
 		if finfo.flags&fOmitEmpty != 0 && isEmptyValue(fv) {
 			continue
@@ -463,69 +515,10 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 			continue
 		}
 
-		if fv.CanInterface() && fv.Type().Implements(marshalerAttrType) {
-			attr, err := fv.Interface().(MarshalerAttr).MarshalXMLAttr(name)
-			if err != nil {
-				return err
-			}
-			if attr.Name.Local != "" {
-				start.Attr = append(start.Attr, attr)
-			}
-			continue
-		}
-
-		if fv.CanAddr() {
-			pv := fv.Addr()
-			if pv.CanInterface() && pv.Type().Implements(marshalerAttrType) {
-				attr, err := pv.Interface().(MarshalerAttr).MarshalXMLAttr(name)
-				if err != nil {
-					return err
-				}
-				if attr.Name.Local != "" {
-					start.Attr = append(start.Attr, attr)
-				}
-				continue
-			}
-		}
-
-		if fv.CanInterface() && fv.Type().Implements(textMarshalerType) {
-			text, err := fv.Interface().(encoding.TextMarshaler).MarshalText()
-			if err != nil {
-				return err
-			}
-			start.Attr = append(start.Attr, Attr{name, string(text)})
-			continue
-		}
-
-		if fv.CanAddr() {
-			pv := fv.Addr()
-			if pv.CanInterface() && pv.Type().Implements(textMarshalerType) {
-				text, err := pv.Interface().(encoding.TextMarshaler).MarshalText()
-				if err != nil {
-					return err
-				}
-				start.Attr = append(start.Attr, Attr{name, string(text)})
-				continue
-			}
-		}
-
-		// Dereference or skip nil pointer, interface values.
-		switch fv.Kind() {
-		case reflect.Ptr, reflect.Interface:
-			if fv.IsNil() {
-				continue
-			}
-			fv = fv.Elem()
-		}
-
-		s, b, err := p.marshalSimple(fv.Type(), fv)
-		if err != nil {
+		name := Name{Space: finfo.xmlns, Local: finfo.name}
+		if err := p.marshalAttr(&start, name, fv); err != nil {
 			return err
 		}
-		if b != nil {
-			s = string(b)
-		}
-		start.Attr = append(start.Attr, Attr{name, s})
 	}
 
 	if err := p.writeStart(&start); err != nil {
@@ -553,6 +546,90 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 	}
 
 	return p.cachedWriteError()
+}
+
+// marshalAttr marshals an attribute with the given name and value, adding to start.Attr.
+func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value) error {
+	if val.CanInterface() && val.Type().Implements(marshalerAttrType) {
+		attr, err := val.Interface().(MarshalerAttr).MarshalXMLAttr(name)
+		if err != nil {
+			return err
+		}
+		if attr.Name.Local != "" {
+			start.Attr = append(start.Attr, attr)
+		}
+		return nil
+	}
+
+	if val.CanAddr() {
+		pv := val.Addr()
+		if pv.CanInterface() && pv.Type().Implements(marshalerAttrType) {
+			attr, err := pv.Interface().(MarshalerAttr).MarshalXMLAttr(name)
+			if err != nil {
+				return err
+			}
+			if attr.Name.Local != "" {
+				start.Attr = append(start.Attr, attr)
+			}
+			return nil
+		}
+	}
+
+	if val.CanInterface() && val.Type().Implements(textMarshalerType) {
+		text, err := val.Interface().(encoding.TextMarshaler).MarshalText()
+		if err != nil {
+			return err
+		}
+		start.Attr = append(start.Attr, Attr{name, string(text)})
+		return nil
+	}
+
+	if val.CanAddr() {
+		pv := val.Addr()
+		if pv.CanInterface() && pv.Type().Implements(textMarshalerType) {
+			text, err := pv.Interface().(encoding.TextMarshaler).MarshalText()
+			if err != nil {
+				return err
+			}
+			start.Attr = append(start.Attr, Attr{name, string(text)})
+			return nil
+		}
+	}
+
+	// Dereference or skip nil pointer, interface values.
+	switch val.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if val.IsNil() {
+			return nil
+		}
+		val = val.Elem()
+	}
+
+	// Walk slices.
+	if val.Kind() == reflect.Slice && val.Type().Elem().Kind() != reflect.Uint8 {
+		n := val.Len()
+		for i := 0; i < n; i++ {
+			if err := p.marshalAttr(start, name, val.Index(i)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if val.Type() == attrType {
+		start.Attr = append(start.Attr, val.Interface().(Attr))
+		return nil
+	}
+
+	s, b, err := p.marshalSimple(val.Type(), val)
+	if err != nil {
+		return err
+	}
+	if b != nil {
+		s = string(b)
+	}
+	start.Attr = append(start.Attr, Attr{name, s})
+	return nil
 }
 
 // defaultStart returns the default start element to use,
@@ -716,6 +793,20 @@ func (p *printer) marshalSimple(typ reflect.Type, val reflect.Value) (string, []
 
 var ddBytes = []byte("--")
 
+// indirect drills into interfaces and pointers, returning the pointed-at value.
+// If it encounters a nil interface or pointer, indirect returns that nil value.
+// This can turn into an infinite loop given a cyclic chain,
+// but it matches the Go 1 behavior.
+func indirect(vf reflect.Value) reflect.Value {
+	for vf.Kind() == reflect.Interface || vf.Kind() == reflect.Ptr {
+		if vf.IsNil() {
+			return vf
+		}
+		vf = vf.Elem()
+	}
+	return vf
+}
+
 func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 	s := parentStack{p: p}
 	for i := range tinfo.fields {
@@ -725,22 +816,23 @@ func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 		}
 		vf := finfo.value(val)
 
-		// Dereference or skip nil pointer, interface values.
-		switch vf.Kind() {
-		case reflect.Ptr, reflect.Interface:
-			if !vf.IsNil() {
-				vf = vf.Elem()
-			}
-		}
-
 		switch finfo.flags & fMode {
-		case fCharData:
+		case fCDATA, fCharData:
+			emit := EscapeText
+			if finfo.flags&fMode == fCDATA {
+				emit = emitCDATA
+			}
+			if err := s.trim(finfo.parents); err != nil {
+				return err
+			}
 			if vf.CanInterface() && vf.Type().Implements(textMarshalerType) {
 				data, err := vf.Interface().(encoding.TextMarshaler).MarshalText()
 				if err != nil {
 					return err
 				}
-				Escape(p, data)
+				if err := emit(p, data); err != nil {
+					return err
+				}
 				continue
 			}
 			if vf.CanAddr() {
@@ -750,27 +842,39 @@ func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 					if err != nil {
 						return err
 					}
-					Escape(p, data)
+					if err := emit(p, data); err != nil {
+						return err
+					}
 					continue
 				}
 			}
+
 			var scratch [64]byte
+			vf = indirect(vf)
 			switch vf.Kind() {
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-				Escape(p, strconv.AppendInt(scratch[:0], vf.Int(), 10))
+				if err := emit(p, strconv.AppendInt(scratch[:0], vf.Int(), 10)); err != nil {
+					return err
+				}
 			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-				Escape(p, strconv.AppendUint(scratch[:0], vf.Uint(), 10))
+				if err := emit(p, strconv.AppendUint(scratch[:0], vf.Uint(), 10)); err != nil {
+					return err
+				}
 			case reflect.Float32, reflect.Float64:
-				Escape(p, strconv.AppendFloat(scratch[:0], vf.Float(), 'g', -1, vf.Type().Bits()))
+				if err := emit(p, strconv.AppendFloat(scratch[:0], vf.Float(), 'g', -1, vf.Type().Bits())); err != nil {
+					return err
+				}
 			case reflect.Bool:
-				Escape(p, strconv.AppendBool(scratch[:0], vf.Bool()))
+				if err := emit(p, strconv.AppendBool(scratch[:0], vf.Bool())); err != nil {
+					return err
+				}
 			case reflect.String:
-				if err := EscapeText(p, []byte(vf.String())); err != nil {
+				if err := emit(p, []byte(vf.String())); err != nil {
 					return err
 				}
 			case reflect.Slice:
 				if elem, ok := vf.Interface().([]byte); ok {
-					if err := EscapeText(p, elem); err != nil {
+					if err := emit(p, elem); err != nil {
 						return err
 					}
 				}
@@ -778,6 +882,10 @@ func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 			continue
 
 		case fComment:
+			if err := s.trim(finfo.parents); err != nil {
+				return err
+			}
+			vf = indirect(vf)
 			k := vf.Kind()
 			if !(k == reflect.String || k == reflect.Slice && vf.Type().Elem().Kind() == reflect.Uint8) {
 				return fmt.Errorf("xml: bad type for comment field of %s", val.Type())
@@ -792,14 +900,14 @@ func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 			switch k {
 			case reflect.String:
 				s := vf.String()
-				dashDash = strings.Index(s, "--") >= 0
+				dashDash = strings.Contains(s, "--")
 				dashLast = s[len(s)-1] == '-'
 				if !dashDash {
 					p.WriteString(s)
 				}
 			case reflect.Slice:
 				b := vf.Bytes()
-				dashDash = bytes.Index(b, ddBytes) >= 0
+				dashDash = bytes.Contains(b, ddBytes)
 				dashLast = b[len(b)-1] == '-'
 				if !dashDash {
 					p.Write(b)
@@ -818,6 +926,7 @@ func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 			continue
 
 		case fInnerXml:
+			vf = indirect(vf)
 			iface := vf.Interface()
 			switch raw := iface.(type) {
 			case []byte:
@@ -891,8 +1000,8 @@ type parentStack struct {
 }
 
 // trim updates the XML context to match the longest common prefix of the stack
-// and the given parents.  A closing tag will be written for every parent
-// popped.  Passing a zero slice or nil will close all the elements.
+// and the given parents. A closing tag will be written for every parent
+// popped. Passing a zero slice or nil will close all the elements.
 func (s *parentStack) trim(parents []string) error {
 	split := 0
 	for ; split < len(parents) && split < len(s.stack); split++ {
@@ -905,7 +1014,7 @@ func (s *parentStack) trim(parents []string) error {
 			return err
 		}
 	}
-	s.stack = parents[:split]
+	s.stack = s.stack[:split]
 	return nil
 }
 
@@ -920,7 +1029,7 @@ func (s *parentStack) push(parents []string) error {
 	return nil
 }
 
-// A MarshalXMLError is returned when Marshal encounters a type
+// UnsupportedTypeError is returned when Marshal encounters a type
 // that cannot be converted into XML.
 type UnsupportedTypeError struct {
 	Type reflect.Type

--- a/vendor/github.com/vmware/govmomi/vim25/xml/read.go
+++ b/vendor/github.com/vmware/govmomi/vim25/xml/read.go
@@ -1,4 +1,4 @@
-// Copyright 2009 The Go Authors.  All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -27,7 +27,7 @@ import (
 // discarded.
 //
 // Because Unmarshal uses the reflect package, it can only assign
-// to exported (upper case) fields.  Unmarshal uses a case-sensitive
+// to exported (upper case) fields. Unmarshal uses a case-sensitive
 // comparison to match XML element names to tag values and struct
 // field names.
 //
@@ -37,9 +37,9 @@ import (
 //
 //   * If the struct has a field of type []byte or string with tag
 //      ",innerxml", Unmarshal accumulates the raw XML nested inside the
-//      element in that field.  The rest of the rules still apply.
+//      element in that field. The rest of the rules still apply.
 //
-//   * If the struct has a field named XMLName of type xml.Name,
+//   * If the struct has a field named XMLName of type Name,
 //      Unmarshal records the element name in that field.
 //
 //   * If the XMLName field has an associated tag of the form
@@ -52,6 +52,11 @@ import (
 //      the explicit name in a struct field tag of the form "name,attr",
 //      Unmarshal records the attribute value in that field.
 //
+//   * If the XML element has an attribute not handled by the previous
+//      rule and the struct has a field with an associated tag containing
+//      ",any,attr", Unmarshal records the attribute value in the first
+//      such field.
+//
 //   * If the XML element contains character data, that data is
 //      accumulated in the first struct field that has tag ",chardata".
 //      The struct field may have type []byte or string.
@@ -59,7 +64,7 @@ import (
 //
 //   * If the XML element contains comments, they are accumulated in
 //      the first struct field that has tag ",comment".  The struct
-//      field may have type []byte or string.  If there is no such
+//      field may have type []byte or string. If there is no such
 //      field, the comments are discarded.
 //
 //   * If the XML element contains a sub-element whose name matches
@@ -85,7 +90,12 @@ import (
 //   * An anonymous struct field is handled as if the fields of its
 //      value were part of the outer struct.
 //
-//   * A struct field with tag "-" is never unmarshalled into.
+//   * A struct field with tag "-" is never unmarshaled into.
+//
+// If Unmarshal encounters a field type that implements the Unmarshaler
+// interface, Unmarshal calls its UnmarshalXML method to produce the value from
+// the XML element.  Otherwise, if the value implements
+// encoding.TextUnmarshaler, Unmarshal calls that value's UnmarshalText method.
 //
 // Unmarshal maps an XML element to a string or []byte by saving the
 // concatenation of that element's character data in the string or
@@ -94,34 +104,42 @@ import (
 // Unmarshal maps an attribute value to a string or []byte by saving
 // the value in the string or slice.
 //
-// Unmarshal maps an XML element to a slice by extending the length of
-// the slice and mapping the element to the newly created value.
+// Unmarshal maps an attribute value to an Attr by saving the attribute,
+// including its name, in the Attr.
+//
+// Unmarshal maps an XML element or attribute value to a slice by
+// extending the length of the slice and mapping the element or attribute
+// to the newly created value.
 //
 // Unmarshal maps an XML element or attribute value to a bool by
-// setting it to the boolean value represented by the string.
+// setting it to the boolean value represented by the string. Whitespace
+// is trimmed and ignored.
 //
 // Unmarshal maps an XML element or attribute value to an integer or
 // floating-point field by setting the field to the result of
-// interpreting the string value in decimal.  There is no check for
-// overflow.
+// interpreting the string value in decimal. There is no check for
+// overflow. Whitespace is trimmed and ignored.
 //
-// Unmarshal maps an XML element to an xml.Name by recording the
-// element name.
+// Unmarshal maps an XML element to a Name by recording the element
+// name.
 //
 // Unmarshal maps an XML element to a pointer by setting the pointer
 // to a freshly allocated value and then mapping the element to that value.
 //
+// A missing element or empty attribute value will be unmarshaled as a zero value.
+// If the field is a slice, a zero value will be appended to the field. Otherwise, the
+// field will be set to its zero value.
 func Unmarshal(data []byte, v interface{}) error {
 	return NewDecoder(bytes.NewReader(data)).Decode(v)
 }
 
-// Decode works like xml.Unmarshal, except it reads the decoder
+// Decode works like Unmarshal, except it reads the decoder
 // stream to find the start element.
 func (d *Decoder) Decode(v interface{}) error {
 	return d.DecodeElement(v, nil)
 }
 
-// DecodeElement works like xml.Unmarshal except that it takes
+// DecodeElement works like Unmarshal except that it takes
 // a pointer to the start XML element to decode into v.
 // It is useful when a client reads some raw XML tokens itself
 // but also wants to defer to Unmarshal for some elements.
@@ -133,7 +151,7 @@ func (d *Decoder) DecodeElement(v interface{}, start *StartElement) error {
 	return d.unmarshal(val.Elem(), start)
 }
 
-// An UnmarshalError represents an error in the unmarshalling process.
+// An UnmarshalError represents an error in the unmarshaling process.
 type UnmarshalError string
 
 func (e UnmarshalError) Error() string { return string(e) }
@@ -148,7 +166,7 @@ func (e UnmarshalError) Error() string { return string(e) }
 // UnmarshalXML must consume exactly one XML element.
 // One common implementation strategy is to unmarshal into
 // a separate value with a layout matching the expected XML
-// using d.DecodeElement,  and then to copy the data from
+// using d.DecodeElement, and then to copy the data from
 // that value into the receiver.
 // Another common strategy is to use d.Token to process the
 // XML object one token at a time.
@@ -180,19 +198,19 @@ func receiverType(val interface{}) string {
 
 // unmarshalInterface unmarshals a single XML element into val.
 // start is the opening tag of the element.
-func (p *Decoder) unmarshalInterface(val Unmarshaler, start *StartElement) error {
+func (d *Decoder) unmarshalInterface(val Unmarshaler, start *StartElement) error {
 	// Record that decoder must stop at end tag corresponding to start.
-	p.pushEOF()
+	d.pushEOF()
 
-	p.unmarshalDepth++
-	err := val.UnmarshalXML(p, *start)
-	p.unmarshalDepth--
+	d.unmarshalDepth++
+	err := val.UnmarshalXML(d, *start)
+	d.unmarshalDepth--
 	if err != nil {
-		p.popEOF()
+		d.popEOF()
 		return err
 	}
 
-	if !p.popEOF() {
+	if !d.popEOF() {
 		return fmt.Errorf("xml: %s.UnmarshalXML did not consume entire <%s> element", receiverType(val), start.Name.Local)
 	}
 
@@ -202,11 +220,11 @@ func (p *Decoder) unmarshalInterface(val Unmarshaler, start *StartElement) error
 // unmarshalTextInterface unmarshals a single XML element into val.
 // The chardata contained in the element (but not its children)
 // is passed to the text unmarshaler.
-func (p *Decoder) unmarshalTextInterface(val encoding.TextUnmarshaler, start *StartElement) error {
+func (d *Decoder) unmarshalTextInterface(val encoding.TextUnmarshaler) error {
 	var buf []byte
 	depth := 1
 	for depth > 0 {
-		t, err := p.Token()
+		t, err := d.Token()
 		if err != nil {
 			return err
 		}
@@ -225,14 +243,13 @@ func (p *Decoder) unmarshalTextInterface(val encoding.TextUnmarshaler, start *St
 }
 
 // unmarshalAttr unmarshals a single XML attribute into val.
-func (p *Decoder) unmarshalAttr(val reflect.Value, attr Attr) error {
+func (d *Decoder) unmarshalAttr(val reflect.Value, attr Attr) error {
 	if val.Kind() == reflect.Ptr {
 		if val.IsNil() {
 			val.Set(reflect.New(val.Type().Elem()))
 		}
 		val = val.Elem()
 	}
-
 	if val.CanInterface() && val.Type().Implements(unmarshalerAttrType) {
 		// This is an unmarshaler with a non-pointer receiver,
 		// so it's likely to be incorrect, but we do what we're told.
@@ -258,11 +275,30 @@ func (p *Decoder) unmarshalAttr(val reflect.Value, attr Attr) error {
 		}
 	}
 
-	copyValue(val, []byte(attr.Value))
-	return nil
+	if val.Type().Kind() == reflect.Slice && val.Type().Elem().Kind() != reflect.Uint8 {
+		// Slice of element values.
+		// Grow slice.
+		n := val.Len()
+		val.Set(reflect.Append(val, reflect.Zero(val.Type().Elem())))
+
+		// Recur to read element into slice.
+		if err := d.unmarshalAttr(val.Index(n), attr); err != nil {
+			val.SetLen(n)
+			return err
+		}
+		return nil
+	}
+
+	if val.Type() == attrType {
+		val.Set(reflect.ValueOf(attr))
+		return nil
+	}
+
+	return copyValue(val, []byte(attr.Value))
 }
 
 var (
+	attrType            = reflect.TypeOf(Attr{})
 	unmarshalerType     = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
 	unmarshalerAttrType = reflect.TypeOf((*UnmarshalerAttr)(nil)).Elem()
 	textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
@@ -271,21 +307,9 @@ var (
 // Find reflect.Type for an element's type attribute.
 func (p *Decoder) typeForElement(val reflect.Value, start *StartElement) reflect.Type {
 	t := ""
-	for i, a := range start.Attr {
+	for _, a := range start.Attr {
 		if a.Name == xmlSchemaInstance || a.Name == xsiType {
 			t = a.Value
-			// HACK: ensure xsi:type is last in the list to avoid using that value for
-			// a "type" attribute, such as ManagedObjectReference.Type for example.
-			// Note that xsi:type is already the last attribute in VC/ESX responses.
-			// This is only an issue with govmomi simulator generated responses.
-			// Proper fix will require finding a few needles in this xml package haystack.
-			// Note: govmomi uses xmlSchemaInstance, other clients (e.g. rbvmomi) use xsiType.
-			// They are the same thing to XML parsers, but not to this hack here.
-			x := len(start.Attr) - 1
-			if i != x {
-				start.Attr[i] = start.Attr[x]
-				start.Attr[x] = a
-			}
 			break
 		}
 	}
@@ -312,11 +336,11 @@ func (p *Decoder) typeForElement(val reflect.Value, start *StartElement) reflect
 }
 
 // Unmarshal a single XML element into val.
-func (p *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
+func (d *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 	// Find start element if we need it.
 	if start == nil {
 		for {
-			tok, err := p.Token()
+			tok, err := d.Token()
 			if err != nil {
 				return err
 			}
@@ -329,10 +353,10 @@ func (p *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 
 	// Try to figure out type for empty interface values.
 	if val.Kind() == reflect.Interface && val.IsNil() {
-		typ := p.typeForElement(val, start)
+		typ := d.typeForElement(val, start)
 		if typ != nil {
 			pval := reflect.New(typ).Elem()
-			err := p.unmarshal(pval, start)
+			err := d.unmarshal(pval, start)
 			if err != nil {
 				return err
 			}
@@ -371,24 +395,24 @@ func (p *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 	if val.CanInterface() && val.Type().Implements(unmarshalerType) {
 		// This is an unmarshaler with a non-pointer receiver,
 		// so it's likely to be incorrect, but we do what we're told.
-		return p.unmarshalInterface(val.Interface().(Unmarshaler), start)
+		return d.unmarshalInterface(val.Interface().(Unmarshaler), start)
 	}
 
 	if val.CanAddr() {
 		pv := val.Addr()
 		if pv.CanInterface() && pv.Type().Implements(unmarshalerType) {
-			return p.unmarshalInterface(pv.Interface().(Unmarshaler), start)
+			return d.unmarshalInterface(pv.Interface().(Unmarshaler), start)
 		}
 	}
 
 	if val.CanInterface() && val.Type().Implements(textUnmarshalerType) {
-		return p.unmarshalTextInterface(val.Interface().(encoding.TextUnmarshaler), start)
+		return d.unmarshalTextInterface(val.Interface().(encoding.TextUnmarshaler))
 	}
 
 	if val.CanAddr() {
 		pv := val.Addr()
 		if pv.CanInterface() && pv.Type().Implements(textUnmarshalerType) {
-			return p.unmarshalTextInterface(pv.Interface().(encoding.TextUnmarshaler), start)
+			return d.unmarshalTextInterface(pv.Interface().(encoding.TextUnmarshaler))
 		}
 	}
 
@@ -414,7 +438,7 @@ func (p *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 		// TODO: For now, simply ignore the field. In the near
 		//       future we may choose to unmarshal the start
 		//       element on it, if not nil.
-		return p.Skip()
+		return d.Skip()
 
 	case reflect.Slice:
 		typ := v.Type()
@@ -427,19 +451,10 @@ func (p *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 		// Slice of element values.
 		// Grow slice.
 		n := v.Len()
-		if n >= v.Cap() {
-			ncap := 2 * n
-			if ncap < 4 {
-				ncap = 4
-			}
-			new := reflect.MakeSlice(typ, n, ncap)
-			reflect.Copy(new, v)
-			v.Set(new)
-		}
-		v.SetLen(n + 1)
+		v.Set(reflect.Append(val, reflect.Zero(v.Type().Elem())))
 
 		// Recur to read element into slice.
-		if err := p.unmarshal(v.Index(n), start); err != nil {
+		if err := d.unmarshal(v.Index(n), start); err != nil {
 			v.SetLen(n)
 			return err
 		}
@@ -483,23 +498,45 @@ func (p *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 		}
 
 		// Assign attributes.
-		// Also, determine whether we need to save character data or comments.
+		for _, a := range start.Attr {
+			handled := false
+			any := -1
+			for i := range tinfo.fields {
+				finfo := &tinfo.fields[i]
+				switch finfo.flags & fMode {
+				case fAttr:
+					strv := finfo.value(sv)
+					if a.Name.Local == finfo.name && (finfo.xmlns == "" || finfo.xmlns == a.Name.Space) {
+						needTypeAttr := (finfo.flags & fTypeAttr) != 0
+						// HACK: avoid using xsi:type value for a "type" attribute, such as ManagedObjectReference.Type for example.
+						if needTypeAttr || (a.Name != xmlSchemaInstance && a.Name != xsiType) {
+							if err := d.unmarshalAttr(strv, a); err != nil {
+								return err
+							}
+						}
+						handled = true
+					}
+
+				case fAny | fAttr:
+					if any == -1 {
+						any = i
+					}
+				}
+			}
+			if !handled && any >= 0 {
+				finfo := &tinfo.fields[any]
+				strv := finfo.value(sv)
+				if err := d.unmarshalAttr(strv, a); err != nil {
+					return err
+				}
+			}
+		}
+
+		// Determine whether we need to save character data or comments.
 		for i := range tinfo.fields {
 			finfo := &tinfo.fields[i]
 			switch finfo.flags & fMode {
-			case fAttr:
-				strv := finfo.value(sv)
-				// Look for attribute.
-				for _, a := range start.Attr {
-					if a.Name.Local == finfo.name && (finfo.xmlns == "" || finfo.xmlns == a.Name.Space) {
-						if err := p.unmarshalAttr(strv, a); err != nil {
-							return err
-						}
-						break
-					}
-				}
-
-			case fCharData:
+			case fCDATA, fCharData:
 				if !saveData.IsValid() {
 					saveData = finfo.value(sv)
 				}
@@ -517,11 +554,11 @@ func (p *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 			case fInnerXml:
 				if !saveXML.IsValid() {
 					saveXML = finfo.value(sv)
-					if p.saved == nil {
+					if d.saved == nil {
 						saveXMLIndex = 0
-						p.saved = new(bytes.Buffer)
+						d.saved = new(bytes.Buffer)
 					} else {
-						saveXMLIndex = p.savedOffset()
+						saveXMLIndex = d.savedOffset()
 					}
 				}
 			}
@@ -534,9 +571,9 @@ Loop:
 	for {
 		var savedOffset int
 		if saveXML.IsValid() {
-			savedOffset = p.savedOffset()
+			savedOffset = d.savedOffset()
 		}
-		tok, err := p.Token()
+		tok, err := d.Token()
 		if err != nil {
 			return err
 		}
@@ -544,28 +581,28 @@ Loop:
 		case StartElement:
 			consumed := false
 			if sv.IsValid() {
-				consumed, err = p.unmarshalPath(tinfo, sv, nil, &t)
+				consumed, err = d.unmarshalPath(tinfo, sv, nil, &t)
 				if err != nil {
 					return err
 				}
 				if !consumed && saveAny.IsValid() {
 					consumed = true
-					if err := p.unmarshal(saveAny, &t); err != nil {
+					if err := d.unmarshal(saveAny, &t); err != nil {
 						return err
 					}
 				}
 			}
 			if !consumed {
-				if err := p.Skip(); err != nil {
+				if err := d.Skip(); err != nil {
 					return err
 				}
 			}
 
 		case EndElement:
 			if saveXML.IsValid() {
-				saveXMLData = p.saved.Bytes()[saveXMLIndex:savedOffset]
+				saveXMLData = d.saved.Bytes()[saveXMLIndex:savedOffset]
 				if saveXMLIndex == 0 {
-					p.saved = nil
+					d.saved = nil
 				}
 			}
 			break Loop
@@ -614,7 +651,9 @@ Loop:
 	case reflect.String:
 		t.SetString(string(saveXMLData))
 	case reflect.Slice:
-		t.Set(reflect.ValueOf(saveXMLData))
+		if t.Type().Elem().Kind() == reflect.Uint8 {
+			t.Set(reflect.ValueOf(saveXMLData))
+		}
 	}
 
 	return nil
@@ -637,7 +676,11 @@ func copyValue(dst reflect.Value, src []byte) (err error) {
 	default:
 		return errors.New("cannot unmarshal into " + dst0.Type().String())
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		itmp, err := strconv.ParseInt(string(src), 10, dst.Type().Bits())
+		if len(src) == 0 {
+			dst.SetInt(0)
+			return nil
+		}
+		itmp, err := strconv.ParseInt(strings.TrimSpace(string(src)), 10, dst.Type().Bits())
 		if err != nil {
 			return err
 		}
@@ -663,19 +706,32 @@ func copyValue(dst reflect.Value, src []byte) (err error) {
 				utmp = uint64(uint64(itmp))
 			}
 		} else {
-			utmp, err = strconv.ParseUint(string(src), 10, dst.Type().Bits())
+			if len(src) == 0 {
+				dst.SetUint(0)
+				return nil
+			}
+
+			utmp, err = strconv.ParseUint(strings.TrimSpace(string(src)), 10, dst.Type().Bits())
 			if err != nil {
 				return err
 			}
 		}
 		dst.SetUint(utmp)
 	case reflect.Float32, reflect.Float64:
-		ftmp, err := strconv.ParseFloat(string(src), dst.Type().Bits())
+		if len(src) == 0 {
+			dst.SetFloat(0)
+			return nil
+		}
+		ftmp, err := strconv.ParseFloat(strings.TrimSpace(string(src)), dst.Type().Bits())
 		if err != nil {
 			return err
 		}
 		dst.SetFloat(ftmp)
 	case reflect.Bool:
+		if len(src) == 0 {
+			dst.SetBool(false)
+			return nil
+		}
 		value, err := strconv.ParseBool(strings.TrimSpace(string(src)))
 		if err != nil {
 			return err
@@ -698,7 +754,7 @@ func copyValue(dst reflect.Value, src []byte) (err error) {
 // The consumed result tells whether XML elements have been consumed
 // from the Decoder until start's matching end element, or if it's
 // still untouched because start is uninteresting for sv's fields.
-func (p *Decoder) unmarshalPath(tinfo *typeInfo, sv reflect.Value, parents []string, start *StartElement) (consumed bool, err error) {
+func (d *Decoder) unmarshalPath(tinfo *typeInfo, sv reflect.Value, parents []string, start *StartElement) (consumed bool, err error) {
 	recurse := false
 Loop:
 	for i := range tinfo.fields {
@@ -713,7 +769,7 @@ Loop:
 		}
 		if len(finfo.parents) == len(parents) && finfo.name == start.Name.Local {
 			// It's a perfect match, unmarshal the field.
-			return true, p.unmarshal(finfo.value(sv), start)
+			return true, d.unmarshal(finfo.value(sv), start)
 		}
 		if len(finfo.parents) > len(parents) && finfo.parents[len(parents)] == start.Name.Local {
 			// It's a prefix for the field. Break and recurse
@@ -736,18 +792,18 @@ Loop:
 	// prefix. Recurse and attempt to match these.
 	for {
 		var tok Token
-		tok, err = p.Token()
+		tok, err = d.Token()
 		if err != nil {
 			return true, err
 		}
 		switch t := tok.(type) {
 		case StartElement:
-			consumed2, err := p.unmarshalPath(tinfo, sv, parents, &t)
+			consumed2, err := d.unmarshalPath(tinfo, sv, parents, &t)
 			if err != nil {
 				return true, err
 			}
 			if !consumed2 {
-				if err := p.Skip(); err != nil {
+				if err := d.Skip(); err != nil {
 					return true, err
 				}
 			}

--- a/vendor/github.com/vmware/govmomi/vim25/xml/typeinfo.go
+++ b/vendor/github.com/vmware/govmomi/vim25/xml/typeinfo.go
@@ -1,4 +1,4 @@
-// Copyright 2011 The Go Authors.  All rights reserved.
+// Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -31,6 +31,7 @@ type fieldFlags int
 const (
 	fElement fieldFlags = 1 << iota
 	fAttr
+	fCDATA
 	fCharData
 	fInnerXml
 	fComment
@@ -39,29 +40,28 @@ const (
 	fOmitEmpty
 	fTypeAttr
 
-	fMode = fElement | fAttr | fCharData | fInnerXml | fComment | fAny
+	fMode = fElement | fAttr | fCDATA | fCharData | fInnerXml | fComment | fAny
+
+	xmlName = "XMLName"
 )
 
-var tinfoMap = make(map[reflect.Type]*typeInfo)
-var tinfoLock sync.RWMutex
+var tinfoMap sync.Map // map[reflect.Type]*typeInfo
 
 var nameType = reflect.TypeOf(Name{})
 
 // getTypeInfo returns the typeInfo structure with details necessary
-// for marshalling and unmarshalling typ.
+// for marshaling and unmarshaling typ.
 func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
-	tinfoLock.RLock()
-	tinfo, ok := tinfoMap[typ]
-	tinfoLock.RUnlock()
-	if ok {
-		return tinfo, nil
+	if ti, ok := tinfoMap.Load(typ); ok {
+		return ti.(*typeInfo), nil
 	}
-	tinfo = &typeInfo{}
+
+	tinfo := &typeInfo{}
 	if typ.Kind() == reflect.Struct && typ != nameType {
 		n := typ.NumField()
 		for i := 0; i < n; i++ {
 			f := typ.Field(i)
-			if f.PkgPath != "" || f.Tag.Get("xml") == "-" {
+			if (f.PkgPath != "" && !f.Anonymous) || f.Tag.Get("xml") == "-" {
 				continue // Private field
 			}
 
@@ -94,7 +94,7 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 				return nil, err
 			}
 
-			if f.Name == "XMLName" {
+			if f.Name == xmlName {
 				tinfo.xmlname = finfo
 				continue
 			}
@@ -105,10 +105,9 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 			}
 		}
 	}
-	tinfoLock.Lock()
-	tinfoMap[typ] = tinfo
-	tinfoLock.Unlock()
-	return tinfo, nil
+
+	ti, _ := tinfoMap.LoadOrStore(typ, tinfo)
+	return ti.(*typeInfo), nil
 }
 
 // structFieldInfo builds and returns a fieldInfo for f.
@@ -131,6 +130,8 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 			switch flag {
 			case "attr":
 				finfo.flags |= fAttr
+			case "cdata":
+				finfo.flags |= fCDATA
 			case "chardata":
 				finfo.flags |= fCharData
 			case "innerxml":
@@ -151,8 +152,8 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 		switch mode := finfo.flags & fMode; mode {
 		case 0:
 			finfo.flags |= fElement
-		case fAttr, fCharData, fInnerXml, fComment, fAny:
-			if f.Name == "XMLName" || tag != "" && mode != fAttr {
+		case fAttr, fCDATA, fCharData, fInnerXml, fComment, fAny, fAny | fAttr:
+			if f.Name == xmlName || tag != "" && mode != fAttr {
 				valid = false
 			}
 		default:
@@ -177,7 +178,7 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 			f.Name, typ, f.Tag.Get("xml"))
 	}
 
-	if f.Name == "XMLName" {
+	if f.Name == xmlName {
 		// The XMLName field records the XML element name. Don't
 		// process it as usual because its name should default to
 		// empty rather than to the field name.
@@ -214,7 +215,7 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 	}
 
 	// If the field type has an XMLName field, the names must match
-	// so that the behavior of both marshalling and unmarshalling
+	// so that the behavior of both marshaling and unmarshaling
 	// is straightforward and unambiguous.
 	if finfo.flags&fElement != 0 {
 		ftyp := f.Type
@@ -239,11 +240,11 @@ func lookupXMLName(typ reflect.Type) (xmlname *fieldInfo) {
 	}
 	for i, n := 0, typ.NumField(); i < n; i++ {
 		f := typ.Field(i)
-		if f.Name != "XMLName" {
+		if f.Name != xmlName {
 			continue
 		}
 		finfo, err := structFieldInfo(typ, &f)
-		if finfo.name != "" && err == nil {
+		if err == nil && finfo.name != "" {
 			return finfo
 		}
 		// Also consider errors as a non-existent field tag
@@ -334,7 +335,7 @@ Loop:
 	return nil
 }
 
-// A TagPathError represents an error in the unmarshalling process
+// A TagPathError represents an error in the unmarshaling process
 // caused by the use of field tags with conflicting paths.
 type TagPathError struct {
 	Struct       reflect.Type

--- a/vendor/github.com/vmware/govmomi/vim25/xml/xml.go
+++ b/vendor/github.com/vmware/govmomi/vim25/xml/xml.go
@@ -7,8 +7,8 @@
 package xml
 
 // References:
-//    Annotated XML spec: http://www.xml.com/axml/testaxml.htm
-//    XML name spaces: http://www.w3.org/TR/REC-xml-names/
+//    Annotated XML spec: https://www.xml.com/axml/testaxml.htm
+//    XML name spaces: https://www.w3.org/TR/REC-xml-names/
 
 // TODO(rsc):
 //	Test error handling.
@@ -61,6 +61,7 @@ type StartElement struct {
 	Attr []Attr
 }
 
+// Copy creates a new copy of StartElement.
 func (e StartElement) Copy() StartElement {
 	attrs := make([]Attr, len(e.Attr))
 	copy(attrs, e.Attr)
@@ -89,12 +90,14 @@ func makeCopy(b []byte) []byte {
 	return b1
 }
 
+// Copy creates a new copy of CharData.
 func (c CharData) Copy() CharData { return CharData(makeCopy(c)) }
 
 // A Comment represents an XML comment of the form <!--comment-->.
 // The bytes do not include the <!-- and --> comment markers.
 type Comment []byte
 
+// Copy creates a new copy of Comment.
 func (c Comment) Copy() Comment { return Comment(makeCopy(c)) }
 
 // A ProcInst represents an XML processing instruction of the form <?target inst?>
@@ -103,6 +106,7 @@ type ProcInst struct {
 	Inst   []byte
 }
 
+// Copy creates a new copy of ProcInst.
 func (p ProcInst) Copy() ProcInst {
 	p.Inst = makeCopy(p.Inst)
 	return p
@@ -112,6 +116,7 @@ func (p ProcInst) Copy() ProcInst {
 // The bytes do not include the <! and > markers.
 type Directive []byte
 
+// Copy creates a new copy of Directive.
 func (d Directive) Copy() Directive { return Directive(makeCopy(d)) }
 
 // CopyToken returns a copy of a Token.
@@ -131,6 +136,23 @@ func CopyToken(t Token) Token {
 	return t
 }
 
+// A TokenReader is anything that can decode a stream of XML tokens, including a
+// Decoder.
+//
+// When Token encounters an error or end-of-file condition after successfully
+// reading a token, it returns the token. It may return the (non-nil) error from
+// the same call or return the error (and a nil token) from a subsequent call.
+// An instance of this general case is that a TokenReader returning a non-nil
+// token at the end of the token stream may return either io.EOF or a nil error.
+// The next Read should return nil, io.EOF.
+//
+// Implementations of Token are discouraged from returning a nil token with a
+// nil error. Callers should treat a return of nil, nil as indicating that
+// nothing happened; in particular it does not indicate EOF.
+type TokenReader interface {
+	Token() (Token, error)
+}
+
 // A Decoder represents an XML parser reading a particular input stream.
 // The parser assumes that its input is encoded in UTF-8.
 type Decoder struct {
@@ -146,9 +168,9 @@ type Decoder struct {
 	//
 	// Setting:
 	//
-	//	d.Strict = false;
-	//	d.AutoClose = HTMLAutoClose;
-	//	d.Entity = HTMLEntity
+	//	d.Strict = false
+	//	d.AutoClose = xml.HTMLAutoClose
+	//	d.Entity = xml.HTMLEntity
 	//
 	// creates a parser that can handle typical HTML.
 	//
@@ -177,7 +199,7 @@ type Decoder struct {
 	// charset-conversion readers, converting from the provided
 	// non-UTF-8 charset into UTF-8. If CharsetReader is nil or
 	// returns an error, parsing stops with an error. One of the
-	// the CharsetReader's result values must be non-nil.
+	// CharsetReader's result values must be non-nil.
 	CharsetReader func(charset string, input io.Reader) (io.Reader, error)
 
 	// DefaultSpace sets the default name space used for unadorned tags,
@@ -189,6 +211,7 @@ type Decoder struct {
 	TypeFunc func(string) (reflect.Type, bool)
 
 	r              io.ByteReader
+	t              TokenReader
 	buf            bytes.Buffer
 	saved          *bytes.Buffer
 	stk            *stack
@@ -200,6 +223,7 @@ type Decoder struct {
 	ns             map[string]string
 	err            error
 	line           int
+	offset         int64
 	unmarshalDepth int
 }
 
@@ -217,12 +241,28 @@ func NewDecoder(r io.Reader) *Decoder {
 	return d
 }
 
+// NewTokenDecoder creates a new XML parser using an underlying token stream.
+func NewTokenDecoder(t TokenReader) *Decoder {
+	// Is it already a Decoder?
+	if d, ok := t.(*Decoder); ok {
+		return d
+	}
+	d := &Decoder{
+		ns:       make(map[string]string),
+		t:        t,
+		nextByte: -1,
+		line:     1,
+		Strict:   true,
+	}
+	return d
+}
+
 // Token returns the next XML token in the input stream.
 // At the end of the input stream, Token returns nil, io.EOF.
 //
 // Slices of bytes in the returned token data refer to the
 // parser's internal buffer and remain valid only until the next
-// call to Token.  To acquire a copy of the bytes, call CopyToken
+// call to Token. To acquire a copy of the bytes, call CopyToken
 // or the token's Copy method.
 //
 // Token expands self-closing elements such as <br/>
@@ -230,25 +270,30 @@ func NewDecoder(r io.Reader) *Decoder {
 //
 // Token guarantees that the StartElement and EndElement
 // tokens it returns are properly nested and matched:
-// if Token encounters an unexpected end element,
+// if Token encounters an unexpected end element
+// or EOF before all expected end elements,
 // it will return an error.
 //
 // Token implements XML name spaces as described by
-// http://www.w3.org/TR/REC-xml-names/.  Each of the
+// https://www.w3.org/TR/REC-xml-names/.  Each of the
 // Name structures contained in the Token has the Space
 // set to the URL identifying its name space when known.
 // If Token encounters an unrecognized name space prefix,
 // it uses the prefix as the Space rather than report an error.
-func (d *Decoder) Token() (t Token, err error) {
+func (d *Decoder) Token() (Token, error) {
+	var t Token
+	var err error
 	if d.stk != nil && d.stk.kind == stkEOF {
-		err = io.EOF
-		return
+		return nil, io.EOF
 	}
 	if d.nextToken != nil {
 		t = d.nextToken
 		d.nextToken = nil
 	} else if t, err = d.rawToken(); err != nil {
-		return
+		if err == io.EOF && d.stk != nil && d.stk.kind != stkEOF {
+			err = d.syntaxError("unexpected EOF")
+		}
+		return t, err
 	}
 
 	if !d.Strict {
@@ -264,12 +309,12 @@ func (d *Decoder) Token() (t Token, err error) {
 		// to the other attribute names, so process
 		// the translations first.
 		for _, a := range t1.Attr {
-			if a.Name.Space == "xmlns" {
+			if a.Name.Space == xmlnsPrefix {
 				v, ok := d.ns[a.Name.Local]
 				d.pushNs(a.Name.Local, v, ok)
 				d.ns[a.Name.Local] = a.Value
 			}
-			if a.Name.Space == "" && a.Name.Local == "xmlns" {
+			if a.Name.Space == "" && a.Name.Local == xmlnsPrefix {
 				// Default space for untagged names
 				v, ok := d.ns[""]
 				d.pushNs("", v, ok)
@@ -291,23 +336,27 @@ func (d *Decoder) Token() (t Token, err error) {
 		}
 		t = t1
 	}
-	return
+	return t, err
 }
 
-const xmlURL = "http://www.w3.org/XML/1998/namespace"
+const (
+	xmlURL      = "http://www.w3.org/XML/1998/namespace"
+	xmlnsPrefix = "xmlns"
+	xmlPrefix   = "xml"
+)
 
 // Apply name space translation to name n.
 // The default name space (for Space=="")
 // applies only to element names, not to attribute names.
 func (d *Decoder) translate(n *Name, isElementName bool) {
 	switch {
-	case n.Space == "xmlns":
+	case n.Space == xmlnsPrefix:
 		return
 	case n.Space == "" && !isElementName:
 		return
-	case n.Space == "xml":
+	case n.Space == xmlPrefix:
 		n.Space = xmlURL
-	case n.Space == "" && n.Local == "xmlns":
+	case n.Space == "" && n.Local == xmlnsPrefix:
 		return
 	}
 	if v, ok := d.ns[n.Space]; ok {
@@ -330,7 +379,7 @@ func (d *Decoder) switchToReader(r io.Reader) {
 }
 
 // Parsing state - stack holds old name space translations
-// and the current set of open elements.  The translations to pop when
+// and the current set of open elements. The translations to pop when
 // ending a given tag are *below* it on the stack, which is
 // more work but forced on us by XML.
 type stack struct {
@@ -501,6 +550,9 @@ func (d *Decoder) RawToken() (Token, error) {
 }
 
 func (d *Decoder) rawToken() (Token, error) {
+	if d.t != nil {
+		return d.t.Token()
+	}
 	if d.err != nil {
 		return nil, d.err
 	}
@@ -552,7 +604,6 @@ func (d *Decoder) rawToken() (Token, error) {
 
 	case '?':
 		// <?: Processing instruction.
-		// TODO(rsc): Should parse the <?xml declaration to make sure the version is 1.0.
 		var target string
 		if target, ok = d.name(); !ok {
 			if d.err == nil {
@@ -577,8 +628,14 @@ func (d *Decoder) rawToken() (Token, error) {
 		data = data[0 : len(data)-2] // chop ?>
 
 		if target == "xml" {
-			enc := procInstEncoding(string(data))
-			if enc != "" && enc != "utf-8" && enc != "UTF-8" {
+			content := string(data)
+			ver := procInst("version", content)
+			if ver != "" && ver != "1.0" {
+				d.err = fmt.Errorf("xml: unsupported version %q; only version 1.0 is supported", ver)
+				return nil, d.err
+			}
+			enc := procInst("encoding", content)
+			if enc != "" && enc != "utf-8" && enc != "UTF-8" && !strings.EqualFold(enc, "utf-8") {
 				if d.CharsetReader == nil {
 					d.err = fmt.Errorf("xml: encoding %q declared but Decoder.CharsetReader is nil", enc)
 					return nil, d.err
@@ -619,7 +676,12 @@ func (d *Decoder) rawToken() (Token, error) {
 					return nil, d.err
 				}
 				d.buf.WriteByte(b)
-				if b0 == '-' && b1 == '-' && b == '>' {
+				if b0 == '-' && b1 == '-' {
+					if b != '>' {
+						d.err = d.syntaxError(
+							`invalid sequence "--" not allowed in comments`)
+						return nil, d.err
+					}
 					break
 				}
 				b0, b1 = b1, b
@@ -726,7 +788,7 @@ func (d *Decoder) rawToken() (Token, error) {
 		return nil, d.err
 	}
 
-	attr = make([]Attr, 0, 4)
+	attr = []Attr{}
 	for {
 		d.space()
 		if b, ok = d.mustgetc(); !ok {
@@ -748,14 +810,7 @@ func (d *Decoder) rawToken() (Token, error) {
 		}
 		d.ungetc(b)
 
-		n := len(attr)
-		if n >= cap(attr) {
-			nattr := make([]Attr, n, 2*cap(attr))
-			copy(nattr, attr)
-			attr = nattr
-		}
-		attr = attr[0 : n+1]
-		a := &attr[n]
+		a := Attr{}
 		if a.Name, ok = d.nsname(); !ok {
 			if d.err == nil {
 				d.err = d.syntaxError("expected attribute name in element")
@@ -770,10 +825,9 @@ func (d *Decoder) rawToken() (Token, error) {
 			if d.Strict {
 				d.err = d.syntaxError("attribute name without = in element")
 				return nil, d.err
-			} else {
-				d.ungetc(b)
-				a.Value = a.Name.Local
 			}
+			d.ungetc(b)
+			a.Value = a.Name.Local
 		} else {
 			d.space()
 			data := d.attrval()
@@ -782,6 +836,7 @@ func (d *Decoder) rawToken() (Token, error) {
 			}
 			a.Value = string(data)
 		}
+		attr = append(attr, a)
 	}
 	if empty {
 		d.needClose = true
@@ -812,7 +867,7 @@ func (d *Decoder) attrval() []byte {
 		if !ok {
 			return nil
 		}
-		// http://www.w3.org/TR/REC-html40/intro/sgmltut.html#h-3.2.2
+		// https://www.w3.org/TR/REC-html40/intro/sgmltut.html#h-3.2.2
 		if 'a' <= b && b <= 'z' || 'A' <= b && b <= 'Z' ||
 			'0' <= b && b <= '9' || b == '_' || b == ':' || b == '-' {
 			d.buf.WriteByte(b)
@@ -863,7 +918,15 @@ func (d *Decoder) getc() (b byte, ok bool) {
 	if b == '\n' {
 		d.line++
 	}
+	d.offset++
 	return b, true
+}
+
+// InputOffset returns the input stream byte offset of the current decoder position.
+// The offset gives the location of the end of the most recently returned token
+// and the beginning of the next token.
+func (d *Decoder) InputOffset() int64 {
+	return d.offset
 }
 
 // Return saved offset.
@@ -895,6 +958,7 @@ func (d *Decoder) ungetc(b byte) {
 		d.line--
 	}
 	d.nextByte = int(b)
+	d.offset--
 }
 
 var entity = map[string]int{
@@ -1002,7 +1066,6 @@ Input:
 					if d.err != nil {
 						return nil
 					}
-					ok = false
 				}
 				if b, ok = d.mustgetc(); !ok {
 					return nil
@@ -1075,13 +1138,13 @@ Input:
 }
 
 // Decide whether the given rune is in the XML Character Range, per
-// the Char production of http://www.xml.com/axml/testaxml.htm,
+// the Char production of https://www.xml.com/axml/testaxml.htm,
 // Section 2.2 Characters.
 func isInCharacterRange(r rune) (inrange bool) {
 	return r == 0x09 ||
 		r == 0x0A ||
 		r == 0x0D ||
-		r >= 0x20 && r <= 0xDF77 ||
+		r >= 0x20 && r <= 0xD7FF ||
 		r >= 0xE000 && r <= 0xFFFD ||
 		r >= 0x10000 && r <= 0x10FFFF
 }
@@ -1113,12 +1176,12 @@ func (d *Decoder) name() (s string, ok bool) {
 	}
 
 	// Now we check the characters.
-	s = d.buf.String()
-	if !isName([]byte(s)) {
-		d.err = d.syntaxError("invalid XML name: " + s)
+	b := d.buf.Bytes()
+	if !isName(b) {
+		d.err = d.syntaxError("invalid XML name: " + string(b))
 		return "", false
 	}
-	return s, true
+	return string(b), true
 }
 
 // Read a name and append its bytes to d.buf.
@@ -1204,8 +1267,8 @@ func isNameString(s string) bool {
 }
 
 // These tables were generated by cut and paste from Appendix B of
-// the XML spec at http://www.xml.com/axml/testaxml.htm
-// and then reformatting.  First corresponds to (Letter | '_' | ':')
+// the XML spec at https://www.xml.com/axml/testaxml.htm
+// and then reformatting. First corresponds to (Letter | '_' | ':')
 // and second corresponds to NameChar.
 
 var first = &unicode.RangeTable{
@@ -1522,7 +1585,9 @@ var second = &unicode.RangeTable{
 
 // HTMLEntity is an entity map containing translations for the
 // standard HTML entity characters.
-var HTMLEntity = htmlEntity
+//
+// See the Decoder.Strict and Decoder.Entity fields' documentation.
+var HTMLEntity map[string]string = htmlEntity
 
 var htmlEntity = map[string]string{
 	/*
@@ -1789,7 +1854,9 @@ var htmlEntity = map[string]string{
 
 // HTMLAutoClose is the set of HTML elements that
 // should be considered to close automatically.
-var HTMLAutoClose = htmlAutoClose
+//
+// See the Decoder.Strict and Decoder.Entity fields' documentation.
+var HTMLAutoClose []string = htmlAutoClose
 
 var htmlAutoClose = []string{
 	/*
@@ -1812,20 +1879,27 @@ var htmlAutoClose = []string{
 }
 
 var (
-	esc_quot = []byte("&#34;") // shorter than "&quot;"
-	esc_apos = []byte("&#39;") // shorter than "&apos;"
-	esc_amp  = []byte("&amp;")
-	esc_lt   = []byte("&lt;")
-	esc_gt   = []byte("&gt;")
-	esc_tab  = []byte("&#x9;")
-	esc_nl   = []byte("&#xA;")
-	esc_cr   = []byte("&#xD;")
-	esc_fffd = []byte("\uFFFD") // Unicode replacement character
+	escQuot = []byte("&#34;") // shorter than "&quot;"
+	escApos = []byte("&#39;") // shorter than "&apos;"
+	escAmp  = []byte("&amp;")
+	escLT   = []byte("&lt;")
+	escGT   = []byte("&gt;")
+	escTab  = []byte("&#x9;")
+	escNL   = []byte("&#xA;")
+	escCR   = []byte("&#xD;")
+	escFFFD = []byte("\uFFFD") // Unicode replacement character
 )
 
 // EscapeText writes to w the properly escaped XML equivalent
 // of the plain text data s.
 func EscapeText(w io.Writer, s []byte) error {
+	return escapeText(w, s, true)
+}
+
+// escapeText writes to w the properly escaped XML equivalent
+// of the plain text data s. If escapeNewline is true, newline
+// characters will be escaped.
+func escapeText(w io.Writer, s []byte, escapeNewline bool) error {
 	var esc []byte
 	last := 0
 	for i := 0; i < len(s); {
@@ -1833,24 +1907,27 @@ func EscapeText(w io.Writer, s []byte) error {
 		i += width
 		switch r {
 		case '"':
-			esc = esc_quot
+			esc = escQuot
 		case '\'':
-			esc = esc_apos
+			esc = escApos
 		case '&':
-			esc = esc_amp
+			esc = escAmp
 		case '<':
-			esc = esc_lt
+			esc = escLT
 		case '>':
-			esc = esc_gt
+			esc = escGT
 		case '\t':
-			esc = esc_tab
+			esc = escTab
 		case '\n':
-			esc = esc_nl
+			if !escapeNewline {
+				continue
+			}
+			esc = escNL
 		case '\r':
-			esc = esc_cr
+			esc = escCR
 		default:
 			if !isInCharacterRange(r) || (r == 0xFFFD && width == 1) {
-				esc = esc_fffd
+				esc = escFFFD
 				break
 			}
 			continue
@@ -1863,10 +1940,8 @@ func EscapeText(w io.Writer, s []byte) error {
 		}
 		last = i
 	}
-	if _, err := w.Write(s[last:]); err != nil {
-		return err
-	}
-	return nil
+	_, err := w.Write(s[last:])
+	return err
 }
 
 // EscapeString writes to p the properly escaped XML equivalent
@@ -1879,24 +1954,24 @@ func (p *printer) EscapeString(s string) {
 		i += width
 		switch r {
 		case '"':
-			esc = esc_quot
+			esc = escQuot
 		case '\'':
-			esc = esc_apos
+			esc = escApos
 		case '&':
-			esc = esc_amp
+			esc = escAmp
 		case '<':
-			esc = esc_lt
+			esc = escLT
 		case '>':
-			esc = esc_gt
+			esc = escGT
 		case '\t':
-			esc = esc_tab
+			esc = escTab
 		case '\n':
-			esc = esc_nl
+			esc = escNL
 		case '\r':
-			esc = esc_cr
+			esc = escCR
 		default:
 			if !isInCharacterRange(r) || (r == 0xFFFD && width == 1) {
-				esc = esc_fffd
+				esc = escFFFD
 				break
 			}
 			continue
@@ -1915,16 +1990,55 @@ func Escape(w io.Writer, s []byte) {
 	EscapeText(w, s)
 }
 
-// procInstEncoding parses the `encoding="..."` or `encoding='...'`
+var (
+	cdataStart  = []byte("<![CDATA[")
+	cdataEnd    = []byte("]]>")
+	cdataEscape = []byte("]]]]><![CDATA[>")
+)
+
+// emitCDATA writes to w the CDATA-wrapped plain text data s.
+// It escapes CDATA directives nested in s.
+func emitCDATA(w io.Writer, s []byte) error {
+	if len(s) == 0 {
+		return nil
+	}
+	if _, err := w.Write(cdataStart); err != nil {
+		return err
+	}
+	for {
+		i := bytes.Index(s, cdataEnd)
+		if i >= 0 && i+len(cdataEnd) <= len(s) {
+			// Found a nested CDATA directive end.
+			if _, err := w.Write(s[:i]); err != nil {
+				return err
+			}
+			if _, err := w.Write(cdataEscape); err != nil {
+				return err
+			}
+			i += len(cdataEnd)
+		} else {
+			if _, err := w.Write(s); err != nil {
+				return err
+			}
+			break
+		}
+		s = s[i:]
+	}
+	_, err := w.Write(cdataEnd)
+	return err
+}
+
+// procInst parses the `param="..."` or `param='...'`
 // value out of the provided string, returning "" if not found.
-func procInstEncoding(s string) string {
+func procInst(param, s string) string {
 	// TODO: this parsing is somewhat lame and not exact.
 	// It works for all actual cases, though.
-	idx := strings.Index(s, "encoding=")
+	param = param + "="
+	idx := strings.Index(s, param)
 	if idx == -1 {
 		return ""
 	}
-	v := s[idx+len("encoding="):]
+	v := s[idx+len(param):]
 	if v == "" {
 		return ""
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -557,7 +557,7 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
-# github.com/vmware/govmomi v0.22.2
+# github.com/vmware/govmomi v0.23.1
 github.com/vmware/govmomi
 github.com/vmware/govmomi/find
 github.com/vmware/govmomi/list
@@ -566,6 +566,7 @@ github.com/vmware/govmomi/object
 github.com/vmware/govmomi/ovf
 github.com/vmware/govmomi/property
 github.com/vmware/govmomi/session
+github.com/vmware/govmomi/session/keepalive
 github.com/vmware/govmomi/task
 github.com/vmware/govmomi/vapi/internal
 github.com/vmware/govmomi/vapi/library

--- a/website/pages/docs/builders/vmware/vsphere-iso.mdx
+++ b/website/pages/docs/builders/vmware/vsphere-iso.mdx
@@ -216,7 +216,7 @@ iso_paths = [
 
 @include 'builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx'
 
-Minimal example of usage:
+Minimal example of usage to import a VM template:
 
 <Tabs>
 <Tab heading="JSON">
@@ -233,6 +233,31 @@ Minimal example of usage:
 ```hcl
 	content_library_destination {
 			library = "Packer Library Test"
+	}
+```
+
+</Tab>
+</Tabs>
+
+Minimal example of usage to import a OVF template:
+
+<Tabs>
+<Tab heading="JSON">
+
+```json
+	"content_library_destination" : {
+	    "library": "Packer Library Test",
+	    "ovf": true
+	}
+```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+	content_library_destination {
+			library = "Packer Library Test"
+			ovf = true
 	}
 ```
 

--- a/website/pages/partials/builder/vsphere/clone/Config-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/clone/Config-not-required.mdx
@@ -8,8 +8,8 @@
 - `export` (\*common.ExportConfig) - Configuration for exporting VM to an ovf file.
   The VM will not be exported if no [Export Configuration](#export-configuration) is specified.
 
-- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Configuration for importing the VM template to a Content Library.
-  The VM template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
+- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Configuration for importing a VM template or OVF template to a Content Library.
+  The template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
   The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
 
 - `customize` (\*CustomizeConfig) - Customize the cloned VM to configure host, network, or licensing settings. See the [customization options](#customization).

--- a/website/pages/partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -4,7 +4,12 @@
   The Content Library should be of type Local to allow deploying virtual machines.
 
 - `name` (string) - Name of the library item that will be created. The name of the item should be different from [vm_name](#vm_name).
-  Defaults to [vm_name](#vm_name) + timestamp.
+  Defaults to [vm_name](#vm_name) + timestamp. If the item already exists, then it will be updated
+  with the new template if the operation is compatible with the vSphere API version.
+  
+  ~> **Note**: Updating an existing library item is an operation added in vSphere API 6.9.1. Lower
+  versions will fail to update an existing library item, and therefore, a non-existing name
+  should be given in order to create a new library item.
 
 - `description` (string) - Description of the library item that will be created. Defaults to "Packer imported [vm_name](#vm_name) VM template".
 

--- a/website/pages/partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -1,29 +1,35 @@
 <!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
 
-- `library` (string) - Name of the library in which the new library item containing the VM template should be created.
+- `library` (string) - Name of the library in which the new library item containing the template should be created/updated.
   The Content Library should be of type Local to allow deploying virtual machines.
 
-- `name` (string) - Name of the library item that will be created. The name of the item should be different from [vm_name](#vm_name).
-  Defaults to [vm_name](#vm_name) + timestamp. If the item already exists, then it will be updated
-  with the new template if the operation is compatible with the vSphere API version.
+- `name` (string) - Name of the library item that will be created or updated.
+  For VM templates, the name of the item should be different from [vm_name](#vm_name) and
+  the default is [vm_name](#vm_name) + timestamp when not set. VM templates will be always imported to a new library item.
+  For OVF templates, the name defaults to [vm_name](#vm_name) when not set, and if an item with the same name already
+  exists it will be then updated with the new OVF template, otherwise a new item will be created.
   
-  ~> **Note**: Updating an existing library item is an operation added in vSphere API 6.9.1. Lower
-  versions will fail to update an existing library item, and therefore, a non-existing name
-  should be given in order to create a new library item.
+  ~> **Note**: It's not possible to update existing library items with a new VM template. If updating an existing library
+  item is necessary, use an OVF template instead by setting the [ovf](#ovf) option as `true`.
 
-- `description` (string) - Description of the library item that will be created. Defaults to "Packer imported [vm_name](#vm_name) VM template".
+- `description` (string) - Description of the library item that will be created.
+  This option is not used when importing OVF templates.
+  Defaults to "Packer imported [vm_name](#vm_name) VM template".
 
 - `cluster` (string) - Cluster onto which the virtual machine template should be placed.
   If cluster and resource_pool are both specified, resource_pool must belong to cluster.
   If cluster and host are both specified, host must be a member of cluster.
+  This option is not used when importing OVF templates.
   Defaults to [cluster](#cluster).
 
 - `folder` (string) - Virtual machine folder into which the virtual machine template should be placed.
+  This option is not used when importing OVF templates.
   Defaults to the same folder as the source virtual machine.
 
 - `host` (string) - Host onto which the virtual machine template should be placed.
   If host and resource_pool are both specified, resource_pool must belong to host.
   If host and cluster are both specified, host must be a member of cluster.
+  This option is not used when importing OVF templates.
   Defaults to [host](#host).
 
 - `resource_pool` (string) - Resource pool into which the virtual machine template should be placed.
@@ -31,6 +37,10 @@
   the system will attempt to choose a suitable resource pool for the virtual machine template.
 
 - `datastore` (string) - The datastore for the virtual machine template's configuration and log files.
+  This option is not used when importing OVF templates.
   Defaults to the storage backing associated with the library specified by library.
 
-- `destroy` (bool) - If set to true, the VM will be destroyed after deploying the template to the Content Library. Defaults to `false`.
+- `destroy` (bool) - If set to true, the VM will be destroyed after deploying the template to the Content Library.
+  Defaults to `false`.
+
+- `ovf` (bool) - When set to true, Packer will import and OVF template to the content library item. Defaults to `false`.

--- a/website/pages/partials/builder/vsphere/common/ContentLibraryDestinationConfig.mdx
+++ b/website/pages/partials/builder/vsphere/common/ContentLibraryDestinationConfig.mdx
@@ -1,4 +1,5 @@
 <!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
 
-With this configuration Packer creates a library item in a content library whose content is a virtual machine template created from the just built VM.
-The virtual machine template is stored in a newly created library item.
+With this configuration Packer creates a library item in a content library whose content is a VM template
+or an OVF template created from the just built VM.
+The template is stored in a existing or newly created library item.


### PR DESCRIPTION
This updates the govmomi version to make use of the new function responsible for cloning the VM into the Content Library as an OVF template. 
With the OVF template is possible to update existing library items and to use the VM name as the library item name. 

Closes https://github.com/hashicorp/packer/issues/9711