### PR TITLE
googlecompute-export: Add logging.write to service account scopes

### DIFF
--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -183,6 +183,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packer.Ui, artifact 
 			"https://www.googleapis.com/auth/compute",
 			"https://www.googleapis.com/auth/devstorage.full_control",
 			"https://www.googleapis.com/auth/userinfo.email",
+			"https://www.googleapis.com/auth/logging.write",
 		},
 	}
 	if p.config.ServiceAccountEmail != "" {


### PR DESCRIPTION
With the default list of service account scopes in `googlecompute-export`, I see `logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.` in the console of instance that performs the export:

```
Debian GNU/Linux 9 cloud-puppet-xenial-28512fb-1606726453-exporter ttyS0



cloud-puppet-xenial-28512fb-1606726453-exporter login: Nov 30 09:02:55 localhost GCEGuestAgent[811]: 2020-11-30T09:02:55.7270Z GCEGuestAgent Info: Updating keys for user gke-e8756b7f43b1db4a3d2e.

Nov 30 09:02:55 localhost GCEGuestAgent[811]: 2020-11-30T09:02:55.7273Z GCEGuestAgent Info: Creating user gke-d9c33130bc75e65aaf32.

[   11.320989] google_guest_agent[811]: 2020/11/30 09:02:55 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:02:55 localhost google_guest_agent[811]: 2020/11/30 09:02:55 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:02:55 localhost GCEGuestAgent[811]: 2020-11-30T09:02:55.8530Z GCEGuestAgent Info: Updating keys for user gke-d9c33130bc75e65aaf32.

Nov 30 09:02:55 localhost GCEGuestAgent[811]: 2020-11-30T09:02:55.8534Z GCEGuestAgent Info: Creating user gke-872fdd485e2234e364d0.

Nov 30 09:02:55 localhost GCEGuestAgent[811]: 2020-11-30T09:02:55.9647Z GCEGuestAgent Info: Updating keys for user gke-872fdd485e2234e364d0.

Nov 30 09:02:55 localhost GCEGuestAgent[811]: 2020-11-30T09:02:55.9650Z GCEGuestAgent Info: Creating user gke-98ae88e4156048deec5c.

Nov 30 09:02:56 localhost GCEGuestAgent[811]: 2020-11-30T09:02:56.0757Z GCEGuestAgent Info: Updating keys for user gke-98ae88e4156048deec5c.

Nov 30 09:02:56 localhost GCEGuestAgent[811]: 2020-11-30T09:02:56.0761Z GCEGuestAgent Info: Creating user gke-b84ed7f4f2c179a6028f.

Nov 30 09:02:56 localhost GCEGuestAgent[811]: 2020-11-30T09:02:56.1880Z GCEGuestAgent Info: Updating keys for user gke-b84ed7f4f2c179a6028f.

Nov 30 09:02:56 localhost systemd[1]: Time has been changed

[   12.355720] Nov 30 09:02:56 localhost google_guest_agent[811]: 2020/11/30 09:02:56 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

google_guest_agent[811]: 2020/11/30 09:02:56 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:03:03 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:03 GCEMetadataScripts: startup-script: Created [https://www.googleapis.com/compute/v1/projects/foo/zones/us-central1-a/disks/cloud-puppet-xenial-28512fb-1606726453-exporter-toexport].

Nov 30 09:03:03 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:03 GCEMetadataScripts: startup-script: NAME                                                      ZONE           SIZE_GB  TYPE         STATUS

Nov 30 09:03:03 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:03 GCEMetadataScripts: startup-script: cloud-puppet-xenial-28512fb-1606726453-exporter-toexport  us-central1-a  20       pd-standard  READY

Nov 30 09:03:03 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:03 GCEMetadataScripts: startup-script: Attaching disk...

[   20.228740] google_metadata_script_runner[812]: 2020/11/30 09:03:04 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:03:04 localhost google_metadata_script_runner[812]: 2020/11/30 09:03:04 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

[   22.515842] scsi 0:0:2:0: Direct-Access     Google   PersistentDisk   1    PQ: 0 ANSI: 6

Nov 30 09:03:06 localhost kernel: [   22.515842] scsi 0:0:2:0: Direct-Access     Google   PersistentDisk   1    PQ: 0 ANSI: 6

[   22.567876] sd 0:0:2:0: Attached scsi generic sg1 type 0

[   22.573374] sd 0:0:2:0: [sdb] 41943040 512-byte logical blocks: (21.5 GB/20.0 GiB)

[   22.581225] sd 0:0:2:0: [sdb] 4096-byte physical blocks

Nov 30 09:03:06 [   22.586977] sd 0:0:2:0: [sdb] Write Protect is off

localhost kernel[   22.593190] sd 0:0:2:0: [sdb] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA

: [   22.567876] sd 0:0:2:0: Attached scsi generic sg1 type 0

Nov 30 09:03:06 localhost kernel:[   22.611918]  sdb: sdb1

 [   22.573374] [   22.616748] sd 0:0:2:0: [sdb] Attached SCSI disk

sd 0:0:2:0: [sdb] 41943040 512-byte logical blocks: (21.5 GB/20.0 GiB)

Nov 30 09:03:06 localhost kernel: [   22.581225] sd 0:0:2:0: [sdb] 4096-byte physical blocks

Nov 30 09:03:06 localhost kernel: [   22.586977] sd 0:0:2:0: [sdb] Write Protect is off

Nov 30 09:03:06 localhost kernel: [   22.593064] sd 0:0:2:0: [sdb] Mode Sense: 1f 00 00 08

Nov 30 09:03:06 localhost kernel: [   22.593190] sd 0:0:2:0: [sdb] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA

Nov 30 09:03:06 localhost kernel: [   22.611918]  sdb: sdb1

Nov 30 09:03:06 localhost kernel: [   22.616748] sd 0:0:2:0: [sdb] Attached SCSI disk

Nov 30 09:03:08 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:08 GCEMetadataScripts: startup-script: Updated [https://www.googleapis.com/compute/v1/projects/foo/zones/us-central1-a/instances/cloud-puppet-xenial-28512fb-1606726453-exporter].

Nov 30 09:03:08 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:08 GCEMetadataScripts: startup-script: GCEExport: Running export tool.

Nov 30 09:03:08 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:08 GCEMetadataScripts: startup-script: GCEExport: Disk /dev/disk/by-id/google-toexport is 20 GiB, compressed size will most likely be much smaller.

Nov 30 09:03:08 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:08 GCEMetadataScripts: startup-script: GCEExport: Beginning export process...

Nov 30 09:03:08 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:08 GCEMetadataScripts: startup-script: GCEExport: Copying "/dev/disk/by-id/google-toexport" to gs://foo/cloud-puppet-xenial/cloud-puppet-xenial-28512fb-1606726453.tar.gz.

Nov 30 09:03:08 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:08 GCEMetadataScripts: startup-script: GCEExport: No local cache set, streaming directly to GCS.

Nov 30 09:03:08 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:08 GCEMetadataScripts: startup-script: GCEExport: Creating gzipped image of "/dev/disk/by-id/google-toexport".

[   25.236768] google_metadata_script_runner[812]: 2020/11/30 09:03:09 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:03:09 localhost google_metadata_script_runner[812]: 2020/11/30 09:03:09 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:03:14 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:14 GCEMetadataScripts: startup-script: GCEExport: Read 402 MiB of 20 GiB (80 MiB/sec), total written size: 95 MiB (19 MiB/sec)

[   30.242239] google_metadata_script_runner[812]: 2020/11/30 09:03:14 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:03:14 localhost google_metadata_script_runner[812]: 2020/11/30 09:03:14 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:03:44 localhost GCEMetadataScripts[812]: 2020/11/30 09:03:44 GCEMetadataScripts: startup-script: GCEExport: Read 2.8 GiB of 20 GiB (83 MiB/sec), total written size: 908 MiB (27 MiB/sec)

[   60.245542] google_metadata_script_runner[812]: 2020/11/30 09:03:44 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:03:44 localhost google_metadata_script_runner[812]: 2020/11/30 09:03:44 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:04:14 localhost GCEMetadataScripts[812]: 2020/11/30 09:04:14 GCEMetadataScripts: startup-script: GCEExport: Read 5.7 GiB of 20 GiB (100 MiB/sec), total written size: 1.4 GiB (18 MiB/sec)

[   90.253240] google_metadata_script_runner[812]: 2020/11/30 09:04:14 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:04:14 localhost google_metadata_script_runner[812]: 2020/11/30 09:04:14 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:04:44 localhost GCEMetadataScripts[812]: 2020/11/30 09:04:44 GCEMetadataScripts: startup-script: GCEExport: Read 9.2 GiB of 20 GiB (119 MiB/sec), total written size: 1.5 GiB (2.0 MiB/sec)

[  120.261902] google_metadata_script_runner[812]: 2020/11/30 09:04:44 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:04:44 localhost google_metadata_script_runner[812]: 2020/11/30 09:04:44 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:05:14 localhost GCEMetadataScripts[812]: 2020/11/30 09:05:14 GCEMetadataScripts: startup-script: GCEExport: Read 13 GiB of 20 GiB (120 MiB/sec), total written size: 1.5 GiB (1.4 MiB/sec)

[  150.266637] google_metadata_script_runner[812]: 2020/11/30 09:05:14 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.

Nov 30 09:05:14 localhost google_metadata_script_runner[812]: 2020/11/30 09:05:14 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.
```

The error is caused by not having `logging.write` in the default list of scopes for the service account.

By adding `https://www.googleapis.com/auth/logging.write` in the list of scope we get rid of the error, which is harmelss as the export finishes but it pollutes the console log of the instance and distracts the engineer from looking at the valuable log information.

BTW: I think that it times for `googlecompute-export` to get support for [configurable scopes](https://www.packer.io/docs/builders/googlecompute#scopes) in the same way we have for `googlecompute` builder.


