### PR TITLE
builder/amazon: Add io2 as a supported volume type

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -134,8 +134,8 @@ func (blockDevice BlockDevice) BuildEC2BlockDeviceMapping() *ec2.BlockDeviceMapp
 		ebsBlockDevice.VolumeSize = aws.Int64(blockDevice.VolumeSize)
 	}
 
-	// IOPS is only valid for io1 type
-	if blockDevice.VolumeType == "io1" {
+	// IOPS is only valid for io1 and io2 types
+	if blockDevice.VolumeType == "io1" || blockDevice.VolumeType == "io2" {
 		ebsBlockDevice.Iops = aws.Int64(blockDevice.IOPS)
 	}
 

--- a/builder/amazon/common/block_device_test.go
+++ b/builder/amazon/common/block_device_test.go
@@ -69,6 +69,25 @@ func TestBlockDevice(t *testing.T) {
 		{
 			Config: &BlockDevice{
 				DeviceName:          "/dev/sdb",
+				VolumeType:          "io2",
+				VolumeSize:          8,
+				DeleteOnTermination: true,
+				IOPS:                1000,
+			},
+
+			Result: &ec2.BlockDeviceMapping{
+				DeviceName: aws.String("/dev/sdb"),
+				Ebs: &ec2.EbsBlockDevice{
+					VolumeType:          aws.String("io2"),
+					VolumeSize:          aws.Int64(8),
+					DeleteOnTermination: aws.Bool(true),
+					Iops:                aws.Int64(1000),
+				},
+			},
+		},
+		{
+			Config: &BlockDevice{
+				DeviceName:          "/dev/sdb",
 				VolumeType:          "gp2",
 				VolumeSize:          8,
 				DeleteOnTermination: true,


### PR DESCRIPTION
In current versions of packer, a user will get the following error when attempting to build an AMI with an io2 volume type:
```
==> amazon-ebs: Error launching source instance: InvalidParameterCombination: The parameter iops must be specified for io2 volumes.
==> amazon-ebs: 	status code: 400, request id: 990a232d-2727-47f6-a857-e136ff26d442
```

[io2](https://aws.amazon.com/blogs/aws/new-ebs-volume-type-io2-more-iops-gib-higher-durability/) volumes are new as of 2020-08-24. This PR adds support for specifying them in a packer template and having the iops value specified take effect, eliminating the error above.

closes #10108 