### PR TITLE
HCL2: add variable validation

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -324,6 +324,52 @@ func TestBuild(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			name: "hcl - valid validation rule for default value",
+			args: []string{
+				filepath.Join(testFixture("hcl", "validation", "map")),
+			},
+			expectedCode: 0,
+		},
+
+		{
+			name: "hcl - valid setting from varfile",
+			args: []string{
+				"-var-file", filepath.Join(testFixture("hcl", "validation", "map", "valid_value.pkrvars.hcl")),
+				filepath.Join(testFixture("hcl", "validation", "map")),
+			},
+			expectedCode: 0,
+		},
+
+		{
+			name: "hcl - invalid setting from varfile",
+			args: []string{
+				"-var-file", filepath.Join(testFixture("hcl", "validation", "map", "invalid_value.pkrvars.hcl")),
+				filepath.Join(testFixture("hcl", "validation", "map")),
+			},
+			expectedCode: 1,
+		},
+
+		{
+			name: "hcl - valid cmd ( invalid varfile bypased )",
+			args: []string{
+				"-var-file", filepath.Join(testFixture("hcl", "validation", "map", "invalid_value.pkrvars.hcl")),
+				"-var", `image_metadata={key = "new_value", something = { foo = "bar" }}`,
+				filepath.Join(testFixture("hcl", "validation", "map")),
+			},
+			expectedCode: 0,
+		},
+
+		{
+			name: "hcl - invalid cmd ( valid varfile bypased )",
+			args: []string{
+				"-var-file", filepath.Join(testFixture("hcl", "validation", "map", "valid_value.pkrvars.hcl")),
+				"-var", `image_metadata={key = "?", something = { foo = "wrong" }}`,
+				filepath.Join(testFixture("hcl", "validation", "map")),
+			},
+			expectedCode: 1,
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/test-fixtures/hcl/validation/map/definition.pkr.hcl
+++ b/command/test-fixtures/hcl/validation/map/definition.pkr.hcl
@@ -1,0 +1,19 @@
+
+variable "image_metadata" {
+  default = {
+    key: "value",
+    something: { 
+      foo: "bar",
+    }
+  }
+  validation {
+    condition     = length(var.image_metadata.key) > 4
+    error_message = "The image_metadata.key field must be more than 4 runes."
+  }
+  validation {
+    condition     = substr(var.image_metadata.something.foo, 0, 3) == "bar"
+    error_message = "The image_metadata.something.foo field must start with \"bar\"."
+  }
+}
+
+build {}

--- a/command/test-fixtures/hcl/validation/map/invalid_value.pkrvars.hcl
+++ b/command/test-fixtures/hcl/validation/map/invalid_value.pkrvars.hcl
@@ -1,0 +1,7 @@
+
+image_metadata = {
+  key: "value",
+  something: { 
+    foo: "woo",
+  }
+}

--- a/command/test-fixtures/hcl/validation/map/valid_value.pkrvars.hcl
+++ b/command/test-fixtures/hcl/validation/map/valid_value.pkrvars.hcl
@@ -1,0 +1,7 @@
+
+image_metadata = {
+  key: "value",
+  something: { 
+    foo: "barwoo",
+  }
+}

--- a/hcl2template/addrs/doc.go
+++ b/hcl2template/addrs/doc.go
@@ -1,0 +1,11 @@
+// Package addrs contains types that represent "addresses", which are
+// references to specific objects within a Packer configuration.
+//
+// All addresses have string representations based on HCL traversal syntax
+// which should be used in the user-interface, and also in-memory
+// representations that can be used internally.
+//
+// All types within this package should be treated as immutable, even if this
+// is not enforced by the Go compiler. It is always an implementation error
+// to modify an address object in-place after it is initially constructed.
+package addrs

--- a/hcl2template/addrs/input_variable.go
+++ b/hcl2template/addrs/input_variable.go
@@ -1,0 +1,11 @@
+package addrs
+
+// InputVariable is the address of an input variable.
+type InputVariable struct {
+	referenceable
+	Name string
+}
+
+func (v InputVariable) String() string {
+	return "var." + v.Name
+}

--- a/hcl2template/addrs/parse_ref.go
+++ b/hcl2template/addrs/parse_ref.go
@@ -1,0 +1,93 @@
+package addrs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+// Reference describes a reference to an address with source location
+// information.
+type Reference struct {
+	Subject     Referenceable
+	SourceRange hcl.Range
+	Remaining   hcl.Traversal
+}
+
+// ParseRef attempts to extract a referencable address from the prefix of the
+// given traversal, which must be an absolute traversal or this function
+// will panic.
+//
+// If no error diagnostics are returned, the returned reference includes the
+// address that was extracted, the source range it was extracted from, and any
+// remaining relative traversal that was not consumed as part of the
+// reference.
+//
+// If error diagnostics are returned then the Reference value is invalid and
+// must not be used.
+func ParseRef(traversal hcl.Traversal) (*Reference, hcl.Diagnostics) {
+	ref, diags := parseRef(traversal)
+
+	// Normalize a little to make life easier for callers.
+	if ref != nil {
+		if len(ref.Remaining) == 0 {
+			ref.Remaining = nil
+		}
+	}
+
+	return ref, diags
+}
+
+func parseRef(traversal hcl.Traversal) (*Reference, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	root := traversal.RootName()
+	rootRange := traversal[0].SourceRange()
+
+	switch root {
+
+	case "var":
+		name, rng, remain, diags := parseSingleAttrRef(traversal)
+		return &Reference{
+			Subject:     InputVariable{Name: name},
+			SourceRange: rng,
+			Remaining:   remain,
+		}, diags
+
+	default:
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unhandled reference type",
+			Detail:   `Currently parseRef can only parse "var" references.`,
+			Subject:  &rootRange,
+		})
+	}
+	return nil, diags
+}
+
+func parseSingleAttrRef(traversal hcl.Traversal) (string, hcl.Range, hcl.Traversal, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	root := traversal.RootName()
+	rootRange := traversal[0].SourceRange()
+
+	if len(traversal) < 2 {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid reference",
+			Detail:   fmt.Sprintf("The %q object cannot be accessed directly. Instead, access one of its attributes.", root),
+			Subject:  &rootRange,
+		})
+		return "", hcl.Range{}, nil, diags
+	}
+	if attrTrav, ok := traversal[1].(hcl.TraverseAttr); ok {
+		return attrTrav.Name, hcl.RangeBetween(rootRange, attrTrav.SrcRange), traversal[2:], diags
+	}
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Invalid reference",
+		Detail:   fmt.Sprintf("The %q object does not support this operation.", root),
+		Subject:  traversal[1].SourceRange().Ptr(),
+	})
+	return "", hcl.Range{}, nil, diags
+}

--- a/hcl2template/addrs/referenceable.go
+++ b/hcl2template/addrs/referenceable.go
@@ -1,0 +1,18 @@
+package addrs
+
+// Referenceable is an interface implemented by all address types that can
+// appear as references in configuration language expressions.
+type Referenceable interface {
+	referenceableSigil()
+
+	// String produces a string representation of the address that could be
+	// parsed as a HCL traversal and passed to ParseRef to produce an identical
+	// result.
+	String() string
+}
+
+type referenceable struct {
+}
+
+func (r referenceable) referenceableSigil() {
+}

--- a/hcl2template/addrs/referenceable.go
+++ b/hcl2template/addrs/referenceable.go
@@ -3,6 +3,8 @@ package addrs
 // Referenceable is an interface implemented by all address types that can
 // appear as references in configuration language expressions.
 type Referenceable interface {
+	// referenceableSigil is private to ensure that all Referenceables are
+	// implentented in this current package. For now this does nothing.
 	referenceableSigil()
 
 	// String produces a string representation of the address that could be
@@ -11,6 +13,8 @@ type Referenceable interface {
 	String() string
 }
 
+// referenceable is an empty struct that implements Referenceable, add it to
+// your Referenceable struct so that it can be recognized as such.
 type referenceable struct {
 }
 

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -219,11 +219,25 @@ var (
 	}
 )
 
