### PR TITLE
Fix issue with AWS secrets manager override default stage

### DIFF
--- a/template/interpolate/aws/secretsmanager/secretsmanager.go
+++ b/template/interpolate/aws/secretsmanager/secretsmanager.go
@@ -53,9 +53,6 @@ func (c *Client) GetSecret(spec *SecretSpec) (string, error) {
 		SecretId:     aws.String(spec.Name),
 		VersionStage: aws.String("AWSCURRENT"),
 	}
-	if spec.Name != "" {
-		params.VersionStage = aws.String(spec.Key)
-	}
 
 	resp, err := c.api.GetSecretValue(params)
 	if err != nil {

--- a/website/pages/docs/from-1.5/functions/contextual/aws_secretsmanager.mdx
+++ b/website/pages/docs/from-1.5/functions/contextual/aws_secretsmanager.mdx
@@ -12,20 +12,22 @@ Secrets can be read from the [AWS Secrets
 Manager](https://aws.amazon.com/secrets-manager/) and used within your template
 as locals.
 
+~> Note: Support for AWS secrets will always obtain the latest version of a secret, essentially
+AWSCURRENT. Support for previous versions of a secret is not supported.
+
 ```hcl
 aws_secretsmanager(name, key)
 ```
 
 When key is not set (`null` or empty: `""`) then `aws_secretsmanager` returns
-the first secret key stored in secret `name` using the `AWSCURRENT`.
+the first secret key stored in secret `name`.
 
 You can either use this function in a `locals` block or directly inline where
 you want to use the value.
 
 ```hcl
 locals {
-  // null is equivalent to "AWSCURRENT"
-  current_version = aws_secretsmanager("my_secret", null)
+  secret = aws_secretsmanager("my_secret", null)
 }
 
 source "null" "first-example" {
@@ -38,13 +40,50 @@ build {
 
   provisioner "shell-local" {
     environment_vars = ["TESTVAR=${build.PackerRunUUID}"]
-    inline = ["echo current version is '${local.current_version}'",
-              "echo previous version is '${aws_secretsmanager("my_secret", "AWSPREVIOUS")}'."]
+    inline = ["echo my_secret is '${local.secret}'",
+              "echo my_secret using an inline call is '${aws_secretsmanager("my_secret", null)}'."]
   }
 }
 ```
 
-This will load the key stored at behind `my_secret` from aws secrets manager.
+This will load the key stored behind `my_secret` from aws secrets manager.
+
+The retrieval of single key secrets or plaintext secrets can be obtained by specifying (`null` or empty: `""`) as the `key`.
+
+
+When obtaining secrets that have multiple keys you can set `key` to the specific key you would like
+to fetch. For example, given the following secret with two keys if `key` is set to "shell" `aws_secretsmanager` will
+return only its value.
+
+```json
+{
+    "test": "kitchen",
+    "shell": "powershell"
+}
+```
+
+```hcl
+locals {
+  secret = aws_secretsmanager("multikey/secret", "shell")
+}
+
+source "null" "first-example" {
+  communicator = "none"
+}
+
+build {
+  name = "my-build-name"
+  sources = ["null.first-example"]
+
+  provisioner "shell-local" {
+    environment_vars = ["TESTVAR=${build.PackerRunUUID}"]
+    inline = ["echo my_secret is '${local.secret}'"]
+  }
+}
+```
+
+This will load the value `"powershell"` stored in the key `"shell"` behind `multikey/secret`.
+
 
 
 In order to use this function you have to configure valid AWS credentials using


### PR DESCRIPTION
Before change
```
⇶  packer build amazon-ebs_secretsmanager_shell-local.json
Error:
template: root:1:3: executing "root" at <aws_secretsmanager `packer/test/keys`

`shell`>: error calling aws_secretsmanager: ResourceNotFoundException: Secrets
Manager can't find the specified secret value for staging label: shell

2020/10/30 12:53:40 [INFO] (telemetry) Finalizing.
template: root:1:3: executing "root" at <aws_secretsmanager `packer/test/keys`
`shell`>: error calling aws_secretsmanager: ResourceNotFoundException: Secrets
Manager can't find the specified secret value for staging label: shell

⇶  packer build amazon-ebs_secretsmanager_shell-local.json.pkr.hcl
Error: Error in function call

  on amazon-ebs_secretsmanager_shell-local.json.pkr.hcl line 28:
  (source code not available)

Call to function "aws_secretsmanager" failed: ResourceNotFoundException: Secrets
Manager can't find the specified secret value for staging label: home.

```

After change
```
⇶  packer.test build amazon-ebs_secretsmanager_shell-local.json
null: output will be in this color.

==> null: Running local shell script: /tmp/packer-shell463393820
    null: boo
    null: keys:powershell
Build 'null' finished after 8 milliseconds 225 microseconds.

==> Wait completed after 8 milliseconds 319 microseconds

==> Builds finished. The artifacts of successful builds are:
--> null: Did not export anything. This is the null builder

⇶  packer.test build amazon-ebs_secretsmanager_shell-local.json.pkr.hcl
null.autogenerated_1: output will be in this color.

==> null.autogenerated_1: Running local shell script: /tmp/packer-shell834410761
    null.autogenerated_1: boo
    null.autogenerated_1: keys:powershell
Build 'null.autogenerated_1' finished after 18 milliseconds 834 microseconds.

==> Wait completed after 18 milliseconds 954 microseconds

==> Builds finished. The artifacts of successful builds are:
--> null.autogenerated_1: Did not export anything. This is the null builder

```