### PR TITLE
Add Netlify NODE_OPTIONS env to increase old space size

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -10,7 +10,7 @@
   environment = { HASHI_ENV = "production", NODE_ENV = "production" }
 
 [context.deploy-preview]
-  environment = { HASHI_ENV = "staging", NODE_ENV = "production" }
+  environment = { HASHI_ENV = "staging", NODE_ENV = "production", NODE_OPTIONS = "--max_old_space_size=9999" }
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
This is a temporary solution to avoid deploys of preview to fail with OOM. The real and more appropriate solution is being implemented by the frontend team and will roll out soon. 