### PR TITLE
tech-debt: Fix static check issues SA1019 for googlecompute plugins

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 	oslogin "google.golang.org/api/oslogin/v1"
 
 	"github.com/hashicorp/packer/common/retry"
@@ -124,12 +125,12 @@ func NewDriverGCE(ui packer.Ui, p string, conf *jwt.Config, vaultOauth string) (
 	}
 
 	log.Printf("[INFO] Instantiating GCE client...")
-	service, err := compute.New(client)
+	service, err := compute.NewService(context.TODO(), option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
 
-	osLoginService, err := oslogin.New(client)
+	osLoginService, err := oslogin.NewService(context.TODO(), option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}

--- a/post-processor/googlecompute-import/post-processor.go
+++ b/post-processor/googlecompute-import/post-processor.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 	"google.golang.org/api/storage/v1"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
@@ -180,7 +181,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 }
 
 func UploadToBucket(client *http.Client, ui packer.Ui, artifact packer.Artifact, bucket string, gcsObjectName string) (string, error) {
-	service, err := storage.New(client)
+	service, err := storage.NewService(context.TODO(), option.WithHTTPClient(client))
 	if err != nil {
 		return "", err
 	}
@@ -216,7 +217,7 @@ func UploadToBucket(client *http.Client, ui packer.Ui, artifact packer.Artifact,
 }
 
 func CreateGceImage(client *http.Client, ui packer.Ui, project string, rawImageURL string, imageName string, imageDescription string, imageFamily string, imageLabels map[string]string, imageGuestOsFeatures []string) (packer.Artifact, error) {
-	service, err := compute.New(client)
+	service, err := compute.NewService(context.TODO(), option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +271,7 @@ func CreateGceImage(client *http.Client, ui packer.Ui, project string, rawImageU
 }
 
 func DeleteFromBucket(client *http.Client, ui packer.Ui, bucket string, gcsObjectName string) error {
-	service, err := storage.New(client)
+	service, err := storage.NewService(context.TODO(), option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change replaces the deprecated constructors `New` with
`NewService`.

Static check before the change
```
⇶  golangci-lint run --disable-all --no-config --enable=staticcheck | grep SA1019 | grep google
- post-processor/googlecompute-import/post-processor.go:183:18: SA1019:
storage.New is deprecated: please use NewService instead. To provide a
custom HTTP client, use option.WithHTTPClient. If you are using
google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey
with NewService instead.  (staticcheck)
- post-processor/googlecompute-import/post-processor.go:219:18: SA1019:
compute.New is deprecated: please use NewService instead. To provide a
custom HTTP client, use option.WithHTTPClient. If you are using
google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey
with NewService instead.  (staticcheck)
- post-processor/googlecompute-import/post-processor.go:273:18: SA1019:
storage.New is deprecated: please use NewService instead. To provide a
custom HTTP client, use option.WithHTTPClient. If you are using
google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey
with NewService instead.  (staticcheck)
- builder/googlecompute/driver_gce.go:127:18: SA1019: compute.New is
deprecated: please use NewService instead. To provide a custom HTTP
client, use option.WithHTTPClient. If you are using
google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey
with NewService instead.  (staticcheck)
- builder/googlecompute/driver_gce.go:132:25: SA1019: oslogin.New is
deprecated: please use NewService instead. To provide a custom HTTP
client, use option.WithHTTPClient. If you are using
google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey
with NewService instead.  (staticcheck)
```

Static check after change
```
[go-1.15.2] [1] wilken@automaton in ~/Development/packer/
⇶  golangci-lint run --disable-all --no-config --enable=staticcheck | grep SA1019 | grep google

```