### PR TITLE
vsphere: set 'cpu cores per socket' to 'cpu cores' by default

### DIFF
--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -40,7 +40,7 @@ type FlatConfig struct {
 	Datastore                       *string                                     `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
 	SetHostForDatastoreUploads      *bool                                       `mapstructure:"set_host_for_datastore_uploads" cty:"set_host_for_datastore_uploads" hcl:"set_host_for_datastore_uploads"`
 	CPUs                            *int32                                      `mapstructure:"CPUs" cty:"CPUs" hcl:"CPUs"`
-	CpuCores                        *int32                                      `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
+	CPUCoresPerSocket               *int32                                      `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
 	CPUReservation                  *int64                                      `mapstructure:"CPU_reservation" cty:"CPU_reservation" hcl:"CPU_reservation"`
 	CPULimit                        *int64                                      `mapstructure:"CPU_limit" cty:"CPU_limit" hcl:"CPU_limit"`
 	CpuHotAddEnabled                *bool                                       `mapstructure:"CPU_hot_plug" cty:"CPU_hot_plug" hcl:"CPU_hot_plug"`

--- a/builder/vsphere/common/step_hardware.hcl2spec.go
+++ b/builder/vsphere/common/step_hardware.hcl2spec.go
@@ -10,7 +10,7 @@ import (
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatHardwareConfig struct {
 	CPUs                *int32  `mapstructure:"CPUs" cty:"CPUs" hcl:"CPUs"`
-	CpuCores            *int32  `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
+	CPUCoresPerSocket   *int32  `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
 	CPUReservation      *int64  `mapstructure:"CPU_reservation" cty:"CPU_reservation" hcl:"CPU_reservation"`
 	CPULimit            *int64  `mapstructure:"CPU_limit" cty:"CPU_limit" hcl:"CPU_limit"`
 	CpuHotAddEnabled    *bool   `mapstructure:"CPU_hot_plug" cty:"CPU_hot_plug" hcl:"CPU_hot_plug"`

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -41,7 +41,7 @@ type CloneConfig struct {
 
 type HardwareConfig struct {
 	CPUs                int32
-	CpuCores            int32
+	CPUCoresPerSocket   int32
 	CPUReservation      int64
 	CPULimit            int64
 	RAM                 int64
@@ -436,7 +436,7 @@ func (vm *VirtualMachine) Destroy() error {
 func (vm *VirtualMachine) Configure(config *HardwareConfig) error {
 	var confSpec types.VirtualMachineConfigSpec
 	confSpec.NumCPUs = config.CPUs
-	confSpec.NumCoresPerSocket = config.CpuCores
+	confSpec.NumCoresPerSocket = config.CPUCoresPerSocket
 	confSpec.MemoryMB = config.RAM
 
 	var cpuSpec types.ResourceAllocationInfo

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -41,7 +41,7 @@ type FlatConfig struct {
 	Datastore                       *string                                     `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
 	SetHostForDatastoreUploads      *bool                                       `mapstructure:"set_host_for_datastore_uploads" cty:"set_host_for_datastore_uploads" hcl:"set_host_for_datastore_uploads"`
 	CPUs                            *int32                                      `mapstructure:"CPUs" cty:"CPUs" hcl:"CPUs"`
-	CpuCores                        *int32                                      `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
+	CPUCoresPerSocket               *int32                                      `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
 	CPUReservation                  *int64                                      `mapstructure:"CPU_reservation" cty:"CPU_reservation" hcl:"CPU_reservation"`
 	CPULimit                        *int64                                      `mapstructure:"CPU_limit" cty:"CPU_limit" hcl:"CPU_limit"`
 	CpuHotAddEnabled                *bool                                       `mapstructure:"CPU_hot_plug" cty:"CPU_hot_plug" hcl:"CPU_hot_plug"`

--- a/website/pages/partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -2,7 +2,7 @@
 
 - `CPUs` (int32) - Number of CPU sockets.
 
-- `cpu_cores` (int32) - Number of CPU cores per socket.
+- `cpu_cores` (int32) - Number of CPU cores per socket. Defaults to value of `CPUs`
 
 - `CPU_reservation` (int64) - Amount of reserved CPU resources in MHz.
 


### PR DESCRIPTION
VMWare recommends to use lesser number of sockets, see [post](https://blogs.vmware.com/performance/2017/03/virtual-machine-vcpu-and-vnuma-rightsizing-rules-of-thumb.html)

Previously by default Packer didn't passed anything and ESXi generates one core per socket, that could affect performance.
This PR changes that by default only one socket is used. Also added validation.

If someone needs VM with number of CPU cores higher than on physical CPU (e.g. ESXi host have 2+ processors), they need to specify `cpu_cores`. So it's kinda breaking change for such cases. I expect that case to be quite rare.

Also I do think that `cpu_cores` may be renamed to `CPU_cores_per_socket`? Open new issue?
