### PR TITLE
add build.name to hcl code

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -138,7 +138,7 @@ func TestBuild(t *testing.T) {
 		},
 
 		{
-			name: "build name: HCL",
+			name: "source name: HCL",
 			args: []string{
 				"-parallel-builds=1", // to ensure order is kept
 				testFixture("build-name-and-type"),
@@ -297,7 +297,6 @@ func TestBuild(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name: "hcl - recipes - only recipes",
 			args: []string{
@@ -311,6 +310,17 @@ func TestBuild(t *testing.T) {
 				expectedContent: map[string]string{
 					"NULL.spaghetti_carbonara.txt": spaghettiCarbonara,
 					"NULL.lasagna.txt":             lasagna,
+				},
+			},
+		},
+		{
+			name: "hcl - build.name accessible",
+			args: []string{
+				filepath.Join(testFixture("build-name-and-type"), "buildname.pkr.hcl"),
+			},
+			fileCheck: fileCheck{
+				expected: []string{
+					"pineapple.pizza.txt",
 				},
 			},
 		},

--- a/command/test-fixtures/build-name-and-type/buildname.pkr.hcl
+++ b/command/test-fixtures/build-name-and-type/buildname.pkr.hcl
@@ -1,0 +1,16 @@
+source "null" "pizza" {
+    communicator = "none"
+}
+
+build {
+    name = "pineapple"
+    sources = [
+        "sources.null.pizza",
+    ]
+
+    provisioner "shell-local" {
+        inline = [
+            "echo '' > ${build.name}.${source.name}.txt"
+        ]
+    }
+}

--- a/hcl2template/types.hcl_provisioner.go
+++ b/hcl2template/types.hcl_provisioner.go
@@ -31,6 +31,9 @@ func (p *HCL2Provisioner) HCL2Prepare(buildVars map[string]interface{}) error {
 	if len(buildVars) > 0 {
 		ectx = p.evalContext.NewChild()
 		buildValues := map[string]cty.Value{}
+		if !p.evalContext.Variables[buildAccessor].IsNull() {
+			buildValues = p.evalContext.Variables[buildAccessor].AsValueMap()
+		}
 		for k, v := range buildVars {
 			switch v := v.(type) {
 			case string:

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -383,6 +383,7 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packer.Build
 			for _, k := range append(packer.BuilderDataCommonKeys, generatedVars...) {
 				unknownBuildValues[k] = cty.StringVal("<unknown>")
 			}
+			unknownBuildValues["name"] = cty.StringVal(build.Name)
 
 			variables := map[string]cty.Value{
 				sourcesAccessor: cty.ObjectVal(src.ctyValues()),

--- a/website/pages/docs/from-1.5/contextual-variables.mdx
+++ b/website/pages/docs/from-1.5/contextual-variables.mdx
@@ -18,13 +18,27 @@ Build variables will allow you to access connection information and basic instan
 All special build variables are stored in the `build` variable:
 
 ```hcl
-  provisioner "shell" {
-      environment_vars = ["TESTVAR=${build.PackerRunUUID}"]
-      inline = ["echo $TESTVAR"]
+source "null" "first-example" {
+  communicator = "none"
+}
+
+build {
+  name = "my-build-name"
+  sources = ["null.first-example"]
+
+  provisioner "shell-local" {
+    environment_vars = ["TESTVAR=${build.PackerRunUUID}"]
+    inline = ["echo source.name is ${source.name}.",
+              "echo build.name is ${build.name}.",
+              "echo build.PackerRunUUID is $TESTVAR"]
   }
+}
 ```
 
 Here is the list of available build variables:
+
+- **name** Represents the name of the build block being run. This is different
+  than the name of the source block being run.
 
 - **ID**: Represents the vm being provisioned. For example, in Amazon it is the instance id; in digitalocean,
   it is the droplet id; in Vmware, it is the vm name.


### PR DESCRIPTION
Build name and Source name are not the same thing in HCL -- while users can name builds, they previously had not way of accessing the buildname in variables. This adds a "name" key to the build accessor so that users can read out this var.

This checks off a box in https://github.com/hashicorp/packer/issues/9176