### PR TITLE
Feat (builder/oracle-oci): support image launch mode

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -83,6 +83,7 @@ type Config struct {
 	BaseImageFilter    ListImagesRequest `mapstructure:"base_image_filter"`
 	ImageName          string            `mapstructure:"image_name"`
 	ImageCompartmentID string            `mapstructure:"image_compartment_ocid"`
+	LaunchMode         string            `mapstructure:"image_launch_mode"`
 
 	// Instance
 	InstanceName        *string                           `mapstructure:"instance_name"`

--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -276,9 +276,16 @@ func (c *Config) Prepare(raws ...interface{}) error {
 			errs, errors.New("'shape' must be specified"))
 	}
 
-	if c.SubnetID == "" {
+	if (c.SubnetID == "") && (c.CreateVnicDetails.SubnetId == nil) {
 		errs = packer.MultiErrorAppend(
 			errs, errors.New("'subnet_ocid' must be specified"))
+	}
+
+	if c.CreateVnicDetails.SubnetId == nil {
+		c.CreateVnicDetails.SubnetId = &c.SubnetID
+	} else if (*c.CreateVnicDetails.SubnetId != c.SubnetID) && (c.SubnetID != "") {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("'create_vnic_details[subnet]' must match 'subnet_ocid' if both are specified"))
 	}
 
 	if (c.BaseImageID == "") && (c.BaseImageFilter == ListImagesRequest{}) {

--- a/builder/oracle/oci/config.hcl2spec.go
+++ b/builder/oracle/oci/config.hcl2spec.go
@@ -81,6 +81,7 @@ type FlatConfig struct {
 	BaseImageFilter           *FlatListImagesRequest            `mapstructure:"base_image_filter" cty:"base_image_filter" hcl:"base_image_filter"`
 	ImageName                 *string                           `mapstructure:"image_name" cty:"image_name" hcl:"image_name"`
 	ImageCompartmentID        *string                           `mapstructure:"image_compartment_ocid" cty:"image_compartment_ocid" hcl:"image_compartment_ocid"`
+	LaunchMode                *string                           `mapstructure:"image_launch_mode" cty:"image_launch_mode" hcl:"image_launch_mode"`
 	InstanceName              *string                           `mapstructure:"instance_name" cty:"instance_name" hcl:"instance_name"`
 	InstanceTags              map[string]string                 `mapstructure:"instance_tags" cty:"instance_tags" hcl:"instance_tags"`
 	InstanceDefinedTags       map[string]map[string]interface{} `mapstructure:"instance_defined_tags" cty:"instance_defined_tags" hcl:"instance_defined_tags"`
@@ -179,6 +180,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"base_image_filter":            &hcldec.BlockSpec{TypeName: "base_image_filter", Nested: hcldec.ObjectSpec((*FlatListImagesRequest)(nil).HCL2Spec())},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"image_compartment_ocid":       &hcldec.AttrSpec{Name: "image_compartment_ocid", Type: cty.String, Required: false},
+		"image_launch_mode":            &hcldec.AttrSpec{Name: "image_launch_mode", Type: cty.String, Required: false},
 		"instance_name":                &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"instance_tags":                &hcldec.AttrSpec{Name: "instance_tags", Type: cty.Map(cty.String), Required: false},
 		"instance_defined_tags":        &hcldec.AttrSpec{Name: "instance_defined_tags", Type: cty.Map(cty.String), Required: false},

--- a/builder/oracle/oci/config_test.go
+++ b/builder/oracle/oci/config_test.go
@@ -118,6 +118,17 @@ func TestConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("LaunchMode", func(t *testing.T) {
+		raw := testConfig(cfgFile)
+		raw["image_launch_mode"] = "NATIVE"
+
+		var c Config
+		errs := c.Prepare(raw)
+		if errs != nil {
+			t.Fatalf("Unexpected error in configuration %+v", errs)
+		}
+	})
+
 	t.Run("NoAccessConfig", func(t *testing.T) {
 		raw := testConfig(cfgFile)
 		delete(raw, "access_cfg_file")

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -124,7 +124,6 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 		FreeformTags:       d.cfg.InstanceTags,
 		Shape:              &d.cfg.Shape,
 		SourceDetails:      InstanceSourceDetails,
-		SubnetId:           &d.cfg.SubnetID,
 		Metadata:           metadata,
 	}
 

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -145,6 +145,7 @@ func (d *driverOCI) CreateImage(ctx context.Context, id string) (core.Image, err
 		DisplayName:   &d.cfg.ImageName,
 		FreeformTags:  d.cfg.Tags,
 		DefinedTags:   d.cfg.DefinedTags,
+		LaunchMode:    core.CreateImageDetailsLaunchModeEnum(d.cfg.LaunchMode),
 	}})
 
 	if err != nil {

--- a/website/pages/docs/builders/oracle/oci.mdx
+++ b/website/pages/docs/builders/oracle/oci.mdx
@@ -177,6 +177,11 @@ can also be supplied to override the typical auto-generated key:
   Sets the [BootVolumeSizeInGBs](https://godoc.org/github.com/oracle/oci-go-sdk/core#InstanceConfigurationInstanceSourceViaImageDetails)
   when launching the instance. Defaults to `50`.
 
+- `image_launch_mode` (string) - Specifies the configuration mode for launching instances.
+  Valid values are `"NATIVE"`, `"EMULATED"`, `"PARAVIRTUALIZED"`, and `"CUSTOM"`. See the
+  [Oracle CLI docs](https://docs.cloud.oracle.com/en-us/iaas/tools/oci-cli/2.12.5/oci_cli_docs/cmdref/compute/image/create.html#cmdoption-launch-mode)
+  for more information about these modes.
+
 - `use_private_ip` (boolean) - Use private ip addresses to connect to the
   instance via ssh.
 


### PR DESCRIPTION
Adds LaunchMode to the image details.

This PR also removes subnet from `LaunchInstanceDetails` ([deprecated per the SDK](https://github.com/oracle/oci-go-sdk/blob/3a241ac885b562eb247a54b078b8e3d2edd3a882/core/launch_instance_details.go#L164)). This does not change anything for the user, the `subnet_ocid` will simply be passed to `CreateVnicDetails` rather than `LaunchInstanceDetails`. If the user specifies both `subnet_ocid` and `create_vnic_details[subnet_id]`, the values must match or Packer will return an error (behavior similar to the SDK).

Closes #8211
