### PR TITLE
feat(scaleway): get image by label if not an UUID

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	// that will be used to launch a new server and provision it. See
 	// the images list
 	// get the complete list of the accepted image UUID.
+	// The marketplace image label (eg `ubuntu_focal`) also works.
 	Image string `mapstructure:"image" required:"true"`
 	// The name of the server commercial type:
 	// C1, C2L, C2M, C2S, DEV1-S, DEV1-M, DEV1-L, DEV1-XL,

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/flock v0.7.3
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
-	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/shlex v0.0.0-20150127133951-6f45313302b9
@@ -94,7 +93,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-testing-interface v1.0.3 // indirect
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
-	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/mitchellh/iochan v1.0.0
 	github.com/mitchellh/mapstructure v1.2.3
 	github.com/mitchellh/panicwrap v0.0.0-20170106182340-fce601fe5557
@@ -113,7 +111,7 @@ require (
 	github.com/posener/complete v1.2.3
 	github.com/profitbricks/profitbricks-sdk-go v4.0.2+incompatible
 	github.com/satori/go.uuid v1.2.0 // indirect
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.6.0.20200903143645-c0ce17a0443d
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
@@ -137,7 +135,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200918174421-af09f7315aff
-	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200918232735-d647fc253266
 	google.golang.org/api v0.32.0
 	google.golang.org/genproto v0.0.0-20200918140846-d0d605568037 // indirect

--- a/go.sum
+++ b/go.sum
@@ -376,7 +376,6 @@ github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
@@ -513,7 +512,6 @@ github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZX
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
-github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -581,8 +579,8 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.6.0.20200903143645-c0ce17a0443d h1:pK33AoOAlzj6gJs/V1vi2Ouj2u1Ww84pREwxFi1oxkM=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.6.0.20200903143645-c0ce17a0443d/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7 h1:Do8ksLD4Nr3pA0x0hnLOLftZgkiTDvwPDShRTUxtXpE=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=

--- a/vendor/github.com/scaleway/scaleway-sdk-go/api/instance/v1/instance_sdk.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/api/instance/v1/instance_sdk.go
@@ -613,7 +613,7 @@ type Bootscript struct {
 	Initrd string `json:"initrd"`
 	// Kernel: the server kernel version
 	Kernel string `json:"kernel"`
-	// Organization: the bootscript organization
+	// Organization: the bootscript organization ID
 	Organization string `json:"organization"`
 	// Project: the bootscript project ID
 	Project string `json:"project"`
@@ -892,7 +892,7 @@ type PlacementGroup struct {
 	ID string `json:"id"`
 	// Name: the placement group name
 	Name string `json:"name"`
-	// Organization: the placement group organization
+	// Organization: the placement group organization ID
 	Organization string `json:"organization"`
 	// Project: the placement group project ID
 	Project string `json:"project"`
@@ -950,11 +950,11 @@ type SecurityGroup struct {
 	OutboundDefaultPolicy SecurityGroupPolicy `json:"outbound_default_policy"`
 	// Organization: the security groups organization ID
 	Organization string `json:"organization"`
-	// Project: the project ID of the security group
+	// Project: the security group project ID
 	Project string `json:"project"`
-	// OrganizationDefault: true if it is your default security group for this organization
+	// Deprecated: OrganizationDefault: true if it is your default security group for this organization ID
 	OrganizationDefault bool `json:"organization_default"`
-	// ProjectDefault: true if it is your default security group for this project id
+	// ProjectDefault: true if it is your default security group for this project ID
 	ProjectDefault bool `json:"project_default"`
 	// CreationDate: the security group creation date
 	CreationDate *time.Time `json:"creation_date"`
@@ -1014,7 +1014,7 @@ type Server struct {
 	ID string `json:"id"`
 	// Name: the server name
 	Name string `json:"name"`
-	// Organization: the server organization
+	// Organization: the server organization ID
 	Organization string `json:"organization"`
 	// Project: the server project ID
 	Project string `json:"project"`
@@ -1181,37 +1181,41 @@ type SetPlacementGroupServersResponse struct {
 	Servers []*PlacementGroupServer `json:"servers"`
 }
 
+// Snapshot: snapshot
 type Snapshot struct {
+	// ID: the snapshot ID
 	ID string `json:"id"`
-
+	// Name: the snapshot name
 	Name string `json:"name"`
-
+	// Organization: the snapshot organization ID
 	Organization string `json:"organization"`
-	// VolumeType:
+	// Project: the snapshot project ID
+	Project string `json:"project"`
+	// VolumeType: the snapshot volume type
 	//
 	// Default value: l_ssd
 	VolumeType VolumeVolumeType `json:"volume_type"`
-
+	// Size: the snapshot size
 	Size scw.Size `json:"size"`
-	// State:
+	// State: the snapshot state
 	//
 	// Default value: available
 	State SnapshotState `json:"state"`
-
+	// BaseVolume: the volume on which the snapshot is based on
 	BaseVolume *SnapshotBaseVolume `json:"base_volume"`
-
+	// CreationDate: the snapshot creation date
 	CreationDate *time.Time `json:"creation_date"`
-
+	// ModificationDate: the snapshot modification date
 	ModificationDate *time.Time `json:"modification_date"`
-
-	Project string `json:"project"`
-
+	// Zone: the snapshot zone
 	Zone scw.Zone `json:"zone"`
 }
 
+// SnapshotBaseVolume: snapshot. base volume
 type SnapshotBaseVolume struct {
+	// ID: the volume ID on which the snapshot is based on
 	ID string `json:"id"`
-
+	// Name: the volume name on which the snapshot is based on
 	Name string `json:"name"`
 }
 
@@ -1261,29 +1265,29 @@ type UpdateVolumeResponse struct {
 
 // Volume: volume
 type Volume struct {
-	// ID: the volumes unique ID
+	// ID: the volume unique ID
 	ID string `json:"id"`
-	// Name: the volumes names
+	// Name: the volume name
 	Name string `json:"name"`
-	// ExportURI: show the volumes NBD export URI
+	// ExportURI: show the volume NBD export URI
 	ExportURI string `json:"export_uri"`
-	// Size: the volumes disk size
+	// Size: the volume disk size
 	Size scw.Size `json:"size"`
-	// VolumeType: the volumes type
+	// VolumeType: the volume type
 	//
 	// Default value: l_ssd
 	VolumeType VolumeVolumeType `json:"volume_type"`
-	// CreationDate: the volumes creation date
+	// CreationDate: the volume creation date
 	CreationDate *time.Time `json:"creation_date"`
-	// ModificationDate: the volumes modification date
+	// ModificationDate: the volume modification date
 	ModificationDate *time.Time `json:"modification_date"`
-	// Organization: the volumes organization
+	// Organization: the volume organization ID
 	Organization string `json:"organization"`
-	// Project: the volumes project ID
+	// Project: the volume project ID
 	Project string `json:"project"`
 	// Server: the server attached to the volume
 	Server *ServerSummary `json:"server"`
-	// State: the volumes state
+	// State: the volume state
 	//
 	// Default value: available
 	State VolumeState `json:"state"`
@@ -1315,10 +1319,12 @@ type VolumeTemplate struct {
 	//
 	// Default value: l_ssd
 	VolumeType VolumeVolumeType `json:"volume_type,omitempty"`
-	// Organization: organization ID of the volume
-	Organization string `json:"organization,omitempty"`
+	// Deprecated: Organization: organization ID of the volume
+	// Precisely one of Organization, Project must be set.
+	Organization *string `json:"organization,omitempty"`
 	// Project: project ID of the volume
-	Project string `json:"project,omitempty"`
+	// Precisely one of Organization, Project must be set.
+	Project *string `json:"project,omitempty"`
 }
 
 type VolumeType struct {
@@ -1518,7 +1524,7 @@ type ListServersRequest struct {
 	PerPage *uint32 `json:"-"`
 	// Page: a positive integer to choose the page to return
 	Page *int32 `json:"-"`
-	// Organization: list only servers of this organization
+	// Organization: list only servers of this organization ID
 	Organization *string `json:"-"`
 	// Project: list only servers of this project ID
 	Project *string `json:"-"`
@@ -1536,6 +1542,8 @@ type ListServersRequest struct {
 	State *ServerState `json:"-"`
 	// Tags: list servers with these exact tags
 	Tags []string `json:"-"`
+	// PrivateNetwork: list servers in this Private Network
+	PrivateNetwork *string `json:"-"`
 }
 
 // ListServers: list all servers
@@ -1565,6 +1573,7 @@ func (s *API) ListServers(req *ListServersRequest, opts ...scw.RequestOption) (*
 	if len(req.Tags) != 0 {
 		parameter.AddToQuery(query, "tags", strings.Join(req.Tags, ","))
 	}
+	parameter.AddToQuery(query, "private_network", req.PrivateNetwork)
 
 	if fmt.Sprint(req.Zone) == "" {
 		return nil, errors.New("field Zone cannot be empty in request")
@@ -1627,7 +1636,7 @@ type CreateServerRequest struct {
 	BootType *BootType `json:"boot_type,omitempty"`
 	// Bootscript: the bootscript ID to use when `boot_type` is set to `bootscript`
 	Bootscript *string `json:"bootscript,omitempty"`
-	// Organization: the server organization ID
+	// Deprecated: Organization: the server organization ID
 	// Precisely one of Organization, Project must be set.
 	Organization *string `json:"organization,omitempty"`
 	// Project: the server project ID
@@ -1639,8 +1648,6 @@ type CreateServerRequest struct {
 	SecurityGroup *string `json:"security_group,omitempty"`
 	// PlacementGroup: placement group ID if server must be part of a placement group
 	PlacementGroup *string `json:"placement_group,omitempty"`
-	// PrivateNetwork: private Network IDs if the server need to be part of one or more Private Networks
-	PrivateNetwork []string `json:"private_network,omitempty"`
 }
 
 // createServer: create a server
@@ -1774,7 +1781,7 @@ type setServerRequest struct {
 	ID string `json:"-"`
 	// Name: the server name
 	Name string `json:"name"`
-	// Organization: the server organization
+	// Organization: the server organization ID
 	Organization string `json:"organization"`
 	// Project: the server project ID
 	Project string `json:"project"`
@@ -2262,7 +2269,7 @@ type CreateImageRequest struct {
 	DefaultBootscript string `json:"default_bootscript,omitempty"`
 	// ExtraVolumes: additional volumes of the image
 	ExtraVolumes map[string]*VolumeTemplate `json:"extra_volumes,omitempty"`
-	// Organization: organization ID of the image
+	// Deprecated: Organization: organization ID of the image
 	// Precisely one of Organization, Project must be set.
 	Organization *string `json:"organization,omitempty"`
 	// Project: project ID of the image
@@ -2520,10 +2527,10 @@ type CreateSnapshotRequest struct {
 	Name string `json:"name,omitempty"`
 	// VolumeID: UUID of the volume
 	VolumeID string `json:"volume_id,omitempty"`
-
+	// Deprecated: Organization: organization ID of the snapshot
 	// Precisely one of Organization, Project must be set.
 	Organization *string `json:"organization,omitempty"`
-
+	// Project: project ID of the snapshot
 	// Precisely one of Organization, Project must be set.
 	Project *string `json:"project,omitempty"`
 }
@@ -2742,7 +2749,7 @@ type ListVolumesRequest struct {
 	PerPage *uint32 `json:"-"`
 	// Page: a positive integer to choose the page to return
 	Page *int32 `json:"-"`
-	// Organization: filter volume by organization
+	// Organization: filter volume by organization ID
 	Organization *string `json:"-"`
 	// Project: filter volume by project ID
 	Project *string `json:"-"`
@@ -2813,27 +2820,27 @@ func (r *ListVolumesResponse) UnsafeAppend(res interface{}) (uint32, error) {
 
 type CreateVolumeRequest struct {
 	Zone scw.Zone `json:"-"`
-
+	// Name: the volume name
 	Name string `json:"name,omitempty"`
-
+	// Deprecated: Organization: the volume organization ID
 	// Precisely one of Organization, Project must be set.
 	Organization *string `json:"organization,omitempty"`
-	// VolumeType:
+	// Project: the volume project ID
+	// Precisely one of Organization, Project must be set.
+	Project *string `json:"project,omitempty"`
+	// VolumeType: the volume type
 	//
 	// Default value: l_ssd
 	VolumeType VolumeVolumeType `json:"volume_type"`
-
+	// Size: the volume disk size
 	// Precisely one of BaseSnapshot, BaseVolume, Size must be set.
 	Size *scw.Size `json:"size,omitempty"`
-
+	// BaseVolume: the ID of the volume on which this volume will be based
 	// Precisely one of BaseSnapshot, BaseVolume, Size must be set.
 	BaseVolume *string `json:"base_volume,omitempty"`
-
+	// BaseSnapshot: the ID of the snapshot on which this volume will be based
 	// Precisely one of BaseSnapshot, BaseVolume, Size must be set.
 	BaseSnapshot *string `json:"base_snapshot,omitempty"`
-
-	// Precisely one of Organization, Project must be set.
-	Project *string `json:"project,omitempty"`
 }
 
 // CreateVolume: create a volume
@@ -3090,13 +3097,13 @@ type CreateSecurityGroupRequest struct {
 	Name string `json:"name,omitempty"`
 	// Description: description of the security group
 	Description string `json:"description,omitempty"`
-	// Organization: organization the security group belongs to
+	// Deprecated: Organization: organization ID the security group belongs to
 	// Precisely one of Organization, Project must be set.
 	Organization *string `json:"organization,omitempty"`
 	// Project: project ID the security group belong to
 	// Precisely one of Organization, Project must be set.
 	Project *string `json:"project,omitempty"`
-	// OrganizationDefault: whether this security group becomes the default security group for new instances
+	// Deprecated: OrganizationDefault: whether this security group becomes the default security group for new instances
 	//
 	// Default value: false
 	// Precisely one of OrganizationDefault, ProjectDefault must be set.
@@ -3245,38 +3252,38 @@ func (s *API) DeleteSecurityGroup(req *DeleteSecurityGroupRequest, opts ...scw.R
 
 type setSecurityGroupRequest struct {
 	Zone scw.Zone `json:"-"`
-
+	// ID: the ID of the security group (will be ignored)
 	ID string `json:"-"`
-
+	// Name: the name of the security group
 	Name string `json:"name"`
-
+	// CreationDate: the creation date of the security group (will be ignored)
 	CreationDate *time.Time `json:"creation_date"`
-
+	// ModificationDate: the modification date of the security group (will be ignored)
 	ModificationDate *time.Time `json:"modification_date"`
-
+	// Description: the description of the security group
 	Description string `json:"description"`
-
+	// EnableDefaultSecurity: true to block SMTP on IPv4 and IPv6
 	EnableDefaultSecurity bool `json:"enable_default_security"`
-	// InboundDefaultPolicy:
+	// InboundDefaultPolicy: the default inbound policy
 	//
 	// Default value: accept
 	InboundDefaultPolicy SecurityGroupPolicy `json:"inbound_default_policy"`
-
-	Organization string `json:"organization"`
-
-	OrganizationDefault bool `json:"organization_default"`
-	// OutboundDefaultPolicy:
+	// OutboundDefaultPolicy: the default outbound policy
 	//
 	// Default value: accept
 	OutboundDefaultPolicy SecurityGroupPolicy `json:"outbound_default_policy"`
-
-	Servers []*ServerSummary `json:"servers"`
-
-	Stateful bool `json:"stateful"`
-
+	// Organization: the security groups organization ID
+	Organization string `json:"organization"`
+	// Project: the security group project ID
 	Project string `json:"project"`
-
+	// Deprecated: OrganizationDefault: please use project_default instead
+	OrganizationDefault bool `json:"organization_default"`
+	// ProjectDefault: true use this security group for future instances created in this project
 	ProjectDefault bool `json:"project_default"`
+	// Servers: the servers attached to this security group
+	Servers []*ServerSummary `json:"servers"`
+	// Stateful: true to set the security group as stateful
+	Stateful bool `json:"stateful"`
 }
 
 // setSecurityGroup: update a security group
@@ -3637,7 +3644,7 @@ type ListPlacementGroupsRequest struct {
 	PerPage *uint32 `json:"-"`
 	// Page: a positive integer to choose the page to return
 	Page *int32 `json:"-"`
-	// Organization: list only placement groups of this organization
+	// Organization: list only placement groups of this organization ID
 	Organization *string `json:"-"`
 	// Project: list only placement groups of this project ID
 	Project *string `json:"-"`
@@ -3711,17 +3718,17 @@ type CreatePlacementGroupRequest struct {
 	Zone scw.Zone `json:"-"`
 	// Name: name of the placement group
 	Name string `json:"name,omitempty"`
-
+	// Deprecated: Organization: organization ID of the placement group
 	// Precisely one of Organization, Project must be set.
 	Organization *string `json:"organization,omitempty"`
-
+	// Project: project ID of the placement group
 	// Precisely one of Organization, Project must be set.
 	Project *string `json:"project,omitempty"`
-	// PolicyMode:
+	// PolicyMode: the operating mode of the placement group
 	//
 	// Default value: optional
 	PolicyMode PlacementGroupPolicyMode `json:"policy_mode"`
-	// PolicyType:
+	// PolicyType: the policy type of the placement group
 	//
 	// Default value: max_availability
 	PolicyType PlacementGroupPolicyType `json:"policy_type"`
@@ -4114,8 +4121,6 @@ func (s *API) UpdatePlacementGroupServers(req *UpdatePlacementGroupServersReques
 
 type ListIPsRequest struct {
 	Zone scw.Zone `json:"-"`
-	// Project: the project ID the IPs are reserved in
-	Project *string `json:"-"`
 	// Organization: the organization ID the IPs are reserved in
 	Organization *string `json:"-"`
 	// Name: filter on the IP address (Works as a LIKE operation on the IP address)
@@ -4126,6 +4131,8 @@ type ListIPsRequest struct {
 	PerPage *uint32 `json:"-"`
 	// Page: a positive integer to choose the page to return
 	Page *int32 `json:"-"`
+	// Project: the project ID the IPs are reserved in
+	Project *string `json:"-"`
 }
 
 // ListIPs: list all flexible IPs
@@ -4143,11 +4150,11 @@ func (s *API) ListIPs(req *ListIPsRequest, opts ...scw.RequestOption) (*ListIPsR
 	}
 
 	query := url.Values{}
-	parameter.AddToQuery(query, "project", req.Project)
 	parameter.AddToQuery(query, "organization", req.Organization)
 	parameter.AddToQuery(query, "name", req.Name)
 	parameter.AddToQuery(query, "per_page", req.PerPage)
 	parameter.AddToQuery(query, "page", req.Page)
+	parameter.AddToQuery(query, "project", req.Project)
 
 	if fmt.Sprint(req.Zone) == "" {
 		return nil, errors.New("field Zone cannot be empty in request")
@@ -4190,7 +4197,7 @@ func (r *ListIPsResponse) UnsafeAppend(res interface{}) (uint32, error) {
 
 type CreateIPRequest struct {
 	Zone scw.Zone `json:"-"`
-	// Organization: the organization ID the IP is reserved in
+	// Deprecated: Organization: the organization ID the IP is reserved in
 	// Precisely one of Organization, Project must be set.
 	Organization *string `json:"organization,omitempty"`
 	// Project: the project ID the IP is reserved in

--- a/vendor/github.com/scaleway/scaleway-sdk-go/scw/README.md
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/scw/README.md
@@ -5,10 +5,11 @@
 Recommended config file:
 
 ```yaml
-# get your credentials on https://console.scaleway.com/account/credentials
+# Get your credentials on https://console.scaleway.com/project/credentials
 access_key: SCWXXXXXXXXXXXXXXXXX
 secret_key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 default_organization_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+default_project_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 default_region: fr-par
 default_zone: fr-par-1
 ```
@@ -20,7 +21,7 @@ The function [`GetConfigPath`](https://godoc.org/github.com/scaleway/scaleway-sd
 1. Custom directory: `$SCW_CONFIG_PATH`
 2. [XDG base directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html): `$XDG_CONFIG_HOME/scw/config.yaml`
 3. Unix home directory: `$HOME/.config/scw/config.yaml`
-3. Windows home directory: `%USERPROFILE%/.config/scw/config.yaml`
+4. Windows home directory: `%USERPROFILE%/.config/scw/config.yaml`
 
 ## V1 config (DEPRECATED)
 
@@ -43,13 +44,14 @@ scw.NewClient(
 
 ## Environment variables
 
-| Variable                  | Description                                                                                                                             | Legacy variables                                                                                              |
-| :------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ |
-| `$SCW_ACCESS_KEY`         | Access key of a token ([get yours](https://console.scaleway.com/account/credentials))                                                   | `$SCALEWAY_ACCESS_KEY` (used by terraform)                                                                    |
-| `$SCW_SECRET_KEY`         | Secret key of a token ([get yours](https://console.scaleway.com/account/credentials))                                                   | `$SCW_TOKEN` (used by cli), `$SCALEWAY_TOKEN` (used by terraform), `$SCALEWAY_ACCESS_KEY` (used by terraform) |
-| `$SCW_DEFAULT_ORGANIZATION_ID` | Your default organization ID, if you don't have one use your organization ID ([get yours](https://console.scaleway.com/account/credentials)) | `$SCW_ORGANIZATION` (used by cli),`$SCALEWAY_ORGANIZATION` (used by terraform)                                |
-| `$SCW_DEFAULT_REGION`     | Your default [region](https://developers.scaleway.com/en/quickstart/#region-and-zone)                                                   | `$SCW_REGION` (used by cli),`$SCALEWAY_REGION` (used by terraform)                                            |
-| `$SCW_DEFAULT_ZONE`       | Your default [availability zone](https://developers.scaleway.com/en/quickstart/#region-and-zone)                                        | `$SCW_ZONE` (used by cli),`$SCALEWAY_ZONE` (used by terraform)                                                |
-| `$SCW_API_URL`            | Url of the API                                                                                                                          | -                                                                                                             |
-| `$SCW_INSECURE`           | Set this to `true` to enable the insecure mode                                                                                          | `$SCW_TLSVERIFY` (inverse flag used by the cli)                                                               |
-| `$SCW_PROFILE`            | Set the config profile to use                                                                                                           | -                                                                                                             |
+| Variable                       | Description                                                                                      | Legacy variables                                                                                              |
+| :----------------------------- | :----------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| `$SCW_ACCESS_KEY`              | Access key of a token ([get yours](https://console.scaleway.com/project/credentials))            | `$SCALEWAY_ACCESS_KEY` (used by terraform)                                                                    |
+| `$SCW_SECRET_KEY`              | Secret key of a token ([get yours](https://console.scaleway.com/project/credentials))            | `$SCW_TOKEN` (used by cli), `$SCALEWAY_TOKEN` (used by terraform), `$SCALEWAY_ACCESS_KEY` (used by terraform) |
+| `$SCW_DEFAULT_ORGANIZATION_ID` | Your default organization ID ([get yours](https://console.scaleway.com/project/credentials))     | `$SCW_ORGANIZATION` (used by cli),`$SCALEWAY_ORGANIZATION` (used by terraform)                                |
+| `$SCW_DEFAULT_PROJECT_ID`      | Your default project ID ([get yours](https://console.scaleway.com/project/credentials))          |                                                                                                               |
+| `$SCW_DEFAULT_REGION`          | Your default [region](https://developers.scaleway.com/en/quickstart/#region-and-zone)            | `$SCW_REGION` (used by cli),`$SCALEWAY_REGION` (used by terraform)                                            |
+| `$SCW_DEFAULT_ZONE`            | Your default [availability zone](https://developers.scaleway.com/en/quickstart/#region-and-zone) | `$SCW_ZONE` (used by cli),`$SCALEWAY_ZONE` (used by terraform)                                                |
+| `$SCW_API_URL`                 | Url of the API                                                                                   | -                                                                                                             |
+| `$SCW_INSECURE`                | Set this to `true` to enable the insecure mode                                                   | `$SCW_TLSVERIFY` (inverse flag used by the cli)                                                               |
+| `$SCW_PROFILE`                 | Set the config profile to use                                                                    | -                                                                                                             |

--- a/vendor/github.com/scaleway/scaleway-sdk-go/scw/config.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/scw/config.go
@@ -30,7 +30,7 @@ const configFileTemplate = `# Scaleway configuration file
 # - Scaleway Terraform Provider (https://www.terraform.io/docs/providers/scaleway/index.html)
 
 # You need an access key and a secret key to connect to Scaleway API.
-# Generate your token at the following address: https://console.scaleway.com/account/credentials
+# Generate your token at the following address: https://console.scaleway.com/project/credentials
 
 # An access key is a secret key identifier.
 {{ if .AccessKey }}access_key: {{.AccessKey}}{{ else }}# access_key: SCW11111111111111111{{ end }}

--- a/vendor/github.com/scaleway/scaleway-sdk-go/scw/locality.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/scw/locality.go
@@ -23,6 +23,8 @@ const (
 	ZoneFrPar2 = Zone("fr-par-2")
 	// ZoneNlAms1 represents the nl-ams-1 zone
 	ZoneNlAms1 = Zone("nl-ams-1")
+	// ZonePlWaw1 represents the pl-waw-1 zone
+	ZonePlWaw1 = Zone("pl-waw-1")
 )
 
 var (
@@ -31,6 +33,7 @@ var (
 		ZoneFrPar1,
 		ZoneFrPar2,
 		ZoneNlAms1,
+		ZonePlWaw1,
 	}
 )
 
@@ -68,6 +71,8 @@ const (
 	RegionFrPar = Region("fr-par")
 	// RegionNlAms represents the nl-ams region
 	RegionNlAms = Region("nl-ams")
+	// RegionPlWaw represents the pl-waw region
+	RegionPlWaw = Region("pl-waw")
 )
 
 var (
@@ -75,6 +80,7 @@ var (
 	AllRegions = []Region{
 		RegionFrPar,
 		RegionNlAms,
+		RegionPlWaw,
 	}
 )
 
@@ -95,6 +101,8 @@ func (region Region) GetZones() []Zone {
 		return []Zone{ZoneFrPar1, ZoneFrPar2}
 	case RegionNlAms:
 		return []Zone{ZoneNlAms1}
+	case RegionPlWaw:
+		return []Zone{ZonePlWaw1}
 	default:
 		return []Zone{}
 	}

--- a/vendor/github.com/scaleway/scaleway-sdk-go/scw/version.go
+++ b/vendor/github.com/scaleway/scaleway-sdk-go/scw/version.go
@@ -6,6 +6,6 @@ import (
 )
 
 // TODO: versioning process
-const version = "v1.0.0-beta.6+dev"
+const version = "v1.0.0-beta.7"
 
 var userAgent = fmt.Sprintf("scaleway-sdk-go/%s (%s; %s; %s)", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -496,7 +496,7 @@ github.com/profitbricks/profitbricks-sdk-go
 github.com/ryanuber/go-glob
 # github.com/satori/go.uuid v1.2.0
 github.com/satori/go.uuid
-# github.com/scaleway/scaleway-sdk-go v1.0.0-beta.6.0.20200903143645-c0ce17a0443d
+# github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7
 github.com/scaleway/scaleway-sdk-go/api/instance/v1
 github.com/scaleway/scaleway-sdk-go/api/marketplace/v1
 github.com/scaleway/scaleway-sdk-go/internal/async

--- a/website/pages/partials/builder/scaleway/Config-required.mdx
+++ b/website/pages/partials/builder/scaleway/Config-required.mdx
@@ -16,6 +16,7 @@
   that will be used to launch a new server and provision it. See
   the images list
   get the complete list of the accepted image UUID.
+  The marketplace image label (eg `ubuntu_focal`) also works.
 
 - `commercial_type` (string) - The name of the server commercial type:
   C1, C2L, C2M, C2S, DEV1-S, DEV1-M, DEV1-L, DEV1-XL,


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

Allow the user to use an image label (eg `ubuntu_focal`) instead of a hardcoded UUID on the Scaleway builder
