### PR TITLE
provisioner/ansible: Set connection type to local for localhost targets

### DIFF
--- a/provisioner/ansible/provisioner_test.go
+++ b/provisioner/ansible/provisioner_test.go
@@ -433,6 +433,16 @@ default ansible_ssh_host=123.45.67.89 ansible_ssh_user=testuser ansible_ssh_port
 			}),
 			Expected: "default ansible_host=123.45.67.89 ansible_connection=winrm ansible_winrm_transport=basic ansible_shell_type=powershell ansible_user=testuser ansible_port=1234\n",
 		},
+		{
+			AnsibleVersion: 2,
+			User:           "testuser",
+			UseProxy:       confighelper.TriFalse,
+			GeneratedData: basicGenData(map[string]interface{}{
+				"ConnType": "ssh",
+				"Host":     "localhost",
+			}),
+			Expected: "default ansible_host=localhost ansible_connection=local ansible_user=testuser ansible_port=1234\n",
+		},
 	}
 
 	for _, tc := range TestCases {


### PR DESCRIPTION
When using localhost as the connecting target, Ansible will generate an implicit localhost target if one is not defined in inventory.
To prevent this Ansible provides a connection=local flag that prevents Ansible from generating the implicit localhost.
https://docs.ansible.com/ansible/latest/inventory/implicit_localhost.html

This change fixes the issue with using the Amazon SSM connection with Ansible.
As referenced in https://github.com/hashicorp/packer/issues/10035

Closes #10035