### PR TITLE
provisioner/powershell: Add wrapper script to default provisioner runs

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -37,7 +37,7 @@ var psEscape = strings.NewReplacer(
 	"'", "`'",
 )
 
-const PowershellWrapperScript string = `
+const PowershellWrapperScriptLongVersion string = `
 if (Test-Path variable:global:ProgressPreference) {
   set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'
 }
@@ -60,7 +60,7 @@ if ( $LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0 ) {
 exit $exitstatus
 `
 
-const PowershellWrapperScriptShortVersion string = `
+const PowershellWrapperScript string = `
 if (Test-Path variable:global:ProgressPreference) {
   set-variable -name variable:global:ProgressPreference -value 'SilentlyContinue'
 }

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -44,6 +44,7 @@ if (Test-Path variable:global:ProgressPreference) {
 }
 set-variable -name variable:global:ErrorActionPreference -value 'Continue'
 $global:LASTEXITCODE = 0
+$global:lastcmdlet = $null
 trap [Exception] {write-error ($_.Exception.Message);exit 1}
 
 {{if .DebugMode}}
@@ -52,16 +53,24 @@ Set-PsDebug -Trace {{.DebugMode}}
 
 {{.Vars}}
 
+$results = {
+
 {{.Payload}}
 
+$global:lastcmdlet = $?
+}.invokereturnasis()
+
 $exitstatus = 1
-if ($?) {
+
+if ($lastcmdlet) {
 	$exitstatus = 0
 }
 
 if ( $LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0 ) {
  $exitstatus = $LASTEXITCODE
 }
+
+Write-Host $results
 
 exit $exitstatus
 `

--- a/provisioner/powershell/provisioner.hcl2spec.go
+++ b/provisioner/powershell/provisioner.hcl2spec.go
@@ -34,6 +34,7 @@ type FlatConfig struct {
 	ElevatedPassword       *string           `mapstructure:"elevated_password" cty:"elevated_password" hcl:"elevated_password"`
 	ExecutionPolicy        *string           `mapstructure:"execution_policy" cty:"execution_policy" hcl:"execution_policy"`
 	DebugMode              *int              `mapstructure:"debug_mode" cty:"debug_mode" hcl:"debug_mode"`
+	UseErrorWrapperScript  *bool             `mapstructure:"use_error_wrapper" cty:"use_error_wrapper" hcl:"use_error_wrapper"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -73,6 +74,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"elevated_password":          &hcldec.AttrSpec{Name: "elevated_password", Type: cty.String, Required: false},
 		"execution_policy":           &hcldec.AttrSpec{Name: "execution_policy", Type: cty.String, Required: false},
 		"debug_mode":                 &hcldec.AttrSpec{Name: "debug_mode", Type: cty.Number, Required: false},
+		"use_error_wrapper":          &hcldec.AttrSpec{Name: "use_error_wrapper", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/provisioner/powershell/provisioner_acc_test.go
+++ b/provisioner/powershell/provisioner_acc_test.go
@@ -39,6 +39,15 @@ func TestAccPowershellProvisioner_Script(t *testing.T) {
 	acc.TestProvisionersAgainstBuilders(&testProvisioner, t)
 }
 
+func TestAccPowershellProvisioner_ExitCodes(t *testing.T) {
+	acc.TestProvisionersPreCheck(TestProvisionerName, t)
+
+	// This provisioner should fail with an exit code of 1. To assert the failure the fixture
+	// uses the valid_exit_codes option to confirm a non-zero exit code
+	testProvisioner := PowershellProvisionerAccTest{"powershell-exit_codes-provisioner.txt"}
+	acc.TestProvisionersAgainstBuilders(&testProvisioner, t)
+}
+
 type PowershellProvisionerAccTest struct {
 	ConfigName string
 }

--- a/provisioner/powershell/test-fixtures/powershell-exit_codes-provisioner.txt
+++ b/provisioner/powershell/test-fixtures/powershell-exit_codes-provisioner.txt
@@ -1,0 +1,27 @@
+{
+  "type": "powershell",
+  "inline": ["invalid-cmdlet"],
+  "valid_exit_codes": ["1"]
+},
+{
+  "type": "powershell",
+  "inline": ["#Requires -Version 10.0"],
+  "valid_exit_codes": ["1"]
+},
+{
+  "type": "powershell",
+  "script": "../../provisioner/powershell/test-fixtures/scripts/set_version_latest.ps1",
+  "valid_exit_codes": ["0"]
+},
+{
+  "type": "powershell",
+  "elevated_user": "Administrator",
+  "elevated_password": "{{.WinRMPassword}}",
+  "inline": "Get-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion",
+  "valid_exit_codes": ["0"]
+},
+{
+  "type": "powershell",
+  "inline": "sc.exe start Life",
+  "valid_exit_codes": ["1060"]
+}

--- a/provisioner/powershell/test-fixtures/scripts/set_version_latest.ps1
+++ b/provisioner/powershell/test-fixtures/scripts/set_version_latest.ps1
@@ -1,0 +1,13 @@
+# Test fixture is a modified version of the example found at
+# https://www.powershellmagazine.com/2012/10/23/pstip-set-strictmode-why-should-you-care/
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$myNumbersCollection = 1..5
+if($myNumbersCollection -contains 3) {
+    "collection contains 3"
+}
+else {
+    "collection doesn't contain 3"
+}


### PR DESCRIPTION
This change adds a wrapper script to the provisioner for improved error handling. The wrapper script is enabled by default, but will be disabled when using a custom ExecuteCommand or ElevatedExecuteCommand.
    
The wrapper script will include the contents of any provided Inline commands or Scripts as part of its payload and run as a single script with environment variables loaded within the script. This changes the existing behavior of uploading and running any defined script(s) directly to the remote host

Closes #4916, #9757, #9400, #9161 

## Todo
- [ ]  validate approach
- [ ] Fix broken test
- [ ] test against custom execute commands
- [ ] support wrapped script when using execute command
 
