### PR TITLE
docs: Fix trivial json format

### DIFF
--- a/website/content/docs/builders/amazon/index.mdx
+++ b/website/content/docs/builders/amazon/index.mdx
@@ -71,7 +71,7 @@ These look like:
 
 ```json
 "builders": {
-  "type": "amazon-ebs"
+  "type": "amazon-ebs",
   "access_key": "AKIAIOSFODNN7EXAMPLE",
   "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
   "region": "us-east-1",


### PR DESCRIPTION
hi, thanks useful tools and nice document.
Added a comma to the JSON example to fix the formatting.