### PR TITLE
Add more verbose debug output to OpenStack builder

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -71,6 +71,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 }
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
+	if b.config.PackerDebug {
+		b.config.enableDebug(ui)
+	}
+
 	computeClient, err := b.config.computeV2Client()
 	if err != nil {
 		return nil, fmt.Errorf("Error initializing compute client: %s", err)


### PR DESCRIPTION
While working on some new features for the OpenStack builder I noticed that the debug output was pretty sparse and I was lacking detailed information about the OpenStack API requests being made / responses being received to understand what was going on/wrong.

So this PR adds more fine-grained debug output to the OpenStack builder.

When debug mode is enabled this PR instruments the HTTP Client used by the gophercloud OpenStack library with a `DebugRoundTripper` which will output details about the HTTP requests and responses.

The implementation is based on the recommendation offered here: https://github.com/rackspace/gophercloud/pull/601#issuecomment-232235364