### PR TITLE
Add tags as resource tags in the launch template used to request spot instances

### DIFF
--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -273,13 +273,16 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 	}
 
 	// Tell EC2 to create the template
-	_, err = ec2conn.CreateLaunchTemplate(launchTemplate)
+	createLaunchTemplateOutput, err := ec2conn.CreateLaunchTemplate(launchTemplate)
 	if err != nil {
 		err := fmt.Errorf("Error creating launch template for spot instance: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
+
+	launchTemplateId := createLaunchTemplateOutput.LaunchTemplate.LaunchTemplateId
+	ui.Message(fmt.Sprintf("Created Spot Fleet launch template: %s", *launchTemplateId))
 
 	// Add overrides for each user-provided instance type
 	var overrides []*ec2.FleetLaunchTemplateOverridesRequest

--- a/builder/amazon/common/step_run_spot_instance.go
+++ b/builder/amazon/common/step_run_spot_instance.go
@@ -260,6 +260,16 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 				Tags:         spotTags,
 			},
 		}
+		launchTemplate.LaunchTemplateData.TagSpecifications = []*ec2.LaunchTemplateTagSpecificationRequest{
+			{
+				ResourceType: aws.String("instance"),
+				Tags:         spotTags,
+			},
+			{
+				ResourceType: aws.String("volume"),
+				Tags:         spotTags,
+			},
+		}
 	}
 
 	// Tell EC2 to create the template

--- a/builder/amazon/common/step_run_spot_instance_test.go
+++ b/builder/amazon/common/step_run_spot_instance_test.go
@@ -190,7 +190,7 @@ func (m *runSpotEC2ConnMock) CreateTags(req *ec2.CreateTagsInput) (*ec2.CreateTa
 	}
 }
 
-func defaultEc2Mock(instanceId, spotRequestId, volumeId *string) *runSpotEC2ConnMock {
+func defaultEc2Mock(instanceId, spotRequestId, volumeId, launchTemplateId *string) *runSpotEC2ConnMock {
 	instance := &ec2.Instance{
 		InstanceId:            instanceId,
 		SpotInstanceRequestId: spotRequestId,
@@ -205,8 +205,10 @@ func defaultEc2Mock(instanceId, spotRequestId, volumeId *string) *runSpotEC2Conn
 	return &runSpotEC2ConnMock{
 		CreateLaunchTemplateFn: func(in *ec2.CreateLaunchTemplateInput) (*ec2.CreateLaunchTemplateOutput, error) {
 			return &ec2.CreateLaunchTemplateOutput{
-				LaunchTemplate: nil,
-				Warning:        nil,
+				LaunchTemplate: &ec2.LaunchTemplate{
+					LaunchTemplateId: launchTemplateId,
+				},
+				Warning: nil,
 			}, nil
 		},
 		CreateFleetFn: func(*ec2.CreateFleetInput) (*ec2.CreateFleetOutput, error) {
@@ -237,7 +239,8 @@ func TestRun(t *testing.T) {
 	instanceId := aws.String("test-instance-id")
 	spotRequestId := aws.String("spot-id")
 	volumeId := aws.String("volume-id")
-	ec2Mock := defaultEc2Mock(instanceId, spotRequestId, volumeId)
+	launchTemplateId := aws.String("launchTemplateId")
+	ec2Mock := defaultEc2Mock(instanceId, spotRequestId, volumeId, launchTemplateId)
 
 	uiMock := packersdk.TestUi(t)
 
@@ -329,7 +332,8 @@ func TestRun_NoSpotTags(t *testing.T) {
 	instanceId := aws.String("test-instance-id")
 	spotRequestId := aws.String("spot-id")
 	volumeId := aws.String("volume-id")
-	ec2Mock := defaultEc2Mock(instanceId, spotRequestId, volumeId)
+	launchTemplateId := aws.String("lt-id")
+	ec2Mock := defaultEc2Mock(instanceId, spotRequestId, volumeId, launchTemplateId)
 
 	uiMock := packersdk.TestUi(t)
 


### PR DESCRIPTION
According to the APIReference:
<https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html>,
the resource types `instance` and `volume` support tagging on creation.
It is useful to add tags here as it should be more reliable
than tagging them after the spot request is fulfilled as we currently
do. As users may rely on the existence of tags for cleaning up these
resources, I think it is important to tag them as early as possible.