### PR TITLE
Improve vsphere-clone customization example

### DIFF
--- a/website/pages/docs/builders/vmware/vsphere-clone.mdx
+++ b/website/pages/docs/builders/vmware/vsphere-clone.mdx
@@ -141,7 +141,9 @@ can be done via environment variable:
           "network_interface": {
             "ipv4_address": "10.0.0.10",
             "ipv4_netmask": "24"
-          }
+          },
+          "ipv4_gateway": "10.0.0.1",
+          "dns_server_list": ["10.0.0.18"]
  }
 ```
 
@@ -159,6 +161,9 @@ can be done via environment variable:
            ipv4_address = "10.0.0.10"
            ipv4_netmask = "24"
          }
+
+         ipv4_gateway = 10.0.0.1
+         dns_server_list = ["10.0.0.18"]
    }
 ```
 


### PR DESCRIPTION
Just making clear that global gateway and dns settings are not supposed to be set in block form.

Closes https://github.com/hashicorp/packer/issues/10288