### PR TITLE
add progress tracker to vmware-esx iso upload. Add colored prefix to …

### DIFF
--- a/builder/vmware/common/remote_driver.go
+++ b/builder/vmware/common/remote_driver.go
@@ -1,12 +1,16 @@
 package common
 
+import (
+	"github.com/hashicorp/packer/packer"
+)
+
 type RemoteDriver interface {
 	Driver
 
 	// UploadISO uploads a local ISO to the remote side and returns the
 	// new path that should be used in the VMX along with an error if it
 	// exists.
-	UploadISO(path string, checksum string) (string, error)
+	UploadISO(path string, checksum string, ui packer.Ui) (string, error)
 
 	// RemoveCache deletes localPath from the remote cache.
 	RemoveCache(localPath string) error
@@ -24,7 +28,7 @@ type RemoteDriver interface {
 	IsDestroyed() (bool, error)
 
 	// Uploads a local file to remote side.
-	upload(dst, src string) error
+	upload(dst, src string, ui packer.Ui) error
 
 	// Download a remote file to a local file.
 	Download(src, dst string) error

--- a/builder/vmware/common/remote_driver_mock.go
+++ b/builder/vmware/common/remote_driver_mock.go
@@ -1,5 +1,9 @@
 package common
 
+import (
+	"github.com/hashicorp/packer/packer"
+)
+
 type RemoteDriverMock struct {
 	DriverMock
 
@@ -32,7 +36,7 @@ type RemoteDriverMock struct {
 	ReloadVMErr error
 }
 
-func (d *RemoteDriverMock) UploadISO(path string, checksum string) (string, error) {
+func (d *RemoteDriverMock) UploadISO(path string, checksum string, ui packer.Ui) (string, error) {
 	d.UploadISOCalled = true
 	d.UploadISOPath = path
 	return d.UploadISOResult, d.UploadISOErr
@@ -60,7 +64,7 @@ func (d *RemoteDriverMock) IsDestroyed() (bool, error) {
 	return d.IsDestroyedResult, d.IsDestroyedErr
 }
 
-func (d *RemoteDriverMock) upload(dst, src string) error {
+func (d *RemoteDriverMock) upload(dst, src string, ui packer.Ui) error {
 	return d.UploadErr
 }
 

--- a/builder/vmware/common/step_remote_upload.go
+++ b/builder/vmware/common/step_remote_upload.go
@@ -45,7 +45,7 @@ func (s *StepRemoteUpload) Run(ctx context.Context, state multistep.StateBag) mu
 
 	ui.Say(s.Message)
 	log.Printf("Remote uploading: %s", path)
-	newPath, err := remote.UploadISO(path, s.Checksum)
+	newPath, err := remote.UploadISO(path, s.Checksum, ui)
 	if err != nil {
 		err := fmt.Errorf("Error uploading file: %s", err)
 		state.Put("error", err)

--- a/builder/vmware/common/step_upload_vmx.go
+++ b/builder/vmware/common/step_upload_vmx.go
@@ -32,7 +32,7 @@ func (c *StepUploadVMX) Run(ctx context.Context, state multistep.StateBag) multi
 		remoteDriver, ok := driver.(RemoteDriver)
 		if ok {
 			remoteVmxPath := filepath.ToSlash(filepath.Join(fmt.Sprintf("%s", remoteDriver), filepath.Base(vmxPath)))
-			if err := remoteDriver.upload(remoteVmxPath, vmxPath); err != nil {
+			if err := remoteDriver.upload(remoteVmxPath, vmxPath, nil); err != nil {
 				state.Put("error", fmt.Errorf("Error writing VMX: %s", err))
 				return multistep.ActionHalt
 			}


### PR DESCRIPTION
Adds progress tracker to esx uploadISO function. 

Before:
<img width="831" alt="Screen Shot 2020-08-17 at 10 06 06 AM" src="https://user-images.githubusercontent.com/1008838/90423546-870e2980-e071-11ea-964d-3ea859b41d05.png">

After:
<img width="842" alt="Screen Shot 2020-08-17 at 10 05 03 AM" src="https://user-images.githubusercontent.com/1008838/90423549-88d7ed00-e071-11ea-8df2-aacef5ba34b7.png">
