### PR TITLE
HCL: document contextual source variable usage

### DIFF
--- a/website/pages/docs/from-1.5/blocks/source.mdx
+++ b/website/pages/docs/from-1.5/blocks/source.mdx
@@ -39,6 +39,8 @@ build {
 }
 ```
 
+`@include 'from-1.5/contextual-source-variables.mdx'`
+
 ## Related
 
 - The list of available builders can be found in the [builders](/docs/builders)

--- a/website/pages/docs/from-1.5/contextual-variables.mdx
+++ b/website/pages/docs/from-1.5/contextual-variables.mdx
@@ -7,9 +7,12 @@ description: |-
   This page covers all existing special variables.
 ---
 
+`@include 'from-1.5/beta-hcl2-note.mdx'`
+
+`@include 'from-1.5/contextual-source-variables.mdx'`
+
 # Build Variables
 
-`@include 'from-1.5/beta-hcl2-note.mdx'`
 
 Build variables will allow you to access connection information and basic instance state information for a builder.
 All special build variables are stored in the `build` variable:

--- a/website/pages/partials/from-1.5/builds/example-block.mdx
+++ b/website/pages/partials/from-1.5/builds/example-block.mdx
@@ -25,7 +25,7 @@ build {
     }
 
     post-processor "shell-local" {
-        inline = ["echo Hello World"]
+        inline = ["echo Hello World from ${source.type}.${source.name}"]
     }
 }
 ```

--- a/website/pages/partials/from-1.5/contextual-source-variables.mdx
+++ b/website/pages/partials/from-1.5/contextual-source-variables.mdx
@@ -1,0 +1,36 @@
+# Source Variables
+
+It is possible to access the `name` and `type` of your `source` from
+provisioners and post-processors:
+
+```hcl
+source "null" "first-example" {
+  communicator = "none"
+}
+
+build {
+  name = "roles"
+
+  source "null.first-example" {
+    name = "consul"
+  }
+  source "null.first-example" {
+    name = "nomad"
+  }
+  source "null.first-example" {
+    name = "vault"
+  }
+  sources = ["null.first-example"]
+
+  provisioner "shell-local" {
+    inline = ["echo ${source.name} and ${source.type}"]
+  }
+}
+
+# This will echo something like:
+#
+# roles.null.consul: consul and null
+# roles.null.nomad: nomad and null
+# roles.null.vault: vault and null
+# roles.null.first-example: first-example and null
+```


### PR DESCRIPTION
It is possible to use `${source.name}` and `${source.type}`, this was not documented before

related to #9794
