### PR TITLE
scaleway: add pre validate step (check image and snapshot names)

### DIFF
--- a/builder/scaleway/builder.go
+++ b/builder/scaleway/builder.go
@@ -65,6 +65,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	state.Put("ui", ui)
 
 	steps := []multistep.Step{
+		&stepPreValidate{
+			Force:        b.config.PackerForce,
+			ImageName:    b.config.ImageName,
+			SnapshotName: b.config.SnapshotName,
+		},
 		&stepCreateSSHKey{
 			Debug:        b.config.PackerDebug,
 			DebugKeyPath: fmt.Sprintf("scw_%s.pem", b.config.PackerBuildName),

--- a/builder/scaleway/step_pre_validate.go
+++ b/builder/scaleway/step_pre_validate.go
@@ -30,7 +30,9 @@ func (s *stepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 	ui.Say(fmt.Sprintf("Prevalidating image name: %s", s.ImageName))
 
 	instanceAPI := instance.NewAPI(state.Get("client").(*scw.Client))
-	images, err := instanceAPI.ListImages(&instance.ListImagesRequest{})
+	images, err := instanceAPI.ListImages(
+		&instance.ListImagesRequest{Name: &s.ImageName},
+		scw.WithAllPages())
 	if err != nil {
 		err := fmt.Errorf("Error: getting image list: %s", err)
 		state.Put("error", err)
@@ -50,7 +52,9 @@ func (s *stepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 
 	ui.Say(fmt.Sprintf("Prevalidating snapshot name: %s", s.SnapshotName))
 
-	snapshots, err := instanceAPI.ListSnapshots(&instance.ListSnapshotsRequest{})
+	snapshots, err := instanceAPI.ListSnapshots(
+		&instance.ListSnapshotsRequest{Name: &s.SnapshotName},
+		scw.WithAllPages())
 	if err != nil {
 		err := fmt.Errorf("Error: getting snapshot list: %s", err)
 		state.Put("error", err)

--- a/builder/scaleway/step_pre_validate.go
+++ b/builder/scaleway/step_pre_validate.go
@@ -1,0 +1,137 @@
+package scaleway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"github.com/scaleway/scaleway-cli/pkg/api"
+)
+
+// StepPreValidate provides an opportunity to pre-validate any configuration for
+// the build before actually doing any time consuming work
+//
+type stepPreValidate struct {
+	Force        bool
+	ImageName    string
+	SnapshotName string
+}
+
+func (s *stepPreValidate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+
+	if s.Force {
+		ui.Say("Force flag found, skipping prevalidating image name")
+		return multistep.ActionContinue
+	}
+
+	client := state.Get("client").(*api.ScalewayAPI)
+	ui.Say(fmt.Sprintf("Prevalidating image name: %s", s.ImageName))
+
+	images, err := getImages(client)
+	if err != nil {
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	for _, im := range images.Images {
+		if im.Name == s.ImageName {
+			err := fmt.Errorf("Error: image name: '%s' is used by existing image with ID %s",
+				s.ImageName, im.Identifier)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	ui.Say(fmt.Sprintf("Prevalidating snapshot name: %s", s.SnapshotName))
+
+	snapshots, err := client.GetSnapshots()
+	if err != nil {
+		err := fmt.Errorf("Error: getting snapshot list: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	for _, sn := range *snapshots {
+		if sn.Name == s.SnapshotName {
+			err := fmt.Errorf("Error: snapshot name: '%s' is used by existing snapshot with ID %s",
+				s.SnapshotName, sn.Identifier)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepPreValidate) Cleanup(multistep.StateBag) {
+}
+
+// getImages returns a list of all the images in region belonging to the organization
+// configured in client.
+// The (deprecated) package github.com/scaleway/scaleway-cli/pkg/api used by Packer
+// doesn't have this function (it has instead a confusing GetImages() that returns all
+// the market images plus the private images, but the private images are missing the
+// majority of fields...).
+func getImages(client *api.ScalewayAPI) (*api.ScalewayImages, error) {
+	var computeAPI string
+	switch client.Region {
+	case "par1":
+		computeAPI = api.ComputeAPIPar1
+	case "ams1":
+		computeAPI = api.ComputeAPIAms1
+	}
+
+	values := url.Values{}
+	values.Set("organization", client.Organization)
+	resp, err := client.GetResponsePaginate(computeAPI, "images", values)
+	if err != nil {
+		return nil, fmt.Errorf("getting image list: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := handleHTTPError(resp)
+	if err != nil {
+		return nil, fmt.Errorf("reading image list body: %s", err)
+	}
+
+	var images api.ScalewayImages
+	if err = json.Unmarshal(body, &images); err != nil {
+		err = fmt.Errorf("parsing image list: %s", err)
+		return nil, err
+	}
+	return &images, nil
+}
+
+// Copied from scaleway-cli@v0.0.0-20180921094345-7b12c9699d70/pkg/api/api.go because
+// not exported.
+// handleHTTPError checks the statusCode and displays the error
+func handleHTTPError(resp *http.Response) ([]byte, error) {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= http.StatusInternalServerError {
+		return nil, errors.New(string(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		var scwError api.ScalewayAPIError
+		if err := json.Unmarshal(body, &scwError); err != nil {
+			return nil, err
+		}
+		scwError.StatusCode = resp.StatusCode
+		return nil, scwError
+	}
+	return body, nil
+}

--- a/builder/scaleway/step_pre_validate_test.go
+++ b/builder/scaleway/step_pre_validate_test.go
@@ -1,0 +1,166 @@
+package scaleway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"github.com/scaleway/scaleway-cli/pkg/api"
+)
+
+const (
+	organization = "Beagle Boys"
+	token        = "NumberOne"
+	userAgent    = "UA"
+	region       = "par1"
+)
+
+// 1. Configure a httptest server to return the list of fakeImgNames or fakeSnapNames
+//    (depending on the endpoint).
+// 2. Instantiate a Scaleway API client and wire it to send requests to the httptest
+//    server.
+// 3. Return a state (containing the client) ready to be passed to the step.Run() method.
+// 4. Return a teardown function meant to be deferred from the test.
+func setup(t *testing.T, fakeImgNames []string, fakeSnapNames []string) (*multistep.BasicStateBag, func()) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		switch r.URL.Path {
+		case "/images":
+			var imgs api.ScalewayImages
+			for _, name := range fakeImgNames {
+				imgs.Images = append(imgs.Images, api.ScalewayImage{
+					Identifier: strconv.Itoa(rand.Int()),
+					Name:       name,
+				})
+			}
+			enc.Encode(imgs)
+		case "/snapshots":
+			var snaps api.ScalewaySnapshots
+			for _, name := range fakeSnapNames {
+				snaps.Snapshots = append(snaps.Snapshots, api.ScalewaySnapshot{
+					Identifier: strconv.Itoa(rand.Int()),
+					Name:       name,
+				})
+			}
+			enc.Encode(snaps)
+		default:
+			t.Fatalf("fake server: unexpected path: %q", r.URL.Path)
+		}
+	}))
+
+	// Ugly but the only way to wire the httptest server to the client...
+	api.ComputeAPIPar1 = ts.URL
+	api.ComputeAPIAms1 = ts.URL
+
+	client, err := api.NewScalewayAPI(organization, token, userAgent, region)
+	if err != nil {
+		ts.Close()
+		t.Fatalf("setup: client: %s", err)
+	}
+	client.Logger = api.NewDisableLogger()
+
+	state := multistep.BasicStateBag{}
+	state.Put("ui", &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	state.Put("client", client)
+
+	teardown := func() {
+		ts.Close()
+	}
+	return &state, teardown
+}
+
+func TestStepPreValidate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		fakeImgNames  []string
+		fakeSnapNames []string
+		step          stepPreValidate
+		wantAction    multistep.StepAction
+	}{
+		{"happy path: both image name and snapshot name are new",
+			[]string{"image-old"},
+			[]string{"snapshot-old"},
+			stepPreValidate{
+				Force:        false,
+				ImageName:    "image-new",
+				SnapshotName: "snapshot-new",
+			},
+			multistep.ActionContinue,
+		},
+		{"want failure: old image name",
+			[]string{"image-old"},
+			[]string{"snapshot-old"},
+			stepPreValidate{
+				Force:        false,
+				ImageName:    "image-old",
+				SnapshotName: "snapshot-new",
+			},
+			multistep.ActionHalt,
+		},
+		{"want failure: old snapshot name",
+			[]string{"image-old"},
+			[]string{"snapshot-old"},
+			stepPreValidate{
+				Force:        false,
+				ImageName:    "image-new",
+				SnapshotName: "snapshot-old",
+			},
+			multistep.ActionHalt,
+		},
+		{"old image name but force flag",
+			[]string{"image-old"},
+			[]string{"snapshot-old"},
+			stepPreValidate{
+				Force:        true,
+				ImageName:    "image-old",
+				SnapshotName: "snapshot-new",
+			},
+			multistep.ActionContinue,
+		},
+		{"old snapshot name but force flag",
+			[]string{"image-old"},
+			[]string{"snapshot-old"},
+			stepPreValidate{
+				Force:        true,
+				ImageName:    "image-new",
+				SnapshotName: "snapshot-old",
+			},
+			multistep.ActionContinue,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			state, teardown := setup(t, tc.fakeImgNames, tc.fakeSnapNames)
+			defer teardown()
+
+			if action := tc.step.Run(context.Background(), state); action != tc.wantAction {
+				t.Fatalf("step.Run: want: %v; got: %v", tc.wantAction, action)
+			}
+		})
+	}
+}
+
+func TestGetImages(t *testing.T) {
+	state, teardown := setup(t, []string{"image-old-1", "image-old-2"}, []string{})
+	defer teardown()
+	client := state.Get("client").(*api.ScalewayAPI)
+
+	images, err := getImages(client)
+	if err != nil {
+		t.Fatalf("getImages: %v", err)
+	}
+	if len(images.Images) != 2 {
+		t.Fatalf("getImages: len(images): want: 2; got: %d", len(images.Images))
+	}
+}

--- a/helper/multistep/multistep.go
+++ b/helper/multistep/multistep.go
@@ -2,7 +2,10 @@
 // discrete steps.
 package multistep
 
-import "context"
+import (
+	"context"
+	"strconv"
+)
 
 // A StepAction determines the next step to take regarding multi-step actions.
 type StepAction uint
@@ -11,6 +14,18 @@ const (
 	ActionContinue StepAction = iota
 	ActionHalt
 )
+
+// Implement the stringer interface; useful for testing.
+func (a StepAction) String() string {
+	switch a {
+	case ActionContinue:
+		return "ActionContinue"
+	case ActionHalt:
+		return "ActionHalt"
+	default:
+		return "Unexpected value: " + strconv.Itoa(int(a))
+	}
+}
 
 // This is the key set in the state bag when using the basic runner to
 // signal that the step sequence was cancelled.


### PR DESCRIPTION
Closes #9839.

* scaleway: add pre validate step (check image and snapshot names)
  * Before, it was possible to create multiple images with the same name, leading to a confusing and wasteful situation (same for snapshots).
  * Now, we perform the same kind of checks done by the AWS EC2 builder, and refuse to proceed if there is an existing image with the same name (same for snapshots).
  * As usual, invoking `packer build -force` will bypass the checks.
    
* Implement Stringer inteface for multistep.StepAction (this is optional, to get better error message from tests)


