### PR TITLE
builder/amazon: Support for source instance tenancy

### DIFF
--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -635,6 +635,12 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		}
 	}
 
+	if c.Tenancy != "" && c.Tenancy != "default" {
+		if c.SpotPrice != "" {
+			errs = append(errs, fmt.Errorf("Error: Non-default tenancy cannot be used in conjunction with Spot Instances"))
+		}
+	}
+
 	return errs
 }
 

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -376,6 +376,10 @@ type RunConfig struct {
 	// subnet-12345def, where Packer will launch the EC2 instance. This field is
 	// required if you are using an non-default VPC.
 	SubnetId string `mapstructure:"subnet_id" required:"false"`
+	// [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
+	// when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
+	// If unset, the default shared tenancy will be used.
+	Tenancy string `mapstructure:"tenancy" required:"false"`
 	// The name of the temporary key pair to
 	// generate. By default, Packer generates a name that looks like
 	// `packer_<UUID>`, where &lt;UUID&gt; is a 36 character unique identifier.

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -378,7 +378,9 @@ type RunConfig struct {
 	SubnetId string `mapstructure:"subnet_id" required:"false"`
 	// [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
 	// when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
-	// If unset, the default shared tenancy will be used.
+	//
+	// The default is "default", meaning shared tenancy. Allowed values are "default",
+	// "dedicated" and "host".
 	Tenancy string `mapstructure:"tenancy" required:"false"`
 	// The name of the temporary key pair to
 	// generate. By default, Packer generates a name that looks like
@@ -635,10 +637,11 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		}
 	}
 
-	if c.Tenancy != "" && c.Tenancy != "default" {
-		if c.SpotPrice != "" {
-			errs = append(errs, fmt.Errorf("Error: Non-default tenancy cannot be used in conjunction with Spot Instances"))
-		}
+	if c.Tenancy != "" &&
+		c.Tenancy != "default" &&
+		c.Tenancy != "dedicated" &&
+		c.Tenancy != "host" {
+		errs = append(errs, fmt.Errorf("Error: Unknown tenancy type %s", c.Tenancy))
 	}
 
 	return errs

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -232,3 +232,23 @@ func TestRunConfigPrepare_TemporaryKeyPairName(t *testing.T) {
 		t.Fatal("keypair name does not match")
 	}
 }
+
+func TestRunConfigPrepare_TenancySpot(t *testing.T) {
+	c := testConfig()
+	c.Tenancy = "dedicated"
+	c.SpotPrice = "1"
+
+	if err := c.Prepare(nil); len(err) != 1 {
+		t.Fatal("Should error if non-default tenancy and spot price are both set")
+	}
+}
+
+func TestRunConfigPrepare_TenancySpotDefault(t *testing.T) {
+	c := testConfig()
+	c.Tenancy = "default"
+	c.SpotPrice = "1"
+
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatal("Should not error if tenancy is set to default with spot price")
+	}
+}

--- a/builder/amazon/common/run_config_test.go
+++ b/builder/amazon/common/run_config_test.go
@@ -233,22 +233,22 @@ func TestRunConfigPrepare_TemporaryKeyPairName(t *testing.T) {
 	}
 }
 
