### PR TITLE
fix pathing in cd_files copy to make sure directories make it into th…

### DIFF
--- a/common/step_create_cdrom.go
+++ b/common/step_create_cdrom.go
@@ -237,7 +237,7 @@ func (s *StepCreateCD) AddFile(dst, src string) error {
 	}
 
 	// file is a directory, so we need to parse the filename into a path to
-	// dicard and a basename
+	// discard and a basename
 	discardPath, _ := filepath.Split(src)
 
 	// Add a directory and its subdirectories


### PR DESCRIPTION
Pathing previously only worked as expected if directories we used to create cd_files existed in the cwd and were being referenced via relative pathing.

Given this template: 
```
      "cd_files": ["{{ pwd }}/http"],
```

it would fail: 

```
Build 'virtualbox-iso' errored after 1 second 920 milliseconds: Error creating temporary file for CD: error creating new directory /var/folders/8t/0yb5q0_x6mb2jldqq_vjn3lr0000gn/T/packer_to_cdrom525751836/Users/mmarsh/dev/repro_cases/http: mkdir /var/folders/8t/0yb5q0_x6mb2jldqq_vjn3lr0000gn/T/packer_to_cdrom525751836/Users/mmarsh/dev/repro_cases/http: no such file or directory
```

Now instead of trying to create paths `Users/mmarsh/dev/repro_cases/http` in my CD root, it just tries to create `http` since that's the directory I provided. 

Closes #10020