### PR TITLE
Gcp oslogin issue 10170

### DIFF
--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -70,6 +70,9 @@ type Driver interface {
 	// DeleteOSLoginSSHKey deletes the SSH public key for OSLogin with the given key.
 	DeleteOSLoginSSHKey(user, fingerprint string) error
 
+	// If packer is running on a GCE, derives the user from it for use with OSLogin.
+	GetOSLoginUserFromGCE() string
+
 	// Add to the instance metadata for the existing instance
 	AddToInstanceMetadata(zone string, name string, metadata map[string]string) error
 }

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -122,6 +122,9 @@ func NewClientOptionGoogle(account *ServiceAccount, vaultOauth string, impersona
 		// 4. On Google Compute Engine and Google App Engine Managed VMs, it fetches
 		//    credentials from the metadata server.
 		//    (In this final case any provided scopes are ignored.)
+		//
+		//    Note: (4) is not usable with OSLogin on Google Compute Engine (GCE).
+		//    The GCE service account is derived separately and used instead.
 	}
 
 	if err != nil {
@@ -147,7 +150,7 @@ func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 	}
 
 	if metadata.OnGCE() {
-		log.Printf("[INFO] Running on a GCE, capturing it's service account...")
+		log.Printf("[INFO] On GCE, capture service account for OSLogin...")
 		thisGCEUser, err = metadata.NewClient(&http.Client{}).Email("")
 
 		if err != nil {

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -94,6 +94,8 @@ type DriverMock struct {
 	AddToInstanceMetadataKVPairs map[string]string
 	AddToInstanceMetadataErrCh   <-chan error
 	AddToInstanceMetadataErr     error
+
+	OSLoginUserFromGCE string
 }
 
 func (d *DriverMock) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
@@ -307,4 +309,8 @@ func (d *DriverMock) AddToInstanceMetadata(zone string, name string, metadata ma
 	}
 
 	return nil
+}
+
+func (d *DriverMock) GetOSLoginUserFromGCE() string {
+	return d.OSLoginUserFromGCE
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/hashicorp/packer
 
 require (
-	cloud.google.com/go v0.66.0 // indirect
+	cloud.google.com/go v0.66.0
 	github.com/1and1/oneandone-cloudserver-sdk-go v1.0.1
 	github.com/Azure/azure-sdk-for-go v40.5.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.10.0


### PR DESCRIPTION
GCP OSLogin functionality relies on a GCP service account as the identity to use when deriving a SSH key pair.

Here we ensure that if packer is running on a Google Compute Engine (GCE), the GCP service account is derived from that GCE prior to exploring any other credential derivation alternatives (e.g. JWT tokens). This aligns with the GCP credential derivation algorithm.

The linked issue describes how this was not working prior to this fix.

Packer behaviour for OSLogin service account derivation is unchanged when running outside of a GCE.

Tests added:-

- https://github.com/seventieskid/packer/blob/gcp-oslogin-issue-10170/builder/googlecompute/step_import_os_login_ssh_key_test.go#L154-L186

Resolves open issue:-

Closes #10170 
