### PR TITLE
Allows publishing to a  Shared Image Gallery with a different subscription id

### DIFF
--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -128,8 +128,8 @@ func byConcatDecorators(decorators ...autorest.RespondDecorator) autorest.Respon
 	}
 }
 
-func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string,
-	cloud *azure.Environment, SharedGalleryTimeout time.Duration, PollingDuration time.Duration,
+func NewAzureClient(subscriptionID, sigSubscriptionID, resourceGroupName, storageAccountName string,
+	cloud *azure.Environment, sharedGalleryTimeout time.Duration, pollingDuration time.Duration,
 	servicePrincipalToken, servicePrincipalTokenVault *adal.ServicePrincipalToken) (*AzureClient, error) {
 
 	var azureClient = &AzureClient{}
@@ -141,56 +141,56 @@ func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string
 	azureClient.DeploymentsClient.RequestInspector = withInspection(maxlen)
 	azureClient.DeploymentsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.DeploymentsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DeploymentsClient.UserAgent)
-	azureClient.DeploymentsClient.Client.PollingDuration = PollingDuration
+	azureClient.DeploymentsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.DeploymentOperationsClient = resources.NewDeploymentOperationsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DeploymentOperationsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DeploymentOperationsClient.RequestInspector = withInspection(maxlen)
 	azureClient.DeploymentOperationsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.DeploymentOperationsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DeploymentOperationsClient.UserAgent)
-	azureClient.DeploymentOperationsClient.Client.PollingDuration = PollingDuration
+	azureClient.DeploymentOperationsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.DisksClient = compute.NewDisksClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DisksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DisksClient.RequestInspector = withInspection(maxlen)
 	azureClient.DisksClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.DisksClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DisksClient.UserAgent)
-	azureClient.DisksClient.Client.PollingDuration = PollingDuration
+	azureClient.DisksClient.Client.PollingDuration = pollingDuration
 
 	azureClient.GroupsClient = resources.NewGroupsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.GroupsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.GroupsClient.RequestInspector = withInspection(maxlen)
 	azureClient.GroupsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GroupsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GroupsClient.UserAgent)
-	azureClient.GroupsClient.Client.PollingDuration = PollingDuration
+	azureClient.GroupsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.ImagesClient = compute.NewImagesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.ImagesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.ImagesClient.RequestInspector = withInspection(maxlen)
 	azureClient.ImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.ImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.ImagesClient.UserAgent)
-	azureClient.ImagesClient.Client.PollingDuration = PollingDuration
+	azureClient.ImagesClient.Client.PollingDuration = pollingDuration
 
 	azureClient.InterfacesClient = network.NewInterfacesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.InterfacesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.InterfacesClient.RequestInspector = withInspection(maxlen)
 	azureClient.InterfacesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.InterfacesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.InterfacesClient.UserAgent)
-	azureClient.InterfacesClient.Client.PollingDuration = PollingDuration
+	azureClient.InterfacesClient.Client.PollingDuration = pollingDuration
 
 	azureClient.SubnetsClient = network.NewSubnetsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.SubnetsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.SubnetsClient.RequestInspector = withInspection(maxlen)
 	azureClient.SubnetsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.SubnetsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.SubnetsClient.UserAgent)
-	azureClient.SubnetsClient.Client.PollingDuration = PollingDuration
+	azureClient.SubnetsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.VirtualNetworksClient = network.NewVirtualNetworksClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.VirtualNetworksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.VirtualNetworksClient.RequestInspector = withInspection(maxlen)
 	azureClient.VirtualNetworksClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.VirtualNetworksClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.VirtualNetworksClient.UserAgent)
-	azureClient.VirtualNetworksClient.Client.PollingDuration = PollingDuration
+	azureClient.VirtualNetworksClient.Client.PollingDuration = pollingDuration
 
 	azureClient.SecurityGroupsClient = network.NewSecurityGroupsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.SecurityGroupsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
@@ -203,42 +203,44 @@ func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string
 	azureClient.PublicIPAddressesClient.RequestInspector = withInspection(maxlen)
 	azureClient.PublicIPAddressesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.PublicIPAddressesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.PublicIPAddressesClient.UserAgent)
