### PR TITLE
modify a ton of error messages to make them specifically placable.

### DIFF
--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -6,6 +6,7 @@ package clone
 import (
 	"context"
 	"fmt"
+	"log"
 	"path"
 
 	"github.com/hashicorp/packer/builder/vsphere/common"
@@ -85,10 +86,11 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 	ui.Say("Cloning VM...")
 	template, err := d.FindVM(s.Config.Template)
 	if err != nil {
-		state.Put("error", err)
+		state.Put("error", fmt.Errorf("Error finding vm to clone: %s", err))
 		return multistep.ActionHalt
 	}
 
+	log.Printf("[DEBUG 10069] about to call template.Clone command")
 	vm, err := template.Clone(ctx, &driver.CloneConfig{
 		Name:           s.Location.VMName,
 		Folder:         s.Location.Folder,
@@ -103,21 +105,25 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		VAppProperties: s.Config.VAppConfig.Properties,
 	})
 	if err != nil {
+		log.Printf("[DEBUG 10069] Error from calling template.Clone command")
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
 	if vm == nil {
+		log.Printf("[DEBUG 10069] no VM was returned from template.Clone command")
 		return multistep.ActionHalt
 	}
 	state.Put("vm", vm)
 
 	if s.Config.DiskSize > 0 {
+		log.Printf("[DEBUG 10069] Resizing disk...")
 		err = vm.ResizeDisk(s.Config.DiskSize)
 		if err != nil {
 			state.Put("error", err)
 			return multistep.ActionHalt
 		}
 	}
+	log.Printf("[DEBUG 10069] Finished step_clone run method.")
 
 	return multistep.ActionContinue
 }

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -6,7 +6,6 @@ package clone
 import (
 	"context"
 	"fmt"
-	"log"
 	"path"
 
 	"github.com/hashicorp/packer/builder/vsphere/common"

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -90,7 +90,6 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		return multistep.ActionHalt
 	}
 
-	log.Printf("[DEBUG 10069] about to call template.Clone command")
 	vm, err := template.Clone(ctx, &driver.CloneConfig{
 		Name:           s.Location.VMName,
 		Folder:         s.Location.Folder,
@@ -105,25 +104,21 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		VAppProperties: s.Config.VAppConfig.Properties,
 	})
 	if err != nil {
-		log.Printf("[DEBUG 10069] Error from calling template.Clone command")
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
 	if vm == nil {
-		log.Printf("[DEBUG 10069] no VM was returned from template.Clone command")
 		return multistep.ActionHalt
 	}
 	state.Put("vm", vm)
 
 	if s.Config.DiskSize > 0 {
-		log.Printf("[DEBUG 10069] Resizing disk...")
 		err = vm.ResizeDisk(s.Config.DiskSize)
 		if err != nil {
 			state.Put("error", err)
 			return multistep.ActionHalt
 		}
 	}
-	log.Printf("[DEBUG 10069] Finished step_clone run method.")
 
 	return multistep.ActionContinue
 }

--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"fmt"
+	"log"
 	"path"
 	"regexp"
 	"strings"
@@ -39,15 +40,16 @@ func (d *VCenterDriver) NewDatastore(ref *types.ManagedObjectReference) Datastor
 
 // If name is an empty string, then resolve host's one
 func (d *VCenterDriver) FindDatastore(name string, host string) (Datastore, error) {
+	log.Printf("[DEBUG 10069] inside FindDatastore call; name is %s and host is %s", name, host)
 	if name == "" {
 		h, err := d.FindHost(host)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error finding host for to get datastore: %s", err)
 		}
 
 		i, err := h.Info("datastore")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error getting datastore info from host: %s", err)
 		}
 
 		if len(i.Datastore) > 1 {
@@ -57,14 +59,14 @@ func (d *VCenterDriver) FindDatastore(name string, host string) (Datastore, erro
 		ds := d.NewDatastore(&i.Datastore[0])
 		inf, err := ds.Info("name")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error getting datastore name: %s", err)
 		}
 		name = inf.Name
 	}
 
 	ds, err := d.finder.Datastore(d.ctx, name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error finding datastore with name %s: %s", name, err)
 	}
 
 	return &DatastoreDriver{

--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -40,7 +40,6 @@ func (d *VCenterDriver) NewDatastore(ref *types.ManagedObjectReference) Datastor
 
 // If name is an empty string, then resolve host's one
 func (d *VCenterDriver) FindDatastore(name string, host string) (Datastore, error) {
-	log.Printf("[DEBUG 10069] inside FindDatastore call; name is %s and host is %s", name, host)
 	if name == "" {
 		h, err := d.FindHost(host)
 		if err != nil {

--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"fmt"
-	"log"
 	"path"
 	"regexp"
 	"strings"

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -295,23 +295,26 @@ func (vm *VirtualMachineDriver) FloppyDevices() (object.VirtualDeviceList, error
 }
 
 func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) (VirtualMachine, error) {
+	log.Printf("[DEBUG 10069] Inside VirtualMachineDriver.Clone")
 	folder, err := vm.driver.FindFolder(config.Folder)
 	if err != nil {
-		return nil, err
+		log.Printf("[DEBUG 10069] Error from calling vm.Driver.FindFolder")
+		return nil, fmt.Errorf("Error finding filder: %s", err)
 	}
 
 	var relocateSpec types.VirtualMachineRelocateSpec
 
 	pool, err := vm.driver.FindResourcePool(config.Cluster, config.Host, config.ResourcePool)
 	if err != nil {
-		return nil, err
+		log.Printf("[DEBUG 10069] Error from calling FindResourcePool")
+		return nil, fmt.Errorf("Error finding resource pool: %s", err)
 	}
 	poolRef := pool.pool.Reference()
 	relocateSpec.Pool = &poolRef
 
 	datastore, err := vm.driver.FindDatastore(config.Datastore, config.Host)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error finding datastore: %s", err)
 	}
 	datastoreRef := datastore.Reference()
 	relocateSpec.Datastore = &datastoreRef
@@ -325,7 +328,7 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 
 		tpl, err := vm.Info("snapshot")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error getting snapshot info for vm: %s", err)
 		}
 		if tpl.Snapshot == nil {
 			err = errors.New("`linked_clone=true`, but template has no snapshots")
@@ -344,21 +347,21 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 	if config.Network != "" {
 		net, err := vm.driver.FindNetwork(config.Network)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error finding network: %s", err)
 		}
 		backing, err := net.network.EthernetCardBackingInfo(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error finding ethernet card backing info: %s", err)
 		}
 
 		devices, err := vm.vm.Device(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error finding vm devices: %s", err)
 		}
 
 		adapter, err := findNetworkAdapter(devices)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Error finding network adapter: %s", err)
 		}
 
 		current := adapter.GetVirtualEthernetCard()
@@ -375,13 +378,13 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 
 	vAppConfig, err := vm.updateVAppConfig(ctx, config.VAppProperties)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error updating VAppConfig: %s", err)
 	}
 	configSpec.VAppConfig = vAppConfig
 
 	task, err := vm.vm.Clone(vm.driver.ctx, folder.folder, config.Name, cloneSpec)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error calling vm.vm.Clone task: %s", err)
 	}
 
 	info, err := task.WaitForResult(ctx, nil)
@@ -391,7 +394,7 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 			return nil, err
 		}
 
-		return nil, err
+		return nil, fmt.Errorf("Error waiting for vm Clone to complete: %s", err)
 	}
 
 	vmRef, ok := info.Result.(types.ManagedObjectReference)

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -295,10 +295,8 @@ func (vm *VirtualMachineDriver) FloppyDevices() (object.VirtualDeviceList, error
 }
 
 func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) (VirtualMachine, error) {
-	log.Printf("[DEBUG 10069] Inside VirtualMachineDriver.Clone")
 	folder, err := vm.driver.FindFolder(config.Folder)
 	if err != nil {
-		log.Printf("[DEBUG 10069] Error from calling vm.Driver.FindFolder")
 		return nil, fmt.Errorf("Error finding filder: %s", err)
 	}
 
@@ -306,7 +304,6 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 
 	pool, err := vm.driver.FindResourcePool(config.Cluster, config.Host, config.ResourcePool)
 	if err != nil {
-		log.Printf("[DEBUG 10069] Error from calling FindResourcePool")
 		return nil, fmt.Errorf("Error finding resource pool: %s", err)
 	}
 	poolRef := pool.pool.Reference()


### PR DESCRIPTION
Return more targeted error messages so it is easier to tell what part of a VM clone is failing. 

helps debug #10069  and will help future debugging as well