### PR TITLE
Add support for globbing in shell scripts

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -160,6 +160,9 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		if matches, err := filepath.Glob(path); err != nil {
 			errs = packer.MultiErrorAppend(errs,
 				fmt.Errorf("Bad glob pattern '%s': %s", path, err))
+		} else if len(matches) == 0 {
+			errs = packer.MultiErrorAppend(errs,
+				fmt.Errorf("Found no files for path '%s'", path))
 		} else {
 			resolvedScripts = append(resolvedScripts, matches...)
 		}

--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -249,8 +250,8 @@ func TestProvisionerPrepare_ScriptsFromGlob(t *testing.T) {
 
 	inputScripts = append(inputScripts, td+"/*")
 
-	for i := 0; i < 2; i++ {
-		tf, err := ioutil.TempFile(td, "packer")
+	for i := 0; i < 10; i++ {
+		tf, err := ioutil.TempFile(td, fmt.Sprintf("%d_packer", i))
 		if err != nil {
 			t.Fatalf("error tempfile: %s", err)
 		}


### PR DESCRIPTION
Hi folks!

Curious if y'all would be open to the idea of supporting globbing for shell scripts – or possibly anywhere else that makes sense?

There's a couple of projects I work on that run _a ton_ of scripts to build new images, and we prefix those scripts with numbers to represent the order in which Packer runs them – purely to reduce development friction when browsing the files.

Rather than having to update the references in packer.json every time we do any work on those scripts, I thought it'd be neat if we could just glob for all the scripts in that directory and rely on the filenames to run in the order they are named:

```diff
{
  "provisioners": [
    {
      "type": "shell",
      "scripts": [
-        "scripts/10_install_tools.sh",
-        "scripts/20_download_repositories.sh",
-        "scripts/30_build_backend.sh",
-        "scripts/30_build_frontend.sh",
+        "scripts/*.sh"
      ]
    }
  ]
}
```

Soooo I've had a play around at building that!

I'd welcome any thoughts on if this is something the Packer project would be interested in supporting, and any feedback on my attempt at implementing it (I'm far from a Go dev, so this code could be an absolute rats nest!)

Thanks all :)