### PR TITLE
extract builder interface to sdk

### DIFF
--- a/builder/alicloud/ecs/builder.go
+++ b/builder/alicloud/ecs/builder.go
@@ -1,6 +1,6 @@
 //go:generate mapstructure-to-hcl2 -type Config,AlicloudDiskDevice
 
-// The alicloud  contains a packer.Builder implementation that
+// The alicloud  contains a packersdk.Builder implementation that
 // builds ecs images for alicloud.
 package ecs
 

--- a/builder/alicloud/ecs/builder_test.go
+++ b/builder/alicloud/ecs/builder_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	helperconfig "github.com/hashicorp/packer/packer-plugin-sdk/template/config"
 )
 
@@ -24,7 +24,7 @@ func testBuilderConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/amazon/chroot/builder_test.go
+++ b/builder/amazon/chroot/builder_test.go
@@ -3,7 +3,7 @@ package chroot
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -19,7 +19,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/amazon/ebs/acceptance/builder_acceptance.go
+++ b/builder/amazon/ebs/acceptance/builder_acceptance.go
@@ -12,6 +12,7 @@ import (
 	amazonebsbuilder "github.com/hashicorp/packer/builder/amazon/ebs"
 
 	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 
 	testshelper "github.com/hashicorp/packer/helper/tests"
 )
@@ -56,6 +57,6 @@ func (s *AmazonEBSAccTest) CleanUp() error {
 
 func (s *AmazonEBSAccTest) GetBuilderStore() packer.MapOfBuilder {
 	return packer.MapOfBuilder{
-		"amazon-ebs": func() (packer.Builder, error) { return &amazonebsbuilder.Builder{}, nil },
+		"amazon-ebs": func() (packersdk.Builder, error) { return &amazonebsbuilder.Builder{}, nil },
 	}
 }

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -1,7 +1,7 @@
 //go:generate struct-markdown
 //go:generate mapstructure-to-hcl2 -type Config
 
-// The amazonebs package contains a packer.Builder implementation that
+// The amazonebs package contains a packersdk.Builder implementation that
 // builds AMIs for Amazon EC2.
 //
 // In general, there are two types of AMIs that can be created: ebs-backed or

--- a/builder/amazon/ebs/builder_test.go
+++ b/builder/amazon/ebs/builder_test.go
@@ -3,7 +3,7 @@ package ebs
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -21,7 +21,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/amazon/ebssurrogate/builder.go
+++ b/builder/amazon/ebssurrogate/builder.go
@@ -1,7 +1,7 @@
 //go:generate struct-markdown
 //go:generate mapstructure-to-hcl2 -type Config,RootBlockDevice,BlockDevice
 
-// The ebssurrogate package contains a packer.Builder implementation that
+// The ebssurrogate package contains a packersdk.Builder implementation that
 // builds a new EBS-backed AMI using an ephemeral instance.
 package ebssurrogate
 

--- a/builder/amazon/ebssurrogate/builder_test.go
+++ b/builder/amazon/ebssurrogate/builder_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/packer/builder/amazon/common"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -22,7 +22,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatal("Builder should be a builder")
 	}
 }

--- a/builder/amazon/ebsvolume/builder.go
+++ b/builder/amazon/ebsvolume/builder.go
@@ -1,7 +1,7 @@
 //go:generate struct-markdown
 //go:generate mapstructure-to-hcl2 -type Config,BlockDevice
 
-// The ebsvolume package contains a packer.Builder implementation that builds
+// The ebsvolume package contains a packersdk.Builder implementation that builds
 // EBS volumes for Amazon EC2 using an ephemeral instance,
 package ebsvolume
 

--- a/builder/amazon/ebsvolume/builder_test.go
+++ b/builder/amazon/ebsvolume/builder_test.go
@@ -3,7 +3,7 @@ package ebsvolume
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -20,7 +20,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/amazon/instance/builder.go
+++ b/builder/amazon/instance/builder.go
@@ -1,7 +1,7 @@
 //go:generate struct-markdown
 //go:generate mapstructure-to-hcl2 -type Config
 
-// The instance package contains a packer.Builder implementation that builds
+// The instance package contains a packersdk.Builder implementation that builds
 // AMIs for Amazon EC2 backed by instance storage, as opposed to EBS storage.
 package instance
 

