### PR TITLE
fix single tag interpolation to allow golang template engine usage

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -201,8 +201,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			Exclude: []string{
 				"ami_description",
 				"snapshot_tags",
+				"snapshot_tag",
 				"tags",
+				"tag",
 				"root_volume_tags",
+				"root_volume_tag",
 				"command_wrapper",
 				"post_mount_commands",
 				"pre_mount_commands",

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -92,10 +92,15 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			Exclude: []string{
 				"ami_description",
 				"run_tags",
+				"run_tag",
 				"run_volume_tags",
+				"run_volume_tag",
 				"spot_tags",
+				"spot_tag",
 				"snapshot_tags",
+				"snapshot_tag",
 				"tags",
+				"tag",
 			},
 		},
 	}, raws...)

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -91,10 +91,15 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			Exclude: []string{
 				"ami_description",
 				"run_tags",
+				"run_tag",
 				"run_volume_tags",
+				"run_volume_tag",
 				"snapshot_tags",
+				"snapshot_tag",
 				"spot_tags",
+				"spot_tag",
 				"tags",
+				"tag",
 			},
 		},
 	}, raws...)

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -103,6 +103,18 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		PluginType:         BuilderId,
 		Interpolate:        true,
 		InterpolateContext: &b.config.ctx,
+		InterpolateFilter: &interpolate.RenderFilter{
+			Exclude: []string{
+				"run_tags",
+				"run_tag",
+				"run_volume_tags",
+				"run_volume_tag",
+				"spot_tags",
+				"spot_tag",
+				"tags",
+				"tag",
+			},
+		},
 	}, raws...)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Fixes the issue we've been having where dynamic tags and those declared in single tag blocks weren't being template engines like they should