### PR TITLE
Allow to specify boot volume size in OCI builder

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -77,7 +77,7 @@ type Config struct {
 	InstanceTags        map[string]string                 `mapstructure:"instance_tags"`
 	InstanceDefinedTags map[string]map[string]interface{} `mapstructure:"instance_defined_tags"`
 	Shape               string                            `mapstructure:"shape"`
-	BootVolumeSizeInGBs int64                             `mapstructure:"boot_volume_size_in_gbs"`
+	BootVolumeSizeInGBs int64                             `mapstructure:"disk_size"`
 
 	// Metadata optionally contains custom metadata key/value pairs provided in the
 	// configuration. While this can be used to set metadata["user_data"] the explicit
@@ -333,7 +333,7 @@ func (c *Config) Prepare(raws ...interface{}) error {
 		c.BootVolumeSizeInGBs = 50
 	} else if c.BootVolumeSizeInGBs < 50 || c.BootVolumeSizeInGBs > 16384 {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("'boot_volume_size_in_gbs' must be between 50 and 16384 GBs"))
+			errs, errors.New("'disk_size' must be between 50 and 16384 GBs"))
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	InstanceTags        map[string]string                 `mapstructure:"instance_tags"`
 	InstanceDefinedTags map[string]map[string]interface{} `mapstructure:"instance_defined_tags"`
 	Shape               string                            `mapstructure:"shape"`
+	BootVolumeSizeInGBs int64                             `mapstructure:"boot_volume_size_in_gbs"`
 
 	// Metadata optionally contains custom metadata key/value pairs provided in the
 	// configuration. While this can be used to set metadata["user_data"] the explicit
@@ -324,6 +325,15 @@ func (c *Config) Prepare(raws ...interface{}) error {
 			log.Printf("[DEBUG] base64 encoding user data...")
 			c.UserData = base64.StdEncoding.EncodeToString([]byte(c.UserData))
 		}
