### PR TITLE
Hashicorp/packer#9924

### DIFF
--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -65,7 +65,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, err
 	}
 
-	warnings := make([]string, 0)
+	// warnings := make([]string, 0)
 	errs := new(packer.MultiError)
 
 	errs = packer.MultiErrorAppend(errs, c.ConnectConfig.Prepare()...)
@@ -80,8 +80,9 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)
 
-	shutdownWarnings, shutdownErrs := c.ShutdownConfig.Prepare(c.Comm)
-	warnings = append(warnings, shutdownWarnings...)
+	_, shutdownErrs := c.ShutdownConfig.Prepare(c.Comm)
+	// shutdownWarnings, shutdownErrs := c.ShutdownConfig.Prepare(c.Comm)
+	// warnings = append(warnings, shutdownWarnings...)
 	errs = packer.MultiErrorAppend(errs, shutdownErrs...)
 
 	if c.Export != nil {

--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -65,7 +65,9 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, err
 	}
 
+	warnings := make([]string, 0)
 	errs := new(packer.MultiError)
+
 	errs = packer.MultiErrorAppend(errs, c.ConnectConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.CloneConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.LocationConfig.Prepare()...)
@@ -77,7 +79,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)
-	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare()...)
+
+	shutdownWarnings, shutdownErrs := c.ShutdownConfig.Prepare(c.Comm)
+	warnings = append(warnings, shutdownWarnings...)
+	errs = packer.MultiErrorAppend(errs, shutdownErrs...)
+
 	if c.Export != nil {
 		errs = packer.MultiErrorAppend(errs, c.Export.Prepare(&c.ctx, &c.LocationConfig, &c.PackerConfig)...)
 	}