+var ctyValueComparer = cmp.Comparer(func(x, y cty.Value) bool {
+	return x.RawEquals(y)
+})
+
+var ctyTypeComparer = cmp.Comparer(func(x, y cty.Type) bool {
+	if x == cty.NilType && y == cty.NilType {
+		return true
+	}
+	if x == cty.NilType || y == cty.NilType {
+		return false
+	}
+	return x.Equals(y)
+})
+
 var cmpOpts = []cmp.Option{
+	ctyValueComparer,
+	ctyTypeComparer,
 	cmpopts.IgnoreUnexported(
 		PackerConfig{},
-		cty.Value{},
-		cty.Type{},
 		Variable{},
 		SourceBlock{},
 		ProvisionerBlock{},

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -69,8 +69,7 @@ func testParse(t *testing.T, tests []parseTest) {
 			if tt.parseWantDiagHasErrors != gotDiags.HasErrors() {
 				t.Fatalf("Parser.parse() unexpected diagnostics HasErrors. %s", gotDiags)
 			}
-			if diff := cmp.Diff(tt.parseWantCfg, gotCfg, cmpOpts...,
-			); diff != "" {
+			if diff := cmp.Diff(tt.parseWantCfg, gotCfg, cmpOpts...); diff != "" {
 				t.Fatalf("Parser.parse() wrong packer config. %s", diff)
 			}
 

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -74,26 +74,12 @@ func testParse(t *testing.T, tests []parseTest) {
 			}
 
 			if gotCfg != nil && !tt.parseWantDiagHasErrors {
-				gotInputVar := gotCfg.InputVariables
-				for name, value := range tt.parseWantCfg.InputVariables {
-					if variable, ok := gotInputVar[name]; ok {
-						if diff := cmp.Diff(variable, value, cmpOpts...); diff != "" {
-							t.Fatalf("Parser.parse(): unexpected variable values %s: %s", name, diff)
-						}
-					} else {
-						t.Fatalf("Parser.parse() missing input variable. %s", name)
-					}
+				if diff := cmp.Diff(tt.parseWantCfg.InputVariables, gotCfg.InputVariables, cmpOpts...); diff != "" {
+					t.Fatalf("Parser.parse() unexpected input vars. %s", diff)
 				}
 
-				gotLocalVar := gotCfg.LocalVariables
-				for name, value := range tt.parseWantCfg.LocalVariables {
-					if variable, ok := gotLocalVar[name]; ok {
-						if diff := cmp.Diff(variable, value, cmpOpts...); diff != "" {
-							t.Fatalf("Parser.parse(): unexpected variable values %s: %s", name, diff)
-						}
-					} else {
-						t.Fatalf("Parser.parse() missing local variable. %s", name)
-					}
+				if diff := cmp.Diff(tt.parseWantCfg.LocalVariables, gotCfg.LocalVariables, cmpOpts...); diff != "" {
+					t.Fatalf("Parser.parse() unexpected local vars. %s", diff)
 				}
 			}
 

--- a/hcl2template/function/length.go
+++ b/hcl2template/function/length.go
@@ -51,3 +51,9 @@ var LengthFunc = function.New(&function.Spec{
 		}
 	},
 })
+
+// Length returns the number of elements in the given collection or number of
+// Unicode characters in the given string.
+func Length(collection cty.Value) (cty.Value, error) {
+	return LengthFunc.Call([]cty.Value{collection})
+}

--- a/hcl2template/function/length.go
+++ b/hcl2template/function/length.go
@@ -1,0 +1,53 @@
+package function
+
+import (
+	"errors"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+var LengthFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name:             "value",
+			Type:             cty.DynamicPseudoType,
+			AllowDynamicType: true,
+			AllowUnknown:     true,
+		},
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		collTy := args[0].Type()
+		switch {
+		case collTy == cty.String || collTy.IsTupleType() || collTy.IsObjectType() || collTy.IsListType() || collTy.IsMapType() || collTy.IsSetType() || collTy == cty.DynamicPseudoType:
+			return cty.Number, nil
+		default:
+			return cty.Number, errors.New("argument must be a string, a collection type, or a structural type")
+		}
+	},
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		coll := args[0]
+		collTy := args[0].Type()
+		switch {
+		case collTy == cty.DynamicPseudoType:
+			return cty.UnknownVal(cty.Number), nil
+		case collTy.IsTupleType():
+			l := len(collTy.TupleElementTypes())
+			return cty.NumberIntVal(int64(l)), nil
+		case collTy.IsObjectType():
+			l := len(collTy.AttributeTypes())
+			return cty.NumberIntVal(int64(l)), nil
+		case collTy == cty.String:
+			// We'll delegate to the cty stdlib strlen function here, because
+			// it deals with all of the complexities of tokenizing unicode
+			// grapheme clusters.
+			return stdlib.Strlen(coll)
+		case collTy.IsListType() || collTy.IsSetType() || collTy.IsMapType():
+			return coll.Length(), nil
+		default:
+			// Should never happen, because of the checks in our Type func above
+			return cty.UnknownVal(cty.Number), errors.New("impossible value type for length(...)")
+		}
+	},
+})

