### PR TITLE
tests/azure/arm: Update test image name

### DIFF
--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -151,7 +151,7 @@ const testBuilderAccManagedDiskWindowsBuildResourceGroup = `
 
 	  "build_resource_group_name" : "packer-acceptance-test",
 	  "managed_image_resource_group_name": "packer-acceptance-test",
-	  "managed_image_name": "testBuilderAccManagedDiskWindows-{{timestamp}}",
+	  "managed_image_name": "testBuilderAccManagedDiskWindowsBuildResourceGroup-{{timestamp}}",
 
 	  "os_type": "Windows",
 	  "image_publisher": "MicrosoftWindowsServer",


### PR DESCRIPTION
I've run into a few cases where running the full test suite for the ARM builder would fail because of conflicting image names. This is a workaround for now the bigger fix is to have the acceptance clean up any created images.

Results before change
```
the managed image named testBuilderAccManagedDiskWindows-1603151855 already exists in the resource group packer-acceptance-test, use the -force option to automatically delete it.
--- FAIL: TestBuilderAcc_ManagedDisk_Windows_Build_Resource_Group (0.66s)
```

Results after change
```
PASS
ok      github.com/hashicorp/packer/builder/azure/arm   2431.115s

```