### PR TITLE
Removed hardcoded but obsolete Task Scheduler timeout

### DIFF
--- a/provisioner/elevated.go
+++ b/provisioner/elevated.go
@@ -70,7 +70,7 @@ $xml = [xml]@'
     <Hidden>false</Hidden>
     <RunOnlyIfIdle>false</RunOnlyIfIdle>
     <WakeToRun>false</WakeToRun>
-    <ExecutionTimeLimit>PT24H</ExecutionTimeLimit>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
     <Priority>4</Priority>
   </Settings>
   <Actions Context="Author">


### PR DESCRIPTION
The hardcoded Task Scheduler timeout is unnecessary due to other timeout features that packer already provides hence can be set to "indefinitely". This is mandatory since otherwise, processes that pass the 24 hours mark will fail.

This change was discussed and already "pre-approved" [here](https://github.com/hashicorp/packer/issues/9976).