### PR TITLE
Fix errant 2nd binding of string reverse in place of list reverse

### DIFF
--- a/hcl2template/functions.go
+++ b/hcl2template/functions.go
@@ -80,7 +80,7 @@ func Functions(basedir string) map[string]function.Function {
 		"pathexpand":         filesystem.PathExpandFunc,
 		"pow":                stdlib.PowFunc,
 		"range":              stdlib.RangeFunc,
-		"reverse":            stdlib.ReverseFunc,
+		"reverse":            stdlib.ReverseListFunc,
 		"replace":            stdlib.ReplaceFunc,
 		"regex_replace":      stdlib.RegexReplaceFunc,
 		"rsadecrypt":         crypto.RsaDecryptFunc,


### PR DESCRIPTION
The docs at https://www.packer.io/docs/from-1.5/functions/collection/reverse say reverse should be a list reverse, but it appears to not be

```shell
$ packer --version
1.6.5
$ packer console packer/main.pkr.hcl
> reverse([3,2,1])
> Error: Invalid function argument

  on <console-input> line 1:
  (source code not available)

Invalid value for "str" parameter: string required.



> reverse("hello")
> olleh
```

Compare: https://github.com/hashicorp/terraform/blob/6d0db836a9c88927500338315741229a2027df2a/lang/functions.go#L103-L116