--- a/hcl2template/function/length_test.go
+++ b/hcl2template/function/length_test.go
@@ -1,0 +1,139 @@
+package function
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestLength(t *testing.T) {
+	tests := []struct {
+		Value cty.Value
+		Want  cty.Value
+	}{
+		{
+			cty.ListValEmpty(cty.Number),
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.ListVal([]cty.Value{cty.True}),
+			cty.NumberIntVal(1),
+		},
+		{
+			cty.ListVal([]cty.Value{cty.UnknownVal(cty.Bool)}),
+			cty.NumberIntVal(1),
+		},
+		{
+			cty.SetValEmpty(cty.Number),
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.SetVal([]cty.Value{cty.True}),
+			cty.NumberIntVal(1),
+		},
+		{
+			cty.MapValEmpty(cty.Bool),
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.MapVal(map[string]cty.Value{"hello": cty.True}),
+			cty.NumberIntVal(1),
+		},
+		{
+			cty.EmptyTupleVal,
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.UnknownVal(cty.EmptyTuple),
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.TupleVal([]cty.Value{cty.True}),
+			cty.NumberIntVal(1),
+		},
+		{
+			cty.EmptyObjectVal,
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.UnknownVal(cty.EmptyObject),
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.ObjectVal(map[string]cty.Value{"true": cty.True}),
+			cty.NumberIntVal(1),
+		},
+		{
+			cty.UnknownVal(cty.List(cty.Bool)),
+			cty.UnknownVal(cty.Number),
+		},
+		{
+			cty.DynamicVal,
+			cty.UnknownVal(cty.Number),
+		},
+		{
+			cty.StringVal("hello"),
+			cty.NumberIntVal(5),
+		},
+		{
+			cty.StringVal(""),
+			cty.NumberIntVal(0),
+		},
+		{
+			cty.StringVal("1"),
+			cty.NumberIntVal(1),
+		},
+		{
+			cty.StringVal("Живой Журнал"),
+			cty.NumberIntVal(12),
+		},
+		{
+			// note that the dieresis here is intentionally a combining
+			// ligature.
+			cty.StringVal("noël"),
+			cty.NumberIntVal(4),
+		},
+		{
+			// The Es in this string has three combining acute accents.
+			// This tests something that NFC-normalization cannot collapse
+			// into a single precombined codepoint, since otherwise we might
+			// be cheating and relying on the single-codepoint forms.
+			cty.StringVal("wé́́é́́é́́!"),
+			cty.NumberIntVal(5),
+		},
+		{
+			// Go's normalization forms don't handle this ligature, so we
+			// will produce the wrong result but this is now a compatibility
+			// constraint and so we'll test it.
+			cty.StringVal("baﬄe"),
+			cty.NumberIntVal(4),
+		},
+		{
+			cty.StringVal("😸😾"),
+			cty.NumberIntVal(2),
+		},
+		{
+			cty.UnknownVal(cty.String),
+			cty.UnknownVal(cty.Number),
+		},
+		{
+			cty.DynamicVal,
+			cty.UnknownVal(cty.Number),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Length(%#v)", test.Value), func(t *testing.T) {
+			got, err := Length(test.Value)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/hcl2template/functions.go
+++ b/hcl2template/functions.go
@@ -68,7 +68,7 @@ func Functions(basedir string) map[string]function.Function {
 		"jsondecode":         stdlib.JSONDecodeFunc,
 		"jsonencode":         stdlib.JSONEncodeFunc,
 		"keys":               stdlib.KeysFunc,
-		"length":             stdlib.LengthFunc,
+		"length":             pkrfunction.LengthFunc,
 		"log":                stdlib.LogFunc,
 		"lookup":             stdlib.LookupFunc,
 		"lower":              stdlib.LowerFunc,

--- a/hcl2template/testdata/variables/validation/invalid_default.pkr.hcl
+++ b/hcl2template/testdata/variables/validation/invalid_default.pkr.hcl
@@ -1,7 +1,7 @@
 
 variable "image_id" {
   type    = string
-  default = "ami-something-something"
+  default = "potato"
   validation {
     condition     = length(var.image_id) > 4 && substr(var.image_id, 0, 4) == "ami-"
     error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."

--- a/hcl2template/testdata/variables/validation/valid.pkr.hcl
+++ b/hcl2template/testdata/variables/validation/valid.pkr.hcl
@@ -1,0 +1,9 @@
+
+variable "image_id" {
+  type    = string
+  default = "ami-something-something"
+  validation {
+    condition     = length(var.image_id) > 4 && substr(var.image_id, 0, 4) == "ami-"
+    error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
+  }
+}

--- a/hcl2template/testdata/variables/validation/valid_map/definition.pkr.hcl
+++ b/hcl2template/testdata/variables/validation/valid_map/definition.pkr.hcl
@@ -1,0 +1,17 @@
+
+variable "image_metadata" {
+  default = {
+    key: "value",
+    something: { 
+      foo: "bar",
+    }
+  }
+  validation {
+    condition     = length(var.image_metadata.key) > 4
+    error_message = "The image_metadata.key field must be more than 4 runes."
+  }
+  validation {
+    condition     = substr(var.image_metadata.something.foo, 0, 3) == "bar"
+    error_message = "The image_metadata.something.foo field must start with \"bar\"."
+  }
+}

--- a/hcl2template/testdata/variables/validation/valid_map/invalid_value.auto.pkrvars.hcl
+++ b/hcl2template/testdata/variables/validation/valid_map/invalid_value.auto.pkrvars.hcl
@@ -1,0 +1,7 @@
+
+image_metadata = {
+  key: "value",
+  something: { 
+    foo: "woo",
+  }
+}

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -210,9 +210,13 @@ func (c *PackerConfig) evaluateLocalVariable(local *LocalBlock) hcl.Diagnostics 
 		return diags
 	}
 	c.LocalVariables[local.Name] = &Variable{
-		Name:         local.Name,
-		DefaultValue: value,
-		Type:         value.Type(),
+		Name: local.Name,
+		Values: []VariableAssignment{{
+			Value: value,
+			Expr:  local.Expr,
+			From:  "default",
+		}},
+		Type: value.Type(),
 	}
 
 	return diags

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -25,51 +25,58 @@ func TestParser_complete(t *testing.T) {
 				Basedir: "testdata/complete",
 				InputVariables: Variables{
 					"foo": &Variable{
-						Name:         "foo",
-						DefaultValue: cty.StringVal("value"),
+						Name:   "foo",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("value")}},
 					},
 					"image_id": &Variable{
-						Name:         "image_id",
-						DefaultValue: cty.StringVal("image-id-default"),
+						Name:   "image_id",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("image-id-default")}},
 					},
 					"port": &Variable{
-						Name:         "port",
-						DefaultValue: cty.NumberIntVal(42),
+						Name:   "port",
+						Values: []VariableAssignment{{From: "default", Value: cty.NumberIntVal(42)}},
 					},
 					"availability_zone_names": &Variable{
 						Name: "availability_zone_names",
-						DefaultValue: cty.ListVal([]cty.Value{
-							cty.StringVal("A"),
-							cty.StringVal("B"),
-							cty.StringVal("C"),
-						}),
+						Values: []VariableAssignment{{
+							From: "default",
+							Value: cty.ListVal([]cty.Value{
+								cty.StringVal("A"),
+								cty.StringVal("B"),
+								cty.StringVal("C"),
+							}),
+						}},
 					},
 				},
 				LocalVariables: Variables{
 					"feefoo": &Variable{
-						Name:         "feefoo",
-						DefaultValue: cty.StringVal("value_image-id-default"),
+						Name:   "feefoo",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("value_image-id-default")}},
 					},
 					"standard_tags": &Variable{
 						Name: "standard_tags",
-						DefaultValue: cty.ObjectVal(map[string]cty.Value{
-							"Component":   cty.StringVal("user-service"),
-							"Environment": cty.StringVal("production"),
-						}),
+						Values: []VariableAssignment{{From: "default",
+							Value: cty.ObjectVal(map[string]cty.Value{
+								"Component":   cty.StringVal("user-service"),
+								"Environment": cty.StringVal("production"),
+							}),
+						}},
 					},
 					"abc_map": &Variable{
 						Name: "abc_map",
-						DefaultValue: cty.TupleVal([]cty.Value{
-							cty.ObjectVal(map[string]cty.Value{
-								"id": cty.StringVal("a"),
+						Values: []VariableAssignment{{From: "default",
+							Value: cty.TupleVal([]cty.Value{
+								cty.ObjectVal(map[string]cty.Value{
+									"id": cty.StringVal("a"),
+								}),
+								cty.ObjectVal(map[string]cty.Value{
+									"id": cty.StringVal("b"),
+								}),
+								cty.ObjectVal(map[string]cty.Value{
+									"id": cty.StringVal("c"),
+								}),
 							}),
-							cty.ObjectVal(map[string]cty.Value{
-								"id": cty.StringVal("b"),
-							}),
-							cty.ObjectVal(map[string]cty.Value{
-								"id": cty.StringVal("c"),
-							}),
-						}),
+						}},
 					},
 				},
 				Sources: map[SourceRef]SourceBlock{

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -27,14 +27,17 @@ func TestParser_complete(t *testing.T) {
 					"foo": &Variable{
 						Name:   "foo",
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("value")}},
+						Type:   cty.String,
 					},
 					"image_id": &Variable{
 						Name:   "image_id",
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("image-id-default")}},
+						Type:   cty.String,
 					},
 					"port": &Variable{
 						Name:   "port",
 						Values: []VariableAssignment{{From: "default", Value: cty.NumberIntVal(42)}},
+						Type:   cty.Number,
 					},
 					"availability_zone_names": &Variable{
 						Name: "availability_zone_names",
@@ -46,12 +49,14 @@ func TestParser_complete(t *testing.T) {
 								cty.StringVal("C"),
 							}),
 						}},
+						Type: cty.List(cty.String),
 					},
 				},
 				LocalVariables: Variables{
 					"feefoo": &Variable{
 						Name:   "feefoo",
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("value_image-id-default")}},
+						Type:   cty.String,
 					},
 					"standard_tags": &Variable{
 						Name: "standard_tags",
@@ -61,6 +66,10 @@ func TestParser_complete(t *testing.T) {
 								"Environment": cty.StringVal("production"),
 							}),
 						}},
+						Type: cty.Object(map[string]cty.Type{
+							"Component":   cty.String,
+							"Environment": cty.String,
+						}),
 					},
 					"abc_map": &Variable{
 						Name: "abc_map",
@@ -77,6 +86,17 @@ func TestParser_complete(t *testing.T) {
 								}),
 							}),
 						}},
+						Type: cty.Tuple([]cty.Type{
+							cty.Object(map[string]cty.Type{
+								"id": cty.String,
+							}),
+							cty.Object(map[string]cty.Type{
+								"id": cty.String,
+							}),
+							cty.Object(map[string]cty.Type{
+								"id": cty.String,
+							}),
+						}),
 					},
 				},
 				Sources: map[SourceRef]SourceBlock{

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -3,14 +3,19 @@ package hcl2template
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/packer/hcl2template/addrs"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 )
+
+// A consistent detail message for all "not a valid identifier" diagnostics.
+const badIdentifierDetail = "A name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes."
 
 // Local represents a single entry from a "locals" block in a file.
 // The "locals" block itself is not represented, because it serves only to
@@ -46,6 +51,8 @@ type Variable struct {
 	// When Sensitive is set to true Packer will try it best to hide/obfuscate
 	// the variable from the output stream. By replacing the text.
 	Sensitive bool
+
+	Validations []*VariableValidation
 
 	Range hcl.Range
 }
@@ -139,6 +146,28 @@ func (variables *Variables) decodeVariable(key string, attr *hcl.Attribute, ectx
 	return diags
 }
 
+var variableBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "description",
+		},
+		{
+			Name: "default",
+		},
+		{
+			Name: "type",
+		},
+		{
+			Name: "sensitive",
+		},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type: "validation",
+		},
+	},
+}
+
 // decodeVariableBlock decodes a "variables" section the way packer 1 used to
 func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.EvalContext) hcl.Diagnostics {
 	if (*variables) == nil {
@@ -155,51 +184,53 @@ func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.Eval
 		}}
 	}
 
