### PR TITLE
Update build tools to latest supported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.15
     resource_class: medium+
   darwin:
     macos:
-      xcode: "9.0"
+      xcode: "12.0.0"
 
 commands:
   install-go-run-tests-unix:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - install-go-run-tests-unix:
           GOOS: darwin
-          GOVERSION: "1.13"
+          GOVERSION: "1.15"
       - codecov/upload:
           file: coverage.txt
   test-windows:
@@ -76,7 +76,7 @@ jobs:
       shell: bash.exe
     steps:
       - install-go-run-tests-windows:
-          GOVERSION: "1.13"
+          GOVERSION: "1.15"
       - codecov/upload:
           file: coverage.txt
   check-lint:


### PR DESCRIPTION
Upgrades xcode to the latest GM version as version 9.0 will be deprecated on 10/05/2020.

* This PR also takes the opportunity to update to the latest version of Go.