### PR TITLE
Gcp wait to add ssh keys 10312

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -287,8 +287,8 @@ type Config struct {
 	VaultGCPOauthEngine string `mapstructure:"vault_gcp_oauth_engine"`
 	// The time to wait between the creation of the instance used to create the image,
 	// and the addition of SSH configuration, including SSH keys, to that instance.
-	// The delay is intended to protect packer from anything in the instance boot 
-	// sequence that has potential to disrupt the creation of SSH configuration 
+	// The delay is intended to protect packer from anything in the instance boot
+	// sequence that has potential to disrupt the creation of SSH configuration
 	// (e.g. SSH user creation, SSH key creation) on the instance.
 	// Note: All other instance metadata, including startup scripts, are still added to the instance
 	// during it's creation.

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -285,13 +285,17 @@ type Config struct {
 	// https://www.vaultproject.io/docs/commands/#environment-variables
 	// Example:`"vault_gcp_oauth_engine": "gcp/token/my-project-editor",`
 	VaultGCPOauthEngine string `mapstructure:"vault_gcp_oauth_engine"`
-	// The zone in which to launch the instance used to create the image.
-	// Example: "us-central1-a"
-
-	// The time to wait between instance creation and adding SSH keys.
+	// The time to wait between the creation of the instance used to create the image,
+	// and the addition of SSH configuration, including SSH keys, to that instance.
+	// The delay is intended to protect packer from anything in the instance boot 
+	// sequence that has potential to disrupt the creation of SSH configuration 
+	// (e.g. SSH user creation, SSH key creation) on the instance.
+	// Note: All other instance metadata, including startup scripts, are still added to the instance
+	// during it's creation.
 	// Example value: `5m`.
 	WaitToAddSSHKeys time.Duration `mapstructure:"wait_to_add_ssh_keys"`
-
+	// The zone in which to launch the instance used to create the image.
+	// Example: "us-central1-a"
 	Zone string `mapstructure:"zone" required:"true"`
 
 	account            *ServiceAccount

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -287,6 +287,11 @@ type Config struct {
 	VaultGCPOauthEngine string `mapstructure:"vault_gcp_oauth_engine"`
 	// The zone in which to launch the instance used to create the image.
 	// Example: "us-central1-a"
+
+	// The time to wait between instance creation and adding SSH keys.
+	// Example value: `5m`.
+	WaitToAddSSHKeys time.Duration `mapstructure:"wait_to_add_ssh_keys"`
+
 	Zone string `mapstructure:"zone" required:"true"`
 
 	account            *ServiceAccount

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -117,6 +117,7 @@ type FlatConfig struct {
 	UseInternalIP                *bool                      `mapstructure:"use_internal_ip" required:"false" cty:"use_internal_ip" hcl:"use_internal_ip"`
 	UseOSLogin                   *bool                      `mapstructure:"use_os_login" required:"false" cty:"use_os_login" hcl:"use_os_login"`
 	VaultGCPOauthEngine          *string                    `mapstructure:"vault_gcp_oauth_engine" cty:"vault_gcp_oauth_engine" hcl:"vault_gcp_oauth_engine"`
+	WaitToAddSSHKeys             *string                    `mapstructure:"wait_to_add_ssh_keys" cty:"wait_to_add_ssh_keys" hcl:"wait_to_add_ssh_keys"`
 	Zone                         *string                    `mapstructure:"zone" required:"true" cty:"zone" hcl:"zone"`
 }
 
@@ -240,6 +241,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"use_internal_ip":                 &hcldec.AttrSpec{Name: "use_internal_ip", Type: cty.Bool, Required: false},
 		"use_os_login":                    &hcldec.AttrSpec{Name: "use_os_login", Type: cty.Bool, Required: false},
 		"vault_gcp_oauth_engine":          &hcldec.AttrSpec{Name: "vault_gcp_oauth_engine", Type: cty.String, Required: false},
+		"wait_to_add_ssh_keys":            &hcldec.AttrSpec{Name: "wait_to_add_ssh_keys", Type: cty.String, Required: false},
 		"zone":                            &hcldec.AttrSpec{Name: "zone", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -85,6 +85,17 @@ func TestConfigPrepare(t *testing.T) {
 		},
 
 		{
+			"wait_to_add_ssh_keys",
+			"SO BAD",
+			true,
+		},
+		{
+			"wait_to_add_ssh_keys",
+			"5s",
+			false,
+		},
+
+		{
 			"state_timeout",
 			"SO BAD",
 			true,

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -69,6 +69,9 @@ type Driver interface {
 
 	// DeleteOSLoginSSHKey deletes the SSH public key for OSLogin with the given key.
 	DeleteOSLoginSSHKey(user, fingerprint string) error
+
+	// Add to the instance metadata for the existing instance
+	AddToInstanceMetadata(zone string, name string, metadata map[string]string) (<-chan error, error)
 }
 
 type InstanceConfig struct {

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -71,7 +71,7 @@ type Driver interface {
 	DeleteOSLoginSSHKey(user, fingerprint string) error
 
 	// Add to the instance metadata for the existing instance
-	AddToInstanceMetadata(zone string, name string, metadata map[string]string) (<-chan error, error)
+	AddToInstanceMetadata(zone string, name string, metadata map[string]string) error
 }
 
 type InstanceConfig struct {

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -764,6 +764,6 @@ func (d *driverGCE) AddToInstanceMetadata(zone string, name string, metadata map
 	case <-time.After(time.Second * 30):
 		err = errors.New("time out while waiting for SSH keys to be added to instance")
 	}
-	
+
 	return newErrCh, err
 }

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -304,7 +304,6 @@ func (d *DriverMock) AddToInstanceMetadata(zone string, name string, metadata ma
 	if resultCh == nil {
 		ch := make(chan error)
 		close(ch)
-		resultCh = ch
 	}
 
 	return nil

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -295,7 +295,7 @@ func (d *DriverMock) DeleteOSLoginSSHKey(user, fingerprint string) error {
 	return nil
 }
 
-func (d *DriverMock) AddToInstanceMetadata(zone string, name string, metadata map[string]string) (<-chan error, error) {
+func (d *DriverMock) AddToInstanceMetadata(zone string, name string, metadata map[string]string) error {
 	d.AddToInstanceMetadataZone = zone
 	d.AddToInstanceMetadataName = name
 	d.AddToInstanceMetadataKVPairs = metadata
@@ -307,5 +307,5 @@ func (d *DriverMock) AddToInstanceMetadata(zone string, name string, metadata ma
 		resultCh = ch
 	}
 
-	return resultCh, d.AddToInstanceMetadataErr
+	return nil
 }

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -88,6 +88,12 @@ type DriverMock struct {
 	WaitForInstanceZone  string
 	WaitForInstanceName  string
 	WaitForInstanceErrCh <-chan error
+
+	AddToInstanceMetadataZone    string
+	AddToInstanceMetadataName    string
+	AddToInstanceMetadataKVPairs map[string]string
+	AddToInstanceMetadataErrCh   <-chan error
+	AddToInstanceMetadataErr   error
 }
 
 func (d *DriverMock) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
@@ -287,4 +293,19 @@ func (d *DriverMock) ImportOSLoginSSHKey(user, key string) (*oslogin.LoginProfil
 
 func (d *DriverMock) DeleteOSLoginSSHKey(user, fingerprint string) error {
 	return nil
+}
+
+func (d *DriverMock) AddToInstanceMetadata(zone string, name string, metadata map[string]string) (<-chan error, error) {
+	d.AddToInstanceMetadataZone    = zone
+	d.AddToInstanceMetadataName    = name
+	d.AddToInstanceMetadataKVPairs = metadata
+
+	resultCh := d.AddToInstanceMetadataErrCh
+	if resultCh == nil {
+		ch := make(chan error)
+		close(ch)
+		resultCh = ch
+	}
+
+	return resultCh, d.AddToInstanceMetadataErr
 }

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -93,7 +93,7 @@ type DriverMock struct {
 	AddToInstanceMetadataName    string
 	AddToInstanceMetadataKVPairs map[string]string
 	AddToInstanceMetadataErrCh   <-chan error
-	AddToInstanceMetadataErr   error
+	AddToInstanceMetadataErr     error
 }
 
 func (d *DriverMock) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
@@ -296,8 +296,8 @@ func (d *DriverMock) DeleteOSLoginSSHKey(user, fingerprint string) error {
 }
 
 func (d *DriverMock) AddToInstanceMetadata(zone string, name string, metadata map[string]string) (<-chan error, error) {
-	d.AddToInstanceMetadataZone    = zone
-	d.AddToInstanceMetadataName    = name
+	d.AddToInstanceMetadataZone = zone
+	d.AddToInstanceMetadataName = name
 	d.AddToInstanceMetadataKVPairs = metadata
 
 	resultCh := d.AddToInstanceMetadataErrCh

--- a/builder/googlecompute/startup.go
+++ b/builder/googlecompute/startup.go
@@ -1,7 +1,7 @@
 package googlecompute
 
 import (
-	"fmt"
+  "fmt"
 )
 
 const StartupScriptKey string = "startup-script"

--- a/builder/googlecompute/startup.go
+++ b/builder/googlecompute/startup.go
@@ -1,7 +1,7 @@
 package googlecompute
 
 import (
-  "fmt"
+	"fmt"
 )
 
 const StartupScriptKey string = "startup-script"

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"strings"
 	"time"
-	"log"
 
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep"
@@ -142,7 +142,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 
 	var errCh <-chan error
 	metadataNoSSHKeys := make(map[string]string)
-	metadataSSHKeys := make(map[string]string)	
+	metadataSSHKeys := make(map[string]string)
 	metadataForInstance := make(map[string]string)
 
 	metadataNoSSHKeys, metadataSSHKeys, errs := c.createInstanceMetadata(sourceImage, string(c.Comm.SSHPublicKey))
@@ -160,7 +160,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 
 		// Union of both non-SSH key meta data and SSH key meta data
 		addmap(metadataForInstance, metadataSSHKeys)
-		addmap(metadataForInstance, metadataNoSSHKeys)		
+		addmap(metadataForInstance, metadataNoSSHKeys)
 	}
 
 	errCh, err = d.RunInstance(&InstanceConfig{
@@ -230,9 +230,9 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		if cancelled {
 			return multistep.ActionHalt
 		}
-		
+
 		log.Printf("[DEBUG] %s wait is over. Adding SSH keys to existing instance...",
-				c.WaitToAddSSHKeys.String())
+			c.WaitToAddSSHKeys.String())
 		errCh, err = d.AddToInstanceMetadata(c.Zone, name, metadataSSHKeys)
 
 		if err != nil {
@@ -241,7 +241,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 			return multistep.ActionHalt
 		}
 	}
-	
+
 	return multistep.ActionContinue
 }
 
@@ -252,7 +252,7 @@ func (s *StepCreateInstance) waitForBoot(ctx context.Context, waitLen time.Durat
 		return true
 	case <-time.After(waitLen):
 	}
-	
+
 	return false
 }
 
@@ -316,7 +316,7 @@ func (s *StepCreateInstance) Cleanup(state multistep.StateBag) {
 }
 
 func addmap(a map[string]string, b map[string]string) {
-	for k,v := range b {
+	for k, v := range b {
 		a[k] = v
 	}
 }

--- a/builder/googlecompute/step_create_instance_test.go
+++ b/builder/googlecompute/step_create_instance_test.go
@@ -337,7 +337,7 @@ func TestCreateInstanceMetadata_metadataFile(t *testing.T) {
 	c.MetadataFiles["user-data"] = fileName
 
 	// create our metadata
-	metadataNoSSHKeys, _,err := c.createInstanceMetadata(image, "")
+	metadataNoSSHKeys, _, err := c.createInstanceMetadata(image, "")
 
 	assert.True(t, err == nil, "Metadata creation should have succeeded.")
 
@@ -391,14 +391,14 @@ func TestCreateInstanceMetadataWaitToAddSSHKeys(t *testing.T) {
 	c := state.Get("config").(*Config)
 	image := StubImage("test-image", "test-project", []string{}, 100)
 	key := "abcdefgh12345678"
-	
+
 	var waitTime int = 4
 	c.WaitToAddSSHKeys = time.Duration(waitTime) * time.Second
 	c.Metadata = map[string]string{
 		"metadatakey1": "xyz",
 		"metadatakey2": "123",
 	}
-	
+
 	// create our metadata
 	metadataNoSSHKeys, metadataSSHKeys, err := c.createInstanceMetadata(image, key)
 
@@ -406,8 +406,8 @@ func TestCreateInstanceMetadataWaitToAddSSHKeys(t *testing.T) {
 
 	// ensure our metadata is listed
 	assert.True(t, strings.Contains(metadataSSHKeys["ssh-keys"], key), "Instance metadata should contain provided SSH key")
-	assert.True(t, strings.Contains(metadataNoSSHKeys["metadatakey1"], "xyz"), "Instance metadata should contain provided key: metadatakey1")	
-	assert.True(t, strings.Contains(metadataNoSSHKeys["metadatakey2"], "123"), "Instance metadata should contain provided key: metadatakey2")	
+	assert.True(t, strings.Contains(metadataNoSSHKeys["metadatakey1"], "xyz"), "Instance metadata should contain provided key: metadatakey1")
+	assert.True(t, strings.Contains(metadataNoSSHKeys["metadatakey2"], "123"), "Instance metadata should contain provided key: metadatakey2")
 }
 
 func TestStepCreateInstanceWaitToAddSSHKeys(t *testing.T) {
@@ -422,7 +422,7 @@ func TestStepCreateInstanceWaitToAddSSHKeys(t *testing.T) {
 	d.GetImageResult = StubImage("test-image", "test-project", []string{}, 100)
 
 	key := "abcdefgh12345678"
-	
+
 	var waitTime int = 5
 	c.WaitToAddSSHKeys = time.Duration(waitTime) * time.Second
 	c.Comm.SSHPublicKey = []byte(key)
@@ -455,14 +455,14 @@ func TestStepCreateInstanceNoWaitToAddSSHKeys(t *testing.T) {
 	d.GetImageResult = StubImage("test-image", "test-project", []string{}, 100)
 
 	key := "abcdefgh12345678"
-	
+
 	c.Comm.SSHPublicKey = []byte(key)
 
 	c.Metadata = map[string]string{
 		"metadatakey1": "xyz",
 		"metadatakey2": "123",
 	}
-	
+
 	// run the step
 	assert.Equal(t, step.Run(context.Background(), state), multistep.ActionContinue, "Step should have passed and continued.")
 

--- a/website/pages/partials/builder/googlecompute/Config-not-required.mdx
+++ b/website/pages/partials/builder/googlecompute/Config-not-required.mdx
@@ -241,3 +241,12 @@
   instance. For more information, see the Vault docs:
   https://www.vaultproject.io/docs/commands/#environment-variables
   Example:`"vault_gcp_oauth_engine": "gcp/token/my-project-editor",`
+
+- `wait_to_add_ssh_keys` (duration string | ex: "1h5m2s") - The time to wait between the creation of the instance used to create the image,
+  and the addition of SSH configuration, including SSH keys, to that instance.
+  The delay is intended to protect packer from anything in the instance boot
+  sequence that has potential to disrupt the creation of SSH configuration
+  (e.g. SSH user creation, SSH key creation) on the instance.
+  Note: All other instance metadata, including startup scripts, are still added to the instance
+  during it's creation.
+  Example value: `5m`.


### PR DESCRIPTION
Adds a switch called wait_to_add_ssh_keys=20m. We will separate the packer instance creation into three steps:-

a) Create the packer instance WITHOUT SSH keys
b) sleep for the wait_to_add_ssh_keys interval. Configured to be a suitable time interval to allow the GCEGuestAgent to stabilise.
c) Add the SSH keys to the running packer instance

- https://github.com/seventieskid/packer/blob/master/builder/googlecompute/step_create_instance_test.goL389-475

Closes #10312
