### PR TITLE
[WIP] Proxmox builder pass through boot-order

### DIFF
--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -83,6 +83,7 @@ type FlatConfig struct {
 	Pool                      *string                     `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	VMName                    *string                     `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                        `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
+	Boot                      *string                     `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                        `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	Cores                     *int                        `mapstructure:"cores" cty:"cores" hcl:"cores"`
 	CPUType                   *string                     `mapstructure:"cpu_type" cty:"cpu_type" hcl:"cpu_type"`
@@ -190,6 +191,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
+		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"cores":                        &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
 		"cpu_type":                     &hcldec.AttrSpec{Name: "cpu_type", Type: cty.String, Required: false},

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	VMName string `mapstructure:"vm_name"`
 	VMID   int    `mapstructure:"vm_id"`
 
+	Boot           string       `mapstructure:"boot"`
 	Memory         int          `mapstructure:"memory"`
 	Cores          int          `mapstructure:"cores"`
 	CPUType        string       `mapstructure:"cpu_type"`

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -82,6 +82,7 @@ type FlatConfig struct {
 	Pool                      *string             `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	VMName                    *string             `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
+	Boot                      *string             `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	Cores                     *int                `mapstructure:"cores" cty:"cores" hcl:"cores"`
 	CPUType                   *string             `mapstructure:"cpu_type" cty:"cpu_type" hcl:"cpu_type"`
@@ -187,6 +188,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
+		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"cores":                        &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
 		"cpu_type":                     &hcldec.AttrSpec{Name: "cpu_type", Type: cty.String, Required: false},

--- a/builder/proxmox/common/step_start_vm.go
+++ b/builder/proxmox/common/step_start_vm.go
@@ -43,7 +43,7 @@ func (s *stepStartVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Name:         c.VMName,
 		Agent:        agent,
 		QemuKVM:      kvm,
-		Boot:         "cdn", // Boot priority, c:CDROM -> d:Disk -> n:Network
+		Boot:         c.Boot, // Boot priority, example: "order=virtio0;ide2;net0", virtio0:Disk0 -> ide0:CDROM -> net0:Network
 		QemuCpu:      c.CPUType,
 		Description:  "Packer ephemeral build VM",
 		Memory:       c.Memory,

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -83,6 +83,7 @@ type FlatConfig struct {
 	Pool                      *string                     `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	VMName                    *string                     `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMID                      *int                        `mapstructure:"vm_id" cty:"vm_id" hcl:"vm_id"`
+	Boot                      *string                     `mapstructure:"boot" cty:"boot" hcl:"boot"`
 	Memory                    *int                        `mapstructure:"memory" cty:"memory" hcl:"memory"`
 	Cores                     *int                        `mapstructure:"cores" cty:"cores" hcl:"cores"`
 	CPUType                   *string                     `mapstructure:"cpu_type" cty:"cpu_type" hcl:"cpu_type"`
@@ -196,6 +197,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_id":                        &hcldec.AttrSpec{Name: "vm_id", Type: cty.Number, Required: false},
+		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.Number, Required: false},
 		"cores":                        &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
 		"cpu_type":                     &hcldec.AttrSpec{Name: "cpu_type", Type: cty.String, Required: false},

--- a/website/pages/docs/builders/proxmox/clone.mdx
+++ b/website/pages/docs/builders/proxmox/clone.mdx
@@ -190,6 +190,9 @@ in the image's Cloud-Init settings for provisioning.
 
 - `full_clone` (bool) - Whether to run a full or shallow clone from the base clone_vm. Defaults to `true`.
 
+- `boot` - (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
+ Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
+
 ## Example: Cloud-Init enabled Debian
 
 Here is a basic example creating a Debian 10 server image. This assumes

--- a/website/pages/docs/builders/proxmox/iso.mdx
+++ b/website/pages/docs/builders/proxmox/iso.mdx
@@ -256,6 +256,9 @@ builder.
 - `vm_interface` - (string) - Name of the network interface that Packer gets
   the VMs IP from. Defaults to the first non loopback interface.
 
+- `boot` - (string) - Override default boot order. Format example `order=virtio0;ide2;net0`.
+ Prior to Proxmox 6.2-15 the format was `cdn` (c:CDROM -> d:Disk -> n:Network)
+
 ## Boot Command
 
 The `boot_command` configuration is very important: it specifies the keys to


### PR DESCRIPTION
Adding an optional boot config to replace the hardcoded bootorder "cdn" behavior in the Proxmox Builder.

This addresses the issue found in #10252. The issue is the hardcoded boot value in Proxmox Builder config "cdn" seems to no longer be supported and the new format to set boot orders is "order=[type][index];[type][index]". 

Most importantly, not specifying the boot value at all will cause proxmox to fall back to it's get_default_bootorder mechanism, which luckily results in non breaking change to packer proxmox builder.

Example specifying the boot order in the config:

```
"disks": [{
          "type": "scsi",
          "disk_size": "20G",
          "storage_pool": "vmstorage",
          "storage_pool_type": "lvm"
}],
"boot": "order=scsi0;ide2",
"iso_file": "media:iso/{{ user `ubuntu_iso_file` }}"
```

WIP PR to ask for feedback.


Probably
Closes #10252
