### PR TITLE
Update GitHub action

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - name: Add track-internal
         uses: andymckay/labeler@1.0.2
+        if: github.event.issue.pull_request == null
         with:
           repo-token: ${{ secrets.Github_Token }}
           add-labels: "track-internal"


### PR DESCRIPTION
Ignore issue events triggered by pull_requests

According to the GitHub V3 API docs, activity on pull_requests will trigger an issue event.

This change filters out events triggered by pull requests by checking that the pull_request key is null. Which is how one can identify if the event was triggered by a change to a pull request.