### PR TITLE
Fix "edit this page" links in docs

### DIFF
--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -15,6 +15,7 @@ export default function DocsLayout(props) {
       subpath={subpath}
       order={order}
       staticProps={props}
+      mainBranch="master"
     />
   )
 }

--- a/website/pages/guides/[[...page]].jsx
+++ b/website/pages/guides/[[...page]].jsx
@@ -15,6 +15,7 @@ export default function GuidesLayout(props) {
       subpath={subpath}
       order={order}
       staticProps={props}
+      mainBranch="master"
     />
   )
 }

--- a/website/pages/intro/[[...page]].jsx
+++ b/website/pages/intro/[[...page]].jsx
@@ -15,6 +15,7 @@ export default function IntroLayout(props) {
       subpath={subpath}
       order={order}
       staticProps={props}
+      mainBranch="master"
     />
   )
 }


### PR DESCRIPTION
Sorry about this oversight earlier, this should properly patch "edit this page" links at the bottom of docs pages to point to the correct branch.

Closes #10446