### PR TITLE
Ssh redocument options

### DIFF
--- a/helper/communicator/config.go
+++ b/helper/communicator/config.go
@@ -119,7 +119,8 @@ type SSH struct {
 	// The time to wait for SSH to become available. Packer uses this to
 	// determine when the machine has booted so this is usually quite long.
 	// Example value: `10m`.
-	SSHTimeout     time.Duration `mapstructure:"ssh_timeout"`
+	SSHTimeout time.Duration `mapstructure:"ssh_timeout"`
+	// Deprecated in favor of SSHTimeout
 	SSHWaitTimeout time.Duration `mapstructure:"ssh_wait_timeout" undocumented:"true"`
 	// If true, the local SSH agent will be used to authenticate connections to
 	// the source instance. No temporary keypair will be created, and the

--- a/website/pages/docs/builders/alicloud-ecs.mdx
+++ b/website/pages/docs/builders/alicloud-ecs.mdx
@@ -41,9 +41,13 @@ builder.
 
 @include 'builder/alicloud/ecs/AlicloudImageConfig-not-required.mdx'
 
-- `temporary_key_pair_name` (string) - The name of the temporary key pair to
-  generate. By default, Packer generates a name that looks like
-  `packer_<UUID>`, where &lt;UUID&gt; is a 36 character unique identifier.
+@include 'helper/communicator/SSH-Temporary-Key-Pair-not-required.mdx'
+
+@include 'helper/communicator/SSH-Key-Pair-Name-not-required.mdx'
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
+@include 'helper/communicator/SSH-Agent-Auth-not-required.mdx'
 
 ## Basic Example
 

--- a/website/pages/docs/builders/azure/arm.mdx
+++ b/website/pages/docs/builders/azure/arm.mdx
@@ -147,6 +147,16 @@ Providing `temp_resource_group_name` or `location` in combination with
 
 @include 'builder/azure/common/client/Config-not-required.mdx'
 
+### Communicator Config
+
+In addition to the builder options, a communicator may also be defined: 
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
 ## Basic Example
 
 Here is a basic example for Azure.

--- a/website/pages/docs/builders/cloudstack.mdx
+++ b/website/pages/docs/builders/cloudstack.mdx
@@ -145,14 +145,6 @@ builder.
 - `security_groups` (array of strings) - A list of security group IDs or
   names to associate the instance with.
 
-- `ssh_agent_auth` (boolean) - If true, the local SSH agent will be used to
-  authenticate connections to the source instance. No temporary keypair will
-  be created, and the values of `ssh_password` and `ssh_private_key_file`
-  will be ignored. To use this option with a key pair already configured in
-  the source image, leave the `keypair` blank. To associate an existing key
-  pair with the source instance, set the `keypair` field to the name of the
-  key pair.
-
 - `ssl_no_verify` (boolean) - Set to `true` to skip SSL verification.
   Defaults to `false`.
 
@@ -204,6 +196,22 @@ The available variables are:
   that is started serving the directory specified by the `http_directory`
   configuration parameter. If `http_directory` isn't specified, these will be
   blank. Example: `{{.HTTPIP}}:{{.HTTPPort}}/path/to/a/file/in/http_directory`
+
+### Communicator Configuration
+
+#### Optional:
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+@include 'helper/communicator/SSH-Temporary-Key-Pair-not-required.mdx'
+
+@include 'helper/communicator/SSH-Key-Pair-Name-not-required.mdx'
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
+@include 'helper/communicator/SSH-Agent-Auth-not-required.mdx'
 
 ## Basic Example
 

--- a/website/pages/docs/builders/digitalocean.mdx
+++ b/website/pages/docs/builders/digitalocean.mdx
@@ -34,9 +34,16 @@ There are many configuration options available for the builder. They are
 segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
-In addition to the options listed here, a
-[communicator](/docs/templates/communicator) can be configured for this
-builder.
+### Communicator Config
+
+In addition to the builder options, a 
+[communicator](/docs/templates/communicator) can be configured for this builder.
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ### Required:
 

--- a/website/pages/docs/builders/googlecompute.mdx
+++ b/website/pages/docs/builders/googlecompute.mdx
@@ -346,6 +346,16 @@ In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
 builder.
 
+### Communicator Configuration
+
+#### Optional:
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
 ### Required:
 
 @include 'builder/googlecompute/Config-required.mdx'

--- a/website/pages/docs/builders/hetzner-cloud.mdx
+++ b/website/pages/docs/builders/hetzner-cloud.mdx
@@ -33,7 +33,7 @@ In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
 builder.
 
-### Required:
+### Required Builder Configuration options:
 
 - `token` (string) - The client TOKEN to use to access your account. It can
   also be specified via environment variable `HCLOUD_TOKEN`, if set.

--- a/website/pages/docs/builders/hyperv/iso.mdx
+++ b/website/pages/docs/builders/hyperv/iso.mdx
@@ -115,6 +115,8 @@ builder.
 
 @include 'helper/communicator/SSH-not-required.mdx'
 
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
 ### Optional WinRM fields:
 
 @include 'helper/communicator/WinRM-not-required.mdx'

--- a/website/pages/docs/builders/hyperv/vmcx.mdx
+++ b/website/pages/docs/builders/hyperv/vmcx.mdx
@@ -113,6 +113,8 @@ builder.
 
 @include 'helper/communicator/SSH-not-required.mdx'
 
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
 ### Optional WinRM fields:
 
 @include 'helper/communicator/WinRM-not-required.mdx'

--- a/website/pages/docs/builders/jdcloud.mdx
+++ b/website/pages/docs/builders/jdcloud.mdx
@@ -36,6 +36,21 @@ are given below:
 
 - `subnet_id` (string) - An instance is supposed to exists in an subnet, if not specified , we will create new one for you
 
+In addition to the above configuration options, a communicator can be configured for this builder:
+### Communicator Configuration
+
+#### Optional:
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+@include 'helper/communicator/SSH-Temporary-Key-Pair-not-required.mdx'
+
+@include 'helper/communicator/SSH-Key-Pair-Name-not-required.mdx'
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
 ## Examples
 
 Here is a basic example for JDCloud.

--- a/website/pages/docs/builders/linode.mdx
+++ b/website/pages/docs/builders/linode.mdx
@@ -37,7 +37,10 @@ each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
-builder.
+builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ### Required
 

--- a/website/pages/docs/builders/oneandone.mdx
+++ b/website/pages/docs/builders/oneandone.mdx
@@ -20,7 +20,10 @@ each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
-builder.
+builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ### Required
 

--- a/website/pages/docs/builders/oracle/classic.mdx
+++ b/website/pages/docs/builders/oracle/classic.mdx
@@ -159,6 +159,8 @@ If this is set, a few more options become available.
   }
   ```
 
+  See below for more details on configuring this communicator.   
+
 - `builder_image_list` (string) - This is the image to use for the builder
   instance. This _must_ be a linux image, and Oracle Linux is recommended.
   Default: `/oracle/public/OL_7.2_UEKR4_x86_64`.
@@ -180,6 +182,19 @@ If this is set, a few more options become available.
   this command is a template engine and can make use of the following
   variables: `{{ .Username }}`, `{{ .Password }}`, `{{ .AccountID }}`,
   `{{ .ImageFile }}`, and `{{ .SegmentPath }}`.
+
+
+### Communicator Configuration
+
+The `builder_communicator` has the following options:
+
+#### Optional:
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ## Basic Example
 

--- a/website/pages/docs/builders/oracle/oci.mdx
+++ b/website/pages/docs/builders/oracle/oci.mdx
@@ -44,6 +44,11 @@ addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
 builder.
 
+In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
 ### Required
 
 - `availability_domain` (string) - The name of the [Availability

--- a/website/pages/docs/builders/outscale/bsu.mdx
+++ b/website/pages/docs/builders/outscale/bsu.mdx
@@ -197,9 +197,11 @@ builder.
     This will fail unless _exactly_ one OMIS is returned. In the above example,
     `most_recent` will cause this to succeed by selecting the newest image.
 
-- `ssh_keypair_name` (string) - If specified, this is the key that will be used for SSH with the machine. The key must match a key pair name loaded up into Outscale. By default, this is blank, and Packer will generate a temporary keypair unless [`ssh_password`](/docs/communicators/ssh#ssh_password) is used. [`ssh_private_key_file`](/docs/communicators/ssh#ssh_private_key_file) or `ssh_agent_auth` must be specified when `ssh_keypair_name` is utilized.
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
-- `ssh_agent_auth` (boolean) - If true, the local SSH agent will be used to authenticate connections to the source VM. No temporary keypair will be created, and the values of `ssh_password` and `ssh_private_key_file` will be ignored. To use this option with a key pair already configured in the source OMI, leave the `ssh_keypair_name` blank. To associate an existing key pair in Outscale with the source VM, set the `ssh_keypair_name` field to the name of the key pair.
+@include 'helper/communicator/SSH-Key-Pair-Name-not-required.mdx'
+
+@include 'helper/communicator/SSH-Agent-Auth-not-required.mdx'
 
 - `ssh_interface` (string) - One of `public_ip`, `private_ip`, `public_dns`, or `private_dns`. If set, either the public IP address, private IP address, public DNS name or private DNS name will used as the host for SSH. The default behaviour if inside a Net is to use the public IP address if available, otherwise the private IP address will be used. If not in a Net the public DNS name will be used. Also works for WinRM.
 

--- a/website/pages/docs/builders/parallels/iso.mdx
+++ b/website/pages/docs/builders/parallels/iso.mdx
@@ -55,7 +55,10 @@ category, the available options are alphabetized and described.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
-builder.
+builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ## ISO Configuration Reference
 

--- a/website/pages/docs/builders/parallels/pvm.mdx
+++ b/website/pages/docs/builders/parallels/pvm.mdx
@@ -52,7 +52,10 @@ category, the available options are alphabetized and described.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
-builder.
+builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ### Required:
 

--- a/website/pages/docs/builders/profitbricks.mdx
+++ b/website/pages/docs/builders/profitbricks.mdx
@@ -20,7 +20,10 @@ each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
-builder.
+builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ### Required
 

--- a/website/pages/docs/builders/qemu.mdx
+++ b/website/pages/docs/builders/qemu.mdx
@@ -162,6 +162,8 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'helper/communicator/SSH-not-required.mdx'
 
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
 ### Optional WinRM fields:
 
 @include 'helper/communicator/WinRM-not-required.mdx'

--- a/website/pages/docs/builders/scaleway.mdx
+++ b/website/pages/docs/builders/scaleway.mdx
@@ -36,7 +36,10 @@ each category, the available configuration keys are alphabetized.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
-builder.
+builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ### Required:
 

--- a/website/pages/docs/builders/scaleway.mdx
+++ b/website/pages/docs/builders/scaleway.mdx
@@ -105,6 +105,6 @@ access tokens:
 }
 ```
 
