### PR TITLE
Support named provisioners in JSON templates

### DIFF
--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -251,6 +251,12 @@ func (cfg *PackerConfig) getCoreBuildProvisioners(source SourceBlock, blocks []*
 				Provisioner: provisioner,
 			}
 		}
+		if pb.PName != "" {
+			provisioner = &packer.NamedProvisioner{
+				Name:        pb.PName,
+				Provisioner: provisioner,
+			}
+		}
 
 		res = append(res, packer.CoreBuildProvisioner{
 			PType:       pb.PType,

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -136,8 +136,11 @@ func TestParser_complete(t *testing.T) {
 						{
 							PType: "shell",
 							PName: "provisioner that does something",
-							Provisioner: &HCL2Provisioner{
-								Provisioner: basicMockProvisioner,
+							Provisioner: &packer.NamedProvisioner{
+								Name: "provisioner that does something",
+								Provisioner: &HCL2Provisioner{
+									Provisioner: basicMockProvisioner,
+								},
 							},
 						},
 						{
@@ -217,8 +220,11 @@ func TestParser_complete(t *testing.T) {
 						{
 							PType: "shell",
 							PName: "provisioner that does something",
-							Provisioner: &HCL2Provisioner{
-								Provisioner: basicMockProvisioner,
+							Provisioner: &packer.NamedProvisioner{
+								Name: "provisioner that does something",
+								Provisioner: &HCL2Provisioner{
+									Provisioner: basicMockProvisioner,
+								},
 							},
 						},
 						{

--- a/packer/core.go
+++ b/packer/core.go
@@ -180,6 +180,13 @@ func (c *Core) generateCoreBuildProvisioner(rawP *template.Provisioner, rawName 
 			config = append(config, override)
 		}
 	}
+
+	if rawP.Name != "" {
+		provisioner = &NamedProvisioner{
+			Name:        rawP.Name,
+			Provisioner: provisioner,
+		}
+	}
 	// If we're pausing, we wrap the provisioner in a special pauser.
 	if rawP.PauseBefore != 0 {
 		provisioner = &PausedProvisioner{
@@ -209,8 +216,10 @@ func (c *Core) generateCoreBuildProvisioner(rawP *template.Provisioner, rawName 
 			Provisioner: provisioner,
 		}
 	}
+
 	cbp = CoreBuildProvisioner{
 		PType:       rawP.Type,
+		PName:       rawP.Name,
 		Provisioner: provisioner,
 		config:      config,
 	}
@@ -551,7 +560,13 @@ func (c *Core) InspectConfig(opts InspectConfigOptions) int {
 	} else {
 		for _, v := range tpl.Provisioners {
 			ui.Machine("template-provisioner", v.Type)
-			ui.Say(fmt.Sprintf("  %s", v.Type))
+
+			var sb strings.Builder
+			fmt.Fprintf(&sb, "  %s", v.Type)
+			if v.Name != "" {
+				fmt.Fprintf(&sb, ".%s", v.Name)
+			}
+			ui.Say(sb.String())
 		}
 	}
 

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -3,14 +3,14 @@ package packer
 import (
 	"context"
 	"errors"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	configHelper "github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/template"
 )

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -252,3 +252,21 @@ func (p *DebuggedProvisioner) Provision(ctx context.Context, ui Ui, comm Communi
 
 	return p.Provisioner.Provision(ctx, ui, comm, generatedData)
 }
+
+type NamedProvisioner struct {
+	Provisioner Provisioner
+	Name        string
+}
+
+func (n *NamedProvisioner) ConfigSpec() hcldec.ObjectSpec {
+	return n.Provisioner.ConfigSpec()
+}
+
+func (n *NamedProvisioner) Prepare(raws ...interface{}) error {
+	return n.Provisioner.Prepare(raws...)
+}
+
+func (n *NamedProvisioner) Provision(ctx context.Context, ui Ui, comm Communicator, generatedData map[string]interface{}) error {
+	ui.Say(fmt.Sprintf("Starting provisioner %s", n.Name))
+	return n.Provisioner.Provision(ctx, ui, comm, generatedData)
+}

--- a/packer/test-fixtures/build-prov-wrappers.json
+++ b/packer/test-fixtures/build-prov-wrappers.json
@@ -1,0 +1,13 @@
+{
+    "builders": [{
+        "type": "test"
+    }],
+
+    "provisioners": [{
+        "type": "test",
+        "name": "provisioner under test",
+        "timeout": "20m",
+        "pause_before": "10s",
+        "max_retries": 3
+    }]
+}

--- a/template/parse.go
+++ b/template/parse.go
@@ -79,6 +79,7 @@ func (r *rawTemplate) decodeProvisioner(raw interface{}) (Provisioner, error) {
 	delete(p.Config, "max_retries")
 	delete(p.Config, "type")
 	delete(p.Config, "timeout")
+	delete(p.Config, "name")
 
 	if len(p.Config) == 0 {
 		p.Config = nil

--- a/template/parse_test.go
+++ b/template/parse_test.go
@@ -184,6 +184,19 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"parse-provisioner-name.json",
+			&Template{
+				Provisioners: []*Provisioner{
+					{
+						Type: "something",
+						Name: "parse_test",
+					},
+				},
+			},
+			false,
+		},
+
+		{
 			"parse-variable-default.json",
 			&Template{
 				Variables: map[string]*Variable{

--- a/template/template.go
+++ b/template/template.go
@@ -143,6 +143,7 @@ type Provisioner struct {
 	PauseBefore time.Duration          `mapstructure:"pause_before" json:"pause_before,omitempty"`
 	MaxRetries  string                 `mapstructure:"max_retries" json:"max_retries,omitempty"`
 	Timeout     time.Duration          `mapstructure:"timeout" json:"timeout,omitempty"`
+	Name        string                 `mapstructure:"name" json:"name,omitempty"`
 }
 
 // MarshalJSON conducts the necessary flattening of the Provisioner struct

--- a/template/template.hcl2spec.go
+++ b/template/template.hcl2spec.go
@@ -17,6 +17,7 @@ type FlatProvisioner struct {
 	PauseBefore *string                `mapstructure:"pause_before" json:"pause_before,omitempty" cty:"pause_before" hcl:"pause_before"`
 	MaxRetries  *string                `mapstructure:"max_retries" json:"max_retries,omitempty" cty:"max_retries" hcl:"max_retries"`
 	Timeout     *string                `mapstructure:"timeout" json:"timeout,omitempty" cty:"timeout" hcl:"timeout"`
+	Name        *string                `mapstructure:"name" json:"name,omitempty" cty:"name" hcl:"name"`
 }
 
 // FlatMapstructure returns a new FlatProvisioner.
@@ -39,6 +40,7 @@ func (*FlatProvisioner) HCL2Spec() map[string]hcldec.Spec {
 		"pause_before": &hcldec.AttrSpec{Name: "pause_before", Type: cty.String, Required: false},
 		"max_retries":  &hcldec.AttrSpec{Name: "max_retries", Type: cty.String, Required: false},
 		"timeout":      &hcldec.AttrSpec{Name: "timeout", Type: cty.String, Required: false},
+		"name":         &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -59,6 +59,11 @@ func TestTemplateValidate(t *testing.T) {
 		},
 
 		{
+			"validate-good-prov-generic-params.json",
+			false,
+		},
+
+		{
 			"validate-bad-pp-only.json",
 			true,
 		},

--- a/template/test-fixtures/parse-provisioner-name.json
+++ b/template/test-fixtures/parse-provisioner-name.json
@@ -1,0 +1,8 @@
+{
+    "provisioners": [
+        {
+            "type": "something",
+            "name": "parse_test"
+        }
+    ]
+}

--- a/template/test-fixtures/validate-good-prov-generic-params.json
+++ b/template/test-fixtures/validate-good-prov-generic-params.json
@@ -1,0 +1,13 @@
+{
+    "builders": [{
+        "type": "foo"
+    }],
+
+    "provisioners": [{
+        "type": "bar",
+        "timeout": "5m",
+        "name": "provision bar",
+        "max_retries": 10,
+        "pause_before": "10s"
+    }]
+}


### PR DESCRIPTION
Allow specifying names for provisioners in JSON templates. Print name before provisioner start and show it in `packer inspect` similar to how it is shown for HCL templates.

Naming provisioners can be useful, when there are a few of them.
For example, I try split shell provisioners multiple provisioners by grouping them based on the semantic load. It usually turns out in having more than 5 of them and it is getting more difficult to locate the one you need.

Probably Closes #6968