-	var b struct {
-		Description string   `hcl:"description,optional"`
-		Sensitive   bool     `hcl:"sensitive,optional"`
-		Rest        hcl.Body `hcl:",remain"`
-	}
-	diags := gohcl.DecodeBody(block.Body, nil, &b)
-
-	if diags.HasErrors() {
-		return diags
-	}
-
 	name := block.Labels[0]
 
-	res := &Variable{
-		Name:        name,
-		Description: b.Description,
-		Sensitive:   b.Sensitive,
-		Range:       block.DefRange,
+	content, diags := block.Body.Content(variableBlockSchema)
+	if !hclsyntax.ValidIdentifier(name) {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid variable name",
+			Detail:   badIdentifierDetail,
+			Subject:  &block.LabelRanges[0],
+		})
 	}
 
-	attrs, moreDiags := b.Rest.JustAttributes()
-	diags = append(diags, moreDiags...)
+	v := &Variable{
+		Name:  name,
+		Range: block.DefRange,
+	}
 
-	if t, ok := attrs["type"]; ok {
-		delete(attrs, "type")
+	if attr, exists := content.Attributes["description"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Description)
+		diags = append(diags, valDiags...)
+	}
+
+	if t, ok := content.Attributes["type"]; ok {
 		tp, moreDiags := typeexpr.Type(t.Expr)
 		diags = append(diags, moreDiags...)
 		if moreDiags.HasErrors() {
 			return diags
 		}
 
-		res.Type = tp
+		v.Type = tp
 	}
 
-	if def, ok := attrs["default"]; ok {
-		delete(attrs, "default")
+	if attr, exists := content.Attributes["sensitive"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Sensitive)
+		diags = append(diags, valDiags...)
+	}
+
+	if def, ok := content.Attributes["default"]; ok {
 		defaultValue, moreDiags := def.Expr.Value(ectx)
 		diags = append(diags, moreDiags...)
 		if moreDiags.HasErrors() {
 			return diags
 		}
 
-		if res.Type != cty.NilType {
+		if v.Type != cty.NilType {
 			var err error
-			defaultValue, err = convert.Convert(defaultValue, res.Type)
+			defaultValue, err = convert.Convert(defaultValue, v.Type)
 			if err != nil {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
@@ -211,30 +242,175 @@ func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.Eval
 			}
 		}
 
-		res.DefaultValue = defaultValue
+		v.DefaultValue = defaultValue
 
 		// It's possible no type attribute was assigned so lets make sure we
 		// have a valid type otherwise there could be issues parsing the value.
-		if res.Type == cty.NilType {
-			res.Type = res.DefaultValue.Type()
+		if v.Type == cty.NilType {
+			v.Type = v.DefaultValue.Type()
 		}
-	}
-	if len(attrs) > 0 {
-		keys := []string{}
-		for k := range attrs {
-			keys = append(keys, k)
-		}
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagWarning,
-			Summary:  "Unknown keys",
-			Detail:   fmt.Sprintf("unknown variable setting(s): %s", keys),
-			Context:  block.DefRange.Ptr(),
-		})
 	}
 
-	(*variables)[name] = res
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case "validation":
+			vv, moreDiags := decodeVariableValidationBlock(v.Name, block)
+			diags = append(diags, moreDiags...)
+			v.Validations = append(v.Validations, vv)
+		}
+	}
+
+	(*variables)[name] = v
 
 	return diags
+}
+
+var variableValidationBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name:     "condition",
+			Required: true,
+		},
+		{
+			Name:     "error_message",
+			Required: true,
+		},
+	},
+}
+
+// VariableValidation represents a configuration-defined validation rule
+// for a particular input variable, given as a "validation" block inside
+// a "variable" block.
+type VariableValidation struct {
+	// Condition is an expression that refers to the variable being tested and
+	// contains no other references. The expression must return true to
+	// indicate that the value is valid or false to indicate that it is
+	// invalid. If the expression produces an error, that's considered a bug in
+	// the block defining the validation rule, not an error in the caller.
+	Condition hcl.Expression
+
+	// ErrorMessage is one or more full sentences, which would need to be in
+	// English for consistency with the rest of the error message output but
+	// can in practice be in any language as long as it ends with a period.
+	// The message should describe what is required for the condition to return
+	// true in a way that would make sense to a caller of the module.
+	ErrorMessage string
+
+	DeclRange hcl.Range
+}
+
+func decodeVariableValidationBlock(varName string, block *hcl.Block) (*VariableValidation, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	vv := &VariableValidation{
+		DeclRange: block.DefRange,
+	}
+
+	content, moreDiags := block.Body.Content(variableValidationBlockSchema)
+	diags = append(diags, moreDiags...)
+
+	if attr, exists := content.Attributes["condition"]; exists {
+		vv.Condition = attr.Expr
+
+		// The validation condition must refer to the variable itself and
+		// nothing else; to ensure that the variable declaration can't create
+		// additional edges in the dependency graph.
+		goodRefs := 0
+		for _, traversal := range vv.Condition.Variables() {
+
+			ref, moreDiags := addrs.ParseRef(traversal)
+			if !moreDiags.HasErrors() {
+				if addr, ok := ref.Subject.(addrs.InputVariable); ok {
+					if addr.Name == varName {
+						goodRefs++
+						continue // Reference is valid
+					}
+				}
+			}
+
+			// If we fall out here then the reference is invalid.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference in variable validation",
+				Detail:   fmt.Sprintf("The condition for variable %q can only refer to the variable itself, using var.%s.", varName, varName),
+				Subject:  traversal.SourceRange().Ptr(),
+			})
+		}
+		if goodRefs < 1 {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid variable validation condition",
+				Detail:   fmt.Sprintf("The condition for variable %q must refer to var.%s in order to test incoming values.", varName, varName),
+				Subject:  attr.Expr.Range().Ptr(),
+			})
+		}
+	}
+
+	if attr, exists := content.Attributes["error_message"]; exists {
+		moreDiags := gohcl.DecodeExpression(attr.Expr, nil, &vv.ErrorMessage)
+		diags = append(diags, moreDiags...)
+		if !moreDiags.HasErrors() {
+			const errSummary = "Invalid validation error message"
+			switch {
+			case vv.ErrorMessage == "":
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  errSummary,
+					Detail:   "An empty string is not a valid nor useful error message.",
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+			case !looksLikeSentences(vv.ErrorMessage):
+				// Because we're going to include this string verbatim as part
+				// of a bigger error message written in our usual style in
+				// English, we'll require the given error message to conform
+				// to that. We might relax this in future if e.g. we start
+				// presenting these error messages in a different way, or if
+				// Terraform starts supporting producing error messages in
+				// other human languages, etc.
+				// For pragmatism we also allow sentences ending with
+				// exclamation points, but we don't mention it explicitly here
+				// because that's not really consistent with the Terraform UI
+				// writing style.
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  errSummary,
+					Detail:   "Validation error message must be at least one full English sentence starting with an uppercase letter and ending with a period or question mark.",
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+			}
+		}
+	}
+
+	return vv, diags
+}
+
+// looksLikeSentence is a simple heuristic that encourages writing error
+// messages that will be presentable when included as part of a larger error
+// diagnostic whose other text is written in the UI writing style.
+//
+// This is intentionally not a very strong validation since we're assuming that
+// authors want to write good messages and might just need a nudge about
+// Packer's specific style, rather than that they are going to try to work
+// around these rules to write a lower-quality message.
+func looksLikeSentences(s string) bool {
+	if len(s) < 1 {
+		return false
+	}
+	runes := []rune(s) // HCL guarantees that all strings are valid UTF-8
+	first := runes[0]
+	last := runes[len(runes)-1]
+
+	// If the first rune is a letter then it must be an uppercase letter.
+	// (This will only see the first rune in a multi-rune combining sequence,
+	// but the first rune is generally the letter if any are, and if not then
+	// we'll just ignore it because we're primarily expecting English messages
+	// right now anyway, for consistency with all of Terraform's other output.)
+	if unicode.IsLetter(first) && !unicode.IsUpper(first) {
+		return false
+	}
+
+	// The string must be at least one full sentence, which implies having
+	// sentence-ending punctuation.
+	return last == '.' || last == '?' || last == '!'
 }
 
 // Prefix your environment variables with VarEnvPrefix so that Packer can see

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -446,11 +446,11 @@ func decodeVariableValidationBlock(varName string, block *hcl.Block) (*VariableV
 				// English, we'll require the given error message to conform
 				// to that. We might relax this in future if e.g. we start
 				// presenting these error messages in a different way, or if
-				// Terraform starts supporting producing error messages in
+				// Packer starts supporting producing error messages in
 				// other human languages, etc.
 				// For pragmatism we also allow sentences ending with
 				// exclamation points, but we don't mention it explicitly here
-				// because that's not really consistent with the Terraform UI
+				// because that's not really consistent with the Packer UI
 				// writing style.
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
@@ -485,7 +485,7 @@ func looksLikeSentences(s string) bool {
 	// (This will only see the first rune in a multi-rune combining sequence,
 	// but the first rune is generally the letter if any are, and if not then
 	// we'll just ignore it because we're primarily expecting English messages
-	// right now anyway, for consistency with all of Terraform's other output.)
+	// right now anyway, for consistency with all of Packers's other output.)
 	if unicode.IsLetter(first) && !unicode.IsUpper(first) {
 		return false
 	}

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -371,10 +371,10 @@ type VariableValidation struct {
 	// the block defining the validation rule, not an error in the caller.
 	Condition hcl.Expression
 
-	// ErrorMessage is one or more full sentences, which would need to be in
-	// English for consistency with the rest of the error message output but
-	// can in practice be in any language as long as it ends with a period.
-	// The message should describe what is required for the condition to return
+	// ErrorMessage is one or more full sentences, which _should_ be in English
+	// for consistency with the rest of the error message output but can in
+	// practice be in any language as long as it ends with a period. The
+	// message should describe what is required for the condition to return
 	// true in a way that would make sense to a caller of the module.
 	ErrorMessage string
 
@@ -442,20 +442,19 @@ func decodeVariableValidationBlock(varName string, block *hcl.Block) (*VariableV
 				})
 			case !looksLikeSentences(vv.ErrorMessage):
 				// Because we're going to include this string verbatim as part
-				// of a bigger error message written in our usual style in
-				// English, we'll require the given error message to conform
-				// to that. We might relax this in future if e.g. we start
-				// presenting these error messages in a different way, or if
-				// Packer starts supporting producing error messages in
-				// other human languages, etc.
-				// For pragmatism we also allow sentences ending with
-				// exclamation points, but we don't mention it explicitly here
-				// because that's not really consistent with the Packer UI
-				// writing style.
+				// of a bigger error message written in our usual style, we'll
+				// require the given error message to conform to that. We might
+				// relax this in future if e.g. we start presenting these error
+				// messages in a different way, or if Packer starts supporting
+				// producing error messages in other human languages, etc. For
+				// pragmatism we also allow sentences ending with exclamation
+				// points, but we don't mention it explicitly here because
+				// that's not really consistent with the Packer UI writing
+				// style.
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  errSummary,
-					Detail:   "Validation error message must be at least one full English sentence starting with an uppercase letter and ending with a period or question mark.",
+					Detail:   "Validation error message must be at least one full sentence starting with an uppercase letter ( if the alphabet permits it ) and ending with a period or question mark.",
 					Subject:  attr.Expr.Range().Ptr(),
 				})
 			}
