### PR TITLE
make packer compatible with MacOS BigSur by using Apple DHCP leases instead of VMWare leases

### DIFF
--- a/builder/vmware/common/driver.go
+++ b/builder/vmware/common/driver.go
@@ -462,7 +462,7 @@ func (d *VmwareDriver) PotentialGuestIP(state multistep.StateBag) ([]string, err
 			available_lease_entries := make([]appleDhcpLeaseEntry, 0)
 			for _, entry := range leaseEntries {
 				// Next check for any where the hardware address matches.
-				if bytes.Equal(hwaddr, []byte(entry.hwAddress)) {
+				if bytes.Equal(hwaddr, entry.hwAddress) {
 					available_lease_entries = append(available_lease_entries, entry)
 				}
 			}

--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -2452,7 +2452,7 @@ type appleDhcpLeaseEntry struct {
 
 func readAppleDhcpdLeaseEntry(in chan byte) (entry *appleDhcpLeaseEntry, err error) {
 	entry = &appleDhcpLeaseEntry{extra: map[string]string{}}
-	validFieldCount := 0
+	mandatoryFieldCount := 0
 	// Read up to the lease item and validate that it actually matches
 	_, ch := consumeOpenClosePair('{', '}', in)
 	for insideBraces := true; insideBraces; {
@@ -2486,7 +2486,7 @@ func readAppleDhcpdLeaseEntry(in chan byte) (entry *appleDhcpLeaseEntry, err err
 		switch key {
 		case "ip_address":
 			entry.ipAddress = val
-			validFieldCount++
+			mandatoryFieldCount++
 		case "identifier":
 			fallthrough
 		case "hw_address":
@@ -2514,24 +2514,22 @@ func readAppleDhcpdLeaseEntry(in chan byte) (entry *appleDhcpLeaseEntry, err err
 			} else {
 				entry.hwAddress = decodedLease
 			}
-			validFieldCount++
+			mandatoryFieldCount++
 		case "lease":
 			entry.lease = val
-			validFieldCount++
 		case "name":
 			entry.name = val
-			validFieldCount++
 		default:
 			// Just stash it for now because we have no idea what it is.
 			entry.extra[key] = val
 		}
 	}
 	// we have most likely parsed the whole file
-	if validFieldCount == 0 {
+	if mandatoryFieldCount == 0 {
 		return nil, nil
 	}
-	// an entry is composed of 5 mandatory fields, we'll check that they all have been set during the parsing
-	if validFieldCount < 5 {
+	// an entry is composed of 3 mandatory fields, we'll check that they all have been set during the parsing
+	if mandatoryFieldCount < 3 {
 		return entry, fmt.Errorf("Error entry `%v` is missing mandatory information", entry)
 	}
 	return entry, nil

--- a/builder/vmware/common/driver_parser.go
+++ b/builder/vmware/common/driver_parser.go
@@ -2462,7 +2462,7 @@ func readAppleDhcpdLeaseEntry(in chan byte) (entry *appleDhcpLeaseEntry, err err
 		if !ok {
 			insideBraces = false
 		}
-		if item_s == "{" || item_s == "}" {
+		if strings.Contains(item_s, "{") || strings.Contains(item_s, "}") {
 			continue
 		}
 		splittedLine := strings.Split(item_s, "=")

--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -913,6 +913,31 @@ func TestParserReadAppleDhcpdLeaseEntry(t *testing.T) {
 	if result.extra["fake"] != expected_extra_1["fake"] {
 		t.Errorf("expected extra %v, got %v", expected_extra_1["fake"], result.extra["fake"])
 	}
+
+	test_2 := `{
+		ip_address=192.168.111.4
+		hw_address=1,0:c:56:3c:e7:23
+		identifier=1,0:c:56:3c:e7:23
+	}`
+	expected_2 := map[string]string{
+		"ipAddress": "192.168.111.4",
+		"hwAddress": "000c563ce723",
+		"id":        "000c563ce723",
+	}
+
+	result, err = readAppleDhcpdLeaseEntry(consumeAppleLeaseString(test_2))
+	if err != nil {
+		t.Errorf("error parsing entry: %v", err)
+	}
+	if result.ipAddress != expected_2["ipAddress"] {
+		t.Errorf("expected ipAddress %v, got %v", expected_2["ipAddress"], result.ipAddress)
+	}
+	if hex.EncodeToString(result.hwAddress) != expected_2["hwAddress"] {
+		t.Errorf("expected hwAddress %v, got %v", expected_2["hwAddress"], hex.EncodeToString(result.hwAddress))
+	}
+	if hex.EncodeToString(result.id) != expected_2["id"] {
+		t.Errorf("expected id %v, got %v", expected_2["id"], hex.EncodeToString(result.id))
+	}
 }
 
 func TestParserReadAppleDhcpdLeases(t *testing.T) {
@@ -1021,6 +1046,23 @@ func TestParserReadAppleDhcpdLeases(t *testing.T) {
 			t.Errorf("unable to find item with id %v", test_4["id"])
 		} else if hex.EncodeToString(res.hwAddress) != test_4["hwAddress"] {
 			t.Errorf("expected hardware address %s, got %s", test_4["hwAddress"], hex.EncodeToString(res.hwAddress))
+		}
+	}
+
+	test_5 := map[string]string{
+		"ipAddress": "127.0.0.20",
+		"id":        "0dead099aabc",
+		"hwAddress": "0dead099aabc",
+	}
+	test_5_findings := filter_ipAddr(test_5["ipAddress"], results)
+	if len(test_5_findings) != 1 {
+		t.Errorf("expected %d matching entries, got %d", 1, len(test_5_findings))
+	} else {
+		res := find_id(test_5["id"], test_5_findings)
+		if res == nil {
+			t.Errorf("unable to find item with id %v", test_5["id"])
+		} else if hex.EncodeToString(res.hwAddress) != test_5["hwAddress"] {
+			t.Errorf("expected hardware address %s, got %s", test_5["hwAddress"], hex.EncodeToString(res.hwAddress))
 		}
 	}
 }

--- a/builder/vmware/common/driver_parser_test.go
+++ b/builder/vmware/common/driver_parser_test.go
@@ -865,6 +865,166 @@ func TestParserReadDhcpdLeases(t *testing.T) {
 	}
 }
 
+func consumeAppleLeaseString(s string) chan byte {
+	sch := consumeString(s)
+	uncommentedch := uncomment(sch)
+	return filterOutCharacters([]byte{'\r', '\v'}, uncommentedch)
+}
+
+func TestParserReadAppleDhcpdLeaseEntry(t *testing.T) {
+	test_1 := `{
+		ip_address=192.168.111.3
+		hw_address=1,0:c:56:3c:e7:22
+		identifier=1,0:c:56:3c:e7:22
+		lease=0x5fd78ae2
+		name=vagrant-2019
+		fake=field
+	}`
+	expected_1 := map[string]string{
+		"ipAddress": "192.168.111.3",
+		"hwAddress": "000c563ce722",
+		"id":        "000c563ce722",
+		"lease":     "0x5fd78ae2",
+		"name":      "vagrant-2019",
+	}
+	expected_extra_1 := map[string]string{
+		"fake": "field",
+	}
+
+	result, err := readAppleDhcpdLeaseEntry(consumeAppleLeaseString(test_1))
+	if err != nil {
+		t.Errorf("error parsing entry: %v", err)
+	}
+	if result.ipAddress != expected_1["ipAddress"] {
+		t.Errorf("expected ipAddress %v, got %v", expected_1["ipAddress"], result.ipAddress)
+	}
+	if hex.EncodeToString(result.hwAddress) != expected_1["hwAddress"] {
+		t.Errorf("expected hwAddress %v, got %v", expected_1["hwAddress"], hex.EncodeToString(result.hwAddress))
+	}
+	if hex.EncodeToString(result.id) != expected_1["id"] {
+		t.Errorf("expected id %v, got %v", expected_1["id"], hex.EncodeToString(result.id))
+	}
+	if result.lease != expected_1["lease"] {
+		t.Errorf("expected lease %v, got %v", expected_1["lease"], result.lease)
+	}
+	if result.name != expected_1["name"] {
+		t.Errorf("expected name %v, got %v", expected_1["name"], result.name)
+	}
+	if result.extra["fake"] != expected_extra_1["fake"] {
+		t.Errorf("expected extra %v, got %v", expected_extra_1["fake"], result.extra["fake"])
+	}
+}
+
+func TestParserReadAppleDhcpdLeases(t *testing.T) {
+	f, err := os.Open(filepath.Join("testdata", "apple-dhcpd-example.leases"))
+	if err != nil {
+		t.Fatalf("Unable to open dhcpd.leases sample: %s", err)
+	}
+	defer f.Close()
+
+	results, err := ReadAppleDhcpdLeaseEntries(f)
+	if err != nil {
+		t.Fatalf("Error reading lease: %s", err)
+	}
+
+	// some simple utilities
+	filter_ipAddr := func(ipAddress string, items []appleDhcpLeaseEntry) (result []appleDhcpLeaseEntry) {
+		for _, item := range items {
+			if item.ipAddress == ipAddress {
+				result = append(result, item)
+			}
+		}
+		return
+	}
+
+	find_id := func(id string, items []appleDhcpLeaseEntry) *appleDhcpLeaseEntry {
+		for _, item := range items {
+			if id == hex.EncodeToString(item.id) {
+				return &item
+			}
+		}
+		return nil
+	}
+
+	find_hwAddr := func(hwAddr string, items []appleDhcpLeaseEntry) *appleDhcpLeaseEntry {
+		for _, item := range items {
+			if hwAddr == hex.EncodeToString(item.hwAddress) {
+				return &item
+			}
+		}
+		return nil
+	}
+
+	// actual unit tests
+	test_1 := map[string]string{
+		"ipAddress": "127.0.0.19",
+		"id":        "0dead099aabb",
+		"hwAddress": "0dead099aabb",
+	}
+	test_1_findings := filter_ipAddr(test_1["ipAddress"], results)
+	if len(test_1_findings) != 2 {
+		t.Errorf("expected %d matching entries, got %d", 2, len(test_1_findings))
+	} else {
+		res := find_hwAddr(test_1["hwAddress"], test_1_findings)
+		if res == nil {
+			t.Errorf("unable to find item with hwAddress %v", test_1["hwAddress"])
+		} else if hex.EncodeToString(res.id) != test_1["id"] {
+			t.Errorf("expected id %s, got %s", test_1["id"], hex.EncodeToString(res.id))
+		}
+	}
+
+	test_2 := map[string]string{
+		"ipAddress": "127.0.0.19",
+		"id":        "0dead0667788",
+		"hwAddress": "0dead0667788",
+	}
+	test_2_findings := filter_ipAddr(test_2["ipAddress"], results)
+	if len(test_2_findings) != 2 {
+		t.Errorf("expected %d matching entries, got %d", 2, len(test_2_findings))
+	} else {
+		res := find_hwAddr(test_2["hwAddress"], test_2_findings)
+		if res == nil {
+			t.Errorf("unable to find item with hwAddress %v", test_2["hwAddress"])
+		} else if hex.EncodeToString(res.id) != test_2["id"] {
+			t.Errorf("expected id %s, got %s", test_2["id"], hex.EncodeToString(res.id))
+		}
+	}
+
+	test_3 := map[string]string{
+		"ipAddress": "127.0.0.17",
+		"id":        "0dead0334455",
+		"hwAddress": "0dead0667788",
+	}
+	test_3_findings := filter_ipAddr(test_3["ipAddress"], results)
+	if len(test_3_findings) != 2 {
+		t.Errorf("expected %d matching entries, got %d", 2, len(test_3_findings))
+	} else {
+		res := find_id(test_3["id"], test_3_findings)
+		if res == nil {
+			t.Errorf("unable to find item with id %v", test_3["id"])
+		} else if hex.EncodeToString(res.hwAddress) != test_3["hwAddress"] {
+			t.Errorf("expected hardware address %s, got %s", test_3["hwAddress"], hex.EncodeToString(res.hwAddress))
+		}
+	}
+
+	test_4 := map[string]string{
+		"ipAddress": "127.0.0.17",
+		"id":        "0dead0001122",
+		"hwAddress": "0dead0667788",
+	}
+	test_4_findings := filter_ipAddr(test_4["ipAddress"], results)
+	if len(test_4_findings) != 2 {
+		t.Errorf("expected %d matching entries, got %d", 2, len(test_4_findings))
+	} else {
+		res := find_id(test_4["id"], test_4_findings)
+		if res == nil {
+			t.Errorf("unable to find item with id %v", test_4["id"])
+		} else if hex.EncodeToString(res.hwAddress) != test_4["hwAddress"] {
+			t.Errorf("expected hardware address %s, got %s", test_4["hwAddress"], hex.EncodeToString(res.hwAddress))
+		}
+	}
+}
+
 func TestParserTokenizeNetworkingConfig(t *testing.T) {
 	tests := []string{
 		"words       words       words",

--- a/builder/vmware/common/testdata/apple-dhcpd-example.leases
+++ b/builder/vmware/common/testdata/apple-dhcpd-example.leases
@@ -1,0 +1,33 @@
+# this entry is normal
+{
+        ip_address=127.0.0.17
+        hw_address=1,d:ea:d0:66:77:88
+        identifier=1,d:ea:d0:0:11:22
+        lease=0x5fd78ae2
+        name=vagrant-2019
+}
+
+# this entry has tabs
+{
+			ip_address=127.0.0.17
+		hw_address=1,d:ea:d0:66:77:88
+	identifier=1,d:ea:d0:33:44:55
+				lease=0x5fd7b4e5
+        name=vagrant-2019
+}
+
+# These next two entries have the same address, but different uids
+{
+	ip_address=127.0.0.19
+	hw_address=1,d:ea:d0:66:77:88
+	identifier=1,d:ea:d0:66:77:88
+	lease=0x5fd72edc
+	name=vagrant-2019
+}
+{
+	ip_address=127.0.0.19
+	hw_address=1,d:ea:d0:99:aa:bb
+	identifier=1,d:ea:d0:99:aa:bb
+	lease=0x5fd72edc
+	name=vagrant-2019
+}

--- a/builder/vmware/common/testdata/apple-dhcpd-example.leases
+++ b/builder/vmware/common/testdata/apple-dhcpd-example.leases
@@ -31,3 +31,10 @@
 	lease=0x5fd72edc
 	name=vagrant-2019
 }
+
+# this entry does not have all fields
+{
+	ip_address=127.0.0.20
+	hw_address=1,d:ea:d0:99:aa:bc
+	identifier=1,d:ea:d0:99:aa:bc
+}


### PR DESCRIPTION
Please find attached my first PR which aims to make Packer compatible with MacOS BigSur.

## Summary of the issue:
I was trying earlier in the week end to use Packer on my MacBook Pro with MacOS BigSur and stumbled on an error where Packer would loop indefinitely, waiting for VMWare to populate its DHCP lease file which it'll never do.

After some research online, I found this thread on VMWare's forum:
https://communities.vmware.com/t5/VMware-Fusion-Discussions/Big-Sur-hosts-with-Fusion-Is-vmnet-dhcpd-vmnet8-leases-file/m-p/2298927/highlight/true#M140003

It states that Fusion 12 (which is the only VMWare compatible with BigSur) was forced to use Apple's network virtualization API and by doing so it was no longer able to use its own DHCP server and to populate it lease files.

An issue was also opened on Packer:
https://github.com/hashicorp/packer/issues/10177

## Fix proposal
This fix basically adds a new parser for Apple's lease file and integrate it to `PotentialGuestIP` method.

My approach is to always try to look up the IP in Apple's leases files when not found in VMWare's, whatever version of MacOS we are running on.
This way we should be retro compatible and if VMWare manage to bypass the current limitation on their own lease files, no change will be required because we'll always look at VMWare's lease files before Apple's.

I've tried to stick as much as possible to the logic of the existing function to parse and handle VMWare's lease files.

I've included tests that are basically the same one as the one developed for VMWare but for Apple.

## Results
Thanks to this fix, I managed to generate a machine image on MacOS BigSur.

These logs shows that we are able to retrieve the GuestIP from Apple's lease file.
```
==> vmware-iso: Typing the boot command over VNC...
2020/12/13 22:33:41 packer-builder-vmware-iso plugin: Located networkmapper configuration file using Fusion6: /Library/Preferences/VMware Fusion/networking
2020/12/13 22:33:41 packer-builder-vmware-iso plugin: GuestIP discovered device matching nat: vmnet8
2020/12/13 22:33:41 packer-builder-vmware-iso plugin: Lookup up IP information...
2020/12/13 22:33:41 packer-builder-vmware-iso plugin: GuestAddress found MAC address in VMX: 00:0c:29:3b:3c:7d
2020/12/13 22:33:41 packer-builder-vmware-iso plugin: Trying DHCP leases path: /var/db/vmware/vmnet-dhcpd-vmnet8.leases
2020/12/13 22:33:41 packer-builder-vmware-iso plugin: Unable to find an exact match for DHCP lease. Falling back to a loose match for hw address 00:0c:29:3b:3c:7d
2020/12/13 22:33:41 packer-builder-vmware-iso plugin: Trying Apple DHCP leases path: /var/db/dhcpd_leases
2020/12/13 22:33:41 packer-builder-vmware-iso plugin: Error parsing invalid line: `{}`
==> vmware-iso: Waiting for WinRM to become available...
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: Skipping lease entry #1 due to being unable to connect to the host (192.168.111.4) with tcp port (5985).
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: [DEBUG] Unable to get address during connection step: Host is not up
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: Waiting for WinRM, up to timeout: 6h0m0s
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: Located networkmapper configuration file using Fusion6: /Library/Preferences/VMware Fusion/networking
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: GuestIP discovered device matching nat: vmnet8
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: Lookup up IP information...
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: GuestAddress found MAC address in VMX: 00:0c:29:3b:3c:7d
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: Trying DHCP leases path: /var/db/vmware/vmnet-dhcpd-vmnet8.leases
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: Unable to find an exact match for DHCP lease. Falling back to a loose match for hw address 00:0c:29:3b:3c:7d
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: Trying Apple DHCP leases path: /var/db/dhcpd_leases
2020/12/13 22:34:56 packer-builder-vmware-iso plugin: Error parsing invalid line: `{}`
2020/12/13 22:36:03 packer-builder-vmware-iso plugin: Detected IP: 192.168.111.4
```

## Futher improvements
~I still have an error in the logs that shows that my parsing is not perfect:~
```Error parsing invalid line: `{}``` 
~It does not prevent the fix from doing its job but it should be removed and I'll have a look at it ASAP.~

Found and fix in second commit.

Closes #10177
