### PR TITLE
Modularise vCenter rest client

### DIFF
--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -67,10 +67,10 @@ func NewDriver(config *ConnectConfig) (*Driver, error) {
 	finder.SetDatacenter(datacenter)
 
 	d := Driver{
-		ctx:        ctx,
-		client:     client,
+		ctx:    ctx,
+		client: client,
 		restClient: &RestClient{
-			client: rest.NewClient(vimClient),
+			client:      rest.NewClient(vimClient),
 			credentials: credentials,
 		},
 		datacenter: datacenter,
@@ -84,7 +84,7 @@ func NewDriver(config *ConnectConfig) (*Driver, error) {
 // This will allow users without vCenter to use the other features that doesn't use the rest.Client.
 // To use the client login/logout must be done to create an authenticated session.
 type RestClient struct {
-	client *rest.Client
+	client      *rest.Client
 	credentials *url.Userinfo
 }
 

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -19,7 +19,7 @@ type Driver struct {
 	// context that controls the authenticated sessions used to run the VM commands
 	ctx        context.Context
 	client     *govmomi.Client
-	restClient *rest.Client
+	restClient *RestClient
 	finder     *find.Finder
 	datacenter *object.Datacenter
 }
@@ -59,12 +59,6 @@ func NewDriver(config *ConnectConfig) (*Driver, error) {
 		return nil, err
 	}
 
-	restClient := rest.NewClient(vimClient)
-	err = restClient.Login(ctx, credentials)
-	if err != nil {
-		return nil, err
-	}
-
 	finder := find.NewFinder(client.Client, false)
 	datacenter, err := finder.DatacenterOrDefault(ctx, config.Datacenter)
 	if err != nil {
@@ -75,9 +69,29 @@ func NewDriver(config *ConnectConfig) (*Driver, error) {
 	d := Driver{
 		ctx:        ctx,
 		client:     client,
-		restClient: restClient,
+		restClient: &RestClient{
+			client: rest.NewClient(vimClient),
+			credentials: credentials,
+		},
 		datacenter: datacenter,
 		finder:     finder,
 	}
 	return &d, nil
+}
+
+// The rest.Client requires vCenter.
+// RestClient is to modularize the rest.Client session and use it only when is necessary.
+// This will allow users without vCenter to use the other features that doesn't use the rest.Client.
+// To use the client login/logout must be done to create an authenticated session.
+type RestClient struct {
+	client *rest.Client
+	credentials *url.Userinfo
+}
+
+func (r *RestClient) Login(ctx context.Context) error {
+	return r.client.Login(ctx, r.credentials)
+}
+
+func (r *RestClient) Logout(ctx context.Context) error {
+	return r.client.Logout(ctx)
 }

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -10,7 +10,7 @@ type Library struct {
 }
 
 func (d *Driver) FindContentLibrary(name string) (*Library, error) {
-	lm := library.NewManager(d.restClient)
+	lm := library.NewManager(d.restClient.client)
 	l, err := lm.GetLibraryByName(d.ctx, name)
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func (d *Driver) FindContentLibrary(name string) (*Library, error) {
 }
 
 func (d *Driver) FindContentLibraryItem(libraryId string, name string) (*library.Item, error) {
-	lm := library.NewManager(d.restClient)
+	lm := library.NewManager(d.restClient.client)
 	items, err := lm.GetLibraryItems(d.ctx, libraryId)
 	if err != nil {
 		return nil, err

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -684,6 +684,11 @@ func (vm *VirtualMachine) ConvertToTemplate() error {
 }
 
 func (vm *VirtualMachine) ImportOvfToContentLibrary(ovf vcenter.OVF) error {
+	err := vm.driver.restClient.Login(vm.driver.ctx)
+	if err != nil {
+		return err
+	}
+
 	l, err := vm.driver.FindContentLibrary(ovf.Target.LibraryID)
 	if err != nil {
 		return err
@@ -706,12 +711,21 @@ func (vm *VirtualMachine) ImportOvfToContentLibrary(ovf vcenter.OVF) error {
 	ovf.Source.Value = vm.vm.Reference().Value
 	ovf.Source.Type = "VirtualMachine"
 
-	vcm := vcenter.NewManager(vm.driver.restClient)
+	vcm := vcenter.NewManager(vm.driver.restClient.client)
 	_, err = vcm.CreateOVF(vm.driver.ctx, ovf)
-	return err
+	if err != nil {
+		return err
+	}
+
+	return vm.driver.restClient.Logout(vm.driver.ctx)
 }
 
 func (vm *VirtualMachine) ImportToContentLibrary(template vcenter.Template) error {
+	err := vm.driver.restClient.Login(vm.driver.ctx)
+	if err != nil {
+		return err
+	}
+
 	l, err := vm.driver.FindContentLibrary(template.Library)
 	if err != nil {
 		return err
@@ -761,9 +775,13 @@ func (vm *VirtualMachine) ImportToContentLibrary(template vcenter.Template) erro
 		template.VMHomeStorage.Datastore = d.ds.Reference().Value
 	}
 
-	vcm := vcenter.NewManager(vm.driver.restClient)
+	vcm := vcenter.NewManager(vm.driver.restClient.client)
 	_, err = vcm.CreateTemplate(vm.driver.ctx, template)
-	return err
+	if err != nil {
+		return err
+	}
+
+	return vm.driver.restClient.Logout(vm.driver.ctx)
 }
 
 func (vm *VirtualMachine) GetDir() (string, error) {


### PR DESCRIPTION
As the rest-client requires vCenter, users without it are not currently able to move forward in a vsphere build because the rest-client session is being created even when is not used. This PR modularises the rest client to create the rest-client session only when is used. 

Closes https://github.com/hashicorp/packer/issues/9791