@@ -481,11 +480,9 @@ func looksLikeSentences(s string) bool {
 	first := runes[0]
 	last := runes[len(runes)-1]
 
-	// If the first rune is a letter then it must be an uppercase letter.
-	// (This will only see the first rune in a multi-rune combining sequence,
-	// but the first rune is generally the letter if any are, and if not then
-	// we'll just ignore it because we're primarily expecting English messages
-	// right now anyway, for consistency with all of Packers's other output.)
+	// If the first rune is a letter then it must be an uppercase letter. To
+	// sorts of nudge people into writting sentences. For alphabets that don't
+	// have the notion of 'upper', this does nothing.
 	if unicode.IsLetter(first) && !unicode.IsUpper(first) {
 		return false
 	}

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -131,7 +131,7 @@ func TestParse_variables(t *testing.T) {
 					},
 				},
 			},
-			true, false,
+			true, true,
 			[]packer.Build{},
 			false,
 		},

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -26,22 +26,27 @@ func TestParse_variables(t *testing.T) {
 				InputVariables: Variables{
 					"image_name": &Variable{
 						Name:   "image_name",
+						Type:   cty.String,
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo-image-{{user `my_secret`}}")}},
 					},
 					"key": &Variable{
 						Name:   "key",
+						Type:   cty.String,
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("value")}},
 					},
 					"my_secret": &Variable{
 						Name:   "my_secret",
+						Type:   cty.String,
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
 					},
 					"image_id": &Variable{
 						Name:   "image_id",
+						Type:   cty.String,
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("image-id-default")}},
 					},
 					"port": &Variable{
 						Name:   "port",
+						Type:   cty.Number,
 						Values: []VariableAssignment{{From: "default", Value: cty.NumberIntVal(42)}},
 					},
 					"availability_zone_names": &Variable{
@@ -52,6 +57,7 @@ func TestParse_variables(t *testing.T) {
 								cty.StringVal("us-west-1a"),
 							}),
 						}},
+						Type:        cty.List(cty.String),
 						Description: fmt.Sprintln("Describing is awesome ;D"),
 					},
 					"super_secret_password": &Variable{
@@ -61,6 +67,7 @@ func TestParse_variables(t *testing.T) {
 							From:  "default",
 							Value: cty.NullVal(cty.String),
 						}},
+						Type:        cty.String,
 						Description: fmt.Sprintln("Handle with care plz"),
 					},
 				},
@@ -71,6 +78,7 @@ func TestParse_variables(t *testing.T) {
 							From:  "default",
 							Value: cty.StringVal("Community Team"),
 						}},
+						Type: cty.String,
 					},
 					"service_name": &Variable{
 						Name: "service_name",
@@ -78,6 +86,7 @@ func TestParse_variables(t *testing.T) {
 							From:  "default",
 							Value: cty.StringVal("forum"),
 						}},
+						Type: cty.String,
 					},
 				},
 			},
@@ -97,6 +106,7 @@ func TestParse_variables(t *testing.T) {
 							From:  "default",
 							Value: cty.BoolVal(false),
 						}},
+						Type: cty.Bool,
 					},
 				},
 			},
@@ -116,6 +126,7 @@ func TestParse_variables(t *testing.T) {
 							From:  "default",
 							Value: cty.BoolVal(false),
 						}},
+						Type: cty.Bool,
 					},
 				},
 			},
@@ -135,6 +146,7 @@ func TestParse_variables(t *testing.T) {
 							From:  "default",
 							Value: cty.UnknownVal(cty.DynamicPseudoType),
 						}},
+						Type: cty.List(cty.String),
 					},
 				},
 			},
@@ -152,6 +164,7 @@ func TestParse_variables(t *testing.T) {
 					"broken_variable": &Variable{
 						Name:   "broken_variable",
 						Values: []VariableAssignment{{From: "default", Value: cty.BoolVal(true)}},
+						Type:   cty.Bool,
 					},
 				},
 			},
@@ -168,6 +181,7 @@ func TestParse_variables(t *testing.T) {
 				InputVariables: Variables{
 					"foo": &Variable{
 						Name: "foo",
+						Type: cty.String,
 					},
 				},
 			},
@@ -184,6 +198,7 @@ func TestParse_variables(t *testing.T) {
 				InputVariables: Variables{
 					"foo": &Variable{
 						Name: "foo",
+						Type: cty.String,
 					},
 				},
 				Sources: map[SourceRef]SourceBlock{
@@ -222,24 +237,29 @@ func TestParse_variables(t *testing.T) {
 					"name_prefix": &Variable{
 						Name:   "name_prefix",
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
+						Type:   cty.String,
 					},
 				},
 				LocalVariables: Variables{
 					"name_prefix": &Variable{
 						Name:   "name_prefix",
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
+						Type:   cty.String,
 					},
 					"foo": &Variable{
 						Name:   "foo",
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
+						Type:   cty.String,
 					},
 					"bar": &Variable{
 						Name:   "bar",
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
+						Type:   cty.String,
 					},
 					"for_var": &Variable{
 						Name:   "for_var",
 						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
+						Type:   cty.String,
 					},
 					"bar_var": &Variable{
 						Name: "bar_var",
@@ -251,6 +271,11 @@ func TestParse_variables(t *testing.T) {
 								cty.StringVal("foo"),
 							}),
 						}},
+						Type: cty.Tuple([]cty.Type{
+							cty.String,
+							cty.String,
+							cty.String,
+						}),
 					},
 				},
 			},
