### PR TITLE
builder/google: Ensure builder does not crash when using the `-on-error` build flag

### DIFF
--- a/helper/multistep/if.go
+++ b/helper/multistep/if.go
@@ -3,7 +3,7 @@ package multistep
 // if returns step only if on is true.
 func If(on bool, step Step) Step {
 	if on == false {
-		return nil
+		return &nullStep{}
 	}
 	return step
 }

--- a/helper/multistep/multistep.go
+++ b/helper/multistep/multistep.go
@@ -61,3 +61,11 @@ type Runner interface {
 	// Run runs the steps with the given initial state.
 	Run(context.Context, StateBag)
 }
+
+type nullStep struct{}
+
+func (s nullStep) Run(ctx context.Context, state StateBag) StepAction {
+	return ActionContinue
+}
+
+func (s nullStep) Cleanup(state StateBag) {}


### PR DESCRIPTION
This change introduces a new nullStep type that can be used in place of
a nil step. This fixes an issue where multistep.If would return a nil
step if the condition was not met causing a builder to crash when
executed using `-on-error=ask` or `-on-error=abort`.

Closes #10241

Before change
```
⇶  packertest build -on-error=abort googlecompute-centos-shell.json
googlecompute: output will be in this color.

==> googlecompute: Checking image does not exist...
==> googlecompute: Creating temporary rsa SSH key for instance...
Build 'googlecompute' errored after 1 second 372 milliseconds: unexpected EOF

==> Wait completed after 1 second 372 milliseconds

==> Some builds didn't complete successfully and had errors:
--> googlecompute: unexpected EOF

[...]

==> Builds finished but no artifacts were created.
panic: runtime error: invalid memory address or nil pointer dereference
```

After change
```
⇶  packertest build -on-error=abort googlecompute-centos-shell.json
googlecompute: output will be in this color.

[...]

Build 'googlecompute' finished after 3 minutes 44 seconds.

==> Wait completed after 3 minutes 44 seconds

==> Builds finished. The artifacts of successful builds are:
```