### PR TITLE
Builders vsphere-iso and vsphere-clone - CPUs is actually for cores, not sockets.

### DIFF
--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -13,7 +13,7 @@ import (
 )
 
 type HardwareConfig struct {
-	// Number of CPU sockets.
+	// Number of CPU cores.
 	CPUs int32 `mapstructure:"CPUs"`
 	// Number of CPU cores per socket.
 	CpuCores int32 `mapstructure:"cpu_cores"`

--- a/website/pages/partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the HardwareConfig struct in builder/vsphere/common/step_hardware.go; DO NOT EDIT MANUALLY -->
 
-- `CPUs` (int32) - Number of CPU sockets.
+- `CPUs` (int32) - Number of CPU cores.
 
 - `cpu_cores` (int32) - Number of CPU cores per socket.
 


### PR DESCRIPTION
I've tested the behavior of CPUs and cpu_cores against both vSphere 5.5 and 6.7. In both cases, CPUs gives you virtual cores, not sockets.
For example, I want 6 cores per socket across 2 sockets for 12 total cores. Based on the wording of this doc, I set CPUs to 2 and cpu_cores to 6. The documentation implies that will give me 2 sockets with 6 cores each. The actual behavior is you get 2 cores, and when you crack open the VMs configuration, you see that cores per socket is set to 6 -- which is meaningless.

Setting CPUs to 12 and cpu_cores to 6 gives me what I wanted. So the wording I propose is 
```
- `CPUs` (int32) - Number of CPU cores.
```