@@ -282,6 +307,7 @@ func TestParse_variables(t *testing.T) {
 							VariableAssignment{"default", cty.StringVal("bar"), nil},
 							VariableAssignment{"varfile", cty.StringVal("wee"), nil},
 						},
+						Type: cty.String,
 					},
 				},
 			},
@@ -398,6 +424,7 @@ func TestParse_variables(t *testing.T) {
 							{"default", cty.StringVal("ami-something-something"), nil},
 						},
 						Name: "image_id",
+						Type: cty.String,
 						Validations: []*VariableValidation{
 							&VariableValidation{
 								ErrorMessage: `The image_id value must be a valid AMI id, starting with "ami-".`,
@@ -418,8 +445,9 @@ func TestParse_variables(t *testing.T) {
 				Basedir: filepath.Join("testdata", "variables", "validation"),
 				InputVariables: Variables{
 					"image_id": &Variable{
-						Values: []VariableAssignment{{"default", cty.StringVal("ami-something-something"), nil}},
+						Values: []VariableAssignment{{"default", cty.StringVal("potato"), nil}},
 						Name:   "image_id",
+						Type:   cty.String,
 						Validations: []*VariableValidation{
 							&VariableValidation{
 								ErrorMessage: `The image_id value must be a valid AMI id, starting with "ami-".`,
@@ -477,11 +505,11 @@ func TestVariables_collectVariableValues(t *testing.T) {
 				"used_string": &Variable{
 					Type: cty.String,
 					Values: []VariableAssignment{
-						{"default", cty.StringVal(`"default_value"`), nil},
-						{"env", cty.StringVal(`"env_value"`), nil},
-						{"varfile", cty.StringVal(`"xy"`), nil},
-						{"varfile", cty.StringVal(`"varfile_value"`), nil},
-						{"cmd", cty.StringVal(`"cmd_value"`), nil},
+						{"default", cty.StringVal(`default_value`), nil},
+						{"env", cty.StringVal(`env_value`), nil},
+						{"varfile", cty.StringVal(`xy`), nil},
+						{"varfile", cty.StringVal(`varfile_value`), nil},
+						{"cmd", cty.StringVal(`cmd_value`), nil},
 					},
 				},
 			},

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -357,6 +357,28 @@ func TestParse_variables(t *testing.T) {
 			},
 			false,
 		},
+
+		{"valid validation block",
+			defaultParser,
+			parseTestArgs{"testdata/variables/validation/valid.pkr.hcl", nil, nil},
+			&PackerConfig{
+				Basedir: filepath.Join("testdata", "variables", "validation"),
+				InputVariables: Variables{
+					"image_id": &Variable{
+						DefaultValue: cty.StringVal("ami-something-something"),
+						Name:         "image_id",
+						Validations: []*VariableValidation{
+							&VariableValidation{
+								ErrorMessage: `The image_id value must be a valid AMI id, starting with "ami-".`,
+							},
+						},
+					},
+				},
+			},
+			false, false,
+			[]packer.Build{},
+			false,
+		},
 	}
 	testParse(t, tests)
 }

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -25,47 +25,59 @@ func TestParse_variables(t *testing.T) {
 				Basedir: filepath.Join("testdata", "variables"),
 				InputVariables: Variables{
 					"image_name": &Variable{
-						Name:         "image_name",
-						DefaultValue: cty.StringVal("foo-image-{{user `my_secret`}}"),
+						Name:   "image_name",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo-image-{{user `my_secret`}}")}},
 					},
 					"key": &Variable{
-						Name:         "key",
-						DefaultValue: cty.StringVal("value"),
+						Name:   "key",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("value")}},
 					},
 					"my_secret": &Variable{
-						Name:         "my_secret",
-						DefaultValue: cty.StringVal("foo"),
+						Name:   "my_secret",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
 					},
 					"image_id": &Variable{
-						Name:         "image_id",
-						DefaultValue: cty.StringVal("image-id-default"),
+						Name:   "image_id",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("image-id-default")}},
 					},
 					"port": &Variable{
-						Name:         "port",
-						DefaultValue: cty.NumberIntVal(42),
+						Name:   "port",
+						Values: []VariableAssignment{{From: "default", Value: cty.NumberIntVal(42)}},
 					},
 					"availability_zone_names": &Variable{
 						Name: "availability_zone_names",
-						DefaultValue: cty.ListVal([]cty.Value{
-							cty.StringVal("us-west-1a"),
-						}),
+						Values: []VariableAssignment{{
+							From: "default",
+							Value: cty.ListVal([]cty.Value{
+								cty.StringVal("us-west-1a"),
+							}),
+						}},
 						Description: fmt.Sprintln("Describing is awesome ;D"),
 					},
 					"super_secret_password": &Variable{
-						Name:         "super_secret_password",
-						Sensitive:    true,
-						DefaultValue: cty.NullVal(cty.String),
-						Description:  fmt.Sprintln("Handle with care plz"),
+						Name:      "super_secret_password",
+						Sensitive: true,
+						Values: []VariableAssignment{{
+							From:  "default",
+							Value: cty.NullVal(cty.String),
+						}},
+						Description: fmt.Sprintln("Handle with care plz"),
 					},
 				},
 				LocalVariables: Variables{
 					"owner": &Variable{
-						Name:         "owner",
-						DefaultValue: cty.StringVal("Community Team"),
+						Name: "owner",
+						Values: []VariableAssignment{{
+							From:  "default",
+							Value: cty.StringVal("Community Team"),
+						}},
 					},
 					"service_name": &Variable{
-						Name:         "service_name",
-						DefaultValue: cty.StringVal("forum"),
+						Name: "service_name",
+						Values: []VariableAssignment{{
+							From:  "default",
+							Value: cty.StringVal("forum"),
+						}},
 					},
 				},
 			},
@@ -81,6 +93,10 @@ func TestParse_variables(t *testing.T) {
 				InputVariables: Variables{
 					"boolean_value": &Variable{
 						Name: "boolean_value",
+						Values: []VariableAssignment{{
+							From:  "default",
+							Value: cty.BoolVal(false),
+						}},
 					},
 				},
 			},
@@ -96,6 +112,10 @@ func TestParse_variables(t *testing.T) {
 				InputVariables: Variables{
 					"boolean_value": &Variable{
 						Name: "boolean_value",
+						Values: []VariableAssignment{{
+							From:  "default",
+							Value: cty.BoolVal(false),
+						}},
 					},
 				},
 			},
@@ -111,6 +131,10 @@ func TestParse_variables(t *testing.T) {
 				InputVariables: Variables{
 					"broken_type": &Variable{
 						Name: "broken_type",
+						Values: []VariableAssignment{{
+							From:  "default",
+							Value: cty.UnknownVal(cty.DynamicPseudoType),
+						}},
 					},
 				},
 			},
@@ -126,8 +150,8 @@ func TestParse_variables(t *testing.T) {
 				Basedir: filepath.Join("testdata", "variables"),
 				InputVariables: Variables{
 					"broken_variable": &Variable{
-						Name:         "broken_variable",
-						DefaultValue: cty.BoolVal(true),
+						Name:   "broken_variable",
+						Values: []VariableAssignment{{From: "default", Value: cty.BoolVal(true)}},
 					},
 				},
 			},
