### PR TITLE
Add NVMe controller support to vsphere-iso builder

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -98,7 +98,7 @@ type NIC struct {
 }
 
 type CreateConfig struct {
-	DiskControllerType []string // example: "scsi", "pvscsi", "lsilogic"
+	DiskControllerType []string // example: "scsi", "pvscsi", "nvme", "lsilogic"
 
 	Annotation    string
 	Name          string
@@ -841,7 +841,13 @@ func addDisk(_ *VCenterDriver, devices object.VirtualDeviceList, config *CreateC
 
 	var controllers []types.BaseVirtualController
 	for _, controllerType := range config.DiskControllerType {
-		device, err := devices.CreateSCSIController(controllerType)
+		var device types.BaseVirtualDevice
+		var err error
+		if controllerType == "nvme" {
+			device, err = devices.CreateNVMEController()
+		} else {
+			device, err = devices.CreateSCSIController(controllerType)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -149,7 +149,10 @@ type CreateConfig struct {
 	// here](https://code.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
 	// for a full list of possible values.
 	GuestOSType string `mapstructure:"guest_os_type"`
-	// Set VM disk controller type. Example `lsilogic`, pvscsi`, or `scsi`. Use a list to define additional controllers. Defaults to `lsilogic`
+	// Set VM disk controller type. Example `lsilogic`, `pvscsi`, `nvme`, or `scsi`. Use a list to define additional controllers.
+	// Defaults to `lsilogic`. See
+	// [SCSI, SATA, and NVMe Storage Controller Conditions, Limitations, and Compatibility](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-5872D173-A076-42FE-8D0B-9DB0EB0E7362.html#GUID-5872D173-A076-42FE-8D0B-9DB0EB0E7362)
+	// for additional details.
 	DiskControllerType []string `mapstructure:"disk_controller_type"`
 	// A collection of one or more disks to be provisioned along with the VM.
 	Storage []DiskConfig `mapstructure:"storage"`


### PR DESCRIPTION
Adds support for NVMe storage controllers to the existing `disk_controller_type` setting in the `vsphere-iso` builder.

Live tests work in my VMware Cloud on AWS test environment for both Ubuntu Server 20.04.01 (Subiquity) and Windows Server 2019 with virtual hardware version 17 with only one NVMe storage controller and virtual hard disk, as well as the Paravirtual SCSI controller for the OS disk and NVMe for the secondary disk.

I didn't commit the following change since most environments don't have NVMe storage yet, but I changed [builder/vsphere/iso/builder_acc_test.go#L425](github.com/hashicorp/packer/blob/master/builder/vsphere/iso/builder_acc_test.go#L425) from "pvscsi" to "nvme" and ran the following:

### First test run without acceptance tests passes

<details>

```
$ PACKER_ACC=1 ACC_TEST_BUILDERS=vsphere-iso ACC_TEST_PROVISIONERS=all go test ./builder/vsphere/iso/ -v
=== RUN   TestISOBuilderAcc_default
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 1 error occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 1 error occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_default (0.01s)
=== RUN   TestISOBuilderAcc_notes
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 1 error occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 1 error occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_notes (0.00s)
=== RUN   TestISOBuilderAcc_hardware
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 1 error occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 1 error occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_hardware (0.01s)
=== RUN   TestISOBuilderAcc_limit
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 1 error occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 1 error occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_limit (0.00s)
=== RUN   TestISOBuilderAcc_sata
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 1 error occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 1 error occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_sata (0.00s)
=== RUN   TestISOBuilderAcc_cdrom
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 1 error occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 1 error occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_cdrom (0.00s)
=== RUN   TestISOBuilderAcc_networkCard
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 2 errors occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
        * Deprecated configuration key: 'network_card'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 2 errors occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
                * Deprecated configuration key: 'network_card'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_networkCard (0.00s)
=== RUN   TestISOBuilderAcc_createFloppy
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 1 error occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 1 error occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_createFloppy (0.00s)
=== RUN   TestISOBuilderAcc_full
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 3 errors occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
        * Deprecated configuration key: 'disk_thin_provisioned'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
        * Deprecated configuration key: 'network_card'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 3 errors occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
                * Deprecated configuration key: 'disk_thin_provisioned'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
                * Deprecated configuration key: 'network_card'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_full (0.00s)
=== RUN   TestISOBuilderAcc_bootOrder
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 3 errors occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
        * Deprecated configuration key: 'disk_thin_provisioned'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
        * Deprecated configuration key: 'network_card'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 3 errors occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
                * Deprecated configuration key: 'disk_thin_provisioned'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
                * Deprecated configuration key: 'network_card'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_bootOrder (0.01s)
=== RUN   TestISOBuilderAcc_cluster
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 1 error occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 1 error occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_cluster (0.00s)
=== RUN   TestISOBuilderAcc_clusterDRS
2020/09/02 16:50:58 [DEBUG] Parsing template...
2020/09/02 16:50:58 [DEBUG] Initializing core...
2020/09/02 16:50:58 [DEBUG] Retrieving 'test' build
2020/09/02 16:50:58 [DEBUG] Preparing 'test' build
2020/09/02 16:50:58 Build 'test' prepare failure: 2 errors occurred:
        * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
        * Deprecated configuration key: 'network'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


    testing.go:146: Prepare error: 2 errors occurred:
                * Deprecated configuration key: 'disk_size'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
                * Deprecated configuration key: 'network'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.


--- FAIL: TestISOBuilderAcc_clusterDRS (0.00s)
=== RUN   TestCreateConfig_Prepare
--- PASS: TestCreateConfig_Prepare (0.00s)
=== RUN   TestStepCreateVM_Run
2020/09/02 16:50:58 ui: Creating VM...
--- PASS: TestStepCreateVM_Run (0.00s)
=== RUN   TestStepCreateVM_RunHalt
2020/09/02 16:50:58 ui: Creating VM...
--- PASS: TestStepCreateVM_RunHalt (0.00s)
=== RUN   TestStepCreateVM_Cleanup
2020/09/02 16:50:58 ui: Destroying VM...
2020/09/02 16:50:58 ui: Destroying VM...
2020/09/02 16:50:58 ui: Destroying VM...
2020/09/02 16:50:58 ui: Destroying VM...
2020/09/02 16:50:58 ui error: destroy failed
--- PASS: TestStepCreateVM_Cleanup (0.00s)
=== RUN   TestStepRemoteUpload_Run
2020/09/02 16:50:58 ui: Uploading path to packer_cache/path
--- PASS: TestStepRemoteUpload_Run (0.00s)
=== RUN   TestStepRemoteUpload_SkipRun
--- PASS: TestStepRemoteUpload_SkipRun (0.00s)
FAIL
FAIL    github.com/hashicorp/packer/builder/vsphere/iso 1.520s
FAIL
```

</details>

Created bug ticket #9878 to track. Let me know how you want to proceed.

Closes #9869
