### PR TITLE
command/hcl2_upgrade: Update description text for command

### DIFF
--- a/command/hcl2_upgrade.go
+++ b/command/hcl2_upgrade.go
@@ -379,7 +379,7 @@ Usage: packer hcl2_upgrade -output-file=JSON_TEMPLATE.pkr.hcl JSON_TEMPLATE...
 }
 
 func (*HCL2UpgradeCommand) Synopsis() string {
-	return "build image(s) from template"
+	return "transform a JSON template into a HCL2 configuration"
 }
 
 func (*HCL2UpgradeCommand) AutocompleteArgs() complete.Predictor {


### PR DESCRIPTION
Before change
```
Usage: packer [--version] [--help] <command> [<args>]

Available commands are:
    build           build image(s) from template
    console         creates a console for testing variable interpolation
    fix             fixes templates from old versions of packer
    hcl2_upgrade    build image(s) from template
    inspect         see components of a template
    validate        check that a template is valid
    version         Prints the Packer version
```

After change
```
Usage: packer [--version] [--help] <command> [<args>]

Available commands are:
    build           build image(s) from template
    console         creates a console for testing variable interpolation
    fix             fixes templates from old versions of packer
    hcl2_upgrade    transform a JSON template into a HCL2 configuration
    inspect         see components of a template
    validate        check that a template is valid
    version         Prints the Packer version

```