-	azureClient.PublicIPAddressesClient.Client.PollingDuration = PollingDuration
+	azureClient.PublicIPAddressesClient.Client.PollingDuration = pollingDuration
 
 	azureClient.VirtualMachinesClient = compute.NewVirtualMachinesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.VirtualMachinesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.VirtualMachinesClient.RequestInspector = withInspection(maxlen)
 	azureClient.VirtualMachinesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
 	azureClient.VirtualMachinesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.VirtualMachinesClient.UserAgent)
-	azureClient.VirtualMachinesClient.Client.PollingDuration = PollingDuration
+	azureClient.VirtualMachinesClient.Client.PollingDuration = pollingDuration
 
 	azureClient.SnapshotsClient = compute.NewSnapshotsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.SnapshotsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.SnapshotsClient.RequestInspector = withInspection(maxlen)
 	azureClient.SnapshotsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.SnapshotsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.SnapshotsClient.UserAgent)
-	azureClient.SnapshotsClient.Client.PollingDuration = PollingDuration
+	azureClient.SnapshotsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.AccountsClient = armStorage.NewAccountsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.AccountsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.AccountsClient.RequestInspector = withInspection(maxlen)
 	azureClient.AccountsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.AccountsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.AccountsClient.UserAgent)
-	azureClient.AccountsClient.Client.PollingDuration = PollingDuration
+	azureClient.AccountsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.GalleryImageVersionsClient = newCompute.NewGalleryImageVersionsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.GalleryImageVersionsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.GalleryImageVersionsClient.RequestInspector = withInspection(maxlen)
 	azureClient.GalleryImageVersionsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GalleryImageVersionsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GalleryImageVersionsClient.UserAgent)
-	azureClient.GalleryImageVersionsClient.Client.PollingDuration = SharedGalleryTimeout
+	azureClient.GalleryImageVersionsClient.Client.PollingDuration = sharedGalleryTimeout
+	azureClient.GalleryImageVersionsClient.SubscriptionID = sigSubscriptionID
 
 	azureClient.GalleryImagesClient = newCompute.NewGalleryImagesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.GalleryImagesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.GalleryImagesClient.RequestInspector = withInspection(maxlen)
 	azureClient.GalleryImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GalleryImagesClient.UserAgent)
-	azureClient.GalleryImagesClient.Client.PollingDuration = PollingDuration
+	azureClient.GalleryImagesClient.Client.PollingDuration = pollingDuration
+	azureClient.GalleryImagesClient.SubscriptionID = sigSubscriptionID
 
 	keyVaultURL, err := url.Parse(cloud.KeyVaultEndpoint)
 	if err != nil {
@@ -250,7 +252,7 @@ func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string
 	azureClient.VaultClient.RequestInspector = withInspection(maxlen)
 	azureClient.VaultClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.VaultClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.VaultClient.UserAgent)
-	azureClient.VaultClient.Client.PollingDuration = PollingDuration
+	azureClient.VaultClient.Client.PollingDuration = pollingDuration
 
 	// This client is different than the above because it manages the vault
 	// itself rather than the contents of the vault.
@@ -259,7 +261,7 @@ func NewAzureClient(subscriptionID, resourceGroupName, storageAccountName string
 	azureClient.VaultClientDelete.RequestInspector = withInspection(maxlen)
 	azureClient.VaultClientDelete.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.VaultClientDelete.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.VaultClientDelete.UserAgent)