-When you do not specified the `ssh_private_key_file`, a temporarily SSH keypair
+When you do not specify the `ssh_private_key_file`, a temporary SSH keypair
 is generated to connect the server. This key will only allow the `root` user to
 connect the server.

--- a/website/pages/docs/builders/tencentcloud-cvm.mdx
+++ b/website/pages/docs/builders/tencentcloud-cvm.mdx
@@ -125,6 +125,25 @@ a [communicator](/docs/templates/communicator) can be configured for this builde
 - `run_tags` (map of strings) - Tags to apply to the instance that is _launched_ to create the image.
   These tags are _not_ applied to the resulting image.
 
+### Communicator Configuration
+
+In addition to the above options, a communicator can be configured
+for this builder. 
+
+#### Optional:
+
+@include 'helper/communicator/Config-not-required.mdx'
+
+@include 'helper/communicator/SSH-not-required.mdx'
+
+@include 'helper/communicator/SSH-Temporary-Key-Pair-not-required.mdx'
+
+@include 'helper/communicator/SSH-Key-Pair-Name-not-required.mdx'
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
+@include 'helper/communicator/SSH-Agent-Auth-not-required.mdx'
+
 ## Basic Example
 
 Here is a basic example for Tencentcloud.

--- a/website/pages/docs/builders/triton.mdx
+++ b/website/pages/docs/builders/triton.mdx
@@ -49,7 +49,12 @@ segmented below into two categories: required and optional parameters.
 
 In addition to the options listed here, a
 [communicator](/docs/templates/communicator) can be configured for this
