### PR TITLE
Fix retry logic in AWS spot instance tagging

### DIFF
--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -406,7 +406,7 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 	}
 
 	// Retry creating tags for about 2.5 minutes
-	err = retry.Config{Tries: 11, ShouldRetry: func(error) bool {
+	err = retry.Config{Tries: 11, ShouldRetry: func(err error) bool {
 		if awserrors.Matches(err, "InvalidInstanceID.NotFound", "") {
 			return true
 		}


### PR DESCRIPTION
`err` on line 410 is always initialized as nil. This PR fixes it.

Closes #10370
