### PR TITLE
azure-arm builder: Create keyvaults with SoftDelete enabled

### DIFF
--- a/builder/azure/arm/template_factory_test.TestKeyVaultDeployment03.approved.json
+++ b/builder/azure/arm/template_factory_test.TestKeyVaultDeployment03.approved.json
@@ -38,6 +38,7 @@
             "tenantId": "[parameters('tenantId')]"
           }
         ],
+        "enableSoftDelete": "true",
         "enabledForDeployment": "true",
         "enabledForTemplateDeployment": "true",
         "sku": {

--- a/builder/azure/common/template/template.go
+++ b/builder/azure/common/template/template.go
@@ -85,6 +85,7 @@ type Properties struct {
 	DNSSettings                  *network.PublicIPAddressDNSSettings `json:"dnsSettings,omitempty"`
 	EnabledForDeployment         *string                             `json:"enabledForDeployment,omitempty"`
 	EnabledForTemplateDeployment *string                             `json:"enabledForTemplateDeployment,omitempty"`
+	EnableSoftDelete             *string                             `json:"enableSoftDelete,omitempty"`
 	HardwareProfile              *compute.HardwareProfile            `json:"hardwareProfile,omitempty"`
 	IPConfigurations             *[]network.IPConfiguration          `json:"ipConfigurations,omitempty"`
 	NetworkProfile               *compute.NetworkProfile             `json:"networkProfile,omitempty"`

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -554,6 +554,7 @@ const KeyVault = `{
       "properties": {
         "enabledForDeployment": "true",
         "enabledForTemplateDeployment": "true",
+        "enableSoftDelete": "true",
         "tenantId": "[parameters('tenantId')]",
         "accessPolicies": [
           {


### PR DESCRIPTION
**Description**
This PR ensures that temporary key vault created by Packer azure-arm builder always has 'Soft-delete' option enabled.
From [public documentation of Azure Key Vault soft-delete](https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview), having Soft-delete enabled will be the defacto setting and disabling that option will be deprecated.
Some enterprises may already be enforcing Soft-delete to be turned on all newly created key vaults.

**Tests**

1. Ran a Packer build for 'azure-arm' builder to create a Windows 10 image. During the run, inspected the temporary key vault in Azure Portal and validated that 'Soft-delete' property was indeed set to 'Enabled'

1. Successfully ran azure-arm acceptance test: make testacc TEST=./builder/azure/arm/