### PR TITLE
Fix Hyper-V boot command refs #5291

### DIFF
--- a/builder/hyperv/common/step_type_boot_command.go
+++ b/builder/hyperv/common/step_type_boot_command.go
@@ -55,7 +55,7 @@ func (s *StepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		scanCodesToSendString := strings.Join(codes, " ")
 		return driver.TypeScanCodes(vmName, scanCodesToSendString)
 	}
-	d := bootcommand.NewPCXTDriver(sendCodes, -1, s.GroupInterval)
+	d := bootcommand.NewPCXTDriver(sendCodes, 32, s.GroupInterval)
 
 	ui.Say("Typing the boot command...")
 	command, err := interpolate.Render(s.BootCommand, &s.Ctx)


### PR DESCRIPTION
The boot command was being sent as a single long string to be
typed into the Hyper-V VM, which caused some scan codes to be
intermittently skipped.  The boot command is now split up and sent as
chunks of 32 scan codes at a time.  

Closes #5291 