### PR TITLE
fix(yandex): change disk creation method to manual

### DIFF
--- a/builder/yandex/config.go
+++ b/builder/yandex/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	DiskSizeGb int `mapstructure:"disk_size_gb" required:"false"`
 	// Specify disk type for the launched instance. Defaults to `network-hdd`.
 	DiskType string `mapstructure:"disk_type" required:"false"`
-	// Key/value pair labels to apply to the temporary disk.
+	// Key/value pair labels to apply to the disk.
 	DiskLabels map[string]string `mapstructure:"disk_labels" required:"false"`
 	// The description of the resulting image.
 	ImageDescription string `mapstructure:"image_description" required:"false"`

--- a/builder/yandex/config.go
+++ b/builder/yandex/config.go
@@ -44,6 +44,8 @@ type Config struct {
 	DiskSizeGb int `mapstructure:"disk_size_gb" required:"false"`
 	// Specify disk type for the launched instance. Defaults to `network-hdd`.
 	DiskType string `mapstructure:"disk_type" required:"false"`
+	// Key/value pair labels to apply to the temporary disk.
+	DiskLabels map[string]string `mapstructure:"disk_labels" required:"false"`
 	// The description of the resulting image.
 	ImageDescription string `mapstructure:"image_description" required:"false"`
 	//  The family name of the resulting image.

--- a/builder/yandex/config.hcl2spec.go
+++ b/builder/yandex/config.hcl2spec.go
@@ -74,6 +74,7 @@ type FlatConfig struct {
 	DiskName                  *string           `mapstructure:"disk_name" required:"false" cty:"disk_name" hcl:"disk_name"`
 	DiskSizeGb                *int              `mapstructure:"disk_size_gb" required:"false" cty:"disk_size_gb" hcl:"disk_size_gb"`
 	DiskType                  *string           `mapstructure:"disk_type" required:"false" cty:"disk_type" hcl:"disk_type"`
+	DiskLabels                map[string]string `mapstructure:"disk_labels" required:"false" cty:"disk_labels" hcl:"disk_labels"`
 	ImageDescription          *string           `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageFamily               *string           `mapstructure:"image_family" required:"false" cty:"image_family" hcl:"image_family"`
 	ImageLabels               map[string]string `mapstructure:"image_labels" required:"false" cty:"image_labels" hcl:"image_labels"`
@@ -180,6 +181,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_name":                    &hcldec.AttrSpec{Name: "disk_name", Type: cty.String, Required: false},
 		"disk_size_gb":                 &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},
 		"disk_type":                    &hcldec.AttrSpec{Name: "disk_type", Type: cty.String, Required: false},
+		"disk_labels":                  &hcldec.AttrSpec{Name: "disk_labels", Type: cty.Map(cty.String), Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_family":                 &hcldec.AttrSpec{Name: "image_family", Type: cty.String, Required: false},
 		"image_labels":                 &hcldec.AttrSpec{Name: "image_labels", Type: cty.Map(cty.String), Required: false},

--- a/builder/yandex/step_create_instance.go
+++ b/builder/yandex/step_create_instance.go
@@ -56,6 +56,40 @@ func createNetwork(ctx context.Context, c *Config, d Driver) (*vpc.Network, erro
 	return network, nil
 }
 
+func createDisk(ctx context.Context, c *Config, d Driver, sourceImage *Image) (*compute.Disk, error) {
+	req := &compute.CreateDiskRequest{
+		Name:     c.DiskName,
+		FolderId: c.FolderID,
+		TypeId:   c.DiskType,
+		ZoneId:   c.Zone,
+		Size:     int64((datasize.ByteSize(c.DiskSizeGb) * datasize.GB).Bytes()),
+		Source: &compute.CreateDiskRequest_ImageId{
+			ImageId: sourceImage.ID,
+		},
+	}
+	sdk := d.SDK()
+
+	op, err := sdk.WrapOperation(sdk.Compute().Disk().Create(ctx, req))
+	if err != nil {
+		return nil, err
+	}
+	err = op.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := op.Response()
+	if err != nil {
+		return nil, err
+	}
+
+	image, ok := resp.(*compute.Disk)
+	if !ok {
+		return nil, errors.New("disk create operation response doesn't contain Disk")
+	}
+	return image, nil
+
+}
+
 func createSubnet(ctx context.Context, c *Config, d Driver, networkID string) (*vpc.Subnet, error) {
 	req := &vpc.CreateSubnetRequest{
 		FolderId:     c.FolderID,
@@ -154,6 +188,14 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		instanceSubnetID = config.SubnetID
 	}
 
+	// Create a disk manually to have a delete ID
+	ui.Say("Creating disk...")
+	disk, err := createDisk(ctx, config, driver, sourceImage)
+	if err != nil {
+		return stepHaltWithError(state, fmt.Errorf("Error creating disk: %s", err))
+	}
+	state.Put("disk_id", disk.Id)
+
 	// Create an instance based on the configuration
 	ui.Say("Creating instance...")
 
@@ -189,15 +231,8 @@ runcmd:
 		Metadata: instanceMetadata,
 		BootDiskSpec: &compute.AttachedDiskSpec{
 			AutoDelete: false,
-			Disk: &compute.AttachedDiskSpec_DiskSpec_{
-				DiskSpec: &compute.AttachedDiskSpec_DiskSpec{
-					Name:   config.DiskName,
-					TypeId: config.DiskType,
-					Size:   int64((datasize.ByteSize(config.DiskSizeGb) * datasize.GB).Bytes()),
-					Source: &compute.AttachedDiskSpec_DiskSpec_ImageId{
-						ImageId: sourceImage.ID,
-					},
-				},
+			Disk: &compute.AttachedDiskSpec_DiskId{
+				DiskId: disk.Id,
 			},
 		},
 		NetworkInterfaceSpecs: []*compute.NetworkInterfaceSpec{
@@ -255,14 +290,13 @@ runcmd:
 		return stepHaltWithError(state, fmt.Errorf("response doesn't contain Instance"))
 	}
 
-	state.Put("disk_id", instance.BootDisk.DiskId)
 	// instance_id is the generic term used so that users can have access to the
 	// instance id inside of the provisioners, used in step_provision.
 	state.Put("instance_id", instance.Id)
 
 	if s.Debug {
 		ui.Message(fmt.Sprintf("Instance ID %s started. Current instance status %s", instance.Id, instance.Status))
-		ui.Message(fmt.Sprintf("Disk ID %s. ", instance.BootDisk.DiskId))
+		ui.Message(fmt.Sprintf("Disk ID %s. ", disk.Id))
 	}
 
 	// provision generated_data from declared in Builder.Prepare func

--- a/builder/yandex/step_create_instance.go
+++ b/builder/yandex/step_create_instance.go
@@ -61,7 +61,7 @@ func createDisk(ctx context.Context, c *Config, d Driver, sourceImage *Image) (*
 		Name:     c.DiskName,
 		FolderId: c.FolderID,
 		TypeId:   c.DiskType,
-		Labels:  c.DiskLabels,
+		Labels:   c.DiskLabels,
 		ZoneId:   c.Zone,
 		Size:     int64((datasize.ByteSize(c.DiskSizeGb) * datasize.GB).Bytes()),
 		Source: &compute.CreateDiskRequest_ImageId{

--- a/builder/yandex/step_create_instance.go
+++ b/builder/yandex/step_create_instance.go
@@ -61,6 +61,7 @@ func createDisk(ctx context.Context, c *Config, d Driver, sourceImage *Image) (*
 		Name:     c.DiskName,
 		FolderId: c.FolderID,
 		TypeId:   c.DiskType,
+		Labels:  c.DiskLabels,
 		ZoneId:   c.Zone,
 		Size:     int64((datasize.ByteSize(c.DiskSizeGb) * datasize.GB).Bytes()),
 		Source: &compute.CreateDiskRequest_ImageId{

--- a/website/pages/partials/builder/yandex/Config-not-required.mdx
+++ b/website/pages/partials/builder/yandex/Config-not-required.mdx
@@ -9,6 +9,8 @@
 
 - `disk_type` (string) - Specify disk type for the launched instance. Defaults to `network-hdd`.
 
+- `disk_labels` (map[string]string) - Key/value pair labels to apply to the temporary disk.
+
 - `image_description` (string) - The description of the resulting image.
 
 - `image_family` (string) - The family name of the resulting image.

--- a/website/pages/partials/builder/yandex/Config-not-required.mdx
+++ b/website/pages/partials/builder/yandex/Config-not-required.mdx
@@ -9,7 +9,7 @@
 
 - `disk_type` (string) - Specify disk type for the launched instance. Defaults to `network-hdd`.
 
-- `disk_labels` (map[string]string) - Key/value pair labels to apply to the temporary disk.
+- `disk_labels` (map[string]string) - Key/value pair labels to apply to the disk.
 
 - `image_description` (string) - The description of the resulting image.
 


### PR DESCRIPTION
### Description

There is a bug in which interrupting the build does not delete the disk after itself, because it is created indirectly. This PR changes the way of creating a disc to manual
