### PR TITLE
Inspect allow unset variables in HCL2 and JSON

### DIFF
--- a/command/inspect.go
+++ b/command/inspect.go
@@ -44,11 +44,10 @@ func (c *InspectCommand) RunContext(ctx context.Context, cla *InspectArgs) int {
 	if ret != 0 {
 		return ret
 	}
-	diags := packerStarter.Initialize()
-	ret = writeDiags(c.Ui, nil, diags)
-	if ret != 0 {
-		return ret
-	}
+
+	// here we ignore init diags to allow unknown variables to be used
+	_ = packerStarter.Initialize()
+
 	return packerStarter.InspectConfig(packer.InspectConfigOptions{
 		Ui: c.Ui,
 	})

--- a/command/inspect_test.go
+++ b/command/inspect_test.go
@@ -15,6 +15,33 @@ func Test_commands(t *testing.T) {
 		env      []string
 		expected string
 	}{
+		{[]string{"inspect", filepath.Join(testFixture("var-arg"), "fruit_builder.pkr.hcl")}, nil, `Packer Inspect: HCL2 mode
+
+> input-variables:
+
+var.fruit: "<unknown>"
+
+> local-variables:
+
+local.fruit: "<unknown>"
+
+> builds:
+
+  > <unnamed build 0>:
+
+    sources:
+
+      null.builder
+
+    provisioners:
+
+      shell-local
+
+    post-processors:
+
+      <no post-processor>
+
+`},
 		{[]string{"inspect", "-var=fruit=banana", filepath.Join(testFixture("var-arg"), "fruit_builder.pkr.hcl")}, nil, `Packer Inspect: HCL2 mode
 
 > input-variables:

--- a/command/inspect_test.go
+++ b/command/inspect_test.go
@@ -19,7 +19,7 @@ func Test_commands(t *testing.T) {
 
 > input-variables:
 
-var.fruit: "banana" [debug: {Type:cty.String,CmdValue:banana,VarfileValue:null,EnvValue:null,DefaultValue:null}]
+var.fruit: "banana"
 
 > local-variables:
 
@@ -46,7 +46,7 @@ local.fruit: "banana"
 
 > input-variables:
 
-var.fruit: "peach" [debug: {Type:cty.String,CmdValue:peach,VarfileValue:null,EnvValue:null,DefaultValue:banana}]
+var.fruit: "peach"
 
 > local-variables:
 
@@ -58,7 +58,7 @@ var.fruit: "peach" [debug: {Type:cty.String,CmdValue:peach,VarfileValue:null,Env
 
 > input-variables:
 
-var.fruit: "peach" [debug: {Type:cty.String,CmdValue:peach,VarfileValue:null,EnvValue:null,DefaultValue:banana}]
+var.fruit: "peach"
 
 > local-variables:
 

--- a/command/inspect_test.go
+++ b/command/inspect_test.go
@@ -69,11 +69,13 @@ local.fruit: "banana"
       <no post-processor>
 
 `},
-		{[]string{"inspect", "-var=fruit=peach", filepath.Join(testFixture("hcl"), "inspect", "fruit_string.pkr.hcl")}, nil, `Packer Inspect: HCL2 mode
+		{[]string{"inspect", "-var=fruit=peach", "-var=unknown_string=also_peach", `-var=unknown_unknown="peach_too"`, filepath.Join(testFixture("hcl"), "inspect", "fruit_string.pkr.hcl")}, nil, `Packer Inspect: HCL2 mode
 
 > input-variables:
 
 var.fruit: "peach"
+var.unknown_string: "also_peach"
+var.unknown_unknown: "peach_too"
 
 > local-variables:
 
@@ -86,6 +88,8 @@ var.fruit: "peach"
 > input-variables:
 
 var.fruit: "peach"
+var.unknown_string: "<unknown>"
+var.unknown_unknown: "<unknown>"
 
 > local-variables:
 
@@ -121,6 +125,26 @@ Use it at will.
         manifest
         shell-local
 
+`},
+		{[]string{"inspect", filepath.Join(testFixture("inspect"), "unset_var.json")}, nil, `Packer Inspect: JSON mode
+Required variables:
+
+  something
+
+Optional variables and their defaults:
+
+
+Builders:
+
+  <No builders>
+
+Provisioners:
+
+  <No provisioners>
+
+Note: If your build names contain user variables or template
+functions such as 'timestamp', these are processed at build time,
+and therefore only show in their raw form here.
 `},
 	}
 

--- a/command/test-fixtures/hcl/inspect/fruit_string.pkr.hcl
+++ b/command/test-fixtures/hcl/inspect/fruit_string.pkr.hcl
@@ -3,3 +3,10 @@ variable "fruit" {
   type = string
   default = "banana"
 }
+
+variable "unknown_string" {
+  type = string
+}
+
+variable "unknown_unknown" {
+}

--- a/command/test-fixtures/inspect/unset_var.json
+++ b/command/test-fixtures/inspect/unset_var.json
@@ -1,0 +1,5 @@
+{
+    "variables": {
+        "something": null
+    }
+}

--- a/command/test-fixtures/var-arg/fruit_builder.json
+++ b/command/test-fixtures/var-arg/fruit_builder.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-        "fruit": ""
+        "fruit": null
     },
     "builders": [
         {

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -462,7 +462,7 @@ func (p *PackerConfig) printVariables() string {
 	out.WriteString("> input-variables:\n\n")
 	for _, v := range p.InputVariables {
 		val, _ := v.Value()
-		fmt.Fprintf(out, "var.%s: %q [debug: %#v]\n", v.Name, PrintableCtyValue(val), v)
+		fmt.Fprintf(out, "var.%s: %q\n", v.Name, PrintableCtyValue(val))
 	}
 	out.WriteString("\n> local-variables:\n\n")
 	for _, v := range p.LocalVariables {

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -2,6 +2,7 @@ package hcl2template
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/gobwas/glob"
@@ -460,12 +461,18 @@ func (p *PackerConfig) EvaluateExpression(line string) (out string, exit bool, d
 func (p *PackerConfig) printVariables() string {
 	out := &strings.Builder{}
 	out.WriteString("> input-variables:\n\n")
-	for _, v := range p.InputVariables {
+	keys := p.InputVariables.Keys()
+	sort.Strings(keys)
+	for _, key := range keys {
+		v := p.InputVariables[key]
 		val, _ := v.Value()
 		fmt.Fprintf(out, "var.%s: %q\n", v.Name, PrintableCtyValue(val))
 	}
 	out.WriteString("\n> local-variables:\n\n")
-	for _, v := range p.LocalVariables {
+	keys = p.LocalVariables.Keys()
+	sort.Strings(keys)
+	for _, key := range keys {
+		v := p.LocalVariables[key]
 		val, _ := v.Value()
 		fmt.Fprintf(out, "local.%s: %q\n", v.Name, PrintableCtyValue(val))
 	}

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -72,9 +72,7 @@ func (v *Variable) Value() (cty.Value, *hcl.Diagnostic) {
 		}
 	}
 
-	value := cty.NullVal(cty.DynamicPseudoType)
-
-	return value, &hcl.Diagnostic{
+	return cty.UnknownVal(v.Type), &hcl.Diagnostic{
 		Severity: hcl.DiagError,
 		Summary:  fmt.Sprintf("Unset variable %q", v.Name),
 		Detail: "A used variable must be set or have a default value; see " +
@@ -93,7 +91,6 @@ func (variables Variables) Values() (map[string]cty.Value, hcl.Diagnostics) {
 		value, diag := v.Value()
 		if diag != nil {
 			diags = append(diags, diag)
-			continue
 		}
 		res[k] = value
 	}
@@ -208,12 +205,11 @@ func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.Eval
 
 		res.DefaultValue = defaultValue
 
-		// It's possible no type attribute was assigned so lets make
-		// sure we have a valid type otherwise there will be issues parsing the value.
+		// It's possible no type attribute was assigned so lets make sure we
+		// have a valid type otherwise there could be issues parsing the value.
 		if res.Type == cty.NilType {
 			res.Type = res.DefaultValue.Type()
 		}
-
 	}
 	if len(attrs) > 0 {
 		keys := []string{}

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -84,6 +84,14 @@ func (v *Variable) Value() (cty.Value, *hcl.Diagnostic) {
 
 type Variables map[string]*Variable
 
+func (variables Variables) Keys() []string {
+	keys := make([]string, 0, len(variables))
+	for key := range variables {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 func (variables Variables) Values() (map[string]cty.Value, hcl.Diagnostics) {
 	res := map[string]cty.Value{}
 	var diags hcl.Diagnostics


### PR DESCRIPTION
* allows to have unknown/unset values when running packer 'inspect' in JSON and HCL2, close #9679. By ignoring initialisation diagnostics. 
* makes HCL2 Variables return a cty unknown value when no value was set for it

This is more a fix than breaking change in the sense that we ignore the initialisation errors/diags which is something we should have done all along.