### PR TITLE
respect the destroy flag in content library config

### DIFF
--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -125,7 +125,8 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 func (s *StepCloneVM) Cleanup(state multistep.StateBag) {
 	_, cancelled := state.GetOk(multistep.StateCancelled)
 	_, halted := state.GetOk(multistep.StateHalted)
-	if !cancelled && !halted {
+	_, destroy := state.GetOk("destroy_vm")
+	if !cancelled && !halted && !destroy {
 		return
 	}
 

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -123,25 +123,5 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 }
 
 func (s *StepCloneVM) Cleanup(state multistep.StateBag) {
-	_, cancelled := state.GetOk(multistep.StateCancelled)
-	_, halted := state.GetOk(multistep.StateHalted)
-	_, destroy := state.GetOk("destroy_vm")
-	if !cancelled && !halted && !destroy {
-		return
-	}
-
-	ui := state.Get("ui").(packer.Ui)
-
-	st := state.Get("vm")
-	if st == nil {
-		return
-	}
-	vm := st.(*driver.VirtualMachineDriver)
-
-	ui.Say("Destroying VM...")
-
-	err := vm.Destroy()
-	if err != nil {
-		ui.Error(err.Error())
-	}
+	common.CleanupVM(state)
 }

--- a/builder/vsphere/common/cleanup_vm.go
+++ b/builder/vsphere/common/cleanup_vm.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"github.com/hashicorp/packer/builder/vsphere/driver"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+func CleanupVM(state multistep.StateBag) {
+	_, cancelled := state.GetOk(multistep.StateCancelled)
+	_, halted := state.GetOk(multistep.StateHalted)
+	_, destroy := state.GetOk("destroy_vm")
+	if !cancelled && !halted && !destroy {
+		return
+	}
+
+	ui := state.Get("ui").(packer.Ui)
+
+	st := state.Get("vm")
+	if st == nil {
+		return
+	}
+	vm := st.(driver.VirtualMachine)
+
+	ui.Say("Destroying VM...")
+	err := vm.Destroy()
+	if err != nil {
+		ui.Error(err.Error())
+	}
+}

--- a/builder/vsphere/common/cleanup_vm_test.go
+++ b/builder/vsphere/common/cleanup_vm_test.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/hashicorp/packer/builder/vsphere/driver"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+func cleanupTestState(mockVM driver.VirtualMachine) multistep.StateBag {
+	state := new(multistep.BasicStateBag)
+	state.Put("vm", mockVM)
+	state.Put("ui", &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	return state
+}
+
+func Test_CleanupVM(t *testing.T) {
+	type testCase struct {
+		Reason        string
+		ExtraState    map[string]interface{}
+		ExpectDestroy bool
+	}
+	testCases := []testCase{
+		{
+			"if cancelled, we should destroy the VM",
+			map[string]interface{}{multistep.StateCancelled: true},
+			true,
+		},
+		{
+			"if halted, we should destroy the VM",
+			map[string]interface{}{multistep.StateHalted: true},
+			true,
+		},
+		{
+			"if destroy flag is set, we should destroy the VM",
+			map[string]interface{}{"destroy_vm": true},
+			true,
+		},
+		{
+			"if none of the above flags are set, we should not destroy the VM",
+			map[string]interface{}{},
+			false,
+		},
+	}
+	for _, tc := range testCases {
+		mockVM := &driver.VirtualMachineMock{}
+		state := cleanupTestState(mockVM)
+		for k, v := range tc.ExtraState {
+			state.Put(k, v)
+		}
+		CleanupVM(state)
+		if mockVM.DestroyCalled != tc.ExpectDestroy {
+			t.Fatalf("Problem with cleanup: %s", tc.Reason)
+		}
+	}
+
+}

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -277,24 +277,5 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 }
 
 func (s *StepCreateVM) Cleanup(state multistep.StateBag) {
-	_, cancelled := state.GetOk(multistep.StateCancelled)
-	_, halted := state.GetOk(multistep.StateHalted)
-	_, destroy := state.GetOk("destroy_vm")
-	if !cancelled && !halted && !destroy {
-		return
-	}
-
-	ui := state.Get("ui").(packer.Ui)
-
-	st := state.Get("vm")
-	if st == nil {
-		return
-	}
-	vm := st.(driver.VirtualMachine)
-
-	ui.Say("Destroying VM...")
-	err := vm.Destroy()
-	if err != nil {
-		ui.Error(err.Error())
-	}
+	common.CleanupVM(state)
 }


### PR DESCRIPTION
The vmware-clone cleanup method didn't respect the "destroy_vm" flag in the state bag. 

Rather than just adding the check for that tag, this PR moves the cleanup functions (which were functionally identical) from the clone and iso builders into a common function so that in the future they won't drift apart again. Also add tests for the current expected destroy calls

Closes #10164 