### PR TITLE
hcl2_upgrade: fix a case where the generated type is wrong

### DIFF
--- a/command/hcl2_upgrade.go
+++ b/command/hcl2_upgrade.go
@@ -326,24 +326,65 @@ func jsonBodyToHCL2Body(out *hclwrite.Body, kvs map[string]interface{}) {
 
 		switch value := value.(type) {
 		case map[string]interface{}:
-			var first interface{}
-			for _, elem := range value {
-				first = elem
+			var mostComplexElem interface{}
+			for _, randomElem := range value {
+				// HACK: we take the most complex element of that map because
+				// in HCL2, map of objects can be bodies, for example:
+				// map containing object: source_ami_filter {} ( body )
+				// simple string/string map: tags = {} ) ( attribute )
+				//
+				// if we could not find an object in this map then it's most
+				// likely a plain map and so we guess it should be and
+				// attribute. Though now if value refers to something that is
+				// an object but only contains a string or a bool; we could
+				// generate a faulty object. For example a (somewhat invalid)
+				// source_ami_filter where only `most_recent` is set.
+				switch randomElem.(type) {
+				case string, int, float64, bool:
+					if mostComplexElem != nil {
+						continue
+					}
+					mostComplexElem = randomElem
+				default:
+					mostComplexElem = randomElem
+				}
 			}
 
-			switch first.(type) {
-			case string, int, float64:
+			switch mostComplexElem.(type) {
+			case string, int, float64, bool:
 				out.SetAttributeValue(k, hcl2shim.HCL2ValueFromConfigValue(value))
 			default:
 				nestedBlockBody := out.AppendNewBlock(k, nil).Body()
 				jsonBodyToHCL2Body(nestedBlockBody, value)
 			}
+		case map[string]string, map[string]int, map[string]float64:
+			out.SetAttributeValue(k, hcl2shim.HCL2ValueFromConfigValue(value))
 		case []interface{}:
 			if len(value) == 0 {
 				continue
 			}
-			switch value[0].(type) {
+
+			var mostComplexElem interface{}
+			for _, randomElem := range value {
+				// HACK: we take the most complex element of that slice because
+				// in hcl2 slices of plain types can be arrays, for example:
+				// simple string type: owners = ["0000000000"]
+				// object: launch_block_device_mappings {}
+				switch randomElem.(type) {
+				case string, int, float64, bool:
+					if mostComplexElem != nil {
+						continue
+					}
+					mostComplexElem = randomElem
+				default:
+					mostComplexElem = randomElem
+				}
+			}
+			switch mostComplexElem.(type) {
 			case map[string]interface{}:
+				// this is an object in a slice; so we unwrap it. We
+				// could try to remove any 's' suffix in the key, but
+				// this might not work everywhere.
 				for i := range value {
 					value := value[i].(map[string]interface{})
 					nestedBlockBody := out.AppendNewBlock(k, nil).Body()
@@ -351,8 +392,8 @@ func jsonBodyToHCL2Body(out *hclwrite.Body, kvs map[string]interface{}) {
 				}
 				continue
 			default:
+				out.SetAttributeValue(k, hcl2shim.HCL2ValueFromConfigValue(value))
 			}
-			out.SetAttributeValue(k, hcl2shim.HCL2ValueFromConfigValue(value))
 		default:
 			out.SetAttributeValue(k, hcl2shim.HCL2ValueFromConfigValue(value))
 		}


### PR DESCRIPTION
When it encounters `map[string]interface{}` or `[]interface{}` types,  `hcl2_upgrade` now considers the 'most complex' entry in order to tell wether this is going to be a body `body {}` or an attribute `attribute = {}`. Before that, the hcl2_upgrade was random there.

⚠️ That said, if a value refers to something that is an object ( and therefore should be a body ) but only contains a string or a bool; we will generate a faulty object. For example a (somewhat invalid) source_ami_filter: where only `most_recent` is set:

```json
            "source_ami_filter": {
                "most_recent": true
            },
```
hcl2_upgrade will think this is a map of bools and therefore generate:
```hcl
source_ami_filter = {
  most_recent = true # this is invalid, but hcl will give a nice hint
}
```
Instead of a body  (same thing without the first equal sign ).

If this causes issues, a way better ( but probably somewhat harder ) way to do this would be to use the actual plugins structs in order to generate the HCL2, this way we could not go wrong, leveraging strongly typed go ( but this would not work for external plugins )