### PR TITLE
fix crash

### DIFF
--- a/builder/azure/arm/step_delete_additional_disks.go
+++ b/builder/azure/arm/step_delete_additional_disks.go
@@ -61,7 +61,11 @@ func (s *StepDeleteAdditionalDisk) deleteManagedDisk(ctx context.Context, resour
 func (s *StepDeleteAdditionalDisk) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	s.say("Deleting the temporary Additional disk ...")
 
-	var dataDisks = state.Get(constants.ArmAdditionalDiskVhds).([]string)
+	var dataDisks []string
+
+	if disks := state.Get(constants.ArmAdditionalDiskVhds); disks != nil {
+		dataDisks = disks.([]string)
+	}
 	var isManagedDisk = state.Get(constants.ArmIsManagedImage).(bool)
 	var isExistingResourceGroup = state.Get(constants.ArmIsExistingResourceGroup).(bool)
 	var resourceGroupName = state.Get(constants.ArmResourceGroupName).(string)


### PR DESCRIPTION
Found a crash when I cancelled a build during a manual test: 

```
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/Users/mmarsh/Projects/packer/builder/azure/arm/step_delete_additional_disks.go:64 +0x7b3
2020/10/29 14:04:20 packer-builder-azure-arm plugin: github.com/hashicorp/packer/builder/azure/arm.(*StepDeployTemplate).Cleanup(0xc000a83e60, 0x8f2f580, 0xc0003a1aa0)
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/Users/mmarsh/Projects/packer/builder/azure/arm/step_deploy_template.go:86 +0x325
2020/10/29 14:04:20 packer-builder-azure-arm plugin: github.com/hashicorp/packer/helper/multistep.(*BasicRunner).Run(0xc000a9f410, 0x8f2e980, 0xc000162040, 0x8f2f580, 0xc0003a1aa0)
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/Users/mmarsh/Projects/packer/helper/multistep/basic_runner.go:82 +0x177
2020/10/29 14:04:20 packer-builder-azure-arm plugin: github.com/hashicorp/packer/builder/azure/arm.(*Builder).Run(0xc0001d2000, 0x8f2e980, 0xc000162040, 0x8f4b7e0, 0xc000a9e090, 0x8ea1680, 0xc000b42040, 0x0, 0x0, 0x0, ...)
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/Users/mmarsh/Projects/packer/builder/azure/arm/builder.go:283 +0x14aa
2020/10/29 14:04:20 packer-builder-azure-arm plugin: github.com/hashicorp/packer/packer/rpc.(*BuilderServer).Run(0xc000390b40, 0x1, 0xc00011d1d0, 0x0, 0x0)
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/Users/mmarsh/Projects/packer/packer/rpc/builder.go:117 +0x1bd
2020/10/29 14:04:20 packer-builder-azure-arm plugin: reflect.Value.call(0xc00059f080, 0xc000388168, 0x13, 0x8678428, 0x4, 0xc0000b6f08, 0x3, 0x3, 0x0, 0x0, ...)
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/usr/local/go/src/reflect/value.go:460 +0x8ab
2020/10/29 14:04:20 packer-builder-azure-arm plugin: reflect.Value.Call(0xc00059f080, 0xc000388168, 0x13, 0xc00039df08, 0x3, 0x3, 0x1, 0x0, 0x0)
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/usr/local/go/src/reflect/value.go:321 +0xb4
2020/10/29 14:04:20 packer-builder-azure-arm plugin: net/rpc.(*service).call(0xc000390b80, 0xc0004885a0, 0xc00011c5e8, 0xc00011c5f0, 0xc0001bf600, 0xc0002cc5a0, 0x77ef8c0, 0xc00011d1ac, 0x18a, 0x76f12a0, ...)
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/usr/local/go/src/net/rpc/server.go:377 +0x17f
2020/10/29 14:04:20 packer-builder-azure-arm plugin: created by net/rpc.(*Server).ServeCodec
2020/10/29 14:04:20 packer-builder-azure-arm plugin: 	/usr/local/go/src/net/rpc/server.go:474 +0x42b
==> Wait completed after 10 minutes 33 seconds
2020/10/29 14:04:20 /Users/mmarsh/go/bin/packer: plugin process exited
2020/10/29 14:04:20 waiting for all plugin processes to complete...
2020/10/29 14:04:20 /Users/mmarsh/go/bin/packer: plugin process exited
2020/10/29 14:04:20 /Users/mmarsh/go/bin/packer: plugin process exited
!!!!!!!!!!!!!!!!!!!!!!!!!!! PACKER CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

This is because the item being pulled from state doesn't actually exist yet; I've added a nil check to prevent the crash in the future.