### PR TITLE
[WIP] multiplugin template-naming backwards compatibility

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,0 +1,14 @@
+on: [pull_request]
+name: Check Markdown links for modified files
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        file-extension: 'mdx'
+        check-modified-files-only: 'yes'
+        folder-path: 'website/content'
+

--- a/.github/workflows/scheduled-link-checker.yml
+++ b/.github/workflows/scheduled-link-checker.yml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+  - cron: "45 0 * * *"
+name: Check Markdown links on main branch
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        file-extension: 'mdx'
+        folder-path: 'website/content'

--- a/builder/amazon/common/run_config.go
+++ b/builder/amazon/common/run_config.go
@@ -85,7 +85,7 @@ type RunConfig struct {
 	BlockDurationMinutes int64 `mapstructure:"block_duration_minutes" required:"false"`
 	// Packer normally stops the build instance after all provisioners have
 	// run. For Windows instances, it is sometimes desirable to [run
-	// Sysprep](http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ami-create-standard.html)
+	// Sysprep](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/Creating_EBSbacked_WinAMI.html)
 	// which will stop the instance for you. If this is set to `true`, Packer
 	// *will not* stop the instance but will assume that you will send the stop
 	// signal yourself through your final provisioner. You can do this with a

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -196,20 +196,20 @@ type Config struct {
 	// Image Definition won't use this Image Version.
 	SharedGalleryImageVersionExcludeFromLatest bool `mapstructure:"shared_gallery_image_version_exclude_from_latest" required:"false"`
 	// Name of the publisher to use for your base image (Azure Marketplace Images only). See
-	// [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+	// [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
 	// for details.
 	//
 	// CLI example `az vm image list-publishers --location westus`
 	ImagePublisher string `mapstructure:"image_publisher" required:"true"`
 	// Name of the publisher's offer to use for your base image (Azure Marketplace Images only). See
-	// [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+	// [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
 	// for details.
 	//
 	// CLI example
 	// `az vm image list-offers --location westus --publisher Canonical`
 	ImageOffer string `mapstructure:"image_offer" required:"true"`
 	// SKU of the image offer to use for your base image (Azure Marketplace Images only). See
-	// [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+	// [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
 	// for details.
 	//
 	// CLI example

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -143,20 +143,20 @@ type Config struct {
 	SharedGalleryTimeout time.Duration `mapstructure:"shared_image_gallery_timeout"`
 
 	// PublisherName for your base image. See
-	// [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+	// [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
 	// for details.
 	//
 	// CLI example `az vm image list-publishers --location westus`
 	ImagePublisher string `mapstructure:"image_publisher"`
 	// Offer for your base image. See
-	// [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+	// [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
 	// for details.
 	//
 	// CLI example
 	// `az vm image list-offers --location westus --publisher Canonical`
 	ImageOffer string `mapstructure:"image_offer"`
 	// SKU for your base image. See
-	// [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+	// [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
 	// for details.
 	//
 	// CLI example

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -71,7 +71,7 @@ type Config struct {
 	//  * ebfb681885ddf1234c18094a45bbeafd91467911
 	//  * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
 	//  * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-	//  * file:http://releases.ubuntu.com/20.04/MD5SUMS
+	//  * file:http://releases.ubuntu.com/20.04/SHA256SUMS
 	//  * file:file://./local/path/file.sum
 	//  * file:./local/path/file.sum
 	//  * none

--- a/builder/virtualbox/ovf/config.go
+++ b/builder/virtualbox/ovf/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	//  * ebfb681885ddf1234c18094a45bbeafd91467911
 	//  * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
 	//  * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-	//  * file:http://releases.ubuntu.com/20.04/MD5SUMS
+	//  * file:http://releases.ubuntu.com/20.04/SHA256SUMS
 	//  * file:file://./local/path/file.sum
 	//  * file:./local/path/file.sum
 	//  * none

--- a/builder/vsphere/common/step_config_params.go
+++ b/builder/vsphere/common/step_config_params.go
@@ -16,7 +16,7 @@ import (
 
 type ConfigParamsConfig struct {
 	// configuration_parameters is a direct passthrough to the VSphere API's
-	// ConfigSpec: https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.ConfigSpec.html
+	// ConfigSpec: https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.ConfigSpec.html
 	ConfigParams map[string]string `mapstructure:"configuration_parameters"`
 
 	// Enables time synchronization with the host. Defaults to false.

--- a/go.mod
+++ b/go.mod
@@ -148,4 +148,6 @@ require (
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
+replace github.com/hashicorp/packer-plugin-sdk => /Users/mmarsh/Projects/packer-plugin-sdk
+
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/hashicorp/hcl/v2 v2.6.0
-	github.com/hashicorp/packer-plugin-sdk v0.0.4
+	github.com/hashicorp/packer-plugin-sdk v0.0.5
 	github.com/hashicorp/serf v0.9.2 // indirect
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,15 @@
+{
+   "ignorePatterns": [
+    {
+      "pattern": "^https://github.com/hashicorp/packer-plugin-scaffolding"
+    }
+  ],
+  "replacementPatterns": [
+    {
+      "pattern": "^/",
+      "replacement": "https://packer.io/"
+    }
+  ],
+  "timeout": "20s",
+  "retryOn429": true
+}

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,6 +1,15 @@
 {
    "ignorePatterns": [
     {
+      "pattern": "^https://example.com"
+    },
+    {
+      "pattern": "^https://ec2.custom.endpoint.com"
+    },
+    {
+      "pattern": "^https://www.linode.com"
+    },
+    {
       "pattern": "^https://github.com/hashicorp/packer-plugin-scaffolding"
     }
   ],

--- a/packer/plugin/discover.go
+++ b/packer/plugin/discover.go
@@ -236,7 +236,11 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 
 	for _, builderName := range desc.Builders {
 		builderName := builderName // copy to avoid pointer overwrite issue
-		c.builders[pluginPrefix+builderName] = func() (packersdk.Builder, error) {
+		key := pluginPrefix + builderName
+		if builderName == "default" {
+			key = pluginName
+		}
+		c.builders[key] = func() (packersdk.Builder, error) {
 			return c.Client(pluginPath, "start", "builder", builderName).Builder()
 		}
 	}
@@ -246,7 +250,11 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 
 	for _, postProcessorName := range desc.PostProcessors {
 		postProcessorName := postProcessorName // copy to avoid pointer overwrite issue
-		c.postProcessors[pluginPrefix+postProcessorName] = func() (packersdk.PostProcessor, error) {
+		key := pluginPrefix + postProcessorName
+		if postProcessorName == "default" {
+			key = pluginName
+		}
+		c.postProcessors[key] = func() (packersdk.PostProcessor, error) {
 			return c.Client(pluginPath, "start", "post-processor", postProcessorName).PostProcessor()
 		}
 	}
@@ -256,7 +264,11 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 
 	for _, provisionerName := range desc.Provisioners {
 		provisionerName := provisionerName // copy to avoid pointer overwrite issue
-		c.provisioners[pluginPrefix+provisionerName] = func() (packersdk.Provisioner, error) {
+		key := pluginPrefix + provisionerName
+		if provisionerName == "default" {
+			key = pluginName
+		}
+		c.provisioners[key] = func() (packersdk.Provisioner, error) {
 			return c.Client(pluginPath, "start", "provisioner", provisionerName).Provisioner()
 		}
 	}

--- a/packer/plugin/discover.go
+++ b/packer/plugin/discover.go
@@ -237,7 +237,7 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 	for _, builderName := range desc.Builders {
 		builderName := builderName // copy to avoid pointer overwrite issue
 		key := pluginPrefix + builderName
-		if builderName == "default" {
+		if builderName == pluginsdk.DEFAULT_NAME {
 			key = pluginName
 		}
 		c.builders[key] = func() (packersdk.Builder, error) {
@@ -251,7 +251,7 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 	for _, postProcessorName := range desc.PostProcessors {
 		postProcessorName := postProcessorName // copy to avoid pointer overwrite issue
 		key := pluginPrefix + postProcessorName
-		if postProcessorName == "default" {
+		if postProcessorName == pluginsdk.DEFAULT_NAME {
 			key = pluginName
 		}
 		c.postProcessors[key] = func() (packersdk.PostProcessor, error) {
@@ -265,7 +265,7 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 	for _, provisionerName := range desc.Provisioners {
 		provisionerName := provisionerName // copy to avoid pointer overwrite issue
 		key := pluginPrefix + provisionerName
-		if provisionerName == "default" {
+		if provisionerName == pluginsdk.DEFAULT_NAME {
 			key = pluginName
 		}
 		c.provisioners[key] = func() (packersdk.Provisioner, error) {

--- a/packer/plugin/discover.go
+++ b/packer/plugin/discover.go
@@ -244,6 +244,7 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 			return c.Client(pluginPath, "start", "builder", builderName).Builder()
 		}
 	}
+
 	if len(desc.Builders) > 0 {
 		log.Printf("found external %v builders from %s plugin", desc.Builders, pluginName)
 	}
@@ -258,6 +259,7 @@ func (c *Config) discoverMultiPlugin(pluginName, pluginPath string) error {
 			return c.Client(pluginPath, "start", "post-processor", postProcessorName).PostProcessor()
 		}
 	}
+
 	if len(desc.PostProcessors) > 0 {
 		log.Printf("found external %v post-processors from %s plugin", desc.PostProcessors, pluginName)
 	}

--- a/packer/plugin/discover_test.go
+++ b/packer/plugin/discover_test.go
@@ -142,7 +142,7 @@ func generateFakePlugins(dirname string, pluginNames []string) (string, []string
 
 // TestHelperProcess isn't a real test. It's used as a helper process
 // for multiplugin-binary tests.
-func TestHelperPlugins(*testing.T) {
+func TestHelperPlugins(t *testing.T) {
 	if os.Getenv("PKR_WANT_TEST_PLUGINS") != "1" {
 		return
 	}
@@ -162,17 +162,27 @@ func TestHelperPlugins(*testing.T) {
 	}
 
 	pluginName, args := args[0], args[1:]
-	plugin, found := mockPlugins[pluginName]
-	if !found {
-		fmt.Fprintf(os.Stderr, "No %q plugin found\n", pluginName)
-		os.Exit(2)
+
+	allMocks := []map[string]pluginsdk.Set{mockPlugins, defaultNameMock, doubleDefaultMock, badDefaultNameMock}
+	for _, mock := range allMocks {
+		t.Log("Megan 1")
+		plugin, found := mock[pluginName]
+		if found {
+			t.Log("Megan 2")
+			err := plugin.RunCommand(args...)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				t.Log("Megan 3")
+				os.Exit(1)
+			}
+			t.Log("Megan 4")
+			os.Exit(0)
+		}
 	}
 
-	err := plugin.RunCommand(args...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
+	t.Log("Megan 5")
+	fmt.Fprintf(os.Stderr, "No %q plugin found\n", pluginName)
+	os.Exit(2)
 }
 
 // HasExec reports whether the current system can start new processes
@@ -216,24 +226,7 @@ func helperCommand(t *testing.T, s ...string) []string {
 	return append(cmd, s...)
 }
 
-var (
-	mockPlugins = map[string]pluginsdk.Set{
-		"bird": pluginsdk.Set{
-			Builders: map[string]packer.Builder{
-				"feather":   nil,
-				"guacamole": nil,
-			},
-		},
-		"chimney": pluginsdk.Set{
-			PostProcessors: map[string]packer.PostProcessor{
-				"smoke": nil,
-			},
-		},
-	}
-)
-
-func Test_multiplugin_describe(t *testing.T) {
-
+func createMockPlugins(t *testing.T, plugins map[string]pluginsdk.Set) {
 	pluginDir, err := tmp.Dir("pkr-multiplugin-test-*")
 	{
 		// create an exectutable file with a `sh` sheebang
@@ -248,13 +241,11 @@ func Test_multiplugin_describe(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer os.RemoveAll(pluginDir)
 
 		t.Logf("putting temporary mock plugins in %s", pluginDir)
-		defer os.RemoveAll(pluginDir)
 
 		shPath := MustHaveCommand(t, "bash")
-		for name := range mockPlugins {
+		for name := range plugins {
 			plugin := path.Join(pluginDir, "packer-plugin-"+name)
 			fileContent := ""
 			fileContent = fmt.Sprintf("#!%s\n", shPath)
@@ -267,18 +258,78 @@ func Test_multiplugin_describe(t *testing.T) {
 		}
 	}
 	os.Setenv("PACKER_PLUGIN_PATH", pluginDir)
+}
+
+var (
+	mockPlugins = map[string]pluginsdk.Set{
+		"bird": pluginsdk.Set{
+			Builders: map[string]packer.Builder{
+				"feather":   nil,
+				"guacamole": nil,
+			},
+		},
+		"chimney": pluginsdk.Set{
+			PostProcessors: map[string]packer.PostProcessor{
+				"smoke": nil,
+			},
+		},
+	}
+
+	defaultNameMock = map[string]pluginsdk.Set{
+		"foo": pluginsdk.Set{
+			Builders: map[string]packer.Builder{
+				"bar":                  nil,
+				"baz":                  nil,
+				pluginsdk.DEFAULT_NAME: nil,
+			},
+		},
+	}
+
+	doubleDefaultMock = map[string]pluginsdk.Set{
+		"yolo": pluginsdk.Set{
+			Builders: map[string]packer.Builder{
+				"bar":                  nil,
+				"baz":                  nil,
+				pluginsdk.DEFAULT_NAME: nil,
+			},
+			PostProcessors: map[string]packer.PostProcessor{
+				pluginsdk.DEFAULT_NAME: nil,
+			},
+		},
+	}
+
+	badDefaultNameMock = map[string]pluginsdk.Set{
+		"foo": pluginsdk.Set{
+			Builders: map[string]packer.Builder{
+				"bar":                  nil,
+				"baz":                  nil,
+				pluginsdk.DEFAULT_NAME: nil,
+			},
+		},
+	}
+)
+
+func Test_multiplugin_describe(t *testing.T) {
+	createMockPlugins(t, mockPlugins)
+	pluginDir := os.Getenv("PACKER_PLUGIN_PATH")
+	defer os.RemoveAll(pluginDir)
+	t.Log("Megan 1")
 
 	c := Config{}
-	err = c.Discover()
+	t.Log("Megan 2")
+	err := c.Discover()
+	t.Log("Megan 3")
 	if err != nil {
-		t.Fatal(err)
+		t.Log("Megan 5")
+		t.Fatalf("error discovering plugins; %s", err.Error())
 	}
+	t.Log("Megan 4")
 
 	for mockPluginName, plugin := range mockPlugins {
 		for mockBuilderName := range plugin.Builders {
 			expectedBuilderName := mockPluginName + "-" + mockBuilderName
 			if _, found := c.builders[expectedBuilderName]; !found {
-				t.Fatalf("expected to find builder %q", expectedBuilderName)
+				t.Fatalf("expected to find builder %q; got %#v", expectedBuilderName, c.builders)
 			}
 		}
 		for mockProvisionerName := range plugin.Provisioners {
@@ -293,5 +344,36 @@ func Test_multiplugin_describe(t *testing.T) {
 				t.Fatalf("expected to find post-processor %q", expectedPostProcessorName)
 			}
 		}
+	}
+}
+
+func Test_multiplugin_defaultName(t *testing.T) {
+	createMockPlugins(t, defaultNameMock)
+	pluginDir := os.Getenv("PACKER_PLUGIN_PATH")
+	defer os.RemoveAll(pluginDir)
+
+	c := Config{}
+	err := c.Discover()
+	if err != nil {
+		t.Fatalf("error discovering plugins; %s ; mocks are %#v", err.Error(), defaultNameMock)
+	}
+
+	expectedBuilderNames := []string{"foo-bar", "foo-baz", "foo"}
+	for _, mockBuilderName := range expectedBuilderNames {
+		if _, found := c.builders[mockBuilderName]; !found {
+			t.Fatalf("expected to find builder %q; builders is %#v", mockBuilderName, c.builders)
+		}
+	}
+}
+
+func Test_only_one_multiplugin_defaultName_each_plugin_type(t *testing.T) {
+	createMockPlugins(t, doubleDefaultMock)
+	pluginDir := os.Getenv("PACKER_PLUGIN_PATH")
+	defer os.RemoveAll(pluginDir)
+
+	c := Config{}
+	err := c.Discover()
+	if err != nil {
+		t.Fatal("Should not have error because pluginsdk.DEFAULT_NAME is used twice but only once per plugin type.")
 	}
 }

--- a/website/README.md
+++ b/website/README.md
@@ -20,6 +20,7 @@ This subdirectory contains the entire source for the [Packer Website](https://pa
 - [Editing Markdown Content](#editing-markdown-content)
 - [Editing Navigation Sidebars](#editing-navigation-sidebars)
 - [Changing the Release Version](#changing-the-release-version)
+- [Link Validation](#link-validation)
 - [Redirects](#redirects)
 - [Browser Support](#browser-support)
 - [Deployment](#deployment)
@@ -148,7 +149,7 @@ $ curl ...
 </Tab>
 </Tabs>
 
-Contined normal markdown content
+Continued normal markdown content
 ````
 
 The intentionally skipped line is a limitation of the mdx parser which is being actively worked on. All tabs must have a heading, and there is no limit to the number of tabs, though it is recommended to go for a maximum of three or four.
@@ -375,6 +376,16 @@ You may customize the parameters in any way you'd like. To remove a prerelease f
 
 <!-- BEGIN: redirects -->
 <!-- Generated text, do not edit directly -->
+
+## Link Validation
+
+The Packer GitHub repository is configured to run a [Markdown Link Check](https://github.com/gaurav-nelson/github-action-markdown-link-check#github-action---markdown-link-check-%EF%B8%8F) on a nightly basis to check for potential broken links within the Packer documentation. There is also a GitHub action that will check any modified `.mdx` files on new pull-requests.
+
+The master configuration file for the markdown-link-checker is called `mlc_config.json` and is located under the project's root directory.
+The configuration helps with relative links in the documentation that will be valid once deployed, and configures a few ignored URLs which are valid but may not return a valid 200 HTTP response code due to permissions or DDoS protection settings on the domain.
+
+**Potential False Positives**
+The link checker will prepend the BASEURL `https://packer.io/` to any relative links found within the documentation, which can be an issue when adding new `/docs` or `/guides` documents as the pages have not been deployed. To help mitigate this issue check the site preview to ensure newly added documentation pages work as expected.
 
 ## Redirects
 

--- a/website/content/docs/builders/alicloud-ecs.mdx
+++ b/website/content/docs/builders/alicloud-ecs.mdx
@@ -132,11 +132,11 @@ build {
 ~> Note: Since WinRM is closed by default in the system image. If you are
 planning to use Windows as the base image, you need enable it by userdata in
 order to connect to the instance, check
-[alicloud_windows.json](https://github.com/hashicorp/packer/tree/master/examples/alicloud/basic/alicloud_windows.json)
+[alicloud_windows.json](https://github.com/hashicorp/packer/tree/master/builder/alicloud/examples/basic/alicloud_windows.json)
 and
-[winrm_enable_userdata.ps1](https://github.com/hashicorp/packer/tree/master/examples/alicloud/basic/winrm_enable_userdata.ps1)
+[winrm_enable_userdata.ps1](https://github.com/hashicorp/packer/tree/master/builder/alicloud/examples/basic/winrm_enable_userdata.ps1)
 for details.
 
 See the
-[examples/alicloud](https://github.com/hashicorp/packer/tree/master/examples/alicloud)
+[examples/alicloud](https://github.com/hashicorp/packer/tree/master/builder/alicloud/examples)
 folder in the packer project for more examples.

--- a/website/content/docs/builders/amazon/index.mdx
+++ b/website/content/docs/builders/amazon/index.mdx
@@ -71,7 +71,7 @@ These look like:
 
 ```json
 "builders": {
-  "type": "amazon-ebs"
+  "type": "amazon-ebs",
   "access_key": "AKIAIOSFODNN7EXAMPLE",
   "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
   "region": "us-east-1",

--- a/website/content/docs/builders/azure/arm.mdx
+++ b/website/content/docs/builders/azure/arm.mdx
@@ -234,7 +234,7 @@ means executing sysprep, and for Linux this means executing the waagent
 deprovision process.
 
 Please refer to the Azure
-[examples](https://github.com/hashicorp/packer/tree/master/examples/azure) for
+[examples](https://github.com/hashicorp/packer/tree/master/builder/azure/examples) for
 complete examples showing the deprovision process.
 
 ### Windows
@@ -489,5 +489,5 @@ templates and deployments. The time required to deploy a KeyVault template is
 minimal, so overall impact is small.
 
 See the
-[examples/azure](https://github.com/hashicorp/packer/tree/master/examples/azure)
+[examples/azure](https://github.com/hashicorp/packer/tree/master/builder/azure/examples)
 folder in the packer project for more examples.

--- a/website/content/docs/builders/jdcloud.mdx
+++ b/website/content/docs/builders/jdcloud.mdx
@@ -85,4 +85,4 @@ Here is a basic example for JDCloud.
 }
 ```
 
-[Find more examples](https://github.com/hashicorp/packer/tree/master/examples/jdcloud)
+[Find more examples](https://github.com/hashicorp/packer/tree/master/builder/jdcloud/examples)

--- a/website/content/docs/builders/linode.mdx
+++ b/website/content/docs/builders/linode.mdx
@@ -41,6 +41,12 @@ can also be supplied to override the typical auto-generated key:
 
 @include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'
 
+<!--
+  Linode.com has DDOS protection that returns 403 for the markdown link checker
+  so the domain has been added to the ignorepatterns in mlc_config.json
+
+  See https://github.com/tcort/markdown-link-check/issues/109
+-->
 ### Required
 
 - `linode_token` (string) - The client TOKEN to use to access your account.

--- a/website/content/docs/builders/oneandone.mdx
+++ b/website/content/docs/builders/oneandone.mdx
@@ -45,8 +45,10 @@ can also be supplied to override the typical auto-generated key:
 - `retries` (number) - Number of retries Packer will make status requests
   while waiting for the build to complete. Default value "600".
 
+<!-- markdown-link-check-disable -->
 - `url` (string) - Endpoint for the 1&1 REST API. Default URL
   "<https://cloudpanel-api.1and1.com/v1>"
+<!-- markdown-link-check-enable -->
 
 ## Example
 

--- a/website/content/docs/builders/openstack.mdx
+++ b/website/content/docs/builders/openstack.mdx
@@ -93,6 +93,9 @@ builder.
 Here is a basic example. This is a example to build on DevStack running in a
 VM.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "openstack",
@@ -110,10 +113,34 @@ VM.
 }
 ```
 
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+builders "openstack" {
+  identity_endpoint = "http://<devstack-ip>:5000/v3"
+  tenant_name = "admin"
+  domain_name = "Default"
+  username = "admin"
+  password = "<your admin password>"
+  region = "RegionOne"
+  ssh_username = "root"
+  image_name = "Test image"
+  source_image = "<image id>"
+  flavor = "m1.tiny"
+  insecure = "true"
+}
+```
+</Tab>
+</Tabs>
+
 ## Basic Example: Rackspace public cloud
 
 Here is a basic example. This is a working example to build a Ubuntu 12.04 LTS
 (Precise Pangolin) on Rackspace OpenStack cloud offering.
+
+<Tabs>
+<Tab heading="JSON"> 
 
 ```json
 {
@@ -127,11 +154,31 @@ Here is a basic example. This is a working example to build a Ubuntu 12.04 LTS
   "flavor": "2"
 }
 ```
+</Tab>
+
+<Tab heading="HCL2">
+
+```hcl
+builders "openstack" {
+  username = "foo"
+  password = "foo"
+  region = "DFW"
+  ssh_username = "root"
+  image_name = "Test image"
+  source_image = "23b564c9-c3e6-49f9-bc68-86c7a9ab5018"
+  flavor = "2"
+}
+```
+</Tab>
+</Tabs>
 
 ## Basic Example: Private OpenStack cloud
 
 This example builds an Ubuntu 14.04 image on a private OpenStack cloud, powered
 by Metacloud.
+
+<Tabs>
+<Tab heading="JSON">
 
 ```json
 {
@@ -142,6 +189,21 @@ by Metacloud.
   "flavor": "2"
 }
 ```
+</Tab>
+
+<Tab heading="HCL2">
+
+```hcl
+builders "openstack" {
+  ssh_username = "root"
+  image_name = "ubuntu1404_packer_test_1"
+  source_image = "91d9c168-d1e5-49ca-a775-3bfdbb6c97f1"
+  flavor = "2"
+}
+```
+</Tab>
+</Tabs>
+
 
 In this case, the connection information for connecting to OpenStack doesn't
 appear in the template. That is because I source a standard OpenStack script
@@ -182,6 +244,9 @@ A basic example of Instance with a remote root Block Storage service volume.
 This is a working example to build an image on private OpenStack cloud powered
 by Selectel VPC.
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "openstack",
@@ -200,6 +265,30 @@ by Selectel VPC.
   "volume_type": "fast.ru-3a"
 }
 ```
+</Tab>
+
+<Tab heading="HCL2">
+
+```hcl
+builders "openstack" {
+  identity_endpoint = "https://api.selvpc.com/identity/v3"
+  tenant_id = "2e90c5c04c7b4c509be78723e2b55b77"
+  username = "foo"
+  password = "foo"
+  region = "ru-3"
+  ssh_username = "root"
+  image_name = "Test image"
+  source_image = "5f58ea7e-6264-4939-9d0f-0c23072b1132"
+  networks = "9aab504e-bedf-48af-9256-682a7fa3dabb"
+  flavor = "1001"
+  availability_zone = "ru-3a"
+  use_blockstorage_volume = true
+  volume_type = "fast.ru-3a"
+}
+```
+</Tab>
+</Tabs>
+
 
 ## Notes on OpenStack Authorization
 

--- a/website/content/docs/builders/oracle/classic.mdx
+++ b/website/content/docs/builders/oracle/classic.mdx
@@ -17,7 +17,7 @@ image, runs any provisioning necessary on the base image after launching it,
 and finally snapshots it creating a reusable custom image.
 
 It is recommended that you familiarise yourself with the [Key Concepts and
-Terminology](https://docs.oracle.com/en/cloud/iaas/compute-iaas-cloud/stcsg/terminology.html)
+Terminology](https://docs.oracle.com/en/cloud/iaas-classic/compute-iaas-cloud/stcsg/getting-started-oracle-compute-cloud-service.html#GUID-6CB9D494-4F3C-4B78-BD03-127983FEC357)
 prior to using this builder if you have not done so already.
 
 The builder _does not_ manage images. Once it creates an image, it is up to you
@@ -52,7 +52,7 @@ builder. This builder currently only works with the SSH communicator.
 
 - `source_image_list` (string) - This is what image you want to use as your
   base image. See the
-  [documentation](https://docs.oracle.com/en/cloud/iaas/compute-iaas-cloud/stcsg/listing-machine-images.html)
+  [documentation](https://docs.oracle.com/en/cloud/iaas-classic/compute-iaas-cloud/stcsg/managing-machine-images.html#GUID-652E6797-A5B8-40A7-860F-F27FF3E42471)
   for more details. You may use either a public image list, or a private
   image list. To see what public image lists are available, you can use the
   CLI, as described
@@ -66,7 +66,7 @@ builder. This builder currently only works with the SSH communicator.
 - `shape` (string) - The template that determines the number of CPUs, amount
   of memory, and other resources allocated to a newly created instance. For
   more information about shapes, see the documentation
-  [here](https://docs.oracle.com/en/cloud/iaas/compute-iaas-cloud/stcsg/machine-images-and-shapes.html).
+  [here](https://docs.oracle.com/en/cloud/iaas-classic/compute-iaas-cloud/stcsg/creating-instances.html#GUID-1DD0FA71-AC7B-461C-B8C1-14892725AA69).
 
 - `username` (string) - Your account username.
 
@@ -132,10 +132,6 @@ instance storage. We also attach a new persistent volume, making it twice the
 size of the original. We connect to this instance and copy the contents of the
 first volume into a tarball file on the second volume. We then upload this file
 to Object Storage Classic, and create a new machine image with it.
-
-For more details, see this [blog
-post](https://blogs.oracle.com/cloudmarketplace/creating-an-oracle-compute-machine-image-from-an-instance-with-persistent-boot-storage),
-which discusses the strategy used here.
 
 If this is set, a few more options become available.
 

--- a/website/content/docs/builders/oracle/oci.mdx
+++ b/website/content/docs/builders/oracle/oci.mdx
@@ -186,12 +186,14 @@ can also be supplied to override the typical auto-generated key:
 - `use_private_ip` (boolean) - Use private ip addresses to connect to the
   instance via ssh.
 
+<!-- markdown-link-check-disable -->
 - `metadata` (map of strings) - Metadata optionally contains custom metadata
   key/value pairs provided in the configuration. While this can be used to
   set metadata\["user_data"\] the explicit "user_data" and
   "user_data_file" values will have precedence. An instance's metadata can
   be obtained from at [http://169.254.169.254](http://169.254.169.254) on
   the launched instance.
+<!-- markdown-link-check-enable -->
 
 - `user_data` (string) - User data to be used by cloud-init. See [the Oracle
   docs](https://docs.us-phoenix-1.oraclecloud.com/api/#/en/iaas/20160918/LaunchInstanceDetails)

--- a/website/content/docs/builders/outscale/chroot.mdx
+++ b/website/content/docs/builders/outscale/chroot.mdx
@@ -158,7 +158,7 @@ each category, the available configuration keys are alphabetized.
   when mounting devices. Each option will be prefixed with `-o` and supplied
   to the `mount` command ran by Packer. Because this command is ran in a
   shell, user discretion is advised. See [this manual page for the mount
-  command](http://linuxcommand.org/man_pages/mount8.html) for valid file
+  command](https://linux.die.net/man/8/mount) for valid file
   system specific options.
 
 - `nvme_device_path` (string) - When we call the mount command (by default

--- a/website/content/docs/builders/outscale/index.mdx
+++ b/website/content/docs/builders/outscale/index.mdx
@@ -105,13 +105,13 @@ export OUTSCALE_X509KEY="the/path/to/your/x509key"
 ### Checking that system time is current
 
 Outscale uses the current time as part of the [request signing
-process](http://docs.aws.osc.com/general/latest/gr/sigv4_signing.html). If
+process](https://wiki.outscale.net/display/EN/About+Signatures+of+API+Requests). If
 your system clock is too skewed from the current time, your requests might
 fail. If that's the case, you might see an error like this:
 
     ==> osc-bsu: Error querying OMI: AuthFailure: OUTSCALE was not able to validate the provided access credentials
 
 If you suspect your system's date is wrong, you can compare it against
-<http://www.time.gov/>. On Linux/OS X, you can run the `date` command to get
+<https://www.time.gov/>. On Linux/OS X, you can run the `date` command to get
 the current time. If you're on Linux, you can try setting the time with ntp by
 running `sudo ntpd -q`.

--- a/website/content/docs/builders/profitbricks.mdx
+++ b/website/content/docs/builders/profitbricks.mdx
@@ -60,9 +60,10 @@ can also be supplied to override the typical auto-generated key:
   generate it
 
 - `snapshot_password` (string) - Password for the snapshot.
-
+<!-- markdown-link-check-disable -->
 - `url` (string) - Endpoint for the ProfitBricks REST API. Default URL
   "<https://api.profitbricks.com/rest/v2>"
+<!-- markdown-link-check-enable -->
 
 ## Example
 

--- a/website/content/docs/builders/proxmox/iso.mdx
+++ b/website/content/docs/builders/proxmox/iso.mdx
@@ -212,6 +212,7 @@ builder.
   Defaults to `lsi`.
 
 - `cloud_init` (bool) - If true, add a Cloud-Init CDROM drive after the virtual machine has been converted to a template.
+   Defaults to `false`.
 
 - `cloud_init_storage_pool` - (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.

--- a/website/content/docs/builders/scaleway.mdx
+++ b/website/content/docs/builders/scaleway.mdx
@@ -75,7 +75,6 @@ access tokens:
 
 ```hcl
 builders "scaleway" {
-  type = "scaleway"
   project_id = "YOUR PROJECT ID"
   access_key = "YOUR ACCESS KEY"
   secret_key = "YOUR SECRET KEY"

--- a/website/content/docs/builders/scaleway.mdx
+++ b/website/content/docs/builders/scaleway.mdx
@@ -53,6 +53,9 @@ can also be supplied to override the typical auto-generated key:
 Here is a basic example. It is completely valid as soon as you enter your own
 access tokens:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "scaleway",
@@ -66,6 +69,26 @@ access tokens:
   "ssh_private_key_file": "~/.ssh/id_rsa"
 }
 ```
+</Tab>
+
+<Tab heading="HCL2">
+
+```hcl
+builders "scaleway" {
+  type = "scaleway"
+  project_id = "YOUR PROJECT ID"
+  access_key = "YOUR ACCESS KEY"
+  secret_key = "YOUR SECRET KEY"
+  image = "UUID OF THE BASE IMAGE"
+  zone = "fr-par-1"
+  commercial_type = "DEV1-S"
+  ssh_username = "root"
+  ssh_private_key_file = "~/.ssh/id_rsa"
+}
+```
+</Tab>
+</Tabs>
+
 
 When you do not specify the `ssh_private_key_file`, a temporary SSH keypair
 is generated to connect the server. This key will only allow the `root` user to

--- a/website/content/docs/builders/tencentcloud-cvm.mdx
+++ b/website/content/docs/builders/tencentcloud-cvm.mdx
@@ -182,5 +182,5 @@ Here is a basic example for Tencentcloud.
 ```
 
 See the
-[examples/tencentcloud](https://github.com/hashicorp/packer/tree/master/examples/tencentcloud)
+[examples/tencentcloud](https://github.com/hashicorp/packer/tree/master/builder/tencentcloud/examples)
 folder in the packer project for more examples.

--- a/website/content/docs/extending/custom-builders.mdx
+++ b/website/content/docs/extending/custom-builders.mdx
@@ -56,7 +56,7 @@ configuration, with later parameters overwriting any previous configuration.
 The exact semantics of the merge are left to the builder author.
 
 For decoding the `interface{}` into a meaningful structure, the
-[mapstructure](https://github.com/mitchellh/mapstructure) library is
+[mapstructure](https://godoc.org/github.com/mitchellh/mapstructure) library is
 recommended. Mapstructure will take an `interface{}` and decode it into an
 arbitrarily complex struct. If there are any errors, it generates very human
 friendly errors that can be returned directly from the prepare method.
@@ -88,8 +88,8 @@ And `packer.Cache` is used to store files between multiple Packer runs, and is
 covered in more detail in the cache section below.
 
 Because builder runs are typically a complex set of many steps, the
-[multistep](https://github.com/hashicorp/packer/blob/master/helper/multistep)
-helper is recommended to bring order to the complexity. Multistep is a library
+[multistep](https://godoc.org/github.com/hashicorp/packer-plugin-sdk/multistep)
+package is recommended to bring order to the complexity. Multistep is a library
 which allows you to separate your logic into multiple distinct "steps" and
 string them together. It fully supports cancellation mid-step and so on. Please
 check it out, it is how the built-in builders are all implemented.
@@ -137,7 +137,7 @@ about the artifact results, so it is important it never changes.
 
 Other than the builder ID, the rest should be self-explanatory by reading the
 [packer.Artifact interface
-documentation](https://github.com/hashicorp/packer/blob/master/packer/artifact.go).
+documentation](https://godoc.org/github.com/hashicorp/packer-plugin-sdk/packer#Artifact).
 
 ## Provisioning
 

--- a/website/content/docs/extending/custom-provisioners.mdx
+++ b/website/content/docs/extending/custom-provisioners.mdx
@@ -101,7 +101,7 @@ some sort) or it may be remote (in a cloud). The communicator interface
 abstracts this away so that communication is the same overall.
 
 The documentation around the [code
-itself](https://github.com/hashicorp/packer/blob/master/packer/communicator.go)
+itself](https://godoc.org/github.com/hashicorp/packer-plugin-sdk/packer#Communicator)
 is really great as an overview of how to use the interface. You should begin by
 reading this. Once you have read it, you can see some example usage below:
 

--- a/website/content/docs/extending/plugins.mdx
+++ b/website/content/docs/extending/plugins.mdx
@@ -122,7 +122,7 @@ And, thanks to Go's
 [interfaces](https://golang.org/doc/effective_go.html#interfaces_and_types), it
 doesn't even look like inter-process communication is occurring. You just use
 the interfaces like normal, but in fact they're being executed in a remote
-process. Pretty cool.
+process.
 
 ### Plugin Development Basics
 
@@ -136,11 +136,11 @@ than the following two packages, you're encouraged to use whatever packages you
 want. Because plugins are their own processes, there is no danger of colliding
 dependencies.
 
-- `github.com/hashicorp/packer` - Contains all the interfaces that you have
+- `github.com/hashicorp/packer-plugin-sdk/packer` - Contains all the interfaces that you have
   to implement for any given plugin.
 
-- `github.com/hashicorp/packer/packer/plugin` - Contains the code to serve
-  the plugin. This handles all the inter-process communication stuff.
+- `github.com/hashicorp/packer-plugin-sdk/plugin` - Contains the code to serve
+  the plugin. This handles all the inter-process communication.
 
 There are two steps involved in creating a plugin:
 
@@ -150,9 +150,11 @@ There are two steps involved in creating a plugin:
 2.  Serve the interface by calling the appropriate plugin serving method in
     your main method.
 
-Basic examples are shown below. Note that if you can define a multi-plugin
-binary as it will allow to add more that one plugin per binary.
-
+There are two different ways to serve plugins: an older server (Packer v1.6.6
+and earlier) which serves a single plugin of a single type, and a newer "set"
+server (Packer 1.7.0 and beyond) that allows you to create single binaries that
+contain multiple plugins of different types, and will be able to be discovered
+by the Packer init tooling in development.
 
 <Tabs>
 <Tab heading="Multi-plugin Binary">
@@ -176,6 +178,7 @@ func main() {
 	pps.RegisterBuilder("example", new(ExampleBuilder))
 	pps.RegisterPostProcessor("foo", new(FooPostProcessor))
 	pps.RegisterProvisioner("bar", new(BarProvisioner))
+	pps.RegisterProvisioner(plugin.DEFAULT_NAME, new(BazProvisioner))
 	err := pps.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -184,16 +187,19 @@ func main() {
 }
 ```
 
-**That's it!** `plugin.NewSet` handles all the nitty gritty of
-communicating with Packer core and serving your builder over RPC. It can't get
-much easier than that.
+**That's it!** `plugin.NewSet` handles all the details of communicating with
+Packer core and serving your builder over RPC.
 
 Here the name of the plugin will be used to use each plugin, so if your plugin
-is named `packer-plugin-my`, this would make the following parts available:
+is saved on your filesystem using the name `packer-plugin-my`, you would
+reference the various plugins in your Packer template as:
 
 * the `my-example` builder
 * the `my-foo` post-processor
 * the `my-bar` provisioner
+* the `my` provisioner (This is a special case where you use the root name of
+the plugin rather than a compound name, created by using the plugin.DEFAULT_NAME
+constant. You can use this constant once per plugin set.)
 
 </Tab>
 <Tab heading="Single Plugin Binary">
@@ -216,17 +222,16 @@ func main() {
 }
 ```
 
-**That's it!** `plugin.Server` handles all the nitty gritty of communicating with
-Packer core and serving your builder over RPC. It can't get much easier than
-that.
+**That's it!** `plugin.Server` handles all the details of communicating with
+Packer core and serving your plugins over RPC.
 
 </Tab>
 </Tabs>
 
 
-Next, just build your plugin like a normal Go application, using `go build` or
-however you please. The resulting binary is the plugin that can be installed
-using standard installation procedures.
+Next, build your plugin like any other Go application, using `go build`. The
+resulting binary is the plugin that can be installed using standard installation
+procedures.
 
 The specifics of how to implement each type of interface are covered in the
 relevant subsections available in the navigation to the left.
@@ -259,33 +264,44 @@ the logs to be helpful.
 
 ### Creating a GitHub Release
 
-To create a GitHub release with the assets that will be consumed by Packer, we provide a pre-defined release workflow configuration
-using [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions). We strongly encourage maintainers to use this configuration
-to make sure the release contains the assets expected by Packer to load and use a plugin.
-[GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions) allow you to execute workflows when events on your repository occur.
-You can use this to create releases whenever a new version tag is created on your repository.
+To create a GitHub release with the assets that will be consumed by Packer, we
+provide a pre-defined release workflow configuration using
+[GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions).
+We strongly encourage maintainers to use this configuration to make sure the
+release contains the assets expected by Packer to load and use a plugin.
+[GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions) allow
+you to execute workflows when events on your repository occur. You can use this
+to create releases whenever a new version tag is created on your repository.
 
 Here's what you need to create releases using GitHub Actions:
-1. Generate a GPG key to be used when signing releases (See [GitHub's detailed instructions](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/generating-a-new-gpg-key)
-for help with this step)
+
+1. Generate a GPG key to be used when signing releases (See
+  [GitHub's detailed instructions](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/generating-a-new-gpg-key) for help with this step)
 2. Copy the [GoReleaser configuration from the packer-plugin-scaffolding repository](https://github.com/hashicorp/packer-plugin-scaffolding) to the root of your repository.
 3. Copy the [GitHub Actions workflow from the packer-plugin-scaffolding repository](https://github.com/hashicorp/packer-plugin-scaffolding) to `.github/workflows/release.yml` in your repository.
 4. Go to Settings > Secrets in your repository, and add the following secrets:
     - `GPG_PRIVATE_KEY` - Your ASCII-armored GPG private key. You can export this with `gpg --armor --export-secret-keys [key ID or email]`.
     - `PASSPHRASE` - The passphrase for your GPG private key.
-5. Push a new valid version tag (e.g. `v1.2.3`) to test that the GitHub Actions releaser is working. The tag must be a valid [Semantic Version](https://semver.org/) preceded with a `v`.
+5. Push a new valid version tag (e.g. `v1.2.3`) to test that the GitHub Actions
+  releaser is working. The tag must be a valid
+  [Semantic Version](https://semver.org/) preceded with a `v`.
 6. Make sure to [register your plugin](#registering-the-plugin) with us.
 
-~> **Important:** Avoid modifying or replacing an already-released version of a plugin. Instead, if changes are necessary,
-please release as a new version.
+~> **Important:** Avoid modifying or replacing an already-released version of a
+plugin. Instead, if changes are necessary, please release as a new version.
 
 ### Registering the Plugin
 
-We like to keep all of our products and external plugins release assets together in the same place. To publish
-an external plugin to [releases.hashicorp.com](https://releases.hashicorp.com), we require the maintainer's GPG public key to validate the asset authenticity.
-To register your plugin with HashiCorp, send us your GPG public key and your plugin's GitHub repository via [maintainers@hashicorp.com](mailto://maintainers@hashicorp.com).
+We like to keep all of our products and external plugins release assets together
+in the same place. To publish an external plugin to
+[releases.hashicorp.com](https://releases.hashicorp.com), we require the
+maintainer's GPG public key to validate the asset authenticity. To register
+your plugin with HashiCorp, send us your GPG public key and your plugin's GitHub
+repository via [maintainers@hashicorp.com](mailto://maintainers@hashicorp.com).
 
-To get you GPG public key in ASCII-armor format, use the following command, substituting the GPG key ID or email address:
+To get you GPG public key in ASCII-armor format, use the following command,
+substituting the GPG key ID or email address:
+
 ```bash
 $ gpg --armor --export "{Key ID or email address}"
 ```

--- a/website/content/docs/from-1.5/expressions.mdx
+++ b/website/content/docs/from-1.5/expressions.mdx
@@ -135,7 +135,7 @@ Packer makes one named values available.
 The following named values are available:
 
 - `source.<SOURCE TYPE>.<NAME>` is an object representing a
-  [source](/docs/from-1.5/sources) of the given type
+  [source](/docs/from-1.5/blocks/source) of the given type
   and name.
 
 ### Available Functions

--- a/website/content/docs/post-processors/checksum.mdx
+++ b/website/content/docs/post-processors/checksum.mdx
@@ -43,7 +43,7 @@ a third-party post-processor.
 <Tab heading="HCL2">
 
 ```hcl
-post-processor "checksum" {
+post-processors "checksum" {
   checksum_types = ["sha1", "sha256"]
   output = "packer_{{.BuildName}}_{{.ChecksumType}}.checksum"
 }

--- a/website/content/docs/post-processors/docker-save.mdx
+++ b/website/content/docs/post-processors/docker-save.mdx
@@ -57,7 +57,6 @@ An example is shown below, showing only the post-processor configuration:
 
 ```hcl
 post-processors "docker-save" {
-  type = "docker-save"
   path = "foo.tar"
 }
 ```

--- a/website/content/docs/post-processors/docker-save.mdx
+++ b/website/content/docs/post-processors/docker-save.mdx
@@ -42,9 +42,25 @@ The configuration for this post-processor only requires one option.
 
 An example is shown below, showing only the post-processor configuration:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "docker-save",
   "path": "foo.tar"
 }
 ```
+</Tab>
+
+<Tab heading="HCL2">
+
+```hcl
+post-processor "docker-save" {
+  type = "docker-save"
+  path = "foo.tar"
+}
+```
+</Tab>
+</Tabs>
+

--- a/website/content/docs/post-processors/docker-save.mdx
+++ b/website/content/docs/post-processors/docker-save.mdx
@@ -56,7 +56,7 @@ An example is shown below, showing only the post-processor configuration:
 <Tab heading="HCL2">
 
 ```hcl
-post-processor "docker-save" {
+post-processors "docker-save" {
   type = "docker-save"
   path = "foo.tar"
 }

--- a/website/content/docs/post-processors/docker-tag.mdx
+++ b/website/content/docs/post-processors/docker-tag.mdx
@@ -66,7 +66,6 @@ An example is shown below, showing only the post-processor configuration:
 
 ```hcl
 post-processors "docker-tag" {
-  type = "docker-tag"
   repository = "hashicorp/packer"
   tag = "0.7,anothertag"
 }

--- a/website/content/docs/post-processors/docker-tag.mdx
+++ b/website/content/docs/post-processors/docker-tag.mdx
@@ -50,6 +50,9 @@ settings are optional.
 
 An example is shown below, showing only the post-processor configuration:
 
+<Tabs>
+<Tab heading="JSON">
+
 ```json
 {
   "type": "docker-tag",
@@ -57,6 +60,20 @@ An example is shown below, showing only the post-processor configuration:
   "tag": "0.7,anothertag"
 }
 ```
+</Tab>
+
+<Tab heading="HCL2">
+
+```hcl
+post-processors "docker-tag" {
+  type = "docker-tag"
+  repository = "hashicorp/packer"
+  tag = "0.7,anothertag"
+}
+```
+</Tab>
+</Tabs>
+
 
 This example would take the image created by the Docker builder and tag it into
 the local Docker process with a name of `hashicorp/packer:0.7`.

--- a/website/content/docs/provisioners/ansible.mdx
+++ b/website/content/docs/provisioners/ansible.mdx
@@ -388,7 +388,7 @@ class Connection(SSHConnection):
 Newer versions of Ansible require all plugins to have a documentation string.
 You can see if there is a plugin available for the version of Ansible you are
 using
-[here](https://github.com/hashicorp/packer/tree/master/examples/ansible/connection-plugin).
+[here](https://github.com/hashicorp/packer/tree/master/provisioner/ansible/examples/connection-plugin).
 
 To create the plugin yourself, you will need to copy all of the `options` from
 the `DOCUMENTATION` string from the [ssh.py Ansible connection

--- a/website/content/docs/provisioners/chef-client.mdx
+++ b/website/content/docs/provisioners/chef-client.mdx
@@ -109,7 +109,7 @@ configuration is actually required.
   windows.
 
 - `run_list` (array of strings) - The [run
-  list](http://docs.chef.io/essentials_node_object_run_lists) for Chef.
+  list](https://docs.chef.io/run_lists) for Chef.
   By default this is empty, and will use the run list sent down by the Chef
   Server.
 

--- a/website/content/docs/provisioners/puppet-server.mdx
+++ b/website/content/docs/provisioners/puppet-server.mdx
@@ -84,7 +84,7 @@ listed below:
   ```
 
 * `facter` (object of key/value strings) - Additional
-  [facts](https://puppetlabs.com/facter) to make available to the Puppet run.
+  [facts](https://puppet.com/docs/puppet/latest/facter.html) to make available to the Puppet run.
 
 * `guest_os_type` (string) - The remote host's OS type ('windows' or 'unix')
   to tailor command-line and path separators. (default: unix).

--- a/website/content/partials/builder/amazon/common/RunConfig-not-required.mdx
+++ b/website/content/partials/builder/amazon/common/RunConfig-not-required.mdx
@@ -15,7 +15,7 @@
 
 - `disable_stop_instance` (bool) - Packer normally stops the build instance after all provisioners have
   run. For Windows instances, it is sometimes desirable to [run
-  Sysprep](http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ami-create-standard.html)
+  Sysprep](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/Creating_EBSbacked_WinAMI.html)
   which will stop the instance for you. If this is set to `true`, Packer
   *will not* stop the instance but will assume that you will send the stop
   signal yourself through your final provisioner. You can do this with a

--- a/website/content/partials/builder/azure/arm/Config-required.mdx
+++ b/website/content/partials/builder/azure/arm/Config-required.mdx
@@ -1,20 +1,20 @@
 <!-- Code generated from the comments of the Config struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
 - `image_publisher` (string) - Name of the publisher to use for your base image (Azure Marketplace Images only). See
-  [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+  [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
   for details.
   
   CLI example `az vm image list-publishers --location westus`
 
 - `image_offer` (string) - Name of the publisher's offer to use for your base image (Azure Marketplace Images only). See
-  [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+  [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
   for details.
   
   CLI example
   `az vm image list-offers --location westus --publisher Canonical`
 
 - `image_sku` (string) - SKU of the image offer to use for your base image (Azure Marketplace Images only). See
-  [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+  [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
   for details.
   
   CLI example

--- a/website/content/partials/builder/azure/dtl/Config-not-required.mdx
+++ b/website/content/partials/builder/azure/dtl/Config-not-required.mdx
@@ -46,20 +46,20 @@
   minutes, and `h` for hours.)
 
 - `image_publisher` (string) - PublisherName for your base image. See
-  [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+  [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
   for details.
   
   CLI example `az vm image list-publishers --location westus`
 
 - `image_offer` (string) - Offer for your base image. See
-  [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+  [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
   for details.
   
   CLI example
   `az vm image list-offers --location westus --publisher Canonical`
 
 - `image_sku` (string) - SKU for your base image. See
-  [documentation](https://azure.microsoft.com/en-us/documentation/articles/resource-groups-vm-searching/)
+  [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
   for details.
   
   CLI example

--- a/website/content/partials/builder/vagrant/Config-not-required.mdx
+++ b/website/content/partials/builder/vagrant/Config-not-required.mdx
@@ -17,7 +17,7 @@
    * ebfb681885ddf1234c18094a45bbeafd91467911
    * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
    * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-   * file:http://releases.ubuntu.com/20.04/MD5SUMS
+   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
    * file:file://./local/path/file.sum
    * file:./local/path/file.sum
    * none

--- a/website/content/partials/builder/virtualbox/ovf/Config-required.mdx
+++ b/website/content/partials/builder/virtualbox/ovf/Config-required.mdx
@@ -13,7 +13,7 @@
    * ebfb681885ddf1234c18094a45bbeafd91467911
    * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
    * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-   * file:http://releases.ubuntu.com/20.04/MD5SUMS
+   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
    * file:file://./local/path/file.sum
    * file:./local/path/file.sum
    * none

--- a/website/content/partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
+++ b/website/content/partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
@@ -1,7 +1,7 @@
 <!-- Code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; DO NOT EDIT MANUALLY -->
 
 - `configuration_parameters` (map[string]string) - configuration_parameters is a direct passthrough to the VSphere API's
-  ConfigSpec: https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.ConfigSpec.html
+  ConfigSpec: https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.ConfigSpec.html
 
 - `tools_sync_time` (bool) - Enables time synchronization with the host. Defaults to false.
 

--- a/website/content/partials/packer-plugin-sdk/bootcommand/BootConfig-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/bootcommand/BootConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the BootConfig struct in packer-plugin-sdk/bootcommand/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the BootConfig struct in bootcommand/config.go; DO NOT EDIT MANUALLY -->
 
 - `boot_keygroup_interval` (duration string | ex: "1h5m2s") - Time to wait after sending a group of key pressses. The value of this
   should be a duration. Examples are `5s` and `1m30s` which will cause

--- a/website/content/partials/packer-plugin-sdk/bootcommand/BootConfig.mdx
+++ b/website/content/partials/packer-plugin-sdk/bootcommand/BootConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the BootConfig struct in packer-plugin-sdk/bootcommand/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the BootConfig struct in bootcommand/config.go; DO NOT EDIT MANUALLY -->
 
 The boot configuration is very important: `boot_command` specifies the keys
 to type when the virtual machine is first booted in order to start the OS
@@ -11,62 +11,62 @@ sequence. It is an array only to improve readability within the template.
 There are a set of special keys available. If these are in your boot
 command, they will be replaced by the proper key:
 
-- `<bs>` - Backspace
+-   `<bs>` - Backspace
 
-- `<del>` - Delete
+-   `<del>` - Delete
 
-- `<enter> <return>` - Simulates an actual "enter" or "return" keypress.
+-   `<enter> <return>` - Simulates an actual "enter" or "return" keypress.
 
-- `<esc>` - Simulates pressing the escape key.
+-   `<esc>` - Simulates pressing the escape key.
 
-- `<tab>` - Simulates pressing the tab key.
+-   `<tab>` - Simulates pressing the tab key.
 
-- `<f1> - <f12>` - Simulates pressing a function key.
+-   `<f1> - <f12>` - Simulates pressing a function key.
 
-- `<up> <down> <left> <right>` - Simulates pressing an arrow key.
+-   `<up> <down> <left> <right>` - Simulates pressing an arrow key.
 
-- `<spacebar>` - Simulates pressing the spacebar.
+-   `<spacebar>` - Simulates pressing the spacebar.
 
-- `<insert>` - Simulates pressing the insert key.
+-   `<insert>` - Simulates pressing the insert key.
 
-- `<home> <end>` - Simulates pressing the home and end keys.
+-   `<home> <end>` - Simulates pressing the home and end keys.
 
-- `<pageUp> <pageDown>` - Simulates pressing the page up and page down
-  keys.
+-   `<pageUp> <pageDown>` - Simulates pressing the page up and page down
+    keys.
 
-- `<menu>` - Simulates pressing the Menu key.
+-   `<menu>` - Simulates pressing the Menu key.
 
-- `<leftAlt> <rightAlt>` - Simulates pressing the alt key.
+-   `<leftAlt> <rightAlt>` - Simulates pressing the alt key.
 
-- `<leftCtrl> <rightCtrl>` - Simulates pressing the ctrl key.
+-   `<leftCtrl> <rightCtrl>` - Simulates pressing the ctrl key.
 
-- `<leftShift> <rightShift>` - Simulates pressing the shift key.
+-   `<leftShift> <rightShift>` - Simulates pressing the shift key.
 
-- `<leftSuper> <rightSuper>` - Simulates pressing the ⌘ or Windows key.
+-   `<leftSuper> <rightSuper>` - Simulates pressing the ⌘ or Windows key.
 
-- `<wait> <wait5> <wait10>` - Adds a 1, 5 or 10 second pause before
-  sending any additional keys. This is useful if you have to generally
-  wait for the UI to update before typing more.
+-   `<wait> <wait5> <wait10>` - Adds a 1, 5 or 10 second pause before
+    sending any additional keys. This is useful if you have to generally
+    wait for the UI to update before typing more.
 
-- `<waitXX>` - Add an arbitrary pause before sending any additional keys.
-  The format of `XX` is a sequence of positive decimal numbers, each with
-  optional fraction and a unit suffix, such as `300ms`, `1.5h` or `2h45m`.
-  Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. For
-  example `<wait10m>` or `<wait1m20s>`.
+-   `<waitXX>` - Add an arbitrary pause before sending any additional keys.
+    The format of `XX` is a sequence of positive decimal numbers, each with
+    optional fraction and a unit suffix, such as `300ms`, `1.5h` or `2h45m`.
+    Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. For
+    example `<wait10m>` or `<wait1m20s>`.
 
-- `<XXXOn> <XXXOff>` - Any printable keyboard character, and of these
-  "special" expressions, with the exception of the `<wait>` types, can
-  also be toggled on or off. For example, to simulate ctrl+c, use
-  `<leftCtrlOn>c<leftCtrlOff>`. Be sure to release them, otherwise they
-  will be held down until the machine reboots. To hold the `c` key down,
-  you would use `<cOn>`. Likewise, `<cOff>` to release.
+-   `<XXXOn> <XXXOff>` - Any printable keyboard character, and of these
+     "special" expressions, with the exception of the `<wait>` types, can
+     also be toggled on or off. For example, to simulate ctrl+c, use
+     `<leftCtrlOn>c<leftCtrlOff>`. Be sure to release them, otherwise they
+     will be held down until the machine reboots. To hold the `c` key down,
+     you would use `<cOn>`. Likewise, `<cOff>` to release.
 
-- `{{ .HTTPIP }} {{ .HTTPPort }}` - The IP and port, respectively of an
-  HTTP server that is started serving the directory specified by the
-  `http_directory` configuration parameter. If `http_directory` isn't
-  specified, these will be blank!
+-   `{{ .HTTPIP }} {{ .HTTPPort }}` - The IP and port, respectively of an
+    HTTP server that is started serving the directory specified by the
+    `http_directory` configuration parameter. If `http_directory` isn't
+    specified, these will be blank!
 
-- `{{ .Name }}` - The name of the VM.
+-   `{{ .Name }}` - The name of the VM.
 
 Example boot command. This is actually a working boot command used to start an
 CentOS 6.4 installer:

--- a/website/content/partials/packer-plugin-sdk/bootcommand/VNCConfig-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/bootcommand/VNCConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the VNCConfig struct in packer-plugin-sdk/bootcommand/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the VNCConfig struct in bootcommand/config.go; DO NOT EDIT MANUALLY -->
 
 - `disable_vnc` (bool) - Whether to create a VNC connection or not. A boot_command cannot be used
   when this is true. Defaults to false.

--- a/website/content/partials/packer-plugin-sdk/bootcommand/VNCConfig.mdx
+++ b/website/content/partials/packer-plugin-sdk/bootcommand/VNCConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the VNCConfig struct in packer-plugin-sdk/bootcommand/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the VNCConfig struct in bootcommand/config.go; DO NOT EDIT MANUALLY -->
 
 The boot command "typed" character for character over a VNC connection to
 the machine, simulating a human actually typing the keyboard.

--- a/website/content/partials/packer-plugin-sdk/communicator/Config-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/communicator/Config-not-required.mdx
@@ -1,15 +1,15 @@
-<!-- Code generated from the comments of the Config struct in packer-plugin-sdk/communicator/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the Config struct in communicator/config.go; DO NOT EDIT MANUALLY -->
 
 - `communicator` (string) - Packer currently supports three kinds of communicators:
-
-  - `none` - No communicator will be used. If this is set, most
-    provisioners also can't be used.
-
-  - `ssh` - An SSH connection will be established to the machine. This
-    is usually the default.
-
-  - `winrm` - A WinRM connection will be established.
-
+  
+  -   `none` - No communicator will be used. If this is set, most
+      provisioners also can't be used.
+  
+  -   `ssh` - An SSH connection will be established to the machine. This
+      is usually the default.
+  
+  -   `winrm` - A WinRM connection will be established.
+  
   In addition to the above, some builders have custom communicators they
   can use. For example, the Docker builder has a "docker" communicator
   that uses `docker exec` and `docker cp` to execute scripts and copy
@@ -19,7 +19,7 @@
   guest's bootstrap script, but sometimes you may have a race condition
   where you need Packer to wait before attempting to connect to your
   guest.
-
+  
   If you end up in this situation, you can use the template option
   `pause_before_connecting`. By default, there is no pause. For example if
   you set `pause_before_connecting` to `10m` Packer will check whether it

--- a/website/content/partials/packer-plugin-sdk/communicator/Config.mdx
+++ b/website/content/partials/packer-plugin-sdk/communicator/Config.mdx
@@ -1,5 +1,5 @@
-<!-- Code generated from the comments of the Config struct in packer-plugin-sdk/communicator/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the Config struct in communicator/config.go; DO NOT EDIT MANUALLY -->
 
-Config is the common a builder uses to define and configure a Packer
+Config is the common configuration a builder uses to define and configure a Packer
 communicator. Embed this struct in your builder config to implement
 communicator support.

--- a/website/content/partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the SSH struct in packer-plugin-sdk/communicator/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the SSH struct in communicator/config.go; DO NOT EDIT MANUALLY -->
 
 - `ssh_host` (string) - The address to SSH to. This usually is automatically configured by the
   builder.
@@ -11,11 +11,11 @@
 
 - `ssh_ciphers` ([]string) - This overrides the value of ciphers supported by default by golang.
   The default value is [
-  "aes128-gcm@openssh.com",
-  "chacha20-poly1305@openssh.com",
-  "aes128-ctr", "aes192-ctr", "aes256-ctr",
+    "aes128-gcm@openssh.com",
+    "chacha20-poly1305@openssh.com",
+    "aes128-ctr", "aes192-ctr", "aes256-ctr",
   ]
-
+  
   Valid options for ciphers include:
   "aes128-ctr", "aes192-ctr", "aes256-ctr", "aes128-gcm@openssh.com",
   "chacha20-poly1305@openssh.com",
@@ -89,6 +89,6 @@
   useful if, for example, packer hangs on a connection after a reboot.
   Example: `5m`. Disabled by default.
 
-- `ssh_remote_tunnels` ([]string) -
+- `ssh_remote_tunnels` ([]string) - 
 
-- `ssh_local_tunnels` ([]string) -
+- `ssh_local_tunnels` ([]string) - 

--- a/website/content/partials/packer-plugin-sdk/communicator/SSHInterface-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/communicator/SSHInterface-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the SSHInterface struct in packer-plugin-sdk/communicator/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the SSHInterface struct in communicator/config.go; DO NOT EDIT MANUALLY -->
 
 - `ssh_interface` (string) - One of `public_ip`, `private_ip`, `public_dns`, or `private_dns`. If
   set, either the public IP address, private IP address, public DNS name
@@ -6,7 +6,7 @@
   if inside a VPC is to use the public IP address if available, otherwise
   the private IP address will be used. If not in a VPC the public DNS name
   will be used. Also works for WinRM.
-
+  
   Where Packer is configured for an outbound proxy but WinRM traffic
   should be direct, `ssh_interface` must be set to `private_dns` and
   `<region>.compute.internal` included in the `NO_PROXY` environment

--- a/website/content/partials/packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx
@@ -1,7 +1,7 @@
-<!-- Code generated from the comments of the SSHTemporaryKeyPair struct in packer-plugin-sdk/communicator/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the SSHTemporaryKeyPair struct in communicator/config.go; DO NOT EDIT MANUALLY -->
 
 - `temporary_key_pair_type` (string) - `dsa` | `ecdsa` | `ed25519` | `rsa` ( the default )
-
+  
   Specifies the type of key to create. The possible values are 'dsa',
   'ecdsa', 'ed25519', or 'rsa'.
 

--- a/website/content/partials/packer-plugin-sdk/communicator/SSHTemporaryKeyPair.mdx
+++ b/website/content/partials/packer-plugin-sdk/communicator/SSHTemporaryKeyPair.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the SSHTemporaryKeyPair struct in packer-plugin-sdk/communicator/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the SSHTemporaryKeyPair struct in communicator/config.go; DO NOT EDIT MANUALLY -->
 
 When no ssh credentials are specified, Packer will generate a temporary SSH
 keypair for the instance. You can change the algorithm type and bits

--- a/website/content/partials/packer-plugin-sdk/communicator/WinRM-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/communicator/WinRM-not-required.mdx
@@ -1,11 +1,11 @@
-<!-- Code generated from the comments of the WinRM struct in packer-plugin-sdk/communicator/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the WinRM struct in communicator/config.go; DO NOT EDIT MANUALLY -->
 
 - `winrm_username` (string) - The username to use to connect to WinRM.
 
 - `winrm_password` (string) - The password to use to connect to WinRM.
 
 - `winrm_host` (string) - The address for WinRM to connect to.
-
+  
   NOTE: If using an Amazon EBS builder, you can specify the interface
   WinRM connects to via
   [`ssh_interface`](/docs/builders/amazon-ebs#ssh_interface)
@@ -30,4 +30,4 @@
   for WinRM, rather than default (basic authentication), removing the
   requirement for basic authentication to be enabled within the target
   guest. Further reading for remote connection authentication can be found
-  [here](<https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx>).
+  [here](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx).

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/CDConfig-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/CDConfig-not-required.mdx
@@ -1,47 +1,47 @@
-<!-- Code generated from the comments of the CDConfig struct in packer-plugin-sdk/multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `cd_files` ([]string) - A list of files to place onto a CD that is attached when the VM is
   booted. This can include either files or directories; any directories
   will be copied onto the CD recursively, preserving directory structure
   hierarchy. Symlinks will have the link's target copied into the directory
   tree on the CD where the symlink was. File globbing is allowed.
-
+  
   Usage example (JSON):
-
+  
   ```json
   "cd_files": ["./somedirectory/meta-data", "./somedirectory/user-data"],
   "cd_label": "cidata",
   ```
-
+  
   Usage example (HCL):
-
+  
   ```hcl
   cd_files = ["./somedirectory/meta-data", "./somedirectory/user-data"]
   cd_label = "cidata"
   ```
-
+  
   The above will create a CD with two files, user-data and meta-data in the
   CD root. This specific example is how you would create a CD that can be
   used for an Ubuntu 20.04 autoinstall.
-
+  
   Since globbing is also supported,
-
+  
   ```hcl
   cd_files = ["./somedirectory/*"]
   cd_label = "cidata"
   ```
-
+  
   Would also be an acceptable way to define the above cd. The difference
   between providing the directory with or without the glob is whether the
   directory itself or its contents will be at the CD root.
-
+  
   Use of this option assumes that you have a command line tool installed
   that can handle the iso creation. Packer will use one of the following
   tools:
-
-  - xorriso
-  - mkisofs
-  - hdiutil (normally found in macOS)
-  - oscdimg (normally found in Windows as part of the Windows ADK)
+  
+    * xorriso
+    * mkisofs
+    * hdiutil (normally found in macOS)
+    * oscdimg (normally found in Windows as part of the Windows ADK)
 
 - `cd_label` (string) - CD Label

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/CDConfig.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/CDConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the CDConfig struct in packer-plugin-sdk/multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the CDConfig struct in multistep/commonsteps/extra_iso_config.go; DO NOT EDIT MANUALLY -->
 
 An iso (CD) containing custom files can be made available for your build.
 

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/FloppyConfig-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/FloppyConfig-not-required.mdx
@@ -1,8 +1,8 @@
-<!-- Code generated from the comments of the FloppyConfig struct in packer-plugin-sdk/multistep/commonsteps/floppy_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the FloppyConfig struct in multistep/commonsteps/floppy_config.go; DO NOT EDIT MANUALLY -->
 
 - `floppy_files` ([]string) - A list of files to place onto a floppy disk that is attached when the VM
   is booted. Currently, no support exists for creating sub-directories on
-  the floppy. Wildcard characters (\\\*, ?, and \[\]) are allowed. Directory
+  the floppy. Wildcard characters (\\*, ?, and \[\]) are allowed. Directory
   names are also allowed, which will add all the files found in the
   directory to the floppy.
 
@@ -10,7 +10,7 @@
   similar to the `floppy_files` option except that the directory structure
   is preserved. This is useful for when your floppy disk includes drivers
   or if you just want to organize it's contents as a hierarchy. Wildcard
-  characters (\\\*, ?, and \[\]) are allowed. The maximum summary size of
+  characters (\\*, ?, and \[\]) are allowed. The maximum summary size of
   all files in the listed directories are the same as in `floppy_files`.
 
 - `floppy_label` (string) - Floppy Label

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/FloppyConfig.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/FloppyConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the FloppyConfig struct in packer-plugin-sdk/multistep/commonsteps/floppy_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the FloppyConfig struct in multistep/commonsteps/floppy_config.go; DO NOT EDIT MANUALLY -->
 
 A floppy can be made available for your build. This is most useful for
 unattended Windows installs, which look for an Autounattend.xml file on

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/HTTPConfig-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/HTTPConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the HTTPConfig struct in packer-plugin-sdk/multistep/commonsteps/http_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; DO NOT EDIT MANUALLY -->
 
 - `http_directory` (string) - Path to a directory to serve using an HTTP server. The files in this
   directory will be available over HTTP that will be requestable from the

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/HTTPConfig.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/HTTPConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the HTTPConfig struct in packer-plugin-sdk/multistep/commonsteps/http_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; DO NOT EDIT MANUALLY -->
 
 Packer will create an http server serving `http_directory` when it is set, a
 random free port will be selected and the architecture of the directory
@@ -6,4 +6,4 @@ referenced will be available in your builder.
 
 Example usage from a builder:
 
-`wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg`
+  `wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg`

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/ISOConfig-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/ISOConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ISOConfig struct in packer-plugin-sdk/multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `iso_urls` ([]string) - Multiple URLs for the ISO to download. Packer will try these in order.
   If anything goes wrong attempting to download or while downloading a

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/ISOConfig-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/ISOConfig-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ISOConfig struct in packer-plugin-sdk/multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
 - `iso_checksum` (string) - The checksum for the ISO file or virtual hard drive file. The type of
   the checksum is specified within the checksum field as a prefix, ex:
@@ -7,20 +7,19 @@
   "none", "{$checksum}", "md5:{$checksum}", "sha1:{$checksum}",
   "sha256:{$checksum}", "sha512:{$checksum}" or "file:{$path}". Here is a
   list of valid checksum values:
-
-  - md5:090992ba9fd140077b0661cb75f7ce13
-  - 090992ba9fd140077b0661cb75f7ce13
-  - sha1:ebfb681885ddf1234c18094a45bbeafd91467911
-  - ebfb681885ddf1234c18094a45bbeafd91467911
-  - sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-  - ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
-  - file:http://releases.ubuntu.com/20.04/MD5SUMS
-  - file:file://./local/path/file.sum
-  - file:./local/path/file.sum
-  - none
-    Although the checksum will not be verified when it is set to "none",
-    this is not recommended since these files can be very large and
-    corruption does happen from time to time.
+   * md5:090992ba9fd140077b0661cb75f7ce13
+   * 090992ba9fd140077b0661cb75f7ce13
+   * sha1:ebfb681885ddf1234c18094a45bbeafd91467911
+   * ebfb681885ddf1234c18094a45bbeafd91467911
+   * sha256:ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * ed363350696a726b7932db864dda019bd2017365c9e299627830f06954643f93
+   * file:http://releases.ubuntu.com/20.04/SHA256SUMS
+   * file:file://./local/path/file.sum
+   * file:./local/path/file.sum
+   * none
+  Although the checksum will not be verified when it is set to "none",
+  this is not recommended since these files can be very large and
+  corruption does happen from time to time.
 
 - `iso_url` (string) - A URL to the ISO containing the installation image or virtual hard drive
   (VHD or VHDX) file to clone.

--- a/website/content/partials/packer-plugin-sdk/multistep/commonsteps/ISOConfig.mdx
+++ b/website/content/partials/packer-plugin-sdk/multistep/commonsteps/ISOConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ISOConfig struct in packer-plugin-sdk/multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ISOConfig struct in multistep/commonsteps/iso_config.go; DO NOT EDIT MANUALLY -->
 
 By default, Packer will symlink, download or copy image files to the Packer
 cache into a "`hash($iso_url+$iso_checksum).$iso_target_extension`" file.
@@ -7,11 +7,11 @@ file mode in order to perform a download.
 
 go-getter supports the following protocols:
 
-- Local files
-- Git
-- Mercurial
-- HTTP
-- Amazon S3
+* Local files
+* Git
+* Mercurial
+* HTTP
+* Amazon S3
 
 Examples:
 go-getter can guess the checksum type based on `iso_checksum` length, and it is

--- a/website/content/partials/packer-plugin-sdk/shutdowncommand/ShutdownConfig-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/shutdowncommand/ShutdownConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ShutdownConfig struct in packer-plugin-sdk/shutdowncommand/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ShutdownConfig struct in shutdowncommand/config.go; DO NOT EDIT MANUALLY -->
 
 - `shutdown_command` (string) - The command to use to gracefully shut down the machine once all
   provisioning is complete. By default this is an empty string, which

--- a/website/content/partials/packer-plugin-sdk/shutdowncommand/ShutdownConfig.mdx
+++ b/website/content/partials/packer-plugin-sdk/shutdowncommand/ShutdownConfig.mdx
@@ -1,7 +1,8 @@
-<!-- Code generated from the comments of the ShutdownConfig struct in packer-plugin-sdk/shutdowncommand/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ShutdownConfig struct in shutdowncommand/config.go; DO NOT EDIT MANUALLY -->
 
 ShutdownConfig defines implementation details for shutting down a VM once it
-is done provisioned.
+is done being provisioned.
+
 It is provided as a convenience to encourage builder developers to
 consider implementing these options, which we believe are valuable for all
 builders. It also helps guarantee that option names for similar options

--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -15,6 +15,7 @@ export default function DocsLayout(props) {
       subpath={subpath}
       order={order}
       staticProps={props}
+      mainBranch="master"
     />
   )
 }

--- a/website/pages/guides/[[...page]].jsx
+++ b/website/pages/guides/[[...page]].jsx
@@ -15,6 +15,7 @@ export default function GuidesLayout(props) {
       subpath={subpath}
       order={order}
       staticProps={props}
+      mainBranch="master"
     />
   )
 }

--- a/website/pages/intro/[[...page]].jsx
+++ b/website/pages/intro/[[...page]].jsx
@@ -15,6 +15,7 @@ export default function IntroLayout(props) {
       subpath={subpath}
       order={order}
       staticProps={props}
+      mainBranch="master"
     />
   )
 }


### PR DESCRIPTION
This PR provides the option to have backwards compatible names for single binary plugins being upgraded to multiplugins. 

let's say I have a provisioner I access through the packer template using the name "comment", stored in "packer-provisioner-comment"

If I have a main.go file that registers my provisioner using the multiplugin format:

```
pps.RegisterProvisioner("default", new(CommentProvisioner))
```

this will now provide a custom case that allows a multiplugin named "packer-plugin-comment" to load something from the template named simply "comment" not "default"

TODO: 
- [x] docs
- [ ] tests
- [ ] check in the plugin-side registration that the plugin doesn't try to register more than one "default"