### PR TITLE
Add documented `state_timeout` parameters to Linode builder

### DIFF
--- a/builder/linode/builder_test.go
+++ b/builder/linode/builder_test.go
@@ -3,6 +3,7 @@ package linode
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/packer/packer"
 )
@@ -247,4 +248,44 @@ func TestBuilderPrepare_Label(t *testing.T) {
 		t.Fatal("should have error")
 	}
 
+}
+
+func TestBuilderPrepare_StateTimeout(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test default
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if b.config.StateTimeout != 5*time.Minute {
+		t.Errorf("invalid: %s", b.config.StateTimeout)
+	}
+
+	// Test set
+	config["state_timeout"] = "5m"
+	b = Builder{}
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	// Test bad
+	config["state_timeout"] = "tubes"
+	b = Builder{}
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
 }

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
@@ -24,16 +25,17 @@ type Config struct {
 
 	PersonalAccessToken string `mapstructure:"linode_token"`
 
-	Region       string   `mapstructure:"region"`
-	InstanceType string   `mapstructure:"instance_type"`
-	Label        string   `mapstructure:"instance_label"`
-	Tags         []string `mapstructure:"instance_tags"`
-	Image        string   `mapstructure:"image"`
-	SwapSize     int      `mapstructure:"swap_size"`
-	RootPass     string   `mapstructure:"root_pass"`
-	RootSSHKey   string   `mapstructure:"root_ssh_key"`
-	ImageLabel   string   `mapstructure:"image_label"`
-	Description  string   `mapstructure:"image_description"`
+	Region       string        `mapstructure:"region"`
+	InstanceType string        `mapstructure:"instance_type"`
+	Label        string        `mapstructure:"instance_label"`
+	Tags         []string      `mapstructure:"instance_tags"`
+	Image        string        `mapstructure:"image"`
+	SwapSize     int           `mapstructure:"swap_size"`
+	RootPass     string        `mapstructure:"root_pass"`
+	RootSSHKey   string        `mapstructure:"root_ssh_key"`
+	ImageLabel   string        `mapstructure:"image_label"`
+	Description  string        `mapstructure:"image_description"`
+	StateTimeout time.Duration `mapstructure:"state_timeout" required:"false"`
 }
 
 func createRandomRootPassword() (string, error) {
@@ -92,6 +94,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		if err != nil {
 			errs = packer.MultiErrorAppend(errs, fmt.Errorf("Unable to generate root_pass: %s", err))
 		}
+	}
+
+	if c.StateTimeout == 0 {
+		// Default to 5 minute timeouts waiting for state change
+		c.StateTimeout = 5 * time.Minute
 	}
 
 	if es := c.Comm.Prepare(&c.ctx); len(es) > 0 {

--- a/builder/linode/config.hcl2spec.go
+++ b/builder/linode/config.hcl2spec.go
@@ -74,6 +74,7 @@ type FlatConfig struct {
 	RootSSHKey                *string           `mapstructure:"root_ssh_key" cty:"root_ssh_key" hcl:"root_ssh_key"`
 	ImageLabel                *string           `mapstructure:"image_label" cty:"image_label" hcl:"image_label"`
 	Description               *string           `mapstructure:"image_description" cty:"image_description" hcl:"image_description"`
+	StateTimeout              *string           `mapstructure:"state_timeout" required:"false" cty:"state_timeout" hcl:"state_timeout"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -153,6 +154,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"root_ssh_key":                 &hcldec.AttrSpec{Name: "root_ssh_key", Type: cty.String, Required: false},
 		"image_label":                  &hcldec.AttrSpec{Name: "image_label", Type: cty.String, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
+		"state_timeout":                &hcldec.AttrSpec{Name: "state_timeout", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/linode/step_shutdown_linode.go
+++ b/builder/linode/step_shutdown_linode.go
@@ -14,6 +14,7 @@ type stepShutdownLinode struct {
 }
 
 func (s *stepShutdownLinode) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	c := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 	instance := state.Get("instance").(*linodego.Instance)
 
@@ -25,7 +26,7 @@ func (s *stepShutdownLinode) Run(ctx context.Context, state multistep.StateBag) 
 		return multistep.ActionHalt
 	}
 
-	_, err := s.client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceOffline, 120)
+	_, err := s.client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceOffline, int(c.StateTimeout.Seconds()))
 	if err != nil {
 		err = errors.New("Error shutting down Linode: " + err.Error())
 		state.Put("error", err)


### PR DESCRIPTION
The Linode builder has a documented parameter called `state_timeout` in the docs.
See https://www.packer.io/docs/builders/linode#state_timeout.
However,  this parameter does not exist in reality. This PR adds that and uses it for the shutdown state. 

I am currently running into an error because the default timeout for state transition (i.e. `120 seconds = 2 minutes`) is too short. 

### Screenshot of Failure

<img width="1597" alt="Screen Shot 2020-10-19 at 5 44 32 PM" src="https://user-images.githubusercontent.com/3009118/96515117-c2c09d80-1232-11eb-9605-e035fd8b6480.png">

### Missing Parameters Error

```bash
Error: Failed to prepare build: "linode"

1 error occurred:
	* unknown configuration key: '"state_timeout"'
```