### PR TITLE
Refactor version code

### DIFF
--- a/builder/alicloud/ecs/access_config.go
+++ b/builder/alicloud/ecs/access_config.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/hashicorp/packer/builder/alicloud/version"
 	"github.com/hashicorp/packer/template/interpolate"
-	"github.com/hashicorp/packer/version"
 	"github.com/mitchellh/go-homedir"
 )
 
@@ -78,7 +78,7 @@ func (c *AlicloudAccessConfig) Client() (*ClientWrapper, error) {
 		return nil, err
 	}
 
-	client.AppendUserAgent(Packer, version.FormattedVersion())
+	client.AppendUserAgent(Packer, version.AlicloudPluginVersion.FormattedVersion())
 	client.SetReadTimeout(DefaultRequestReadTimeout)
 	c.client = &ClientWrapper{client}
 

--- a/builder/alicloud/ecs/builder.hcl2spec.go
+++ b/builder/alicloud/ecs/builder.hcl2spec.go
@@ -49,6 +49,7 @@ func (*FlatAlicloudDiskDevice) HCL2Spec() map[string]hcldec.Spec {
 type FlatConfig struct {
 	PackerBuildName                   *string                     `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                 *string                     `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                 *string                     `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                       *bool                       `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                       *bool                       `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                     *string                     `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -165,6 +166,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/alicloud/version/version.go
+++ b/builder/alicloud/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var AlicloudPluginVersion = version.PluginVersion{
+	Version:           packerVersion.Version,
+	VersionPrerelease: packerVersion.VersionPrerelease,
+}

--- a/builder/alicloud/version/version.go
+++ b/builder/alicloud/version/version.go
@@ -5,7 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var AlicloudPluginVersion = version.PluginVersion{
-	Version:           packerVersion.Version,
-	VersionPrerelease: packerVersion.VersionPrerelease,
+var AlicloudPluginVersion *version.PluginVersion
+
+func init() {
+	AlicloudPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/amazon/chroot/builder.hcl2spec.go
+++ b/builder/amazon/chroot/builder.hcl2spec.go
@@ -13,6 +13,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName         *string                           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType       *string                           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion       *string                           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug             *bool                             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce             *bool                             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError           *string                           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -92,6 +93,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":             &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":           &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":           &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                  &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                  &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/amazon/ebs/builder.hcl2spec.go
+++ b/builder/amazon/ebs/builder.hcl2spec.go
@@ -13,6 +13,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                           *string                                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                         *string                                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                         *string                                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                               *bool                                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                               *bool                                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                             *string                                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -161,6 +162,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":             &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":           &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":           &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                  &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                  &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/amazon/ebssurrogate/builder.hcl2spec.go
+++ b/builder/amazon/ebssurrogate/builder.hcl2spec.go
@@ -56,6 +56,7 @@ func (*FlatBlockDevice) HCL2Spec() map[string]hcldec.Spec {
 type FlatConfig struct {
 	PackerBuildName                           *string                                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                         *string                                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                         *string                                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                               *bool                                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                               *bool                                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                             *string                                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -205,6 +206,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":             &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":           &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":           &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                  &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                  &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/amazon/ebsvolume/builder.hcl2spec.go
+++ b/builder/amazon/ebsvolume/builder.hcl2spec.go
@@ -58,6 +58,7 @@ func (*FlatBlockDevice) HCL2Spec() map[string]hcldec.Spec {
 type FlatConfig struct {
 	PackerBuildName                           *string                                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                         *string                                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                         *string                                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                               *bool                                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                               *bool                                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                             *string                                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -185,6 +186,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":             &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":           &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":           &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                  &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                  &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/amazon/instance/builder.hcl2spec.go
+++ b/builder/amazon/instance/builder.hcl2spec.go
@@ -13,6 +13,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                           *string                                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                         *string                                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                         *string                                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                               *bool                                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                               *bool                                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                             *string                                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -167,6 +168,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":             &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":           &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":           &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                  &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                  &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/amazon/version/version.go
+++ b/builder/amazon/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var AWSPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	AWSPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/packer/builder/azure/common"
+	"github.com/hashicorp/packer/builder/azure/version"
 	"github.com/hashicorp/packer/helper/useragent"
 )
 
@@ -140,97 +141,97 @@ func NewAzureClient(subscriptionID, sigSubscriptionID, resourceGroupName, storag
 	azureClient.DeploymentsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DeploymentsClient.RequestInspector = withInspection(maxlen)
 	azureClient.DeploymentsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.DeploymentsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DeploymentsClient.UserAgent)
+	azureClient.DeploymentsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DeploymentsClient.UserAgent)
 	azureClient.DeploymentsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.DeploymentOperationsClient = resources.NewDeploymentOperationsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DeploymentOperationsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DeploymentOperationsClient.RequestInspector = withInspection(maxlen)
 	azureClient.DeploymentOperationsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.DeploymentOperationsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DeploymentOperationsClient.UserAgent)
+	azureClient.DeploymentOperationsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DeploymentOperationsClient.UserAgent)
 	azureClient.DeploymentOperationsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.DisksClient = compute.NewDisksClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DisksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DisksClient.RequestInspector = withInspection(maxlen)
 	azureClient.DisksClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.DisksClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DisksClient.UserAgent)
+	azureClient.DisksClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DisksClient.UserAgent)
 	azureClient.DisksClient.Client.PollingDuration = pollingDuration
 
 	azureClient.GroupsClient = resources.NewGroupsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.GroupsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.GroupsClient.RequestInspector = withInspection(maxlen)
 	azureClient.GroupsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.GroupsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GroupsClient.UserAgent)
+	azureClient.GroupsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GroupsClient.UserAgent)
 	azureClient.GroupsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.ImagesClient = compute.NewImagesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.ImagesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.ImagesClient.RequestInspector = withInspection(maxlen)
 	azureClient.ImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.ImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.ImagesClient.UserAgent)
+	azureClient.ImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.ImagesClient.UserAgent)
 	azureClient.ImagesClient.Client.PollingDuration = pollingDuration
 
 	azureClient.InterfacesClient = network.NewInterfacesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.InterfacesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.InterfacesClient.RequestInspector = withInspection(maxlen)
 	azureClient.InterfacesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.InterfacesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.InterfacesClient.UserAgent)
+	azureClient.InterfacesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.InterfacesClient.UserAgent)
 	azureClient.InterfacesClient.Client.PollingDuration = pollingDuration
 
 	azureClient.SubnetsClient = network.NewSubnetsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.SubnetsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.SubnetsClient.RequestInspector = withInspection(maxlen)
 	azureClient.SubnetsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.SubnetsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.SubnetsClient.UserAgent)
+	azureClient.SubnetsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.SubnetsClient.UserAgent)
 	azureClient.SubnetsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.VirtualNetworksClient = network.NewVirtualNetworksClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.VirtualNetworksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.VirtualNetworksClient.RequestInspector = withInspection(maxlen)
 	azureClient.VirtualNetworksClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.VirtualNetworksClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.VirtualNetworksClient.UserAgent)
+	azureClient.VirtualNetworksClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.VirtualNetworksClient.UserAgent)
 	azureClient.VirtualNetworksClient.Client.PollingDuration = pollingDuration
 
 	azureClient.SecurityGroupsClient = network.NewSecurityGroupsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.SecurityGroupsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.SecurityGroupsClient.RequestInspector = withInspection(maxlen)
 	azureClient.SecurityGroupsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.SecurityGroupsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.SecurityGroupsClient.UserAgent)
+	azureClient.SecurityGroupsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.SecurityGroupsClient.UserAgent)
 
 	azureClient.PublicIPAddressesClient = network.NewPublicIPAddressesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.PublicIPAddressesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.PublicIPAddressesClient.RequestInspector = withInspection(maxlen)
 	azureClient.PublicIPAddressesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.PublicIPAddressesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.PublicIPAddressesClient.UserAgent)
+	azureClient.PublicIPAddressesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.PublicIPAddressesClient.UserAgent)
 	azureClient.PublicIPAddressesClient.Client.PollingDuration = pollingDuration
 
 	azureClient.VirtualMachinesClient = compute.NewVirtualMachinesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.VirtualMachinesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.VirtualMachinesClient.RequestInspector = withInspection(maxlen)
 	azureClient.VirtualMachinesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
-	azureClient.VirtualMachinesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.VirtualMachinesClient.UserAgent)
+	azureClient.VirtualMachinesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.VirtualMachinesClient.UserAgent)
 	azureClient.VirtualMachinesClient.Client.PollingDuration = pollingDuration
 
 	azureClient.SnapshotsClient = compute.NewSnapshotsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.SnapshotsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.SnapshotsClient.RequestInspector = withInspection(maxlen)
 	azureClient.SnapshotsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.SnapshotsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.SnapshotsClient.UserAgent)
+	azureClient.SnapshotsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.SnapshotsClient.UserAgent)
 	azureClient.SnapshotsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.AccountsClient = armStorage.NewAccountsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.AccountsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.AccountsClient.RequestInspector = withInspection(maxlen)
 	azureClient.AccountsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.AccountsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.AccountsClient.UserAgent)
