### PR TITLE
Fixes #9973 by saving the web server binding address into the state

### DIFF
--- a/vendor/github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps/step_http_server.go
+++ b/vendor/github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps/step_http_server.go
@@ -54,14 +54,21 @@ func (s *StepHTTPServer) Run(ctx context.Context, state multistep.StateBag) mult
 		return multistep.ActionHalt
 	}
 
-	ui.Say(fmt.Sprintf("Starting HTTP server on port %d", s.l.Port))
+	httpAddr, present = state.GetOK("http_ip")
+	if present {
+		if httpAddr.(string) == "" {
+			httpAddr = s.HTTPAddress
+		}
+        }
+	ui.Say(fmt.Sprintf("Starting HTTP server on address %s and port %d", httpAddr, s.l.Port))
 
 	// Start the HTTP server and run it in the background
 	fileServer := http.FileServer(http.Dir(s.HTTPDir))
 	server := &http.Server{Addr: httpAddr, Handler: fileServer}
 	go server.Serve(s.l)
 
-	// Save the address into the state so it can be accessed in the future
+	// Save the address and the port into the state so they can be accessed in the future
+	state.Put("http_ip", httpAddr)
 	state.Put("http_port", s.l.Port)
 
 	return multistep.ActionContinue


### PR DESCRIPTION
I had troubles with the web server functionality of the vsphere-iso builder (as documented [here](https://www.packer.io/docs/builders/vsphere-iso#http-directory-configuration)). As explained into the issue itself I think I have found the problem. This PR should fix it.

I hope it's easy enough to be auto-explicative. Happy to give more info if needed.

Closes #9973 
