### PR TITLE
Fix: build.sh: give validateToolPresence a chance to inform the user

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,8 +13,7 @@ set -e
 function validateToolPresence
 {
     local TOOLNAME=$1
-    which ${TOOLNAME} >/dev/null
-    if [ $? -ne 0 ]; then
+    if ! which ${TOOLNAME} >/dev/null; then
         echo "${TOOLNAME} is not on the path. Exiting..."
         exit 1
     fi


### PR DESCRIPTION
Since the build.sh script runs with `set -e` (exit _immediately_ in case
of error), we cannot first call the `which` command and, on a susequent
line, check its exit status with $?, it would be too late. Instead, we
idiomatically check on the same line of the invocation of `which`.

From the confusing:

    $ make bin
    ==> Checking for necessary tools...
    make: *** [bin] Error 1

To the informative:

    $ make bin
    ==> Checking for necessary tools...
    realpath is not on the path. Exiting...
    make: *** [bin] Error 1

