### PR TITLE
Fix typo in Outscale name

### DIFF
--- a/website/pages/docs/builders/outscale/bsusurrogate.mdx
+++ b/website/pages/docs/builders/outscale/bsusurrogate.mdx
@@ -3,7 +3,7 @@ description: |
   The osc-bsusurrogate Packer builder is like the chroot builder, but does not
   require running inside an Outscale virtual machine.
 layout: docs
-page_title: Outacale BSU Surrogate - Builders
+page_title: Outscale BSU Surrogate - Builders
 sidebar_title: BSU Surrogate
 ---
 


### PR DESCRIPTION
Just a little PR to fix typo in documentation

Closes #10050
