### PR TITLE
allow attaching guest additions without a communicator

### DIFF
--- a/builder/virtualbox/common/guest_additions_config.go
+++ b/builder/virtualbox/common/guest_additions_config.go
@@ -83,9 +83,9 @@ func (c *GuestAdditionsConfig) Prepare(communicatorType string) []error {
 			fmt.Errorf("guest_additions_mode is invalid. Must be one of: %v", validModes))
 	}
 
-	if communicatorType == "none" && c.GuestAdditionsMode != "disable" {
-		errs = append(errs, fmt.Errorf("guest_additions_mode has to be "+
-			"'disable' when communicator = 'none'."))
+	if communicatorType == "none" && c.GuestAdditionsMode == "upload" {
+		errs = append(errs, fmt.Errorf("communicator must not be 'none' "+
+			"when guest_additions_mode = 'upload'."))
 	}
 
 	return errs


### PR DESCRIPTION
This avoids the error:
* guest_additions_mode has to be 'disable' when communicator = 'none'.

...when the following are set:
"communicator": "none",
"guest_additions_mode": "attach",

This particular combination of parameters is valid; for example, in my
case, a kickstart post-install script mounts the CD image from /dev/sr1
and runs the installer, without needing any intervention from packer
itself.

From my reading of the documentation, it appears that the "upload" mode
would indeed require a communicator, so I change the logic to check for
that specifically.