### PR TITLE
Feat (oracle-oci): allow freeform and defined tags to be added instance

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -61,7 +61,9 @@ type Config struct {
 	ImageName   string `mapstructure:"image_name"`
 
 	// Instance
-	InstanceName string `mapstructure:"instance_name"`
+	InstanceName        string `mapstructure:"instance_name"`
+	InstanceTags        map[string]string `mapstructure:"instance_tags"`
+	InstanceDefinedTags map[string]map[string]interface{} `mapstructure:"instance_defined_tags"`
 
 	// Metadata optionally contains custom metadata key/value pairs provided in the
 	// configuration. While this can be used to set metadata["user_data"] the explicit

--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -61,8 +61,8 @@ type Config struct {
 	ImageName   string `mapstructure:"image_name"`
 
 	// Instance
-	InstanceName        string `mapstructure:"instance_name"`
-	InstanceTags        map[string]string `mapstructure:"instance_tags"`
+	InstanceName        string                            `mapstructure:"instance_name"`
+	InstanceTags        map[string]string                 `mapstructure:"instance_tags"`
 	InstanceDefinedTags map[string]map[string]interface{} `mapstructure:"instance_defined_tags"`
 
 	// Metadata optionally contains custom metadata key/value pairs provided in the

--- a/builder/oracle/oci/config.hcl2spec.go
+++ b/builder/oracle/oci/config.hcl2spec.go
@@ -79,6 +79,8 @@ type FlatConfig struct {
 	Shape                     *string                           `mapstructure:"shape" cty:"shape" hcl:"shape"`
 	ImageName                 *string                           `mapstructure:"image_name" cty:"image_name" hcl:"image_name"`
 	InstanceName              *string                           `mapstructure:"instance_name" cty:"instance_name" hcl:"instance_name"`
+	InstanceTags              map[string]string                 `mapstructure:"instance_tags" cty:"instance_tags" hcl:"instance_tags"`
+	InstanceDefinedTags       map[string]map[string]interface{} `mapstructure:"instance_defined_tags" cty:"instance_defined_tags" hcl:"instance_defined_tags"`
 	Metadata                  map[string]string                 `mapstructure:"metadata" cty:"metadata" hcl:"metadata"`
 	UserData                  *string                           `mapstructure:"user_data" cty:"user_data" hcl:"user_data"`
 	UserDataFile              *string                           `mapstructure:"user_data_file" cty:"user_data_file" hcl:"user_data_file"`
@@ -169,6 +171,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shape":                        &hcldec.AttrSpec{Name: "shape", Type: cty.String, Required: false},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
+		"instance_tags":                &hcldec.AttrSpec{Name: "instance_tags", Type: cty.Map(cty.String), Required: false},
+		"instance_defined_tags":        &hcldec.AttrSpec{Name: "instance_defined_tags", Type: cty.Map(cty.String), Required: false},
 		"metadata":                     &hcldec.AttrSpec{Name: "metadata", Type: cty.Map(cty.String), Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -54,6 +54,8 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 	instanceDetails := core.LaunchInstanceDetails{
 		AvailabilityDomain: &d.cfg.AvailabilityDomain,
 		CompartmentId:      &d.cfg.CompartmentID,
+		DefinedTags:        d.cfg.InstanceDefinedTags,
+		FreeformTags:       d.cfg.InstanceTags,
 		ImageId:            &d.cfg.BaseImageID,
 		Shape:              &d.cfg.Shape,
 		SubnetId:           &d.cfg.SubnetID,

--- a/website/pages/docs/builders/oracle/oci.mdx
+++ b/website/pages/docs/builders/oracle/oci.mdx
@@ -134,6 +134,12 @@ builder.
 - `instance_name` (string) - The name to assign to the instance used for the image creation process.
   If not set a name of the form `instanceYYYYMMDDhhmmss` will be used.
 
+- `instance_tags` (map of strings) - Add one or more freeform tags to the instance used for the 
+  image creation process.
+
+- `instance_defined_tags` (map of maps of strings) - Add one or more defined tags for a given namespace
+  to the instance used for the image creation process.
+
 - `use_private_ip` (boolean) - Use private ip addresses to connect to the
   instance via ssh.
 


### PR DESCRIPTION
Adds `DefinedTags` and `FreeformTags` to launch instance details from the SDK. I have confirmed that I can create a dev build of Packer using these changes, and that running this Packer to build an Oracle Image successfully launches a Compute Instance with tags automatically applied. To my template I simply added:
```
"instance_tags": { "testing": "yes" },
"instance_defined_tags": {
    "Oracle-Tags": {
        "IsPrinciple": "true"
    }
},
```
and got the behavior I was expecting (those tags automatically applied to the instance).

Automated tests are passing. However, running make test locally on a Macbook produces a panic:

```
--- FAIL: TestConfig (0.49s)
    --- FAIL: TestConfig/NoAccessConfig (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1be1e55]

goroutine 54 [running]:
testing.tRunner.func1.1(0x1d65120, 0x2b3d580)
	/usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc00044f440)
	/usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:943 +0x3f9
panic(0x1d65120, 0x2b3d580)
	/usr/local/Cellar/go/1.14.3/libexec/src/runtime/panic.go:969 +0x166
github.com/hashicorp/packer/builder/oracle/oci.TestConfig.func2(0xc00044f440)
	xxx/packer/builder/oracle/oci/config_test.go:92 +0x625
testing.tRunner(0xc00044f440, 0xc0003da780)
	/usr/local/Cellar/go/1.14.3/libexec/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
```
This panic is also raised from the master branch, so is not related to this PR, just noting it here. This does not happen in a Docker container.

Closes #6313