### PR TITLE
Report the time of provisioners: 

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hako/durafmt"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/common/retry"
@@ -278,6 +279,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 	uploadedScripts := []string{p.config.RemoteEnvVarPath}
 	for _, path := range scripts {
 		ui.Say(fmt.Sprintf("Provisioning with powershell script: %s", path))
+		executionStartTime := time.Now()
 
 		log.Printf("Opening %s for reading", path)
 		fi, err := os.Stat(path)
@@ -329,6 +331,11 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		if err := p.config.ValidExitCode(cmd.ExitStatus()); err != nil {
 			return err
 		}
+
+		executionEndTime := time.Now()
+		executionDuration := executionEndTime.Sub(executionStartTime)
+		fmtExecutionDuration := durafmt.Parse(executionDuration.Truncate(time.Second)).LimitFirstN(2)
+		ui.Say(fmt.Sprintf("Provisioning with powershell script '%s' took %s", path, fmtExecutionDuration))
 	}
 
 	if p.config.SkipClean {

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hako/durafmt"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/common/retry"
@@ -275,6 +276,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 
 	for _, path := range scripts {
 		ui.Say(fmt.Sprintf("Provisioning with shell script: %s", path))
+		executionStartTime := time.Now()
 
 		log.Printf("Opening %s for reading", path)
 		f, err := os.Open(path)
@@ -346,6 +348,11 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		} else if err := p.config.ValidExitCode(cmd.ExitStatus()); err != nil {
 			return err
 		}
+
+		executionEndTime := time.Now()
+		executionDuration := executionEndTime.Sub(executionStartTime)
+		fmtExecutionDuration := durafmt.Parse(executionDuration.Truncate(time.Second)).LimitFirstN(2)
+		ui.Say(fmt.Sprintf("Provisioning with shell script: '%s' took %s", path, fmtExecutionDuration))
 
 		if p.config.SkipClean {
 			continue

--- a/provisioner/windows-shell/provisioner.go
+++ b/provisioner/windows-shell/provisioner.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hako/durafmt"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/common/retry"
@@ -176,6 +177,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 
 	for _, path := range scripts {
 		ui.Say(fmt.Sprintf("Provisioning with shell script: %s", path))
+		executionStartTime := time.Now()
 
 		log.Printf("Opening %s for reading", path)
 		f, err := os.Open(path)
@@ -225,6 +227,11 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		if err := p.config.ValidExitCode(cmd.ExitStatus()); err != nil {
 			return err
 		}
+
+		executionEndTime := time.Now()
+		executionDuration := executionEndTime.Sub(executionStartTime)
+		fmtExecutionDuration := durafmt.Parse(executionDuration.Truncate(time.Second)).LimitFirstN(2)
+		ui.Say(fmt.Sprintf("Provisioning with shell script '%s' took %s", path, fmtExecutionDuration))
 	}
 
 	return nil


### PR DESCRIPTION
This pull-request adds additional logging to the following provisioners:
- shell
- powershell
- windows-shell
- windows-restart

Additional logging includes the duration of every script that is run on machine. It improves visibility and allows to find bottlenecks (scripts that take too much time).

Example of output:
![image](https://user-images.githubusercontent.com/16715858/96467856-0e277b80-1234-11eb-98b2-a3796b641f81.png)

Closes #10072
