### PR TITLE
Fix typo in option description

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -382,7 +382,7 @@ Options:
 
   -color=false                  Disable color output. (Default: color)
   -debug                        Debug mode enabled for builds.
-  -except=foo,bar,baz           Run all builds and post-procesors other than these.
+  -except=foo,bar,baz           Run all builds and post-processors other than these.
   -only=foo,bar,baz             Build only the specified builds.
   -force                        Force a build to continue if artifacts exist, deletes existing artifacts.
   -machine-readable             Produce machine-readable output.

--- a/contrib/zsh-completion/_packer
+++ b/contrib/zsh-completion/_packer
@@ -14,7 +14,7 @@ _packer () {
     '-force[Force a build to continue if artifacts exist, deletes existing artifacts.]'
     '-machine-readable[Produce machine-readable output.]'
     '-color=[(false) Disable color output. (Default: color)]'
-    '-except=[(foo,bar,baz) Run all builds and post-procesors other than these.]'
+    '-except=[(foo,bar,baz) Run all builds and post-processors other than these.]'
     '-on-error=[(cleanup,abort,ask) If the build fails do: clean up (default), abort, or ask.]'
     '-only=[(foo,bar,baz) Only build the given builds by name.]'
     '-parallel=[(false) Disable parallelization. (Default: false)]'


### PR DESCRIPTION
Fixes typo in build option description for the `-except` option.