@@ -196,34 +220,37 @@ func TestParse_variables(t *testing.T) {
 				Basedir: "testdata/variables/complicated",
 				InputVariables: Variables{
 					"name_prefix": &Variable{
-						Name:         "name_prefix",
-						DefaultValue: cty.StringVal("foo"),
+						Name:   "name_prefix",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
 					},
 				},
 				LocalVariables: Variables{
 					"name_prefix": &Variable{
-						Name:         "name_prefix",
-						DefaultValue: cty.StringVal("foo"),
+						Name:   "name_prefix",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
 					},
 					"foo": &Variable{
-						Name:         "foo",
-						DefaultValue: cty.StringVal("foo"),
+						Name:   "foo",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
 					},
 					"bar": &Variable{
-						Name:         "bar",
-						DefaultValue: cty.StringVal("foo"),
+						Name:   "bar",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
 					},
 					"for_var": &Variable{
-						Name:         "for_var",
-						DefaultValue: cty.StringVal("foo"),
+						Name:   "for_var",
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("foo")}},
 					},
 					"bar_var": &Variable{
 						Name: "bar_var",
-						DefaultValue: cty.TupleVal([]cty.Value{
-							cty.StringVal("foo"),
-							cty.StringVal("foo"),
-							cty.StringVal("foo"),
-						}),
+						Values: []VariableAssignment{{
+							From: "default",
+							Value: cty.TupleVal([]cty.Value{
+								cty.StringVal("foo"),
+								cty.StringVal("foo"),
+								cty.StringVal("foo"),
+							}),
+						}},
 					},
 				},
 			},
@@ -250,9 +277,11 @@ func TestParse_variables(t *testing.T) {
 				Basedir: filepath.Join("testdata", "variables"),
 				InputVariables: Variables{
 					"foo": &Variable{
-						DefaultValue: cty.StringVal("bar"),
-						Name:         "foo",
-						VarfileValue: cty.StringVal("wee"),
+						Name: "foo",
+						Values: []VariableAssignment{
+							VariableAssignment{"default", cty.StringVal("bar"), nil},
+							VariableAssignment{"varfile", cty.StringVal("wee"), nil},
+						},
 					},
 				},
 			},
