### PR TITLE
[HCL2] add an hcl2-json test

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -560,6 +560,17 @@ func TestBuildExceptFileCommaFlags(t *testing.T) {
 			buildNotExpectedFiles:    []string{"chocolate.txt", "vanilla.txt", "tomato.txt", "unnamed.txt"},
 			postProcNotExpectedFiles: []string{"pear.txt, banana.txt"},
 		},
+		{
+			name: "HCL2-JSON: except build and post-processor",
+			args: []string{
+				"-parallel-builds=1",
+				"-except=file.chocolate,file.vanilla,tomato",
+				filepath.Join(testFixture("build-only"), "template.pkr.json"),
+			},
+			expectedFiles:            []string{"apple.txt", "cherry.txt", "peach.txt"},
+			buildNotExpectedFiles:    []string{"chocolate.txt", "vanilla.txt", "tomato.txt", "unnamed.txt"},
+			postProcNotExpectedFiles: []string{"pear.txt, banana.txt"},
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/test-fixtures/build-only/template.pkr.json
+++ b/command/test-fixtures/build-only/template.pkr.json
@@ -1,0 +1,83 @@
+{
+  "source": {
+    "file": {
+      "chocolate": {
+        "content": "chocolate",
+        "target": "chocolate.txt"
+      }
+    },
+    "file": {
+      "vanilla": {
+        "content": "vanilla",
+        "target": "vanilla.txt"
+      }
+    },
+    "file": {
+      "cherry": {
+        "content": "cherry",
+        "target": "cherry.txt"
+      }
+    }
+  },
+  "build": {
+    "sources": [
+      "sources.file.chocolate",
+      "sources.file.vanilla",
+      "sources.file.cherry"
+    ],
+    "provisioner": [
+      {
+        "shell-local": {
+          "name": "apple",
+          "inline": [
+            "echo apple > apple.txt"
+          ]
+        }
+      }
+    ],
+    "post-processor": [
+      {
+        "shell-local": {
+          "name": "peach",
+          "inline": [
+            "echo peach > peach.txt"
+          ]
+        }
+      },
+      {
+        "shell-local": {
+          "name": "pear",
+          "inline": [
+            "echo pear > pear.txt"
+          ]
+        }
+      },
+      {
+        "shell-local": {
+          "name": "banana",
+          "inline": [
+            "echo banana > banana.txt"
+          ]
+        }
+      },
+      {
+        "shell-local": {
+          "name": "tomato",
+          "inline": [
+            "echo tomato > tomato.txt"
+          ]
+        }
+      },
+      {
+        "shell-local": {
+          "only": [
+            "sources.file.chocolate"
+          ],
+          "inline": [
+            "echo unnamed > unnamed.txt"
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds a test/example for an HCL2-JSON packer config.
The HCL2 library does everything here and its very well tested but it's always nice to at least have one test/example.