### PR TITLE
allow to discover & start packer-plugin-* muliplugin binaries

### DIFF
--- a/packer-plugin-sdk/plugin/set.go
+++ b/packer-plugin-sdk/plugin/set.go
@@ -73,10 +73,10 @@ func (i *Set) RegisterProvisioner(name string, provisioner packersdk.Provisioner
 //  * "start post-processor example" starts the post-processor "example"
 func (i *Set) Run() error {
 	args := os.Args[1:]
-	return i.run(args...)
+	return i.RunCommand(args...)
 }
 
-func (i *Set) run(args ...string) error {
+func (i *Set) RunCommand(args ...string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("needs at least one argument")
 	}

--- a/packer-plugin-sdk/plugin/set_test.go
+++ b/packer-plugin-sdk/plugin/set_test.go
@@ -47,7 +47,7 @@ func TestSet(t *testing.T) {
 		t.Fatalf("Unexpected description: %s", diff)
 	}
 
-	err := set.run("start", "builder", "example")
+	err := set.RunCommand("start", "builder", "example")
 	if diff := cmp.Diff(err.Error(), ErrManuallyStartedPlugin.Error()); diff != "" {
 		t.Fatalf("Unexpected error: %s", diff)
 	}

--- a/packer/plugin/discover.go
+++ b/packer/plugin/discover.go
@@ -193,8 +193,17 @@ func (c *Config) discoverSingle(glob string) (map[string]string, error) {
 			continue
 		}
 
+		// On Windows, ignore any plugins that don't end in .exe.
+		// We could do a full PATHEXT parse, but this is probably good enough.
+		if runtime.GOOS == "windows" && strings.ToLower(filepath.Ext(file)) != ".exe" {
+			log.Printf(
+				"[DEBUG] Ignoring plugin match %s, no exe extension",
+				match)
+			continue
+		}
+
 		// If the filename has a ".", trim up to there
-		if idx := strings.LastIndex(file, "."); idx >= 0 {
+		if idx := strings.Index(file, ".exe"); idx >= 0 {
 			file = file[:idx]
 		}
 

--- a/packer/plugin/discover.go
+++ b/packer/plugin/discover.go
@@ -193,15 +193,6 @@ func (c *Config) discoverSingle(glob string) (map[string]string, error) {
 			continue
 		}
 
-		// On Windows, ignore any plugins that don't end in .exe.
-		// We could do a full PATHEXT parse, but this is probably good enough.
-		if runtime.GOOS == "windows" && strings.ToLower(filepath.Ext(file)) != ".exe" {
-			log.Printf(
-				"[DEBUG] Ignoring plugin match %s, no exe extension",
-				match)
-			continue
-		}
-
 		// If the filename has a ".", trim up to there
 		if idx := strings.Index(file, ".exe"); idx >= 0 {
 			file = file[:idx]

--- a/packer/plugin/discover.go
+++ b/packer/plugin/discover.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/pathing"
 	pluginsdk "github.com/hashicorp/packer/packer-plugin-sdk/plugin"
@@ -237,7 +236,7 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 
 	for _, builderName := range desc.Builders {
 		builderName := builderName // copy to avoid pointer overwrite issue
-		c.builders[pluginPrefix+builderName] = func() (packer.Builder, error) {
+		c.builders[pluginPrefix+builderName] = func() (packersdk.Builder, error) {
 			return c.Client(pluginPath, "start", "builder", builderName).Builder()
 		}
 	}
@@ -247,7 +246,7 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 
 	for _, postProcessorName := range desc.PostProcessors {
 		postProcessorName := postProcessorName // copy to avoid pointer overwrite issue
-		c.postProcessors[pluginPrefix+postProcessorName] = func() (packer.PostProcessor, error) {
+		c.postProcessors[pluginPrefix+postProcessorName] = func() (packersdk.PostProcessor, error) {
 			return c.Client(pluginPath, "start", "post-processor", postProcessorName).PostProcessor()
 		}
 	}
@@ -257,7 +256,7 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 
 	for _, provisionerName := range desc.Provisioners {
 		provisionerName := provisionerName // copy to avoid pointer overwrite issue
-		c.provisioners[pluginPrefix+provisionerName] = func() (packer.Provisioner, error) {
+		c.provisioners[pluginPrefix+provisionerName] = func() (packersdk.Provisioner, error) {
 			return c.Client(pluginPath, "start", "provisioner", provisionerName).Provisioner()
 		}
 	}

--- a/packer/plugin/discover.go
+++ b/packer/plugin/discover.go
@@ -194,7 +194,7 @@ func (c *Config) discoverSingle(glob string) (map[string]string, error) {
 		}
 
 		// If the filename has a ".", trim up to there
-		if idx := strings.Index(file, ".exe"); idx >= 0 {
+		if idx := strings.LastIndex(file, "."); idx >= 0 {
 			file = file[:idx]
 		}
 

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -187,6 +187,9 @@ func HasExec() bool {
 		if runtime.GOARCH == "arm64" {
 			return false
 		}
+	case "windows":
+		// TODO(azr): Fix this once versioning is added and we know more
+		return false
 	}
 	return true
 }
@@ -256,11 +259,7 @@ func Test_multiplugin_describe(t *testing.T) {
 		for name := range mockPlugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
 			fileContent := ""
-			if runtime.GOOS == "windows" {
-				plugin += ".sh"
-			} else {
-				fileContent = fmt.Sprintf("#!%s\n", shPath)
-			}
+			fileContent = fmt.Sprintf("#!%s\n", shPath)
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),
 				" ")

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -255,7 +255,12 @@ func Test_multiplugin_describe(t *testing.T) {
 		shPath := MustHaveCommand(t, "bash")
 		for name := range mockPlugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
-			fileContent := fmt.Sprintf("#!%s\n", shPath)
+			fileContent := ""
+			if runtime.GOOS == "windows" {
+				plugin += ".sh"
+			} else {
+				fileContent = fmt.Sprintf("#!%s\n", shPath)
+			}
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),
 				" ")

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -2,9 +2,7 @@ package plugin
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -265,14 +263,6 @@ func Test_multiplugin_describe(t *testing.T) {
 				" ")
 			if err := ioutil.WriteFile(plugin, []byte(fileContent), os.ModePerm); err != nil {
 				t.Fatalf("failed to create fake plugin binary: %v", err)
-			}
-			{ // cat
-				fh, err := os.Open(plugin)
-				if err != nil {
-					log.Fatal(err)
-				}
-
-				_, _ = io.Copy(os.Stdout, fh)
 			}
 		}
 	}

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -2,7 +2,9 @@ package plugin
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -247,7 +249,7 @@ func Test_multiplugin_describe(t *testing.T) {
 		}
 		defer os.RemoveAll(pluginDir)
 
-		t.Logf("working in %s", pluginDir)
+		t.Logf("putting temporary mock plugins in %s", pluginDir)
 		defer os.RemoveAll(pluginDir)
 
 		shPath := MustHaveCommand(t, "sh")
@@ -259,6 +261,14 @@ func Test_multiplugin_describe(t *testing.T) {
 				" ")
 			if err := ioutil.WriteFile(plugin, []byte(fileContent), os.ModePerm); err != nil {
 				t.Fatalf("failed to create fake plugin binary: %v", err)
+			}
+			{ // cat
+				fh, err := os.Open(plugin)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				_, _ = io.Copy(os.Stdout, fh)
 			}
 		}
 	}

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -253,6 +253,10 @@ func Test_multiplugin_describe(t *testing.T) {
 		defer os.RemoveAll(pluginDir)
 
 		shPath := MustHaveCommand(t, "sh")
+		if runtime.GOOS == "windows" {
+			// Hopefully sh is in the path then
+			shPath = "sh"
+		}
 		for name := range mockPlugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
 			fileContent := fmt.Sprintf("#!%s\n", shPath)

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -260,7 +260,9 @@ func Test_multiplugin_describe(t *testing.T) {
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),
 				" ")
-			ioutil.WriteFile(plugin, []byte(fileContent), os.ModePerm)
+			if err := ioutil.WriteFile(plugin, []byte(fileContent), os.ModePerm); err != nil {
+				t.Fatalf("failed to create fake plugin binary: %v", err)
+			}
 		}
 	}
 	os.Setenv("PACKER_PLUGIN_PATH", pluginDir)

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -229,9 +229,15 @@ func Test_multiplugin_describe(t *testing.T) {
 
 	pluginDir, err := tmp.Dir("pkr-multiplugin-test-*")
 	{
-		// create fake plugins that are started through SH
-		// they actually start TestHelperPlugins which in turn allow to call
-		// describe upon plugins
+		// create an exectutable file with a `sh` sheebang
+		// this file will look like:
+		// #!/bin/sh
+		// PKR_WANT_TEST_PLUGINS=1 ...plugin/debug.test -test.run=TestHelperPlugins -- bird $@
+		// 'bird' is the mock plugin we want to start
+		// $@ just passes all passed arguments
+		// This will allow to run the fake plugin from go tests which in turn
+		// will run go tests callback to `TestHelperPlugins`, this one will be
+		// transparently calling our mock multiplugins `mockPlugins`.
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -253,6 +253,9 @@ func Test_multiplugin_describe(t *testing.T) {
 		shPath := MustHaveCommand(t, "sh")
 		for name := range mockPlugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
+			if runtime.GOOS == "windows" {
+				plugin += ".exe"
+			}
 			fileContent := fmt.Sprintf("#!%s\n", shPath)
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -168,7 +168,11 @@ func TestHelperPlugins(*testing.T) {
 		os.Exit(2)
 	}
 
-	plugin.RunCommand(args...)
+	err := plugin.RunCommand(args...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 }
 
 // HasExec reports whether the current system can start new processes

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -253,7 +253,7 @@ func Test_multiplugin_describe(t *testing.T) {
 		shPath := MustHaveCommand(t, "sh")
 		for name := range mockPlugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
-			fileContent := fmt.Sprintf("#!%s\n", shPath)
+			fileContent := fmt.Sprintf("#!%q\n", shPath)
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),
 				" ")

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -253,7 +253,7 @@ func Test_multiplugin_describe(t *testing.T) {
 		shPath := MustHaveCommand(t, "sh")
 		for name := range mockPlugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
-			fileContent := fmt.Sprintf("#!%q\n", shPath)
+			fileContent := fmt.Sprintf("#!%s\n", shPath)
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),
 				" ")

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -252,11 +252,7 @@ func Test_multiplugin_describe(t *testing.T) {
 		t.Logf("putting temporary mock plugins in %s", pluginDir)
 		defer os.RemoveAll(pluginDir)
 
-		shPath := MustHaveCommand(t, "sh")
-		if runtime.GOOS == "windows" {
-			// Hopefully sh is in the path then
-			shPath = "sh"
-		}
+		shPath := MustHaveCommand(t, "bash")
 		for name := range mockPlugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
 			fileContent := fmt.Sprintf("#!%s\n", shPath)

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -4,11 +4,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	pluginsdk "github.com/hashicorp/packer/packer-plugin-sdk/plugin"
+	"github.com/hashicorp/packer/packer-plugin-sdk/tmp"
 )
 
 func newConfig() Config {
@@ -133,4 +138,144 @@ func generateFakePlugins(dirname string, pluginNames []string) (string, []string
 	}
 
 	return dir, plugins, cleanUpFunc, nil
+}
+
+// TestHelperProcess isn't a real test. It's used as a helper process
+// for multiplugin-binary tests.
+func TestHelperPlugins(*testing.T) {
+	if os.Getenv("PKR_WANT_TEST_PLUGINS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+
+	pluginName, args := args[0], args[1:]
+	plugin, found := mockPlugins[pluginName]
+	if !found {
+		fmt.Fprintf(os.Stderr, "No %q plugin found\n", pluginName)
+		os.Exit(2)
+	}
+
+	plugin.RunCommand(args...)
+}
+
+// HasExec reports whether the current system can start new processes
+// using os.StartProcess or (more commonly) exec.Command.
+func HasExec() bool {
+	switch runtime.GOOS {
+	case "js":
+		return false
+	case "darwin":
+		if runtime.GOARCH == "arm64" {
+			return false
+		}
+	}
+	return true
+}
+
+// MustHaveExec checks that the current system can start new processes
+// using os.StartProcess or (more commonly) exec.Command.
+// If not, MustHaveExec calls t.Skip with an explanation.
+func MustHaveExec(t testing.TB) {
+	if !HasExec() {
+		t.Skipf("skipping test: cannot exec subprocess on %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+func MustHaveCommand(t testing.TB, cmd string) string {
+	path, err := exec.LookPath(cmd)
+	if err != nil {
+		t.Skipf("skipping test: cannot find the %q command: %v", cmd, err)
+	}
+	return path
+}
+
+func helperCommand(t *testing.T, s ...string) []string {
+	MustHaveExec(t)
+
+	cmd := []string{os.Args[0], "-test.run=TestHelperPlugins", "--"}
+	return append(cmd, s...)
+}
+
+var (
+	mockPlugins = map[string]pluginsdk.Set{
+		"bird": pluginsdk.Set{
+			Builders: map[string]packer.Builder{
+				"feather":   nil,
+				"guacamole": nil,
+			},
+		},
+		"chimney": pluginsdk.Set{
+			PostProcessors: map[string]packer.PostProcessor{
+				"smoke": nil,
+			},
+		},
+	}
+)
+
+func Test_multiplugin_describe(t *testing.T) {
+
+	pluginDir, err := tmp.Dir("pkr-multiplugin-test-*")
+	{
+		// create fake plugins that are started through SH
+		// they actually start TestHelperPlugins which in turn allow to call
+		// describe upon plugins
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(pluginDir)
+
+		t.Logf("working in %s", pluginDir)
+		defer os.RemoveAll(pluginDir)
+
+		shPath := MustHaveCommand(t, "sh")
+		for name := range mockPlugins {
+			plugin := path.Join(pluginDir, "packer-plugin-"+name)
+			fileContent := fmt.Sprintf("#!%s\n", shPath)
+			fileContent += strings.Join(
+				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),
+				" ")
+			ioutil.WriteFile(plugin, []byte(fileContent), os.ModePerm)
+		}
+	}
+	os.Setenv("PACKER_PLUGIN_PATH", pluginDir)
+
+	c := Config{}
+	err = c.Discover()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for mockPluginName, plugin := range mockPlugins {
+		for mockBuilderName := range plugin.Builders {
+			expectedBuilderName := mockPluginName + "-" + mockBuilderName
+			if _, found := c.builders[expectedBuilderName]; !found {
+				t.Fatalf("expected to find builder %q", expectedBuilderName)
+			}
+		}
+		for mockProvisionerName := range plugin.Provisioners {
+			expectedProvisionerName := mockPluginName + "-" + mockProvisionerName
+			if _, found := c.provisioners[expectedProvisionerName]; !found {
+				t.Fatalf("expected to find builder %q", expectedProvisionerName)
+			}
+		}
+		for mockPostProcessorName := range plugin.PostProcessors {
+			expectedPostProcessorName := mockPluginName + "-" + mockPostProcessorName
+			if _, found := c.postProcessors[expectedPostProcessorName]; !found {
+				t.Fatalf("expected to find post-processor %q", expectedPostProcessorName)
+			}
+		}
+	}
 }

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -253,9 +253,6 @@ func Test_multiplugin_describe(t *testing.T) {
 		shPath := MustHaveCommand(t, "sh")
 		for name := range mockPlugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
-			if runtime.GOOS == "windows" {
-				plugin += ".exe"
-			}
 			fileContent := fmt.Sprintf("#!%s\n", shPath)
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),


### PR DESCRIPTION
This is merging into #10272 :

- [x] feature
- [x] tests
- [x] ~docs~ : done in #10272

```shellsession
$ ./packer-plugin-amazon describe | jq .
{
  "version": "1.6.6-dev",
  "sdk_version": "1.6.6-dev",
  "builders": [
    "chroot",
    "ebs",
    "ebssurrogate",
    "ebsvolume"
  ],
  "post_processors": [
    "import"
  ],
  "provisioners": []
}
$ PACKER_LOGS=1 packerdev build my-aws.pkr.hcl
2020/11/18 13:10:26 [INFO] Packer version: 1.6.6-dev [go1.15.4 darwin amd64]
[...]
2020/11/18 13:10:26 [DEBUG] Discovered plugin: amazon = /Users/azr/go/src/github.com/hashicorp/packer/packer-plugin-amazon
2020/11/18 13:10:27 found external [chroot ebs ebssurrogate ebsvolume] builders from amazon
2020/11/18 13:10:27 found external [import] post-processors from amazon
[...]
2020/11/18 13:10:27 Creating plugin client for path: /Users/azr/go/src/github.com/hashicorp/packer/packer-plugin-amazon [start builder ebs]
2020/11/18 13:10:27 Starting plugin: /Users/azr/go/src/github.com/hashicorp/packer/packer-plugin-amazon []string{"/Users/azr/go/src/github.com/hashicorp/packer/packer-plugin-amazon", "start", "builder", "ebs"}
2020/11/18 13:10:27 Waiting for RPC address for: /Users/azr/go/src/github.com/hashicorp/packer/packer-plugin-amazon
2020/11/18 13:10:27 packer-plugin-amazon plugin: 2020/11/18 13:10:27 Plugin address: unix /var/folders/3k/2gb5ct4s7cncr52_jh2kz6cw0000gq/T/packer-plugin838795940
2020/11/18 13:10:27 packer-plugin-amazon plugin: 2020/11/18 13:10:27 Waiting for connection...
2020/11/18 13:10:27 Received unix RPC address for /Users/azr/go/src/github.com/hashicorp/packer/packer-plugin-amazon: addr is /var/folders/3k/2gb5ct4s7cncr52_jh2kz6cw0000gq/T/packer-plugin838795940
2020/11/18 13:10:27 packer-plugin-amazon plugin: 2020/11/18 13:10:27 Serving a plugin connection...
2020/11/18 13:10:27 packer-plugin-amazon plugin: 2020/11/18 13:10:27 [TRACE] starting builder ebs
2020/11/18 13:10:27 packer-plugin-amazon plugin: 2020/11/18 13:10:27 [INFO] (aws): No AWS timeout and polling overrides have been set. Packer will default to waiter-specific delays and timeouts. If you would like to customize the length of time between retries and max number of retries you may do so by setting the environment variables AWS_POLL_DELAY_SECONDS and AWS_MAX_ATTEMPTS or the configuration options aws_polling_delay_seconds and aws_polling_max_attempts to your desired values.
2020/11/18 13:10:27 [TRACE] validateValue: not active for standard_tags, so skipping
2020/11/18 13:10:27 Creating plugin client for path: /var/folders/3k/2gb5ct4s7cncr52_jh2kz6cw0000gq/T/go-build281883838/b001/exe/packer [plugin packer-provisioner-shell]
[...]
2020/11/18 13:10:27 Received unix RPC address for /var/folders/3k/2gb5ct4s7cncr52_jh2kz6cw0000gq/T/go-build281883838/b001/exe/packer: addr is /var/folders/3k/2gb5ct4s7cncr52_jh2kz6cw0000gq/T/packer-plugin336280519
2020/11/18 13:10:27 packer-post-processor-shell-local plugin: Plugin address: unix /var/folders/3k/2gb5ct4s7cncr52_jh2kz6cw0000gq/T/packer-plugin336280519
2020/11/18 13:10:27 packer-post-processor-shell-local plugin: Waiting for connection...
2020/11/18 13:10:27 packer-post-processor-shell-local plugin: Serving a plugin connection...
[...]
amazon-ebs.var_tags: output will be in this color.
[...]
```

For the tests in go we create a bash script that in turn calls back to Go. I could not make the tests to work on windows and then would like to postpone testing this for when we know more about the finite layout of this feature. That is mainly: how things are going to work with versioning and such.