### PR TITLE
Ansible Galaxy Collections support in Ansible provisioner

### DIFF
--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -645,7 +645,7 @@ func (p *Provisioner) executeGalaxy(ui packer.Ui, comm packer.Communicator) erro
 	}
 	// Add collections_path argument if specified
 	if p.config.CollectionsPath != "" {
-		collectionArgs = append(roleArgs, "-p", filepath.ToSlash(p.config.CollectionsPath))
+		collectionArgs = append(collectionArgs, "-p", filepath.ToSlash(p.config.CollectionsPath))
 	}
 
 	roleInstallError := p.invokeGalaxyCommand(roleArgs, ui, comm)

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -653,7 +653,7 @@ func (p *Provisioner) executeGalaxy(ui packer.Ui, comm packer.Communicator) erro
 	if roleInstallError != nil {
 		return roleInstallError
 	}
-	// If all is well, proceed with collections install
+	// If all is well, proceed with collection install
 	// This variable isn't strictly necessary but including for readability to match the role installation
 	collectionInstallError := p.invokeGalaxyCommand(roleArgs, ui, comm)
 	return collectionInstallError

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -645,7 +645,7 @@ func (p *Provisioner) executeGalaxy(ui packer.Ui, comm packer.Communicator) erro
 	}
 	// Add collections_path argument if specified
 	if p.config.CollectionsPath != "" {
-		roleArgs = append(roleArgs, "-p", filepath.ToSlash(p.config.CollectionsPath))
+		collectionArgs = append(roleArgs, "-p", filepath.ToSlash(p.config.CollectionsPath))
 	}
 
 	roleInstallError := p.invokeGalaxyCommand(roleArgs, ui, comm)
@@ -655,7 +655,7 @@ func (p *Provisioner) executeGalaxy(ui packer.Ui, comm packer.Communicator) erro
 	}
 	// If all is well, proceed with collection install
 	// This variable isn't strictly necessary but including for readability to match the role installation
-	collectionInstallError := p.invokeGalaxyCommand(roleArgs, ui, comm)
+	collectionInstallError := p.invokeGalaxyCommand(collectionArgs, ui, comm)
 	return collectionInstallError
 }
 

--- a/provisioner/ansible/provisioner.hcl2spec.go
+++ b/provisioner/ansible/provisioner.hcl2spec.go
@@ -39,6 +39,7 @@ type FlatConfig struct {
 	GalaxyCommand         *string           `mapstructure:"galaxy_command" cty:"galaxy_command" hcl:"galaxy_command"`
 	GalaxyForceInstall    *bool             `mapstructure:"galaxy_force_install" cty:"galaxy_force_install" hcl:"galaxy_force_install"`
 	RolesPath             *string           `mapstructure:"roles_path" cty:"roles_path" hcl:"roles_path"`
+	CollectionsPath       *string           `mapstructure:"collections_path" cty:"collections_path" hcl:"collections_path"`
 	UseProxy              *bool             `mapstructure:"use_proxy" cty:"use_proxy" hcl:"use_proxy"`
 }
 
@@ -84,6 +85,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"galaxy_command":             &hcldec.AttrSpec{Name: "galaxy_command", Type: cty.String, Required: false},
 		"galaxy_force_install":       &hcldec.AttrSpec{Name: "galaxy_force_install", Type: cty.Bool, Required: false},
 		"roles_path":                 &hcldec.AttrSpec{Name: "roles_path", Type: cty.String, Required: false},
+		"collections_path":           &hcldec.AttrSpec{Name: "collections_path", Type: cty.String, Required: false},
 		"use_proxy":                  &hcldec.AttrSpec{Name: "use_proxy", Type: cty.Bool, Required: false},
 	}
 	return s

