### PR TITLE
Feat (oracle/oci): allow specifying image compartment

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -69,8 +69,9 @@ type Config struct {
 	CompartmentID      string `mapstructure:"compartment_ocid"`
 
 	// Image
-	BaseImageID string `mapstructure:"base_image_ocid"`
-	ImageName   string `mapstructure:"image_name"`
+	BaseImageID        string `mapstructure:"base_image_ocid"`
+	ImageName          string `mapstructure:"image_name"`
+	ImageCompartmentID string `mapstructure:"image_compartment_ocid"`
 
 	// Instance
 	InstanceName        string                            `mapstructure:"instance_name"`
@@ -252,6 +253,10 @@ func (c *Config) Prepare(raws ...interface{}) error {
 
 	if c.CompartmentID == "" && tenancyOCID != "" {
 		c.CompartmentID = tenancyOCID
+	}
+
+	if c.ImageCompartmentID == "" {
+		c.ImageCompartmentID = c.CompartmentID
 	}
 
 	if c.Shape == "" {

--- a/builder/oracle/oci/config.hcl2spec.go
+++ b/builder/oracle/oci/config.hcl2spec.go
@@ -77,6 +77,7 @@ type FlatConfig struct {
 	CompartmentID             *string                           `mapstructure:"compartment_ocid" cty:"compartment_ocid" hcl:"compartment_ocid"`
 	BaseImageID               *string                           `mapstructure:"base_image_ocid" cty:"base_image_ocid" hcl:"base_image_ocid"`
 	ImageName                 *string                           `mapstructure:"image_name" cty:"image_name" hcl:"image_name"`
+	ImageCompartmentID        *string                           `mapstructure:"image_compartment_ocid" cty:"image_compartment_ocid" hcl:"image_compartment_ocid"`
 	InstanceName              *string                           `mapstructure:"instance_name" cty:"instance_name" hcl:"instance_name"`
 	InstanceTags              map[string]string                 `mapstructure:"instance_tags" cty:"instance_tags" hcl:"instance_tags"`
 	InstanceDefinedTags       map[string]map[string]interface{} `mapstructure:"instance_defined_tags" cty:"instance_defined_tags" hcl:"instance_defined_tags"`
@@ -171,6 +172,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"compartment_ocid":             &hcldec.AttrSpec{Name: "compartment_ocid", Type: cty.String, Required: false},
 		"base_image_ocid":              &hcldec.AttrSpec{Name: "base_image_ocid", Type: cty.String, Required: false},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
+		"image_compartment_ocid":       &hcldec.AttrSpec{Name: "image_compartment_ocid", Type: cty.String, Required: false},
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"instance_tags":                &hcldec.AttrSpec{Name: "instance_tags", Type: cty.Map(cty.String), Required: false},
 		"instance_defined_tags":        &hcldec.AttrSpec{Name: "instance_defined_tags", Type: cty.Map(cty.String), Required: false},

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -99,7 +99,7 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 // CreateImage creates a new custom image.
 func (d *driverOCI) CreateImage(ctx context.Context, id string) (core.Image, error) {
 	res, err := d.computeClient.CreateImage(ctx, core.CreateImageRequest{CreateImageDetails: core.CreateImageDetails{
-		CompartmentId: &d.cfg.CompartmentID,
+		CompartmentId: &d.cfg.ImageCompartmentID,
 		InstanceId:    &id,
 		DisplayName:   &d.cfg.ImageName,
 		FreeformTags:  d.cfg.Tags,

--- a/website/pages/docs/builders/oracle/oci.mdx
+++ b/website/pages/docs/builders/oracle/oci.mdx
@@ -71,7 +71,7 @@ can also be supplied to override the typical auto-generated key:
   operation available in the Core Services API.
 
 - `compartment_ocid` (string) - The OCID of the
-  [compartment](https://docs.us-phoenix-1.oraclecloud.com/Content/GSG/Tasks/choosingcompartments.htm)
+  [compartment](https://docs.us-phoenix-1.oraclecloud.com/Content/GSG/Tasks/choosingcompartments.htm) that the instance will run in.
 
 - `shape` (string) - The template that determines the number of CPUs, amount
   of memory, and other resources allocated to a newly created instance.
@@ -135,6 +135,8 @@ can also be supplied to override the typical auto-generated key:
   if present. This cannot be used along with the `use_instance_principals` key.
 
 - `image_name` (string) - The name to assign to the resulting custom image.
+
+- `image_compartment_ocid` (string) - The OCID of the target compartment for the resulting image. Defaults to `compartment_ocid`.
 
 - `instance_name` (string) - The name to assign to the instance used for the image creation process.
   If not set a name of the form `instanceYYYYMMDDhhmmss` will be used.


### PR DESCRIPTION
Adds option `image_compartment_ocid` for user to specify a compartment for the image to be saved in. By default, this is the same as `compartment_ocid`, so is backward compatible.

Closes #6844