### PR TITLE
Add calls to winrepo.update_git_repos and pkg.refresh_db

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-testing-interface v1.0.3 // indirect
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
+	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/mitchellh/iochan v1.0.0
 	github.com/mitchellh/mapstructure v1.2.3
 	github.com/mitchellh/panicwrap v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -376,6 +376,7 @@ github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
@@ -510,6 +511,8 @@ github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZX
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -398,6 +398,32 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 		}
 	}
 
+	if p.config.GuestOSType == provisioner.WindowsOSType {
+		{
+			ui.Message("Running salt-call --local winrepo.update_git_repos")
+			cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("%s --local winrepo.update_git_repos", filepath.Join(p.config.SaltBinDir, "salt-call")))}
+			if err = cmd.RunWithUi(ctx, comm, ui); (err != nil || cmd.ExitStatus() != 0) && !p.config.NoExitOnFailure {
+				if err == nil {
+					err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus())
+				}
+
+				return fmt.Errorf("Error executing salt-call --local winrepo.update_git_repos: %s", err)
+			}
+		}
+
+		{
+			ui.Message("Running salt-call --local pkg.refresh_db")
+			cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("%s --local pkg.refresh_db", filepath.Join(p.config.SaltBinDir, "salt-call")))}
+			if err = cmd.RunWithUi(ctx, comm, ui); (err != nil || cmd.ExitStatus() != 0) && !p.config.NoExitOnFailure {
+				if err == nil {
+					err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus())
+				}
+
+				return fmt.Errorf("Error executing salt-call --local pkg.refresh_db: %s", err)
+			}
+		}
+	}
+
 	ui.Message(fmt.Sprintf("Running: salt-call --local %s", p.config.CmdArgs))
 	cmd := &packer.RemoteCmd{Command: p.sudo(fmt.Sprintf("%s --local %s", filepath.Join(p.config.SaltBinDir, "salt-call"), p.config.CmdArgs))}
 	if err = cmd.RunWithUi(ctx, comm, ui); (err != nil || cmd.ExitStatus() != 0) && !p.config.NoExitOnFailure {

--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -399,64 +399,54 @@ func (p *Provisioner) Provision(ctx context.Context, ui packer.Ui, comm packer.C
 	}
 
 	if p.config.GuestOSType == provisioner.WindowsOSType {
-		{
-			ui.Message("Downloading Git for Windows")
-			cmd := &packer.RemoteCmd{Command: fmt.Sprintf("powershell [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri https://github.com/git-for-windows/git/releases/download/v2.28.0.windows.1/Git-2.28.0-64-bit.exe -OutFile $env:TEMP/Git.exe")}
-			if err = cmd.RunWithUi(ctx, comm, ui); (err != nil || cmd.ExitStatus() != 0) && !p.config.NoExitOnFailure {
-				if err == nil {
-					err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus())
-				}
-
-				return fmt.Errorf("Unable to Download Git for Windows: %s", err)
+		ui.Message("Downloading Git for Windows")
+		cmd1 := &packer.RemoteCmd{Command: fmt.Sprintf("powershell [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri https://github.com/git-for-windows/git/releases/download/v2.28.0.windows.1/Git-2.28.0-64-bit.exe -OutFile $env:TEMP/Git.exe")}
+		if err = cmd1.RunWithUi(ctx, comm, ui); (err != nil || cmd1.ExitStatus() != 0) && !p.config.NoExitOnFailure {
+			if err == nil {
+				err = fmt.Errorf("Bad exit status: %d", cmd1.ExitStatus())
 			}
+
+			return fmt.Errorf("Unable to Download Git for Windows: %s", err)
 		}
 
-		{
-			ui.Message("Installing Git for Windows")
-			cmd := &packer.RemoteCmd{Command: fmt.Sprintf("powershell Start-Process -FilePath $env:TEMP/Git.exe /SILENT -Wait")}
-			if err = cmd.RunWithUi(ctx, comm, ui); (err != nil || cmd.ExitStatus() != 0) && !p.config.NoExitOnFailure {
-				if err == nil {
-					err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus())
-				}
-
-				return fmt.Errorf("Unable to Install Git for Windows: %s", err)
+		ui.Message("Installing Git for Windows")
+		cmd2 := &packer.RemoteCmd{Command: fmt.Sprintf("powershell Start-Process -FilePath $env:TEMP/Git.exe /SILENT -Wait")}
+		if err = cmd2.RunWithUi(ctx, comm, ui); (err != nil || cmd2.ExitStatus() != 0) && !p.config.NoExitOnFailure {
+			if err == nil {
+				err = fmt.Errorf("Bad exit status: %d", cmd2.ExitStatus())
 			}
+
+			return fmt.Errorf("Unable to Install Git for Windows: %s", err)
 		}
 
-		{
-			ui.Message("Cleaning Up After Git for Windows")
-			cmd := &packer.RemoteCmd{Command: fmt.Sprintf("powershell Remove-Item $env:TEMP/Git.exe")}
-			if err = cmd.RunWithUi(ctx, comm, ui); (err != nil || cmd.ExitStatus() != 0) && !p.config.NoExitOnFailure {
-				if err == nil {
-					err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus())
-				}
-
-				return fmt.Errorf("Unable to Clean-up After Git for Windows: %s", err)
+		ui.Message("Cleaning Up After Git for Windows")
+		cmd3 := &packer.RemoteCmd{Command: fmt.Sprintf("powershell Remove-Item $env:TEMP/Git.exe")}
+		if err = cmd3.RunWithUi(ctx, comm, ui); (err != nil || cmd3.ExitStatus() != 0) && !p.config.NoExitOnFailure {
+			if err == nil {
+				err = fmt.Errorf("Bad exit status: %d", cmd3.ExitStatus())
 			}
+
+			return fmt.Errorf("Unable to Clean-up After Git for Windows: %s", err)
 		}
 
-		{
-			ui.Message("Running salt-call --local winrepo.update_git_repos")
-			cmd := &packer.RemoteCmd{Command: fmt.Sprintf("%s --local winrepo.update_git_repos", filepath.Join(p.config.SaltBinDir, "salt-call"))}
-			if err = cmd.RunWithUi(ctx, comm, ui); (err != nil || cmd.ExitStatus() != 0) && !p.config.NoExitOnFailure {
-				if err == nil {
-					err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus())
-				}
-
-				return fmt.Errorf("Error executing salt-call --local winrepo.update_git_repos: %s", err)
+		ui.Message("Running salt-call --local winrepo.update_git_repos")
+		cmd4 := &packer.RemoteCmd{Command: fmt.Sprintf("%s --local winrepo.update_git_repos", filepath.Join(p.config.SaltBinDir, "salt-call"))}
+		if err = cmd4.RunWithUi(ctx, comm, ui); (err != nil || cmd4.ExitStatus() != 0) && !p.config.NoExitOnFailure {
+			if err == nil {
+				err = fmt.Errorf("Bad exit status: %d", cmd4.ExitStatus())
 			}
+
+			return fmt.Errorf("Error executing salt-call --local winrepo.update_git_repos: %s", err)
 		}
 
-		{
-			ui.Message("Running salt-call --local pkg.refresh_db")
-			cmd := &packer.RemoteCmd{Command: fmt.Sprintf("%s --local pkg.refresh_db", filepath.Join(p.config.SaltBinDir, "salt-call"))}
-			if err = cmd.RunWithUi(ctx, comm, ui); (err != nil || cmd.ExitStatus() != 0) && !p.config.NoExitOnFailure {
-				if err == nil {
-					err = fmt.Errorf("Bad exit status: %d", cmd.ExitStatus())
-				}
-
-				return fmt.Errorf("Error executing salt-call --local pkg.refresh_db: %s", err)
+		ui.Message("Running salt-call --local pkg.refresh_db")
+		cmd5 := &packer.RemoteCmd{Command: fmt.Sprintf("%s --local pkg.refresh_db", filepath.Join(p.config.SaltBinDir, "salt-call"))}
+		if err = cmd5.RunWithUi(ctx, comm, ui); (err != nil || cmd5.ExitStatus() != 0) && !p.config.NoExitOnFailure {
+			if err == nil {
+				err = fmt.Errorf("Bad exit status: %d", cmd5.ExitStatus())
 			}
+
+			return fmt.Errorf("Error executing salt-call --local pkg.refresh_db: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Update the salt-masterless provisioner to include calls to winrepo.update_git_repos and pkg.refresh_db prior to calling highstate when the operating system is Windows. This is necessary setup the local package repository on the masterless minion and enable Windows packages to be installed.