### PR TITLE
Move step_create_disk into common folder, and add to vmx builder

### DIFF
--- a/builder/vmware/common/disk_config.go
+++ b/builder/vmware/common/disk_config.go
@@ -1,0 +1,69 @@
+//go:generate struct-markdown
+
+package common
+
+import (
+	"github.com/hashicorp/packer/template/interpolate"
+)
+
+type DiskConfig struct {
+	// The size(s) of any additional
+	// hard disks for the VM in megabytes. If this is not specified then the VM
+	// will only contain a primary hard disk. The builder uses expandable, not
+	// fixed-size virtual hard disks, so the actual file representing the disk will
+	// not use the full size unless it is full.
+	AdditionalDiskSize []uint `mapstructure:"disk_additional_size" required:"false"`
+	// The adapter type of the VMware virtual disk to create. This option is
+	// for advanced usage, modify only if you know what you're doing. Some of
+	// the options you can specify are `ide`, `sata`, `nvme` or `scsi` (which
+	// uses the "lsilogic" scsi interface by default). If you specify another
+	// option, Packer will assume that you're specifying a `scsi` interface of
+	// that specified type. For more information, please consult [Virtual Disk
+	// Manager User's Guide](http://www.vmware.com/pdf/VirtualDiskManager.pdf)
+	// for desktop VMware clients. For ESXi, refer to the proper ESXi
+	// documentation.
+	DiskAdapterType string `mapstructure:"disk_adapter_type" required:"false"`
+	// The filename of the virtual disk that'll be created,
+	// without the extension. This defaults to "disk".
+	DiskName string `mapstructure:"vmdk_name" required:"false"`
+	// The type of VMware virtual disk to create. This
+	// option is for advanced usage.
+	//
+	//   For desktop VMware clients:
+	//
+	//   Type ID | Description
+	//   ------- | ---
+	//   `0`     | Growable virtual disk contained in a single file (monolithic sparse).
+	//   `1`     | Growable virtual disk split into 2GB files (split sparse).
+	//   `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
+	//   `3`     | Preallocated virtual disk split into 2GB files (split flat).
+	//   `4`     | Preallocated virtual disk compatible with ESX server (VMFS flat).
+	//   `5`     | Compressed disk optimized for streaming.
+	//
+	//   The default is `1`.
+	//
+	//   For ESXi, this defaults to `zeroedthick`. The available options for ESXi
+	//   are: `zeroedthick`, `eagerzeroedthick`, `thin`. `rdm:dev`, `rdmp:dev`,
+	//   `2gbsparse` are not supported. Due to default disk compaction, when using
+	//   `zeroedthick` or `eagerzeroedthick` set `skip_compaction` to `true`.
+	//
+	//   For more information, please consult the [Virtual Disk Manager User's
+	//   Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
+	//   VMware clients. For ESXi, refer to the proper ESXi documentation.
+	DiskTypeId string `mapstructure:"disk_type_id" required:"false"`
+}
+
+func (c *DiskConfig) Prepare(ctx *interpolate.Context) []error {
+	var errs []error
+
+	if c.DiskName == "" {
+		c.DiskName = "disk"
+	}
+
+	if c.DiskAdapterType == "" {
+		// Default is lsilogic
+		c.DiskAdapterType = "lsilogic"
+	}
+
+	return errs
+}

