### PR TITLE
scaleway: use the SDK functions to load profile from file and env

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -6,8 +6,6 @@ package scaleway
 import (
 	"errors"
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/common/uuid"
@@ -116,51 +114,39 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	c.UserAgent = useragent.String()
 
-	// Deprecated variables
-	if c.Organization == "" {
-		if os.Getenv("SCALEWAY_ORGANIZATION") != "" {
-			c.Organization = os.Getenv("SCALEWAY_ORGANIZATION")
-		} else {
-			log.Printf("Deprecation warning: Use SCALEWAY_ORGANIZATION environment variable and organization_id argument instead of api_access_key argument and SCALEWAY_API_ACCESS_KEY environment variable.")
-			c.Organization = os.Getenv("SCALEWAY_API_ACCESS_KEY")
-		}
+	configFile, err := scw.LoadConfig()
+	// If the config file do not exist, don't return an error as we may find config in ENV or flags.
+	if _, isNotFoundError := err.(*scw.ConfigFileNotFoundError); isNotFoundError {
+		configFile = &scw.Config{}
+	} else if err != nil {
+		return nil, err
 	}
-	if c.Organization != "" {
-		warnings = append(warnings, "organization_id is deprecated in favor of project_id")
-		c.ProjectID = c.Organization
+	activeProfile, err := configFile.GetActiveProfile()
+	if err != nil {
+		return nil, err
 	}
 
-	if c.Token == "" {
-		c.Token = os.Getenv("SCALEWAY_API_TOKEN")
-	}
-	if c.Token != "" {
-		warnings = append(warnings, "token is deprecated in favor of secret_key")
-		c.SecretKey = c.Token
-	}
-
-	if c.Region != "" {
-		warnings = append(warnings, "region is deprecated in favor of zone")
-		c.Zone = c.Region
-	}
+	envProfile := scw.LoadEnvProfile()
+	profile := scw.MergeProfiles(activeProfile, envProfile)
 
 	if c.AccessKey == "" {
-		c.AccessKey = os.Getenv(scw.ScwAccessKeyEnv)
+		c.AccessKey = *profile.AccessKey
 	}
 
 	if c.SecretKey == "" {
-		c.SecretKey = os.Getenv(scw.ScwSecretKeyEnv)
+		c.SecretKey = *profile.SecretKey
 	}
 
 	if c.ProjectID == "" {
-		c.ProjectID = os.Getenv(scw.ScwDefaultProjectIDEnv)
+		c.ProjectID = *profile.DefaultProjectID
 	}
 
 	if c.Zone == "" {
-		c.Zone = os.Getenv(scw.ScwDefaultZoneEnv)
+		c.Zone = *profile.DefaultZone
 	}
 
 	if c.APIURL == "" {
-		c.APIURL = os.Getenv(scw.ScwAPIURLEnv)
+		c.APIURL = *profile.APIURL
 	}
 
 	if c.SnapshotName == "" {

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -25,18 +25,23 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 	// The AccessKey corresponding to the secret key.
+	// Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
 	// It can also be specified via the environment variable SCW_ACCESS_KEY.
 	AccessKey string `mapstructure:"access_key" required:"true"`
 	// The SecretKey to authenticate against the Scaleway API.
+	// Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
 	// It can also be specified via the environment variable SCW_SECRET_KEY.
 	SecretKey string `mapstructure:"secret_key" required:"true"`
 	// The Project ID in which the instances, volumes and snapshots will be created.
+	// Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
 	// It can also be specified via the environment variable SCW_DEFAULT_PROJECT_ID.
 	ProjectID string `mapstructure:"project_id" required:"true"`
 	// The Zone in which the instances, volumes and snapshots will be created.
+	// Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
 	// It can also be specified via the environment variable SCW_DEFAULT_ZONE
 	Zone string `mapstructure:"zone" required:"true"`
 	// The Scaleway API URL to use
+	// Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
 	// It can also be specified via the environment variable SCW_API_URL
 	APIURL string `mapstructure:"api_url"`
 

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -153,6 +153,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.SecretKey = c.Token
 	}
 
+	if c.Region != "" {
+		warnings = append(warnings, "region is deprecated in favor of zone")
+		c.Zone = c.Region
+	}
+
 	if c.AccessKey == "" {
 		if profile.AccessKey != nil {
 			c.AccessKey = *profile.AccessKey

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -130,23 +130,33 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	profile := scw.MergeProfiles(activeProfile, envProfile)
 
 	if c.AccessKey == "" {
-		c.AccessKey = *profile.AccessKey
+		if profile.AccessKey != nil {
+			c.AccessKey = *profile.AccessKey
+		}
 	}
 
 	if c.SecretKey == "" {
-		c.SecretKey = *profile.SecretKey
+		if profile.SecretKey != nil {
+			c.SecretKey = *profile.SecretKey
+		}
 	}
 
 	if c.ProjectID == "" {
-		c.ProjectID = *profile.DefaultProjectID
+		if profile.DefaultProjectID != nil {
+			c.ProjectID = *profile.DefaultProjectID
+		}
 	}
 
 	if c.Zone == "" {
-		c.Zone = *profile.DefaultZone
+		if profile.DefaultZone != nil {
+			c.Zone = *profile.DefaultZone
+		}
 	}
 
 	if c.APIURL == "" {
-		c.APIURL = *profile.APIURL
+		if profile.APIURL != nil {
+			c.APIURL = *profile.APIURL
+		}
 	}
 
 	if c.SnapshotName == "" {
@@ -182,12 +192,12 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 	if c.ProjectID == "" {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("Scaleway Project ID must be specified"))
+			errs, errors.New("scaleway Project ID must be specified"))
 	}
 
 	if c.SecretKey == "" {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("Scaleway Secret Key must be specified"))
+			errs, errors.New("scaleway Secret Key must be specified"))
 	}
 
 	if c.AccessKey == "" {
@@ -197,7 +207,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.Zone == "" {
 		errs = packer.MultiErrorAppend(
-			errs, errors.New("Scaleway Zone is required"))
+			errs, errors.New("scaleway Zone is required"))
 	}
 
 	if c.CommercialType == "" {
@@ -215,5 +225,6 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	packer.LogSecretFilter.Set(c.Token)
+	packer.LogSecretFilter.Set(c.SecretKey)
 	return warnings, nil
 }

--- a/builder/scaleway/step_create_image.go
+++ b/builder/scaleway/step_create_image.go
@@ -45,7 +45,7 @@ func (s *stepImage) Run(ctx context.Context, state multistep.StateBag) multistep
 
 	imageResp, err := instanceAPI.GetImage(&instance.GetImageRequest{
 		ImageID: imageID,
-	})
+	}, scw.WithContext(ctx))
 	if err != nil {
 		err := fmt.Errorf("Error getting initial image info: %s", err)
 		state.Put("error", err)
@@ -62,7 +62,7 @@ func (s *stepImage) Run(ctx context.Context, state multistep.StateBag) multistep
 		DefaultBootscript: bootscriptID,
 		Name:              c.ImageName,
 		RootVolume:        snapshotID,
-	})
+	}, scw.WithContext(ctx))
 	if err != nil {
 		err := fmt.Errorf("Error creating image: %s", err)
 		state.Put("error", err)

--- a/builder/scaleway/step_create_server.go
+++ b/builder/scaleway/step_create_server.go
@@ -41,7 +41,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 		Name:           c.ServerName,
 		Image:          c.Image,
 		Tags:           tags,
-	})
+	}, scw.WithContext(ctx))
 	if err != nil {
 		err := fmt.Errorf("Error creating server: %s", err)
 		state.Put("error", err)
@@ -52,7 +52,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 	_, err = instanceAPI.ServerAction(&instance.ServerActionRequest{
 		Action:   instance.ServerActionPoweron,
 		ServerID: createServerResp.Server.ID,
-	})
+	}, scw.WithContext(ctx))
 	if err != nil {
 		err := fmt.Errorf("Error starting server: %s", err)
 		state.Put("error", err)

--- a/builder/scaleway/step_pre_validate.go
+++ b/builder/scaleway/step_pre_validate.go
@@ -32,7 +32,7 @@ func (s *stepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 	instanceAPI := instance.NewAPI(state.Get("client").(*scw.Client))
 	images, err := instanceAPI.ListImages(
 		&instance.ListImagesRequest{Name: &s.ImageName},
-		scw.WithAllPages())
+		scw.WithAllPages(), scw.WithContext(ctx))
 	if err != nil {
 		err := fmt.Errorf("Error: getting image list: %s", err)
 		state.Put("error", err)
@@ -54,7 +54,7 @@ func (s *stepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 
 	snapshots, err := instanceAPI.ListSnapshots(
 		&instance.ListSnapshotsRequest{Name: &s.SnapshotName},
-		scw.WithAllPages())
+		scw.WithAllPages(), scw.WithContext(ctx))
 	if err != nil {
 		err := fmt.Errorf("Error: getting snapshot list: %s", err)
 		state.Put("error", err)

--- a/builder/scaleway/step_shutdown.go
+++ b/builder/scaleway/step_shutdown.go
@@ -22,7 +22,7 @@ func (s *stepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	_, err := instanceAPI.ServerAction(&instance.ServerActionRequest{
 		Action:   instance.ServerActionPoweroff,
 		ServerID: serverID,
-	})
+	}, scw.WithContext(ctx))
 	if err != nil {
 		err := fmt.Errorf("Error stopping server: %s", err)
 		state.Put("error", err)

--- a/builder/scaleway/step_snapshot.go
+++ b/builder/scaleway/step_snapshot.go
@@ -23,7 +23,7 @@ func (s *stepSnapshot) Run(ctx context.Context, state multistep.StateBag) multis
 	createSnapshotResp, err := instanceAPI.CreateSnapshot(&instance.CreateSnapshotRequest{
 		Name:     c.SnapshotName,
 		VolumeID: volumeID,
-	})
+	}, scw.WithContext(ctx))
 	if err != nil {
 		err := fmt.Errorf("Error creating snapshot: %s", err)
 		state.Put("error", err)

--- a/website/pages/partials/builder/scaleway/Config-not-required.mdx
+++ b/website/pages/partials/builder/scaleway/Config-not-required.mdx
@@ -1,6 +1,7 @@
 <!-- Code generated from the comments of the Config struct in builder/scaleway/config.go; DO NOT EDIT MANUALLY -->
 
 - `api_url` (string) - The Scaleway API URL to use
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
   It can also be specified via the environment variable SCW_API_URL
 
 - `snapshot_name` (string) - The name of the resulting snapshot that will

--- a/website/pages/partials/builder/scaleway/Config-required.mdx
+++ b/website/pages/partials/builder/scaleway/Config-required.mdx
@@ -1,15 +1,19 @@
 <!-- Code generated from the comments of the Config struct in builder/scaleway/config.go; DO NOT EDIT MANUALLY -->
 
 - `access_key` (string) - The AccessKey corresponding to the secret key.
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
   It can also be specified via the environment variable SCW_ACCESS_KEY.
 
 - `secret_key` (string) - The SecretKey to authenticate against the Scaleway API.
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
   It can also be specified via the environment variable SCW_SECRET_KEY.
 
 - `project_id` (string) - The Project ID in which the instances, volumes and snapshots will be created.
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
   It can also be specified via the environment variable SCW_DEFAULT_PROJECT_ID.
 
 - `zone` (string) - The Zone in which the instances, volumes and snapshots will be created.
+  Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
   It can also be specified via the environment variable SCW_DEFAULT_ZONE
 
 - `image` (string) - The UUID of the base image to use. This is the image


### PR DESCRIPTION
Remove deprecated variables and use standard SDK based for profile loading.

So the precedence would be:
1. Config file (~/.config/scw/config.yaml)
2. Environment variables
3. Direct variables 