### PR TITLE
Fix linting issues for SA6005 check

### DIFF
--- a/builder/oneandone/config.go
+++ b/builder/oneandone/config.go
@@ -94,7 +94,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 				errs, err)
 		}
 		for _, dc := range dcs {
-			if strings.ToLower(dc.CountryCode) == strings.ToLower(c.DataCenterName) {
+			if strings.EqualFold(dc.CountryCode, c.DataCenterName) {
 				c.DataCenterId = dc.Id
 				break
 			}

--- a/builder/profitbricks/step_create_server.go
+++ b/builder/profitbricks/step_create_server.go
@@ -251,7 +251,7 @@ func (d *stepCreateServer) getImageAlias(imageAlias string, location string, ui 
 			if i != "" {
 				alias = i
 			}
-			if alias != "" && strings.ToLower(alias) == strings.ToLower(imageAlias) {
+			if alias != "" && strings.EqualFold(alias, imageAlias) {
 				return alias
 			}
 		}

--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -1196,7 +1196,7 @@ func (e *DhcpConfiguration) HostByName(host string) (configDeclaration, error) {
 		switch entry.id[0].(type) {
 		case pDeclarationHost:
 			id := entry.id[0].(pDeclarationHost)
-			if strings.ToLower(id.name) == strings.ToLower(host) {
+			if strings.EqualFold(id.name, host) {
 				result = append(result, entry)
 			}
 		}
@@ -1237,7 +1237,7 @@ func (e NetworkMap) NameIntoDevices(name string) ([]string, error) {
 	var devices []string
 
 	for _, val := range e {
-		if strings.ToLower(val["name"]) == strings.ToLower(name) {
+		if strings.EqualFold(val["name"], name) {
 			devices = append(devices, val["device"])
 		}
 	}
@@ -1250,7 +1250,7 @@ func (e NetworkMap) NameIntoDevices(name string) ([]string, error) {
 }
 func (e NetworkMap) DeviceIntoName(device string) (string, error) {
 	for _, val := range e {
-		if strings.ToLower(val["device"]) == strings.ToLower(device) {
+		if strings.EqualFold(val["device"], device) {
 			return val["name"], nil
 		}
 	}


### PR DESCRIPTION
Before change
```
⇶  golangci-lint run --disable-all --no-config --enable=staticcheck | ack SA6005
builder/profitbricks/step_create_server.go:254:22: SA6005: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (staticcheck)
builder/oneandone/config.go:97:7: SA6005: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (staticcheck)
builder/vmware/common/driver_parser.go:1199:7: SA6005: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (staticcheck)
```

After change
```
⇶  golangci-lint run --disable-all --no-config --enable=staticcheck | ack SA6005

```