### PR TITLE
Accept content library path in iso_paths

### DIFF
--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -2,8 +2,11 @@ package driver
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
@@ -57,6 +60,21 @@ func (d *Driver) FindDatastore(name string, host string) (*Datastore, error) {
 	}, nil
 }
 
+func (d *Driver) GetDatastoreName(id string) string {
+	obj := types.ManagedObjectReference{
+		Type:  "Datastore",
+		Value: id,
+	}
+	pc := property.DefaultCollector(d.vimClient)
+	var me mo.ManagedEntity
+
+	err := pc.RetrieveOne(d.ctx, obj, []string{"name"}, &me)
+	if err != nil {
+		return id
+	}
+	return me.Name
+}
+
 func (ds *Datastore) Info(params ...string) (*mo.Datastore, error) {
 	var p []string
 	if len(params) == 0 {
@@ -83,6 +101,42 @@ func (ds *Datastore) Name() string {
 
 func (ds *Datastore) ResolvePath(path string) string {
 	return ds.ds.Path(path)
+}
+
+// The file ID isn't available via the API, so we use DatastoreBrowser to search
+func (d *Driver) GetDatastoreFilePath(datastoreID, dir, filename string) (string, error) {
+	ref := types.ManagedObjectReference{Type: "Datastore", Value: datastoreID}
+	ds := object.NewDatastore(d.vimClient, ref)
+
+	b, err := ds.Browser(d.ctx)
+	if err != nil {
+		return filename, err
+	}
+	ext := path.Ext(filename)
+	pat := strings.Replace(filename, ext, "*"+ext, 1)
+	spec := types.HostDatastoreBrowserSearchSpec{
+		MatchPattern: []string{pat},
+	}
+
+	task, err := b.SearchDatastore(d.ctx, dir, &spec)
+	if err != nil {
+		return filename, err
+	}
+
+	info, err := task.WaitForResult(d.ctx, nil)
+	if err != nil {
+		return filename, err
+	}
+
+	res, ok := info.Result.(types.HostDatastoreBrowserSearchResults)
+	if !ok {
+		return filename, fmt.Errorf("search(%s) result type=%T", pat, info.Result)
+	}
+
+	if len(res.File) != 1 {
+		return filename, fmt.Errorf("search(%s) result files=%d", pat, len(res.File))
+	}
+	return res.File[0].GetFileInfo().Path, nil
 }
 
 func (ds *Datastore) UploadFile(src, dst, host string, set_host_for_datastore_uploads bool) error {

--- a/builder/vsphere/driver/datastore_test.go
+++ b/builder/vsphere/driver/datastore_test.go
@@ -1,0 +1,54 @@
+package driver
+
+import "testing"
+
+func TestDatastoreIsoPath(t *testing.T) {
+	tc := []struct {
+		isoPath  string
+		filePath string
+		valid    bool
+	}{
+		{
+			isoPath:  "[datastore] dir/subdir/file",
+			filePath: "dir/subdir/file",
+			valid:    true,
+		},
+		{
+			isoPath:  "[] dir/subdir/file",
+			filePath: "dir/subdir/file",
+			valid:    true,
+		},
+		{
+			isoPath:  "dir/subdir/file",
+			filePath: "dir/subdir/file",
+			valid:    true,
+		},
+		{
+			isoPath:  "[datastore] /dir/subdir/file",
+			filePath: "/dir/subdir/file",
+			valid:    true,
+		},
+		{
+			isoPath: "/dir/subdir/file [datastore] ",
+			valid:   false,
+		},
+		{
+			isoPath: "[datastore][] /dir/subdir/file",
+			valid:   false,
+		},
+	}
+
+	for _, c := range tc {
+		dsIsoPath := &DatastoreIsoPath{path: c.isoPath}
+		if dsIsoPath.Validate() != c.valid {
+			t.Fatalf("Expecting %s to be %t but was %t", c.isoPath, c.valid, !c.valid)
+		}
+		if !c.valid {
+			continue
+		}
+		filePath := dsIsoPath.GetFilePath()
+		if filePath != c.filePath {
+			t.Fatalf("Expecting %s but got %s", c.filePath, filePath)
+		}
+	}
+}

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -19,6 +19,7 @@ type Driver struct {
 	// context that controls the authenticated sessions used to run the VM commands
 	ctx        context.Context
 	client     *govmomi.Client
+	vimClient  *vim25.Client
 	restClient *RestClient
 	finder     *find.Finder
 	datacenter *object.Datacenter
@@ -67,8 +68,9 @@ func NewDriver(config *ConnectConfig) (*Driver, error) {
 	finder.SetDatacenter(datacenter)
 
 	d := Driver{
-		ctx:    ctx,
-		client: client,
+		ctx:       ctx,
+		client:    client,
+		vimClient: vimClient,
 		restClient: &RestClient{
 			client:      rest.NewClient(vimClient),
 			credentials: credentials,

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -1,6 +1,11 @@
 package driver
 
 import (
+	"fmt"
+	"log"
+	"path"
+	"strings"
+
 	"github.com/vmware/govmomi/vapi/library"
 )
 
@@ -9,7 +14,7 @@ type Library struct {
 	library *library.Library
 }
 
-func (d *Driver) FindContentLibrary(name string) (*Library, error) {
+func (d *Driver) FindContentLibraryByName(name string) (*Library, error) {
 	lm := library.NewManager(d.restClient.client)
 	l, err := lm.GetLibraryByName(d.ctx, name)
 	if err != nil {
@@ -33,4 +38,50 @@ func (d *Driver) FindContentLibraryItem(libraryId string, name string) (*library
 		}
 	}
 	return nil, nil
+}
+
+func (d *Driver) FindContentLibraryFileDatastorePath(isoPath string) string {
+	log.Printf("Check if ISO path is a Content Library path")
+	err := d.restClient.Login(d.ctx)
+	if err != nil {
+		log.Printf("vCenter client not available. ISO path not identified as a Content Library path")
+		return isoPath
+	}
+
+	trimmedPath := strings.TrimLeft(isoPath, " ")
+	trimmedPath = strings.TrimLeft(trimmedPath, "/")
+	libraryName := strings.Split(trimmedPath, "/")[0]
+	itemName := strings.Split(trimmedPath, "/")[1]
+	isoFile := strings.Split(trimmedPath, "/")[2]
+
+	lib, err := d.FindContentLibraryByName(libraryName)
+	if err != nil {
+		log.Printf("ISO path not identified as a Content Library path")
+		return isoPath
+	}
+	log.Printf("ISO path identified as a Content Library path")
+	log.Printf("Finding the equivalent datastore path for the Content Library ISO file path")
+	libItem, err := d.FindContentLibraryItem(lib.library.ID, itemName)
+	if err != nil {
+		log.Printf("[WARN] Couldn't find item %s: %s", itemName, err.Error())
+		log.Printf("Trying to use %s as the datastore path", isoPath)
+		return isoPath
+	}
+	if libItem == nil {
+		log.Printf("[WARN] Couldn't find item %s", itemName)
+		log.Printf("Trying to use %s as the datastore path", isoPath)
+		return isoPath
+	}
+	datastoreName := d.GetDatastoreName(lib.library.Storage[0].DatastoreID)
+	libItemDir := fmt.Sprintf("[%s] contentlib-%s/%s", datastoreName, lib.library.ID, libItem.ID)
+
+	isoFilePath, err := d.GetDatastoreFilePath(lib.library.Storage[0].DatastoreID, libItemDir, isoFile)
+	if err != nil {
+		log.Printf("[WARN] Couldn't find datastore ID path for %s", isoFile)
+		log.Printf("Trying to use %s as the datastore path", isoPath)
+		return isoPath
+	}
+
+	_ = d.restClient.Logout(d.ctx)
+	return path.Join(libItemDir, isoFilePath)
 }

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -37,51 +37,77 @@ func (d *Driver) FindContentLibraryItem(libraryId string, name string) (*library
 			return &item, nil
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("Item %s not found", name)
 }
 
-func (d *Driver) FindContentLibraryFileDatastorePath(isoPath string) string {
+func (d *Driver) FindContentLibraryFileDatastorePath(isoPath string) (string, error) {
 	log.Printf("Check if ISO path is a Content Library path")
 	err := d.restClient.Login(d.ctx)
 	if err != nil {
 		log.Printf("vCenter client not available. ISO path not identified as a Content Library path")
-		return isoPath
+		return isoPath, err
 	}
 
-	trimmedPath := strings.TrimLeft(isoPath, " ")
-	trimmedPath = strings.TrimLeft(trimmedPath, "/")
-	libraryName := strings.Split(trimmedPath, "/")[0]
-	itemName := strings.Split(trimmedPath, "/")[1]
-	isoFile := strings.Split(trimmedPath, "/")[2]
+	libraryFilePath := &LibraryFilePath{path: isoPath}
+	err = libraryFilePath.Validate()
+	if err != nil {
+		log.Printf("ISO path not identified as a Content Library path")
+		return isoPath, err
+	}
+	libraryName := libraryFilePath.GetLibraryName()
+	itemName := libraryFilePath.GetLibraryItemName()
+	isoFile := libraryFilePath.GetFileName()
 
 	lib, err := d.FindContentLibraryByName(libraryName)
 	if err != nil {
 		log.Printf("ISO path not identified as a Content Library path")
-		return isoPath
+		return isoPath, err
 	}
 	log.Printf("ISO path identified as a Content Library path")
 	log.Printf("Finding the equivalent datastore path for the Content Library ISO file path")
 	libItem, err := d.FindContentLibraryItem(lib.library.ID, itemName)
 	if err != nil {
 		log.Printf("[WARN] Couldn't find item %s: %s", itemName, err.Error())
-		log.Printf("Trying to use %s as the datastore path", isoPath)
-		return isoPath
+		return isoPath, err
 	}
-	if libItem == nil {
-		log.Printf("[WARN] Couldn't find item %s", itemName)
-		log.Printf("Trying to use %s as the datastore path", isoPath)
-		return isoPath
+	datastoreName, err := d.GetDatastoreName(lib.library.Storage[0].DatastoreID)
+	if err != nil {
+		log.Printf("[WARN] Couldn't find datastore name for library %s", libraryName)
+		return isoPath, err
 	}
-	datastoreName := d.GetDatastoreName(lib.library.Storage[0].DatastoreID)
 	libItemDir := fmt.Sprintf("[%s] contentlib-%s/%s", datastoreName, lib.library.ID, libItem.ID)
 
 	isoFilePath, err := d.GetDatastoreFilePath(lib.library.Storage[0].DatastoreID, libItemDir, isoFile)
 	if err != nil {
 		log.Printf("[WARN] Couldn't find datastore ID path for %s", isoFile)
-		log.Printf("Trying to use %s as the datastore path", isoPath)
-		return isoPath
+		return isoPath, err
 	}
 
 	_ = d.restClient.Logout(d.ctx)
-	return path.Join(libItemDir, isoFilePath)
+	return path.Join(libItemDir, isoFilePath), nil
+}
+
+type LibraryFilePath struct {
+	path string
+}
+
+func (l *LibraryFilePath) Validate() error {
+	l.path = strings.TrimLeft(l.path, "/")
+	parts := strings.Split(l.path, "/")
+	if len(parts) != 3 {
+		return fmt.Errorf("Not a valid Content Library File path. The path must contain the nanmes for the library, item and file.")
+	}
+	return nil
+}
+
+func (l *LibraryFilePath) GetLibraryName() string {
+	return strings.Split(l.path, "/")[0]
+}
+
+func (l *LibraryFilePath) GetLibraryItemName() string {
+	return strings.Split(l.path, "/")[1]
+}
+
+func (l *LibraryFilePath) GetFileName() string {
+	return strings.Split(l.path, "/")[2]
 }

--- a/builder/vsphere/driver/library_test.go
+++ b/builder/vsphere/driver/library_test.go
@@ -1,0 +1,62 @@
+package driver
+
+import "testing"
+
+func TestLibraryFilePath(t *testing.T) {
+	tc := []struct {
+		filePath        string
+		libraryName     string
+		libraryItemName string
+		fileName        string
+		valid           bool
+	}{
+		{
+			filePath:        "lib/item/file",
+			libraryName:     "lib",
+			libraryItemName: "item",
+			fileName:        "file",
+			valid:           true,
+		},
+		{
+			filePath:        "/lib/item/file",
+			libraryName:     "lib",
+			libraryItemName: "item",
+			fileName:        "file",
+			valid:           true,
+		},
+		{
+			filePath: "/lib/item/filedir/file",
+			valid:    false,
+		},
+		{
+			filePath: "/lib/item",
+			valid:    false,
+		},
+		{
+			filePath: "/lib",
+			valid:    false,
+		},
+	}
+
+	for _, c := range tc {
+		libraryFilePath := &LibraryFilePath{path: c.filePath}
+		if err := libraryFilePath.Validate(); err != nil {
+			if c.valid {
+				t.Fatalf("Expecting %s to be valid", c.filePath)
+			}
+			continue
+		}
+		libraryName := libraryFilePath.GetLibraryName()
+		if libraryName != c.libraryName {
+			t.Fatalf("Expecting %s but got %s", c.libraryName, libraryName)
+		}
+		libraryItemName := libraryFilePath.GetLibraryItemName()
+		if libraryItemName != c.libraryItemName {
+			t.Fatalf("Expecting %s but got %s", c.libraryItemName, libraryItemName)
+		}
+		fileName := libraryFilePath.GetFileName()
+		if fileName != c.fileName {
+			t.Fatalf("Expecting %s but got %s", c.fileName, fileName)
+		}
+	}
+}

--- a/builder/vsphere/iso/step_add_cdrom.go
+++ b/builder/vsphere/iso/step_add_cdrom.go
@@ -15,8 +15,14 @@ import (
 type CDRomConfig struct {
 	// Which controller to use. Example: `sata`. Defaults to `ide`.
 	CdromType string `mapstructure:"cdrom_type"`
-	// List of datastore paths to ISO files that will be mounted to the VM.
-	// Example: `"[datastore1] ISO/ubuntu.iso"`.
+	// List of Datastore or Content Library paths to ISO files that will be mounted to the VM.
+	// Here's an HCL2 example:
+	// ```hcl
+	// iso_paths = [
+	//   "[datastore1] ISO/ubuntu.iso",
+	//   "Packer Library Test/ubuntu-16.04.6-server-amd64/ubuntu-16.04.6-server-amd64.iso"
+	// ]
+	// ```
 	ISOPaths []string `mapstructure:"iso_paths"`
 }
 

--- a/website/pages/partials/builder/vsphere/iso/CDRomConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/iso/CDRomConfig-not-required.mdx
@@ -2,5 +2,11 @@
 
 - `cdrom_type` (string) - Which controller to use. Example: `sata`. Defaults to `ide`.
 
-- `iso_paths` ([]string) - List of datastore paths to ISO files that will be mounted to the VM.
-  Example: `"[datastore1] ISO/ubuntu.iso"`.
+- `iso_paths` ([]string) - List of Datastore or Content Library paths to ISO files that will be mounted to the VM.
+  Here's an HCL2 example:
+  ```hcl
+  iso_paths = [
+    "[datastore1] ISO/ubuntu.iso",
+    "Packer Library Test/ubuntu-16.04.6-server-amd64/ubuntu-16.04.6-server-amd64.iso"
+  ]
+  ```


### PR DESCRIPTION
Whenever a content library path is identified in iso_paths, a transformation will happen to make the path a datastore path and use it to mount an iso file.

Closes https://github.com/hashicorp/packer/issues/9687