### PR TITLE
Add check for empty artifact.Files slice

### DIFF
--- a/post-processor/digitalocean-import/post-processor.go
+++ b/post-processor/digitalocean-import/post-processor.go
@@ -243,7 +243,6 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 }
 
 func extractImageArtifact(artifacts []string) (string, error) {
-	var source string
 	artifactCount := len(artifacts)
 
 	if artifactCount == 0 {
@@ -255,22 +254,15 @@ func extractImageArtifact(artifacts []string) (string, error) {
 	}
 
 	validSuffix := []string{"raw", "img", "qcow2", "vhdx", "vdi", "vmdk", "tar.bz2", "tar.xz", "tar.gz"}
-
-artifactLoop:
 	for _, path := range artifacts {
 		for _, suffix := range validSuffix {
 			if strings.HasSuffix(path, suffix) {
-				source = path
-				break artifactLoop
+				return path, nil
 			}
 		}
 	}
 
-	if source == "" {
-		return "", fmt.Errorf("Image file not found")
-	}
-
-	return source, nil
+	return "", fmt.Errorf("no valid image file found")
 }
 
 func uploadImageToSpaces(source string, p *PostProcessor, s *session.Session) (err error) {

--- a/post-processor/digitalocean-import/post-processor_test.go
+++ b/post-processor/digitalocean-import/post-processor_test.go
@@ -10,25 +10,30 @@ func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
 	var _ packer.PostProcessor = new(PostProcessor)
 }
 
-func TestPostProcsor_extractImageArtifact(t *testing.T) {
+func TestPostProcessor_ImageArtifactExtraction(t *testing.T) {
 	tt := []struct {
-		Name      string
-		Source    string
-		Artifacts []string
+		Name          string
+		Source        string
+		Artifacts     []string
+		ExpectedError string
 	}{
-		{Name: "EmptyArtifacts"},
+		{Name: "EmptyArtifacts", ExpectedError: "no artifacts were provided"},
 		{Name: "SingleArtifact", Source: "Sample.img", Artifacts: []string{"Sample.img"}},
 		{Name: "SupportedArtifact", Source: "Example.tar.xz", Artifacts: []string{"Sample", "SomeZip.zip", "Example.tar.xz"}},
 		{Name: "FirstSupportedArtifact", Source: "SomeVMDK.vmdk", Artifacts: []string{"Sample", "SomeVMDK.vmdk", "Example.xz"}},
-		{Name: "NonSupportedArtifact", Artifacts: []string{"Sample", "SomeZip.zip", "Example.xz"}},
+		{Name: "NonSupportedArtifact", Artifacts: []string{"Sample", "SomeZip.zip", "Example.xz"}, ExpectedError: "no valid image file found"},
 	}
 
 	for _, tc := range tt {
 		tc := tc
-		source, _ := extractImageArtifact(tc.Artifacts)
+		source, err := extractImageArtifact(tc.Artifacts)
 
 		if tc.Source != source {
 			t.Errorf("expected the source to be %q, but got %q", tc.Source, source)
+		}
+
+		if err != nil && (tc.ExpectedError != err.Error()) {
+			t.Errorf("unexpected error received; expected %q, but got %q", tc.ExpectedError, err.Error())
 		}
 	}
 }

--- a/post-processor/digitalocean-import/post-processor_test.go
+++ b/post-processor/digitalocean-import/post-processor_test.go
@@ -9,3 +9,26 @@ import (
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
 	var _ packer.PostProcessor = new(PostProcessor)
 }
+
+func TestPostProcsor_extractImageArtifact(t *testing.T) {
+	tt := []struct {
+		Name      string
+		Source    string
+		Artifacts []string
+	}{
+		{Name: "EmptyArtifacts"},
+		{Name: "SingleArtifact", Source: "Sample.img", Artifacts: []string{"Sample.img"}},
+		{Name: "SupportedArtifact", Source: "Example.tar.xz", Artifacts: []string{"Sample", "SomeZip.zip", "Example.tar.xz"}},
+		{Name: "FirstSupportedArtifact", Source: "SomeVMDK.vmdk", Artifacts: []string{"Sample", "SomeVMDK.vmdk", "Example.xz"}},
+		{Name: "NonSupportedArtifact", Artifacts: []string{"Sample", "SomeZip.zip", "Example.xz"}},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		source, _ := extractImageArtifact(tc.Artifacts)
+
+		if tc.Source != source {
+			t.Errorf("expected the source to be %q, but got %q", tc.Source, source)
+		}
+	}
+}


### PR DESCRIPTION
Tests before change
```
⇶  go test ./post-processor/digitalocean-import/... -run=TestPostProcsor_extractImageArtifact
2020/08/31 13:51:25 Looking for image in artifact
--- FAIL: TestPostProcsor_extractImageArtifact (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 7 [running]:
testing.tRunner.func1.1(0xfb0300, 0xc000456460)
        /usr/local/go/src/testing/testing.go:940 +0x2f5
testing.tRunner.func1(0xc0003ab560)
        /usr/local/go/src/testing/testing.go:943 +0x3f9
panic(0xfb0300, 0xc000456460)
        /usr/local/go/src/runtime/panic.go:969 +0x166
github.com/hashicorp/packer/post-processor/digitalocean-import.extractImageArtifact(0x0, 0x0, 0x0, 0x24, 0xc000060ea0, 0x453937, 0x1431250)
        /home/wilken/Development/packer/post-processor/digitalocean-import/post-processor.go:262 +0x36d
github.com/hashicorp/packer/post-processor/digitalocean-import.TestPostProcsor_extractImageArtifact(0xc0003ab560)
        /home/wilken/Development/packer/post-processor/digitalocean-import/post-processor_test.go:28 +0x2b0
testing.tRunner(0xc0003ab560, 0x1077208)
        /usr/local/go/src/testing/testing.go:991 +0xdc
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1042 +0x357
FAIL    github.com/hashicorp/packer/post-processor/digitalocean-import  0.009s
FAIL
```

Tests after change
```
[go-1.14.2] [1] wilken@automaton in ~/Development/packer/ on fix_9848 (ahead 1)
⇶  go test ./post-processor/digitalocean-import/... -run=TestPostProcsor_extractImageArtifact
ok      github.com/hashicorp/packer/post-processor/digitalocean-import  0.006s
```

Closes #9848 
