### PR TITLE
[WIP] Add: Support configuring of all network adapters instead only the fir…

### DIFF
--- a/website/content/docs/builders/vmware/vsphere-clone.mdx
+++ b/website/content/docs/builders/vmware/vsphere-clone.mdx
@@ -44,6 +44,24 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'builder/vsphere/clone/CloneConfig-not-required.mdx'
 
+Example of usage:
+
+<Tabs>
+<Tab heading="JSON">
+```json
+"network": "new_network_for_network_adapter_0, , new_network_for_network_adapter_2",
+"mac_address": "mac_address_for_network_adapter_0, , mac_address_for_network_adapter_2"
+ }
+```
+</Tab>
+<Tab heading="HCL2">
+```hcl
+network = new_network_for_network_adapter_0, , new_network_for_network_adapter_2'
+mac_address = 'mac_address_for_network_adapter_0, , mac_address_for_network_adapter_2'
+```
+</Tab>
+</Tabs>
+
 @include 'builder/vsphere/common/StorageConfig-not-required.mdx'
 
 ### Storage Configuration

--- a/website/content/partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/website/content/partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -6,12 +6,14 @@
 
 - `linked_clone` (bool) - Create VM as a linked clone from latest snapshot. Defaults to `false`.
 
-- `network` (string) - Set the network in which the VM will be connected to. If no network is
+- `network` (string) - Sets the network in which the VM will be connected to. If no network is
   specified, `host` must be specified to allow Packer to look for the
   available network. If the network is inside a network folder in vCenter,
   you need to provide the full path to the network.
+  A comma separated list sets the network for each  network adapter individually.
 
 - `mac_address` (string) - Sets a custom Mac Address to the network adapter. If set, the [network](#network) must be also specified.
+  A comma separated list sets a custom Mac Address for each network adapter individually.
 
 - `notes` (string) - VM notes.
 


### PR DESCRIPTION
### Why
vsphere-clone allows to reconfigure the first existing network adapter with _network_ and _mac_address_.
With this PR vsphere-clone now supports reconfiguring all network adapters.

### Scenario: Template with multiple networks to be reconfigured
Given VMware vSphere template
  And template network adapter A connected to network11
  And template network adapter B connected to network12
  And packer script reconfiguring both network adapters _(see examples below)_
When I clone template
Then VM is created
  But VM network adapter A is connected to network21
  But VM network adapter B is connected to network22

### Notes
For backward compatibility I decided to extend the meaning of _network_ and _mac_address_.
First I though about introducing network_adapters from vsphere-iso, but didn't wanna complicate things more than required for me. Being able to change the network names is enough for me.
To include reconfiguring the MAC addresses as well is a bonus and done to keep thinks aligned.

### Examples

**Backwards compatible reconfiguring first network adapter only:**
"network": "new_network",
"mac_address": "..."

**Reconfiguring all network adapters:**
"network": "new_network_for_network_adapter_0, new_network_for_network_adapter_1, new_network_for_network_adapter_2",
"mac_address": "<mac_address_for_network_adapter_0>, <mac_address_for_network_adapter_1>, <mac_address_for_network_adapter_2>"

**Reconfiguring only some network adapters:**
"network": "new_network_for_network_adapter_0, , new_network_for_network_adapter_2",
"mac_address": "<mac_address_for_network_adapter_0>, , <mac_address_for_network_adapter_2>"