### PR TITLE
adding support for root volume encryption for amazon-chroot

### DIFF
--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -10,11 +10,14 @@ package chroot
 import (
 	"context"
 	"errors"
+	"fmt"
+	"regexp"
 	"runtime"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
+	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/chroot"
 	"github.com/hashicorp/packer/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep"
@@ -169,6 +172,26 @@ type Config struct {
 	// [`dynamic_block`](/docs/configuration/from-1.5/expressions#dynamic-blocks)
 	// will allow you to create those programatically.
 	RootVolumeTag config.KeyValues `mapstructure:"root_volume_tag" required:"false"`
+	// Whether or not to encrypt the volumes that are *launched*. By default, Packer will keep
+	// the encryption setting to what it was in the source image when set to `false`. Setting true will
+	// always result in an encrypted one.
+	RootVolumeEncryptBoot config.Trilean `mapstructure:"root_volume_encrypt_boot" required:"false"`
+	// ID, alias or ARN of the KMS key to use for *launched* volumes encryption.
+	//
+	// Set this value if you select `root_volume_encrypt_boot`, but don't want to use the
+	// region's default KMS key.
+	//
+	// If you have a custom kms key you'd like to apply to the launch volume,
+	// and are only building in one region, it is more efficient to set this
+	// and `root_volume_encrypt_boot` to `true` and not use `encrypt_boot` and `kms_key_id`. This saves
+	// potentially many minutes at the end of the build by preventing Packer
+	// from having to copy and re-encrypt the image at the end of the build.
+	//
+	// For valid formats see *KmsKeyId* in the [AWS API docs -
+	// CopyImage](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html).
+	// This field is validated by Packer, when using an alias, you will have to
+	// prefix `kms_key_id` with `alias/`.
+	RootVolumeKmsKeyId string `mapstructure:"root_volume_kms_key_id" required:"false"`
 	// what architecture to use when registering the final AMI; valid options
 	// are "x86_64" or "arm64". Defaults to "x86_64".
 	Architecture string `mapstructure:"ami_architecture" required:"false"`
@@ -322,6 +345,17 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			errs = packersdk.MultiErrorAppend(
 				errs, errors.New("If root_device_name is specified, ami_block_device_mappings must be specified"))
 		}
+
+		if b.config.RootVolumeKmsKeyId != "" {
+			if b.config.RootVolumeEncryptBoot.False() {
+				errs = packer.MultiErrorAppend(
+					errs, errors.New("If you have set root_kms_key_id, root_encrypt_boot must also be true."))
+			} else if b.config.RootVolumeEncryptBoot.True() && !validateKmsKey(b.config.RootVolumeKmsKeyId) {
+				errs = packer.MultiErrorAppend(
+					errs, fmt.Errorf("%q is not a valid KMS Key Id.", b.config.RootVolumeKmsKeyId))
+			}
+		}
+
 	}
 	valid := false
 	for _, validArch := range []string{"x86_64", "arm64"} {
@@ -402,11 +436,13 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			GeneratedData: generatedData,
 		},
 		&StepCreateVolume{
-			PollingConfig:  b.config.PollingConfig,
-			RootVolumeType: b.config.RootVolumeType,
-			RootVolumeSize: b.config.RootVolumeSize,
-			RootVolumeTags: b.config.RootVolumeTags,
-			Ctx:            b.config.ctx,
+			PollingConfig:         b.config.PollingConfig,
+			RootVolumeType:        b.config.RootVolumeType,
+			RootVolumeSize:        b.config.RootVolumeSize,
+			RootVolumeTags:        b.config.RootVolumeTags,
+			RootVolumeEncryptBoot: b.config.RootVolumeEncryptBoot,
+			RootVolumeKmsKeyId:    b.config.RootVolumeKmsKeyId,
+			Ctx:                   b.config.ctx,
 		},
 		&StepAttachVolume{
 			PollingConfig: b.config.PollingConfig,
@@ -500,4 +536,23 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	}
 
 	return artifact, nil
+}
+
+func validateKmsKey(kmsKey string) (valid bool) {
+	kmsKeyIdPattern := `[a-f0-9-]+$`
+	aliasPattern := `alias/[a-zA-Z0-9:/_-]+$`
+	kmsArnStartPattern := `^arn:aws(-us-gov)?:kms:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12}):`
+	if regexp.MustCompile(fmt.Sprintf("^%s", kmsKeyIdPattern)).MatchString(kmsKey) {
+		return true
+	}
+	if regexp.MustCompile(fmt.Sprintf("^%s", aliasPattern)).MatchString(kmsKey) {
+		return true
+	}
+	if regexp.MustCompile(fmt.Sprintf("%skey/%s", kmsArnStartPattern, kmsKeyIdPattern)).MatchString(kmsKey) {
+		return true
+	}
+	if regexp.MustCompile(fmt.Sprintf("%s%s", kmsArnStartPattern, aliasPattern)).MatchString(kmsKey) {
+		return true
+	}
+	return false
 }

