### PR TITLE
add colored prefix to progress tracker bar so it's clearer what build…

### DIFF
--- a/packer/ui.go
+++ b/packer/ui.go
@@ -91,6 +91,10 @@ func (u *ColoredUi) Machine(t string, args ...string) {
 	u.Ui.Machine(t, args...)
 }
 
+func (u *ColoredUi) TrackProgress(src string, currentSize, totalSize int64, stream io.ReadCloser) io.ReadCloser {
+	return u.Ui.TrackProgress(u.colorize(src, u.Color, false), currentSize, totalSize, stream)
+}
+
 func (u *ColoredUi) colorize(message string, color UiColor, bold bool) string {
 	if !u.supportsColors() {
 		return message
@@ -172,7 +176,7 @@ func (u *TargetedUI) prefixLines(arrow bool, message string) string {
 }
 
 func (u *TargetedUI) TrackProgress(src string, currentSize, totalSize int64, stream io.ReadCloser) io.ReadCloser {
-	return u.Ui.TrackProgress(src, currentSize, totalSize, stream)
+	return u.Ui.TrackProgress(u.prefixLines(false, src), currentSize, totalSize, stream)
 }
 
 // The BasicUI is a UI that reads and writes from a standard Go reader


### PR DESCRIPTION
Modifies progress tracker to use color and prefix of current UI so that it's easier to understand which build owns which progress bar in a multi-build parallel setup.

Before:
<img width="844" alt="Screen Shot 2020-08-17 at 10 11 01 AM" src="https://user-images.githubusercontent.com/1008838/90423871-174c6e80-e072-11ea-9dd6-06abfeab4a0e.png">

After:
<img width="840" alt="Screen Shot 2020-08-17 at 10 10 14 AM" src="https://user-images.githubusercontent.com/1008838/90423851-0dc30680-e072-11ea-9385-b4de279b174a.png">
