### PR TITLE
Fix duplication of main disk in QEMU

### DIFF
--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -554,11 +554,6 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		}
 	}
 
-	if c.DiskImage && len(c.AdditionalDiskSize) > 0 {
-		errs = packersdk.MultiErrorAppend(
-			errs, errors.New("disk_additional_size can only be used when disk_image is false"))
-	}
-
 	if c.SkipResizeDisk && !(c.DiskImage) {
 		errs = packersdk.MultiErrorAppend(
 			errs, errors.New("skip_resize_disk can only be used when disk_image is true"))

--- a/builder/qemu/config_test.go
+++ b/builder/qemu/config_test.go
@@ -196,8 +196,8 @@ func TestBuilderPrepare_AdditionalDiskSize(t *testing.T) {
 	if len(warns) > 0 {
 		t.Fatalf("bad: %#v", warns)
 	}
-	if err == nil {
-		t.Fatalf("should have error")
+	if err != nil {
+		t.Fatalf("should not have error")
 	}
 
 	delete(config, "disk_image")

--- a/builder/qemu/step_create_disk_test.go
+++ b/builder/qemu/step_create_disk_test.go
@@ -1,6 +1,7 @@
 package qemu
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -27,17 +28,20 @@ func Test_buildCreateCommand(t *testing.T) {
 		},
 		{
 			&stepCreateDisk{
-				Format:         "qcow2",
-				UseBackingFile: true,
+				Format:             "qcow2",
+				DiskImage:          true,
+				UseBackingFile:     true,
+				AdditionalDiskSize: []string{"1M", "2M"},
 			},
 			0,
 			[]string{"create", "-f", "qcow2", "-b", "source.qcow2", "target.qcow2", "1234M"},
-			"Basic, happy path, backing store, no extra args",
+			"Basic, happy path, backing store, additional disks",
 		},
 		{
 			&stepCreateDisk{
 				Format:         "qcow2",
 				UseBackingFile: true,
+				DiskImage:      true,
 			},
 			1,
 			[]string{"create", "-f", "qcow2", "target.qcow2", "1234M"},
@@ -47,6 +51,7 @@ func Test_buildCreateCommand(t *testing.T) {
 			&stepCreateDisk{
 				Format:         "qcow2",
 				UseBackingFile: true,
+				DiskImage:      true,
 				QemuImgArgs: QemuImgArgs{
 					Create: []string{"-foo", "bar"},
 				},
@@ -75,6 +80,97 @@ func Test_buildCreateCommand(t *testing.T) {
 		command := tc.Step.buildCreateCommand("target.qcow2", "1234M", tc.I, state)
 
 		assert.Equal(t, command, tc.Expected,
+			fmt.Sprintf("%s. Expected %#v", tc.Reason, tc.Expected))
+	}
+}
+
+func Test_StepCreateCalled(t *testing.T) {
+	type testCase struct {
+		Step     *stepCreateDisk
+		Expected []string
+		Reason   string
+	}
+	testcases := []testCase{
+		{
+			&stepCreateDisk{
+				Format:         "qcow2",
+				DiskImage:      true,
+				DiskSize:       "1M",
+				VMName:         "target",
+				UseBackingFile: true,
+			},
+			[]string{
+				"create", "-f", "qcow2", "-b", "source.qcow2", "target", "1M",
+			},
+			"Basic, happy path, backing store, no additional disks",
+		},
+		{
+			&stepCreateDisk{
+				Format:         "raw",
+				DiskImage:      false,
+				DiskSize:       "4M",
+				VMName:         "target",
+				UseBackingFile: false,
+			},
+			[]string{
+				"create", "-f", "raw", "target", "4M",
+			},
+			"Basic, happy path, raw, no additional disks",
+		},
+		{
+			&stepCreateDisk{
+				Format:             "qcow2",
+				DiskImage:          true,
+				DiskSize:           "4M",
+				VMName:             "target",
+				UseBackingFile:     false,
+				AdditionalDiskSize: []string{"3M", "8M"},
+			},
+			[]string{
+				"create", "-f", "qcow2", "target-1", "3M",
+				"create", "-f", "qcow2", "target-2", "8M",
+			},
+			"Skips disk creation when disk can be copied",
+		},
+		{
+			&stepCreateDisk{
+				Format:         "qcow2",
+				DiskImage:      true,
+				DiskSize:       "4M",
+				VMName:         "target",
+				UseBackingFile: false,
+			},
+			nil,
+			"Skips disk creation when disk can be copied",
+		},
+		{
+			&stepCreateDisk{
+				Format:             "qcow2",
+				DiskImage:          true,
+				DiskSize:           "1M",
+				VMName:             "target",
+				UseBackingFile:     true,
+				AdditionalDiskSize: []string{"3M", "8M"},
+			},
+			[]string{
+				"create", "-f", "qcow2", "-b", "source.qcow2", "target", "1M",
+				"create", "-f", "qcow2", "target-1", "3M",
+				"create", "-f", "qcow2", "target-2", "8M",
+			},
+			"Basic, happy path, backing store, additional disks",
+		},
+	}
+
+	for _, tc := range testcases {
+		d := new(DriverMock)
+		state := copyTestState(t, d)
+		state.Put("iso_path", "source.qcow2")
+		action := tc.Step.Run(context.TODO(), state)
+		if action != multistep.ActionContinue {
+			t.Fatalf("Should have gotten an ActionContinue")
+		}
+
+		assert.Equal(t, d.QemuImgCalls, tc.Expected,
 			fmt.Sprintf("%s. Expected %#v", tc.Reason, tc.Expected))
 	}
 }

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -209,12 +209,7 @@ func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag
 
 	// Configure virtual hard drives
 	if s.atLeastVersion2 {
-		// We have different things to attach based on whether we are booting
-		// from an iso or a boot image.
 		drivesToAttach := []string{}
-		if config.DiskImage {
-			drivesToAttach = append(drivesToAttach, imgPath)
-		}
 
 		if v, ok := state.GetOk("qemu_disk_paths"); ok {
 			diskFullPaths := v.([]string)

--- a/builder/qemu/step_run_test.go
+++ b/builder/qemu/step_run_test.go
@@ -150,7 +150,8 @@ func Test_DriveAndDeviceArgs(t *testing.T) {
 				DetectZeroes: "off",
 			},
 			map[string]interface{}{
-				"cd_path": "fake_cd_path.iso",
+				"cd_path":         "fake_cd_path.iso",
+				"qemu_disk_paths": []string{"path_to_output"},
 			},
 			&stepRun{
 				DiskImage:       true,
@@ -178,7 +179,8 @@ func Test_DriveAndDeviceArgs(t *testing.T) {
 				DetectZeroes: "on",
 			},
 			map[string]interface{}{
-				"cd_path": "fake_cd_path.iso",
+				"cd_path":         "fake_cd_path.iso",
+				"qemu_disk_paths": []string{"path_to_output"},
 			},
 			&stepRun{
 				DiskImage:       true,
@@ -381,7 +383,8 @@ func Test_DriveAndDeviceArgs(t *testing.T) {
 				Format:        "qcow2",
 			},
 			map[string]interface{}{
-				"cd_path": "fake_cd_path.iso",
+				"cd_path":         "fake_cd_path.iso",
+				"qemu_disk_paths": []string{"path_to_output"},
 			},
 			&stepRun{
 				DiskImage:       true,


### PR DESCRIPTION
Instead of sometimes appending the main disk image to `qemu_disk_paths`, always do so. 

Also, now allows for use of `disk_additional_size` together with `disk_image`. I'm curious why this was prevented in the first place, it seems to me that allowing it won't cause any issues. 

I did some preliminary testing with various combinations of `disk_image`, `use_backing_file` and `additional_disk_size`. Seems to be running the correct QEMU commands but would love to have someone do more testing. 

Closes #10223

Test blob for Busy People: https://github.com/serverwentdown/packer/releases/download/duplicate-output-file/packer-linux-amd64