### PR TITLE
HCL: hide sensitive variables from output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.mdx text eol=lf
 *.ps1 text eol=lf
 *.hcl text eol=lf
+*.txt text eol=lf
 go.mod text eol=lf
 go.sum text eol=lf
 common/test-fixtures/root/*	eol=lf

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bytes"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -25,6 +26,15 @@ func outputCommand(t *testing.T, m Meta) (string, string) {
 	out := ui.Writer.(*bytes.Buffer)
 	err := ui.ErrorWriter.(*bytes.Buffer)
 	return out.String(), err.String()
+}
+
+func testFixtureContent(n ...string) string {
+	path := filepath.Join(append([]string{fixturesDir}, n...)...)
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
 }
 
 func testFixture(n ...string) string {

--- a/command/inspect_test.go
+++ b/command/inspect_test.go
@@ -153,6 +153,13 @@ Note: If your build names contain user variables or template
 functions such as 'timestamp', these are processed at build time,
 and therefore only show in their raw form here.
 `},
+		{
+			[]string{
+				"inspect", filepath.Join(testFixture("hcl-inspect-with-sensitive-vars")),
+			},
+			nil,
+			testFixtureContent("hcl-inspect-with-sensitive-vars", "expected-output.txt"),
+		},
 	}
 
 	for _, tc := range tc {

--- a/command/test-fixtures/hcl-inspect-with-sensitive-vars/expected-output.txt
+++ b/command/test-fixtures/hcl-inspect-with-sensitive-vars/expected-output.txt
@@ -1,0 +1,16 @@
+Packer Inspect: HCL2 mode
+
+> input-variables:
+
+var.not_sensitive: "I am soooo not sensitive"
+var.not_sensitive_unknown: "<unknown>"
+var.sensitive: "<sensitive>"
+var.sensitive_array: "[\n  \"<sensitive>\",\n  \"<sensitive>\",\n]"
+var.sensitive_tags: "{\n  \"first_key\" = \"<sensitive>\"\n  \"second_key\" = \"<sensitive>\"\n}"
+var.sensitive_unknown: "<unknown>"
+
+> local-variables:
+
+
+> builds:
+

--- a/command/test-fixtures/hcl-inspect-with-sensitive-vars/vars.pkr.hcl
+++ b/command/test-fixtures/hcl-inspect-with-sensitive-vars/vars.pkr.hcl
@@ -1,0 +1,29 @@
+
+variable "not_sensitive" {
+  default   = "I am soooo not sensitive"
+}
+
+variable "not_sensitive_unknown" {
+}
+
+variable "sensitive" {
+  default   = "I am soooo sensitive"
+  sensitive = true
+}
+
+variable "sensitive_array" {
+  default   = ["Im supersensitive", "me too !!!!"]
+  sensitive = true
+}
+
+variable "sensitive_tags" {
+  default   = {
+      first_key  = "this-is-mega-sensitive"
+      second_key = "this-is-also-sensitive"
+  }
+  sensitive = true
+}
+
+variable "sensitive_unknown" {
+  sensitive = true
+}

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -186,7 +186,7 @@ func (cfg *PackerConfig) Initialize() hcl.Diagnostics {
 		if !value.IsWhollyKnown() && value.IsNull() && !value.Type().Equals(cty.String) {
 			continue
 		}
-		cty.Walk(value, func(_ cty.Path, nested cty.Value) (bool, error) {
+		_ = cty.Walk(value, func(_ cty.Path, nested cty.Value) (bool, error) {
 			if nested.IsWhollyKnown() && !nested.IsNull() && nested.Type().Equals(cty.String) {
 				packer.LogSecretFilter.Set(nested.AsString())
 			}

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -183,9 +183,6 @@ func (cfg *PackerConfig) Initialize() hcl.Diagnostics {
 			continue
 		}
 		value, _ := variable.Value()
-		if !value.IsWhollyKnown() && value.IsNull() && !value.Type().Equals(cty.String) {
-			continue
-		}
 		_ = cty.Walk(value, func(_ cty.Path, nested cty.Value) (bool, error) {
 			if nested.IsWhollyKnown() && !nested.IsNull() && nested.Type().Equals(cty.String) {
 				packer.LogSecretFilter.Set(nested.AsString())

--- a/website/pages/docs/from-1.5/blocks/variable.mdx
+++ b/website/pages/docs/from-1.5/blocks/variable.mdx
@@ -30,6 +30,8 @@ Example of a variable assignment from a file:
 
 `@include 'from-1.5/variables/must-be-set.mdx'`
 
+`@include 'from-1.5/variables/sensitive.mdx'`
+
 # More on variables
 
 - Read the [full variables](/docs/from-1.5/variables) description for a more

--- a/website/pages/docs/from-1.5/variables.mdx
+++ b/website/pages/docs/from-1.5/variables.mdx
@@ -356,3 +356,5 @@ other variables: the last value found overrides the previous values.
 |   `var.bar` in .pkr.hcl file   | error, "bar undeclared" |  error, "bar undeclared"  |
 |     `-var bar=yz` argument     | error, "bar undeclared" |  error, "bar undeclared"  |
 |    `export PKR_VAR_bar=yz`     |            -            |             -             |
+
+`@include 'from-1.5/variables/sensitive.mdx'`

--- a/website/pages/partials/from-1.5/variables/foo-block.mdx
+++ b/website/pages/partials/from-1.5/variables/foo-block.mdx
@@ -1,8 +1,11 @@
 ```hcl
 # variables.pkr.hcl
 variable "foo" {
-    type = string
-    default = "the default value of the `foo` variable"
+    type        = string
+    default     = "the default value of the `foo` variable"
     description = "description of the `foo` variable"
+    sensitive   = false
+    # When a variable is sensitive all string-values from that variable will be
+    # obfuscated from Packer's output.
 }
 ```

--- a/website/pages/partials/from-1.5/variables/sensitive.mdx
+++ b/website/pages/partials/from-1.5/variables/sensitive.mdx
@@ -1,0 +1,23 @@
+## A variable can be sensitive
+
+When a variable is sensitive all string-values from that variable will be
+obfuscated from Packer's output :
+
+```hcl
+# var-foo.pkr.hcl
+variable "foo" {
+    sensitive = true
+    default   = {
+        key = "SECR3TP4SSW0RD"
+    }
+}
+```
+
+```shell-session
+$ packer inspect var-foo.pkr.hcl
+Packer Inspect: HCL2 mode
+
+> input-variables:
+var.foo: "{\n  \"key\" = \"<sensitive>\"\n }"
+...
+```


### PR DESCRIPTION
This allows to obfuscate sensitive variables from output by outputting `"<sensitive>"` in place.

fixes #9939 