### PR TITLE
amazon/ebssurrogate: apply snapshot tags right when taking snapshot

### DIFF
--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -333,6 +333,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			PollingConfig:   b.config.PollingConfig,
 			LaunchDevices:   launchDevices,
 			SnapshotOmitMap: b.config.LaunchMappings.GetOmissions(),
+			SnapshotTags:    b.config.SnapshotTags,
+			Ctx:             b.config.ctx,
 		},
 		&awscommon.StepDeregisterAMI{
 			AccessConfig:        &b.config.AccessConfig,


### PR DESCRIPTION
amazon/ebssurrogate should send along the snapshot tags at snapshot creation time to address the use case where policies require all resources to be properly tagged at creation time.

Closes #10144