### PR TITLE
qemu vnc: hardcoded lowerbound leaves negative ports

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -76,9 +76,9 @@ func getCommandArgs(bootDrive string, state multistep.StateBag) ([]string, error
 	var vnc string
 
 	if !config.VNCUsePassword {
-		vnc = fmt.Sprintf("%s:%d", vncIP, vncPort-5900)
+		vnc = fmt.Sprintf("%s:%d", vncIP, vncPort-config.VNCPortMin)
 	} else {
-		vnc = fmt.Sprintf("%s:%d,password", vncIP, vncPort-5900)
+		vnc = fmt.Sprintf("%s:%d,password", vncIP, vncPort-config.VNCPortMin)
 	}
 
 	if config.QMPEnable {


### PR DESCRIPTION
```hcl2
  vnc_port_min = 5000
  vnc_port_max = 5500
```

Build returns faulty:
```
    qemu.one: view the screen of the VM, connect via VNC to vnc://127.0.0.1:5138
(...)
2020/09/06 19:09:52 packer-builder-qemu plugin: Qemu stderr: qemu-system-x86_64: -vnc 127.0.0.1:-762,password: can't convert to a number: -762
```