+	azureClient.AccountsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.AccountsClient.UserAgent)
 	azureClient.AccountsClient.Client.PollingDuration = pollingDuration
 
 	azureClient.GalleryImageVersionsClient = newCompute.NewGalleryImageVersionsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.GalleryImageVersionsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.GalleryImageVersionsClient.RequestInspector = withInspection(maxlen)
 	azureClient.GalleryImageVersionsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.GalleryImageVersionsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GalleryImageVersionsClient.UserAgent)
+	azureClient.GalleryImageVersionsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImageVersionsClient.UserAgent)
 	azureClient.GalleryImageVersionsClient.Client.PollingDuration = sharedGalleryTimeout
 	azureClient.GalleryImageVersionsClient.SubscriptionID = sigSubscriptionID
 
@@ -238,7 +239,7 @@ func NewAzureClient(subscriptionID, sigSubscriptionID, resourceGroupName, storag
 	azureClient.GalleryImagesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.GalleryImagesClient.RequestInspector = withInspection(maxlen)
 	azureClient.GalleryImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GalleryImagesClient.UserAgent)
+	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImagesClient.UserAgent)
 	azureClient.GalleryImagesClient.Client.PollingDuration = pollingDuration
 	azureClient.GalleryImagesClient.SubscriptionID = sigSubscriptionID
 
@@ -251,7 +252,7 @@ func NewAzureClient(subscriptionID, sigSubscriptionID, resourceGroupName, storag
 	azureClient.VaultClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalTokenVault)
 	azureClient.VaultClient.RequestInspector = withInspection(maxlen)
 	azureClient.VaultClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.VaultClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.VaultClient.UserAgent)
+	azureClient.VaultClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.VaultClient.UserAgent)
 	azureClient.VaultClient.Client.PollingDuration = pollingDuration
 
 	// This client is different than the above because it manages the vault
@@ -260,7 +261,7 @@ func NewAzureClient(subscriptionID, sigSubscriptionID, resourceGroupName, storag
 	azureClient.VaultClientDelete.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.VaultClientDelete.RequestInspector = withInspection(maxlen)
 	azureClient.VaultClientDelete.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.VaultClientDelete.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.VaultClientDelete.UserAgent)
+	azureClient.VaultClientDelete.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.VaultClientDelete.UserAgent)
 	azureClient.VaultClientDelete.Client.PollingDuration = pollingDuration
 
 	// If this is a managed disk build, this should be ignored.

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                            *string                            `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                          *string                            `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                          *string                            `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                                *bool                              `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                                *bool                              `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                              *string                            `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -139,6 +140,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":                                &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":                              &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":                              &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                                     &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                                     &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                                  &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/azure/chroot/builder.hcl2spec.go
+++ b/builder/azure/chroot/builder.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                   *string                            `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                 *string                            `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                 *string                            `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                       *bool                              `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                       *bool                              `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                     *string                            `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -64,6 +65,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":               &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":             &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":             &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                    &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                    &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                 &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/azure/common/client/azure_client_set.go
+++ b/builder/azure/common/client/azure_client_set.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"log"
 	"net/http"
 	"regexp"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute/computeapi"
 	"github.com/Azure/go-autorest/autorest"
+	version "github.com/hashicorp/packer/builder/azure/version"
 )
 
 type AzureClientSet interface {
@@ -64,7 +66,10 @@ func (s azureClientSet) SubscriptionID() string {
 }
 
 func (s azureClientSet) configureAutorestClient(c *autorest.Client) {
-	c.AddToUserAgent(useragent.String())
+	err := c.AddToUserAgent(useragent.String(version.AzurePluginVersion.FormattedVersion()))
+	if err != nil {
+		log.Printf("Error appending Packer plugin version to user agent.")
+	}
 	c.Authorizer = s.authorizer
 	c.Sender = s.sender
 }
@@ -72,7 +77,7 @@ func (s azureClientSet) configureAutorestClient(c *autorest.Client) {
 func (s azureClientSet) MetadataClient() MetadataClientAPI {
 	return metadataClient{
 		s.sender,
-		useragent.String(),
+		useragent.String(version.AzurePluginVersion.FormattedVersion()),
 	}
 }
 

--- a/builder/azure/common/client/devicelogin.go
+++ b/builder/azure/common/client/devicelogin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+	version "github.com/hashicorp/packer/builder/azure/version"
 	"github.com/hashicorp/packer/helper/useragent"
 )
 
@@ -123,7 +124,7 @@ func tokenFromFile(say func(string), oauthCfg adal.OAuthConfig, tokenPath, clien
 // endpoint is polled until user gives consent, denies or the flow times out.
 // Returned token must be saved.
 func tokenFromDeviceFlow(say func(string), oauthCfg adal.OAuthConfig, clientID, resource string) (*adal.ServicePrincipalToken, error) {
-	cl := autorest.NewClientWithUserAgent(useragent.String())
+	cl := autorest.NewClientWithUserAgent(useragent.String(version.AzurePluginVersion.FormattedVersion()))
 	deviceCode, err := adal.InitiateDeviceAuth(&cl, oauthCfg, clientID, resource)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to start device auth: %v", err)

--- a/builder/azure/dtl/azure_client.go
+++ b/builder/azure/dtl/azure_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/packer/builder/azure/common"
+	"github.com/hashicorp/packer/builder/azure/version"
 	"github.com/hashicorp/packer/helper/useragent"
 )
 
@@ -142,28 +143,28 @@ func NewAzureClient(subscriptionID, resourceGroupName string,
 	azureClient.DtlVirtualMachineClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DtlVirtualMachineClient.RequestInspector = withInspection(maxlen)
 	azureClient.DtlVirtualMachineClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
-	azureClient.DtlVirtualMachineClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DtlVirtualMachineClient.UserAgent)
+	azureClient.DtlVirtualMachineClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DtlVirtualMachineClient.UserAgent)
 	azureClient.DtlVirtualMachineClient.Client.PollingDuration = PollingDuration
 
 	azureClient.DtlEnvironmentsClient = dtl.NewEnvironmentsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DtlEnvironmentsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DtlEnvironmentsClient.RequestInspector = withInspection(maxlen)
 	azureClient.DtlEnvironmentsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
-	azureClient.DtlEnvironmentsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DtlEnvironmentsClient.UserAgent)
+	azureClient.DtlEnvironmentsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DtlEnvironmentsClient.UserAgent)
 	azureClient.DtlEnvironmentsClient.Client.PollingDuration = PollingDuration
 
 	azureClient.DtlLabsClient = dtl.NewLabsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DtlLabsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DtlLabsClient.RequestInspector = withInspection(maxlen)
 	azureClient.DtlLabsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
-	azureClient.DtlLabsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DtlLabsClient.UserAgent)
+	azureClient.DtlLabsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DtlLabsClient.UserAgent)
 	azureClient.DtlLabsClient.Client.PollingDuration = PollingDuration
 
 	azureClient.DtlCustomImageClient = dtl.NewCustomImagesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DtlCustomImageClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DtlCustomImageClient.RequestInspector = withInspection(maxlen)
 	azureClient.DtlCustomImageClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
-	azureClient.DtlCustomImageClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DtlCustomImageClient.UserAgent)
+	azureClient.DtlCustomImageClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DtlCustomImageClient.UserAgent)
 	azureClient.DtlCustomImageClient.PollingDuration = autorest.DefaultPollingDuration
 	azureClient.DtlCustomImageClient.Client.PollingDuration = PollingDuration
 
@@ -171,14 +172,14 @@ func NewAzureClient(subscriptionID, resourceGroupName string,
 	azureClient.DtlVirtualNetworksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.DtlVirtualNetworksClient.RequestInspector = withInspection(maxlen)
 	azureClient.DtlVirtualNetworksClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
-	azureClient.DtlVirtualNetworksClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.DtlVirtualNetworksClient.UserAgent)
+	azureClient.DtlVirtualNetworksClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DtlVirtualNetworksClient.UserAgent)
 	azureClient.DtlVirtualNetworksClient.Client.PollingDuration = PollingDuration
 
 	azureClient.GalleryImageVersionsClient = newCompute.NewGalleryImageVersionsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.GalleryImageVersionsClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.GalleryImageVersionsClient.RequestInspector = withInspection(maxlen)
 	azureClient.GalleryImageVersionsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.GalleryImageVersionsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GalleryImageVersionsClient.UserAgent)
+	azureClient.GalleryImageVersionsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImageVersionsClient.UserAgent)
 	azureClient.GalleryImageVersionsClient.Client.PollingDuration = SharedGalleryTimeout
 	azureClient.GalleryImageVersionsClient.Client.PollingDuration = PollingDuration
 
@@ -186,7 +187,7 @@ func NewAzureClient(subscriptionID, resourceGroupName string,
 	azureClient.GalleryImagesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.GalleryImagesClient.RequestInspector = withInspection(maxlen)
 	azureClient.GalleryImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
-	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(), azureClient.GalleryImagesClient.UserAgent)
+	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImagesClient.UserAgent)
 	azureClient.GalleryImagesClient.Client.PollingDuration = PollingDuration
 
 	return azureClient, nil