--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -349,7 +349,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		if b.config.RootVolumeKmsKeyId != "" {
 			if b.config.RootVolumeEncryptBoot.False() {
 				errs = packer.MultiErrorAppend(
-					errs, errors.New("If you have set root_kms_key_id, root_encrypt_boot must also be true."))
+					errs, errors.New("If you have set root_volume_kms_key_id, root_volume_encrypt_boot must also be true."))
 			} else if b.config.RootVolumeEncryptBoot.True() && !validateKmsKey(b.config.RootVolumeKmsKeyId) {
 				errs = packer.MultiErrorAppend(
 					errs, fmt.Errorf("%q is not a valid KMS Key Id.", b.config.RootVolumeKmsKeyId))

--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
-	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/chroot"
 	"github.com/hashicorp/packer/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep"
@@ -347,10 +346,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 		if b.config.RootVolumeKmsKeyId != "" {
 			if b.config.RootVolumeEncryptBoot.False() {
-				errs = packer.MultiErrorAppend(
+				errs = packersdk.MultiErrorAppend(
 					errs, errors.New("If you have set root_volume_kms_key_id, root_volume_encrypt_boot must also be true."))
 			} else if b.config.RootVolumeEncryptBoot.True() && !awscommon.ValidateKmsKey(b.config.RootVolumeKmsKeyId) {
-				errs = packer.MultiErrorAppend(
+				errs = packersdk.MultiErrorAppend(
 					errs, fmt.Errorf("%q is not a valid KMS Key Id.", b.config.RootVolumeKmsKeyId))
 			}
 		}

--- a/builder/amazon/chroot/builder.go
+++ b/builder/amazon/chroot/builder.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"runtime"
 
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/builder/amazon/chroot/builder.hcl2spec.go
+++ b/builder/amazon/chroot/builder.hcl2spec.go
@@ -157,13 +157,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"source_ami":                    &hcldec.AttrSpec{Name: "source_ami", Type: cty.String, Required: false},
 		"source_ami_filter":             &hcldec.BlockSpec{TypeName: "source_ami_filter", Nested: hcldec.ObjectSpec((*common.FlatAmiFilterOptions)(nil).HCL2Spec())},
 		"root_volume_tags":              &hcldec.AttrSpec{Name: "root_volume_tags", Type: cty.Map(cty.String), Required: false},
-<<<<<<< HEAD
 		"root_volume_tag":               &hcldec.BlockListSpec{TypeName: "root_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
-=======
-		"root_volume_tag":               &hcldec.BlockListSpec{TypeName: "root_volume_tag", Nested: hcldec.ObjectSpec((*hcl2template.FlatKeyValue)(nil).HCL2Spec())},
 		"root_volume_encrypt_boot":      &hcldec.AttrSpec{Name: "root_volume_encrypt_boot", Type: cty.Bool, Required: false},
 		"root_volume_kms_key_id":        &hcldec.AttrSpec{Name: "root_volume_kms_key_id", Type: cty.String, Required: false},
->>>>>>> d2717fdcb (adding support for root volume encryption for amazon-chroot)
 		"ami_architecture":              &hcldec.AttrSpec{Name: "ami_architecture", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/amazon/chroot/builder.hcl2spec.go
+++ b/builder/amazon/chroot/builder.hcl2spec.go
@@ -76,6 +76,8 @@ type FlatConfig struct {
 	SourceAmiFilter         *common.FlatAmiFilterOptions      `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter" hcl:"source_ami_filter"`
 	RootVolumeTags          map[string]string                 `mapstructure:"root_volume_tags" required:"false" cty:"root_volume_tags" hcl:"root_volume_tags"`
 	RootVolumeTag           []config.FlatKeyValue             `mapstructure:"root_volume_tag" required:"false" cty:"root_volume_tag" hcl:"root_volume_tag"`
+	RootVolumeEncryptBoot   *bool                             `mapstructure:"root_volume_encrypt_boot" required:"false" cty:"root_volume_encrypt_boot" hcl:"root_volume_encrypt_boot"`
+	RootVolumeKmsKeyId      *string                           `mapstructure:"root_volume_kms_key_id" required:"false" cty:"root_volume_kms_key_id" hcl:"root_volume_kms_key_id"`
 	Architecture            *string                           `mapstructure:"ami_architecture" required:"false" cty:"ami_architecture" hcl:"ami_architecture"`
 }
 
@@ -155,7 +157,13 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"source_ami":                    &hcldec.AttrSpec{Name: "source_ami", Type: cty.String, Required: false},
 		"source_ami_filter":             &hcldec.BlockSpec{TypeName: "source_ami_filter", Nested: hcldec.ObjectSpec((*common.FlatAmiFilterOptions)(nil).HCL2Spec())},
 		"root_volume_tags":              &hcldec.AttrSpec{Name: "root_volume_tags", Type: cty.Map(cty.String), Required: false},
+<<<<<<< HEAD
 		"root_volume_tag":               &hcldec.BlockListSpec{TypeName: "root_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
+=======
+		"root_volume_tag":               &hcldec.BlockListSpec{TypeName: "root_volume_tag", Nested: hcldec.ObjectSpec((*hcl2template.FlatKeyValue)(nil).HCL2Spec())},
+		"root_volume_encrypt_boot":      &hcldec.AttrSpec{Name: "root_volume_encrypt_boot", Type: cty.Bool, Required: false},
+		"root_volume_kms_key_id":        &hcldec.AttrSpec{Name: "root_volume_kms_key_id", Type: cty.String, Required: false},
+>>>>>>> d2717fdcb (adding support for root volume encryption for amazon-chroot)
 		"ami_architecture":              &hcldec.AttrSpec{Name: "ami_architecture", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/amazon/chroot/step_create_volume.go
+++ b/builder/amazon/chroot/step_create_volume.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer/packer-plugin-sdk/template/interpolate"
 	"github.com/hashicorp/packer/template/interpolate"
 )

--- a/builder/amazon/chroot/step_create_volume.go
+++ b/builder/amazon/chroot/step_create_volume.go
@@ -9,13 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awscommon "github.com/hashicorp/packer/builder/amazon/common"
-	"github.com/hashicorp/packer/helper/config"
-	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer/packer-plugin-sdk/template/interpolate"
-	"github.com/hashicorp/packer/template/interpolate"
 )
 
 // StepCreateVolume creates a new volume from the snapshot of the root

--- a/builder/amazon/chroot/step_create_volume_test.go
+++ b/builder/amazon/chroot/step_create_volume_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	confighelper "github.com/hashicorp/packer/helper/config"
+	confighelper "github.com/hashicorp/packer/packer-plugin-sdk/template/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -215,7 +215,7 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 
 	}
 	for _, kmsKey := range kmsKeys {
-		if !validateKmsKey(kmsKey) {
+		if !ValidateKmsKey(kmsKey) {
 			errs = append(errs, fmt.Errorf("%q is not a valid KMS Key Id.", kmsKey))
 		}
 	}
@@ -289,7 +289,7 @@ func (c *AMIConfig) prepareRegions(accessConfig *AccessConfig) (errs []error) {
 }
 
 // See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html
-func validateKmsKey(kmsKey string) (valid bool) {
+func ValidateKmsKey(kmsKey string) (valid bool) {
 	kmsKeyIdPattern := `[a-f0-9-]+$`
 	aliasPattern := `alias/[a-zA-Z0-9:/_-]+$`
 	kmsArnStartPattern := `^arn:aws(-us-gov)?:kms:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12}):`

--- a/website/content/partials/builder/amazon/chroot/Config-not-required.mdx
+++ b/website/content/partials/builder/amazon/chroot/Config-not-required.mdx
@@ -130,5 +130,25 @@
   [`dynamic_block`](/docs/configuration/from-1.5/expressions#dynamic-blocks)
   will allow you to create those programatically.
 
+- `root_volume_encrypt_boot` (boolean) - Whether or not to encrypt the volumes that are *launched*. By default, Packer will keep
+  the encryption setting to what it was in the source image when set to `false`. Setting true will
+  always result in an encrypted one.
+
+- `root_volume_kms_key_id` (string) - ID, alias or ARN of the KMS key to use for *launched* volumes encryption.
+  
+  Set this value if you select `root_volume_encrypt_boot`, but don't want to use the
+  region's default KMS key.
+  
+  If you have a custom kms key you'd like to apply to the launch volume,
+  and are only building in one region, it is more efficient to set this
+  and `root_volume_encrypt_boot` to `true` and not use `encrypt_boot` and `kms_key_id`. This saves
+  potentially many minutes at the end of the build by preventing Packer
+  from having to copy and re-encrypt the image at the end of the build.
+  
+  For valid formats see *KmsKeyId* in the [AWS API docs -
+  CopyImage](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html).
+  This field is validated by Packer, when using an alias, you will have to
+  prefix `kms_key_id` with `alias/`.
+
 - `ami_architecture` (string) - what architecture to use when registering the final AMI; valid options
   are "x86_64" or "arm64". Defaults to "x86_64".


### PR DESCRIPTION
Issue:
The builder amazon-chroot only allows to encrypt the resulting AMI via the `encrypt_boot` and `kms_key_id`, which copies the intermediary AMI which may or may not be already encrypted, and performs a copy AMI call to perform the encryption. Unfortunately AWS has a hard limit of concurrent Snapshot copies (1) and we've seen our Packer builds take about 1 hour+ build times when usually would take 5-7mins when performing multiple concurrent packer amazon-chroot builds since they wait on their invisible queue.

Solution:
Add parameters `root_volume_encrypt_boot` and `root_volume_kms_key_id` to the amazon-chroot builder to allow the users to launch volumes with encryption and skip the copy command at the end. AWS added this feature about a year and half ago (2) and is supported by the Go AWS SDK version that Packer is using currently (3). This is a similar flow to the `launch_block_devices_mapping` that the builder amazon-ebs uses to launch encrypted volumes.

Sources:

1. https://aws.amazon.com/about-aws/whats-new/2020/04/amazon-ebs-increases-concurrent-snapshot-copy-limits-to-20-snapshots-per-destination-region/
2. https://aws.amazon.com/about-aws/whats-new/2019/05/launch-encrypted-ebs-backed-ec2-instances-from-unencrypted-amis-in-a-single-step/
3. https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#CreateVolumeInput

Custom Packer build output:
```
==> amazon-chroot: Pausing after run of step 'StepFlock'. Press enter to continue.
2020/11/10 00:08:54 packer-builder-amazon-chroot plugin: Device: /dev/sdf
==> amazon-chroot: Pausing after run of step 'StepPrepareDevice'. Press enter to continue.
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin: Searching for root device of the image (/dev/xvda)
==> amazon-chroot: Creating the root volume...
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin: Setting Enabled KMS key to launched Volume
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin: Setting custom KMS Key ID to launched Volume
    amazon-chroot: Adding tag: "AmiName": "testing-amazon-chroot-0.0.1-b79"
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin: Create args: {
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:   AvailabilityZone: "us-west-2b",
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:   Encrypted: true,
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:   KmsKeyId: "xxxxxxxxxxxxxxxxxxx",
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:   Size: 8,
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:   SnapshotId: "snap-xxxxxxxxxxxxxxxxxxx",
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:   TagSpecifications: [{
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:       ResourceType: "volume",
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:       Tags: [
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:         {
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:           Key: "AmiName",
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:           Value: "testing-amazon-chroot-0.0.1-b79"
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:         }
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:       ]
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:     }],
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin:   VolumeType: "gp2"
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin: }
2020/11/10 00:08:55 packer-builder-amazon-chroot plugin: Volume ID: vol-xxxxxxxxxxxxxxxxxxx
==> amazon-chroot: Pausing after run of step 'StepCreateVolume'. Press enter to continue.
==> amazon-chroot: Attaching the root volume to /dev/sdf
==> amazon-chroot: Pausing after run of step 'StepAttachVolume'. Press enter to continue.
2020/11/10 00:09:46 packer-builder-amazon-chroot plugin: Unlocking file lock...
2020/11/10 00:09:46 packer-builder-amazon-chroot plugin: Unlocking: /var/lock/packer-chroot/lock
==> amazon-chroot: Pausing after run of step 'StepEarlyUnflock'. Press enter to continue.
....
....
==> amazon-chroot: Unmounting the root device...
==> amazon-chroot: Detaching EBS volume...
==> amazon-chroot: Creating snapshot...
    amazon-chroot: Snapshot ID: snap-xxxxxxxxxxxxxxxxxxx
==> amazon-chroot: Deregistered AMI testing-amazon-chroot-0.0.1-b79, id: ami-xxxxxxxxxxxxxxxxxxx
==> amazon-chroot: Registering the AMI...
==> amazon-chroot: AMI: ami-xxxxxxxxxxxxxxxxxxx
==> amazon-chroot: Waiting for AMI to become ready...
==> amazon-chroot: Adding tags to AMI (ami-xxxxxxxxxxxxxxxxxxx)...
==> amazon-chroot: Tagging snapshot: snap-xxxxxxxxxxxxxxxxxxx
==> amazon-chroot: Creating AMI tags
    amazon-chroot: Adding tag: "Name": "testing-amazon-chroot-0.0.1-b79"
    amazon-chroot: Adding tag: "Version": "0.0.1"
==> amazon-chroot: Creating snapshot tags
==> amazon-chroot: Deleting the created EBS volume...
==> amazon-chroot: Running post-processor: manifest
```

PS: First time contributing to an open-source project, so exciting!!