### PR TITLE
Outscale outscale.hk endpoint support

### DIFF
--- a/builder/osc/common/access_config.go
+++ b/builder/osc/common/access_config.go
@@ -47,6 +47,11 @@ func (c *AccessConfig) NewOSCClient() *osc.APIClient {
 
 	if c.CustomEndpointOAPI == "" {
 		c.CustomEndpointOAPI = "outscale.com/oapi/latest"
+
+		if c.RawRegion == "cn-southeast-1" {
+			c.CustomEndpointOAPI = "outscale.hk/oapi/latest"
+		}
+
 	}
 
 	if c.X509certPath == "" {


### PR DESCRIPTION

Adding `outscale.hk` endpoint support when the users specify `cn-southeast-1` region.

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #10186 
