### PR TITLE
Add packer-plugin-check command

### DIFF
--- a/cmd/packer-plugin-check/main.go
+++ b/cmd/packer-plugin-check/main.go
@@ -1,4 +1,4 @@
-// packer-plugin-check is a command used by plugins to template compatibility and basic configuration
+// packer-plugin-check is a command used by plugins to validate compatibility and basic configuration
 // to work with Packer.
 package main
 
@@ -64,7 +64,7 @@ func main() {
 
 // checkDocumentation looks for the presence of a docs folder with mdx files inside.
 // It is not possible to predict the number of mdx files for a given plugin.
-// Because of that, finding one file inside de folder is enough to template the knowledge of docs generation.
+// Because of that, finding one file inside the folder is enough to validate the docs existence.
 func checkDocumentation() error {
 	// TODO: this should be updated once we have defined what's going to be for plguin's docs
 	wd, err := os.Getwd()
@@ -128,7 +128,7 @@ func discoverAndLoad() error {
 		return err
 	}
 
-	// TODO: template correctness of plugins loaded by checking them against the output of the `describe` command.
+	// TODO: validate correctness of plugins loaded by checking them against the output of the `describe` command.
 	builders, provisioners, postProcessors := config.GetPlugins()
 	if len(builders) == 0 &&
 		len(provisioners) == 0 &&

--- a/cmd/packer-plugin-check/main.go
+++ b/cmd/packer-plugin-check/main.go
@@ -109,7 +109,7 @@ func checkPluginName(name string) error {
 		strings.HasPrefix(name, "packer-post-processor-") {
 		fmt.Printf("\n[WARNING] Plugin is named with old prefix `packer-[builder|provisioner|post-processor]-{name})`. " +
 			"These will be detected but Packer cannot install them automatically. " +
-			"The plguin must be a multiplugin named as packer-plugin-{name} to become available through `packer init` command.\n")
+			"The plugin must be a multi-plugin named packer-plugin-{name} to be installable through the `packer init` command.\n")
 		return nil
 	}
 	return fmt.Errorf("plugin's name is not valid")

--- a/cmd/packer-plugin-check/main.go
+++ b/cmd/packer-plugin-check/main.go
@@ -109,7 +109,7 @@ func checkPluginName(name string) error {
 		strings.HasPrefix(name, "packer-post-processor-") {
 		fmt.Printf("\n[WARNING] Plugin is named with old prefix `packer-[builder|provisioner|post-processor]-{name})`. " +
 			"These will be detected but Packer cannot install them automatically. " +
-			"Update the name to packer-plugin-{name} and the plugin will become available through `packer init` command.\n")
+			"The plguin must be a multiplugin named as packer-plugin-{name} to become available through `packer init` command.\n")
 		return nil
 	}
 	return fmt.Errorf("plugin's name is not valid")

--- a/cmd/packer-plugin-check/main.go
+++ b/cmd/packer-plugin-check/main.go
@@ -82,7 +82,7 @@ func checkHCL2Specs() error {
 	var hcl2found bool
 	_ = filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
-			if info.Name() == "website" || info.Name() == ".github" {
+			if info.Name() == "docs" || info.Name() == ".github" {
 				return filepath.SkipDir
 			}
 		} else {
@@ -100,9 +100,9 @@ func checkHCL2Specs() error {
 	return fmt.Errorf("no hcl2spec.go files found, make sure to generate them before releasing")
 }
 
-// checkDocumentation looks for the presence of a website folder with mdx files inside.
+// checkDocumentation looks for the presence of a docs folder with mdx files inside.
 // It is not possible to predict the number of mdx files for a given plugin.
-// Because of that, finding one file inside de folder is enough to validate the knowledge of website generation.
+// Because of that, finding one file inside de folder is enough to validate the knowledge of docs generation.
 func checkDocumentation() error {
 	// TODO: this should be updated once we have defined what's going to be for plguin's docs
 	wd, err := os.Getwd()
@@ -110,17 +110,17 @@ func checkDocumentation() error {
 		return err
 	}
 
-	websiteDir := wd + "/website"
-	stat, err := os.Stat(websiteDir)
+	docsDir := wd + "/docs"
+	stat, err := os.Stat(docsDir)
 	if err != nil {
-		return fmt.Errorf("could not find website folter: %s", err.Error())
+		return fmt.Errorf("could not find docs folter: %s", err.Error())
 	}
 	if !stat.IsDir() {
-		return fmt.Errorf("expecting website do be a directory of mdx files")
+		return fmt.Errorf("expecting docs do be a directory of mdx files")
 	}
 
 	var mdxFound bool
-	_ = filepath.Walk(websiteDir, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(docsDir, func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() && filepath.Ext(path) == ".mdx" {
 			mdxFound = true
 			return io.EOF
@@ -145,9 +145,9 @@ func checkPluginName(name string) error {
 	if strings.HasPrefix(name, "packer-builder-") ||
 		strings.HasPrefix(name, "packer-provisioner-") ||
 		strings.HasPrefix(name, "packer-post-processor-") {
-		fmt.Printf("[WARNING] Plugin is named with old prefix `packer-[builder|provisioner|post-processor]-{name})`. \n" +
-			"These will be detected but Packer cannot install them automatically. \n" +
-			"Update the name to packer-plugin-{name} and the plugin will become available through `packer init` command.")
+		fmt.Printf("\n[WARNING] Plugin is named with old prefix `packer-[builder|provisioner|post-processor]-{name})`. " +
+			"These will be detected but Packer cannot install them automatically. " +
+			"Update the name to packer-plugin-{name} and the plugin will become available through `packer init` command.\n")
 		return nil
 	}
 	return fmt.Errorf("plugin's name is not valid")

--- a/cmd/packer-plugin-check/main.go
+++ b/cmd/packer-plugin-check/main.go
@@ -1,0 +1,150 @@
+// plugin-check is a command used by plugins to validate compatibility and basic configuration
+// to work with Packer.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/packer/packer/plugin"
+)
+
+const packerPluginCheck = "packer-plugin-check"
+
+var (
+	hcl2spec = flag.Bool("hcl2spec", false, "flag to indicate that hcl2spec files should be checked.")
+	website  = flag.Bool("website", false, "flag to indicate that website files should be checked.")
+	load     = flag.Bool("load", false, "flag to check plugin can be loaded by Packer.")
+)
+
+// Usage is a replacement usage function for the flags package.
+func Usage() {
+	fmt.Fprintf(os.Stderr, "Usage of "+packerPluginCheck+":\n")
+	fmt.Fprintf(os.Stderr, "\t"+packerPluginCheck+" [flags]\n")
+	fmt.Fprintf(os.Stderr, "Flags:\n")
+	flag.PrintDefaults()
+}
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix(packerPluginCheck + ": ")
+	flag.Usage = Usage
+	flag.Parse()
+
+	if *hcl2spec == false && *website == false && *load == false {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	if *hcl2spec {
+		if err := checkHCL2Specs(); err != nil {
+			fmt.Printf(err.Error())
+			os.Exit(2)
+		}
+		fmt.Printf("Plugin succesfully passed hcl2spec check.\n")
+	}
+
+	if *website {
+		_ = checkWebsite()
+	}
+
+	if *load {
+		if err := discoverAndLoad(); err != nil {
+			fmt.Printf(err.Error())
+			os.Exit(2)
+		}
+		fmt.Printf("Plugin succesfully passed loading check.\n")
+	}
+}
+
+// checkHCL2Specs looks for the presence of a hcl2spec.go file in the current directory.
+// It is not possible to predict the number of hcl2spec.go files for a given plugin.
+// Because of that, finding one file is enough to validate the knowledge of hcl2spec generation.
+func checkHCL2Specs() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	var hcl2found bool
+	_ = filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			if info.Name() == "website" || info.Name() == ".github" {
+				return filepath.SkipDir
+			}
+		} else {
+			if strings.HasSuffix(path, "hcl2spec.go") {
+				hcl2found = true
+				return io.EOF
+			}
+		}
+		return nil
+	})
+
+	if hcl2found {
+		return nil
+	}
+	return fmt.Errorf("No hcl2spec.go files found. Please, make sure to generate them before releasing.")
+}
+
+// checkWebsite looks for the presence of a website folder with mdx files inside.
+// It is not possible to predict the number of mdx files for a given plugin.
+// Because of that, finding one file inside de folder is enough to validate the knowledge of website generation.
+func checkWebsite() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	websiteDir := wd + "/website"
+	stat, err := os.Stat(websiteDir)
+	if err != nil {
+		return fmt.Errorf("could not find website folter: %s", err.Error())
+	}
+	if !stat.IsDir() {
+		return fmt.Errorf("expecting website do be a directory of mdx files")
+	}
+
+	var mdxFound bool
+	_ = filepath.Walk(websiteDir, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() && filepath.Ext(path) == ".mdx" {
+			mdxFound = true
+			return io.EOF
+		}
+		return nil
+	})
+
+	if mdxFound {
+		fmt.Printf("a mdx file was found inside website folder\n")
+		return nil
+	}
+	return fmt.Errorf("No website files found. Please, make sure to generate them before releasing.")
+}
+
+func discoverAndLoad() error {
+	// TODO: add warning for non `packer-plugin-*` plugins.
+	// these will be detected but Packer cannot install them automatically.
+
+	config := plugin.Config{
+		PluginMinPort: 10000,
+		PluginMaxPort: 25000,
+	}
+	err := config.Discover()
+	if err != nil {
+		return err
+	}
+
+	builders, provisioners, postProcessors := config.GetPlugins()
+	if len(builders) == 0 &&
+		len(provisioners) == 0 &&
+		len(postProcessors) == 0 {
+		return fmt.Errorf("couldn't indentify any Builder/Provisioner/Post-Processor from plugin binary")
+	}
+
+	return nil
+}

--- a/cmd/packer-plugin-check/main.go
+++ b/cmd/packer-plugin-check/main.go
@@ -36,7 +36,7 @@ func main() {
 	flag.Usage = Usage
 	flag.Parse()
 
-	if *hcl2spec == false && *docs == false && len(*load) == 0 {
+	if flag. NFlag() == 0 {
 		flag.Usage()
 		os.Exit(2)
 	}

--- a/cmd/packer-plugin-check/main.go
+++ b/cmd/packer-plugin-check/main.go
@@ -116,7 +116,7 @@ func checkPluginName(name string) error {
 }
 
 // discoverAndLoad will discover the plugin binary from the current directory and load any builder/provisioner/post-processor
-// in the plugin configuration. At least one builder, provisioner, or post-processor should be found to template the plugin's
+// in the plugin configuration. At least one builder, provisioner, or post-processor should be found to validate the plugin's
 // compatibility with Packer.
 func discoverAndLoad() error {
 	config := plugin.Config{

--- a/cmd/packer-plugin-check/main.go
+++ b/cmd/packer-plugin-check/main.go
@@ -36,7 +36,7 @@ func main() {
 	flag.Usage = Usage
 	flag.Parse()
 
-	if flag. NFlag() == 0 {
+	if flag.NFlag() == 0 {
 		flag.Usage()
 		os.Exit(2)
 	}
@@ -85,11 +85,12 @@ func checkHCL2Specs() error {
 			if info.Name() == "docs" || info.Name() == ".github" {
 				return filepath.SkipDir
 			}
-		} else {
-			if strings.HasSuffix(path, "hcl2spec.go") {
-				hcl2found = true
-				return io.EOF
-			}
+			return nil
+		}
+
+		if strings.HasSuffix(path, "hcl2spec.go") {
+			hcl2found = true
+			return io.EOF
 		}
 		return nil
 	})


### PR DESCRIPTION
This PR adds the packer-plugin-check command to be used by plugins to check for compatibility. 
```
Usage of packer-plugin-check:
        packer-plugin-check [flags]
Flags:
  -docs
        flag to indicate that documentation files should be checked.
  -load string
        flag to check if plugin can be loaded by Packer and is compatible with HCL2.
```

Some WIP that has to be implemented later because is still depending on workflows that are WIP: 
- [ ] Validate plugins loaded against the `describe` output.
- [ ] Confirm how we check for existing docs and update the check if it's necessary

Both can be done later when these workflows are done. 

This is how it looks with GoReleaser in a GitHub Action: https://github.com/sylviamoss/packer-provisioner-comment/runs/1517723279?check_suite_focus=true#step:6:58