### PR TITLE
fix fixer deprecated options conflict

### DIFF
--- a/fix/fixer_proxmox_type.go
+++ b/fix/fixer_proxmox_type.go
@@ -7,8 +7,8 @@ import (
 // FixerProxmoxType updates proxmox builder types to proxmox-iso
 type FixerProxmoxType struct{}
 
-func (FixerProxmoxType) DeprecatedOptions() []string {
-	return []string{}
+func (FixerProxmoxType) DeprecatedOptions() map[string][]string {
+	return map[string][]string{}
 }
 
 func (FixerProxmoxType) Fix(input map[string]interface{}) (map[string]interface{}, error) {


### PR DESCRIPTION
Just merged that Proxmox PR which included a new fixer that didn't match the changes I just made to the fixer interface, which broke the main branch. Fix is easy enough though :D 