-builder.
+builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
+
+@include 'helper/communicator/SSH-Agent-Auth-not-required.mdx'
 
 ### Required:
 

--- a/website/pages/docs/builders/virtualbox/iso.mdx
+++ b/website/pages/docs/builders/virtualbox/iso.mdx
@@ -171,10 +171,6 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'helper/communicator/SSH-not-required.mdx'
 
-@include 'helper/communicator/SSH-Temporary-Key-Pair-not-required.mdx'
-
-@include 'helper/communicator/SSH-Key-Pair-Name-not-required.mdx'
-
 @include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 @include 'helper/communicator/SSH-Agent-Auth-not-required.mdx'

--- a/website/pages/docs/builders/yandex.mdx
+++ b/website/pages/docs/builders/yandex.mdx
@@ -63,7 +63,10 @@ optional. Within each category, the available options are alphabetized and
 described.
 
 In addition to the options listed here, a [communicator](/docs/templates/communicator)
-can be configured for this builder.
+can be configured for this builder. In addition to the options defined there, a private key file
+can also be supplied to override the typical auto-generated key:
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ### Required:
 

--- a/website/pages/partials/builders/virtualbox-ssh-key-pair.mdx
+++ b/website/pages/partials/builders/virtualbox-ssh-key-pair.mdx
@@ -1,17 +1,17 @@
 ### SSH key pair automation
 
 The VirtualBox builders can inject the current SSH key pair's public key into
-the template using the following variable:
-
-- `SSHPublicKey` (_VirtualBox builders only_) - This is the SSH public key
-  as a line in OpenSSH authorized_keys format.
+the template using the `SSHPublicKey` template engine.  This is the SSH public 
+key as a line in OpenSSH authorized_keys format.
 
 When a private key is provided using `ssh_private_key_file`, the key's
-corresponding public key can be accessed using the above variables.
+corresponding public key can be accessed using the above engine.
+
+@include 'helper/communicator/SSH-Private-Key-File-not-required.mdx'
 
 If `ssh_password` and `ssh_private_key_file` are not specified, Packer will
 automatically generate en ephemeral key pair. The key pair's public key can
-be accessed using the template variables.
+be accessed using the template engine.
 
 For example, the public key can be provided in the boot command as a URL
 encoded string by appending `| urlquery` to the variable:


### PR DESCRIPTION
I went through a bunch of our builders to make sure that we had the ssh options properly documented for each. closes #9889