### PR TITLE
Replace kardianos/osext with stdlib

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/packer/command"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer/plugin"
-	"github.com/kardianos/osext"
 )
 
 // PACKERSPACE is used to represent the spaces that separate args for a command
@@ -131,7 +130,7 @@ func (c *config) Discover() error {
 	}
 
 	// Next, look in the same directory as the executable.
-	exePath, err := osext.Executable()
+	exePath, err := os.Executable()
 	if err != nil {
 		log.Printf("[ERR] Error loading exe directory: %s", err)
 	} else {
@@ -311,7 +310,7 @@ func (c *config) discoverSingle(glob string) (map[string]string, error) {
 
 func (c *config) discoverInternalComponents() error {
 	// Get the packer binary path
-	packerPath, err := osext.Executable()
+	packerPath, err := os.Executable()
 	if err != nil {
 		log.Printf("[ERR] Error loading exe directory: %s", err)
 		return err
@@ -373,7 +372,7 @@ func (c *config) pluginClient(path string) *plugin.Client {
 		// If that doesn't work, look for it in the same directory
 		// as the `packer` executable (us).
 		log.Printf("Plugin could not be found at %s (%v). Checking same directory as executable.", originalPath, err)
-		exePath, err := osext.Executable()
+		exePath, err := os.Executable()
 		if err != nil {
 			log.Printf("Couldn't get current exe path: %s", err)
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62
 	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
-	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
+	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1 // indirect
 	github.com/klauspost/compress v0.0.0-20160131094358-f86d2e6d8a77 // indirect
 	github.com/klauspost/cpuid v0.0.0-20160106104451-349c67577817 // indirect
 	github.com/klauspost/crc32 v0.0.0-20160114101742-999f3125931f // indirect


### PR DESCRIPTION
os.Executable is available since go1.8
https://github.com/kardianos/osext/blob/master/osext_go18.go

kardianos/osext is still in go.mod, because the old version of panicwrap needs this.