### PR TITLE
WaitForIP should not return an error if an IP is not found

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -658,7 +658,8 @@ func (vm *VirtualMachineDriver) WaitForIP(ctx context.Context, ipNet *net.IPNet)
 		}
 	}
 
-	return "", fmt.Errorf("unable to find an IP")
+	// unable to find an IP
+	return "", nil
 }
 
 func (vm *VirtualMachineDriver) PowerOff() error {


### PR DESCRIPTION
Closes #10236

