### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.15
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
     resource_class: medium+
   darwin:
     macos:
@@ -153,7 +153,7 @@ jobs:
           destination: /
   build-website-docker-image:
     docker:
-      - image: circleci/buildpack-deps
+      - image: docker.mirror.hashicorp.services/circleci/buildpack-deps
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
       - checkout
@@ -167,14 +167,14 @@ jobs:
                 echo "Dependencies have not changed, not building a new website docker image."
             else
                 cd website/
+                docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
                 docker build -t hashicorp/packer-website:$IMAGE_TAG .
                 docker tag hashicorp/packer-website:$IMAGE_TAG hashicorp/packer-website:latest
-                docker login -u $WEBSITE_DOCKER_USER -p $WEBSITE_DOCKER_PASS
                 docker push hashicorp/packer-website
             fi
   algolia-index:
     docker:
-      - image: node:12
+      - image: docker.mirror.hashicorp.services/node:12
     steps:
       - checkout
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM docker.mirror.hashicorp.services/ubuntu:16.04
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.3-alpine
+FROM docker.mirror.hashicorp.services/node:10.16.3-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,7 +1,7 @@
 # Default: run this if working on the website locally to run in watch mode.
 website:
 	@echo "==> Downloading latest Docker image..."
-	@docker pull hashicorp/packer-website
+	@docker pull docker.mirror.hashicorp.services/hashicorp/packer-website
 	@echo "==> Starting website in Docker..."
 	@docker run \
 		--interactive \
@@ -17,7 +17,7 @@ website:
 # This command will generate a static version of the website to the "out" folder.
 build:
 	@echo "==> Downloading latest Docker image..."
-	@docker pull hashicorp/packer-website
+	@docker pull docker.mirror.hashicorp.services/hashicorp/packer-website
 	@echo "==> Starting build in Docker..."
 	@docker run \
 		--interactive \
@@ -26,7 +26,7 @@ build:
 		--workdir "/website" \
 		--volume "$(shell pwd):/website" \
 		--volume "/website/node_modules" \
-		hashicorp/packer-website \
+		docker.mirror.hashicorp.services/hashicorp/packer-website \
 		npm run static
 
 # If you are changing node dependencies locally, run this to generate a new


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. We're updating CircleCI configs, docker compose, dockerfiles, relevant parts of Makefiles, and travis configs. Github actions are excluded, as Github is handling the issue on their end. LMK if you have any q's, otherwise feel free to approve and merge on your own.