### PR TITLE
aws ebs_surrogate: fix unhonored kms_key_id

### DIFF
--- a/builder/amazon/ebssurrogate/block_device.go
+++ b/builder/amazon/ebssurrogate/block_device.go
@@ -3,9 +3,6 @@
 package ebssurrogate
 
 import (
-	"strings"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
 	"github.com/hashicorp/packer/template/interpolate"
@@ -39,50 +36,6 @@ func (bds BlockDevices) BuildEC2BlockDeviceMappings() []*ec2.BlockDeviceMapping 
 		blockDevices = append(blockDevices, blockDevice.BuildEC2BlockDeviceMapping())
 	}
 	return blockDevices
-}
-
-func (blockDevice BlockDevice) BuildEC2BlockDeviceMapping() *ec2.BlockDeviceMapping {
-
-	mapping := &ec2.BlockDeviceMapping{
-		DeviceName: aws.String(blockDevice.DeviceName),
-	}
-
-	if blockDevice.NoDevice {
-		mapping.NoDevice = aws.String("")
-		return mapping
-	} else if blockDevice.VirtualName != "" {
-		if strings.HasPrefix(blockDevice.VirtualName, "ephemeral") {
-			mapping.VirtualName = aws.String(blockDevice.VirtualName)
-		}
-		return mapping
-	}
-
-	ebsBlockDevice := &ec2.EbsBlockDevice{
-		DeleteOnTermination: aws.Bool(blockDevice.DeleteOnTermination),
-	}
-
-	if blockDevice.VolumeType != "" {
-		ebsBlockDevice.VolumeType = aws.String(blockDevice.VolumeType)
-	}
-
-	if blockDevice.VolumeSize > 0 {
-		ebsBlockDevice.VolumeSize = aws.Int64(blockDevice.VolumeSize)
-	}
-
-	// IOPS is only valid for io1 type
-	if blockDevice.VolumeType == "io1" {
-		ebsBlockDevice.Iops = aws.Int64(blockDevice.IOPS)
-	}
-
-	// You cannot specify Encrypted if you specify a Snapshot ID
-	if blockDevice.SnapshotId != "" {
-		ebsBlockDevice.SnapshotId = aws.String(blockDevice.SnapshotId)
-	}
-	ebsBlockDevice.Encrypted = blockDevice.Encrypted.ToBoolPointer()
-
-	mapping.Ebs = ebsBlockDevice
-
-	return mapping
 }
 
 func (bds BlockDevices) Prepare(ctx *interpolate.Context) (errs []error) {


### PR DESCRIPTION
The surrogate builder test situation isn't the best, but this should actually improve coverage as we rely on the common builder test coverage.

I have verified that this fixes the issue and will use the provided key.

Closes #9958 