-func TestRunConfigPrepare_TenancySpot(t *testing.T) {
+func TestRunConfigPrepare_TenancyBad(t *testing.T) {
 	c := testConfig()
-	c.Tenancy = "dedicated"
-	c.SpotPrice = "1"
+	c.Tenancy = "not_real"
 
 	if err := c.Prepare(nil); len(err) != 1 {
-		t.Fatal("Should error if non-default tenancy and spot price are both set")
+		t.Fatal("Should error if tenancy is set to an invalid type")
 	}
 }
 
-func TestRunConfigPrepare_TenancySpotDefault(t *testing.T) {
-	c := testConfig()
-	c.Tenancy = "default"
-	c.SpotPrice = "1"
-
-	if err := c.Prepare(nil); len(err) != 0 {
-		t.Fatal("Should not error if tenancy is set to default with spot price")
+func TestRunConfigPrepare_TenancyGood(t *testing.T) {
+	validTenancy := []string{"", "default", "dedicated", "host"}
+	for _, vt := range validTenancy {
+		c := testConfig()
+		c.Tenancy = vt
+		if err := c.Prepare(nil); len(err) != 0 {
+			t.Fatalf("Should not error if tenancy is set to %s", vt)
+		}
 	}
 }

--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -33,6 +33,7 @@ type StepRunSourceInstance struct {
 	IsRestricted                      bool
 	SourceAMI                         string
 	Tags                              map[string]string
+	Tenancy                           string
 	UserData                          string
 	UserDataFile                      string
 	VolumeTags                        map[string]string
@@ -193,6 +194,10 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 
 	if s.ExpectedRootDevice == "ebs" {
 		runOpts.InstanceInitiatedShutdownBehavior = &s.InstanceInitiatedShutdownBehavior
+	}
+
+	if s.Tenancy != "" {
+		runOpts.Placement.Tenancy = aws.String(s.Tenancy)
 	}
 
 	var runResp *ec2.Reservation

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -206,6 +206,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
+			Tenancy:                           b.config.Tenancy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,

--- a/builder/amazon/ebs/builder.hcl2spec.go
+++ b/builder/amazon/ebs/builder.hcl2spec.go
@@ -81,6 +81,7 @@ type FlatConfig struct {
 	SpotTag                                   []hcl2template.FlatKeyValue            `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 	TemporaryKeyPairName                      *string                                `mapstructure:"temporary_key_pair_name" required:"false" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -226,6 +227,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*hcl2template.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -228,6 +228,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
+			Tenancy:                           b.config.Tenancy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,

--- a/builder/amazon/ebssurrogate/builder.hcl2spec.go
+++ b/builder/amazon/ebssurrogate/builder.hcl2spec.go
@@ -103,6 +103,7 @@ type FlatConfig struct {
 	SpotTag                                   []hcl2template.FlatKeyValue            `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 	TemporaryKeyPairName                      *string                                `mapstructure:"temporary_key_pair_name" required:"false" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -249,6 +250,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*hcl2template.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -209,6 +209,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
+			Tenancy:                           b.config.Tenancy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,

--- a/builder/amazon/ebsvolume/builder.hcl2spec.go
+++ b/builder/amazon/ebsvolume/builder.hcl2spec.go
@@ -105,6 +105,7 @@ type FlatConfig struct {
 	SpotTag                                   []hcl2template.FlatKeyValue            `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 	TemporaryKeyPairName                      *string                                `mapstructure:"temporary_key_pair_name" required:"false" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -229,6 +230,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*hcl2template.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -286,6 +286,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			IsRestricted:             b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                b.config.SourceAmi,
 			Tags:                     b.config.RunTags,
+			Tenancy:                  b.config.Tenancy,
 			UserData:                 b.config.UserData,
 			UserDataFile:             b.config.UserDataFile,
 		}

--- a/builder/amazon/instance/builder.hcl2spec.go
+++ b/builder/amazon/instance/builder.hcl2spec.go
@@ -81,6 +81,7 @@ type FlatConfig struct {
 	SpotTag                                   []hcl2template.FlatKeyValue            `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 	TemporaryKeyPairName                      *string                                `mapstructure:"temporary_key_pair_name" required:"false" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -232,6 +233,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*hcl2template.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/website/pages/partials/builder/amazon/common/RunConfig-not-required.mdx
+++ b/website/pages/partials/builder/amazon/common/RunConfig-not-required.mdx
@@ -293,7 +293,9 @@
 
 - `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
   when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
-  If unset, the default shared tenancy will be used.
+  
+  The default is "default", meaning shared tenancy. Allowed values are "default",
+  "dedicated" and "host".
 
 - `temporary_key_pair_name` (string) - The name of the temporary key pair to
   generate. By default, Packer generates a name that looks like

--- a/website/pages/partials/builder/amazon/common/RunConfig-not-required.mdx
+++ b/website/pages/partials/builder/amazon/common/RunConfig-not-required.mdx
@@ -291,6 +291,10 @@
   subnet-12345def, where Packer will launch the EC2 instance. This field is
   required if you are using an non-default VPC.
 
+- `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
+  when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
+  If unset, the default shared tenancy will be used.
+
 - `temporary_key_pair_name` (string) - The name of the temporary key pair to
   generate. By default, Packer generates a name that looks like
   `packer_<UUID>`, where &lt;UUID&gt; is a 36 character unique identifier.


### PR DESCRIPTION
Allow for packer to spin up source instances using dedicated hosts by setting the [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) value.