### PR TITLE
skip slot 7 in disk creation so we don't use reserved slot

### DIFF
--- a/builder/vmware/common/step_create_disks.go
+++ b/builder/vmware/common/step_create_disks.go
@@ -45,8 +45,13 @@ func (s *StepCreateDisks) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	// Additional disks
 	if len(s.AdditionalDiskSize) > 0 {
+		incrementer := 1
 		for i, diskSize := range s.AdditionalDiskSize {
-			path := filepath.Join(*s.OutputDir, fmt.Sprintf("%s-%d.vmdk", s.DiskName, i+1))
+			// scsi slot 7 is reserved, so we skip it.
+			if i+incrementer == 7 {
+				incrementer = 2
+			}
+			path := filepath.Join(*s.OutputDir, fmt.Sprintf("%s-%d.vmdk", s.DiskName, i+incrementer))
 			diskFullPaths = append(diskFullPaths, path)
 			size := fmt.Sprintf("%dM", uint64(diskSize))
 			diskSizes = append(diskSizes, size)

--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -115,9 +115,14 @@ func (s *stepCreateVMX) Run(ctx context.Context, state multistep.StateBag) multi
 
 	// Mount extra vmdks we created earlier.
 	if len(config.AdditionalDiskSize) > 0 {
+		incrementer := 1
 		for i := range config.AdditionalDiskSize {
+			// slot 7 is special and reserved, so we need to skip that index.
+			if i+1 == 7 {
+				incrementer = 2
+			}
 			ictx.Data = &additionalDiskTemplateData{
-				DiskNumber: i + 1,
+				DiskNumber: i + incrementer,
 				DiskName:   config.DiskName,
 			}
 


### PR DESCRIPTION
Add a simple check to disk creation and mounting via vmx to avoid using reserved 7th slot
Closes #9936 