### PR TITLE
fix step_shutdown when a null communicator is used

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -130,7 +130,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&common.StepCleanupTempKeys{
 			Comm: &b.config.CommConfig.Comm,
 		},
-		new(stepShutdown),
+		&stepShutdown{
+			ShutdownTimeout: b.config.ShutdownTimeout,
+			ShutdownCommand: b.config.ShutdownCommand,
+			Comm:            &b.config.CommConfig.Comm,
+		},
 		&stepConvertDisk{
 			DiskCompression: b.config.DiskCompression,
 			Format:          b.config.Format,

--- a/builder/qemu/step_shutdown_test.go
+++ b/builder/qemu/step_shutdown_test.go
@@ -1,0 +1,88 @@
+package qemu
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+func Test_Shutdown_Null_success(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", packer.TestUi(t))
+	driverMock := new(DriverMock)
+	driverMock.WaitForShutdownState = true
+	state.Put("driver", driverMock)
+
+	step := &stepShutdown{
+		ShutdownCommand: "",
+		ShutdownTimeout: 5 * time.Minute,
+		Comm: &communicator.Config{
+			Type: "none",
+		},
+	}
+	action := step.Run(context.TODO(), state)
+	if action != multistep.ActionContinue {
+		t.Fatalf("Should have successfully shut down.")
+	}
+	err := state.Get("error")
+	if err != nil {
+		err = err.(error)
+		t.Fatalf("Shutdown shouldn't have errored; err: %v", err)
+	}
+}
+
+func Test_Shutdown_Null_failure(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", packer.TestUi(t))
+	driverMock := new(DriverMock)
+	driverMock.WaitForShutdownState = false
+	state.Put("driver", driverMock)
+
+	step := &stepShutdown{
+		ShutdownCommand: "",
+		ShutdownTimeout: 5 * time.Minute,
+		Comm: &communicator.Config{
+			Type: "none",
+		},
+	}
+	action := step.Run(context.TODO(), state)
+	if action != multistep.ActionHalt {
+		t.Fatalf("Shouldn't have successfully shut down.")
+	}
+	err := state.Get("error")
+	if err == nil {
+		t.Fatalf("Shutdown should have errored")
+	}
+}
+
+func Test_Shutdown_NoShutdownCommand(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", packer.TestUi(t))
+	driverMock := new(DriverMock)
+	state.Put("driver", driverMock)
+
+	step := &stepShutdown{
+		ShutdownCommand: "",
+		ShutdownTimeout: 5 * time.Minute,
+		Comm: &communicator.Config{
+			Type: "ssh",
+		},
+	}
+	action := step.Run(context.TODO(), state)
+	if action != multistep.ActionContinue {
+		t.Fatalf("Should have successfully shut down.")
+	}
+
+	if !driverMock.StopCalled {
+		t.Fatalf("should have called Stop through the driver.")
+	}
+	err := state.Get("error")
+	if err != nil {
+		err = err.(error)
+		t.Fatalf("Shutdown shouldn't have errored; err: %v", err)
+	}
+}


### PR DESCRIPTION
This PR fixes a regression where the none communicator is not waiting properly for instance shutdown. 

This was caused by the refactor commit 3577c4a2831e44f6335390eb65b27301bdc09b6f

We used to not create any communicator, but now we create a stand-in "none" communicator. This means the check for a "nil" value in step_shutdown didn't work properly anymore. I've written some tests to make the current expected behavior clear.

Closes #10167 