--- a/builder/azure/dtl/config.hcl2spec.go
+++ b/builder/azure/dtl/config.hcl2spec.go
@@ -38,6 +38,7 @@ func (*FlatArtifactParameter) HCL2Spec() map[string]hcldec.Spec {
 type FlatConfig struct {
 	PackerBuildName                     *string                            `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                   *string                            `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                   *string                            `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                         *bool                              `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                         *bool                              `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                       *string                            `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -151,6 +152,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":                        &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":                      &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":                      &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                             &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                             &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                          &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/azure/version/version.go
+++ b/builder/azure/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var AzurePluginVersion = version.PluginVersion{
+	Version:           packerVersion.Version,
+	VersionPrerelease: packerVersion.VersionPrerelease,
+}

--- a/builder/azure/version/version.go
+++ b/builder/azure/version/version.go
@@ -5,7 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var AzurePluginVersion = version.PluginVersion{
-	Version:           packerVersion.Version,
-	VersionPrerelease: packerVersion.VersionPrerelease,
+var AzurePluginVersion *version.PluginVersion
+
+func init() {
+	AzurePluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/cloudstack/config.hcl2spec.go
+++ b/builder/cloudstack/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -126,6 +127,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/cloudstack/version/version.go
+++ b/builder/cloudstack/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var CloudstackPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	CloudstackPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/digitalocean/config.hcl2spec.go
+++ b/builder/digitalocean/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -97,6 +98,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/digitalocean/version/version.go
+++ b/builder/digitalocean/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var DockerPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	DockerPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/docker/config.hcl2spec.go
+++ b/builder/docker/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -110,6 +111,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/docker/version/version.go
+++ b/builder/docker/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var DigitalOceanPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	DigitalOceanPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/file/config.hcl2spec.go
+++ b/builder/file/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -35,6 +36,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/file/version/version.go
+++ b/builder/file/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var FilePluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	FilePluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName              *string                    `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType            *string                    `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion            *string                    `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                  *bool                      `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                  *bool                      `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                *string                    `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -133,6 +134,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":               &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":             &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":             &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                    &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                    &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                 &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/api/option"
 	oslogin "google.golang.org/api/oslogin/v1"
 
+	"github.com/hashicorp/packer/builder/googlecompute/version"
 	"github.com/hashicorp/packer/common/retry"
 	"github.com/hashicorp/packer/helper/useragent"
 	"github.com/hashicorp/packer/packer"
@@ -146,7 +147,7 @@ func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 	}
 
 	// Set UserAgent
-	service.UserAgent = useragent.String()
+	service.UserAgent = useragent.String(version.GCEPluginVersion.FormattedVersion())
 
 	return &driverGCE{
 		projectId:      config.ProjectId,

--- a/builder/googlecompute/version/version.go
+++ b/builder/googlecompute/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var GCEPluginVersion = version.PluginVersion{
+	Version:           packerVersion.Version,
+	VersionPrerelease: packerVersion.VersionPrerelease,
+}

--- a/builder/googlecompute/version/version.go
+++ b/builder/googlecompute/version/version.go
@@ -5,7 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var GCEPluginVersion = version.PluginVersion{
-	Version:           packerVersion.Version,
-	VersionPrerelease: packerVersion.VersionPrerelease,
+var GCEPluginVersion *version.PluginVersion
+
+func init() {
+	GCEPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/hcloud/config.hcl2spec.go
+++ b/builder/hcloud/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -95,6 +96,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/hcloud/version/version.go
+++ b/builder/hcloud/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var HcloudPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	HcloudPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/hyperone/config.hcl2spec.go
+++ b/builder/hyperone/config.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string                      `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string                      `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string                      `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool                        `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool                        `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string                      `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -118,6 +119,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/hyperone/version/version.go
+++ b/builder/hyperone/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var HyperonePluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	HyperonePluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/hyperv/iso/builder.hcl2spec.go
+++ b/builder/hyperv/iso/builder.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType              *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion              *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                    *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                    *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                  *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -132,6 +133,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":                &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":              &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":              &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                     &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                     &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                  &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/hyperv/version/version.go
+++ b/builder/hyperv/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var HypervPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	HypervPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/hyperv/vmcx/builder.hcl2spec.go
+++ b/builder/hyperv/vmcx/builder.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType              *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion              *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                    *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                    *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                  *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -134,6 +135,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":                &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":              &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":              &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                     &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                     &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                  &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/jdcloud/common.hcl2spec.go
+++ b/builder/jdcloud/common.hcl2spec.go
@@ -73,6 +73,7 @@ type FlatConfig struct {
 	PublicIpId                *string           `cty:"public_ip_id" hcl:"public_ip_id"`
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -156,6 +157,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"public_ip_id":                 &hcldec.AttrSpec{Name: "public_ip_id", Type: cty.String, Required: false},
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/jdcloud/version/version.go
+++ b/builder/jdcloud/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var JDCloudPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	JDCloudPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/linode/config.hcl2spec.go
+++ b/builder/linode/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -93,6 +94,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/linode/linode.go
+++ b/builder/linode/linode.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/packer/version"
+	"github.com/hashicorp/packer/builder/linode/version"
 	"github.com/linode/linodego"
 	"golang.org/x/oauth2"
 )
@@ -23,7 +23,7 @@ func newLinodeClient(pat string) linodego.Client {
 
 	projectURL := "https://www.packer.io"
 	userAgent := fmt.Sprintf("Packer/%s (+%s) linodego/%s",
-		version.FormattedVersion(), projectURL, linodego.Version)
+		version.LinodePluginVersion.FormattedVersion(), projectURL, linodego.Version)
 
 	client.SetUserAgent(userAgent)
 	return client

--- a/builder/linode/version/version.go
+++ b/builder/linode/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var LinodePluginVersion = version.PluginVersion{
+	Version:           packerVersion.Version,
+	VersionPrerelease: packerVersion.VersionPrerelease,
+}

--- a/builder/linode/version/version.go
+++ b/builder/linode/version/version.go
@@ -5,7 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var LinodePluginVersion = version.PluginVersion{
-	Version:           packerVersion.Version,
-	VersionPrerelease: packerVersion.VersionPrerelease,
+var LinodePluginVersion *version.PluginVersion
+
+func init() {
+	LinodePluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/lxc/config.hcl2spec.go
+++ b/builder/lxc/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -44,6 +45,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/lxc/version/version.go
+++ b/builder/lxc/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var LXCPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	LXCPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/lxd/config.hcl2spec.go
+++ b/builder/lxd/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -40,6 +41,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/lxd/version/version.go
+++ b/builder/lxd/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var LXDPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	LXDPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/ncloud/config.hcl2spec.go
+++ b/builder/ncloud/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                   *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                 *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                 *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                       *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                       *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                     *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -93,6 +94,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":                     &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":                   &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":                   &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                          &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                          &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                       &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/ncloud/version/version.go
+++ b/builder/ncloud/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var NCloudPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	NCloudPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/null/config.hcl2spec.go
+++ b/builder/null/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -81,6 +82,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/null/version/version.go
+++ b/builder/null/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var NullPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	NullPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/oneandone/config.hcl2spec.go
+++ b/builder/oneandone/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -89,6 +90,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/oneandone/version/version.go
+++ b/builder/oneandone/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var OneAndOnePluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	OneAndOnePluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/openstack/builder.hcl2spec.go
+++ b/builder/openstack/builder.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName             *string                 `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType           *string                 `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion           *string                 `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                 *bool                   `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                 *bool                   `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError               *string                 `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -141,6 +142,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":             &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":           &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":           &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                  &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                  &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/openstack/version/version.go
+++ b/builder/openstack/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var OpenstackPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	OpenstackPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/oracle/classic/builder.hcl2spec.go
+++ b/builder/oracle/classic/builder.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string                  `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string                  `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string                  `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool                    `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool                    `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string                  `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -102,6 +103,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/oracle/oci/config.hcl2spec.go
+++ b/builder/oracle/oci/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string                           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string                           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string                           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool                             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool                             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string                           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -109,6 +110,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/oracle/version/version.go
+++ b/builder/oracle/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var OraclePluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	OraclePluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/osc/bsu/builder.hcl2spec.go
+++ b/builder/osc/bsu/builder.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName             *string                                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType           *string                                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion           *string                                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                 *bool                                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                 *bool                                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError               *string                                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -137,6 +138,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":                    &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":                  &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":                  &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                         &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                         &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                      &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/osc/bsusurrogate/builder.hcl2spec.go
+++ b/builder/osc/bsusurrogate/builder.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName             *string                                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType           *string                                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion           *string                                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                 *bool                                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                 *bool                                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError               *string                                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -138,6 +139,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":                    &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":                  &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":                  &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                         &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                         &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                      &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/osc/bsuvolume/builder.hcl2spec.go
+++ b/builder/osc/bsuvolume/builder.hcl2spec.go
@@ -51,6 +51,7 @@ func (*FlatBlockDevice) HCL2Spec() map[string]hcldec.Spec {
 type FlatConfig struct {
 	PackerBuildName             *string                                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType           *string                                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion           *string                                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                 *bool                                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                 *bool                                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError               *string                                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -161,6 +162,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":                    &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":                  &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":                  &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                         &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                         &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                      &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/osc/chroot/builder.hcl2spec.go
+++ b/builder/osc/chroot/builder.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName         *string                      `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType       *string                      `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion       *string                      `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug             *bool                        `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce             *bool                        `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError           *string                      `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -76,6 +77,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/osc/version/version.go
+++ b/builder/osc/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var OutscalePluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	OutscalePluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/parallels/iso/builder.hcl2spec.go
+++ b/builder/parallels/iso/builder.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -117,6 +118,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/parallels/pvm/config.hcl2spec.go
+++ b/builder/parallels/pvm/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -100,6 +101,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/parallels/version/version.go
+++ b/builder/parallels/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var ParallelsPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	ParallelsPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/profitbricks/config.hcl2spec.go
+++ b/builder/profitbricks/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -93,6 +94,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/profitbricks/version/version.go
+++ b/builder/profitbricks/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var ProfitbricksPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	ProfitbricksPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string                     `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string                     `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string                     `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool                       `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool                       `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string                     `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -119,6 +120,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string             `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string             `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string             `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool               `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool               `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string             `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -116,6 +117,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string                     `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string                     `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string                     `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool                       `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool                       `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string                     `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -125,6 +126,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/proxmox/version/version.go
+++ b/builder/proxmox/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var ProxmoxPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	ProxmoxPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -143,6 +144,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/qemu/version/version.go
+++ b/builder/qemu/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var QemuPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	QemuPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/hashicorp/packer/builder/scaleway/version"
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/common/uuid"
 	"github.com/hashicorp/packer/helper/communicator"
@@ -114,7 +115,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	var warnings []string
 
-	c.UserAgent = useragent.String()
+	c.UserAgent = useragent.String(version.ScalewayPluginVersion.FormattedVersion())
 
 	// Deprecated variables
 	if c.Organization == "" {

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -97,6 +98,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/scaleway/version/version.go
+++ b/builder/scaleway/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ScalewayPluginVersion = version.PluginVersion{
+	Version:           packerVersion.Version,
+	VersionPrerelease: packerVersion.VersionPrerelease,
+}

--- a/builder/scaleway/version/version.go
+++ b/builder/scaleway/version/version.go
@@ -5,7 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ScalewayPluginVersion = version.PluginVersion{
-	Version:           packerVersion.Version,
-	VersionPrerelease: packerVersion.VersionPrerelease,
+var ScalewayPluginVersion *version.PluginVersion
+
+func init() {
+	ScalewayPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/tencentcloud/cvm/builder.hcl2spec.go
+++ b/builder/tencentcloud/cvm/builder.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string                     `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string                     `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string                     `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool                       `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool                       `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string                     `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -120,6 +121,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/tencentcloud/version/version.go
+++ b/builder/tencentcloud/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var TencentPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	TencentPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/triton/config.hcl2spec.go
+++ b/builder/triton/config.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string                      `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string                      `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string                      `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool                        `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool                        `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string                      `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -105,6 +106,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":               &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":             &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":             &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                    &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                    &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                 &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/triton/version/version.go
+++ b/builder/triton/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var TritonPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	TritonPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/ucloud/common/access_config.go
+++ b/builder/ucloud/common/access_config.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/hashicorp/packer/builder/ucloud/version"
 	"github.com/hashicorp/packer/template/interpolate"
-	"github.com/hashicorp/packer/version"
 	"github.com/ucloud/ucloud-sdk-go/external"
 	"github.com/ucloud/ucloud-sdk-go/private/protocol/http"
 	"github.com/ucloud/ucloud-sdk-go/services/uaccount"
@@ -68,7 +68,7 @@ func (c *AccessConfig) Client() (*UCloudClient, error) {
 		cfg.BaseUrl = c.BaseUrl
 	}
 	cfg.LogLevel = log.PanicLevel
-	cfg.UserAgent = fmt.Sprintf("Packer-UCloud/%s", version.FormattedVersion())
+	cfg.UserAgent = fmt.Sprintf("Packer-UCloud/%s", version.UcloudPluginVersion.FormattedVersion())
 	// set default max retry count
 	cfg.MaxRetries = 3
 

--- a/builder/ucloud/uhost/builder.hcl2spec.go
+++ b/builder/ucloud/uhost/builder.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string                       `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string                       `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string                       `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool                         `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool                         `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string                       `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -107,6 +108,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/ucloud/version/version.go
+++ b/builder/ucloud/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var UcloudPluginVersion = version.PluginVersion{
+	Version:           packerVersion.Version,
+	VersionPrerelease: packerVersion.VersionPrerelease,
+}

--- a/builder/ucloud/version/version.go
+++ b/builder/ucloud/version/version.go
@@ -5,7 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var UcloudPluginVersion = version.PluginVersion{
-	Version:           packerVersion.Version,
-	VersionPrerelease: packerVersion.VersionPrerelease,
+var UcloudPluginVersion *version.PluginVersion
+
+func init() {
+	UcloudPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/vagrant/builder.hcl2spec.go
+++ b/builder/vagrant/builder.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -119,6 +120,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/vagrant/version/version.go
+++ b/builder/vagrant/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var VagrantPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	VagrantPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/virtualbox/iso/builder.hcl2spec.go
+++ b/builder/virtualbox/iso/builder.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -142,6 +143,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/virtualbox/ovf/config.hcl2spec.go
+++ b/builder/virtualbox/ovf/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -129,6 +130,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/virtualbox/version/version.go
+++ b/builder/virtualbox/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var VirtualboxPluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	VirtualboxPluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/virtualbox/vm/config.hcl2spec.go
+++ b/builder/virtualbox/vm/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -127,6 +128,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/vmware/iso/config.hcl2spec.go
+++ b/builder/vmware/iso/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -158,6 +159,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":              &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":            &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":            &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                   &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                   &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/vmware/version/version.go
+++ b/builder/vmware/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var VMwarePluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	VMwarePluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/vmware/vmx/config.hcl2spec.go
+++ b/builder/vmware/vmx/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -139,6 +140,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":              &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":            &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":            &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                   &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                   &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                 *string                                     `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType               *string                                     `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion               *string                                     `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                     *bool                                       `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                     *bool                                       `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                   *string                                     `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -148,6 +149,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":              &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":            &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":            &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                   &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                   &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                 *string                                     `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType               *string                                     `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion               *string                                     `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                     *bool                                       `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                     *bool                                       `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                   *string                                     `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -152,6 +153,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":              &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":            &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":            &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                   &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                   &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/vsphere/version/version.go
+++ b/builder/vsphere/version/version.go
@@ -5,9 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var ExoscaleImportPluginVersion *version.PluginVersion
+var VSpherePluginVersion *version.PluginVersion
 
 func init() {
-	ExoscaleImportPluginVersion = version.InitializePluginVersion(
+	VSpherePluginVersion = version.InitializePluginVersion(
 		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/builder/yandex/config.hcl2spec.go
+++ b/builder/yandex/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -117,6 +118,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/builder/yandex/driver_yc.go
+++ b/builder/yandex/driver_yc.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/hashicorp/packer/builder/yandex/version"
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/compute/v1"
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/endpoint"
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
@@ -83,7 +84,7 @@ func NewDriverYC(ui packer.Ui, ac *AccessConfig) (Driver, error) {
 	// Now we will have new request id for every retry attempt.
 	interceptorChain := grpc_middleware.ChainUnaryClient(retryInterceptor, requestIDInterceptor)
 
-	userAgentMD := metadata.Pairs("user-agent", useragent.String())
+	userAgentMD := metadata.Pairs("user-agent", useragent.String(version.YandexPluginVersion.FormattedVersion()))
 
 	sdk, err := ycsdk.Build(context.Background(), sdkConfig,
 		grpc.WithDefaultCallOptions(grpc.Header(&userAgentMD)),

--- a/builder/yandex/version/version.go
+++ b/builder/yandex/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var YandexPluginVersion = version.PluginVersion{
+	Version:           packerVersion.Version,
+	VersionPrerelease: packerVersion.VersionPrerelease,
+}

--- a/builder/yandex/version/version.go
+++ b/builder/yandex/version/version.go
@@ -5,7 +5,9 @@ import (
 	packerVersion "github.com/hashicorp/packer/version"
 )
 
-var YandexPluginVersion = version.PluginVersion{
-	Version:           packerVersion.Version,
-	VersionPrerelease: packerVersion.VersionPrerelease,
+var YandexPluginVersion *version.PluginVersion
+
+func init() {
+	YandexPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
 }

--- a/command/build.go
+++ b/command/build.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/packer/hcl2template"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template"
+	"github.com/hashicorp/packer/version"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/hako/durafmt"
@@ -62,10 +63,12 @@ func (c *BuildCommand) ParseArgs(args []string) (*BuildArgs, int) {
 
 func (m *Meta) GetConfigFromHCL(cla *MetaArgs) (*hcl2template.PackerConfig, int) {
 	parser := &hcl2template.Parser{
-		Parser:                hclparse.NewParser(),
-		BuilderSchemas:        m.CoreConfig.Components.BuilderStore,
-		ProvisionersSchemas:   m.CoreConfig.Components.ProvisionerStore,
-		PostProcessorsSchemas: m.CoreConfig.Components.PostProcessorStore,
+		CorePackerVersion:       version.SemVer,
+		CorePackerVersionString: version.FormattedVersion(),
+		Parser:                  hclparse.NewParser(),
+		BuilderSchemas:          m.CoreConfig.Components.BuilderStore,
+		ProvisionersSchemas:     m.CoreConfig.Components.ProvisionerStore,
+		PostProcessorsSchemas:   m.CoreConfig.Components.PostProcessorStore,
 	}
 	cfg, diags := parser.Parse(cla.Path, cla.VarFiles, cla.Vars)
 	return cfg, writeDiags(m.Ui, parser.Files(), diags)

--- a/common/packer_config.go
+++ b/common/packer_config.go
@@ -6,6 +6,7 @@ package common
 type PackerConfig struct {
 	PackerBuildName     string            `mapstructure:"packer_build_name"`
 	PackerBuilderType   string            `mapstructure:"packer_builder_type"`
+	PackerCoreVersion   bool              `mapstructure:"packer_core_version"`
 	PackerDebug         bool              `mapstructure:"packer_debug"`
 	PackerForce         bool              `mapstructure:"packer_force"`
 	PackerOnError       string            `mapstructure:"packer_on_error"`

--- a/common/packer_config.go
+++ b/common/packer_config.go
@@ -6,7 +6,7 @@ package common
 type PackerConfig struct {
 	PackerBuildName     string            `mapstructure:"packer_build_name"`
 	PackerBuilderType   string            `mapstructure:"packer_builder_type"`
-	PackerCoreVersion   bool              `mapstructure:"packer_core_version"`
+	PackerCoreVersion   string            `mapstructure:"packer_core_version"`
 	PackerDebug         bool              `mapstructure:"packer_debug"`
 	PackerForce         bool              `mapstructure:"packer_force"`
 	PackerOnError       string            `mapstructure:"packer_on_error"`

--- a/common/shell-local/config.hcl2spec.go
+++ b/common/shell-local/config.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -44,6 +45,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/packer/packer"
-	"github.com/hashicorp/packer/version"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -21,6 +20,10 @@ type PackerConfig struct {
 	}
 	// Directory where the config files are defined
 	Basedir string
+
+	// Core Packer version, for reference by plugins and template functions.
+	CorePackerVersionString string
+
 	// directory Packer was called from
 	Cwd string
 
@@ -84,7 +87,7 @@ func (cfg *PackerConfig) EvalContext(variables map[string]cty.Value) *hcl.EvalCo
 			}),
 			buildAccessor: cty.UnknownVal(cty.EmptyObject),
 			packerAccessor: cty.ObjectVal(map[string]cty.Value{
-				"version": cty.StringVal(version.FormattedVersion()),
+				"version": cty.StringVal(cfg.CorePackerVersionString),
 			}),
 			pathVariablesAccessor: cty.ObjectVal(map[string]cty.Value{
 				"cwd":  cty.StringVal(strings.ReplaceAll(cfg.Cwd, `\`, `/`)),

--- a/hcl2template/version_required.go
+++ b/hcl2template/version_required.go
@@ -3,8 +3,8 @@ package hcl2template
 import (
 	"fmt"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
-	pkrversion "github.com/hashicorp/packer/version"
 )
 
 // CheckCoreVersionRequirements visits each of the block in the given
@@ -14,7 +14,7 @@ import (
 // The returned diagnostics will contain errors if any constraints do not match.
 // The returned diagnostics might also return warnings, which should be
 // displayed to the user.
-func (cfg *PackerConfig) CheckCoreVersionRequirements() hcl.Diagnostics {
+func (cfg *PackerConfig) CheckCoreVersionRequirements(coreVersion *version.Version) hcl.Diagnostics {
 	if cfg == nil {
 		return nil
 	}
@@ -22,13 +22,13 @@ func (cfg *PackerConfig) CheckCoreVersionRequirements() hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
 	for _, constraint := range cfg.Packer.VersionConstraints {
-		if !constraint.Required.Check(pkrversion.SemVer) {
+		if !constraint.Required.Check(coreVersion) {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Unsupported Packer Core version",
 				Detail: fmt.Sprintf(
 					"This configuration does not support Packer version %s. To proceed, either choose another supported Packer version or update this version constraint. Version constraints are normally set for good reason, so updating the constraint may lead to other errors or unexpected behavior.",
-					pkrversion.String(),
+					coreVersion.String(),
 				),
 				Subject: constraint.DeclRange.Ptr(),
 			})

--- a/helper/config/decode.go
+++ b/helper/config/decode.go
@@ -113,6 +113,7 @@ func Decode(target interface{}, config *DecodeOpts, raws ...interface{}) error {
 		} else {
 			config.InterpolateContext.BuildName = ctx.BuildName
 			config.InterpolateContext.BuildType = ctx.BuildType
+			config.InterpolateContext.CorePackerVersionString = ctx.CorePackerVersionString
 			config.InterpolateContext.TemplatePath = ctx.TemplatePath
 			config.InterpolateContext.UserVariables = ctx.UserVariables
 			if config.InterpolateContext.Data == nil {
@@ -259,11 +260,12 @@ func DetectContextData(raws ...interface{}) (map[interface{}]interface{}, []inte
 // detecting things like user variables from the raw configuration params.
 func DetectContext(raws ...interface{}) (*interpolate.Context, error) {
 	var s struct {
-		BuildName     string            `mapstructure:"packer_build_name"`
-		BuildType     string            `mapstructure:"packer_builder_type"`
-		TemplatePath  string            `mapstructure:"packer_template_path"`
-		Vars          map[string]string `mapstructure:"packer_user_variables"`
-		SensitiveVars []string          `mapstructure:"packer_sensitive_variables"`
+		BuildName               string            `mapstructure:"packer_build_name"`
+		BuildType               string            `mapstructure:"packer_builder_type"`
+		CorePackerVersionString string            `mapstructure:"packer_core_version"`
+		TemplatePath            string            `mapstructure:"packer_template_path"`
+		Vars                    map[string]string `mapstructure:"packer_user_variables"`
+		SensitiveVars           []string          `mapstructure:"packer_sensitive_variables"`
 	}
 
 	for _, r := range raws {
@@ -274,11 +276,12 @@ func DetectContext(raws ...interface{}) (*interpolate.Context, error) {
 	}
 
 	return &interpolate.Context{
-		BuildName:          s.BuildName,
-		BuildType:          s.BuildType,
-		TemplatePath:       s.TemplatePath,
-		UserVariables:      s.Vars,
-		SensitiveVariables: s.SensitiveVars,
+		BuildName:               s.BuildName,
+		BuildType:               s.BuildType,
+		CorePackerVersionString: s.CorePackerVersionString,
+		TemplatePath:            s.TemplatePath,
+		UserVariables:           s.Vars,
+		SensitiveVariables:      s.SensitiveVars,
 	}, nil
 }
 

--- a/helper/useragent/useragent.go
+++ b/helper/useragent/useragent.go
@@ -3,8 +3,6 @@ package useragent
 import (
 	"fmt"
 	"runtime"
-
-	"github.com/hashicorp/packer/version"
 )
 
 var (
@@ -19,17 +17,10 @@ var (
 
 	// goarch is the architecture - variable for tests.
 	goarch = runtime.GOARCH
-
-	// versionFunc is the func that returns the current version. This is a
-	// function to take into account the different build processes and distinguish
-	// between enterprise and oss builds.
-	versionFunc = func() string {
-		return version.FormattedVersion()
-	}
 )
 
 // String returns the consistent user-agent string for Packer.
-func String() string {
+func String(packerVersion string) string {
 	return fmt.Sprintf("Packer/%s (+%s; %s; %s/%s)",
-		versionFunc(), projectURL, rt, goos, goarch)
+		packerVersion, projectURL, rt, goos, goarch)
 }

--- a/helper/useragent/useragent_test.go
+++ b/helper/useragent/useragent_test.go
@@ -9,9 +9,8 @@ func TestUserAgent(t *testing.T) {
 	rt = "go5.0"
 	goos = "linux"
 	goarch = "amd64"
-	versionFunc = func() string { return "1.2.3" }
 
-	act := String()
+	act := String("1.2.3")
 
 	exp := "Packer/1.2.3 (+https://packer-test.com; go5.0; linux/amd64)"
 	if exp != act {

--- a/helper/version/version.go
+++ b/helper/version/version.go
@@ -1,0 +1,52 @@
+// Version helps plugin creators set and track the plugin version using the same
+// convenience functions used by the Packer core.
+package version
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+)
+
+// The git commit that was compiled. This will be filled in by the compiler.
+var GitCommit string
+
+type PluginVersion struct {
+	// The main version number that is being run at the moment.
+	Version string
+	// A pre-release marker for the version. If this is "" (empty string)
+	// then it means that it is a final release. Otherwise, this is a pre-release
+	// such as "dev" (in development), "beta", "rc1", etc.
+	VersionPrerelease string
+}
+
+func (p *PluginVersion) FormattedVersion() string {
+	var versionString bytes.Buffer
+	fmt.Fprintf(&versionString, "%s", p.Version)
+	if p.VersionPrerelease != "" {
+		fmt.Fprintf(&versionString, "-%s", p.VersionPrerelease)
+
+		if GitCommit != "" {
+			fmt.Fprintf(&versionString, " (%s)", GitCommit)
+		}
+	}
+
+	return versionString.String()
+}
+
+func (p *PluginVersion) Semver() *version.Version {
+	// SemVer is an instance of version.Version. This has the secondary
+	// benefit of verifying during tests and init time that our version is a
+	// proper semantic version, which should always be the case.
+	SemVer := version.Must(version.NewVersion(p.Version))
+	return SemVer
+}
+
+// String returns the complete version string, including prerelease
+func (p *PluginVersion) String() string {
+	if p.VersionPrerelease != "" {
+		return fmt.Sprintf("%s-%s", p.Version, p.VersionPrerelease)
+	}
+	return p.Version
+}

--- a/helper/version/version.go
+++ b/helper/version/version.go
@@ -12,20 +12,39 @@ import (
 // The git commit that was compiled. This will be filled in by the compiler.
 var GitCommit string
 
+// InitializePluginVersion initializes the SemVer and returns a version var.
+// If the provided "version" string is not valid, the call to version.Must
+// will panic. Therefore, this function should always be called in a package
+// init() function to make sure that plugins are following proper semantic
+// versioning and to make sure that plugins which aren't following proper
+// semantic versioning crash immediately rather than later.
+func InitializePluginVersion(vers, versionPrerelease string) *PluginVersion {
+	pv := PluginVersion{
+		version:           vers,
+		versionPrerelease: versionPrerelease,
+	}
+	// This call initializes the SemVer to make sure that if Packer crashes due
+	// to an invalid SemVer it's at the very beginning of the Packer run.
+	pv.semVer = version.Must(version.NewVersion(vers))
+	return &pv
+}
+
 type PluginVersion struct {
 	// The main version number that is being run at the moment.
-	Version string
+	version string
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease string
+	versionPrerelease string
+	// The Semantic Version of the plugin. Used for version constraint comparisons
+	semVer *version.Version
 }
 
 func (p *PluginVersion) FormattedVersion() string {
 	var versionString bytes.Buffer
-	fmt.Fprintf(&versionString, "%s", p.Version)
-	if p.VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, "-%s", p.VersionPrerelease)
+	fmt.Fprintf(&versionString, "%s", p.version)
+	if p.versionPrerelease != "" {
+		fmt.Fprintf(&versionString, "-%s", p.versionPrerelease)
 
 		if GitCommit != "" {
 			fmt.Fprintf(&versionString, " (%s)", GitCommit)
@@ -35,18 +54,28 @@ func (p *PluginVersion) FormattedVersion() string {
 	return versionString.String()
 }
 
-func (p *PluginVersion) Semver() *version.Version {
-	// SemVer is an instance of version.Version. This has the secondary
-	// benefit of verifying during tests and init time that our version is a
-	// proper semantic version, which should always be the case.
-	SemVer := version.Must(version.NewVersion(p.Version))
-	return SemVer
+func (p *PluginVersion) SemVer() *version.Version {
+	if p.semVer != nil {
+		// SemVer is an instance of version.Version. This has the secondary
+		// benefit of verifying during tests and init time that our version is a
+		// proper semantic version, which should always be the case.
+		p.semVer = version.Must(version.NewVersion(p.version))
+	}
+	return p.semVer
+}
+
+func (p *PluginVersion) GetVersion() string {
+	return p.version
+}
+
+func (p *PluginVersion) GetVersionPrerelease() string {
+	return p.versionPrerelease
 }
 
 // String returns the complete version string, including prerelease
 func (p *PluginVersion) String() string {
-	if p.VersionPrerelease != "" {
-		return fmt.Sprintf("%s-%s", p.Version, p.VersionPrerelease)
+	if p.versionPrerelease != "" {
+		return fmt.Sprintf("%s-%s", p.version, p.versionPrerelease)
 	}
-	return p.Version
+	return p.version
 }

--- a/packer/build.go
+++ b/packer/build.go
@@ -166,7 +166,7 @@ func (b *CoreBuild) Prepare() (warn []string, err error) {
 	packerConfig := map[string]interface{}{
 		BuildNameConfigKey:     b.Type,
 		BuilderTypeConfigKey:   b.BuilderType,
-		CoreVersionConfigKey:   version.Version,
+		CoreVersionConfigKey:   version.FormattedVersion(),
 		DebugConfigKey:         b.debug,
 		ForceConfigKey:         b.force,
 		OnErrorConfigKey:       b.onError,

--- a/packer/build.go
+++ b/packer/build.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/packer/common/packerbuilderdata"
+	"github.com/hashicorp/packer/version"
 )
 
 const (
@@ -18,6 +19,11 @@ const (
 	// of the builder that is run. This is useful for provisioners and
 	// such who want to make use of this.
 	BuilderTypeConfigKey = "packer_builder_type"
+
+	// this is the key in the configuration that is set to the version of the
+	// Packer Core. This can be used by plugins to set user agents, etc, without
+	// having to import the Core to find out the Packer version.
+	CoreVersionConfigKey = "packer_core_version"
 
 	// This is the key in configurations that is set to "true" when Packer
 	// debugging is enabled.
@@ -160,6 +166,7 @@ func (b *CoreBuild) Prepare() (warn []string, err error) {
 	packerConfig := map[string]interface{}{
 		BuildNameConfigKey:     b.Type,
 		BuilderTypeConfigKey:   b.BuilderType,
+		CoreVersionConfigKey:   version.Version,
 		DebugConfigKey:         b.debug,
 		ForceConfigKey:         b.force,
 		OnErrorConfigKey:       b.onError,

--- a/packer/build_test.go
+++ b/packer/build_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer/common/packerbuilderdata"
+	"github.com/hashicorp/packer/version"
 )
 
 func boolPointer(tf bool) *bool {
@@ -41,6 +42,7 @@ func testDefaultPackerConfig() map[string]interface{} {
 	return map[string]interface{}{
 		BuildNameConfigKey:     "test",
 		BuilderTypeConfigKey:   "foo",
+		CoreVersionConfigKey:   version.FormattedVersion(),
 		DebugConfigKey:         false,
 		ForceConfigKey:         false,
 		OnErrorConfigKey:       "cleanup",

--- a/post-processor/alicloud-import/post-processor.hcl2spec.go
+++ b/post-processor/alicloud-import/post-processor.hcl2spec.go
@@ -13,6 +13,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName                   *string                      `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType                 *string                      `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion                 *string                      `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                       *bool                        `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                       *bool                        `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                     *string                      `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -137,6 +138,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":            &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":          &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":          &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                 &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                 &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":              &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/alicloud-import/version/version.go
+++ b/post-processor/alicloud-import/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var AlicloudImportPluginVersion *version.PluginVersion
+
+func init() {
+	AlicloudImportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/amazon-import/post-processor.hcl2spec.go
+++ b/post-processor/amazon-import/post-processor.hcl2spec.go
@@ -12,6 +12,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName       *string                           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType     *string                           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion     *string                           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug           *bool                             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce           *bool                             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError         *string                           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -65,6 +66,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":             &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":           &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":           &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                  &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                  &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/amazon-import/version/version.go
+++ b/post-processor/amazon-import/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var AmazonImportPluginVersion *version.PluginVersion
+
+func init() {
+	AmazonImportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/artifice/post-processor.hcl2spec.go
+++ b/post-processor/artifice/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -34,6 +35,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/artifice/version/version.go
+++ b/post-processor/artifice/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ArtificePluginVersion *version.PluginVersion
+
+func init() {
+	ArtificePluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/checksum/post-processor.hcl2spec.go
+++ b/post-processor/checksum/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -34,6 +35,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/checksum/version/version.go
+++ b/post-processor/checksum/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ChecksumPluginVersion *version.PluginVersion
+
+func init() {
+	ChecksumPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/compress/post-processor.hcl2spec.go
+++ b/post-processor/compress/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -37,6 +38,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/compress/version/version.go
+++ b/post-processor/compress/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var CompressPluginVersion *version.PluginVersion
+
+func init() {
+	CompressPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/digitalocean-import/post-processor.hcl2spec.go
+++ b/post-processor/digitalocean-import/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -45,6 +46,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/digitalocean-import/version/version.go
+++ b/post-processor/digitalocean-import/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var DigitalOceanImportPluginVersion *version.PluginVersion
+
+func init() {
+	DigitalOceanImportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/docker-import/post-processor.hcl2spec.go
+++ b/post-processor/docker-import/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -35,6 +36,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/docker-import/version/version.go
+++ b/post-processor/docker-import/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var DockerImportPluginVersion *version.PluginVersion
+
+func init() {
+	DockerImportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/docker-push/post-processor.hcl2spec.go
+++ b/post-processor/docker-push/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -41,6 +42,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/docker-push/version/version.go
+++ b/post-processor/docker-push/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var DockerPushPluginVersion *version.PluginVersion
+
+func init() {
+	DockerPushPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/docker-save/post-processor.hcl2spec.go
+++ b/post-processor/docker-save/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -33,6 +34,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/docker-save/version/version.go
+++ b/post-processor/docker-save/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var DockerSavePluginVersion *version.PluginVersion
+
+func init() {
+	DockerSavePluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/docker-tag/post-processor.hcl2spec.go
+++ b/post-processor/docker-tag/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -36,6 +37,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/docker-tag/version/version.go
+++ b/post-processor/docker-tag/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var DockerTagPluginVersion *version.PluginVersion
+
+func init() {
+	DockerTagPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/exoscale-import/post-processor.go
+++ b/post-processor/exoscale-import/post-processor.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/post-processor/artifice"
-	"github.com/hashicorp/packer/version"
+	"github.com/hashicorp/packer/post-processor/exoscale-import/version"
 )
 
 var (
@@ -51,7 +51,7 @@ type Config struct {
 }
 
 func init() {
-	egoscale.UserAgent = "Packer-Exoscale/" + version.FormattedVersion() + " " + egoscale.UserAgent
+	egoscale.UserAgent = "Packer-Exoscale/" + version.ExoscaleImportPluginVersion.FormattedVersion() + " " + egoscale.UserAgent
 }
 
 type PostProcessor struct {

--- a/post-processor/exoscale-import/post-processor.hcl2spec.go
+++ b/post-processor/exoscale-import/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName         *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType       *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion       *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug             *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce             *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError           *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -44,6 +45,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/exoscale-import/version/version.go
+++ b/post-processor/exoscale-import/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ExoscaleImportPluginVersion = version.PluginVersion{
+	Version:           packerVersion.Version,
+	VersionPrerelease: packerVersion.VersionPrerelease,
+}

--- a/post-processor/googlecompute-export/post-processor.hcl2spec.go
+++ b/post-processor/googlecompute-export/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -43,6 +44,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":           &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":         &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":         &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":             &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/googlecompute-export/version/version.go
+++ b/post-processor/googlecompute-export/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var GCPExportPluginVersion *version.PluginVersion
+
+func init() {
+	GCPExportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/googlecompute-import/post-processor.hcl2spec.go
+++ b/post-processor/googlecompute-import/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -45,6 +46,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":           &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":         &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":         &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":             &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/googlecompute-import/version/version.go
+++ b/post-processor/googlecompute-import/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var GCPImportPluginVersion *version.PluginVersion
+
+func init() {
+	GCPImportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/manifest/post-processor.hcl2spec.go
+++ b/post-processor/manifest/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -36,6 +37,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/manifest/version/version.go
+++ b/post-processor/manifest/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ManifestPluginVersion *version.PluginVersion
+
+func init() {
+	ManifestPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/shell-local/version/version.go
+++ b/post-processor/shell-local/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ShellLocalPluginVersion *version.PluginVersion
+
+func init() {
+	ShellLocalPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/ucloud-import/post-processor.hcl2spec.go
+++ b/post-processor/ucloud-import/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName       *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType     *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion     *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug           *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce           *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError         *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -48,6 +49,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/ucloud-import/version/version.go
+++ b/post-processor/ucloud-import/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var UCloudImportPluginVersion *version.PluginVersion
+
+func init() {
+	UCloudImportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/vagrant-cloud/post-processor.hcl2spec.go
+++ b/post-processor/vagrant-cloud/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName       *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType     *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion     *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug           *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce           *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError         *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -41,6 +42,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/vagrant-cloud/version/version.go
+++ b/post-processor/vagrant-cloud/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var VagrantCloudPluginVersion *version.PluginVersion
+
+func init() {
+	VagrantCloudPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/vagrant/post-processor.hcl2spec.go
+++ b/post-processor/vagrant/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName              *string                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType            *string                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion            *string                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                  *bool                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                  *bool                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError                *string                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -39,6 +40,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":              &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":            &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":            &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                   &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                   &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/vagrant/version/version.go
+++ b/post-processor/vagrant/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var VagrantPostprocessorVersion *version.PluginVersion
+
+func init() {
+	VagrantPostprocessorVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/vsphere-template/post-processor.hcl2spec.go
+++ b/post-processor/vsphere-template/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -42,6 +43,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/vsphere-template/version/version.go
+++ b/post-processor/vsphere-template/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var VSphereTemplatePostprocessorVersion *version.PluginVersion
+
+func init() {
+	VSphereTemplatePostprocessorVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/vsphere/post-processor.hcl2spec.go
+++ b/post-processor/vsphere/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -47,6 +48,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/vsphere/version/version.go
+++ b/post-processor/vsphere/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var VSpherePostprocessorVersion *version.PluginVersion
+
+func init() {
+	VSpherePostprocessorVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/yandex-export/post-processor.hcl2spec.go
+++ b/post-processor/yandex-export/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName       *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType     *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion     *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug           *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce           *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError         *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -44,6 +45,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/yandex-export/version/version.go
+++ b/post-processor/yandex-export/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var YandexExportPluginVersion *version.PluginVersion
+
+func init() {
+	YandexExportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/post-processor/yandex-import/post-processor.hcl2spec.go
+++ b/post-processor/yandex-import/post-processor.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName       *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType     *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion     *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug           *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce           *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError         *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -45,6 +46,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/post-processor/yandex-import/version/version.go
+++ b/post-processor/yandex-import/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var YandexImportPluginVersion *version.PluginVersion
+
+func init() {
+	YandexImportPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/ansible-local/provisioner.hcl2spec.go
+++ b/provisioner/ansible-local/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -47,6 +48,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/ansible-local/version/version.go
+++ b/provisioner/ansible-local/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var AnsibleLocalPluginVersion *version.PluginVersion
+
+func init() {
+	AnsibleLocalPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/ansible/provisioner.hcl2spec.go
+++ b/provisioner/ansible/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName       *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType     *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion     *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug           *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce           *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError         *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -57,6 +58,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/ansible/version/version.go
+++ b/provisioner/ansible/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var AnsiblePluginVersion *version.PluginVersion
+
+func init() {
+	AnsiblePluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/azure-dtlartifact/provisioner.hcl2spec.go
+++ b/provisioner/azure-dtlartifact/provisioner.hcl2spec.go
@@ -38,6 +38,7 @@ func (*FlatArtifactParameter) HCL2Spec() map[string]hcldec.Spec {
 type FlatConfig struct {
 	PackerBuildName        *string                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType      *string                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion      *string                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug            *bool                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce            *bool                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError          *string                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -75,6 +76,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/azure-dtlartifact/version/version.go
+++ b/provisioner/azure-dtlartifact/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var AzureDTLPluginVersion *version.PluginVersion
+
+func init() {
+	AzureDTLPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/breakpoint/provisioner.hcl2spec.go
+++ b/provisioner/breakpoint/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -34,6 +35,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/breakpoint/version/version.go
+++ b/provisioner/breakpoint/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var BreakpointPluginVersion *version.PluginVersion
+
+func init() {
+	BreakpointPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/chef-client/provisioner.hcl2spec.go
+++ b/provisioner/chef-client/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName            *string                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType          *string                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion          *string                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                *bool                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                *bool                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError              *string                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -60,6 +61,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":              &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":            &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":            &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                   &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                   &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/chef-client/version/version.go
+++ b/provisioner/chef-client/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ChefClientPluginVersion *version.PluginVersion
+
+func init() {
+	ChefClientPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/chef-solo/provisioner.hcl2spec.go
+++ b/provisioner/chef-solo/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName            *string                `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType          *string                `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion          *string                `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug                *bool                  `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce                *bool                  `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError              *string                `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -50,6 +51,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":              &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":            &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":            &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":                   &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":                   &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":                &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/chef-solo/version/version.go
+++ b/provisioner/chef-solo/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ChefSoloPluginVersion *version.PluginVersion
+
+func init() {
+	ChefSoloPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/converge/provisioner.hcl2spec.go
+++ b/provisioner/converge/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName      *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType    *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion    *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug          *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce          *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError        *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -42,6 +43,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/converge/version/version.go
+++ b/provisioner/converge/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ConvergePluginVersion *version.PluginVersion
+
+func init() {
+	ConvergePluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/file/provisioner.hcl2spec.go
+++ b/provisioner/file/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -37,6 +38,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/file/version/version.go
+++ b/provisioner/file/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var FileProvisionerVersion *version.PluginVersion
+
+func init() {
+	FileProvisionerVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/inspec/provisioner.hcl2spec.go
+++ b/provisioner/inspec/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName      *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType    *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion    *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug          *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce          *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError        *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -44,6 +45,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/inspec/version/version.go
+++ b/provisioner/inspec/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var InspecPluginVersion *version.PluginVersion
+
+func init() {
+	InspecPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/powershell/provisioner.hcl2spec.go
+++ b/provisioner/powershell/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName        *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType      *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion      *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug            *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce            *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError          *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -50,6 +51,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/powershell/version/version.go
+++ b/provisioner/powershell/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var PowershellPluginVersion *version.PluginVersion
+
+func init() {
+	PowershellPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/puppet-masterless/provisioner.hcl2spec.go
+++ b/provisioner/puppet-masterless/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -48,6 +49,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/puppet-masterless/version/version.go
+++ b/provisioner/puppet-masterless/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var PuppetMasterlessPluginVersion *version.PluginVersion
+
+func init() {
+	PuppetMasterlessPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/puppet-server/provisioner.hcl2spec.go
+++ b/provisioner/puppet-server/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName      *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType    *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion    *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug          *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce          *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError        *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -48,6 +49,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/puppet-server/version/version.go
+++ b/provisioner/puppet-server/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var PuppetServerPluginVersion *version.PluginVersion
+
+func init() {
+	PuppetServerPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/salt-masterless/provisioner.hcl2spec.go
+++ b/provisioner/salt-masterless/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -49,6 +50,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/salt-masterless/version/version.go
+++ b/provisioner/salt-masterless/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var SaltPluginVersion *version.PluginVersion
+
+func init() {
+	SaltPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/shell-local/version/version.go
+++ b/provisioner/shell-local/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ShellLocalProvisionerVersion *version.PluginVersion
+
+func init() {
+	ShellLocalProvisionerVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/shell/provisioner.hcl2spec.go
+++ b/provisioner/shell/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -49,6 +50,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/shell/version/version.go
+++ b/provisioner/shell/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var ShellPluginVersion *version.PluginVersion
+
+func init() {
+	ShellPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/sleep/version/version.go
+++ b/provisioner/sleep/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var SleepProvisionerVersion *version.PluginVersion
+
+func init() {
+	SleepProvisionerVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/windows-restart/provisioner.hcl2spec.go
+++ b/provisioner/windows-restart/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -37,6 +38,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/windows-restart/version/version.go
+++ b/provisioner/windows-restart/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var WindowsRestartPluginVersion *version.PluginVersion
+
+func init() {
+	WindowsRestartPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/provisioner/windows-shell/provisioner.hcl2spec.go
+++ b/provisioner/windows-shell/provisioner.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 type FlatConfig struct {
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
 	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
 	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
@@ -42,6 +43,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},
+		"packer_core_version":        &hcldec.AttrSpec{Name: "packer_core_version", Type: cty.String, Required: false},
 		"packer_debug":               &hcldec.AttrSpec{Name: "packer_debug", Type: cty.Bool, Required: false},
 		"packer_force":               &hcldec.AttrSpec{Name: "packer_force", Type: cty.Bool, Required: false},
 		"packer_on_error":            &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},

--- a/provisioner/windows-shell/version/version.go
+++ b/provisioner/windows-shell/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"github.com/hashicorp/packer/helper/version"
+	packerVersion "github.com/hashicorp/packer/version"
+)
+
+var WindowsShellPluginVersion *version.PluginVersion
+
+func init() {
+	WindowsShellPluginVersion = version.InitializePluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease)
+}

--- a/template/interpolate/funcs.go
+++ b/template/interpolate/funcs.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/packer/common/packerbuilderdata"
 	commontpl "github.com/hashicorp/packer/common/template"
 	"github.com/hashicorp/packer/common/uuid"
-	"github.com/hashicorp/packer/version"
 	strftime "github.com/jehiah/go-strftime"
 )
 
@@ -242,8 +241,12 @@ func funcGenUuid(ctx *Context) interface{} {
 }
 
 func funcGenPackerVersion(ctx *Context) interface{} {
-	return func() string {
-		return version.FormattedVersion()
+	return func() (string, error) {
+		if ctx == nil || ctx.CorePackerVersionString == "" {
+			return "", errors.New("packer_version not available")
+		}
+
+		return ctx.CorePackerVersionString, nil
 	}
 }
 

--- a/template/interpolate/funcs_test.go
+++ b/template/interpolate/funcs_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/packer/common/packerbuilderdata"
-	"github.com/hashicorp/packer/version"
 )
 
 func TestFuncBuildName(t *testing.T) {
@@ -413,7 +412,9 @@ func TestFuncPackerBuild(t *testing.T) {
 func TestFuncPackerVersion(t *testing.T) {
 	template := `{{packer_version}}`
 
-	ctx := &Context{}
+	ctx := &Context{
+		CorePackerVersionString: "1.4.3-dev [DEADC0DE]",
+	}
 	i := &I{Value: template}
 
 	result, err := i.Render(ctx)
@@ -422,9 +423,9 @@ func TestFuncPackerVersion(t *testing.T) {
 	}
 
 	// Only match the X.Y.Z portion of the whole version string.
-	if !strings.HasPrefix(result, version.Version) {
+	if !strings.HasPrefix(result, "1.4.3-dev [DEADC0DE]") {
 		t.Fatalf("Expected input to include: %s\n\nGot: %s",
-			version.Version, result)
+			"1.4.3-dev [DEADC0DE]", result)
 	}
 }
 

--- a/template/interpolate/i.go
+++ b/template/interpolate/i.go
@@ -35,9 +35,10 @@ type Context struct {
 	//
 	// TemplatePath is the path to the template that this is being
 	// rendered within.
-	BuildName    string
-	BuildType    string
-	TemplatePath string
+	BuildName               string
+	BuildType               string
+	CorePackerVersionString string
+	TemplatePath            string
 }
 
 // NewContext returns an initialized empty context.

--- a/version/version.go
+++ b/version/version.go
@@ -16,10 +16,7 @@ const Version = "1.6.6"
 // such as "dev" (in development), "beta", "rc1", etc.
 const VersionPrerelease = "dev"
 
-var PackerVersion = pluginVersion.PluginVersion{
-	Version:           Version,
-	VersionPrerelease: VersionPrerelease,
-}
+var PackerVersion *pluginVersion.PluginVersion
 
 func FormattedVersion() string {
 	return PackerVersion.FormattedVersion()
@@ -31,7 +28,8 @@ func FormattedVersion() string {
 var SemVer *version.Version
 
 func init() {
-	SemVer = version.Must(version.NewVersion(Version))
+	PackerVersion = pluginVersion.InitializePluginVersion(Version, VersionPrerelease)
+	SemVer = PackerVersion.SemVer()
 }
 
 // String returns the complete version string, including prerelease

--- a/version/version.go
+++ b/version/version.go
@@ -1,10 +1,8 @@
 package version
 
 import (
-	"bytes"
-	"fmt"
-
 	"github.com/hashicorp/go-version"
+	pluginVersion "github.com/hashicorp/packer/helper/version"
 )
 
 // The git commit that was compiled. This will be filled in by the compiler.
@@ -18,18 +16,13 @@ const Version = "1.6.6"
 // such as "dev" (in development), "beta", "rc1", etc.
 const VersionPrerelease = "dev"
 
+var PackerVersion = pluginVersion.PluginVersion{
+	Version:           Version,
+	VersionPrerelease: VersionPrerelease,
+}
+
 func FormattedVersion() string {
-	var versionString bytes.Buffer
-	fmt.Fprintf(&versionString, "%s", Version)
-	if VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, "-%s", VersionPrerelease)
-
-		if GitCommit != "" {
-			fmt.Fprintf(&versionString, " (%s)", GitCommit)
-		}
-	}
-
-	return versionString.String()
+	return PackerVersion.FormattedVersion()
 }
 
 // SemVer is an instance of version.Version. This has the secondary
@@ -43,8 +36,5 @@ func init() {
 
 // String returns the complete version string, including prerelease
 func String() string {
-	if VersionPrerelease != "" {
-		return fmt.Sprintf("%s-%s", Version, VersionPrerelease)
-	}
-	return Version
+	return PackerVersion.String()
 }


### PR DESCRIPTION
This PR is another step towards extracting the Packer plugin SDK. This refactors the code so that builders and future sdk code don't need access to packer/version, preventing that unneeded import. 

This PR does the following: 
- Creates a helper/version package that will live in the SDK. It defines a "PluginVersion" struct that has the ability to generate the SemVer and FormattedVersion that was originally handled in the packer/version package. This will allow the standalone plugins to easily and consistently define their versions.
- Modifies the packer/version package to make use of the new helper/version code.
- Adds $PLUGIN/version packages to all of the plugins. Those plugins that imported packer/version still do for now, but once the builders are split out into standalone plugins we will remove that import and replace the version in each plugin with string constants that match whatever core version is released at the time of the split. From there forward, version will be decoupled between the core and individual plugins. 
- Adds a "PackerCoreVersion" field to the PackerConfig struct. This allows the core to pass its version to the plugins at decode time, allowing them to properly interpolate the "{{ packer_version }}" properly without importing the core. 
- Adds a "PackerCoreVersionFormattedString" field to the hcl packer_config so that the hcl `packer.version` can be accessed properly.
- Adds a  "PackerCoreVersion" field to the hcl packer_config so that version checks against the Core semver can continue properly

So far I have only implemented "Version" directories for plugins that import packer/version -- adding these directories to the remaining plugins will be a task for later down the road when we split them out of the core. 