-	azureClient.VaultClientDelete.Client.PollingDuration = PollingDuration
+	azureClient.VaultClientDelete.Client.PollingDuration = pollingDuration
 
 	// If this is a managed disk build, this should be ignored.
 	if resourceGroupName != "" && storageAccountName != "" {

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -84,6 +84,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	ui.Message("Creating Azure Resource Manager (ARM) client ...")
 	azureClient, err := NewAzureClient(
 		b.config.ClientConfig.SubscriptionID,
+		b.config.SharedGalleryDestination.SigDestinationSubscription,
 		b.config.ResourceGroupName,
 		b.config.StorageAccount,
 		b.config.ClientConfig.CloudEnvironment(),

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -90,6 +90,7 @@ type SharedImageGallery struct {
 }
 
 type SharedImageGalleryDestination struct {
+	SigDestinationSubscription       string   `mapstructure:"subscription"`
 	SigDestinationResourceGroup      string   `mapstructure:"resource_group"`
 	SigDestinationGalleryName        string   `mapstructure:"gallery_name"`
 	SigDestinationImageName          string   `mapstructure:"image_name"`
@@ -118,31 +119,64 @@ type Config struct {
 	// Use a [Shared Gallery
 	// image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
 	// as the source for this build. *VHD targets are incompatible with this
-	// build type* - the target must be a *Managed Image*.
+	// build type* - the target must be a *Managed Image*. When using shared_image_gallery as a source, image_publisher,
+	// image_offer, image_sku, image_version, and custom_managed_image_name should not be set.
 	//
-	//     "shared_image_gallery": {
-	//         "subscription": "00000000-0000-0000-0000-00000000000",
-	//         "resource_group": "ResourceGroup",
-	//         "gallery_name": "GalleryName",
-	//         "image_name": "ImageName",
-	//         "image_version": "1.0.0"
-	//     }
-	//     "managed_image_name": "TargetImageName",
-	//     "managed_image_resource_group_name": "TargetResourceGroup"
+	// In JSON
+	// ```json
+	// "shared_image_gallery": {
+	//     "subscription": "00000000-0000-0000-0000-00000000000",
+	//     "resource_group": "ResourceGroup",
+	//     "gallery_name": "GalleryName",
+	//     "image_name": "ImageName",
+	//     "image_version": "1.0.0"
+	// }
+	// "managed_image_name": "TargetImageName",
+	// "managed_image_resource_group_name": "TargetResourceGroup"
+	// ```
+	// In HCL2
+	// ```hcl
+	// shared_image_gallery {
+	//     subscription = "00000000-0000-0000-0000-00000000000"
+	//	   resource_group = "ResourceGroup"
+	//	   gallery_name = "GalleryName"
+	//	   image_name = "ImageName"
+	//	   image_version = "1.0.0"
+	// }
+	// managed_image_name = "TargetImageName"
+	// managed_image_resource_group_name = "TargetResourceGroup"
+	// ```
 	SharedGallery SharedImageGallery `mapstructure:"shared_image_gallery" required:"false"`
 	// The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
 	//
 	// Following is an example.
 	//
-	//     "shared_image_gallery_destination": {
-	//         "resource_group": "ResourceGroup",
-	//         "gallery_name": "GalleryName",
-	//         "image_name": "ImageName",
-	//         "image_version": "1.0.0",
-	//         "replication_regions": ["regionA", "regionB", "regionC"]
-	//     }
-	//     "managed_image_name": "TargetImageName",
-	//     "managed_image_resource_group_name": "TargetResourceGroup"
+	// In JSON
+	// ```json
+	// "shared_image_gallery_destination": {
+	//     "subscription": "00000000-0000-0000-0000-00000000000",
+	//     "resource_group": "ResourceGroup",
+	//     "gallery_name": "GalleryName",
+	//     "image_name": "ImageName",
+	//     "image_version": "1.0.0",
+	//     "replication_regions": ["regionA", "regionB", "regionC"]
+	// }
+	// "managed_image_name": "TargetImageName",
+	// "managed_image_resource_group_name": "TargetResourceGroup"
+	// ```
+	// In HCL2
+	// ```hcl
+	// shared_image_gallery_destination {
+	//     subscription = "00000000-0000-0000-0000-00000000000"
+	//	   resource_group = "ResourceGroup"
+	//	   gallery_name = "GalleryName"
+	//	   image_name = "ImageName"
+	//	   image_version = "1.0.0"
+	//     replication_regions = ["regionA", "regionB", "regionC"]
+	// }
+	// managed_image_name = "TargetImageName"
+	// managed_image_resource_group_name = "TargetResourceGroup"
+	// ```
 	SharedGalleryDestination SharedImageGalleryDestination `mapstructure:"shared_image_gallery_destination"`
 	// How long to wait for an image to be published to the shared image
 	// gallery before timing out. If your Packer build is failing on the
@@ -977,6 +1011,9 @@ func assertRequiredParametersSet(c *Config, errs *packer.MultiError) {
 		}
 		if len(c.SharedGalleryDestination.SigDestinationReplicationRegions) == 0 {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("A list of replication_regions must be specified for shared_image_gallery_destination"))
+		}
+		if c.SharedGalleryDestination.SigDestinationSubscription == "" {
+			c.SharedGalleryDestination.SigDestinationSubscription = c.ClientConfig.SubscriptionID
 		}
 	}
 	if c.SharedGalleryTimeout == 0 {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -138,10 +138,10 @@ type Config struct {
 	// ```hcl
 	// shared_image_gallery {
 	//     subscription = "00000000-0000-0000-0000-00000000000"
-	//	   resource_group = "ResourceGroup"
-	//	   gallery_name = "GalleryName"
-	//	   image_name = "ImageName"
-	//	   image_version = "1.0.0"
+	//     resource_group = "ResourceGroup"
+	//     gallery_name = "GalleryName"
+	//     image_name = "ImageName"
+	//     image_version = "1.0.0"
 	// }
 	// managed_image_name = "TargetImageName"
 	// managed_image_resource_group_name = "TargetResourceGroup"

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -168,10 +168,10 @@ type Config struct {
 	// ```hcl
 	// shared_image_gallery_destination {
 	//     subscription = "00000000-0000-0000-0000-00000000000"
-	//	   resource_group = "ResourceGroup"
-	//	   gallery_name = "GalleryName"
-	//	   image_name = "ImageName"
-	//	   image_version = "1.0.0"
+	//     resource_group = "ResourceGroup"
+	//     gallery_name = "GalleryName"
+	//     image_name = "ImageName"
+	//     image_version = "1.0.0"
 	//     replication_regions = ["regionA", "regionB", "regionC"]
 	// }
 	// managed_image_name = "TargetImageName"

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -311,6 +311,7 @@ func (*FlatSharedImageGallery) HCL2Spec() map[string]hcldec.Spec {
 // FlatSharedImageGalleryDestination is an auto-generated flat version of SharedImageGalleryDestination.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatSharedImageGalleryDestination struct {
+	SigDestinationSubscription       *string  `mapstructure:"subscription" cty:"subscription" hcl:"subscription"`
 	SigDestinationResourceGroup      *string  `mapstructure:"resource_group" cty:"resource_group" hcl:"resource_group"`
 	SigDestinationGalleryName        *string  `mapstructure:"gallery_name" cty:"gallery_name" hcl:"gallery_name"`
 	SigDestinationImageName          *string  `mapstructure:"image_name" cty:"image_name" hcl:"image_name"`
@@ -330,6 +331,7 @@ func (*SharedImageGalleryDestination) FlatMapstructure() interface{ HCL2Spec() m
 // The decoded values from this spec will then be applied to a FlatSharedImageGalleryDestination.
 func (*FlatSharedImageGalleryDestination) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
+		"subscription":        &hcldec.AttrSpec{Name: "subscription", Type: cty.String, Required: false},
 		"resource_group":      &hcldec.AttrSpec{Name: "resource_group", Type: cty.String, Required: false},
 		"gallery_name":        &hcldec.AttrSpec{Name: "gallery_name", Type: cty.String, Required: false},
 		"image_name":          &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},

--- a/website/pages/docs/builders/azure/arm.mdx
+++ b/website/pages/docs/builders/azure/arm.mdx
@@ -108,21 +108,7 @@ When creating a managed image the following additional options are required:
   [documentation](https://docs.microsoft.com/en-us/azure/storage/storage-managed-disks-overview#images)
   to learn more about managed images.
 
-Creating a managed image using a [Shared Gallery image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/) as the source can be achieved by specifying the `shared_image_gallery` configuration option.
-When using shared_image_gallery as a source, image_publisher, image_offer, image_sku, image_version, and
-custom_managed_image_name should not be set.
-
-The following is an example.
-
-      "shared_image_gallery": {
-          "subscription": "00000000-0000-0000-0000-00000000000",
-          "resource_group": "ResourceGroup",
-          "gallery_name": "GalleryName",
-          "image_name": "ImageName",
-          "image_version": "1.0.0"
-      }
-      "managed_image_name": "TargetImageName",
-      "managed_image_resource_group_name": "TargetResourceGroup"
+Creating a managed image using a [Shared Gallery image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/) as the source can be achieved by specifying the [shared_image_gallery](#shared_image_gallery) configuration option.
 
 #### Resource Group Usage
 
@@ -251,6 +237,9 @@ after that. The possible states, in case you want to wait for another state,
 [are documented
 here](https://technet.microsoft.com/en-us/library/hh824815.aspx)
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "provisioners": [
@@ -270,6 +259,26 @@ here](https://technet.microsoft.com/en-us/library/hh824815.aspx)
 }
 ```
 
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+provisioner "powershell" {
+   inline = [
+        " # NOTE: the following *3* lines are only needed if the you have installed the Guest Agent.",
+        "  while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "  while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "  while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+
+        "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit /mode:vm",
+        "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
+   ]
+}
+```
+
+</Tab>
+</Tabs>
+
 The Windows Guest Agent participates in the Sysprep process. The agent must be
 fully installed before the VM can be sysprep'ed. To ensure this is true all
 agent services must be running before executing sysprep.exe. The above JSON
@@ -287,6 +296,9 @@ correctly -- for example, if it is waiting for a reboot that you never perform.
 The following provisioner snippet shows how to deprovision a Linux VM.
 Deprovision should be the last operation executed by a build.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "provisioners": [
@@ -301,6 +313,22 @@ Deprovision should be the last operation executed by a build.
   ]
 }
 ```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+provisioner "shell" {
+   execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'"
+   inline = [
+        "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
+   ]
+   inline_shebang = "/bin/sh -x"
+}
+```
+
+</Tab>
+</Tabs>
 
 To learn more about the Linux deprovision process please see WALinuxAgent's
 [README](https://github.com/Azure/WALinuxAgent/blob/master/README.md).

--- a/website/pages/partials/builder/azure/arm/Config-not-required.mdx
+++ b/website/pages/partials/builder/azure/arm/Config-not-required.mdx
@@ -14,31 +14,64 @@
 - `shared_image_gallery` (SharedImageGallery) - Use a [Shared Gallery
   image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
   as the source for this build. *VHD targets are incompatible with this
-  build type* - the target must be a *Managed Image*.
+  build type* - the target must be a *Managed Image*. When using shared_image_gallery as a source, image_publisher,
+  image_offer, image_sku, image_version, and custom_managed_image_name should not be set.
   
-      "shared_image_gallery": {
-          "subscription": "00000000-0000-0000-0000-00000000000",
-          "resource_group": "ResourceGroup",
-          "gallery_name": "GalleryName",
-          "image_name": "ImageName",
-          "image_version": "1.0.0"
-      }
-      "managed_image_name": "TargetImageName",
-      "managed_image_resource_group_name": "TargetResourceGroup"
+  In JSON
+  ```json
+  "shared_image_gallery": {
+      "subscription": "00000000-0000-0000-0000-00000000000",
+      "resource_group": "ResourceGroup",
+      "gallery_name": "GalleryName",
+      "image_name": "ImageName",
+      "image_version": "1.0.0"
+  }
+  "managed_image_name": "TargetImageName",
+  "managed_image_resource_group_name": "TargetResourceGroup"
+  ```
+  In HCL2
+  ```hcl
+  shared_image_gallery {
+      subscription = "00000000-0000-0000-0000-00000000000"
+  	   resource_group = "ResourceGroup"
+  	   gallery_name = "GalleryName"
+  	   image_name = "ImageName"
+  	   image_version = "1.0.0"
+  }
+  managed_image_name = "TargetImageName"
+  managed_image_resource_group_name = "TargetResourceGroup"
+  ```
 
 - `shared_image_gallery_destination` (SharedImageGalleryDestination) - The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
   
   Following is an example.
   
-      "shared_image_gallery_destination": {
-          "resource_group": "ResourceGroup",
-          "gallery_name": "GalleryName",
-          "image_name": "ImageName",
-          "image_version": "1.0.0",
-          "replication_regions": ["regionA", "regionB", "regionC"]
-      }
-      "managed_image_name": "TargetImageName",
-      "managed_image_resource_group_name": "TargetResourceGroup"
+  In JSON
+  ```json
+  "shared_image_gallery_destination": {
+      "subscription": "00000000-0000-0000-0000-00000000000",
+      "resource_group": "ResourceGroup",
+      "gallery_name": "GalleryName",
+      "image_name": "ImageName",
+      "image_version": "1.0.0",
+      "replication_regions": ["regionA", "regionB", "regionC"]
+  }
+  "managed_image_name": "TargetImageName",
+  "managed_image_resource_group_name": "TargetResourceGroup"
+  ```
+  In HCL2
+  ```hcl
+  shared_image_gallery_destination {
+      subscription = "00000000-0000-0000-0000-00000000000"
+  	   resource_group = "ResourceGroup"
+  	   gallery_name = "GalleryName"
+  	   image_name = "ImageName"
+  	   image_version = "1.0.0"
+      replication_regions = ["regionA", "regionB", "regionC"]
+  }
+  managed_image_name = "TargetImageName"
+  managed_image_resource_group_name = "TargetResourceGroup"
+  ```
 
 - `shared_image_gallery_timeout` (duration string | ex: "1h5m2s") - How long to wait for an image to be published to the shared image
   gallery before timing out. If your Packer build is failing on the

--- a/website/pages/partials/builder/azure/arm/Config-not-required.mdx
+++ b/website/pages/partials/builder/azure/arm/Config-not-required.mdx
@@ -33,10 +33,10 @@
   ```hcl
   shared_image_gallery {
       subscription = "00000000-0000-0000-0000-00000000000"
-  	   resource_group = "ResourceGroup"
-  	   gallery_name = "GalleryName"
-  	   image_name = "ImageName"
-  	   image_version = "1.0.0"
+      resource_group = "ResourceGroup"
+      gallery_name = "GalleryName"
+      image_name = "ImageName"
+      image_version = "1.0.0"
   }
   managed_image_name = "TargetImageName"
   managed_image_resource_group_name = "TargetResourceGroup"

--- a/website/pages/partials/builder/azure/arm/Config-not-required.mdx
+++ b/website/pages/partials/builder/azure/arm/Config-not-required.mdx
@@ -63,10 +63,10 @@
   ```hcl
   shared_image_gallery_destination {
       subscription = "00000000-0000-0000-0000-00000000000"
-  	   resource_group = "ResourceGroup"
-  	   gallery_name = "GalleryName"
-  	   image_name = "ImageName"
-  	   image_version = "1.0.0"
+      resource_group = "ResourceGroup"
+      gallery_name = "GalleryName"
+      image_name = "ImageName"
+      image_version = "1.0.0"
       replication_regions = ["regionA", "regionB", "regionC"]
   }
   managed_image_name = "TargetImageName"

--- a/website/pages/partials/builder/azure/arm/SharedImageGalleryDestination-not-required.mdx
+++ b/website/pages/partials/builder/azure/arm/SharedImageGalleryDestination-not-required.mdx
@@ -1,5 +1,7 @@
 <!-- Code generated from the comments of the SharedImageGalleryDestination struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
+- `subscription` (string) - Sig Destination Subscription
+
 - `resource_group` (string) - Sig Destination Resource Group
 
 - `gallery_name` (string) - Sig Destination Gallery Name


### PR DESCRIPTION
This adds the subscription option to the `shared_image_gallery_destination`.  This is done by updating the client with the destination subscription id. 

Closes https://github.com/hashicorp/packer/issues/8608