### PR TITLE
builder/qemu: Add ok check for state values

### DIFF
--- a/builder/qemu/step_create_disk.go
+++ b/builder/qemu/step_create_disk.go
@@ -32,12 +32,11 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 		return multistep.ActionContinue
 	}
 
-	var diskFullPaths, diskSizes []string
-
 	ui.Say("Creating required virtual machine disks")
 	// The 'main' or 'default' disk
-	diskFullPaths = append(diskFullPaths, filepath.Join(s.OutputDir, name))
-	diskSizes = append(diskSizes, s.DiskSize)
+	diskFullPaths := []string{filepath.Join(s.OutputDir, name)}
+	diskSizes := []string{s.DiskSize}
+
 	// Additional disks
 	if len(s.AdditionalDiskSize) > 0 {
 		for i, diskSize := range s.AdditionalDiskSize {

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -216,8 +216,10 @@ func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag
 			drivesToAttach = append(drivesToAttach, imgPath)
 		}
 
-		diskFullPaths := state.Get("qemu_disk_paths").([]string)
-		drivesToAttach = append(drivesToAttach, diskFullPaths...)
+		if v, ok := state.GetOk("qemu_disk_paths"); ok {
+			diskFullPaths := v.([]string)
+			drivesToAttach = append(drivesToAttach, diskFullPaths...)
+		}
 
 		for i, drivePath := range drivesToAttach {
 			driveArgumentString := fmt.Sprintf("file=%s,if=%s,cache=%s,discard=%s,format=%s", drivePath, config.DiskInterface, config.DiskCache, config.DiskDiscard, config.Format)
@@ -284,7 +286,9 @@ func (s *stepRun) applyUserOverrides(defaultArgs map[string]interface{}, config 
 
 		commHostPort := 0
 		if config.CommConfig.Comm.Type != "none" {
-			commHostPort = state.Get("commHostPort").(int)
+			if v, ok := state.GetOk("commHostPort"); ok {
+				commHostPort = v.(int)
+			}
 		}
 		httpIp := state.Get("http_ip").(string)
 		httpPort := state.Get("http_port").(int)


### PR DESCRIPTION
This changes fixes two crashes in `step_run` that expects certain
information to be in state from prior steps. This change requires
testing to ensure the bugs have been fixed.

I believe there may be more state values that need to be checked as they
may not be put into state if a build configuration has attributes that
would skip or otherwise not put data into the statebag.


Closes #10232
Closes #10202