--- a/test/fixtures/provisioner-ansible/galaxy-playbook.yml
+++ b/test/fixtures/provisioner-ansible/galaxy-playbook.yml
@@ -1,0 +1,33 @@
+---
+- hosts: default:packer-test
+  gather_facts: no
+  collections:
+    - artis3n.github
+  tasks:
+    - name: touch
+      raw: touch /tmp/ansible-raw-test
+    - name: raw test
+      raw: date
+    - name: command test
+      command: echo "the command module"
+    - name: prepare remote directory
+      command: mkdir /tmp/remote-dir
+      args:
+        creates: /tmp/remote-dir
+    - name: transfer file.txt
+      copy: src=dir/file.txt dest=/tmp/remote-dir/file.txt
+    - name: fetch file.text
+      fetch: src=/tmp/remote-dir/file.txt dest=fetched-dir validate=yes fail_on_missing=yes
+    - name: copy contents of directory
+      copy: src=dir/contents-only/ dest=/tmp/remote-dir
+    - name: fetch contents of directory
+      fetch: src=/tmp/remote-dir/file.txt dest="fetched-dir/{{ inventory_hostname }}/tmp/remote-dir/contents-only/" flat=yes validate=yes fail_on_missing=yes
+    - name: copy directory recursively
+      copy: src=dir/subdir dest=/tmp/remote-dir
+    - name: fetch recursively copied directory
+      fetch: src=/tmp/remote-dir/subdir/file.txt dest=fetched-dir validate=yes fail_on_missing=yes
+    - copy: src=largish-file.txt dest=/tmp/largish-file.txt
+    - name: test collection - fetch latest repo version
+      set_fact:
+        # Ansible will fail if collection is not installed
+        packer_version: "{{ lookup('artis3n.github.latest_release', 'hashicorp/packer' }}"

--- a/test/fixtures/provisioner-ansible/galaxy.json
+++ b/test/fixtures/provisioner-ansible/galaxy.json
@@ -1,0 +1,21 @@
+{
+  "variables": {},
+  "provisioners": [
+    {
+      "type":  "ansible",
+      "playbook_file": "./playbook.yml",
+      "galaxy_file": "./requirements.yml"
+    }
+  ],
+  "builders": [
+    {
+      "type": "googlecompute",
+      "account_file": "{{user `account_file`}}",
+      "project_id": "{{user `project_id`}}",
+      "image_name": "packerbats-galaxy-{{timestamp}}",
+      "source_image": "debian-8-jessie-v20161027",
+      "zone": "us-central1-a",
+      "ssh_username": "debian"
+    }
+  ]
+}

--- a/test/fixtures/provisioner-ansible/galaxy.json
+++ b/test/fixtures/provisioner-ansible/galaxy.json
@@ -3,7 +3,7 @@
   "provisioners": [
     {
       "type":  "ansible",
-      "playbook_file": "./playbook.yml",
+      "playbook_file": "./galaxy-playbook.yml",
       "galaxy_file": "./requirements.yml"
     }
   ],

--- a/test/fixtures/provisioner-ansible/requirements.yml
+++ b/test/fixtures/provisioner-ansible/requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: artis3n.github

--- a/test/provisioner_ansible.bats
+++ b/test/provisioner_ansible.bats
@@ -65,6 +65,14 @@ teardown() {
     diff -r dir fetched-dir/packer-test/tmp/remote-dir > /dev/null
 }
 
