### PR TITLE
fully destroy vm if it was cancelled or errored

### DIFF
--- a/builder/vmware/common/step_register.go
+++ b/builder/vmware/common/step_register.go
@@ -54,7 +54,7 @@ func (s *StepRegister) Cleanup(state multistep.StateBag) {
 	}
 
 	if remoteDriver, ok := driver.(RemoteDriver); ok {
-		if s.SkipExport {
+		if s.SkipExport && !cancelled && !halted {
 			ui.Say("Unregistering virtual machine...")
 			if err := remoteDriver.Unregister(s.registeredPath); err != nil {
 				ui.Error(fmt.Sprintf("Error unregistering VM: %s", err))


### PR DESCRIPTION
Make sure to fully destroy the vm instead of just unregistering it, if the build was cancelled or failed. this prevents leaving files around on the datastore. 

Needs testing -- as soon as I made this change our test cluster went down so I need to rebuild it.