### PR TITLE
docs: Add default value for cloud_init in builders/proxmox

### DIFF
--- a/website/content/docs/builders/proxmox/iso.mdx
+++ b/website/content/docs/builders/proxmox/iso.mdx
@@ -212,6 +212,7 @@ builder.
   Defaults to `lsi`.
 
 - `cloud_init` (bool) - If true, add a Cloud-Init CDROM drive after the virtual machine has been converted to a template.
+   Defaults to `false`.
 
 - `cloud_init_storage_pool` - (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.


### PR DESCRIPTION
Tiny enhancement for the proxmox iso builder docs.
This would have save me to dig it up in the code.

The default value is set here:
https://github.com/hashicorp/packer/blob/master/builder/proxmox/common/config.go#L105