### PR TITLE
provisioner/windows-shell: Add HCL2 example to documentation

### DIFF
--- a/website/pages/docs/provisioners/windows-shell.mdx
+++ b/website/pages/docs/provisioners/windows-shell.mdx
@@ -18,12 +18,27 @@ The windows-shell Packer provisioner runs commands on a Windows machine using
 
 The example below is fully functional.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "windows-shell",
   "inline": ["dir c:\\"]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+provisioner "windows-shell" {
+  inline = ["dir c:\\"]
+}
+```
+
+</Tab>
+</Tabs>
 
 ## Configuration Reference
 


### PR DESCRIPTION
Relates to: #9668