### PR TITLE
command/fmt: Ensure all variable files ending in `.pkrvars.hcl` get formatted

### DIFF
--- a/command/fmt.go
+++ b/command/fmt.go
@@ -72,7 +72,7 @@ func (*FormatCommand) Help() string {
 Usage: packer fmt [options] [TEMPLATE]
 
   Rewrites all Packer configuration files to a canonical format. Both
-  configuration files (.pkr.hcl) and variable files (.pkrvars) are updated.
+  configuration files (.pkr.hcl) and variable files (.pkrvars.hcl) are updated.
   JSON files (.json) are not modified.
 
   If TEMPATE is "." the current directory will be used. The given content must

--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -1,0 +1,52 @@
+package command
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	packersdk "github.com/hashicorp/packer/packer-plugin-sdk/packer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFmt(t *testing.T) {
+	s := &strings.Builder{}
+	ui := &packersdk.BasicUi{
+		Writer: s,
+	}
+	c := &FormatCommand{
+		Meta: testMeta(t),
+	}
+
+	c.Ui = ui
+
+	args := []string{"-check=true", filepath.Join(testFixture("fmt"), "formatted.pkr.hcl")}
+	if code := c.Run(args); code != 0 {
+		fatalCommand(t, c.Meta)
+	}
+	expected := ""
+	assert.Equal(t, expected, strings.TrimSpace(s.String()))
+}
+
+func TestFmt_unformattedPKRVarsTemplate(t *testing.T) {
+	c := &FormatCommand{
+		Meta: testMeta(t),
+	}
+
+	args := []string{"-check=true", filepath.Join(testFixture("fmt"), "unformatted.pkrvars.hcl")}
+	if code := c.Run(args); code != 3 {
+		fatalCommand(t, c.Meta)
+	}
+}
+
+func TestFmt_unfomattedTemlateDirectory(t *testing.T) {
+	c := &FormatCommand{
+		Meta: testMeta(t),
+	}
+
+	args := []string{"-check=true", filepath.Join(testFixture("fmt"), "")}
+
+	if code := c.Run(args); code != 3 {
+		fatalCommand(t, c.Meta)
+	}
+}

--- a/command/test-fixtures/fmt/formatted.pkr.hcl
+++ b/command/test-fixtures/fmt/formatted.pkr.hcl
@@ -1,0 +1,7 @@
+source "null" "example" {
+  communicator = "none"
+}
+
+build {
+  sources = ["source.null.example"]
+}

--- a/command/test-fixtures/fmt/unformatted.auto.pkrvars.hcl
+++ b/command/test-fixtures/fmt/unformatted.auto.pkrvars.hcl
@@ -1,0 +1,1 @@
+region ="us-west-2"

--- a/command/test-fixtures/fmt/unformatted.pkr.hcl
+++ b/command/test-fixtures/fmt/unformatted.pkr.hcl
@@ -1,0 +1,11 @@
+variable "region" {
+  type =string
+}
+
+source "amazon-ebs" "example" {
+  region = var.region
+}
+
+build {
+  sources = ["source.amazon-ebs.example"]
+}

--- a/command/test-fixtures/fmt/unformatted.pkrvars.hcl
+++ b/command/test-fixtures/fmt/unformatted.pkrvars.hcl
@@ -1,0 +1,3 @@
+ami_filter_name ="amzn2-ami-hvm-*-x86_64-gp2"
+ami_filter_owners =[ "137112412989" ]
+

--- a/formatted.pkr.hcl
+++ b/formatted.pkr.hcl
@@ -1,0 +1,7 @@
+source "null" "example" {
+  communicator = "none"
+}
+
+build {
+  sources = ["source.null.example"]
+}

--- a/hcl2template/formatter_test.go
+++ b/hcl2template/formatter_test.go
@@ -18,6 +18,7 @@ func TestHCL2Formatter_Format(t *testing.T) {
 		FormatExpected bool
 	}{
 		{Name: "Unformatted file", Path: "testdata/format/unformatted.pkr.hcl", FormatExpected: true},
+		{Name: "Unformatted vars file", Path: "testdata/format/unformatted.pkrvars.hcl", FormatExpected: true},
 		{Name: "Formatted file", Path: "testdata/format/formatted.pkr.hcl"},
 		{Name: "Directory", Path: "testdata/format", FormatExpected: true},
 	}

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -63,10 +63,12 @@ type Parser struct {
 }
 
 const (
-	hcl2FileExt        = ".pkr.hcl"
-	hcl2JsonFileExt    = ".pkr.json"
-	hcl2VarFileExt     = ".auto.pkrvars.hcl"
-	hcl2VarJsonFileExt = ".auto.pkrvars.json"
+	hcl2FileExt            = ".pkr.hcl"
+	hcl2JsonFileExt        = ".pkr.json"
+	hcl2VarFileExt         = ".pkrvars.hcl"
+	hcl2VarJsonFileExt     = ".pkrvars.json"
+	hcl2AutoVarFileExt     = ".auto.pkrvars.hcl"
+	hcl2AutoVarJsonFileExt = ".auto.pkrvars.json"
 )
 
 // Parse will Parse all HCL files in filename. Path can be a folder or a file.
@@ -162,7 +164,7 @@ func (p *Parser) Parse(filename string, varFiles []string, argVars map[string]st
 
 	// parse var files
 	{
-		hclVarFiles, jsonVarFiles, moreDiags := GetHCL2Files(filename, hcl2VarFileExt, hcl2VarJsonFileExt)
+		hclVarFiles, jsonVarFiles, moreDiags := GetHCL2Files(filename, hcl2AutoVarFileExt, hcl2AutoVarJsonFileExt)
 		diags = append(diags, moreDiags...)
 		for _, file := range varFiles {
 			switch filepath.Ext(file) {

--- a/hcl2template/testdata/format/unformatted.pkrvars.hcl
+++ b/hcl2template/testdata/format/unformatted.pkrvars.hcl
@@ -1,0 +1,3 @@
+ami_filter_name ="amzn2-ami-hvm-*-x86_64-gp2"
+ami_filter_owners =[ "137112412989" ]
+

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -796,7 +796,7 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			var files []*hcl.File
 			parser := getBasicParser()
 			for i, hclContent := range tt.args.hclFiles {
-				file, diags := parser.ParseHCL([]byte(hclContent), fmt.Sprintf("test_file_%d_*"+hcl2VarFileExt, i))
+				file, diags := parser.ParseHCL([]byte(hclContent), fmt.Sprintf("test_file_%d_*"+hcl2AutoVarFileExt, i))
 				if diags != nil {
 					t.Fatalf("ParseHCLFile %d: %v", i, diags)
 				}


### PR DESCRIPTION
Before change
```
⇶  packer fmt -check /tmp/unformatted.pkrvars.hcl
Error: Cannot tell whether /tmp/unformatted.pkrvars.hcl contains HCL2 configuration data

⇶  echo $?
1
```

After fix
```
⇶  packer fmt -check /tmp/unformatted.pkrvars.hcl
/tmp/unformatted.pkrvars.hcl

⇶  echo $?
3

⇶  packer fmt -check command/test-fixtures/fmt
command/test-fixtures/fmt/unformatted.pkr.hcl
command/test-fixtures/fmt/unformatted.auto.pkrvars.hcl
command/test-fixtures/fmt/unformatted.pkrvars.hcl

```


Closes #10350