### PR TITLE
Fix proxmox page links

### DIFF
--- a/website/pages/docs/builders/proxmox/index.mdx
+++ b/website/pages/docs/builders/proxmox/index.mdx
@@ -16,13 +16,13 @@ machines and store them as new Proxmox Virutal Machine images.
 
 Packer is able to target both ISO and existing Cloud-Init images:
 
-- [proxmox-clone](/docs/builders/proxmox-clone) - The proxmox image
+- [proxmox-clone](/docs/builders/proxmox/clone) - The proxmox image
   Packer builder is able to create new images for use with
   Proxmox VE. The builder takes a cloud-init enabled virtual machine
   template name, runs any provisioning necessary on the image after
   launching it, then creates a virtual machine template.
 
-- [proxmox-iso](/docs/builders/proxmox-iso) - The proxmox Packer
+- [proxmox-iso](/docs/builders/proxmox/iso) - The proxmox Packer
   builder is able to create new images for use with
   Proxmox VE. The builder takes an ISO source, runs any provisioning
   necessary on the image after launching it, then creates a virtual machine


### PR DESCRIPTION
This fixes the proxmox page links that are currently broken on the website. I'm not exactly sure how the code generation works, but the files are named proxmox-clone.mdx and proxmox-iso.mdx, which seem to be routed to proxmox/clone and proxmox/iso.