### PR TITLE
HCL2: when the type of a variable is not known evaluate setting as a literal string

### DIFF
--- a/command/console_test.go
+++ b/command/console_test.go
@@ -32,6 +32,10 @@ func Test_console(t *testing.T) {
 		{"var.images", []string{"console", filepath.Join(testFixture("var-arg"), "map.pkr.hcl")}, nil, "{\n" + `  "key" = "value"` + "\n}\n"},
 		{"path.cwd", []string{"console", filepath.Join(testFixture("var-arg"), "map.pkr.hcl")}, nil, strings.ReplaceAll(cwd, `\`, `/`) + "\n"},
 		{"path.root", []string{"console", filepath.Join(testFixture("var-arg"), "map.pkr.hcl")}, nil, strings.ReplaceAll(testFixture("var-arg"), `\`, `/`) + "\n"},
+		{"var.list_of_string[0]", []string{"console", `-var=list_of_string=["first"]`, filepath.Join(testFixture("hcl", "variables", "list_of_string"))}, nil, "first\n"},
+		{"var.untyped[2]", []string{"console", filepath.Join(testFixture("hcl", "variables", "untyped_var"))}, nil, "strings\n"},
+		{"var.untyped", []string{"console", `-var=untyped=just_a_string`, filepath.Join(testFixture("hcl", "variables", "untyped_var"))}, nil, "just_a_string\n"},
+		{"var.untyped", []string{"console", filepath.Join(testFixture("hcl", "variables", "untyped_var", "var.pkr.hcl"))}, []string{"PKR_VAR_untyped=just_a_string"}, "just_a_string\n"},
 	}
 
 	for _, tc := range tc {

--- a/command/inspect_test.go
+++ b/command/inspect_test.go
@@ -69,13 +69,19 @@ local.fruit: "banana"
       <no post-processor>
 
 `},
-		{[]string{"inspect", "-var=fruit=peach", "-var=unknown_string=also_peach", `-var=unknown_unknown="peach_too"`, filepath.Join(testFixture("hcl"), "inspect", "fruit_string.pkr.hcl")}, nil, `Packer Inspect: HCL2 mode
+		{[]string{"inspect", "-var=fruit=peach",
+			"-var=unknown_string=also_peach",
+			`-var=unknown_unknown=["peach_too"]`,
+			`-var=unknown_list_of_string=["first_peach", "second_peach"]`,
+			filepath.Join(testFixture("hcl"), "inspect", "fruit_string.pkr.hcl")}, nil,
+			`Packer Inspect: HCL2 mode
 
 > input-variables:
 
 var.fruit: "peach"
+var.unknown_list_of_string: "[\n  \"first_peach\",\n  \"second_peach\",\n]"
 var.unknown_string: "also_peach"
-var.unknown_unknown: "peach_too"
+var.unknown_unknown: "[\"peach_too\"]"
 
 > local-variables:
 
@@ -88,6 +94,7 @@ var.unknown_unknown: "peach_too"
 > input-variables:
 
 var.fruit: "peach"
+var.unknown_list_of_string: "<unknown>"
 var.unknown_string: "<unknown>"
 var.unknown_unknown: "<unknown>"
 

--- a/command/test-fixtures/hcl/inspect/fruit_string.pkr.hcl
+++ b/command/test-fixtures/hcl/inspect/fruit_string.pkr.hcl
@@ -8,5 +8,10 @@ variable "unknown_string" {
   type = string
 }
 
+
+variable "unknown_list_of_string" {
+  type = list(string)
+}
+
 variable "unknown_unknown" {
 }

--- a/command/test-fixtures/hcl/variables/list_of_string/var.pkr.hcl
+++ b/command/test-fixtures/hcl/variables/list_of_string/var.pkr.hcl
@@ -1,0 +1,4 @@
+
+variable "list_of_string" {
+  type = list(string)
+}

--- a/command/test-fixtures/hcl/variables/untyped_var/settings.auto.pkrvars.hcl
+++ b/command/test-fixtures/hcl/variables/untyped_var/settings.auto.pkrvars.hcl
@@ -1,0 +1,2 @@
+
+untyped = ["slice", "of", "strings"]

--- a/command/test-fixtures/hcl/variables/untyped_var/var.pkr.hcl
+++ b/command/test-fixtures/hcl/variables/untyped_var/var.pkr.hcl
@@ -1,0 +1,3 @@
+
+variable "untyped" {
+}

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -426,7 +426,9 @@ func (cfg *PackerConfig) collectInputVariableValues(env []string, files []*hcl.F
 // The specified filename is to identify the source of where value originated from in the diagnostics report, if there is an error.
 func expressionFromVariableDefinition(filename string, value string, variableType cty.Type) (hclsyntax.Expression, hcl.Diagnostics) {
 	switch variableType {
-	case cty.String, cty.Number:
+	case cty.String, cty.Number, cty.NilType:
+		// when the type is nil (not set in a variable block) we default to
+		// interpreting everything as a string literal.
 		return &hclsyntax.LiteralValueExpr{Val: cty.StringVal(value)}, nil
 	default:
 		return hclsyntax.ParseExpression([]byte(value), filename, hcl.Pos{Line: 1, Column: 1})

--- a/website/pages/docs/from-1.5/variables.mdx
+++ b/website/pages/docs/from-1.5/variables.mdx
@@ -132,6 +132,13 @@ Constraints](https://www.terraform.io/docs/configuration/types.html).
 If both the `type` and `default` arguments are specified, the given default
 value must be convertible to the specified type.
 
+If only `default` is specified, the type of the default value will be used.
+
+When the `type` and `default` are both *not* specified and you try to set a
+variable [from env vars](#environment-variables) or [from the command
+line](#variables-on-the-command-line), the variable will always be interpreted
+as a string.
+
 ## Input Variable Documentation
 
 Because the input variables of a build are part of its user interface, you can


### PR DESCRIPTION
this is based upon the tests of #9832, that is to merge/review first

close #9789