### PR TITLE
Return error if ssh-config command fails

### DIFF
--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -154,8 +154,10 @@ func (d *Vagrant_2_2_Driver) SSHConfig(id string) (*VagrantSSHConfig, error) {
 	sshConf := &VagrantSSHConfig{}
 
 	stdout, stderr, err := d.vagrantCmd(args...)
-	if stderr != "" {
-		err := fmt.Errorf("ssh-config command returned error: %s", stderr)
+	if err != nil {
+		if stderr != "" {
+			err = fmt.Errorf("ssh-config command returned errors: %s", stderr)
+		}
 		return sshConf, err
 	}
 	lines := strings.Split(stdout, "\n")


### PR DESCRIPTION
Update error detection to return an error if the process fails instead
of testing for content in stderr. Not sure if there were specific error
cases that were being encountered where stderr would end up with error
information but the command would provide a successful exit code. If
there are cases where that occurs, I'm happy to resolve that on the
Vagrant side.

This fixes the issue described in hashicorp/vagrant#12013 where a
warning of experimental features being enabled is output to stderr.