--- a/builder/vmware/common/step_create_disks_test.go
+++ b/builder/vmware/common/step_create_disks_test.go
@@ -1,0 +1,144 @@
+package common
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepCreateDisks_impl(t *testing.T) {
+	var _ multistep.Step = new(StepCreateDisks)
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+func NewTestCreateDiskStep() *StepCreateDisks {
+	return &StepCreateDisks{
+		OutputDir:          strPtr("output_dir"),
+		CreateMainDisk:     true,
+		DiskName:           "disk_name",
+		MainDiskSize:       uint(1024),
+		AdditionalDiskSize: []uint{},
+		DiskAdapterType:    "fake_adapter",
+		DiskTypeId:         "1",
+	}
+}
+
+func TestStepCreateDisks_MainOnly(t *testing.T) {
+	state := testState(t)
+	step := NewTestCreateDiskStep()
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+	if !driver.CreateDiskCalled {
+		t.Fatalf("Should have called create disk.")
+	}
+
+	diskFullPaths, ok := state.Get("disk_full_paths").([]string)
+	if !ok {
+		t.Fatalf("Should be able to load disk_full_paths from state")
+	}
+
+	assert.Equal(t, diskFullPaths, []string{filepath.Join("output_dir", "disk_name.vmdk")})
+
+	// Cleanup
+	step.Cleanup(state)
+}
+
+func TestStepCreateDisks_MainAndExtra(t *testing.T) {
+	state := testState(t)
+	step := NewTestCreateDiskStep()
+	step.AdditionalDiskSize = []uint{1024, 2048, 4096}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+	if !driver.CreateDiskCalled {
+		t.Fatalf("Should have called create disk.")
+	}
+
+	diskFullPaths, ok := state.Get("disk_full_paths").([]string)
+	if !ok {
+		t.Fatalf("Should be able to load disk_full_paths from state")
+	}
+
+	assert.Equal(t, diskFullPaths,
+		[]string{
+			filepath.Join("output_dir", "disk_name.vmdk"),
+			filepath.Join("output_dir", "disk_name-1.vmdk"),
+			filepath.Join("output_dir", "disk_name-2.vmdk"),
+			filepath.Join("output_dir", "disk_name-3.vmdk"),
+		})
+	// Cleanup
+	step.Cleanup(state)
+}
+
+func TestStepCreateDisks_ExtraOnly(t *testing.T) {
+	state := testState(t)
+	step := NewTestCreateDiskStep()
+	step.CreateMainDisk = false
+	step.AdditionalDiskSize = []uint{1024, 2048, 4096}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+	if !driver.CreateDiskCalled {
+		t.Fatalf("Should have called create disk.")
+	}
+
+	diskFullPaths, ok := state.Get("disk_full_paths").([]string)
+	if !ok {
+		t.Fatalf("Should be able to load disk_full_paths from state")
+	}
+
+	assert.Equal(t, diskFullPaths,
+		[]string{
+			filepath.Join("output_dir", "disk_name-1.vmdk"),
+			filepath.Join("output_dir", "disk_name-2.vmdk"),
+			filepath.Join("output_dir", "disk_name-3.vmdk"),
+		})
+
+	// Cleanup
+	step.Cleanup(state)
+}
+
+func TestStepCreateDisks_Nothing(t *testing.T) {
+	state := testState(t)
+	step := NewTestCreateDiskStep()
+	step.CreateMainDisk = false
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+	if _, ok := state.GetOk("error"); ok {
+		t.Fatal("should NOT have error")
+	}
+
+	driver := state.Get("driver").(*DriverMock)
+	if driver.CreateDiskCalled {
+		t.Fatalf("Should not have called create disk.")
+	}
+
+	// Cleanup
+	step.Cleanup(state)
+}

--- a/builder/vmware/iso/builder.go
+++ b/builder/vmware/iso/builder.go
@@ -83,7 +83,15 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			DoCleanup: b.config.DriverConfig.CleanUpRemoteCache,
 			Checksum:  b.config.ISOChecksum,
 		},