--- a/builder/vsphere/common/step_shutdown.go
+++ b/builder/vsphere/common/step_shutdown.go
@@ -47,7 +47,6 @@ type StepShutdown struct {
 
 func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
-	comm := state.Get("communicator").(packer.Communicator)
 	vm := state.Get("vm").(*driver.VirtualMachineDriver)
 
 	if off, _ := vm.IsPoweredOff(); off {
@@ -59,6 +58,9 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	if s.Config.DisableShutdown {
 		ui.Say("Automatic shutdown disabled. Please shutdown virtual machine.")
 	} else if s.Config.Command != "" {
+		// Communicator is not needed unless shutdown_command is populated
+		comm := state.Get("communicator").(packer.Communicator)
+
 		ui.Say("Executing shutdown command...")
 		log.Printf("Shutdown command: %s", s.Config.Command)
 

--- a/builder/vsphere/common/step_shutdown.go
+++ b/builder/vsphere/common/step_shutdown.go
@@ -71,7 +71,6 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 		ui.Say("Automatic shutdown disabled. Please shutdown virtual machine.")
 	} else if s.Config.Command != "" {
 		// Communicator is not needed unless shutdown_command is populated
-		comm := state.Get("communicator").(packer.Communicator)
 
 		ui.Say("Executing shutdown command...")
 		log.Printf("Shutdown command: %s", s.Config.Command)

--- a/builder/vsphere/common/step_shutdown.go
+++ b/builder/vsphere/common/step_shutdown.go
@@ -55,7 +55,17 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 		return multistep.ActionContinue
 	}
 
-	if s.Config.DisableShutdown {
+	if state.Get("communicator") == nil {
+
+		ui.Say("The `communicator` is 'none', automatic shutdown disabled.")
+		if s.Config.Command != "" {
+			ui.Message("The parameter `shutdown_command` is ignored as it requires a `communicator`.")
+		}
+
+		msg := fmt.Sprintf("Please shutdown virtual machine within %s.", s.Config.Timeout)
+		ui.Message(msg)
+
+	} else if s.Config.DisableShutdown {
 		ui.Say("Automatic shutdown disabled. Please shutdown virtual machine.")
 	} else if s.Config.Command != "" {
 		// Communicator is not needed unless shutdown_command is populated

--- a/builder/vsphere/common/step_shutdown.go
+++ b/builder/vsphere/common/step_shutdown.go
@@ -61,7 +61,8 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 		return multistep.ActionContinue
 	}
 
-	if state.Get("communicator") == nil {
+	comm, _ := state.Get("communicator").(packer.Communicator)
+	if comm == nil {
 
 		msg := fmt.Sprintf("Please shutdown virtual machine within %s.", s.Config.Timeout)
 		ui.Message(msg)

--- a/builder/vsphere/common/step_shutdown.go
+++ b/builder/vsphere/common/step_shutdown.go
@@ -16,16 +16,18 @@ import (
 )
 
 type ShutdownConfig struct {
-	// Specify a VM guest shutdown command. VMware guest tools are used by
-	// default.
+	// Specify a VM guest shutdown command. This command will be executed using
+	// the `communicator`. Otherwise the VMware guest tools are used to gracefully
+	// shutdown the VM guest.
 	Command string `mapstructure:"shutdown_command"`
 	// Amount of time to wait for graceful VM shutdown.
 	// Defaults to 5m or five minutes.
+	// This will likely need to be modified if the `communicator` is 'none'.
 	Timeout time.Duration `mapstructure:"shutdown_timeout"`
 	// Packer normally halts the virtual machine after all provisioners have
 	// run when no `shutdown_command` is defined. If this is set to `true`, Packer
 	// *will not* halt the virtual machine but will assume that you will send the stop
-	// signal yourself through the preseed.cfg or your final provisioner.
+	// signal yourself through a script or the final provisioner.
 	// Packer will wait for a default of five minutes until the virtual machine is shutdown.
 	// The timeout can be changed using `shutdown_timeout` option.
 	DisableShutdown bool `mapstructure:"disable_shutdown"`

--- a/builder/vsphere/common/step_shutdown.go
+++ b/builder/vsphere/common/step_shutdown.go
@@ -28,7 +28,7 @@ type ShutdownConfig struct {
 	// Packer normally halts the virtual machine after all provisioners have
 	// run when no `shutdown_command` is defined. If this is set to `true`, Packer
 	// *will not* halt the virtual machine but will assume that you will send the stop
-	// signal yourself through a script or the final provisioner.
+	// signal yourself through a preseed.cfg, a script or the final provisioner.
 	// Packer will wait for a default of five minutes until the virtual machine is shutdown.
 	// The timeout can be changed using `shutdown_timeout` option.
 	DisableShutdown bool `mapstructure:"disable_shutdown"`

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -77,40 +77,40 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepConfigParams{
 			Config: &b.config.ConfigParamsConfig,
 		},
+		&packerCommon.StepCreateFloppy{
+			Files:       b.config.FloppyFiles,
+			Directories: b.config.FloppyDirectories,
+			Label:       b.config.FloppyLabel,
+		},
+		&StepAddFloppy{
+			Config:                     &b.config.FloppyConfig,
+			Datastore:                  b.config.Datastore,
+			Host:                       b.config.Host,
+			SetHostForDatastoreUploads: b.config.SetHostForDatastoreUploads,
+		},
+		&common.StepHTTPIPDiscover{
+			HTTPIP:  b.config.BootConfig.HTTPIP,
+			Network: b.config.WaitIpConfig.GetIPNet(),
+		},
+		&packerCommon.StepHTTPServer{
+			HTTPDir:     b.config.HTTPDir,
+			HTTPPortMin: b.config.HTTPPortMin,
+			HTTPPortMax: b.config.HTTPPortMax,
+			HTTPAddress: b.config.HTTPAddress,
+		},
+		&common.StepRun{
+			Config:   &b.config.RunConfig,
+			SetOrder: true,
+		},
+		&common.StepBootCommand{
+			Config: &b.config.BootConfig,
+			Ctx:    b.config.ctx,
+			VMName: b.config.VMName,
+		},
 	)
 
 	if b.config.Comm.Type != "none" {
 		steps = append(steps,
-			&packerCommon.StepCreateFloppy{
-				Files:       b.config.FloppyFiles,
-				Directories: b.config.FloppyDirectories,
-				Label:       b.config.FloppyLabel,
-			},
-			&common.StepAddFloppy{
-				Config:                     &b.config.FloppyConfig,
-				Datastore:                  b.config.Datastore,
-				Host:                       b.config.Host,
-				SetHostForDatastoreUploads: b.config.SetHostForDatastoreUploads,
-			},
-			&common.StepHTTPIPDiscover{
-				HTTPIP:  b.config.BootConfig.HTTPIP,
-				Network: b.config.WaitIpConfig.GetIPNet(),
-			},
-			&packerCommon.StepHTTPServer{
-				HTTPDir:     b.config.HTTPDir,
-				HTTPPortMin: b.config.HTTPPortMin,
-				HTTPPortMax: b.config.HTTPPortMax,
-				HTTPAddress: b.config.HTTPAddress,
-			},
-			&common.StepRun{
-				Config:   &b.config.RunConfig,
-				SetOrder: true,
-			},
-			&common.StepBootCommand{
-				Config: &b.config.BootConfig,
-				Ctx:    b.config.ctx,
-				VMName: b.config.VMName,
-			},
 			&common.StepWaitForIp{
 				Config: &b.config.WaitIpConfig,
 			},
@@ -123,15 +123,15 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			&common.StepShutdown{
 				Config: &b.config.ShutdownConfig,
 			},
-			&common.StepRemoveFloppy{
-				Datastore: b.config.Datastore,
-				Host:      b.config.Host,
-			},
 		)
 	}
 
 	steps = append(steps,
-		&common.StepRemoveCDRom{
+		&StepRemoveFloppy{
+			Datastore: b.config.Datastore,
+			Host:      b.config.Host,
+		},
+		&StepRemoveCDRom{
 			Config: &b.config.RemoveCDRomConfig,
 		},
 		&common.StepCreateSnapshot{

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -120,13 +120,13 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 				SSHConfig: b.config.Comm.SSHConfigFunc(),
 			},
 			&packerCommon.StepProvision{},
-			&common.StepShutdown{
-				Config: &b.config.ShutdownConfig,
-			},
 		)
 	}
 
 	steps = append(steps,
+		&common.StepShutdown{
+			Config: &b.config.ShutdownConfig,
+		},
 		&StepRemoveFloppy{
 			Datastore: b.config.Datastore,
 			Host:      b.config.Host,

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -82,7 +82,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Directories: b.config.FloppyDirectories,
 			Label:       b.config.FloppyLabel,
 		},
-		&StepAddFloppy{
+		&common.StepAddFloppy{
 			Config:                     &b.config.FloppyConfig,
 			Datastore:                  b.config.Datastore,
 			Host:                       b.config.Host,
@@ -127,11 +127,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepShutdown{
 			Config: &b.config.ShutdownConfig,
 		},
-		&StepRemoveFloppy{
+		&common.StepRemoveFloppy{
 			Datastore: b.config.Datastore,
 			Host:      b.config.Host,
 		},
-		&StepRemoveCDRom{
+		&common.StepRemoveCDRom{
 			Config: &b.config.RemoveCDRomConfig,
 		},
 		&common.StepCreateSnapshot{

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -86,7 +86,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)
-	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare()...)
+
+	shutdownWarnings, shutdownErrs := c.ShutdownConfig.Prepare(c.Comm)
+	warnings = append(warnings, shutdownWarnings...)
+	errs = packer.MultiErrorAppend(errs, shutdownErrs...)
+
 	if c.Export != nil {
 		errs = packer.MultiErrorAppend(errs, c.Export.Prepare(&c.ctx, &c.LocationConfig, &c.PackerConfig)...)
 	}

--- a/website/pages/partials/builder/vsphere/common/ShutdownConfig-not-required.mdx
+++ b/website/pages/partials/builder/vsphere/common/ShutdownConfig-not-required.mdx
@@ -1,14 +1,16 @@
 <!-- Code generated from the comments of the ShutdownConfig struct in builder/vsphere/common/step_shutdown.go; DO NOT EDIT MANUALLY -->
 
-- `shutdown_command` (string) - Specify a VM guest shutdown command. VMware guest tools are used by
-  default.
+- `shutdown_command` (string) - Specify a VM guest shutdown command. This command will be executed using
+  the `communicator`. Otherwise the VMware guest tools are used to gracefully
+  shutdown the VM guest.
 
 - `shutdown_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for graceful VM shutdown.
   Defaults to 5m or five minutes.
+  This will likely need to be modified if the `communicator` is 'none'.
 
 - `disable_shutdown` (bool) - Packer normally halts the virtual machine after all provisioners have
   run when no `shutdown_command` is defined. If this is set to `true`, Packer
   *will not* halt the virtual machine but will assume that you will send the stop
-  signal yourself through the preseed.cfg or your final provisioner.
+  signal yourself through a preseed.cfg, a script or the final provisioner.
   Packer will wait for a default of five minutes until the virtual machine is shutdown.
   The timeout can be changed using `shutdown_timeout` option.


### PR DESCRIPTION
This addresses #9924 where the build with fail when the resulting VM and the Packer host is expected to not communicate and the `communicator` is configured as none to reflect that.

This is my first time contributing here and using Go so I wasn't really sure how to contribute to the automated testing. I did a few tests [here](https://github.com/hashicorp/packer/issues/9924#issuecomment-695059605).

Closes #9924 
