### PR TITLE
Fix GCP HCL image_encryption_key fields and use the same casing in JSON and HCL2

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -87,12 +87,18 @@ type Config struct {
 	// * kmsKeyName -  The name of the encryption key that is stored in Google Cloud KMS.
 	// * RawKey: - A 256-bit customer-supplied encryption key, encodes in RFC 4648 base64.
 	//
-	// example:
+	// examples:
 	//
 	//  ```json
 	//  {
 	//     "kmsKeyName": "projects/${project}/locations/${region}/keyRings/computeEngine/cryptoKeys/computeEngine/cryptoKeyVersions/4"
 	//  }
+	//  ```
+	//
+	//  ```hcl
+	//   image_encryption_key {
+	//     kmsKeyName = "projects/${var.project}/locations/${var.region}/keyRings/computeEngine/cryptoKeys/computeEngine/cryptoKeyVersions/4"
+	//   }
 	//  ```
 	ImageEncryptionKey *CustomerEncryptionKey `mapstructure:"image_encryption_key" required:"false"`
 	// The name of the image family to which the resulting image belongs. You
@@ -539,11 +545,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 type CustomerEncryptionKey struct {
 	// KmsKeyName: The name of the encryption key that is stored in Google
 	// Cloud KMS.
-	KmsKeyName string `json:"kmsKeyName,omitempty"`
+	KmsKeyName string `mapstructure:"kmsKeyName" json:"kmsKeyName,omitempty"`
 
 	// RawKey: Specifies a 256-bit customer-supplied encryption key, encoded
 	// in RFC 4648 base64 to either encrypt or decrypt this resource.
-	RawKey string `json:"rawKey,omitempty"`
+	RawKey string `mapstructure:"rawKey" json:"rawKey,omitempty"`
 }
 
 func (k *CustomerEncryptionKey) ComputeType() *compute.CustomerEncryptionKey {

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -242,8 +242,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatCustomerEncryptionKey is an auto-generated flat version of CustomerEncryptionKey.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatCustomerEncryptionKey struct {
-	KmsKeyName *string `json:"kmsKeyName,omitempty" cty:"kms_key_name" hcl:"kms_key_name"`
-	RawKey     *string `json:"rawKey,omitempty" cty:"raw_key" hcl:"raw_key"`
+	KmsKeyName *string `mapstructure:"kmsKeyName" json:"kmsKeyName,omitempty" cty:"kmsKeyName" hcl:"kmsKeyName"`
+	RawKey     *string `mapstructure:"rawKey" json:"rawKey,omitempty" cty:"rawKey" hcl:"rawKey"`
 }
 
 // FlatMapstructure returns a new FlatCustomerEncryptionKey.
@@ -258,8 +258,8 @@ func (*CustomerEncryptionKey) FlatMapstructure() interface{ HCL2Spec() map[strin
 // The decoded values from this spec will then be applied to a FlatCustomerEncryptionKey.
 func (*FlatCustomerEncryptionKey) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"kms_key_name": &hcldec.AttrSpec{Name: "kms_key_name", Type: cty.String, Required: false},
-		"raw_key":      &hcldec.AttrSpec{Name: "raw_key", Type: cty.String, Required: false},
+		"kmsKeyName": &hcldec.AttrSpec{Name: "kmsKeyName", Type: cty.String, Required: false},
+		"rawKey":     &hcldec.AttrSpec{Name: "rawKey", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/website/pages/partials/builder/googlecompute/Config-not-required.mdx
+++ b/website/pages/partials/builder/googlecompute/Config-not-required.mdx
@@ -53,12 +53,18 @@
   * kmsKeyName -  The name of the encryption key that is stored in Google Cloud KMS.
   * RawKey: - A 256-bit customer-supplied encryption key, encodes in RFC 4648 base64.
   
-  example:
+  examples:
   
    ```json
    {
       "kmsKeyName": "projects/${project}/locations/${region}/keyRings/computeEngine/cryptoKeys/computeEngine/cryptoKeyVersions/4"
    }
+   ```
+  
+   ```hcl
+    image_encryption_key {
+      kmsKeyName = "projects/${var.project}/locations/${var.region}/keyRings/computeEngine/cryptoKeys/computeEngine/cryptoKeyVersions/4"
+    }
    ```
 
 - `image_family` (string) - The name of the image family to which the resulting image belongs. You

--- a/website/pages/partials/builder/googlecompute/CustomerEncryptionKey-not-required.mdx
+++ b/website/pages/partials/builder/googlecompute/CustomerEncryptionKey-not-required.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the CustomerEncryptionKey struct in builder/googlecompute/config.go; DO NOT EDIT MANUALLY -->
+
+- `kmsKeyName` (string) - KmsKeyName: The name of the encryption key that is stored in Google
+  Cloud KMS.
+
+- `rawKey` (string) - RawKey: Specifies a 256-bit customer-supplied encryption key, encoded
+  in RFC 4648 base64 to either encrypt or decrypt this resource.


### PR DESCRIPTION
this closes #9997.

the JSON and HCL2 keys have to be the same.