-		&stepCreateDisk{},
+		&vmwcommon.StepCreateDisks{
+			OutputDir:          &b.config.OutputDir,
+			CreateMainDisk:     true,
+			DiskName:           b.config.DiskName,
+			MainDiskSize:       b.config.DiskSize,
+			AdditionalDiskSize: b.config.AdditionalDiskSize,
+			DiskAdapterType:    b.config.DiskAdapterType,
+			DiskTypeId:         b.config.DiskTypeId,
+		},
 		&stepCreateVMX{},
 		&vmwcommon.StepConfigureVMX{
 			CustomData:  b.config.VMXData,

--- a/builder/vmware/iso/config.go
+++ b/builder/vmware/iso/config.go
@@ -33,55 +33,12 @@ type Config struct {
 	vmwcommon.ToolsConfig          `mapstructure:",squash"`
 	vmwcommon.VMXConfig            `mapstructure:",squash"`
 	vmwcommon.ExportConfig         `mapstructure:",squash"`
-	// The size(s) of any additional
-	// hard disks for the VM in megabytes. If this is not specified then the VM
-	// will only contain a primary hard disk. The builder uses expandable, not
-	// fixed-size virtual hard disks, so the actual file representing the disk will
-	// not use the full size unless it is full.
-	AdditionalDiskSize []uint `mapstructure:"disk_additional_size" required:"false"`
-	// The adapter type of the VMware virtual disk to create. This option is
-	// for advanced usage, modify only if you know what you're doing. Some of
-	// the options you can specify are `ide`, `sata`, `nvme` or `scsi` (which
-	// uses the "lsilogic" scsi interface by default). If you specify another
-	// option, Packer will assume that you're specifying a `scsi` interface of
-	// that specified type. For more information, please consult [Virtual Disk
-	// Manager User's Guide](http://www.vmware.com/pdf/VirtualDiskManager.pdf)
-	// for desktop VMware clients. For ESXi, refer to the proper ESXi
-	// documentation.
-	DiskAdapterType string `mapstructure:"disk_adapter_type" required:"false"`
-	// The filename of the virtual disk that'll be created,
-	// without the extension. This defaults to packer.
-	DiskName string `mapstructure:"vmdk_name" required:"false"`
+	vmwcommon.DiskConfig           `mapstructure:",squash"`
 	// The size of the hard disk for the VM in megabytes.
 	// The builder uses expandable, not fixed-size virtual hard disks, so the
 	// actual file representing the disk will not use the full size unless it
 	// is full. By default this is set to 40000 (about 40 GB).
 	DiskSize uint `mapstructure:"disk_size" required:"false"`
-	// The type of VMware virtual disk to create. This
-	// option is for advanced usage.
-	//
-	//   For desktop VMware clients:
-	//
-	//   Type ID | Description
-	//   ------- | ---
-	//   `0`     | Growable virtual disk contained in a single file (monolithic sparse).
-	//   `1`     | Growable virtual disk split into 2GB files (split sparse).
-	//   `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
-	//   `3`     | Preallocated virtual disk split into 2GB files (split flat).
-	//   `4`     | Preallocated virtual disk compatible with ESX server (VMFS flat).
-	//   `5`     | Compressed disk optimized for streaming.
-	//
-	//   The default is `1`.
-	//
-	//   For ESXi, this defaults to `zeroedthick`. The available options for ESXi
-	//   are: `zeroedthick`, `eagerzeroedthick`, `thin`. `rdm:dev`, `rdmp:dev`,
-	//   `2gbsparse` are not supported. Due to default disk compaction, when using
-	//   `zeroedthick` or `eagerzeroedthick` set `skip_compaction` to `true`.
-	//
-	//   For more information, please consult the [Virtual Disk Manager User's
-	//   Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
-	//   VMware clients. For ESXi, refer to the proper ESXi documentation.
-	DiskTypeId string `mapstructure:"disk_type_id" required:"false"`
 	// The adapter type (or bus) that will be used
 	// by the cdrom device. This is chosen by default based on the disk adapter
 	// type. VMware tends to lean towards ide for the cdrom device unless
@@ -155,26 +112,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, c.FloppyConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.VNCConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.ExportConfig.Prepare(&c.ctx)...)
-
-	if c.DiskName == "" {
-		c.DiskName = "disk"
-	}
+	errs = packer.MultiErrorAppend(errs, c.DiskConfig.Prepare(&c.ctx)...)
 
 	if c.DiskSize == 0 {
 		c.DiskSize = 40000
-	}
-
-	if c.DiskAdapterType == "" {
-		// Default is lsilogic
-		c.DiskAdapterType = "lsilogic"
-	}
-
-	if !c.SkipCompaction {
-		if c.RemoteType == "esx5" {
-			if c.DiskTypeId == "" {
-				c.SkipCompaction = true
-			}
-		}
 	}
 
 	if c.DiskTypeId == "" {
@@ -183,6 +124,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 		if c.RemoteType == "esx5" {
 			c.DiskTypeId = "zeroedthick"
+			c.SkipCompaction = true
 		}
 	}
 

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -126,8 +126,8 @@ type FlatConfig struct {
 	AdditionalDiskSize        []uint            `mapstructure:"disk_additional_size" required:"false" cty:"disk_additional_size" hcl:"disk_additional_size"`
 	DiskAdapterType           *string           `mapstructure:"disk_adapter_type" required:"false" cty:"disk_adapter_type" hcl:"disk_adapter_type"`
 	DiskName                  *string           `mapstructure:"vmdk_name" required:"false" cty:"vmdk_name" hcl:"vmdk_name"`
-	DiskSize                  *uint             `mapstructure:"disk_size" required:"false" cty:"disk_size" hcl:"disk_size"`
 	DiskTypeId                *string           `mapstructure:"disk_type_id" required:"false" cty:"disk_type_id" hcl:"disk_type_id"`
+	DiskSize                  *uint             `mapstructure:"disk_size" required:"false" cty:"disk_size" hcl:"disk_size"`
 	CdromAdapterType          *string           `mapstructure:"cdrom_adapter_type" required:"false" cty:"cdrom_adapter_type" hcl:"cdrom_adapter_type"`
 	GuestOSType               *string           `mapstructure:"guest_os_type" required:"false" cty:"guest_os_type" hcl:"guest_os_type"`
 	Version                   *string           `mapstructure:"version" required:"false" cty:"version" hcl:"version"`
@@ -265,8 +265,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_additional_size":           &hcldec.AttrSpec{Name: "disk_additional_size", Type: cty.List(cty.Number), Required: false},
 		"disk_adapter_type":              &hcldec.AttrSpec{Name: "disk_adapter_type", Type: cty.String, Required: false},
 		"vmdk_name":                      &hcldec.AttrSpec{Name: "vmdk_name", Type: cty.String, Required: false},
-		"disk_size":                      &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"disk_type_id":                   &hcldec.AttrSpec{Name: "disk_type_id", Type: cty.String, Required: false},
+		"disk_size":                      &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"cdrom_adapter_type":             &hcldec.AttrSpec{Name: "cdrom_adapter_type", Type: cty.String, Required: false},
 		"guest_os_type":                  &hcldec.AttrSpec{Name: "guest_os_type", Type: cty.String, Required: false},
 		"version":                        &hcldec.AttrSpec{Name: "version", Type: cty.String, Required: false},

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -74,6 +74,15 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			DoCleanup: true,
 			Checksum:  "none",
 		},
+		&vmwcommon.StepCreateDisks{
+			OutputDir:          &b.config.OutputDir,
+			CreateMainDisk:     false,
+			DiskName:           b.config.DiskName,
+			MainDiskSize:       0,
+			AdditionalDiskSize: b.config.AdditionalDiskSize,
+			DiskAdapterType:    b.config.DiskAdapterType,
+			DiskTypeId:         b.config.DiskTypeId,
+		},
 		&StepCloneVMX{
 			Path:      b.config.SourcePath,
 			OutputDir: &b.config.OutputDir,

--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	vmwcommon.ToolsConfig          `mapstructure:",squash"`
 	vmwcommon.VMXConfig            `mapstructure:",squash"`
 	vmwcommon.ExportConfig         `mapstructure:",squash"`
+	vmwcommon.DiskConfig           `mapstructure:",squash"`
 	// By default Packer creates a 'full' clone of the virtual machine
 	// specified in source_path. The resultant virtual machine is fully
 	// independant from the parent it was cloned from.
@@ -89,6 +90,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, c.FloppyConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.VNCConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.ExportConfig.Prepare(&c.ctx)...)
+	errs = packer.MultiErrorAppend(errs, c.DiskConfig.Prepare(&c.ctx)...)
 
 	if c.RemoteType == "" {
 		if c.SourcePath == "" {
@@ -109,6 +111,15 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		if c.RemoteType != "esx5" {
 			errs = packer.MultiErrorAppend(errs,
 				fmt.Errorf("Only 'esx5' value is accepted for remote_type"))
+		}
+	}
+
+	if c.DiskTypeId == "" {
+		// Default is growable virtual disk split in 2GB files.
+		c.DiskTypeId = "1"
+
+		if c.RemoteType == "esx5" {
+			c.DiskTypeId = "zeroedthick"
 		}
 	}
 

--- a/builder/vmware/vmx/config.hcl2spec.go
+++ b/builder/vmware/vmx/config.hcl2spec.go
@@ -108,6 +108,10 @@ type FlatConfig struct {
 	SkipExport                *bool             `mapstructure:"skip_export" required:"false" cty:"skip_export" hcl:"skip_export"`
 	KeepRegistered            *bool             `mapstructure:"keep_registered" required:"false" cty:"keep_registered" hcl:"keep_registered"`
 	SkipCompaction            *bool             `mapstructure:"skip_compaction" required:"false" cty:"skip_compaction" hcl:"skip_compaction"`
+	AdditionalDiskSize        []uint            `mapstructure:"disk_additional_size" required:"false" cty:"disk_additional_size" hcl:"disk_additional_size"`
+	DiskAdapterType           *string           `mapstructure:"disk_adapter_type" required:"false" cty:"disk_adapter_type" hcl:"disk_adapter_type"`
+	DiskName                  *string           `mapstructure:"vmdk_name" required:"false" cty:"vmdk_name" hcl:"vmdk_name"`
+	DiskTypeId                *string           `mapstructure:"disk_type_id" required:"false" cty:"disk_type_id" hcl:"disk_type_id"`
 	Linked                    *bool             `mapstructure:"linked" required:"false" cty:"linked" hcl:"linked"`
 	SourcePath                *string           `mapstructure:"source_path" required:"true" cty:"source_path" hcl:"source_path"`
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name" hcl:"vm_name"`
@@ -224,6 +228,10 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"skip_export":                    &hcldec.AttrSpec{Name: "skip_export", Type: cty.Bool, Required: false},
 		"keep_registered":                &hcldec.AttrSpec{Name: "keep_registered", Type: cty.Bool, Required: false},
 		"skip_compaction":                &hcldec.AttrSpec{Name: "skip_compaction", Type: cty.Bool, Required: false},
+		"disk_additional_size":           &hcldec.AttrSpec{Name: "disk_additional_size", Type: cty.List(cty.Number), Required: false},
+		"disk_adapter_type":              &hcldec.AttrSpec{Name: "disk_adapter_type", Type: cty.String, Required: false},
+		"vmdk_name":                      &hcldec.AttrSpec{Name: "vmdk_name", Type: cty.String, Required: false},
+		"disk_type_id":                   &hcldec.AttrSpec{Name: "disk_type_id", Type: cty.String, Required: false},
 		"linked":                         &hcldec.AttrSpec{Name: "linked", Type: cty.Bool, Required: false},
 		"source_path":                    &hcldec.AttrSpec{Name: "source_path", Type: cty.String, Required: false},
 		"vm_name":                        &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},

--- a/website/pages/docs/builders/vmware/iso.mdx
+++ b/website/pages/docs/builders/vmware/iso.mdx
@@ -95,6 +95,12 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'builder/vmware/iso/Config-not-required.mdx'
 
+### Extra Disk Configuration
+
+#### Optional:
+
+@include 'builder/vmware/common/DiskConfig-not-required.mdx'
+
 ### ISO Configuration
 
 @include 'common/ISOConfig.mdx'

--- a/website/pages/docs/builders/vmware/vmx.mdx
+++ b/website/pages/docs/builders/vmware/vmx.mdx
@@ -72,12 +72,6 @@ There are many configuration options available for the VMware builder. They are
 organized below into two categories: required and optional. Within each
 category, the available options are alphabetized and described.
 
-In addition to the options listed here, a
-[communicator](/docs/templates/communicator) can be configured for this
-builder.
-
-## Configuration Reference
-
 There are many configuration options available for the builder. In addition to
 the items listed here, you will want to look at the general configuration
 references for
@@ -102,6 +96,12 @@ necessary for this build to succeed and can be found further down the page.
 #### Optional:
 
 @include 'builder/vmware/vmx/Config-not-required.mdx'
+
+### Extra Disk Configuration
+
+#### Optional:
+
+@include 'builder/vmware/common/DiskConfig-not-required.mdx'
 
 ### Http directory configuration
 

--- a/website/pages/partials/builder/vmware/common/DiskConfig-not-required.mdx
+++ b/website/pages/partials/builder/vmware/common/DiskConfig-not-required.mdx
@@ -1,0 +1,45 @@
+<!-- Code generated from the comments of the DiskConfig struct in builder/vmware/common/disk_config.go; DO NOT EDIT MANUALLY -->
+
+- `disk_additional_size` ([]uint) - The size(s) of any additional
+  hard disks for the VM in megabytes. If this is not specified then the VM
+  will only contain a primary hard disk. The builder uses expandable, not
+  fixed-size virtual hard disks, so the actual file representing the disk will
+  not use the full size unless it is full.
+
+- `disk_adapter_type` (string) - The adapter type of the VMware virtual disk to create. This option is
+  for advanced usage, modify only if you know what you're doing. Some of
+  the options you can specify are `ide`, `sata`, `nvme` or `scsi` (which
+  uses the "lsilogic" scsi interface by default). If you specify another
+  option, Packer will assume that you're specifying a `scsi` interface of
+  that specified type. For more information, please consult [Virtual Disk
+  Manager User's Guide](http://www.vmware.com/pdf/VirtualDiskManager.pdf)
+  for desktop VMware clients. For ESXi, refer to the proper ESXi
+  documentation.
+
+- `vmdk_name` (string) - The filename of the virtual disk that'll be created,
+  without the extension. This defaults to "disk".
+
+- `disk_type_id` (string) - The type of VMware virtual disk to create. This
+  option is for advanced usage.
+  
+    For desktop VMware clients:
+  
+    Type ID | Description
+    ------- | ---
+    `0`     | Growable virtual disk contained in a single file (monolithic sparse).
+    `1`     | Growable virtual disk split into 2GB files (split sparse).
+    `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
+    `3`     | Preallocated virtual disk split into 2GB files (split flat).
+    `4`     | Preallocated virtual disk compatible with ESX server (VMFS flat).
+    `5`     | Compressed disk optimized for streaming.
+  
+    The default is `1`.
+  
+    For ESXi, this defaults to `zeroedthick`. The available options for ESXi
+    are: `zeroedthick`, `eagerzeroedthick`, `thin`. `rdm:dev`, `rdmp:dev`,
+    `2gbsparse` are not supported. Due to default disk compaction, when using
+    `zeroedthick` or `eagerzeroedthick` set `skip_compaction` to `true`.
+  
+    For more information, please consult the [Virtual Disk Manager User's
+    Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
+    VMware clients. For ESXi, refer to the proper ESXi documentation.

--- a/website/pages/partials/builder/vmware/iso/Config-not-required.mdx
+++ b/website/pages/partials/builder/vmware/iso/Config-not-required.mdx
@@ -1,53 +1,9 @@
 <!-- Code generated from the comments of the Config struct in builder/vmware/iso/config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_additional_size` ([]uint) - The size(s) of any additional
-  hard disks for the VM in megabytes. If this is not specified then the VM
-  will only contain a primary hard disk. The builder uses expandable, not
-  fixed-size virtual hard disks, so the actual file representing the disk will
-  not use the full size unless it is full.
-
-- `disk_adapter_type` (string) - The adapter type of the VMware virtual disk to create. This option is
-  for advanced usage, modify only if you know what you're doing. Some of
-  the options you can specify are `ide`, `sata`, `nvme` or `scsi` (which
-  uses the "lsilogic" scsi interface by default). If you specify another
-  option, Packer will assume that you're specifying a `scsi` interface of
-  that specified type. For more information, please consult [Virtual Disk
-  Manager User's Guide](http://www.vmware.com/pdf/VirtualDiskManager.pdf)
-  for desktop VMware clients. For ESXi, refer to the proper ESXi
-  documentation.
-
-- `vmdk_name` (string) - The filename of the virtual disk that'll be created,
-  without the extension. This defaults to packer.
-
 - `disk_size` (uint) - The size of the hard disk for the VM in megabytes.
   The builder uses expandable, not fixed-size virtual hard disks, so the
   actual file representing the disk will not use the full size unless it
   is full. By default this is set to 40000 (about 40 GB).
-
-- `disk_type_id` (string) - The type of VMware virtual disk to create. This
-  option is for advanced usage.
-  
-    For desktop VMware clients:
-  
-    Type ID | Description
-    ------- | ---
-    `0`     | Growable virtual disk contained in a single file (monolithic sparse).
-    `1`     | Growable virtual disk split into 2GB files (split sparse).
-    `2`     | Preallocated virtual disk contained in a single file (monolithic flat).
-    `3`     | Preallocated virtual disk split into 2GB files (split flat).
-    `4`     | Preallocated virtual disk compatible with ESX server (VMFS flat).
-    `5`     | Compressed disk optimized for streaming.
-  
-    The default is `1`.
-  
-    For ESXi, this defaults to `zeroedthick`. The available options for ESXi
-    are: `zeroedthick`, `eagerzeroedthick`, `thin`. `rdm:dev`, `rdmp:dev`,
-    `2gbsparse` are not supported. Due to default disk compaction, when using
-    `zeroedthick` or `eagerzeroedthick` set `skip_compaction` to `true`.
-  
-    For more information, please consult the [Virtual Disk Manager User's
-    Guide](https://www.vmware.com/pdf/VirtualDiskManager.pdf) for desktop
-    VMware clients. For ESXi, refer to the proper ESXi documentation.
 
 - `cdrom_adapter_type` (string) - The adapter type (or bus) that will be used
   by the cdrom device. This is chosen by default based on the disk adapter


### PR DESCRIPTION
Add additional disk configuration to vmware-vmx builder as well.  Previously only implemented for vmware-iso builder.

Closes #7170 

