### PR TITLE
minor doc update with missing "use" vsphere config

### DIFF
--- a/builder/vsphere/common/config_location.go
+++ b/builder/vsphere/common/config_location.go
@@ -30,7 +30,7 @@ type LocationConfig struct {
 	// VMWare datastore. Required if `host` is a cluster, or if `host` has
 	// multiple datastores.
 	Datastore string `mapstructure:"datastore"`
-	// Set this to true if packer should the host for uploading files
+	// Set this to true if packer should use the host for uploading files
 	// to the datastore. Defaults to false.
 	SetHostForDatastoreUploads bool `mapstructure:"set_host_for_datastore_uploads"`
 }

--- a/website/content/partials/builder/vsphere/common/LocationConfig-not-required.mdx
+++ b/website/content/partials/builder/vsphere/common/LocationConfig-not-required.mdx
@@ -20,5 +20,5 @@
 - `datastore` (string) - VMWare datastore. Required if `host` is a cluster, or if `host` has
   multiple datastores.
 
-- `set_host_for_datastore_uploads` (bool) - Set this to true if packer should the host for uploading files
+- `set_host_for_datastore_uploads` (bool) - Set this to true if packer should use the host for uploading files
   to the datastore. Defaults to false.


### PR DESCRIPTION
Missing word in set_host_for_datastore_uploads doc
Closes hashicorp#10459

Comment/doc change only, should not need any tests.
