### PR TITLE
Add vsphere-clone mac_address option

### DIFF
--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -30,6 +30,7 @@ type FlatConfig struct {
 	DiskSize                        *int64                                      `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	LinkedClone                     *bool                                       `mapstructure:"linked_clone" cty:"linked_clone" hcl:"linked_clone"`
 	Network                         *string                                     `mapstructure:"network" cty:"network" hcl:"network"`
+	MacAddress                      *string                                     `mapstructure:"mac_address" cty:"mac_address" hcl:"mac_address"`
 	Notes                           *string                                     `mapstructure:"notes" cty:"notes" hcl:"notes"`
 	VAppConfig                      *FlatvAppConfig                             `mapstructure:"vapp" cty:"vapp" hcl:"vapp"`
 	VMName                          *string                                     `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
@@ -153,6 +154,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_size":                      &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"linked_clone":                   &hcldec.AttrSpec{Name: "linked_clone", Type: cty.Bool, Required: false},
 		"network":                        &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
+		"mac_address":                    &hcldec.AttrSpec{Name: "mac_address", Type: cty.String, Required: false},
 		"notes":                          &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
 		"vapp":                           &hcldec.BlockSpec{TypeName: "vapp", Nested: hcldec.ObjectSpec((*FlatvAppConfig)(nil).HCL2Spec())},
 		"vm_name":                        &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -58,6 +58,10 @@ func (c *CloneConfig) Prepare() []error {
 		errs = append(errs, fmt.Errorf("'linked_clone' and 'disk_size' cannot be used together"))
 	}
 
+	if c.MacAddress != "" && c.Network == "" {
+		errs = append(errs, fmt.Errorf("'network' is required when 'mac_address' is specified"))
+	}
+
 	return errs
 }
 

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -37,6 +37,8 @@ type CloneConfig struct {
 	// available network. If the network is inside a network folder in vCenter,
 	// you need to provide the full path to the network.
 	Network string `mapstructure:"network"`
+	// Sets a custom Mac Address to the network adapter. If set, the [network](#network) must be also specified.
+	MacAddress string `mapstructure:"mac_address"`
 	// VM notes.
 	Notes string `mapstructure:"notes"`
 	// Set the vApp Options to a virtual machine.
@@ -92,6 +94,7 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Datastore:      s.Location.Datastore,
 		LinkedClone:    s.Config.LinkedClone,
 		Network:        s.Config.Network,
+		MacAddress:     s.Config.MacAddress,
 		Annotation:     s.Config.Notes,
 		VAppProperties: s.Config.VAppConfig.Properties,
 	})

--- a/builder/vsphere/clone/step_clone.hcl2spec.go
+++ b/builder/vsphere/clone/step_clone.hcl2spec.go
@@ -13,6 +13,7 @@ type FlatCloneConfig struct {
 	DiskSize    *int64          `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	LinkedClone *bool           `mapstructure:"linked_clone" cty:"linked_clone" hcl:"linked_clone"`
 	Network     *string         `mapstructure:"network" cty:"network" hcl:"network"`
+	MacAddress  *string         `mapstructure:"mac_address" cty:"mac_address" hcl:"mac_address"`
 	Notes       *string         `mapstructure:"notes" cty:"notes" hcl:"notes"`
 	VAppConfig  *FlatvAppConfig `mapstructure:"vapp" cty:"vapp" hcl:"vapp"`
 }
@@ -33,6 +34,7 @@ func (*FlatCloneConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_size":    &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"linked_clone": &hcldec.AttrSpec{Name: "linked_clone", Type: cty.Bool, Required: false},
 		"network":      &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
+		"mac_address":  &hcldec.AttrSpec{Name: "mac_address", Type: cty.String, Required: false},
 		"notes":        &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
 		"vapp":         &hcldec.BlockSpec{TypeName: "vapp", Nested: hcldec.ObjectSpec((*FlatvAppConfig)(nil).HCL2Spec())},
 	}

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -69,6 +69,7 @@ type CloneConfig struct {
 	Datastore      string
 	LinkedClone    bool
 	Network        string
+	MacAddress     string
 	Annotation     string
 	VAppProperties map[string]string
 }
@@ -344,7 +345,9 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 			return nil, err
 		}
 
-		adapter.GetVirtualEthernetCard().Backing = backing
+		current := adapter.GetVirtualEthernetCard()
+		current.Backing = backing
+		current.MacAddress = config.MacAddress
 
 		config := &types.VirtualDeviceConfigSpec{
 			Device:    adapter.(types.BaseVirtualDevice),

--- a/website/pages/partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -11,6 +11,8 @@
   available network. If the network is inside a network folder in vCenter,
   you need to provide the full path to the network.
 
+- `mac_address` (string) - Sets a custom Mac Address to the network adapter. If set, the [network](#network) must be also specified.
+
 - `notes` (string) - VM notes.
 
 - `vapp` (vAppConfig) - Set the vApp Options to a virtual machine.


### PR DESCRIPTION
If `mac_address` is set, then the mac address of the clone machine will have this value. 

Closes https://github.com/hashicorp/packer/issues/9862