### PR TITLE
GCP add timeout to GCP metadata server read

### DIFF
--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -70,9 +70,6 @@ type Driver interface {
 	// DeleteOSLoginSSHKey deletes the SSH public key for OSLogin with the given key.
 	DeleteOSLoginSSHKey(user, fingerprint string) error
 
-	// If packer is running on a GCE, derives the user from it for use with OSLogin.
-	GetOSLoginUserFromGCE() string
-
 	// Add to the instance metadata for the existing instance
 	AddToInstanceMetadata(zone string, name string, metadata map[string]string) error
 }

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -136,8 +136,6 @@ func NewClientOptionGoogle(account *ServiceAccount, vaultOauth string, impersona
 
 func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 
-	var thisGCEUser string
-
 	opts, err := NewClientOptionGoogle(config.Account, config.VaultOauthEngineName, config.ImpersonateServiceAccountName)
 	if err != nil {
 		return nil, err
@@ -149,7 +147,7 @@ func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 		return nil, err
 	}
 
-	thisGCEUser = getGCEUser()
+	thisGCEUser := getGCEUser()
 
 	log.Printf("[INFO] Instantiating OS Login client...")
 	osLoginService, err := oslogin.NewService(context.TODO(), opts)
@@ -798,8 +796,6 @@ func (d *driverGCE) AddToInstanceMetadata(zone string, name string, metadata map
 // It makes little sense to run packer on GCP in this way, however, we defensively timeout in those cases, rather than abort.
 func getGCEUser() string {
 
-	var thisGCEUser string
-
 	metadataCheckTimeout := 5 * time.Second
 	metadataCheckChl := make(chan string, 1)
 
@@ -813,10 +809,10 @@ func getGCEUser() string {
 
 	select {
 	case thisGCEUser := <-metadataCheckChl:
-		fmt.Printf("[INFO] GCE service account %s will be used for OSLogin", thisGCEUser)
+		log.Printf("[INFO] GCE service account %s will be used for OSLogin", thisGCEUser)
+	    return thisGCEUser
 	case <-time.After(metadataCheckTimeout):
-		fmt.Printf("[INFO] Timeout after %s whilst waiting for google metadata server.", metadataCheckTimeout)
+		log.Printf("[INFO] Timeout after %s whilst waiting for google metadata server.", metadataCheckTimeout)
+	    return ""
 	}
-
-	return thisGCEUser
 }

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -94,8 +94,6 @@ type DriverMock struct {
 	AddToInstanceMetadataKVPairs map[string]string
 	AddToInstanceMetadataErrCh   <-chan error
 	AddToInstanceMetadataErr     error
-
-	OSLoginUserFromGCE string
 }
 
 func (d *DriverMock) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
@@ -309,8 +307,4 @@ func (d *DriverMock) AddToInstanceMetadata(zone string, name string, metadata ma
 	}
 
 	return nil
-}
-
-func (d *DriverMock) GetOSLoginUserFromGCE() string {
-	return d.OSLoginUserFromGCE
 }

--- a/builder/googlecompute/step_import_os_login_ssh_key_test.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key_test.go
@@ -150,37 +150,3 @@ func TestStepImportOSLoginSSHKey_withPrivateSSHKey(t *testing.T) {
 		t.Errorf("expected to not see a public key when using a dedicated private key, but got %q", pubKey)
 	}
 }
-
-func TestStepImportOSLoginSSHKey_onGCE(t *testing.T) {
-
-	state := testState(t)
-	d := state.Get("driver").(*DriverMock)
-	step := new(StepImportOSLoginSSHKey)
-	defer step.Cleanup(state)
-
-	fakeAccountEmail := "testing@packer.io"
-
-	config := state.Get("config").(*Config)
-	config.UseOSLogin = true
-	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
-
-	d.OSLoginUserFromGCE = fakeAccountEmail
-
-	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
-		t.Fatalf("bad action: %#v", action)
-	}
-
-	if step.accountEmail != fakeAccountEmail {
-		t.Fatalf("expected accountEmail to be %q but got %q", fakeAccountEmail, step.accountEmail)
-	}
-
-	pubKey, ok := state.GetOk("ssh_key_public_sha256")
-	if !ok {
-		t.Fatal("expected to see a public key")
-	}
-
-	sha256sum := sha256.Sum256(config.Comm.SSHPublicKey)
-	if pubKey != hex.EncodeToString(sha256sum[:]) {
-		t.Errorf("expected to see a matching public key, but got %q", pubKey)
-	}
-}


### PR DESCRIPTION
When running packer on Gitlab docker-engine runners, packer does not have the access rights to read the native GCE user from the GCP metadata server. This is necessary to facilitate GCP OSLogin.

If this isn't possible, fall back to previous 1.6.5 behaviour.

Don't throw abort, but control instead based on timeout of that read.

Closes #10406
