### PR TITLE
integration/secretsmanager: Add support for AWS SharedConfig file

### DIFF
--- a/template/interpolate/aws/secretsmanager/secretsmanager.go
+++ b/template/interpolate/aws/secretsmanager/secretsmanager.go
@@ -5,6 +5,7 @@ package secretsmanager
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -31,14 +32,15 @@ func New(config *AWSConfig) *Client {
 
 func (c *Client) newSession(config *AWSConfig) *session.Session {
 	// Initialize config with error verbosity
-	sess := aws.NewConfig().WithCredentialsChainVerboseErrors(true)
+	sessConfig := aws.NewConfig().WithCredentialsChainVerboseErrors(true)
 
 	if config.Region != "" {
-		sess = sess.WithRegion(config.Region)
+		sessConfig = sessConfig.WithRegion(config.Region)
 	}
 
 	opts := session.Options{
-		Config: *sess,
+		SharedConfigState: session.SharedConfigEnable,
+		Config:            *sessConfig,
 	}
 
 	return session.Must(session.NewSessionWithOptions(opts))
@@ -102,5 +104,5 @@ func getSecretValue(s *SecretString, spec *SecretSpec) (string, error) {
 		return v, nil
 	}
 
-	return "", errors.New("No secret found")
+	return "", fmt.Errorf("No secret found for key %q", spec.Key)
 }

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -299,12 +299,12 @@ func funcGenAwsSecrets(ctx *Context) interface{} {
 		if !ctx.EnableEnv {
 			// The error message doesn't have to be that detailed since
 			// semantic checks should catch this.
-			return "", errors.New("AWS Secrets Manager vars are only allowed in the variables section")
+			return "", errors.New("AWS Secrets Manager is only allowed in the variables section")
 		}
 
 		// Check if at least 1 parameter has been used
 		if len(secret) == 0 {
-			return "", errors.New("At least one parameter must be used")
+			return "", errors.New("At least one secret name must be provided")
 		}
 		// client uses AWS SDK CredentialChain method. So,credentials can
 		// be loaded from credential file, environment variables, or IAM
@@ -329,7 +329,7 @@ func funcGenAwsSecrets(ctx *Context) interface{} {
 
 		s, err := client.GetSecret(spec)
 		if err != nil {
-			return "", fmt.Errorf("Error getting secret: %s", err)
+			return "", err
 		}
 		return s, nil
 	}


### PR DESCRIPTION
This change updates the AWS Secrets manager session authentication
logic to support reading the AWS configuration file for default
credentials and region settings, if they are not provided via
environment variables.

* Modify error output a little to remove stutter "error ... : error ...`

Closes #9237


Results before change
```
unset AWS_REGION
⇶  ~/pkg/packer build amazon-ebs_secretsmanager_shell-local.json
template: root:1:3: executing "root" at <aws_secretsmanager `packer/test/keys`
`shell`>: error calling aws_secretsmanager: Error getting secret: MissingRegion:
could not find region configuration
```

Results after change
```
unset AWS_REGION
⇶  ~/pkg/packer build amazon-ebs_secretsmanager_shell-local.json
null: output will be in this color.

==> null: Running local shell script: /tmp/packer-shell721444992
    null: powershell
Build 'null' finished after 4 milliseconds 121 microseconds.

==> Wait completed after 4 milliseconds 192 microseconds

==> Builds finished. The artifacts of successful builds are:
```