--- a/builder/amazon/instance/builder_test.go
+++ b/builder/amazon/instance/builder_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() (config map[string]interface{}, tf *os.File) {
@@ -33,7 +33,7 @@ func testConfig() (config map[string]interface{}, tf *os.File) {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/azure/chroot/builder.go
+++ b/builder/azure/chroot/builder.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hcldec"
 	azcommon "github.com/hashicorp/packer/builder/azure/common"
 	"github.com/hashicorp/packer/builder/azure/common/client"
-	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/chroot"
 	"github.com/hashicorp/packer/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep"
@@ -146,7 +145,7 @@ type Builder struct {
 }
 
 // verify interface implementation
-var _ packer.Builder = &Builder{}
+var _ packersdk.Builder = &Builder{}
 
 func (b *Builder) ConfigSpec() hcldec.ObjectSpec { return b.config.FlatMapstructure().HCL2Spec() }
 

--- a/builder/cloudstack/builder.go
+++ b/builder/cloudstack/builder.go
@@ -32,7 +32,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	return nil, nil, nil
 }
 
-// Run implements the packer.Builder interface.
+// Run implements the packersdk.Builder interface.
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook) (packersdk.Artifact, error) {
 	b.ui = ui
 

--- a/builder/cloudstack/builder_test.go
+++ b/builder/cloudstack/builder_test.go
@@ -3,14 +3,14 @@ package cloudstack
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_Impl(t *testing.T) {
 	var raw interface{} = &Builder{}
 
-	if _, ok := raw.(packer.Builder); !ok {
-		t.Fatalf("Builder does not implement packer.Builder")
+	if _, ok := raw.(packersdk.Builder); !ok {
+		t.Fatalf("Builder does not implement packersdk.Builder")
 	}
 }
 

--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -1,4 +1,4 @@
-// The digitalocean package contains a packer.Builder implementation
+// The digitalocean package contains a packersdk.Builder implementation
 // that builds DigitalOcean images (snapshots).
 
 package digitalocean

--- a/builder/digitalocean/builder_test.go
+++ b/builder/digitalocean/builder_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -21,7 +21,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/docker/builder_test.go
+++ b/builder/docker/builder_test.go
@@ -3,9 +3,9 @@ package docker
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_implBuilder(t *testing.T) {
-	var _ packer.Builder = new(Builder)
+	var _ packersdk.Builder = new(Builder)
 }

--- a/builder/file/builder_test.go
+++ b/builder/file/builder_test.go
@@ -6,12 +6,11 @@ import (
 	"testing"
 
 	builderT "github.com/hashicorp/packer/helper/builder/testing"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_implBuilder(t *testing.T) {
-	var _ packer.Builder = new(Builder)
+	var _ packersdk.Builder = new(Builder)
 }
 
 func TestBuilderFileAcc_content(t *testing.T) {

--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -1,4 +1,4 @@
-// The googlecompute package contains a packer.Builder implementation that
+// The googlecompute package contains a packersdk.Builder implementation that
 // builds images for Google Compute Engine.
 package googlecompute
 

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -45,7 +45,7 @@ const (
 	DefaultPassword = ""
 )
 
-// Builder implements packer.Builder and builds the actual Hyperv
+// Builder implements packersdk.Builder and builds the actual Hyperv
 // images.
 type Builder struct {
 	config Config

--- a/builder/hyperv/iso/builder_test.go
+++ b/builder/hyperv/iso/builder_test.go
@@ -33,7 +33,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Error("Builder must implement builder.")
 	}
 }

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -36,7 +36,7 @@ const (
 	DefaultPassword = ""
 )
 
-// Builder implements packer.Builder and builds the actual Hyperv
+// Builder implements packersdk.Builder and builds the actual Hyperv
 // images.
 type Builder struct {
 	config Config

--- a/builder/hyperv/vmcx/builder_test.go
+++ b/builder/hyperv/vmcx/builder_test.go
@@ -32,7 +32,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Error("Builder must implement builder.")
 	}
 }

--- a/builder/linode/builder.go
+++ b/builder/linode/builder.go
@@ -1,4 +1,4 @@
-// The linode package contains a packer.Builder implementation
+// The linode package contains a packersdk.Builder implementation
 // that builds Linode images.
 package linode
 

--- a/builder/linode/builder_test.go
+++ b/builder/linode/builder_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -21,7 +21,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/lxc/builder_test.go
+++ b/builder/lxc/builder_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -50,7 +50,7 @@ func TestBuilderPrepare_ConfigFile(t *testing.T) {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/lxd/builder_test.go
+++ b/builder/lxd/builder_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -71,7 +71,7 @@ func TestBuilderPrepare_ConfigFile(t *testing.T) {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/ncloud/builder.go
+++ b/builder/ncloud/builder.go
@@ -11,7 +11,7 @@ import (
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-// Builder assume this implements packer.Builder
+// Builder assume this implements packersdk.Builder
 type Builder struct {
 	config   Config
 	stateBag multistep.StateBag

--- a/builder/null/builder_test.go
+++ b/builder/null/builder_test.go
@@ -3,9 +3,9 @@ package null
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_implBuilder(t *testing.T) {
-	var _ packer.Builder = new(Builder)
+	var _ packersdk.Builder = new(Builder)
 }

--- a/builder/oneandone/builder_test.go
+++ b/builder/oneandone/builder_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -19,7 +19,7 @@ func testConfig() map[string]interface{} {
 func TestImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -1,6 +1,6 @@
 //go:generate mapstructure-to-hcl2 -type Config,ImageFilter,ImageFilterOptions
 
-// The openstack package contains a packer.Builder implementation that
+// The openstack package contains a packersdk.Builder implementation that
 // builds Images for openstack.
 
 package openstack

--- a/builder/openstack/builder_test.go
+++ b/builder/openstack/builder_test.go
@@ -3,13 +3,13 @@ package openstack
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/oracle/oci/builder.go
+++ b/builder/oracle/oci/builder.go
@@ -1,4 +1,4 @@
-// Package oci contains a packer.Builder implementation that builds Oracle
+// Package oci contains a packersdk.Builder implementation that builds Oracle
 // Bare Metal Cloud Services (OCI) images.
 package oci
 

--- a/builder/oracle/oci/builder_test.go
+++ b/builder/oracle/oci/builder_test.go
@@ -3,13 +3,13 @@ package oci
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/osc/bsu/builder.go
+++ b/builder/osc/bsu/builder.go
@@ -1,6 +1,6 @@
 //go:generate mapstructure-to-hcl2 -type Config
 
-// Package bsu contains a packer.Builder implementation that
+// Package bsu contains a packersdk.Builder implementation that
 // builds OMIs for Outscale OAPI.
 //
 // In general, there are two types of OMIs that can be created: ebs-backed or

--- a/builder/osc/bsu/builder_test.go
+++ b/builder/osc/bsu/builder_test.go
@@ -3,7 +3,7 @@ package bsu
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -21,7 +21,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/osc/bsusurrogate/builder.go
+++ b/builder/osc/bsusurrogate/builder.go
@@ -1,6 +1,6 @@
 //go:generate mapstructure-to-hcl2 -type Config,RootBlockDevice
 
-// Package bsusurrogate contains a packer.Builder implementation that
+// Package bsusurrogate contains a packersdk.Builder implementation that
 // builds a new EBS-backed OMI using an ephemeral instance.
 package bsusurrogate
 

--- a/builder/osc/bsusurrogate/builder_test.go
+++ b/builder/osc/bsusurrogate/builder_test.go
@@ -3,13 +3,13 @@ package bsusurrogate
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatal("Builder should be a builder")
 	}
 }

--- a/builder/osc/bsuvolume/builder.go
+++ b/builder/osc/bsuvolume/builder.go
@@ -1,6 +1,6 @@
 //go:generate mapstructure-to-hcl2 -type Config,BlockDevice
 
-// The ebsvolume package contains a packer.Builder implementation that
+// The ebsvolume package contains a packersdk.Builder implementation that
 // builds EBS volumes for Outscale using an ephemeral instance,
 package bsuvolume
 

--- a/builder/osc/bsuvolume/builder_test.go
+++ b/builder/osc/bsuvolume/builder_test.go
@@ -3,7 +3,7 @@ package bsuvolume
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -20,7 +20,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/parallels/iso/builder_test.go
+++ b/builder/parallels/iso/builder_test.go
@@ -24,7 +24,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Error("Builder must implement builder.")
 	}
 }

--- a/builder/parallels/pvm/builder.go
+++ b/builder/parallels/pvm/builder.go
@@ -13,7 +13,7 @@ import (
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-// Builder implements packer.Builder and builds the actual Parallels
+// Builder implements packersdk.Builder and builds the actual Parallels
 // images.
 type Builder struct {
 	config Config

--- a/builder/profitbricks/builder_test.go
+++ b/builder/profitbricks/builder_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -20,7 +20,7 @@ func testConfig() map[string]interface{} {
 func TestImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/proxmox/clone/builder.go
+++ b/builder/proxmox/clone/builder.go
@@ -4,7 +4,6 @@ import (
 	proxmoxapi "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	proxmox "github.com/hashicorp/packer/builder/proxmox/common"
-	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 
@@ -19,8 +18,8 @@ type Builder struct {
 	config Config
 }
 
-// Builder implements packer.Builder
-var _ packer.Builder = &Builder{}
+// Builder implements packersdk.Builder
+var _ packersdk.Builder = &Builder{}
 
 func (b *Builder) ConfigSpec() hcldec.ObjectSpec { return b.config.FlatMapstructure().HCL2Spec() }
 

--- a/builder/proxmox/iso/builder.go
+++ b/builder/proxmox/iso/builder.go
@@ -6,7 +6,6 @@ import (
 	proxmoxapi "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	proxmox "github.com/hashicorp/packer/builder/proxmox/common"
-	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep/commonsteps"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
@@ -19,8 +18,8 @@ type Builder struct {
 	config Config
 }
 
-// Builder implements packer.Builder
-var _ packer.Builder = &Builder{}
+// Builder implements packersdk.Builder
+var _ packersdk.Builder = &Builder{}
 
 func (b *Builder) ConfigSpec() hcldec.ObjectSpec { return b.config.FlatMapstructure().HCL2Spec() }
 

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -3,13 +3,13 @@ package qemu
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Error("Builder must implement builder.")
 	}
 }

--- a/builder/scaleway/builder.go
+++ b/builder/scaleway/builder.go
@@ -1,4 +1,4 @@
-// The scaleway package contains a packer.Builder implementation
+// The scaleway package contains a packersdk.Builder implementation
 // that builds Scaleway images (snapshots).
 
 package scaleway

--- a/builder/scaleway/builder_test.go
+++ b/builder/scaleway/builder_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -22,7 +22,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/ucloud/uhost/builder.go
+++ b/builder/ucloud/uhost/builder.go
@@ -1,6 +1,6 @@
 //go:generate mapstructure-to-hcl2 -type Config
 
-// The ucloud-uhost contains a packer.Builder implementation that
+// The ucloud-uhost contains a packersdk.Builder implementation that
 // builds uhost images for UCloud UHost instance.
 package uhost
 

--- a/builder/ucloud/uhost/builder_test.go
+++ b/builder/ucloud/uhost/builder_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	ucloudcommon "github.com/hashicorp/packer/builder/ucloud/common"
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testBuilderConfig() map[string]interface{} {
@@ -25,7 +25,7 @@ func testBuilderConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/packer/packer-plugin-sdk/template/interpolate"
 )
 
-// Builder implements packer.Builder and builds the actual VirtualBox
+// Builder implements packersdk.Builder and builds the actual VirtualBox
 // images.
 type Builder struct {
 	config Config

--- a/builder/vagrant/builder_test.go
+++ b/builder/vagrant/builder_test.go
@@ -3,13 +3,13 @@ package vagrant
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/virtualbox/iso/acceptance/builder_acceptance.go
+++ b/builder/virtualbox/iso/acceptance/builder_acceptance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/packer/builder/virtualbox/iso"
 
 	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 
 	testshelper "github.com/hashicorp/packer/helper/tests"
 )
@@ -41,6 +42,6 @@ func (v *VirtualBoxISOAccTest) CleanUp() error {
 
 func (v *VirtualBoxISOAccTest) GetBuilderStore() packer.MapOfBuilder {
 	return packer.MapOfBuilder{
-		"virtualbox-iso": func() (packer.Builder, error) { return &iso.Builder{}, nil },
+		"virtualbox-iso": func() (packersdk.Builder, error) { return &iso.Builder{}, nil },
 	}
 }

--- a/builder/virtualbox/iso/builder_test.go
+++ b/builder/virtualbox/iso/builder_test.go
@@ -24,7 +24,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Error("Builder must implement builder.")
 	}
 }

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -13,7 +13,7 @@ import (
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-// Builder implements packer.Builder and builds the actual VirtualBox
+// Builder implements packersdk.Builder and builds the actual VirtualBox
 // images.
 type Builder struct {
 	config Config

--- a/builder/virtualbox/vm/builder.go
+++ b/builder/virtualbox/vm/builder.go
@@ -13,7 +13,7 @@ import (
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-// Builder implements packer.Builder and builds the actual VirtualBox
+// Builder implements packersdk.Builder and builds the actual VirtualBox
 // images.
 type Builder struct {
 	config Config

--- a/builder/vmware/iso/builder_test.go
+++ b/builder/vmware/iso/builder_test.go
@@ -25,7 +25,7 @@ func testConfig() map[string]interface{} {
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Error("Builder must implement builder.")
 	}
 }

--- a/builder/vmware/iso/step_create_vmx_test.go
+++ b/builder/vmware/iso/step_create_vmx_test.go
@@ -139,7 +139,7 @@ func setupVMwareBuild(t *testing.T, builderConfig map[string]string, provisioner
 	// create our config to test the vmware-iso builder
 	components := packer.ComponentFinder{
 		BuilderStore: packer.MapOfBuilder{
-			"vmware-iso": func() (packer.Builder, error) { return &Builder{}, nil },
+			"vmware-iso": func() (packersdk.Builder, error) { return &Builder{}, nil },
 		},
 		Hook: func(n string) (packersdk.Hook, error) {
 			return &packersdk.DispatchHook{}, nil

--- a/builder/vmware/iso/step_create_vmx_test.go
+++ b/builder/vmware/iso/step_create_vmx_test.go
@@ -145,7 +145,7 @@ func setupVMwareBuild(t *testing.T, builderConfig map[string]string, provisioner
 			return &packersdk.DispatchHook{}, nil
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
-			"shell": func() (packer.Provisioner, error) { return &shell.Provisioner{}, nil },
+			"shell": func() (packersdk.Provisioner, error) { return &shell.Provisioner{}, nil },
 		},
 		PostProcessorStore: packer.MapOfPostProcessor{
 			"something": func() (packer.PostProcessor, error) { return &packer.MockPostProcessor{}, nil },

--- a/builder/vmware/iso/step_create_vmx_test.go
+++ b/builder/vmware/iso/step_create_vmx_test.go
@@ -148,7 +148,7 @@ func setupVMwareBuild(t *testing.T, builderConfig map[string]string, provisioner
 			"shell": func() (packersdk.Provisioner, error) { return &shell.Provisioner{}, nil },
 		},
 		PostProcessorStore: packer.MapOfPostProcessor{
-			"something": func() (packer.PostProcessor, error) { return &packer.MockPostProcessor{}, nil },
+			"something": func() (packersdk.PostProcessor, error) { return &packer.MockPostProcessor{}, nil },
 		},
 	}
 	config := packer.CoreConfig{

--- a/builder/vmware/vmx/builder.go
+++ b/builder/vmware/vmx/builder.go
@@ -15,7 +15,7 @@ import (
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-// Builder implements packer.Builder and builds the actual VMware
+// Builder implements packersdk.Builder and builds the actual VMware
 // images.
 type Builder struct {
 	config Config

--- a/builder/vsphere/clone/builder_test.go
+++ b/builder/vsphere/clone/builder_test.go
@@ -3,13 +3,13 @@ package clone
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestCloneBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{}
 	raw = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/builder/yandex/builder_test.go
+++ b/builder/yandex/builder_test.go
@@ -3,12 +3,12 @@ package yandex
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
 	var raw interface{} = &Builder{}
-	if _, ok := raw.(packer.Builder); !ok {
+	if _, ok := raw.(packersdk.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}
 }

--- a/command/build_parallel_test.go
+++ b/command/build_parallel_test.go
@@ -69,9 +69,9 @@ func testMetaParallel(t *testing.T, builder *ParallelTestBuilder, locked *Locked
 		CoreConfig: &packer.CoreConfig{
 			Components: packer.ComponentFinder{
 				BuilderStore: packer.MapOfBuilder{
-					"parallel-test": func() (packer.Builder, error) { return builder, nil },
-					"file":          func() (packer.Builder, error) { return &file.Builder{}, nil },
-					"lock":          func() (packer.Builder, error) { return locked, nil },
+					"parallel-test": func() (packersdk.Builder, error) { return builder, nil },
+					"file":          func() (packersdk.Builder, error) { return &file.Builder{}, nil },
+					"lock":          func() (packersdk.Builder, error) { return locked, nil },
 				},
 				ProvisionerStore: packer.MapOfProvisioner{
 					"sleep": func() (packer.Provisioner, error) { return &sleep.Provisioner{}, nil },

--- a/command/build_parallel_test.go
+++ b/command/build_parallel_test.go
@@ -74,7 +74,7 @@ func testMetaParallel(t *testing.T, builder *ParallelTestBuilder, locked *Locked
 					"lock":          func() (packersdk.Builder, error) { return locked, nil },
 				},
 				ProvisionerStore: packer.MapOfProvisioner{
-					"sleep": func() (packer.Provisioner, error) { return &sleep.Provisioner{}, nil },
+					"sleep": func() (packersdk.Provisioner, error) { return &sleep.Provisioner{}, nil },
 				},
 			},
 		},

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -846,8 +846,8 @@ func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {
 			"file":        func() (packersdk.Provisioner, error) { return &filep.Provisioner{}, nil },
 		},
 		PostProcessorStore: packer.MapOfPostProcessor{
-			"shell-local": func() (packer.PostProcessor, error) { return &shell_local_pp.PostProcessor{}, nil },
-			"manifest":    func() (packer.PostProcessor, error) { return &manifest.PostProcessor{}, nil },
+			"shell-local": func() (packersdk.PostProcessor, error) { return &shell_local_pp.PostProcessor{}, nil },
+			"manifest":    func() (packersdk.PostProcessor, error) { return &manifest.PostProcessor{}, nil },
 		},
 	}
 	return &packer.CoreConfig{

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -837,8 +837,8 @@ func fileExists(filename string) bool {
 func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {
 	components := packer.ComponentFinder{
 		BuilderStore: packer.MapOfBuilder{
-			"file": func() (packer.Builder, error) { return &file.Builder{}, nil },
-			"null": func() (packer.Builder, error) { return &null.Builder{}, nil },
+			"file": func() (packersdk.Builder, error) { return &file.Builder{}, nil },
+			"null": func() (packersdk.Builder, error) { return &null.Builder{}, nil },
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
 			"shell-local": func() (packer.Provisioner, error) { return &shell_local.Provisioner{}, nil },

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -841,9 +841,9 @@ func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {
 			"null": func() (packersdk.Builder, error) { return &null.Builder{}, nil },
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
-			"shell-local": func() (packer.Provisioner, error) { return &shell_local.Provisioner{}, nil },
-			"shell":       func() (packer.Provisioner, error) { return &shell.Provisioner{}, nil },
-			"file":        func() (packer.Provisioner, error) { return &filep.Provisioner{}, nil },
+			"shell-local": func() (packersdk.Provisioner, error) { return &shell_local.Provisioner{}, nil },
+			"shell":       func() (packersdk.Provisioner, error) { return &shell.Provisioner{}, nil },
+			"file":        func() (packersdk.Provisioner, error) { return &filep.Provisioner{}, nil },
 		},
 		PostProcessorStore: packer.MapOfPostProcessor{
 			"shell-local": func() (packer.PostProcessor, error) { return &shell_local_pp.PostProcessor{}, nil },

--- a/command/build_timeout_test.go
+++ b/command/build_timeout_test.go
@@ -17,7 +17,7 @@ import (
 func testCoreConfigSleepBuilder(t *testing.T) *packer.CoreConfig {
 	components := packer.ComponentFinder{
 		BuilderStore: packer.MapOfBuilder{
-			"file": func() (packer.Builder, error) { return &file.Builder{}, nil },
+			"file": func() (packersdk.Builder, error) { return &file.Builder{}, nil },
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
 			"sleep":       func() (packer.Provisioner, error) { return &sleep.Provisioner{}, nil },

--- a/command/build_timeout_test.go
+++ b/command/build_timeout_test.go
@@ -20,8 +20,8 @@ func testCoreConfigSleepBuilder(t *testing.T) *packer.CoreConfig {
 			"file": func() (packersdk.Builder, error) { return &file.Builder{}, nil },
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
-			"sleep":       func() (packer.Provisioner, error) { return &sleep.Provisioner{}, nil },
-			"shell-local": func() (packer.Provisioner, error) { return &shell_local.Provisioner{}, nil },
+			"sleep":       func() (packersdk.Provisioner, error) { return &sleep.Provisioner{}, nil },
+			"shell-local": func() (packersdk.Provisioner, error) { return &shell_local.Provisioner{}, nil },
 		},
 	}
 	return &packer.CoreConfig{

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -119,9 +119,9 @@ func commandMeta() Meta {
 func getBareComponentFinder() packer.ComponentFinder {
 	return packer.ComponentFinder{
 		BuilderStore: packer.MapOfBuilder{
-			"file":       func() (packer.Builder, error) { return &file.Builder{}, nil },
-			"null":       func() (packer.Builder, error) { return &null.Builder{}, nil },
-			"amazon-ebs": func() (packer.Builder, error) { return &ebs.Builder{}, nil },
+			"file":       func() (packersdk.Builder, error) { return &file.Builder{}, nil },
+			"null":       func() (packersdk.Builder, error) { return &null.Builder{}, nil },
+			"amazon-ebs": func() (packersdk.Builder, error) { return &ebs.Builder{}, nil },
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
 			"shell-local": func() (packer.Provisioner, error) { return &shell_local.Provisioner{}, nil },

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -124,9 +124,9 @@ func getBareComponentFinder() packer.ComponentFinder {
 			"amazon-ebs": func() (packersdk.Builder, error) { return &ebs.Builder{}, nil },
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
-			"shell-local": func() (packer.Provisioner, error) { return &shell_local.Provisioner{}, nil },
-			"shell":       func() (packer.Provisioner, error) { return &shell.Provisioner{}, nil },
-			"file":        func() (packer.Provisioner, error) { return &filep.Provisioner{}, nil },
+			"shell-local": func() (packersdk.Provisioner, error) { return &shell_local.Provisioner{}, nil },
+			"shell":       func() (packersdk.Provisioner, error) { return &shell.Provisioner{}, nil },
+			"file":        func() (packersdk.Provisioner, error) { return &filep.Provisioner{}, nil },
 		},
 		PostProcessorStore: packer.MapOfPostProcessor{
 			"shell-local": func() (packer.PostProcessor, error) { return &shell_local_pp.PostProcessor{}, nil },

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -129,8 +129,8 @@ func getBareComponentFinder() packer.ComponentFinder {
 			"file":        func() (packersdk.Provisioner, error) { return &filep.Provisioner{}, nil },
 		},
 		PostProcessorStore: packer.MapOfPostProcessor{
-			"shell-local": func() (packer.PostProcessor, error) { return &shell_local_pp.PostProcessor{}, nil },
-			"manifest":    func() (packer.PostProcessor, error) { return &manifest.PostProcessor{}, nil },
+			"shell-local": func() (packersdk.PostProcessor, error) { return &shell_local_pp.PostProcessor{}, nil },
+			"manifest":    func() (packersdk.PostProcessor, error) { return &manifest.PostProcessor{}, nil },
 		},
 	}
 }

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/packer/plugin"
 
@@ -188,7 +187,7 @@ var Provisioners = map[string]packersdk.Provisioner{
 	"windows-shell":     new(windowsshellprovisioner.Provisioner),
 }
 
-var PostProcessors = map[string]packer.PostProcessor{
+var PostProcessors = map[string]packersdk.PostProcessor{
 	"alicloud-import":      new(alicloudimportpostprocessor.PostProcessor),
 	"amazon-import":        new(amazonimportpostprocessor.PostProcessor),
 	"artifice":             new(artificepostprocessor.PostProcessor),

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -167,7 +167,7 @@ var Builders = map[string]packersdk.Builder{
 	"yandex":              new(yandexbuilder.Builder),
 }
 
-var Provisioners = map[string]packer.Provisioner{
+var Provisioners = map[string]packersdk.Provisioner{
 	"ansible":           new(ansibleprovisioner.Provisioner),
 	"ansible-local":     new(ansiblelocalprovisioner.Provisioner),
 	"azure-dtlartifact": new(azuredtlartifactprovisioner.Provisioner),

--- a/command/plugin.go
+++ b/command/plugin.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/packer/plugin"
 
 	alicloudecsbuilder "github.com/hashicorp/packer/builder/alicloud/ecs"
@@ -111,7 +112,7 @@ type PluginCommand struct {
 	Meta
 }
 
-var Builders = map[string]packer.Builder{
+var Builders = map[string]packersdk.Builder{
 	"alicloud-ecs":        new(alicloudecsbuilder.Builder),
 	"amazon-chroot":       new(amazonchrootbuilder.Builder),
 	"amazon-ebs":          new(amazonebsbuilder.Builder),

--- a/config.go
+++ b/config.go
@@ -103,12 +103,12 @@ func (c *config) loadSingleComponent(path string) (string, error) {
 		}
 	case strings.HasPrefix(pluginName, "packer-post-processor-"):
 		pluginName = pluginName[len("packer-post-processor-"):]
-		c.PostProcessors[pluginName] = func() (packer.PostProcessor, error) {
+		c.PostProcessors[pluginName] = func() (packersdk.PostProcessor, error) {
 			return c.pluginClient(path).PostProcessor()
 		}
 	case strings.HasPrefix(pluginName, "packer-provisioner-"):
 		pluginName = pluginName[len("packer-provisioner-"):]
-		c.Provisioners[pluginName] = func() (packer.Provisioner, error) {
+		c.Provisioners[pluginName] = func() (packersdk.Provisioner, error) {
 			return c.pluginClient(path).Provisioner()
 		}
 	}
@@ -194,16 +194,16 @@ func (c *config) StarHook(name string) (packersdk.Hook, error) {
 	return c.pluginClient(name).Hook()
 }
 
-// This is a proper packer.PostProcessorFunc that can be used to load
-// packer.PostProcessor implementations from defined plugins.
-func (c *config) StartPostProcessor(name string) (packer.PostProcessor, error) {
+// This is a proper packersdk.PostProcessorFunc that can be used to load
+// packersdk.PostProcessor implementations from defined plugins.
+func (c *config) StartPostProcessor(name string) (packersdk.PostProcessor, error) {
 	log.Printf("Loading post-processor: %s", name)
 	return c.PostProcessors.Start(name)
 }
 
 // This is a proper packer.ProvisionerFunc that can be used to load
 // packer.Provisioner implementations from defined plugins.
-func (c *config) StartProvisioner(name string) (packer.Provisioner, error) {
+func (c *config) StartProvisioner(name string) (packersdk.Provisioner, error) {
 	log.Printf("Loading provisioner: %s\n", name)
 	return c.Provisioners.Start(name)
 }
@@ -242,7 +242,7 @@ func (c *config) discoverExternalComponents(path string) error {
 	}
 	for pluginName, pluginPath := range pluginPaths {
 		newPath := pluginPath // this needs to be stored in a new variable for the func below
-		c.PostProcessors[pluginName] = func() (packer.PostProcessor, error) {
+		c.PostProcessors[pluginName] = func() (packersdk.PostProcessor, error) {
 			return c.pluginClient(newPath).PostProcessor()
 		}
 		externallyUsed = append(externallyUsed, pluginName)
@@ -259,7 +259,7 @@ func (c *config) discoverExternalComponents(path string) error {
 	}
 	for pluginName, pluginPath := range pluginPaths {
 		newPath := pluginPath // this needs to be stored in a new variable for the func below
-		c.Provisioners[pluginName] = func() (packer.Provisioner, error) {
+		c.Provisioners[pluginName] = func() (packersdk.Provisioner, error) {
 			return c.pluginClient(newPath).Provisioner()
 		}
 		externallyUsed = append(externallyUsed, pluginName)
@@ -333,7 +333,7 @@ func (c *config) discoverInternalComponents() error {
 		provisioner := provisioner
 		_, found := (c.Provisioners)[provisioner]
 		if !found {
-			c.Provisioners[provisioner] = func() (packer.Provisioner, error) {
+			c.Provisioners[provisioner] = func() (packersdk.Provisioner, error) {
 				bin := fmt.Sprintf("%s%splugin%spacker-provisioner-%s",
 					packerPath, PACKERSPACE, PACKERSPACE, provisioner)
 				return c.pluginClient(bin).Provisioner()
@@ -345,7 +345,7 @@ func (c *config) discoverInternalComponents() error {
 		postProcessor := postProcessor
 		_, found := (c.PostProcessors)[postProcessor]
 		if !found {
-			c.PostProcessors[postProcessor] = func() (packer.PostProcessor, error) {
+			c.PostProcessors[postProcessor] = func() (packersdk.PostProcessor, error) {
 				bin := fmt.Sprintf("%s%splugin%spacker-post-processor-%s",
 					packerPath, PACKERSPACE, PACKERSPACE, postProcessor)
 				return c.pluginClient(bin).PostProcessor()

--- a/config.go
+++ b/config.go
@@ -98,7 +98,7 @@ func (c *config) loadSingleComponent(path string) (string, error) {
 	switch {
 	case strings.HasPrefix(pluginName, "packer-builder-"):
 		pluginName = pluginName[len("packer-builder-"):]
-		c.Builders[pluginName] = func() (packer.Builder, error) {
+		c.Builders[pluginName] = func() (packersdk.Builder, error) {
 			return c.pluginClient(path).Builder()
 		}
 	case strings.HasPrefix(pluginName, "packer-post-processor-"):
@@ -180,9 +180,9 @@ func (c *config) Discover() error {
 	return nil
 }
 
-// This is a proper packer.BuilderFunc that can be used to load packer.Builder
+// This is a proper packer.BuilderFunc that can be used to load packersdk.Builder
 // implementations from the defined plugins.
-func (c *config) StartBuilder(name string) (packer.Builder, error) {
+func (c *config) StartBuilder(name string) (packersdk.Builder, error) {
 	log.Printf("Loading builder: %s\n", name)
 	return c.Builders.Start(name)
 }
@@ -225,7 +225,7 @@ func (c *config) discoverExternalComponents(path string) error {
 	}
 	for pluginName, pluginPath := range pluginPaths {
 		newPath := pluginPath // this needs to be stored in a new variable for the func below
-		c.Builders[pluginName] = func() (packer.Builder, error) {
+		c.Builders[pluginName] = func() (packersdk.Builder, error) {
 			return c.pluginClient(newPath).Builder()
 		}
 		externallyUsed = append(externallyUsed, pluginName)
@@ -321,7 +321,7 @@ func (c *config) discoverInternalComponents() error {
 		builder := builder
 		_, found := (c.Builders)[builder]
 		if !found {
-			c.Builders[builder] = func() (packer.Builder, error) {
+			c.Builders[builder] = func() (packersdk.Builder, error) {
 				bin := fmt.Sprintf("%s%splugin%spacker-builder-%s",
 					packerPath, PACKERSPACE, PACKERSPACE, builder)
 				return c.pluginClient(bin).Builder()

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -30,8 +30,8 @@ func getBasicParser() *Parser {
 			"file":  func() (packersdk.Provisioner, error) { return &MockProvisioner{}, nil },
 		},
 		PostProcessorsSchemas: packer.MapOfPostProcessor{
-			"amazon-import": func() (packer.PostProcessor, error) { return &MockPostProcessor{}, nil },
-			"manifest":      func() (packer.PostProcessor, error) { return &MockPostProcessor{}, nil },
+			"amazon-import": func() (packersdk.PostProcessor, error) { return &MockPostProcessor{}, nil },
+			"manifest":      func() (packersdk.PostProcessor, error) { return &MockPostProcessor{}, nil },
 		},
 	}
 }

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -26,8 +26,8 @@ func getBasicParser() *Parser {
 			"null":           func() (packersdk.Builder, error) { return &null.Builder{}, nil },
 		},
 		ProvisionersSchemas: packer.MapOfProvisioner{
-			"shell": func() (packer.Provisioner, error) { return &MockProvisioner{}, nil },
-			"file":  func() (packer.Provisioner, error) { return &MockProvisioner{}, nil },
+			"shell": func() (packersdk.Provisioner, error) { return &MockProvisioner{}, nil },
+			"file":  func() (packersdk.Provisioner, error) { return &MockProvisioner{}, nil },
 		},
 		PostProcessorsSchemas: packer.MapOfPostProcessor{
 			"amazon-import": func() (packer.PostProcessor, error) { return &MockPostProcessor{}, nil },

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/packer/builder/null"
 	. "github.com/hashicorp/packer/hcl2template/internal"
 	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/template/config"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -20,9 +21,9 @@ func getBasicParser() *Parser {
 	return &Parser{
 		Parser: hclparse.NewParser(),
 		BuilderSchemas: packer.MapOfBuilder{
-			"amazon-ebs":     func() (packer.Builder, error) { return &MockBuilder{}, nil },
-			"virtualbox-iso": func() (packer.Builder, error) { return &MockBuilder{}, nil },
-			"null":           func() (packer.Builder, error) { return &null.Builder{}, nil },
+			"amazon-ebs":     func() (packersdk.Builder, error) { return &MockBuilder{}, nil },
+			"virtualbox-iso": func() (packersdk.Builder, error) { return &MockBuilder{}, nil },
+			"null":           func() (packersdk.Builder, error) { return &null.Builder{}, nil },
 		},
 		ProvisionersSchemas: packer.MapOfProvisioner{
 			"shell": func() (packer.Provisioner, error) { return &MockProvisioner{}, nil },

--- a/hcl2template/internal/mock.go
+++ b/hcl2template/internal/mock.go
@@ -90,7 +90,7 @@ type MockProvisioner struct {
 	Config MockConfig
 }
 
-var _ packer.Provisioner = new(MockProvisioner)
+var _ packersdk.Provisioner = new(MockProvisioner)
 
 func (b *MockProvisioner) ConfigSpec() hcldec.ObjectSpec {
 	return b.Config.FlatMapstructure().HCL2Spec()

--- a/hcl2template/internal/mock.go
+++ b/hcl2template/internal/mock.go
@@ -70,7 +70,7 @@ type MockBuilder struct {
 	Config MockConfig
 }
 
-var _ packer.Builder = new(MockBuilder)
+var _ packersdk.Builder = new(MockBuilder)
 
 func (b *MockBuilder) ConfigSpec() hcldec.ObjectSpec { return b.Config.FlatMapstructure().HCL2Spec() }
 

--- a/hcl2template/internal/mock.go
+++ b/hcl2template/internal/mock.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/template/config"
 	"github.com/zclconf/go-cty/cty"
@@ -112,7 +111,7 @@ type MockPostProcessor struct {
 	Config MockConfig
 }
 
-var _ packer.PostProcessor = new(MockPostProcessor)
+var _ packersdk.PostProcessor = new(MockPostProcessor)
 
 func (b *MockPostProcessor) ConfigSpec() hcldec.ObjectSpec {
 	return b.Config.FlatMapstructure().HCL2Spec()

--- a/hcl2template/types.build.post-processor.go
+++ b/hcl2template/types.build.post-processor.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 // ProvisionerBlock references a detected but unparsed post processor
@@ -61,7 +61,7 @@ func (p *Parser) decodePostProcessor(block *hcl.Block) (*PostProcessorBlock, hcl
 	return postProcessor, diags
 }
 
-func (cfg *PackerConfig) startPostProcessor(source SourceBlock, pp *PostProcessorBlock, ectx *hcl.EvalContext) (packer.PostProcessor, hcl.Diagnostics) {
+func (cfg *PackerConfig) startPostProcessor(source SourceBlock, pp *PostProcessorBlock, ectx *hcl.EvalContext) (packersdk.PostProcessor, hcl.Diagnostics) {
 	// ProvisionerBlock represents a detected but unparsed provisioner
 	var diags hcl.Diagnostics
 

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	hcl2shim "github.com/hashicorp/packer/hcl2template/shim"
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -148,7 +148,7 @@ func (p *Parser) decodeProvisioner(block *hcl.Block, cfg *PackerConfig) (*Provis
 	return provisioner, diags
 }
 
-func (cfg *PackerConfig) startProvisioner(source SourceBlock, pb *ProvisionerBlock, ectx *hcl.EvalContext) (packer.Provisioner, hcl.Diagnostics) {
+func (cfg *PackerConfig) startProvisioner(source SourceBlock, pb *ProvisionerBlock, ectx *hcl.EvalContext) (packersdk.Provisioner, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	provisioner, err := cfg.provisionersSchemas.Start(pb.PType)

--- a/hcl2template/types.hcl_post-processor.go
+++ b/hcl2template/types.hcl_post-processor.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -16,7 +15,7 @@ import (
 // calling PostProcess: with contextual variables.
 // This permits using "${build.ID}" values for example.
 type HCL2PostProcessor struct {
-	PostProcessor      packer.PostProcessor
+	PostProcessor      packersdk.PostProcessor
 	postProcessorBlock *PostProcessorBlock
 	evalContext        *hcl.EvalContext
 	builderVariables   map[string]string

--- a/hcl2template/types.hcl_provisioner.go
+++ b/hcl2template/types.hcl_provisioner.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -16,7 +15,7 @@ import (
 // calling Provision: with contextual variables.
 // This permits using "${build.ID}" values for example.
 type HCL2Provisioner struct {
-	Provisioner      packer.Provisioner
+	Provisioner      packersdk.Provisioner
 	provisionerBlock *ProvisionerBlock
 	evalContext      *hcl.EvalContext
 	builderVariables map[string]string

--- a/hcl2template/types.source.go
+++ b/hcl2template/types.source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -88,7 +89,7 @@ func (p *Parser) decodeSource(block *hcl.Block) (SourceBlock, hcl.Diagnostics) {
 	return source, diags
 }
 
-func (cfg *PackerConfig) startBuilder(source SourceBlock, ectx *hcl.EvalContext, opts packer.GetBuildsOptions) (packer.Builder, hcl.Diagnostics, []string) {
+func (cfg *PackerConfig) startBuilder(source SourceBlock, ectx *hcl.EvalContext, opts packer.GetBuildsOptions) (packersdk.Builder, hcl.Diagnostics, []string) {
 	var diags hcl.Diagnostics
 
 	builder, err := cfg.builderSchemas.Start(source.Type)

--- a/helper/builder/testing/testing.go
+++ b/helper/builder/testing/testing.go
@@ -28,7 +28,7 @@ type TestCase struct {
 
 	// Builder is the Builder that will be tested. It will be available
 	// as the "test" builder in the template.
-	Builder packer.Builder
+	Builder packersdk.Builder
 
 	// Template is the template contents to use.
 	Template string
@@ -66,10 +66,10 @@ type TestT interface {
 
 type TestBuilderStore struct {
 	packer.BuilderStore
-	StartFn func(name string) (packer.Builder, error)
+	StartFn func(name string) (packersdk.Builder, error)
 }
 
-func (tbs TestBuilderStore) Start(name string) (packer.Builder, error) { return tbs.StartFn(name) }
+func (tbs TestBuilderStore) Start(name string) (packersdk.Builder, error) { return tbs.StartFn(name) }
 
 // Test performs an acceptance test on a backend with the given test case.
 //
@@ -115,7 +115,7 @@ func Test(t TestT, c TestCase) {
 	core := packer.NewCore(&packer.CoreConfig{
 		Components: packer.ComponentFinder{
 			BuilderStore: TestBuilderStore{
-				StartFn: func(n string) (packer.Builder, error) {
+				StartFn: func(n string) (packersdk.Builder, error) {
 					if n == "test" {
 						return c.Builder, nil
 					}

--- a/helper/tests/core.go
+++ b/helper/tests/core.go
@@ -29,8 +29,8 @@ func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {
 			"amazon-ebs": func() (packersdk.Builder, error) { return &amazonebsbuilder.Builder{}, nil },
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
-			"shell": func() (packer.Provisioner, error) { return &shell.Provisioner{}, nil },
-			"file":  func() (packer.Provisioner, error) { return &fileprovisioner.Provisioner{}, nil },
+			"shell": func() (packersdk.Provisioner, error) { return &shell.Provisioner{}, nil },
+			"file":  func() (packersdk.Provisioner, error) { return &fileprovisioner.Provisioner{}, nil },
 		},
 		PostProcessorStore: packer.MapOfPostProcessor{},
 	}

--- a/helper/tests/core.go
+++ b/helper/tests/core.go
@@ -26,7 +26,7 @@ func FileExists(filename string) bool {
 func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {
 	components := packer.ComponentFinder{
 		BuilderStore: packer.MapOfBuilder{
-			"amazon-ebs": func() (packer.Builder, error) { return &amazonebsbuilder.Builder{}, nil },
+			"amazon-ebs": func() (packersdk.Builder, error) { return &amazonebsbuilder.Builder{}, nil },
 		},
 		ProvisionerStore: packer.MapOfProvisioner{
 			"shell": func() (packer.Provisioner, error) { return &shell.Provisioner{}, nil },

--- a/packer-plugin-sdk/packer/builder.go
+++ b/packer-plugin-sdk/packer/builder.go
@@ -2,8 +2,6 @@ package packer
 
 import (
 	"context"
-
-	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 // Implementers of Builder are responsible for actually building images
@@ -17,7 +15,7 @@ import (
 // parallelism is strictly disabled, so it is safe to request input from
 // stdin and so on.
 type Builder interface {
-	packersdk.HCL2Speccer
+	HCL2Speccer
 
 	// Prepare is responsible for configuring the builder and validating
 	// that configuration. Any setup should be done in this method. Note that
@@ -37,5 +35,5 @@ type Builder interface {
 	Prepare(...interface{}) ([]string, []string, error)
 
 	// Run is where the actual build should take place. It takes a Build and a Ui.
-	Run(context.Context, packersdk.Ui, packersdk.Hook) (packersdk.Artifact, error)
+	Run(context.Context, Ui, Hook) (Artifact, error)
 }

--- a/packer-plugin-sdk/packer/post_processor.go
+++ b/packer-plugin-sdk/packer/post_processor.go
@@ -2,8 +2,6 @@ package packer
 
 import (
 	"context"
-
-	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 // A PostProcessor is responsible for taking an artifact of a build
@@ -12,7 +10,7 @@ import (
 // the result of a build, compresses it, and returns a new artifact containing
 // a single file of the prior artifact compressed.
 type PostProcessor interface {
-	packersdk.HCL2Speccer
+	HCL2Speccer
 
 	// Configure is responsible for setting up configuration, storing
 	// the state for later, and returning and errors, such as validation
@@ -26,5 +24,5 @@ type PostProcessor interface {
 	// user input for keep_input_artifact is ignored and the artifact is either
 	// kept or discarded according to the value set in `keep`.
 	// PostProcess is cancellable using context
-	PostProcess(context.Context, packersdk.Ui, packersdk.Artifact) (a packersdk.Artifact, keep bool, forceOverride bool, err error)
+	PostProcess(context.Context, Ui, Artifact) (a Artifact, keep bool, forceOverride bool, err error)
 }

--- a/packer-plugin-sdk/packer/provisioner.go
+++ b/packer-plugin-sdk/packer/provisioner.go
@@ -1,0 +1,20 @@
+package packer
+
+import "context"
+
+// A provisioner is responsible for installing and configuring software
+// on a machine prior to building the actual image.
+type Provisioner interface {
+	HCL2Speccer
+
+	// Prepare is called with a set of configurations to setup the
+	// internal state of the provisioner. The multiple configurations
+	// should be merged in some sane way.
+	Prepare(...interface{}) error
+
+	// Provision is called to actually provision the machine. A context is
+	// given for cancellation, a UI is given to communicate with the user, and
+	// a communicator is given that is guaranteed to be connected to some
+	// machine so that provisioning can be done.
+	Provision(context.Context, Ui, Communicator, map[string]interface{}) error
+}

--- a/packer/build.go
+++ b/packer/build.go
@@ -118,7 +118,7 @@ type CoreBuild struct {
 // CoreBuildPostProcessor Keeps track of the post-processor and the
 // configuration of the post-processor used within a build.
 type CoreBuildPostProcessor struct {
-	PostProcessor     PostProcessor
+	PostProcessor     packersdk.PostProcessor
 	PType             string
 	PName             string
 	config            map[string]interface{}
@@ -130,7 +130,7 @@ type CoreBuildPostProcessor struct {
 type CoreBuildProvisioner struct {
 	PType       string
 	PName       string
-	Provisioner Provisioner
+	Provisioner packersdk.Provisioner
 	config      []interface{}
 }
 

--- a/packer/build.go
+++ b/packer/build.go
@@ -95,7 +95,7 @@ type Build interface {
 type CoreBuild struct {
 	BuildName          string
 	Type               string
-	Builder            Builder
+	Builder            packersdk.Builder
 	BuilderConfig      interface{}
 	BuilderType        string
 	hooks              map[string][]packersdk.Hook

--- a/packer/core.go
+++ b/packer/core.go
@@ -56,10 +56,10 @@ type BuilderFunc func(name string) (packersdk.Builder, error)
 type HookFunc func(name string) (packersdk.Hook, error)
 
 // The function type used to lookup PostProcessor implementations.
-type PostProcessorFunc func(name string) (PostProcessor, error)
+type PostProcessorFunc func(name string) (packersdk.PostProcessor, error)
 
 // The function type used to lookup Provisioner implementations.
-type ProvisionerFunc func(name string) (Provisioner, error)
+type ProvisionerFunc func(name string) (packersdk.Provisioner, error)
 
 type BasicStore interface {
 	Has(name string) bool
@@ -73,12 +73,12 @@ type BuilderStore interface {
 
 type ProvisionerStore interface {
 	BasicStore
-	Start(name string) (Provisioner, error)
+	Start(name string) (packersdk.Provisioner, error)
 }
 
 type PostProcessorStore interface {
 	BasicStore
-	Start(name string) (PostProcessor, error)
+	Start(name string) (packersdk.PostProcessor, error)
 }
 
 // ComponentFinder is a struct that contains the various function

--- a/packer/core.go
+++ b/packer/core.go
@@ -50,7 +50,7 @@ type CoreConfig struct {
 }
 
 // The function type used to lookup Builder implementations.
-type BuilderFunc func(name string) (Builder, error)
+type BuilderFunc func(name string) (packersdk.Builder, error)
 
 // The function type used to lookup Hook implementations.
 type HookFunc func(name string) (packersdk.Hook, error)
@@ -68,7 +68,7 @@ type BasicStore interface {
 
 type BuilderStore interface {
 	BasicStore
-	Start(name string) (Builder, error)
+	Start(name string) (packersdk.Builder, error)
 }
 
 type ProvisionerStore interface {

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -801,9 +801,9 @@ func TestCoreBuild_provRetry(t *testing.T) {
 	pString := new(MockProvisioner)
 	pInt := new(MockProvisioner)
 	config.Components.ProvisionerStore = MapOfProvisioner{
-		"test-string": func() (Provisioner, error) { return pString, nil },
+		"test-string": func() (packersdk.Provisioner, error) { return pString, nil },
 		// backwards compatibility
-		"test-integer": func() (Provisioner, error) { return pInt, nil },
+		"test-integer": func() (packersdk.Provisioner, error) { return pInt, nil },
 	}
 	core := TestCore(t, config)
 

--- a/packer/maps.go
+++ b/packer/maps.go
@@ -6,14 +6,14 @@ import (
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-type MapOfProvisioner map[string]func() (Provisioner, error)
+type MapOfProvisioner map[string]func() (packersdk.Provisioner, error)
 
 func (mop MapOfProvisioner) Has(provisioner string) bool {
 	_, res := mop[provisioner]
 	return res
 }
 
-func (mop MapOfProvisioner) Start(provisioner string) (Provisioner, error) {
+func (mop MapOfProvisioner) Start(provisioner string) (packersdk.Provisioner, error) {
 	p, found := mop[provisioner]
 	if !found {
 		return nil, fmt.Errorf("Unknown provisioner %s", provisioner)
@@ -29,14 +29,14 @@ func (mop MapOfProvisioner) List() []string {
 	return res
 }
 
-type MapOfPostProcessor map[string]func() (PostProcessor, error)
+type MapOfPostProcessor map[string]func() (packersdk.PostProcessor, error)
 
 func (mopp MapOfPostProcessor) Has(postProcessor string) bool {
 	_, res := mopp[postProcessor]
 	return res
 }
 
-func (mopp MapOfPostProcessor) Start(postProcessor string) (PostProcessor, error) {
+func (mopp MapOfPostProcessor) Start(postProcessor string) (packersdk.PostProcessor, error) {
 	p, found := mopp[postProcessor]
 	if !found {
 		return nil, fmt.Errorf("Unknown post-processor %s", postProcessor)

--- a/packer/maps.go
+++ b/packer/maps.go
@@ -2,6 +2,8 @@ package packer
 
 import (
 	"fmt"
+
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 type MapOfProvisioner map[string]func() (Provisioner, error)
@@ -50,14 +52,14 @@ func (mopp MapOfPostProcessor) List() []string {
 	return res
 }
 
-type MapOfBuilder map[string]func() (Builder, error)
+type MapOfBuilder map[string]func() (packersdk.Builder, error)
 
 func (mob MapOfBuilder) Has(builder string) bool {
 	_, res := mob[builder]
 	return res
 }
 
-func (mob MapOfBuilder) Start(builder string) (Builder, error) {
+func (mob MapOfBuilder) Start(builder string) (packersdk.Builder, error) {
 	d, found := mob[builder]
 	if !found {
 		return nil, fmt.Errorf("Unknown builder %s", builder)

--- a/packer/plugin/builder.go
+++ b/packer/plugin/builder.go
@@ -5,12 +5,11 @@ import (
 	"log"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 type cmdBuilder struct {
-	builder packer.Builder
+	builder packersdk.Builder
 	client  *Client
 }
 

--- a/packer/plugin/client.go
+++ b/packer/plugin/client.go
@@ -16,7 +16,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	packrpc "github.com/hashicorp/packer/packer/rpc"
 )
@@ -153,7 +152,7 @@ func (c *Client) Hook() (packersdk.Hook, error) {
 
 // Returns a post-processor implementation that is communicating over
 // this client. If the client hasn't been started, this will start it.
-func (c *Client) PostProcessor() (packer.PostProcessor, error) {
+func (c *Client) PostProcessor() (packersdk.PostProcessor, error) {
 	client, err := c.packrpcClient()
 	if err != nil {
 		return nil, err

--- a/packer/plugin/client.go
+++ b/packer/plugin/client.go
@@ -164,7 +164,7 @@ func (c *Client) PostProcessor() (packer.PostProcessor, error) {
 
 // Returns a provisioner implementation that is communicating over this
 // client. If the client hasn't been started, this will start it.
-func (c *Client) Provisioner() (packer.Provisioner, error) {
+func (c *Client) Provisioner() (packersdk.Provisioner, error) {
 	client, err := c.packrpcClient()
 	if err != nil {
 		return nil, err

--- a/packer/plugin/client.go
+++ b/packer/plugin/client.go
@@ -131,7 +131,7 @@ func (c *Client) Exited() bool {
 
 // Returns a builder implementation that is communicating over this
 // client. If the client hasn't been started, this will start it.
-func (c *Client) Builder() (packer.Builder, error) {
+func (c *Client) Builder() (packersdk.Builder, error) {
 	client, err := c.packrpcClient()
 	if err != nil {
 		return nil, err

--- a/packer/plugin/post_processor.go
+++ b/packer/plugin/post_processor.go
@@ -5,12 +5,11 @@ import (
 	"log"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 type cmdPostProcessor struct {
-	p      packer.PostProcessor
+	p      packersdk.PostProcessor
 	client *Client
 }
 

--- a/packer/plugin/provisioner.go
+++ b/packer/plugin/provisioner.go
@@ -5,12 +5,11 @@ import (
 	"log"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 type cmdProvisioner struct {
-	p      packer.Provisioner
+	p      packersdk.Provisioner
 	client *Client
 }
 

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -12,26 +12,9 @@ import (
 	"github.com/hashicorp/packer/packer-plugin-sdk/packerbuilderdata"
 )
 
-// A provisioner is responsible for installing and configuring software
-// on a machine prior to building the actual image.
-type Provisioner interface {
-	packersdk.HCL2Speccer
-
-	// Prepare is called with a set of configurations to setup the
-	// internal state of the provisioner. The multiple configurations
-	// should be merged in some sane way.
-	Prepare(...interface{}) error
-
-	// Provision is called to actually provision the machine. A context is
-	// given for cancellation, a UI is given to communicate with the user, and
-	// a communicator is given that is guaranteed to be connected to some
-	// machine so that provisioning can be done.
-	Provision(context.Context, packersdk.Ui, packersdk.Communicator, map[string]interface{}) error
-}
-
 // A HookedProvisioner represents a provisioner and information describing it
 type HookedProvisioner struct {
-	Provisioner Provisioner
+	Provisioner packersdk.Provisioner
 	Config      interface{}
 	TypeName    string
 }
@@ -151,7 +134,7 @@ func (h *ProvisionHook) Run(ctx context.Context, name string, ui packersdk.Ui, c
 // the provisioner is actually run.
 type PausedProvisioner struct {
 	PauseBefore time.Duration
-	Provisioner Provisioner
+	Provisioner packersdk.Provisioner
 }
 
 func (p *PausedProvisioner) ConfigSpec() hcldec.ObjectSpec { return p.ConfigSpec() }
@@ -177,7 +160,7 @@ func (p *PausedProvisioner) Provision(ctx context.Context, ui packersdk.Ui, comm
 // the provisioner whenever there's an error.
 type RetriedProvisioner struct {
 	MaxRetries  int
-	Provisioner Provisioner
+	Provisioner packersdk.Provisioner
 }
 
 func (r *RetriedProvisioner) ConfigSpec() hcldec.ObjectSpec { return r.ConfigSpec() }
@@ -218,7 +201,7 @@ func (r *RetriedProvisioner) Provision(ctx context.Context, ui packersdk.Ui, com
 // DebuggedProvisioner is a Provisioner implementation that waits until a key
 // press before the provisioner is actually run.
 type DebuggedProvisioner struct {
-	Provisioner Provisioner
+	Provisioner packersdk.Provisioner
 
 	cancelCh chan struct{}
 	doneCh   chan struct{}

--- a/packer/provisioner_test.go
+++ b/packer/provisioner_test.go
@@ -91,7 +91,7 @@ func TestProvisionHook_cancel(t *testing.T) {
 // TODO(mitchellh): Test that they're run in the proper order
 
 func TestPausedProvisioner_impl(t *testing.T) {
-	var _ Provisioner = new(PausedProvisioner)
+	var _ packersdk.Provisioner = new(PausedProvisioner)
 }
 
 func TestPausedProvisionerPrepare(t *testing.T) {
@@ -174,7 +174,7 @@ func TestPausedProvisionerCancel(t *testing.T) {
 }
 
 func TestDebuggedProvisioner_impl(t *testing.T) {
-	var _ Provisioner = new(DebuggedProvisioner)
+	var _ packersdk.Provisioner = new(DebuggedProvisioner)
 }
 
 func TestDebuggedProvisionerPrepare(t *testing.T) {
@@ -234,7 +234,7 @@ func TestDebuggedProvisionerCancel(t *testing.T) {
 }
 
 func TestRetriedProvisioner_impl(t *testing.T) {
-	var _ Provisioner = new(RetriedProvisioner)
+	var _ packersdk.Provisioner = new(RetriedProvisioner)
 }
 
 func TestRetriedProvisionerPrepare(t *testing.T) {

--- a/packer/provisioner_timeout.go
+++ b/packer/provisioner_timeout.go
@@ -11,7 +11,7 @@ import (
 // TimeoutProvisioner is a Provisioner implementation that can timeout after a
 // duration
 type TimeoutProvisioner struct {
-	Provisioner
+	packersdk.Provisioner
 	Timeout time.Duration
 }
 

--- a/packer/rpc/builder.go
+++ b/packer/rpc/builder.go
@@ -4,24 +4,23 @@ import (
 	"context"
 	"log"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-// An implementation of packer.Builder where the builder is actually executed
+// An implementation of packersdk.Builder where the builder is actually executed
 // over an RPC connection.
 type builder struct {
 	commonClient
 }
 
-// BuilderServer wraps a packer.Builder implementation and makes it exportable
+// BuilderServer wraps a packersdk.Builder implementation and makes it exportable
 // as part of a Golang RPC server.
 type BuilderServer struct {
 	context       context.Context
 	contextCancel func()
 
 	commonServer
-	builder packer.Builder
+	builder packersdk.Builder
 }
 
 type BuilderPrepareArgs struct {

--- a/packer/rpc/builder_test.go
+++ b/packer/rpc/builder_test.go
@@ -155,5 +155,5 @@ func TestBuilderCancel(t *testing.T) {
 }
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
-	var _ packer.Builder = new(builder)
+	var _ packersdk.Builder = new(builder)
 }

--- a/packer/rpc/client.go
+++ b/packer/rpc/client.go
@@ -89,7 +89,7 @@ func (c *Client) Build() packer.Build {
 	}
 }
 
-func (c *Client) Builder() packer.Builder {
+func (c *Client) Builder() packersdk.Builder {
 	return &builder{
 		commonClient: commonClient{
 			endpoint: DefaultBuilderEndpoint,

--- a/packer/rpc/client.go
+++ b/packer/rpc/client.go
@@ -129,7 +129,7 @@ func (c *Client) PostProcessor() packer.PostProcessor {
 	}
 }
 
-func (c *Client) Provisioner() packer.Provisioner {
+func (c *Client) Provisioner() packersdk.Provisioner {
 	return &provisioner{
 		commonClient: commonClient{
 			endpoint: DefaultProvisionerEndpoint,

--- a/packer/rpc/client.go
+++ b/packer/rpc/client.go
@@ -119,7 +119,7 @@ func (c *Client) Hook() packersdk.Hook {
 	}
 }
 
-func (c *Client) PostProcessor() packer.PostProcessor {
+func (c *Client) PostProcessor() packersdk.PostProcessor {
 	return &postProcessor{
 		commonClient: commonClient{
 			endpoint: DefaultPostProcessorEndpoint,

--- a/packer/rpc/post_processor.go
+++ b/packer/rpc/post_processor.go
@@ -4,24 +4,23 @@ import (
 	"context"
 	"log"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-// An implementation of packer.PostProcessor where the PostProcessor is actually
+// An implementation of packersdk.PostProcessor where the PostProcessor is actually
 // executed over an RPC connection.
 type postProcessor struct {
 	commonClient
 }
 
-// PostProcessorServer wraps a packer.PostProcessor implementation and makes it
+// PostProcessorServer wraps a packersdk.PostProcessor implementation and makes it
 // exportable as part of a Golang RPC server.
 type PostProcessorServer struct {
 	context       context.Context
 	contextCancel func()
 
 	commonServer
-	p packer.PostProcessor
+	p packersdk.PostProcessor
 }
 
 type PostProcessorConfigureArgs struct {

--- a/packer/rpc/post_processor_test.go
+++ b/packer/rpc/post_processor_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
@@ -134,7 +133,7 @@ func TestPostProcessorRPC_cancel(t *testing.T) {
 func TestPostProcessor_Implements(t *testing.T) {
 	var raw interface{}
 	raw = new(postProcessor)
-	if _, ok := raw.(packer.PostProcessor); !ok {
+	if _, ok := raw.(packersdk.PostProcessor); !ok {
 		t.Fatal("not a postprocessor")
 	}
 }

--- a/packer/rpc/provisioner.go
+++ b/packer/rpc/provisioner.go
@@ -4,24 +4,23 @@ import (
 	"context"
 	"log"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
-// An implementation of packer.Provisioner where the provisioner is actually
+// An implementation of packersdk.Provisioner where the provisioner is actually
 // executed over an RPC connection.
 type provisioner struct {
 	commonClient
 }
 
-// ProvisionerServer wraps a packer.Provisioner implementation and makes it
+// ProvisionerServer wraps a packersdk.Provisioner implementation and makes it
 // exportable as part of a Golang RPC server.
 type ProvisionerServer struct {
 	context       context.Context
 	contextCancel func()
 
 	commonServer
-	p packer.Provisioner
+	p packersdk.Provisioner
 }
 
 type ProvisionerPrepareArgs struct {

--- a/packer/rpc/provisioner_test.go
+++ b/packer/rpc/provisioner_test.go
@@ -50,5 +50,5 @@ func TestProvisionerRPC(t *testing.T) {
 }
 
 func TestProvisioner_Implements(t *testing.T) {
-	var _ packer.Provisioner = new(provisioner)
+	var _ packersdk.Provisioner = new(provisioner)
 }

--- a/packer/rpc/server.go
+++ b/packer/rpc/server.go
@@ -113,7 +113,7 @@ func (s *Server) RegisterPostProcessor(p packer.PostProcessor) error {
 	})
 }
 
-func (s *Server) RegisterProvisioner(p packer.Provisioner) error {
+func (s *Server) RegisterProvisioner(p packersdk.Provisioner) error {
 	return s.server.RegisterName(DefaultProvisionerEndpoint, &ProvisionerServer{
 		commonServer: commonServer{
 			selfConfigurable: p,

--- a/packer/rpc/server.go
+++ b/packer/rpc/server.go
@@ -77,7 +77,7 @@ func (s *Server) RegisterBuild(b packer.Build) error {
 	})
 }
 
-func (s *Server) RegisterBuilder(b packer.Builder) error {
+func (s *Server) RegisterBuilder(b packersdk.Builder) error {
 	return s.server.RegisterName(DefaultBuilderEndpoint, &BuilderServer{
 		commonServer: commonServer{
 			selfConfigurable: b,

--- a/packer/rpc/server.go
+++ b/packer/rpc/server.go
@@ -103,7 +103,7 @@ func (s *Server) RegisterHook(h packersdk.Hook) error {
 	})
 }
 
-func (s *Server) RegisterPostProcessor(p packer.PostProcessor) error {
+func (s *Server) RegisterPostProcessor(p packersdk.PostProcessor) error {
 	return s.server.RegisterName(DefaultPostProcessorEndpoint, &PostProcessorServer{
 		commonServer: commonServer{
 			selfConfigurable: p,

--- a/packer/testing.go
+++ b/packer/testing.go
@@ -12,7 +12,7 @@ func TestCoreConfig(t *testing.T) *CoreConfig {
 	// Create some test components
 	components := ComponentFinder{
 		BuilderStore: MapOfBuilder{
-			"test": func() (Builder, error) { return &MockBuilder{}, nil },
+			"test": func() (packersdk.Builder, error) { return &MockBuilder{}, nil },
 		},
 	}
 
@@ -46,7 +46,7 @@ func TestBuilder(t *testing.T, c *CoreConfig, n string) *MockBuilder {
 	var b MockBuilder
 
 	c.Components.BuilderStore = MapOfBuilder{
-		n: func() (Builder, error) { return &b, nil },
+		n: func() (packersdk.Builder, error) { return &b, nil },
 	}
 
 	return &b

--- a/packer/testing.go
+++ b/packer/testing.go
@@ -58,7 +58,7 @@ func TestProvisioner(t *testing.T, c *CoreConfig, n string) *MockProvisioner {
 	var b MockProvisioner
 
 	c.Components.ProvisionerStore = MapOfProvisioner{
-		n: func() (Provisioner, error) { return &b, nil },
+		n: func() (packersdk.Provisioner, error) { return &b, nil },
 	}
 
 	return &b
@@ -70,7 +70,7 @@ func TestPostProcessor(t *testing.T, c *CoreConfig, n string) *MockPostProcessor
 	var b MockPostProcessor
 
 	c.Components.PostProcessorStore = MapOfPostProcessor{
-		n: func() (PostProcessor, error) { return &b, nil },
+		n: func() (packersdk.PostProcessor, error) { return &b, nil },
 	}
 
 	return &b

--- a/post-processor/digitalocean-import/post-processor_test.go
+++ b/post-processor/digitalocean-import/post-processor_test.go
@@ -3,11 +3,11 @@ package digitaloceanimport
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-	var _ packer.PostProcessor = new(PostProcessor)
+	var _ packersdk.PostProcessor = new(PostProcessor)
 }
 
 func TestPostProcessor_ImageArtifactExtraction(t *testing.T) {

--- a/post-processor/docker-import/post-processor_test.go
+++ b/post-processor/docker-import/post-processor_test.go
@@ -3,9 +3,9 @@ package dockerimport
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-	var _ packer.PostProcessor = new(PostProcessor)
+	var _ packersdk.PostProcessor = new(PostProcessor)
 }

--- a/post-processor/docker-push/post-processor_test.go
+++ b/post-processor/docker-push/post-processor_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer/builder/docker"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	dockerimport "github.com/hashicorp/packer/post-processor/docker-import"
 )
@@ -19,7 +18,7 @@ func testUi() *packersdk.BasicUi {
 }
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-	var _ packer.PostProcessor = new(PostProcessor)
+	var _ packersdk.PostProcessor = new(PostProcessor)
 }
 
 func TestPostProcessor_PostProcess(t *testing.T) {

--- a/post-processor/docker-save/post-processor_test.go
+++ b/post-processor/docker-save/post-processor_test.go
@@ -3,9 +3,9 @@ package dockersave
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-	var _ packer.PostProcessor = new(PostProcessor)
+	var _ packersdk.PostProcessor = new(PostProcessor)
 }

--- a/post-processor/docker-tag/post-processor_test.go
+++ b/post-processor/docker-tag/post-processor_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer/builder/docker"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	dockerimport "github.com/hashicorp/packer/post-processor/docker-import"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +35,7 @@ func testUi() *packersdk.BasicUi {
 }
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-	var _ packer.PostProcessor = new(PostProcessor)
+	var _ packersdk.PostProcessor = new(PostProcessor)
 }
 
 func TestPostProcessor_PostProcess(t *testing.T) {

--- a/post-processor/shell-local/post-processor_test.go
+++ b/post-processor/shell-local/post-processor_test.go
@@ -6,12 +6,12 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-	var _ packer.PostProcessor = new(PostProcessor)
+	var _ packersdk.PostProcessor = new(PostProcessor)
 }
 
 func testConfig() map[string]interface{} {
@@ -23,7 +23,7 @@ func testConfig() map[string]interface{} {
 func TestPostProcessor_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &PostProcessor{}
-	if _, ok := raw.(packer.PostProcessor); !ok {
+	if _, ok := raw.(packersdk.PostProcessor); !ok {
 		t.Fatalf("must be a post processor")
 	}
 }

--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -1,6 +1,6 @@
 //go:generate mapstructure-to-hcl2 -type Config
 
-// vagrant_cloud implements the packer.PostProcessor interface and adds a
+// vagrant_cloud implements the packersdk.PostProcessor interface and adds a
 // post-processor that uploads artifacts from the vagrant post-processor
 // and vagrant builder to Vagrant Cloud (vagrantcloud.com) or manages
 // self hosted boxes on the Vagrant Cloud

--- a/post-processor/vagrant-cloud/post-processor_test.go
+++ b/post-processor/vagrant-cloud/post-processor_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/stretchr/testify/assert"
 )
@@ -425,7 +424,7 @@ func testUi() *packersdk.BasicUi {
 }
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-	var _ packer.PostProcessor = new(PostProcessor)
+	var _ packersdk.PostProcessor = new(PostProcessor)
 }
 
 func TestProviderFromBuilderName(t *testing.T) {

--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -1,6 +1,6 @@
 //go:generate mapstructure-to-hcl2 -type Config
 
-// vagrant implements the packer.PostProcessor interface and adds a
+// vagrant implements the packersdk.PostProcessor interface and adds a
 // post-processor that turns artifacts of known builders into Vagrant
 // boxes.
 package vagrant

--- a/post-processor/vagrant/post-processor_test.go
+++ b/post-processor/vagrant/post-processor_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
@@ -34,7 +33,7 @@ func testUi() *packersdk.BasicUi {
 }
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-	var _ packer.PostProcessor = new(PostProcessor)
+	var _ packersdk.PostProcessor = new(PostProcessor)
 }
 
 func TestPostProcessorPrepare_compressionLevel(t *testing.T) {

--- a/provisioner/ansible-local/provisioner_test.go
+++ b/provisioner/ansible-local/provisioner_test.go
@@ -21,7 +21,7 @@ import (
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/ansible/provisioner_test.go
+++ b/provisioner/ansible/provisioner_test.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep/commonsteps"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	confighelper "github.com/hashicorp/packer/packer-plugin-sdk/template/config"
@@ -43,7 +42,7 @@ func testConfig(t *testing.T) map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/chef-client/provisioner_test.go
+++ b/provisioner/chef-client/provisioner_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
@@ -20,7 +19,7 @@ func testConfig() map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/chef-solo/provisioner_test.go
+++ b/provisioner/chef-solo/provisioner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -15,7 +16,7 @@ func testConfig() map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/converge/provisioner_test.go
+++ b/provisioner/converge/provisioner_test.go
@@ -3,7 +3,7 @@ package converge
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -21,7 +21,7 @@ func testConfig() map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatal("must be a Provisioner")
 	}
 }

--- a/provisioner/file/provisioner_test.go
+++ b/provisioner/file/provisioner_test.go
@@ -23,7 +23,7 @@ func testConfig() map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a provisioner")
 	}
 }

--- a/provisioner/inspec/provisioner_test.go
+++ b/provisioner/inspec/provisioner_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 // Be sure to remove the InSpec stub file in each test with:
@@ -35,7 +35,7 @@ func testConfig(t *testing.T) map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/powershell/provisioner_acc_test.go
+++ b/provisioner/powershell/provisioner_acc_test.go
@@ -65,8 +65,8 @@ func (s *PowershellProvisionerAccTest) GetConfig() (string, error) {
 
 func (s *PowershellProvisionerAccTest) GetProvisionerStore() packer.MapOfProvisioner {
 	return packer.MapOfProvisioner{
-		TestProvisionerName: func() (packer.Provisioner, error) { return &powershell.Provisioner{}, nil },
-		"windows-shell":     func() (packer.Provisioner, error) { return &windowsshellprovisioner.Provisioner{}, nil },
+		TestProvisionerName: func() (packersdk.Provisioner, error) { return &powershell.Provisioner{}, nil },
+		"windows-shell":     func() (packersdk.Provisioner, error) { return &windowsshellprovisioner.Provisioner{}, nil },
 	}
 }
 

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -46,7 +46,7 @@ func TestProvisionerPrepare_extractScript(t *testing.T) {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/puppet-masterless/provisioner_test.go
+++ b/provisioner/puppet-masterless/provisioner_test.go
@@ -32,7 +32,7 @@ func testConfig() (config map[string]interface{}, tf *os.File) {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/puppet-server/provisioner_test.go
+++ b/provisioner/puppet-server/provisioner_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() (config map[string]interface{}, tf *os.File) {
@@ -24,7 +24,7 @@ func testConfig() (config map[string]interface{}, tf *os.File) {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -18,7 +18,7 @@ func testConfig() map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/shell-local/provisioner_acc_test.go
+++ b/provisioner/shell-local/provisioner_acc_test.go
@@ -42,7 +42,7 @@ func (s *ShellLocalProvisionerAccTest) GetConfig() (string, error) {
 
 func (s *ShellLocalProvisionerAccTest) GetProvisionerStore() packer.MapOfProvisioner {
 	return packer.MapOfProvisioner{
-		"shell-local": func() (packer.Provisioner, error) { return &shell.Provisioner{}, nil },
+		"shell-local": func() (packersdk.Provisioner, error) { return &shell.Provisioner{}, nil },
 	}
 }
 

--- a/provisioner/shell-local/provisioner_test.go
+++ b/provisioner/shell-local/provisioner_test.go
@@ -3,11 +3,11 @@ package shell
 import (
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func TestProvisioner_impl(t *testing.T) {
-	var _ packer.Provisioner = new(Provisioner)
+	var _ packersdk.Provisioner = new(Provisioner)
 }
 
 func TestConfigPrepare(t *testing.T) {

--- a/provisioner/shell/provisioner_acc_test.go
+++ b/provisioner/shell/provisioner_acc_test.go
@@ -45,8 +45,8 @@ func (s *ShellProvisionerAccTest) GetConfig() (string, error) {
 
 func (s *ShellProvisionerAccTest) GetProvisionerStore() packer.MapOfProvisioner {
 	return packer.MapOfProvisioner{
-		"shell": func() (packer.Provisioner, error) { return &shell.Provisioner{}, nil },
-		"file":  func() (packer.Provisioner, error) { return &file.Provisioner{}, nil },
+		"shell": func() (packersdk.Provisioner, error) { return &shell.Provisioner{}, nil },
+		"file":  func() (packersdk.Provisioner, error) { return &file.Provisioner{}, nil },
 	}
 }
 

--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep/commonsteps"
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
 func testConfig() map[string]interface{} {
@@ -20,7 +20,7 @@ func testConfig() map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/sleep/provisioner.go
+++ b/provisioner/sleep/provisioner.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/template/config"
 )
@@ -16,7 +15,7 @@ type Provisioner struct {
 	Duration time.Duration
 }
 
-var _ packer.Provisioner = new(Provisioner)
+var _ packersdk.Provisioner = new(Provisioner)
 
 func (p *Provisioner) ConfigSpec() hcldec.ObjectSpec { return p.FlatMapstructure().HCL2Spec() }
 

--- a/provisioner/windows-restart/provisioner_test.go
+++ b/provisioner/windows-restart/provisioner_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/packer/packer"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
 
@@ -18,7 +17,7 @@ func testConfig() map[string]interface{} {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/provisioner/windows-shell/provisioner_test.go
+++ b/provisioner/windows-shell/provisioner_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/packer-plugin-sdk/multistep/commonsteps"
 	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 )
@@ -49,7 +48,7 @@ func TestProvisionerPrepare_extractScript(t *testing.T) {
 func TestProvisioner_Impl(t *testing.T) {
 	var raw interface{}
 	raw = &Provisioner{}
-	if _, ok := raw.(packer.Provisioner); !ok {
+	if _, ok := raw.(packersdk.Provisioner); !ok {
 		t.Fatalf("must be a Provisioner")
 	}
 }

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -97,7 +97,7 @@ type plugin struct {
 func makeMap(varName, varType string, items []plugin) string {
 	output := ""
 
-	output += fmt.Sprintf("var %s = map[string]packer.%s{\n", varName, varType)
+	output += fmt.Sprintf("var %s = map[string]packersdk.%s{\n", varName, varType)
 	for _, item := range items {
 		output += fmt.Sprintf("\t\"%s\":   new(%s.%s),\n", item.PluginName, item.ImportName, item.TypeName)
 	}

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -90,7 +90,7 @@ type plugin struct {
 // makeMap creates a map named Name with type packer.Name that looks something
 // like this:
 //
-// var Builders = map[string]packer.Builder{
+// var Builders = map[string]packersdk.Builder{
 // 	"amazon-chroot":   new(chroot.Builder),
 // 	"amazon-ebs":      new(ebs.Builder),
 // 	"amazon-instance": new(instance.Builder),
@@ -254,6 +254,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/packer/packer"
+packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/packer/plugin"
 
 IMPORTS

--- a/website/pages/partials/builder/hyperv/iso/Builder.mdx
+++ b/website/pages/partials/builder/hyperv/iso/Builder.mdx
@@ -1,4 +1,4 @@
 <!-- Code generated from the comments of the Builder struct in builder/hyperv/iso/builder.go; DO NOT EDIT MANUALLY -->
 
-Builder implements packer.Builder and builds the actual Hyperv
+Builder implements packersdk.Builder and builds the actual Hyperv
 images.

--- a/website/pages/partials/builder/hyperv/vmcx/Builder.mdx
+++ b/website/pages/partials/builder/hyperv/vmcx/Builder.mdx
@@ -1,4 +1,4 @@
 <!-- Code generated from the comments of the Builder struct in builder/hyperv/vmcx/builder.go; DO NOT EDIT MANUALLY -->
 
-Builder implements packer.Builder and builds the actual Hyperv
+Builder implements packersdk.Builder and builds the actual Hyperv
 images.

--- a/website/pages/partials/builder/vagrant/Builder.mdx
+++ b/website/pages/partials/builder/vagrant/Builder.mdx
@@ -1,4 +1,4 @@
 <!-- Code generated from the comments of the Builder struct in builder/vagrant/builder.go; DO NOT EDIT MANUALLY -->
 
-Builder implements packer.Builder and builds the actual VirtualBox
+Builder implements packersdk.Builder and builds the actual VirtualBox
 images.


### PR DESCRIPTION
More work on sdk extraction; this removes the packer.Builder, packer.PostProcessor, and packer.Provisoner interfaces to the SDK, and fixes generation code to point to the right place. 