### PR TITLE
fix(proxmox): use default values when possible

### DIFF
--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -45,7 +45,6 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		QemuKVM:      kvm,
 		Boot:         c.Boot, // Boot priority, example: "order=virtio0;ide2;net0", virtio0:Disk0 -> ide0:CDROM -> net0:Network
 		QemuCpu:      c.CPUType,
-		Description:  "Packer ephemeral build VM",
 		Memory:       c.Memory,
 		QemuCores:    c.Cores,
 		QemuSockets:  c.Sockets,


### PR DESCRIPTION
Use default values when possible for the Proxmox provider.

- Don't set a `Description` as the template will be used for "final" (non-ephemeral) VMs and the description will be wrong. 
- Don't hardcode `Boot` parameter. From my tests, this is breaking the booting order and will always load the CDROM every time. Let the API use the default value (hard-drive, cd-rom and network).  