### PR TITLE
OpenStack builder: Add support for external source image url

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -98,11 +98,13 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			DebugKeyPath: fmt.Sprintf("os_%s.pem", b.config.PackerBuildName),
 		},
 		&StepSourceImageInfo{
-			SourceImage:      b.config.RunConfig.SourceImage,
-			SourceImageName:  b.config.RunConfig.SourceImageName,
-			SourceImageOpts:  b.config.RunConfig.sourceImageOpts,
-			SourceMostRecent: b.config.SourceImageFilters.MostRecent,
-			SourceProperties: b.config.SourceImageFilters.Filters.Properties,
+			SourceImage:               b.config.RunConfig.SourceImage,
+			SourceImageName:           b.config.RunConfig.SourceImageName,
+			ExternalSourceImageURL:    b.config.RunConfig.ExternalSourceImageURL,
+			ExternalSourceImageFormat: b.config.RunConfig.ExternalSourceImageFormat,
+			SourceImageOpts:           b.config.RunConfig.sourceImageOpts,
+			SourceMostRecent:          b.config.SourceImageFilters.MostRecent,
+			SourceProperties:          b.config.SourceImageFilters.Filters.Properties,
 		},
 		&StepDiscoverNetwork{
 			Networks:              b.config.Networks,

--- a/builder/openstack/builder.hcl2spec.go
+++ b/builder/openstack/builder.hcl2spec.go
@@ -95,6 +95,8 @@ type FlatConfig struct {
 	SSHIPVersion                *string                 `mapstructure:"ssh_ip_version" required:"false" cty:"ssh_ip_version" hcl:"ssh_ip_version"`
 	SourceImage                 *string                 `mapstructure:"source_image" required:"true" cty:"source_image" hcl:"source_image"`
 	SourceImageName             *string                 `mapstructure:"source_image_name" required:"true" cty:"source_image_name" hcl:"source_image_name"`
+	ExternalSourceImageURL      *string                 `mapstructure:"external_source_image_url" required:"true" cty:"external_source_image_url" hcl:"external_source_image_url"`
+	ExternalSourceImageFormat   *string                 `mapstructure:"external_source_image_format" required:"false" cty:"external_source_image_format" hcl:"external_source_image_format"`
 	SourceImageFilters          *FlatImageFilter        `mapstructure:"source_image_filter" required:"true" cty:"source_image_filter" hcl:"source_image_filter"`
 	Flavor                      *string                 `mapstructure:"flavor" required:"true" cty:"flavor" hcl:"flavor"`
 	AvailabilityZone            *string                 `mapstructure:"availability_zone" required:"false" cty:"availability_zone" hcl:"availability_zone"`
@@ -220,6 +222,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_ip_version":                &hcldec.AttrSpec{Name: "ssh_ip_version", Type: cty.String, Required: false},
 		"source_image":                  &hcldec.AttrSpec{Name: "source_image", Type: cty.String, Required: false},
 		"source_image_name":             &hcldec.AttrSpec{Name: "source_image_name", Type: cty.String, Required: false},
+		"external_source_image_url":     &hcldec.AttrSpec{Name: "external_source_image_url", Type: cty.String, Required: false},
+		"external_source_image_format":  &hcldec.AttrSpec{Name: "external_source_image_format", Type: cty.String, Required: false},
 		"source_image_filter":           &hcldec.BlockSpec{TypeName: "source_image_filter", Nested: hcldec.ObjectSpec((*FlatImageFilter)(nil).HCL2Spec())},
 		"flavor":                        &hcldec.AttrSpec{Name: "flavor", Type: cty.String, Required: false},
 		"availability_zone":             &hcldec.AttrSpec{Name: "availability_zone", Type: cty.String, Required: false},

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/doc.go
@@ -1,0 +1,27 @@
+/*
+Package imageimport enables management of images import and retrieval of the
+Imageservice Import API information.
+
+Example to Get an information about the Import API
+
+  importInfo, err := imageimport.Get(imagesClient).Extract()
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", importInfo)
+
+Example to Create a new image import
+
+  createOpts := imageimport.CreateOpts{
+    Name: imageimport.WebDownloadMethod,
+    URI:  "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
+  }
+  imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+
+  err := imageimport.Create(imagesClient, imageID, createOpts).ExtractErr()
+  if err != nil {
+    panic(err)
+  }
+*/
+package imageimport

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/requests.go
@@ -1,0 +1,55 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+// ImportMethod represents valid Import API method.
+type ImportMethod string
+
+const (
+	// GlanceDirectMethod represents glance-direct Import API method.
+	GlanceDirectMethod ImportMethod = "glance-direct"
+
+	// WebDownloadMethod represents web-download Import API method.
+	WebDownloadMethod ImportMethod = "web-download"
+)
+
+// Get retrieves Import API information data.
+func Get(c *gophercloud.ServiceClient) (r GetResult) {
+	resp, err := c.Get(infoURL(c), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateOptsBuilder allows to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToImportCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new image import.
+type CreateOpts struct {
+	Name ImportMethod `json:"name"`
+	URI  string       `json:"uri"`
+}
+
+// ToImportCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToImportCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"method": b}, nil
+}
+
+// Create requests the creation of a new image import on the server.
+func Create(client *gophercloud.ServiceClient, imageID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToImportCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(importURL(client, imageID), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/results.go
@@ -1,0 +1,38 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation. Call its Extract method
+// to interpret it as ImportInfo.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult is the result of import Create operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type CreateResult struct {
+	gophercloud.ErrResult
+}
+
+// ImportInfo represents information data for the Import API.
+type ImportInfo struct {
+	ImportMethods ImportMethods `json:"import-methods"`
+}
+
+// ImportMethods contains information about available Import API methods.
+type ImportMethods struct {
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Value       []string `json:"value"`
+}
+
+// Extract is a function that accepts a result and extracts ImportInfo.
+func (r commonResult) Extract() (*ImportInfo, error) {
+	var s *ImportInfo
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/urls.go
@@ -1,0 +1,17 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "images"
+	infoPath     = "info"
+	resourcePath = "import"
+)
+
+func infoURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(infoPath, resourcePath)
+}
+
+func importURL(c *gophercloud.ServiceClient, imageID string) string {
+	return c.ServiceURL(rootPath, imageID, resourcePath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -273,6 +273,7 @@ github.com/gophercloud/gophercloud/openstack/identity/v2/tokens
 github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/ec2tokens
 github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/oauth1
 github.com/gophercloud/gophercloud/openstack/identity/v3/tokens
+github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport
 github.com/gophercloud/gophercloud/openstack/imageservice/v2/images
 github.com/gophercloud/gophercloud/openstack/imageservice/v2/members
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external

--- a/website/pages/partials/builder/openstack/RunConfig-not-required.mdx
+++ b/website/pages/partials/builder/openstack/RunConfig-not-required.mdx
@@ -9,6 +9,8 @@
   connect via whichever IP address is returned first from the OpenStack
   API.
 
+- `external_source_image_format` (string) - The format of the external source image to use, e.g. qcow2, raw.
+
 - `availability_zone` (string) - The availability zone to launch the server in. If this isn't specified,
   the default enforced by your OpenStack cluster will be used. This may be
   required for some OpenStack clusters.

--- a/website/pages/partials/builder/openstack/RunConfig-required.mdx
+++ b/website/pages/partials/builder/openstack/RunConfig-required.mdx
@@ -8,6 +8,9 @@
 - `source_image_name` (string) - The name of the base image to use. This is an alternative way of
   providing source_image and only either of them can be specified.
 
+- `external_source_image_url` (string) - The URL of an external base image to use. This is an alternative way of
+  providing source_image and only either of them can be specified.
+
 - `source_image_filter` (ImageFilter) - Filters used to populate filter options. Example:
   
   ```json


### PR DESCRIPTION
Currently the OpenStack builder expects that the source image for the Packer image build already exists on the OpenStack cluster. However that's not always the case and prevents Packer from being used for creating images for a brand new OpenStack cluster in initial state with no images.

I would like to introduce a new feature to the OpenStack builder which allows to specify an external source image.

This PR adds:
- a new set of configuration properties which allow a user to specify the URL and format of an external source image e.g. from the [Ubuntu Cloud images repo](https://cloud-images.ubuntu.com/) (`ExternalSourceImageURL` and `ExternalSourceImageFormat`)
- logic that given an external source image URL and format calls the OpenStack Glance [interoperable image import API](https://docs.openstack.org/glance/ussuri/admin/interoperable-image-import.html) to let Glance download and import an image from the given URL using a temporary, generated name
- an extension of the Packer logic to use the newly imported image as the source image
- a cleanup mechanism to remove the previously downloaded and imported external source image once the Packer image build is complete
- some unit tests to verify some of the changed / extended logic