### PR TITLE
make the default target generate dev builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export GOLDFLAGS
 .PHONY: bin checkversion ci ci-lint default install-build-deps install-gen-deps fmt fmt-docs fmt-examples generate install-lint-deps lint \
 	releasebin test testacc testrace
 
-default: install-build-deps install-gen-deps generate bin
+default: install-build-deps install-gen-deps generate dev
 
 ci: testrace ## Test in continuous integration
 


### PR DESCRIPTION
TODO: scripts/build.sh doesn't work with osx unless you have linux tools installed, because of the requirement for realpath. we should also fix this. 