### PR TITLE
Removing obsolete HCL notes from CLI for validate and command

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -81,7 +81,7 @@ Usage: packer console [options] [TEMPLATE]
 
 Options:
   -var 'key=value'       Variable for templates, can be used multiple times.
-  -var-file=path         JSON or HCL2 file containing user variables. [ Note that even in HCL mode this expects file to contain JSON, a fix is comming soon ]
+  -var-file=path         JSON or HCL2 file containing user variables.
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/validate.go
+++ b/command/validate.go
@@ -92,7 +92,7 @@ Options:
   -except=foo,bar,baz    Validate all builds other than these.
   -only=foo,bar,baz      Validate only these builds.
   -var 'key=value'       Variable for templates, can be used multiple times.
-  -var-file=path         JSON or HCL2 file containing user variables. [ Note that even in HCL mode this expects file to contain JSON, a fix is comming soon ]
+  -var-file=path         JSON or HCL2 file containing user variables.
 `
 
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
As described and documented within #10460 this is removing obsolete notes in output of `validate` and `console`.

Closes #10460 
