### PR TITLE
bump default max_retries

### DIFF
--- a/builder/amazon/common/access_config.go
+++ b/builder/amazon/common/access_config.go
@@ -403,6 +403,12 @@ func (c *AccessConfig) Prepare(ctx *interpolate.Context) []error {
 	}
 	c.PollingConfig.LogEnvOverrideWarnings()
 
+	// Default MaxRetries to 10, to make throttling issues less likely. The
+	// Aws sdk defaults this to 3, which regularly gets tripped by users.
+	if c.MaxRetries == 0 {
+		c.MaxRetries = 10
+	}
+
 	return errs
 }
 


### PR DESCRIPTION
Bump the default MaxRetries in AWS to prevent users getting throttling errors without having to wrap every single API call in a retry function. 

Closes #10071 