@@ -279,14 +308,14 @@ func TestParse_variables(t *testing.T) {
 				Basedir: filepath.Join("testdata", "variables"),
 				InputVariables: Variables{
 					"max_retries": &Variable{
-						Name:         "max_retries",
-						DefaultValue: cty.StringVal("1"),
-						Type:         cty.String,
+						Name:   "max_retries",
+						Values: []VariableAssignment{{"default", cty.StringVal("1"), nil}},
+						Type:   cty.String,
 					},
 					"max_retries_int": &Variable{
-						Name:         "max_retries_int",
-						DefaultValue: cty.NumberIntVal(1),
-						Type:         cty.Number,
+						Name:   "max_retries_int",
+						Values: []VariableAssignment{{"default", cty.NumberIntVal(1), nil}},
+						Type:   cty.Number,
 					},
 				},
 				Sources: map[SourceRef]SourceBlock{
@@ -365,8 +394,10 @@ func TestParse_variables(t *testing.T) {
 				Basedir: filepath.Join("testdata", "variables", "validation"),
 				InputVariables: Variables{
 					"image_id": &Variable{
-						DefaultValue: cty.StringVal("ami-something-something"),
-						Name:         "image_id",
+						Values: []VariableAssignment{
+							{"default", cty.StringVal("ami-something-something"), nil},
+						},
+						Name: "image_id",
 						Validations: []*VariableValidation{
 							&VariableValidation{
 								ErrorMessage: `The image_id value must be a valid AMI id, starting with "ami-".`,
@@ -377,6 +408,28 @@ func TestParse_variables(t *testing.T) {
 			},
 			false, false,
 			[]packer.Build{},
+			false,
+		},
+
+		{"valid validation block - invalid default",
+			defaultParser,
+			parseTestArgs{"testdata/variables/validation/invalid_default.pkr.hcl", nil, nil},
+			&PackerConfig{
+				Basedir: filepath.Join("testdata", "variables", "validation"),
+				InputVariables: Variables{
+					"image_id": &Variable{
+						Values: []VariableAssignment{{"default", cty.StringVal("ami-something-something"), nil}},
+						Name:   "image_id",
+						Validations: []*VariableValidation{
+							&VariableValidation{
+								ErrorMessage: `The image_id value must be a valid AMI id, starting with "ami-".`,
+							},
+						},
+					},
+				},
+			},
+			true, true,
+			nil,
 			false,
 		},
 	}
@@ -402,8 +455,10 @@ func TestVariables_collectVariableValues(t *testing.T) {
 
 		{name: "string",
 			variables: Variables{"used_string": &Variable{
-				DefaultValue: cty.StringVal("default_value"),
-				Type:         cty.String,
+				Values: []VariableAssignment{
+					{"default", cty.StringVal("default_value"), nil},
+				},
+				Type: cty.String,
 			}},
 			args: args{
 				env: []string{`PKR_VAR_used_string=env_value`},
@@ -420,11 +475,14 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			wantDiags: false,
 			wantVariables: Variables{
 				"used_string": &Variable{
-					Type:         cty.String,
-					CmdValue:     cty.StringVal("cmd_value"),
-					VarfileValue: cty.StringVal("varfile_value"),
-					EnvValue:     cty.StringVal("env_value"),
-					DefaultValue: cty.StringVal("default_value"),
+					Type: cty.String,
+					Values: []VariableAssignment{
+						{"default", cty.StringVal(`"default_value"`), nil},
+						{"env", cty.StringVal(`"env_value"`), nil},
+						{"varfile", cty.StringVal(`"xy"`), nil},
+						{"varfile", cty.StringVal(`"varfile_value"`), nil},
+						{"cmd", cty.StringVal(`"cmd_value"`), nil},
+					},
 				},
 			},
 			wantValues: map[string]cty.Value{
@@ -434,8 +492,10 @@ func TestVariables_collectVariableValues(t *testing.T) {
 
 		{name: "quoted string",
 			variables: Variables{"quoted_string": &Variable{
-				DefaultValue: cty.StringVal(`"default_value"`),
-				Type:         cty.String,
+				Values: []VariableAssignment{
+					{"default", cty.StringVal(`"default_value"`), nil},
+				},
+				Type: cty.String,
 			}},
 			args: args{
 				env: []string{`PKR_VAR_quoted_string="env_value"`},
@@ -452,11 +512,14 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			wantDiags: false,
 			wantVariables: Variables{
 				"quoted_string": &Variable{
-					Type:         cty.String,
-					CmdValue:     cty.StringVal(`"cmd_value"`),
-					VarfileValue: cty.StringVal(`"varfile_value"`),
-					EnvValue:     cty.StringVal(`"env_value"`),
-					DefaultValue: cty.StringVal(`"default_value"`),
+					Type: cty.String,
+					Values: []VariableAssignment{
+						{"default", cty.StringVal(`"default_value"`), nil},
+						{"env", cty.StringVal(`"env_value"`), nil},
+						{"varfile", cty.StringVal(`"xy"`), nil},
+						{"varfile", cty.StringVal(`"varfile_value"`), nil},
+						{"cmd", cty.StringVal(`"cmd_value"`), nil},
+					},
 				},
 			},
 			wantValues: map[string]cty.Value{
@@ -466,8 +529,10 @@ func TestVariables_collectVariableValues(t *testing.T) {
 
 		{name: "array of strings",
 			variables: Variables{"used_strings": &Variable{
-				DefaultValue: stringListVal("default_value_1"),
-				Type:         cty.List(cty.String),
+				Values: []VariableAssignment{
+					{"default", stringListVal("default_value_1"), nil},
+				},
+				Type: cty.List(cty.String),
 			}},
 			args: args{
 				env: []string{`PKR_VAR_used_strings=["env_value_1", "env_value_2"]`},
@@ -484,11 +549,14 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			wantDiags: false,
 			wantVariables: Variables{
 				"used_strings": &Variable{
-					Type:         cty.List(cty.String),
-					CmdValue:     stringListVal("cmd_value_1"),
-					VarfileValue: stringListVal("varfile_value_1"),
-					EnvValue:     stringListVal("env_value_1", "env_value_2"),
-					DefaultValue: stringListVal("default_value_1"),
+					Type: cty.List(cty.String),
+					Values: []VariableAssignment{
+						{"default", stringListVal("default_value_1"), nil},
+						{"env", stringListVal("env_value_1", "env_value_2"), nil},
+						{"varfile", stringListVal("xy"), nil},
+						{"varfile", stringListVal("varfile_value_1"), nil},
+						{"cmd", stringListVal("cmd_value_1"), nil},
+					},
 				},
 			},
 			wantValues: map[string]cty.Value{
@@ -498,8 +566,8 @@ func TestVariables_collectVariableValues(t *testing.T) {
 
 		{name: "bool",
 			variables: Variables{"enabled": &Variable{
-				DefaultValue: cty.False,
-				Type:         cty.Bool,
+				Values: []VariableAssignment{{"default", cty.False, nil}},
+				Type:   cty.Bool,
 			}},
 			args: args{
 				env: []string{`PKR_VAR_enabled=true`},
@@ -515,11 +583,13 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			wantDiags: false,
 			wantVariables: Variables{
 				"enabled": &Variable{
-					Type:         cty.Bool,
-					CmdValue:     cty.True,
-					VarfileValue: cty.False,
-					EnvValue:     cty.True,
-					DefaultValue: cty.False,
+					Type: cty.Bool,
+					Values: []VariableAssignment{
+						{"default", cty.False, nil},
+						{"env", cty.True, nil},
+						{"varfile", cty.False, nil},
+						{"cmd", cty.True, nil},
+					},
 				},
 			},
 			wantValues: map[string]cty.Value{
@@ -529,8 +599,8 @@ func TestVariables_collectVariableValues(t *testing.T) {
 
 		{name: "invalid env var",
 			variables: Variables{"used_string": &Variable{
-				DefaultValue: cty.StringVal("default_value"),
-				Type:         cty.String,
+				Values: []VariableAssignment{{"default", cty.StringVal("default_value"), nil}},
+				Type:   cty.String,
 			}},
 			args: args{
 				env: []string{`PKR_VAR_used_string`},
@@ -540,8 +610,8 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			wantDiags: false,
 			wantVariables: Variables{
 				"used_string": &Variable{
-					Type:         cty.String,
-					DefaultValue: cty.StringVal("default_value"),
+					Type:   cty.String,
+					Values: []VariableAssignment{{"default", cty.StringVal("default_value"), nil}},
 				},
 			},
 			wantValues: map[string]cty.Value{
@@ -620,8 +690,8 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			wantDiagsHasError: true,
 			wantVariables: Variables{
 				"used_string": &Variable{
-					Type:     cty.List(cty.String),
-					EnvValue: cty.DynamicVal,
+					Type:   cty.List(cty.String),
+					Values: []VariableAssignment{{"env", cty.DynamicVal, nil}},
 				},
 			},
 			wantValues: map[string]cty.Value{
@@ -644,8 +714,8 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			wantDiagsHasError: true,
 			wantVariables: Variables{
 				"used_string": &Variable{
-					Type:         cty.Bool,
-					VarfileValue: cty.DynamicVal,
+					Type:   cty.Bool,
+					Values: []VariableAssignment{{"varfile", cty.DynamicVal, nil}},
 				},
 			},
 			wantValues: map[string]cty.Value{
@@ -670,8 +740,8 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			wantDiagsHasError: true,
 			wantVariables: Variables{
 				"used_string": &Variable{
-					Type:     cty.Bool,
-					CmdValue: cty.DynamicVal,
+					Type:   cty.Bool,
+					Values: []VariableAssignment{{"cmd", cty.DynamicVal, nil}},
 				},
 			},
 			wantValues: map[string]cty.Value{
@@ -714,7 +784,7 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			if tt.wantDiagsHasError != gotDiags.HasErrors() {
 				t.Fatalf("Variables.collectVariableValues() unexpected diagnostics HasErrors. %s", gotDiags)
 			}
-			if diff := cmp.Diff(fmt.Sprintf("%#v", tt.wantVariables), fmt.Sprintf("%#v", tt.variables)); diff != "" {
+			if diff := cmp.Diff(tt.wantVariables, tt.variables, cmpOpts...); diff != "" {
 				t.Fatalf("didn't get expected variables: %s", diff)
 			}
 			values := map[string]cty.Value{}

--- a/website/pages/docs/from-1.5/blocks/variable.mdx
+++ b/website/pages/docs/from-1.5/blocks/variable.mdx
@@ -24,6 +24,8 @@ If a default value is set, the variable is optional. Otherwise, the variable
 
 `@include 'from-1.5/variables/assignment.mdx'`
 
+`@include 'from-1.5/variables/custom-validation.mdx'`
+
 Example of a variable assignment from a file:
 
 `@include 'from-1.5/variables/foo-pkrvar.mdx'`

--- a/website/pages/docs/from-1.5/variables.mdx
+++ b/website/pages/docs/from-1.5/variables.mdx
@@ -162,6 +162,8 @@ maintainers, use comments.
 
 The following sections describe these options in more detail.
 
+`@include 'from-1.5/variables/custom-validation.mdx'`
+
 ### Variables on the Command Line
 
 To specify individual variables on the command line, use the `-var` option when

--- a/website/pages/partials/from-1.5/variables/custom-validation.mdx
+++ b/website/pages/partials/from-1.5/variables/custom-validation.mdx
@@ -1,0 +1,43 @@
+## Custom Validation Rules
+
+In addition to Type Constraints, you can specify arbitrary custom validation
+rules for a particular variable using one or more `validation` block nested
+within the corresponding `variable` block:
+
+```hcl
+variable "image_id" {
+  type        = string
+  description = "The id of the machine image (AMI) to use for the server."
+
+  validation {
+    condition     = length(var.image_id) > 4 && substr(var.image_id, 0, 4) == "ami-"
+    error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
+  }
+}
+```
+
+The `condition` argument is an expression that must use the value of the
+variable to return `true` if the value is valid or `false` if it is invalid.
+The expression can refer only to the variable that the condition applies to,
+and _must not_ produce errors.
+
+If the failure of an expression is the basis of the validation decision, use
+[the `can` function](./functions/can.html) to detect such errors. For example:
+
+```hcl
+variable "image_id" {
+  type        = string
+  description = "The id of the machine image (AMI) to use for the server."
+
+  validation {
+    # regex(...) fails if it cannot find a match
+    condition     = can(regex("^ami-", var.image_id))
+    error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
+  }
+}
+```
+
+If `condition` evaluates to `false`,  an error message including the sentences
+given in `error_message` will be produced. The error message string should be
+at least one full sentence explaining the constraint that failed, using a
+sentence structure similar to the above examples.

--- a/website/pages/partials/from-1.5/variables/custom-validation.mdx
+++ b/website/pages/partials/from-1.5/variables/custom-validation.mdx
@@ -22,7 +22,7 @@ The expression can refer only to the variable that the condition applies to,
 and _must not_ produce errors.
 
 If the failure of an expression is the basis of the validation decision, use
-[the `can` function](./functions/can.html) to detect such errors. For example:
+[the `can` function](/docs/from-1.5/functions/conversion/can) to detect such errors. For example:
 
 ```hcl
 variable "image_id" {
@@ -57,6 +57,11 @@ variable "image_metadata" {
   validation {
     condition     = length(var.image_metadata.key) > 4
     error_message = "The image_metadata.key field must be more than 4 runes."
+  }
+
+  validation {
+    condition     = can(var.image_metadata.something.foo)
+    error_message = "The image_metadata.something.foo field must exist."
   }
 
   validation {

--- a/website/pages/partials/from-1.5/variables/custom-validation.mdx
+++ b/website/pages/partials/from-1.5/variables/custom-validation.mdx
@@ -41,3 +41,28 @@ If `condition` evaluates to `false`,  an error message including the sentences
 given in `error_message` will be produced. The error message string should be
 at least one full sentence explaining the constraint that failed, using a
 sentence structure similar to the above examples.
+
+Validation also works with more complex cases:
+
+```hcl
+variable "image_metadata" {
+
+  default = {
+    key: "value",
+    something: { 
+      foo: "bar",
+    }
+  }
+
+  validation {
+    condition     = length(var.image_metadata.key) > 4
+    error_message = "The image_metadata.key field must be more than 4 runes."
+  }
+
+  validation {
+    condition     = substr(var.image_metadata.something.foo, 0, 3) == "bar"
+    error_message = "The image_metadata.something.foo field must start with \"bar\"."
+  }
+
+}
+```


### PR DESCRIPTION
This:
* Enables adding `validation` blocks to an input variable definition, for example:
```hcl
variable "image_id" {
  type        = string
  description = "The id of the machine image (AMI) to use for the server."

  validation {
    condition     = length(var.image_id) > 4 && substr(var.image_id, 0, 4) == "ami-"
    error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
  }
}
```
* tests for this ⬆️ 
* docs for this ⬆️ 
* updates the `length` function and tests ( mostly from Terraform ) to be able to use it on strings. This is going to be pretty helpful for string validation here. There is no update on the docs here because they were from Terraform, so they used to be wrong.

There's a lot of Terraform code reuse/adaptation here.

close https://github.com/hashicorp/packer/issues/10148