### PR TITLE
Add Azure PFX certificate support

### DIFF
--- a/builder/azure/common/client/tokenprovider_cert.go
+++ b/builder/azure/common/client/tokenprovider_cert.go
@@ -126,12 +126,11 @@ func readCert(file string) (cert *x509.Certificate, key interface{}, err error) 
 
 	if key == nil {
 		key, cert, err = pkcs12.Decode(d, "")
-		certs = append(certs, cert)
-
 		if err != nil {
 			return nil, nil, fmt.Errorf(
 				"Did not find private key in file, tried to read as PKCS#12 and failed: %v", err)
 		}
+		certs = append(certs, cert)
 	}
 
 	if key == nil {


### PR DESCRIPTION
Azure typically uses pfx files for service principal authentication.
These are PKCS#12 files so just try and read a cert file as such if we
can't already read it as PEM.
