### PR TITLE
builder/vsphere: Don't try to delete a cd file from the remote datastore if the upload of the cd failed

### DIFF
--- a/builder/vsphere/common/step_remote_upload.go
+++ b/builder/vsphere/common/step_remote_upload.go
@@ -69,8 +69,11 @@ func (s *StepRemoteUpload) uploadFile(path string, d driver.Driver, ui packer.Ui
 
 	ui.Say(fmt.Sprintf("Uploading %s to %s", filename, remotePath))
 
-	if err := ds.MakeDirectory(remoteDirectory); err != nil {
-		return "", err
+	if exists := ds.DirExists(remotePath); exists == false {
+		log.Printf("Remote directory doesn't exist; creating...")
+		if err := ds.MakeDirectory(remoteDirectory); err != nil {
+			return "", err
+		}
 	}
 
 	if err := ds.UploadFile(path, remotePath, s.Host, s.SetHostForDatastoreUploads); err != nil {

--- a/builder/vsphere/common/step_remote_upload_test.go
+++ b/builder/vsphere/common/step_remote_upload_test.go
@@ -11,7 +11,11 @@ import (
 
 func TestStepRemoteUpload_Run(t *testing.T) {
 	state := basicStateBag(nil)
+	dsMock := driver.DatastoreMock{
+		DirExistsReturn: false,
+	}
 	driverMock := driver.NewDriverMock()
+	driverMock.DatastoreMock = &dsMock
 	state.Put("driver", driverMock)
 	state.Put("iso_path", "[datastore] iso/path")
 

--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -16,6 +16,7 @@ import (
 type Datastore interface {
 	Info(params ...string) (*mo.Datastore, error)
 	FileExists(path string) bool
+	DirExists(path string) bool
 	Name() string
 	ResolvePath(path string) string
 	UploadFile(src, dst, host string, setHost bool) error
@@ -100,6 +101,14 @@ func (ds *DatastoreDriver) Info(params ...string) (*mo.Datastore, error) {
 		return nil, err
 	}
 	return &info, nil
+}
+
+func (ds *DatastoreDriver) DirExists(filepath string) bool {
+	_, err := ds.ds.Stat(ds.driver.ctx, filepath)
+	if _, ok := err.(object.DatastoreNoSuchDirectoryError); ok {
+		return false
+	}
+	return true
 }
 
 func (ds *DatastoreDriver) FileExists(path string) bool {

--- a/builder/vsphere/driver/datastore_mock.go
+++ b/builder/vsphere/driver/datastore_mock.go
@@ -9,6 +9,9 @@ type DatastoreMock struct {
 	FileExistsCalled bool
 	FileExistsReturn bool
 
+	DirExistsCalled bool
+	DirExistsReturn bool
+
 	NameReturn string
 
 	MakeDirectoryCalled bool
@@ -38,7 +41,8 @@ func (ds *DatastoreMock) FileExists(path string) bool {
 }
 
 func (ds *DatastoreMock) DirExists(path string) bool {
-	return true
+	ds.DirExistsCalled = true
+	return ds.DirExistsReturn
 }
 func (ds *DatastoreMock) Name() string {
 	if ds.NameReturn == "" {

--- a/builder/vsphere/driver/datastore_mock.go
+++ b/builder/vsphere/driver/datastore_mock.go
@@ -37,6 +37,9 @@ func (ds *DatastoreMock) FileExists(path string) bool {
 	return ds.FileExistsReturn
 }
 
+func (ds *DatastoreMock) DirExists(path string) bool {
+	return true
+}
 func (ds *DatastoreMock) Name() string {
 	if ds.NameReturn == "" {
 		return "datastore-mock"


### PR DESCRIPTION
This PR does two things: 

1) tracks whether the CD upload was successful before trying to clean the CD up from the remote datastore. 

2) Doesn't set an error in state that will overwrite the actual build error if the CD cleanup fails

Closes #10042

I tested this by manually forcing the upload step to fail with a custom error. 