### PR TITLE
Fix generate errors

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -141,11 +141,8 @@ type AccessConfig struct {
 	// The secret key used to communicate with AWS. [Learn how to set
 	// this](/docs/builders/amazon#specifying-amazon-credentials). This is not required
 	// if you are using `use_vault_aws_engine` for authentication instead.
-	SecretKey string `mapstructure:"secret_key" required:"true"`
-	// Set to true if you want to skip
-	// validation of the ami_regions configuration option. Default false.
-	SkipValidation       bool `mapstructure:"skip_region_validation" required:"false"`
-	SkipMetadataApiCheck bool `mapstructure:"skip_metadata_api_check"`
+	SecretKey            string `mapstructure:"secret_key" required:"true"`
+	SkipMetadataApiCheck bool   `mapstructure:"skip_metadata_api_check"`
 	// Set to true if you want to skip validating AWS credentials before runtime.
 	SkipCredsValidation bool `mapstructure:"skip_credential_validation"`
 	// The access token to use. This is different from the

--- a/builder/amazon/common/access_config_test.go
+++ b/builder/amazon/common/access_config_test.go
@@ -37,20 +37,6 @@ func TestAccessConfigPrepare_Region(t *testing.T) {
 	if err == nil {
 		t.Fatalf("should have region validation err: %s", c.RawRegion)
 	}
-
-	c.RawRegion = "custom"
-	c.SkipValidation = true
-	// testing whole prepare func here; this is checking that validation is
-	// skipped, so we don't need a mock connection
-	if err := c.Prepare(nil); err != nil {
-		t.Fatalf("shouldn't have err: %s", err)
-	}
-
-	c.SkipValidation = false
-	c.RawRegion = ""
-	if err := c.Prepare(nil); err != nil {
-		t.Fatalf("shouldn't have err: %s", err)
-	}
 }
 
 func TestAccessConfigPrepare_RegionRestricted(t *testing.T) {

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -382,10 +382,6 @@ type RunConfig struct {
 	// The default is "default", meaning shared tenancy. Allowed values are "default",
 	// "dedicated" and "host".
 	Tenancy string `mapstructure:"tenancy" required:"false"`
-	// The name of the temporary key pair to
-	// generate. By default, Packer generates a name that looks like
-	// `packer_<UUID>`, where &lt;UUID&gt; is a 36 character unique identifier.
-	TemporaryKeyPairName string `mapstructure:"temporary_key_pair_name" required:"false"`
 	// A list of IPv4 CIDR blocks to be authorized access to the instance, when
 	// packer is creating a temporary security group.
 	//

--- a/builder/amazon/ebs/builder.hcl2spec.go
+++ b/builder/amazon/ebs/builder.hcl2spec.go
@@ -30,7 +30,6 @@ type FlatConfig struct {
 	ProfileName                               *string                                `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
 	RawRegion                                 *string                                `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	SecretKey                                 *string                                `mapstructure:"secret_key" required:"true" cty:"secret_key" hcl:"secret_key"`
-	SkipValidation                            *bool                                  `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	SkipMetadataApiCheck                      *bool                                  `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	SkipCredsValidation                       *bool                                  `mapstructure:"skip_credential_validation" cty:"skip_credential_validation" hcl:"skip_credential_validation"`
 	Token                                     *string                                `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
@@ -43,6 +42,7 @@ type FlatConfig struct {
 	AMIGroups                                 []string                               `mapstructure:"ami_groups" required:"false" cty:"ami_groups" hcl:"ami_groups"`
 	AMIProductCodes                           []string                               `mapstructure:"ami_product_codes" required:"false" cty:"ami_product_codes" hcl:"ami_product_codes"`
 	AMIRegions                                []string                               `mapstructure:"ami_regions" required:"false" cty:"ami_regions" hcl:"ami_regions"`
+	AMISkipRegionValidation                   *bool                                  `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	AMITags                                   map[string]string                      `mapstructure:"tags" required:"false" cty:"tags" hcl:"tags"`
 	AMITag                                    []hcl2template.FlatKeyValue            `mapstructure:"tag" required:"false" cty:"tag" hcl:"tag"`
 	AMIENASupport                             *bool                                  `mapstructure:"ena_support" required:"false" cty:"ena_support" hcl:"ena_support"`
@@ -83,7 +83,6 @@ type FlatConfig struct {
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
 	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
-	TemporaryKeyPairName                      *string                                `mapstructure:"temporary_key_pair_name" required:"false" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile                              *string                                `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
@@ -97,6 +96,7 @@ type FlatConfig struct {
 	SSHUsername                               *string                                `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
 	SSHPassword                               *string                                `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
 	SSHKeyPairName                            *string                                `mapstructure:"ssh_keypair_name" undocumented:"true" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
+	SSHTemporaryKeyPairName                   *string                                `mapstructure:"temporary_key_pair_name" undocumented:"true" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	SSHTemporaryKeyPairType                   *string                                `mapstructure:"temporary_key_pair_type" cty:"temporary_key_pair_type" hcl:"temporary_key_pair_type"`
 	SSHTemporaryKeyPairBits                   *int                                   `mapstructure:"temporary_key_pair_bits" cty:"temporary_key_pair_bits" hcl:"temporary_key_pair_bits"`
 	SSHCiphers                                []string                               `mapstructure:"ssh_ciphers" cty:"ssh_ciphers" hcl:"ssh_ciphers"`
@@ -179,7 +179,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"profile":                       &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"region":                        &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"secret_key":                    &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":        &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_metadata_api_check":       &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"skip_credential_validation":    &hcldec.AttrSpec{Name: "skip_credential_validation", Type: cty.Bool, Required: false},
 		"token":                         &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
@@ -192,6 +191,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ami_groups":                    &hcldec.AttrSpec{Name: "ami_groups", Type: cty.List(cty.String), Required: false},
 		"ami_product_codes":             &hcldec.AttrSpec{Name: "ami_product_codes", Type: cty.List(cty.String), Required: false},
 		"ami_regions":                   &hcldec.AttrSpec{Name: "ami_regions", Type: cty.List(cty.String), Required: false},
+		"skip_region_validation":        &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"tags":                          &hcldec.AttrSpec{Name: "tags", Type: cty.Map(cty.String), Required: false},
 		"tag":                           &hcldec.BlockListSpec{TypeName: "tag", Nested: hcldec.ObjectSpec((*hcl2template.FlatKeyValue)(nil).HCL2Spec())},
 		"ena_support":                   &hcldec.AttrSpec{Name: "ena_support", Type: cty.Bool, Required: false},
@@ -232,7 +232,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
-		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":                        &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
@@ -246,6 +245,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_username":                          &hcldec.AttrSpec{Name: "ssh_username", Type: cty.String, Required: false},
 		"ssh_password":                          &hcldec.AttrSpec{Name: "ssh_password", Type: cty.String, Required: false},
 		"ssh_keypair_name":                      &hcldec.AttrSpec{Name: "ssh_keypair_name", Type: cty.String, Required: false},
+		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_key_pair_type":               &hcldec.AttrSpec{Name: "temporary_key_pair_type", Type: cty.String, Required: false},
 		"temporary_key_pair_bits":               &hcldec.AttrSpec{Name: "temporary_key_pair_bits", Type: cty.Number, Required: false},
 		"ssh_ciphers":                           &hcldec.AttrSpec{Name: "ssh_ciphers", Type: cty.List(cty.String), Required: false},

--- a/builder/amazon/ebs/builder_test.go
+++ b/builder/amazon/ebs/builder_test.go
@@ -47,7 +47,6 @@ func TestBuilderPrepare_AMIName(t *testing.T) {
 
 	// Test good
 	config["ami_name"] = "foo"
-	config["skip_region_validation"] = true
 	_, warnings, err := b.Prepare(config)
 	if len(warnings) > 0 {
 		t.Fatalf("bad: %#v", warnings)
@@ -100,7 +99,6 @@ func TestBuilderPrepare_InvalidShutdownBehavior(t *testing.T) {
 
 	// Test good
 	config["shutdown_behavior"] = "terminate"
-	config["skip_region_validation"] = true
 	_, warnings, err := b.Prepare(config)
 	if len(warnings) > 0 {
 		t.Fatalf("bad: %#v", warnings)

--- a/builder/amazon/ebssurrogate/builder.hcl2spec.go
+++ b/builder/amazon/ebssurrogate/builder.hcl2spec.go
@@ -73,7 +73,6 @@ type FlatConfig struct {
 	ProfileName                               *string                                `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
 	RawRegion                                 *string                                `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	SecretKey                                 *string                                `mapstructure:"secret_key" required:"true" cty:"secret_key" hcl:"secret_key"`
-	SkipValidation                            *bool                                  `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	SkipMetadataApiCheck                      *bool                                  `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	SkipCredsValidation                       *bool                                  `mapstructure:"skip_credential_validation" cty:"skip_credential_validation" hcl:"skip_credential_validation"`
 	Token                                     *string                                `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
@@ -105,7 +104,6 @@ type FlatConfig struct {
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
 	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
-	TemporaryKeyPairName                      *string                                `mapstructure:"temporary_key_pair_name" required:"false" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile                              *string                                `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
@@ -119,6 +117,7 @@ type FlatConfig struct {
 	SSHUsername                               *string                                `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
 	SSHPassword                               *string                                `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
 	SSHKeyPairName                            *string                                `mapstructure:"ssh_keypair_name" undocumented:"true" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
+	SSHTemporaryKeyPairName                   *string                                `mapstructure:"temporary_key_pair_name" undocumented:"true" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	SSHTemporaryKeyPairType                   *string                                `mapstructure:"temporary_key_pair_type" cty:"temporary_key_pair_type" hcl:"temporary_key_pair_type"`
 	SSHTemporaryKeyPairBits                   *int                                   `mapstructure:"temporary_key_pair_bits" cty:"temporary_key_pair_bits" hcl:"temporary_key_pair_bits"`
 	SSHCiphers                                []string                               `mapstructure:"ssh_ciphers" cty:"ssh_ciphers" hcl:"ssh_ciphers"`
@@ -170,6 +169,7 @@ type FlatConfig struct {
 	AMIGroups                                 []string                               `mapstructure:"ami_groups" required:"false" cty:"ami_groups" hcl:"ami_groups"`
 	AMIProductCodes                           []string                               `mapstructure:"ami_product_codes" required:"false" cty:"ami_product_codes" hcl:"ami_product_codes"`
 	AMIRegions                                []string                               `mapstructure:"ami_regions" required:"false" cty:"ami_regions" hcl:"ami_regions"`
+	AMISkipRegionValidation                   *bool                                  `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	AMITags                                   map[string]string                      `mapstructure:"tags" required:"false" cty:"tags" hcl:"tags"`
 	AMITag                                    []hcl2template.FlatKeyValue            `mapstructure:"tag" required:"false" cty:"tag" hcl:"tag"`
 	AMIENASupport                             *bool                                  `mapstructure:"ena_support" required:"false" cty:"ena_support" hcl:"ena_support"`
@@ -223,7 +223,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"profile":                       &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"region":                        &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"secret_key":                    &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":        &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_metadata_api_check":       &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"skip_credential_validation":    &hcldec.AttrSpec{Name: "skip_credential_validation", Type: cty.Bool, Required: false},
 		"token":                         &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
@@ -255,7 +254,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
-		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":                        &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
@@ -269,6 +267,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_username":                          &hcldec.AttrSpec{Name: "ssh_username", Type: cty.String, Required: false},
 		"ssh_password":                          &hcldec.AttrSpec{Name: "ssh_password", Type: cty.String, Required: false},
 		"ssh_keypair_name":                      &hcldec.AttrSpec{Name: "ssh_keypair_name", Type: cty.String, Required: false},
+		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_key_pair_type":               &hcldec.AttrSpec{Name: "temporary_key_pair_type", Type: cty.String, Required: false},
 		"temporary_key_pair_bits":               &hcldec.AttrSpec{Name: "temporary_key_pair_bits", Type: cty.Number, Required: false},
 		"ssh_ciphers":                           &hcldec.AttrSpec{Name: "ssh_ciphers", Type: cty.List(cty.String), Required: false},
@@ -320,6 +319,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ami_groups":                            &hcldec.AttrSpec{Name: "ami_groups", Type: cty.List(cty.String), Required: false},
 		"ami_product_codes":                     &hcldec.AttrSpec{Name: "ami_product_codes", Type: cty.List(cty.String), Required: false},
 		"ami_regions":                           &hcldec.AttrSpec{Name: "ami_regions", Type: cty.List(cty.String), Required: false},
+		"skip_region_validation":                &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"tags":                                  &hcldec.AttrSpec{Name: "tags", Type: cty.Map(cty.String), Required: false},
 		"tag":                                   &hcldec.BlockListSpec{TypeName: "tag", Nested: hcldec.ObjectSpec((*hcl2template.FlatKeyValue)(nil).HCL2Spec())},
 		"ena_support":                           &hcldec.AttrSpec{Name: "ena_support", Type: cty.Bool, Required: false},

--- a/builder/amazon/ebsvolume/builder.hcl2spec.go
+++ b/builder/amazon/ebsvolume/builder.hcl2spec.go
@@ -75,7 +75,6 @@ type FlatConfig struct {
 	ProfileName                               *string                                `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
 	RawRegion                                 *string                                `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	SecretKey                                 *string                                `mapstructure:"secret_key" required:"true" cty:"secret_key" hcl:"secret_key"`
-	SkipValidation                            *bool                                  `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	SkipMetadataApiCheck                      *bool                                  `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	SkipCredsValidation                       *bool                                  `mapstructure:"skip_credential_validation" cty:"skip_credential_validation" hcl:"skip_credential_validation"`
 	Token                                     *string                                `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
@@ -107,7 +106,6 @@ type FlatConfig struct {
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
 	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
-	TemporaryKeyPairName                      *string                                `mapstructure:"temporary_key_pair_name" required:"false" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataFile                              *string                                `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
@@ -121,6 +119,7 @@ type FlatConfig struct {
 	SSHUsername                               *string                                `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
 	SSHPassword                               *string                                `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
 	SSHKeyPairName                            *string                                `mapstructure:"ssh_keypair_name" undocumented:"true" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
+	SSHTemporaryKeyPairName                   *string                                `mapstructure:"temporary_key_pair_name" undocumented:"true" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
 	SSHTemporaryKeyPairType                   *string                                `mapstructure:"temporary_key_pair_type" cty:"temporary_key_pair_type" hcl:"temporary_key_pair_type"`
 	SSHTemporaryKeyPairBits                   *int                                   `mapstructure:"temporary_key_pair_bits" cty:"temporary_key_pair_bits" hcl:"temporary_key_pair_bits"`
 	SSHCiphers                                []string                               `mapstructure:"ssh_ciphers" cty:"ssh_ciphers" hcl:"ssh_ciphers"`
@@ -203,7 +202,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"profile":                       &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"region":                        &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"secret_key":                    &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":        &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_metadata_api_check":       &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"skip_credential_validation":    &hcldec.AttrSpec{Name: "skip_credential_validation", Type: cty.Bool, Required: false},
 		"token":                         &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
@@ -235,7 +233,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
-		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"user_data_file":                        &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
@@ -249,6 +246,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_username":                          &hcldec.AttrSpec{Name: "ssh_username", Type: cty.String, Required: false},
 		"ssh_password":                          &hcldec.AttrSpec{Name: "ssh_password", Type: cty.String, Required: false},
 		"ssh_keypair_name":                      &hcldec.AttrSpec{Name: "ssh_keypair_name", Type: cty.String, Required: false},
+		"temporary_key_pair_name":               &hcldec.AttrSpec{Name: "temporary_key_pair_name", Type: cty.String, Required: false},
 		"temporary_key_pair_type":               &hcldec.AttrSpec{Name: "temporary_key_pair_type", Type: cty.String, Required: false},
 		"temporary_key_pair_bits":               &hcldec.AttrSpec{Name: "temporary_key_pair_bits", Type: cty.Number, Required: false},
 		"ssh_ciphers":                           &hcldec.AttrSpec{Name: "ssh_ciphers", Type: cty.List(cty.String), Required: false},

--- a/builder/amazon/ebsvolume/builder_test.go
+++ b/builder/amazon/ebsvolume/builder_test.go
@@ -61,7 +61,6 @@ func TestBuilderPrepare_InvalidShutdownBehavior(t *testing.T) {
 
 	// Test good
 	config["shutdown_behavior"] = "terminate"
-	config["skip_region_validation"] = true
 	_, warnings, err := b.Prepare(config)
 	if len(warnings) > 0 {
 		t.Fatalf("bad: %#v", warnings)

--- a/builder/hyperv/common/config.go
+++ b/builder/hyperv/common/config.go
@@ -134,8 +134,6 @@ type CommonConfig struct {
 	// If "true", Packer will not delete the VM from
 	// The Hyper-V manager.
 	KeepRegistered bool `mapstructure:"keep_registered" required:"false"`
-
-	Communicator string `mapstructure:"communicator"`
 	// If true skip compacting the hard disk for
 	// the virtual machine when exporting. This defaults to false.
 	SkipCompaction bool `mapstructure:"skip_compaction" required:"false"`

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -91,9 +91,6 @@ type Config struct {
 	// This parameter is required when source_path have more than one provider,
 	// or when using vagrant-cloud post-processor. Defaults to unset.
 	Provider string `mapstructure:"provider" required:"false"`
-
-	Communicator string `mapstructure:"communicator"`
-
 	// Options for the "vagrant init" command
 
 	// What vagrantfile to use

--- a/builder/virtualbox/common/guest_additions_config.go
+++ b/builder/virtualbox/common/guest_additions_config.go
@@ -5,8 +5,6 @@ package common
 import (
 	"fmt"
 	"strings"
-
-	"github.com/hashicorp/packer/packer-plugin-sdk/template/interpolate"
 )
 
 // These are the different valid mode values for "guest_additions_mode" which
@@ -18,7 +16,6 @@ const (
 )
 
 type GuestAdditionsConfig struct {
-	Communicator string `mapstructure:"communicator"`
 	// The method by which guest additions are
 	// made available to the guest for installation. Valid options are `upload`,
 	// `attach`, or `disable`. If the mode is `attach` the guest additions ISO will
@@ -52,13 +49,8 @@ type GuestAdditionsConfig struct {
 	GuestAdditionsURL string `mapstructure:"guest_additions_url" required:"false"`
 }
 
-func (c *GuestAdditionsConfig) Prepare(ctx *interpolate.Context) []error {
+func (c *GuestAdditionsConfig) Prepare(communicatorType string) []error {
 	var errs []error
-
-	if c.Communicator == "none" && c.GuestAdditionsMode != "disable" {
-		errs = append(errs, fmt.Errorf("guest_additions_mode has to be "+
-			"'disable' when communicator = 'none'."))
-	}
 
 	if c.GuestAdditionsMode == "" {
 		c.GuestAdditionsMode = "upload"
@@ -89,6 +81,11 @@ func (c *GuestAdditionsConfig) Prepare(ctx *interpolate.Context) []error {
 	if !validMode {
 		errs = append(errs,
 			fmt.Errorf("guest_additions_mode is invalid. Must be one of: %v", validModes))
+	}
+
+	if communicatorType == "none" && c.GuestAdditionsMode != "disable" {
+		errs = append(errs, fmt.Errorf("guest_additions_mode has to be "+
+			"'disable' when communicator = 'none'."))
 	}
 
 	return errs

--- a/builder/virtualbox/common/guest_additions_config_test.go
+++ b/builder/virtualbox/common/guest_additions_config_test.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"testing"
-
-	"github.com/hashicorp/packer/packer-plugin-sdk/template/interpolate"
 )
 
 func TestGuestAdditionsConfigPrepare(t *testing.T) {
@@ -11,8 +9,7 @@ func TestGuestAdditionsConfigPrepare(t *testing.T) {
 	var errs []error
 
 	c.GuestAdditionsMode = "disable"
-	c.Communicator = "none"
-	errs = c.Prepare(interpolate.NewContext())
+	errs = c.Prepare("none")
 	if len(errs) > 0 {
 		t.Fatalf("should not have error: %s", errs)
 	}

--- a/builder/virtualbox/common/vbox_version_config.go
+++ b/builder/virtualbox/common/vbox_version_config.go
@@ -4,12 +4,9 @@ package common
 
 import (
 	"fmt"
-
-	"github.com/hashicorp/packer/packer-plugin-sdk/template/interpolate"
 )
 
 type VBoxVersionConfig struct {
-	Communicator string `mapstructure:"communicator"`
 	// The path within the virtual machine to
 	// upload a file that contains the VirtualBox version that was used to create
 	// the machine. This information can be useful for provisioning. By default
@@ -19,7 +16,7 @@ type VBoxVersionConfig struct {
 	VBoxVersionFile *string `mapstructure:"virtualbox_version_file" required:"false"`
 }
 
-func (c *VBoxVersionConfig) Prepare(ctx *interpolate.Context) []error {
+func (c *VBoxVersionConfig) Prepare(communicatorType string) []error {
 	var errs []error
 
 	if c.VBoxVersionFile == nil {
@@ -27,7 +24,7 @@ func (c *VBoxVersionConfig) Prepare(ctx *interpolate.Context) []error {
 		c.VBoxVersionFile = &default_file
 	}
 
-	if c.Communicator == "none" && *c.VBoxVersionFile != "" {
+	if communicatorType == "none" && *c.VBoxVersionFile != "" {
 		errs = append(errs, fmt.Errorf("virtualbox_version_file has to be an "+
 			"empty string when communicator = 'none'."))
 	}

--- a/builder/virtualbox/common/vbox_version_config_test.go
+++ b/builder/virtualbox/common/vbox_version_config_test.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"testing"
-
-	"github.com/hashicorp/packer/packer-plugin-sdk/template/interpolate"
 )
 
 func TestVBoxVersionConfigPrepare_BootWait(t *testing.T) {
@@ -12,7 +10,7 @@ func TestVBoxVersionConfigPrepare_BootWait(t *testing.T) {
 
 	// Test empty
 	c = new(VBoxVersionConfig)
-	errs = c.Prepare(interpolate.NewContext())
+	errs = c.Prepare("ssh")
 	if len(errs) > 0 {
 		t.Fatalf("should not have error: %s", errs)
 	}
@@ -25,7 +23,7 @@ func TestVBoxVersionConfigPrepare_BootWait(t *testing.T) {
 	c = new(VBoxVersionConfig)
 	filename := "foo"
 	c.VBoxVersionFile = &filename
-	errs = c.Prepare(interpolate.NewContext())
+	errs = c.Prepare("ssh")
 	if len(errs) > 0 {
 		t.Fatalf("should not have error: %s", errs)
 	}
@@ -42,7 +40,7 @@ func TestVBoxVersionConfigPrepare_empty(t *testing.T) {
 	// Test with nil value
 	c = new(VBoxVersionConfig)
 	c.VBoxVersionFile = nil
-	errs = c.Prepare(interpolate.NewContext())
+	errs = c.Prepare("ssh")
 	if len(errs) > 0 {
 		t.Fatalf("should not have error: %s", errs)
 	}
@@ -55,7 +53,7 @@ func TestVBoxVersionConfigPrepare_empty(t *testing.T) {
 	c = new(VBoxVersionConfig)
 	filename := ""
 	c.VBoxVersionFile = &filename
-	errs = c.Prepare(interpolate.NewContext())
+	errs = c.Prepare("ssh")
 	if len(errs) > 0 {
 		t.Fatalf("should not have error: %s", errs)
 	}
@@ -73,8 +71,7 @@ func TestVBoxVersionConfigPrepare_communicator(t *testing.T) {
 	c = new(VBoxVersionConfig)
 	filename := "test"
 	c.VBoxVersionFile = &filename
-	c.Communicator = "none"
-	errs = c.Prepare(interpolate.NewContext())
+	errs = c.Prepare("none")
 	if len(errs) == 0 {
 		t.Fatalf("should have an error")
 	}

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -156,9 +156,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	errs = packer.MultiErrorAppend(errs, b.config.HWConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxBundleConfig.Prepare(&b.config.ctx)...)
 	errs = packer.MultiErrorAppend(errs, b.config.VBoxManageConfig.Prepare(&b.config.ctx)...)
-	errs = packer.MultiErrorAppend(errs, b.config.VBoxVersionConfig.Prepare(&b.config.ctx)...)
+	errs = packer.MultiErrorAppend(errs, b.config.VBoxVersionConfig.Prepare(b.config.CommConfig.Comm.Type)...)
 	errs = packer.MultiErrorAppend(errs, b.config.BootConfig.Prepare(&b.config.ctx)...)
-	errs = packer.MultiErrorAppend(errs, b.config.GuestAdditionsConfig.Prepare(&b.config.ctx)...)
+	errs = packer.MultiErrorAppend(errs, b.config.GuestAdditionsConfig.Prepare(b.config.CommConfig.Comm.Type)...)
 
 	if b.config.DiskSize == 0 {
 		b.config.DiskSize = 40000

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -118,9 +118,9 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.CommConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.VBoxManageConfig.Prepare(&c.ctx)...)
-	errs = packer.MultiErrorAppend(errs, c.VBoxVersionConfig.Prepare(&c.ctx)...)
+	errs = packer.MultiErrorAppend(errs, c.VBoxVersionConfig.Prepare(c.CommConfig.Comm.Type)...)
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.ctx)...)
-	errs = packer.MultiErrorAppend(errs, c.GuestAdditionsConfig.Prepare(&c.ctx)...)
+	errs = packer.MultiErrorAppend(errs, c.GuestAdditionsConfig.Prepare(c.CommConfig.Comm.Type)...)
 
 	if c.SourcePath == "" {
 		errs = packer.MultiErrorAppend(errs, fmt.Errorf("source_path is required"))

--- a/builder/virtualbox/vm/config.go
+++ b/builder/virtualbox/vm/config.go
@@ -100,9 +100,9 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.CommConfig.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.VBoxManageConfig.Prepare(&c.ctx)...)
-	errs = packer.MultiErrorAppend(errs, c.VBoxVersionConfig.Prepare(&c.ctx)...)
+	errs = packer.MultiErrorAppend(errs, c.VBoxVersionConfig.Prepare(c.CommConfig.Comm.Type)...)
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.ctx)...)
-	errs = packer.MultiErrorAppend(errs, c.GuestAdditionsConfig.Prepare(&c.ctx)...)
+	errs = packer.MultiErrorAppend(errs, c.GuestAdditionsConfig.Prepare(c.CommConfig.Comm.Type)...)
 
 	if c.GuestAdditionsInterface == "" {
 		c.GuestAdditionsInterface = "ide"

--- a/post-processor/amazon-import/post-processor.hcl2spec.go
+++ b/post-processor/amazon-import/post-processor.hcl2spec.go
@@ -29,7 +29,6 @@ type FlatConfig struct {
 	ProfileName           *string                           `mapstructure:"profile" required:"false" cty:"profile" hcl:"profile"`
 	RawRegion             *string                           `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	SecretKey             *string                           `mapstructure:"secret_key" required:"true" cty:"secret_key" hcl:"secret_key"`
-	SkipValidation        *bool                             `mapstructure:"skip_region_validation" required:"false" cty:"skip_region_validation" hcl:"skip_region_validation"`
 	SkipMetadataApiCheck  *bool                             `mapstructure:"skip_metadata_api_check" cty:"skip_metadata_api_check" hcl:"skip_metadata_api_check"`
 	SkipCredsValidation   *bool                             `mapstructure:"skip_credential_validation" cty:"skip_credential_validation" hcl:"skip_credential_validation"`
 	Token                 *string                           `mapstructure:"token" required:"false" cty:"token" hcl:"token"`
@@ -83,7 +82,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"profile":                       &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
 		"region":                        &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"secret_key":                    &hcldec.AttrSpec{Name: "secret_key", Type: cty.String, Required: false},
-		"skip_region_validation":        &hcldec.AttrSpec{Name: "skip_region_validation", Type: cty.Bool, Required: false},
 		"skip_metadata_api_check":       &hcldec.AttrSpec{Name: "skip_metadata_api_check", Type: cty.Bool, Required: false},
 		"skip_credential_validation":    &hcldec.AttrSpec{Name: "skip_credential_validation", Type: cty.Bool, Required: false},
 		"token":                         &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},

--- a/website/pages/partials/builder/amazon/common/AccessConfig-not-required.mdx
+++ b/website/pages/partials/builder/amazon/common/AccessConfig-not-required.mdx
@@ -33,9 +33,6 @@
   profiles](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-profiles)
   for more details.
 
-- `skip_region_validation` (bool) - Set to true if you want to skip
-  validation of the ami_regions configuration option. Default false.
-
 - `skip_metadata_api_check` (bool) - Skip Metadata Api Check
 
 - `skip_credential_validation` (bool) - Set to true if you want to skip validating AWS credentials before runtime.

--- a/website/pages/partials/builder/amazon/common/RunConfig-not-required.mdx
+++ b/website/pages/partials/builder/amazon/common/RunConfig-not-required.mdx
@@ -297,10 +297,6 @@
   The default is "default", meaning shared tenancy. Allowed values are "default",
   "dedicated" and "host".
 
-- `temporary_key_pair_name` (string) - The name of the temporary key pair to
-  generate. By default, Packer generates a name that looks like
-  `packer_<UUID>`, where &lt;UUID&gt; is a 36 character unique identifier.
-
 - `temporary_security_group_source_cidrs` ([]string) - A list of IPv4 CIDR blocks to be authorized access to the instance, when
   packer is creating a temporary security group.
   

--- a/website/pages/partials/builder/hyperv/common/CommonConfig-not-required.mdx
+++ b/website/pages/partials/builder/hyperv/common/CommonConfig-not-required.mdx
@@ -95,8 +95,6 @@
 - `keep_registered` (bool) - If "true", Packer will not delete the VM from
   The Hyper-V manager.
 
-- `communicator` (string) - Communicator
-
 - `skip_compaction` (bool) - If true skip compacting the hard disk for
   the virtual machine when exporting. This defaults to false.
 

--- a/website/pages/partials/builder/vagrant/Config-not-required.mdx
+++ b/website/pages/partials/builder/vagrant/Config-not-required.mdx
@@ -37,8 +37,6 @@
   This parameter is required when source_path have more than one provider,
   or when using vagrant-cloud post-processor. Defaults to unset.
 
-- `communicator` (string) - Communicator
-
 - `vagrantfile_template` (string) - What vagrantfile to use
 
 - `teardown_method` (string) - Whether to halt, suspend, or destroy the box when the build has

--- a/website/pages/partials/builder/virtualbox/common/GuestAdditionsConfig-not-required.mdx
+++ b/website/pages/partials/builder/virtualbox/common/GuestAdditionsConfig-not-required.mdx
@@ -1,7 +1,5 @@
 <!-- Code generated from the comments of the GuestAdditionsConfig struct in builder/virtualbox/common/guest_additions_config.go; DO NOT EDIT MANUALLY -->
 
-- `communicator` (string) - Communicator
-
 - `guest_additions_mode` (string) - The method by which guest additions are
   made available to the guest for installation. Valid options are `upload`,
   `attach`, or `disable`. If the mode is `attach` the guest additions ISO will

--- a/website/pages/partials/builder/virtualbox/common/VBoxVersionConfig-not-required.mdx
+++ b/website/pages/partials/builder/virtualbox/common/VBoxVersionConfig-not-required.mdx
@@ -1,7 +1,5 @@
 <!-- Code generated from the comments of the VBoxVersionConfig struct in builder/virtualbox/common/vbox_version_config.go; DO NOT EDIT MANUALLY -->
 
-- `communicator` (string) - Communicator
-
 - `virtualbox_version_file` (\*string) - The path within the virtual machine to
   upload a file that contains the VirtualBox version that was used to create
   the machine. This information can be useful for provisioning. By default


### PR DESCRIPTION
When running "make generate" against the whole codebase (not advised unless you want your computer to cry), the generator raises a fair number of "duplicate field" warnings -- This PR fixes the field collisions for HashiCorp maintained plugins. 