+@test "ansible provisioner: build galaxy.json" {
+    cd $FIXTURE_ROOT
+    run packer build ${USER_VARS} $FIXTURE_ROOT/galaxy.json
+    [ "$status" -eq 0 ]
+    [ "$(gc_has_image "packerbats-galaxy")" -eq 1 ]
+    diff -r dir fetched-dir/default/tmp/remote-dir > /dev/null
+}
+
 @test "ansible provisioner: build scp.json" {
     cd $FIXTURE_ROOT
     run packer build ${USER_VARS} $FIXTURE_ROOT/scp.json

--- a/website/pages/partials/provisioner/ansible/Config-not-required.mdx
+++ b/website/pages/partials/provisioner/ansible/Config-not-required.mdx
@@ -120,8 +120,8 @@
    test your playbook. this option is not used if you set an `inventory_file`.
 
 - `galaxy_file` (string) - A requirements file which provides a way to
-   install roles with the [ansible-galaxy
-   cli](http://docs.ansible.com/ansible/galaxy.html#the-ansible-galaxy-command-line-tool)
+   install roles or collections with the [ansible-galaxy
+   cli](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#the-ansible-galaxy-command-line-tool)
    on the local machine before executing `ansible-playbook`. By default, this is empty.
 
 - `galaxy_command` (string) - The command to invoke ansible-galaxy. By default, this is
@@ -131,9 +131,14 @@
    Adds `--force` option to `ansible-galaxy` command. By default, this is
    `false`.
 
-- `roles_path` (string) - The path to the directory on your local system to
-    install the roles in. Adds `--roles-path /path/to/your/roles` to
+- `roles_path` (string) - The path to the directory on your local system in which to
+    install the roles. Adds `--roles-path /path/to/your/roles` to
     `ansible-galaxy` command. By default, this is empty, and thus `--roles-path`
+    option is not added to the command.
+
+- `collections_path` (string) - The path to the directory on your local system in which to
+    install the collections. Adds `--collections-path /path/to/your/collections` to
+    `ansible-galaxy` command. By default, this is empty, and thus `--collections-path`
     option is not added to the command.
 
 - `use_proxy` (boolean) - When `true`, set up a localhost proxy adapter


### PR DESCRIPTION
This adds support for installing Ansible Collections during an invocation of the `ansible` provisioner. The galaxy code in `ansible_local` is sort of similar to this but different enough that I'd rather let someone else handle that. This PR only adds the support to the `ansible` provisioner.

Not sure how to best test this at the Go level, but I added an acceptance test using a personal Collection of mine. I imagine some other (stub?) collection would be better suited here. Let me know if I should change this.

Testing it on a real-word Packer thing (https://github.com/artis3n/cloud-hackbox) - 

The provisioner is set up as:

```json
{
            "type": "ansible",
            "playbook_file": "kali/ansible/playbook.yml",
            "galaxy_file": "kali/ansible/requirements.yml",
            "user": "kali",
            "host_alias": "kali",
            "extra_arguments": [
                "-e",
                "ansible_python_interpreter=/usr/bin/python3",
                "--skip-tags",
                "skip"
            ]
        },
```

No collections installed:
![image](https://user-images.githubusercontent.com/6969296/92313108-ab389880-ef95-11ea-9cc6-b8a8d889446d.png)

Building a dev `packer` binary off of the latest sha:

![image](https://user-images.githubusercontent.com/6969296/92313295-2d29c100-ef98-11ea-96ee-baefe4cda8d6.png)

Running the following command fails due to missing `collection`, as expected:

```bash
AWS_MAX_ATTEMPTS=90 AWS_POLL_DELAY=60 pipenv run packer build kali/kali-ami.json
```

No collection install, just looking for roles in the `requirements.yml`:

![image](https://user-images.githubusercontent.com/6969296/92314178-826ad000-efa2-11ea-9181-0cea3e74f615.png)

And my playbook fails:

![image](https://user-images.githubusercontent.com/6969296/92313741-015d0a00-ef9d-11ea-99f2-62908e53f7d8.png)

Now let's try with my dev Packer build:

```bash
pipenv shell
AWS_MAX_ATTEMPTS=90 AWS_POLL_DELAY=60 /home/artis3n/go/src/github.com/hashicorp/packer/bin/packer build kali/kali-ami.json
```

We see that the role + collection installations occur:

![image](https://user-images.githubusercontent.com/6969296/92314149-ed67d700-efa1-11ea-92d3-8b6a18eaba41.png)

And the task that previously failed is working fine:

![image](https://user-images.githubusercontent.com/6969296/92314153-02446a80-efa2-11ea-9ce5-3e5c1cbb72f6.png)

Full gif of the packer build: https://asciinema.org/a/358014

Closes #8821
