### PR TITLE
Add couple of missing LXD builder parameters to documentation

### DIFF
--- a/website/pages/docs/builders/lxd.mdx
+++ b/website/pages/docs/builders/lxd.mdx
@@ -59,8 +59,13 @@ Below is a fully functioning example.
 - `init_sleep` (string) - The number of seconds to sleep between launching
   the LXD instance and provisioning it; defaults to 3 seconds.
 
-- `name` (string) - The name of the started container. Defaults to
-  `packer-$PACKER_BUILD_NAME`.
+- `name` (string) - Name of the builder. Defaults to `lxd`.
+
+- `container_name` (string) - Name of the build container.
+  Defaults to `packer-$name`.
+
+- `profile` - Name of the LXD profile used for the build container.
+  Defaults to `default`.
 
 - `output_image` (string) - The name of the output artifact. Defaults to
   `name`.


### PR DESCRIPTION
I was trying to use Packer to build a very basic LXD image and at first I thought it was not possible to set the build container profile since it was not mentioned in the docs. I've also added the `container_name` parameter since it was not documented.
