### PR TITLE
Add override provisioner's option for HCL2

### DIFF
--- a/command/test-fixtures/hcl/provisioner-override.pkr.hcl
+++ b/command/test-fixtures/hcl/provisioner-override.pkr.hcl
@@ -1,0 +1,19 @@
+source "null" "example1" {
+  communicator = "none"
+}
+
+source "null" "example2" {
+  communicator = "none"
+}
+
+build {
+  sources = ["source.null.example1", "source.null.example2"]
+  provisioner "shell-local" {
+    inline = ["echo not overridden"]
+    override = {
+      example1 = {
+        inline = ["echo yes overridden"]
+      }
+    }
+  }
+}

--- a/command/test-fixtures/provisioners/provisioner-override.json
+++ b/command/test-fixtures/provisioners/provisioner-override.json
@@ -1,0 +1,25 @@
+{
+  "builders": [
+    {
+      "type": "null",
+      "name": "example1",
+      "communicator": "none"
+    },
+    {
+      "type": "null",
+      "name": "example2",
+      "communicator": "none"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell-local",
+      "inline": ["echo not overridden"],
+      "override": {
+        "example1": {
+          "inline": ["echo yes overridden"]
+        }
+      }
+    }
+  ]
+}

--- a/hcl2template/types.hcl_provisioner.go
+++ b/hcl2template/types.hcl_provisioner.go
@@ -3,7 +3,6 @@ package hcl2template
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/packer"
@@ -19,6 +18,7 @@ type HCL2Provisioner struct {
 	provisionerBlock *ProvisionerBlock
 	evalContext      *hcl.EvalContext
 	builderVariables map[string]string
+	override         map[string]interface{}
 }
 
 func (p *HCL2Provisioner) ConfigSpec() hcldec.ObjectSpec {
@@ -55,7 +55,7 @@ func (p *HCL2Provisioner) HCL2Prepare(buildVars map[string]interface{}) error {
 	if diags.HasErrors() {
 		return diags
 	}
-	return p.Provisioner.Prepare(p.builderVariables, flatProvisionerCfg)
+	return p.Provisioner.Prepare(p.builderVariables, flatProvisionerCfg, p.override)
 }
 
 func (p *HCL2Provisioner) Prepare(args ...interface{}) error {

--- a/website/pages/partials/provisioners/common-config.mdx
+++ b/website/pages/partials/provisioners/common-config.mdx
@@ -13,29 +13,53 @@ Parameters common to all provisioners:
   In JSON:
   ```json
   {
-    "type": "shell",
-    "script": "script.sh",
-    "override": {
-      "example_one": {
-        "script": "basic_one-script.sh"
+    "builders": [
+      {
+        "type": "null",
+        "name": "example1",
+        "communicator": "none"
+      },
+      {
+        "type": "null",
+        "name": "example2",
+        "communicator": "none"
       }
-    }
+    ],
+    "provisioners": [
+      {
+        "type": "shell-local",
+        "inline": ["echo not overridden"],
+        "override": {
+          "example1": {
+            "inline": ["echo yes overridden"]
+          }
+        }
+      }
+    ]
   }
   ```
 
   In HCL2:
   ```hcl
-    build {
-        sources = ["docker.example_one", "docker.example_two"]
-        provisioner "shell" {
-            script = "script.sh"
-            override = {
-                example_one = {
-                    script = "basic-one-script.sh"
-                }
-            }
+  source "null" "example1" {
+    communicator = "none"
+  }
+
+  source "null" "example2" {
+    communicator = "none"
+  }
+
+  build {
+    sources = ["source.null.example1", "source.null.example2"]
+    provisioner "shell-local" {
+      inline = ["echo not overridden"]
+      override = {
+        example1 = {
+          inline = ["echo yes overridden"]
         }
+      }
     }
+  }
   ```
 
 - `timeout` (duration) - If the provisioner takes more than for example

--- a/website/pages/partials/provisioners/common-config.mdx
+++ b/website/pages/partials/provisioners/common-config.mdx
@@ -10,16 +10,32 @@ Parameters common to all provisioners:
 - `override` (object) - Override the builder with different settings for a
   specific builder, eg :
 
+  In JSON:
   ```json
   {
     "type": "shell",
     "script": "script.sh",
     "override": {
-      "vmware-iso": {
-        "execute_command": "echo 'password' | sudo -S bash {{.Path}}"
+      "example_one": {
+        "script": "basic_one-script.sh"
       }
     }
   }
+  ```
+
+  In HCL2:
+  ```hcl
+    build {
+        sources = ["docker.example_one", "docker.example_two"]
+        provisioner "shell" {
+            script = "script.sh"
+            override = {
+                example_one = {
+                    script = "basic-one-script.sh"
+                }
+            }
+        }
+    }
   ```
 
 - `timeout` (duration) - If the provisioner takes more than for example


### PR DESCRIPTION
This adds the code to make the provisioner's `override` option work with HCL2, and also the HCL2 example to the docs 👍 