+	}
+
+	// Set default boot volume size to 50 if not set
+	// Check if size set is allowed by OCI
+	if c.BootVolumeSizeInGBs == 0 {
+		c.BootVolumeSizeInGBs = 50
+	} else if c.BootVolumeSizeInGBs < 50 || c.BootVolumeSizeInGBs > 16384 {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("'boot_volume_size_in_gbs' must be between 50 and 16384 GBs"))
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/builder/oracle/oci/config.hcl2spec.go
+++ b/builder/oracle/oci/config.hcl2spec.go
@@ -81,6 +81,7 @@ type FlatConfig struct {
 	InstanceTags              map[string]string                 `mapstructure:"instance_tags" cty:"instance_tags" hcl:"instance_tags"`
 	InstanceDefinedTags       map[string]map[string]interface{} `mapstructure:"instance_defined_tags" cty:"instance_defined_tags" hcl:"instance_defined_tags"`
 	Shape                     *string                           `mapstructure:"shape" cty:"shape" hcl:"shape"`
+	BootVolumeSizeInGBs       *int64                            `mapstructure:"boot_volume_size_in_gbs" cty:"boot_volume_size_in_gbs" hcl:"boot_volume_size_in_gbs"`
 	Metadata                  map[string]string                 `mapstructure:"metadata" cty:"metadata" hcl:"metadata"`
 	UserData                  *string                           `mapstructure:"user_data" cty:"user_data" hcl:"user_data"`
 	UserDataFile              *string                           `mapstructure:"user_data_file" cty:"user_data_file" hcl:"user_data_file"`
@@ -174,6 +175,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"instance_tags":                &hcldec.AttrSpec{Name: "instance_tags", Type: cty.Map(cty.String), Required: false},
 		"instance_defined_tags":        &hcldec.AttrSpec{Name: "instance_defined_tags", Type: cty.Map(cty.String), Required: false},
 		"shape":                        &hcldec.AttrSpec{Name: "shape", Type: cty.String, Required: false},
+		"boot_volume_size_in_gbs":      &hcldec.AttrSpec{Name: "boot_volume_size_in_gbs", Type: cty.Number, Required: false},
 		"metadata":                     &hcldec.AttrSpec{Name: "metadata", Type: cty.Map(cty.String), Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},

--- a/builder/oracle/oci/config.hcl2spec.go
+++ b/builder/oracle/oci/config.hcl2spec.go
@@ -81,7 +81,7 @@ type FlatConfig struct {
 	InstanceTags              map[string]string                 `mapstructure:"instance_tags" cty:"instance_tags" hcl:"instance_tags"`
 	InstanceDefinedTags       map[string]map[string]interface{} `mapstructure:"instance_defined_tags" cty:"instance_defined_tags" hcl:"instance_defined_tags"`
 	Shape                     *string                           `mapstructure:"shape" cty:"shape" hcl:"shape"`
-	BootVolumeSizeInGBs       *int64                            `mapstructure:"boot_volume_size_in_gbs" cty:"boot_volume_size_in_gbs" hcl:"boot_volume_size_in_gbs"`
+	BootVolumeSizeInGBs       *int64                            `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	Metadata                  map[string]string                 `mapstructure:"metadata" cty:"metadata" hcl:"metadata"`
 	UserData                  *string                           `mapstructure:"user_data" cty:"user_data" hcl:"user_data"`
 	UserDataFile              *string                           `mapstructure:"user_data_file" cty:"user_data_file" hcl:"user_data_file"`
@@ -175,7 +175,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"instance_tags":                &hcldec.AttrSpec{Name: "instance_tags", Type: cty.Map(cty.String), Required: false},
 		"instance_defined_tags":        &hcldec.AttrSpec{Name: "instance_defined_tags", Type: cty.Map(cty.String), Required: false},
 		"shape":                        &hcldec.AttrSpec{Name: "shape", Type: cty.String, Required: false},
-		"boot_volume_size_in_gbs":      &hcldec.AttrSpec{Name: "boot_volume_size_in_gbs", Type: cty.Number, Required: false},
+		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"metadata":                     &hcldec.AttrSpec{Name: "metadata", Type: cty.Map(cty.String), Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":               &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},

--- a/builder/oracle/oci/config_test.go
+++ b/builder/oracle/oci/config_test.go
@@ -44,7 +44,8 @@ func testConfig(accessConfFile *os.File) map[string]interface{} {
 		"create_vnic_details": map[string]interface{}{
 			"nsg_ids": []string{"ocd1..."},
 		},
-		"shape": "VM.Standard1.1",
+		"shape":                   "VM.Standard1.1",
+		"boot_volume_size_in_gbs": 60,
 	}
 }
 

--- a/builder/oracle/oci/config_test.go
+++ b/builder/oracle/oci/config_test.go
@@ -44,8 +44,8 @@ func testConfig(accessConfFile *os.File) map[string]interface{} {
 		"create_vnic_details": map[string]interface{}{
 			"nsg_ids": []string{"ocd1..."},
 		},
-		"shape":                   "VM.Standard1.1",
-		"boot_volume_size_in_gbs": 60,
+		"shape":     "VM.Standard1.1",
+		"disk_size": 60,
 	}
 }
 

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -56,7 +56,6 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 		CompartmentId:      &d.cfg.CompartmentID,
 		DefinedTags:        d.cfg.InstanceDefinedTags,
 		FreeformTags:       d.cfg.InstanceTags,
-		ImageId:            &d.cfg.BaseImageID,
 		Shape:              &d.cfg.Shape,
 		SubnetId:           &d.cfg.SubnetID,
 		Metadata:           metadata,
@@ -81,6 +80,12 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 	}
 
 	instanceDetails.CreateVnicDetails = &CreateVnicDetails
+
+	// Create Source details which will be used to Launch Instance
+	instanceDetails.SourceDetails = core.InstanceSourceViaImageDetails{
+		ImageId:             &d.cfg.BaseImageID,
+		BootVolumeSizeInGBs: &d.cfg.BootVolumeSizeInGBs,
+	}
 
 	instance, err := d.computeClient.LaunchInstance(context.TODO(), core.LaunchInstanceRequest{LaunchInstanceDetails: instanceDetails})
 

--- a/website/pages/docs/builders/oracle/oci.mdx
+++ b/website/pages/docs/builders/oracle/oci.mdx
@@ -139,7 +139,7 @@ can also be supplied to override the typical auto-generated key:
 - `instance_name` (string) - The name to assign to the instance used for the image creation process.
   If not set a name of the form `instanceYYYYMMDDhhmmss` will be used.
 
-- `instance_tags` (map of strings) - Add one or more freeform tags to the instance used for the 
+- `instance_tags` (map of strings) - Add one or more freeform tags to the instance used for the
   image creation process.
 
 - `instance_defined_tags` (map of maps of strings) - Add one or more defined tags for a given namespace
@@ -152,6 +152,10 @@ can also be supplied to override the typical auto-generated key:
   (map of maps of strings). See
   [the Oracle docs](https://docs.cloud.oracle.com/en-us/iaas/Content/Network/Tasks/managingVNICs.htm)
   for more information about VNICs.
+
+- `disk_size` (int64) - The size of the boot volume in GBs. Minimum value is 50 and maximum value is 16384 (16TB).
+  Sets the [BootVolumeSizeInGBs](https://godoc.org/github.com/oracle/oci-go-sdk/core#InstanceConfigurationInstanceSourceViaImageDetails)
+  when launching the instance. Defaults to `50`.
 
 - `use_private_ip` (boolean) - Use private ip addresses to connect to the
   instance via ssh.


### PR DESCRIPTION
Currently `oci` builder will use default size (46 Gb) for boot volume and consequently the resulting image.
If a larger default boot volume is required, what we do is manually re-create an image by launching an instance with larger disk size.

This MR allows to pass in a boot volume size in the template creating an image with desired default disk size after the build.
Introduced a new optional variable `boot_volume_size_in_gbs` with Default set to 50 GBs.

Closes #7117
