### PR TITLE
fix: [bsusurrogate] override bsu when omi root device is set

### DIFF
--- a/builder/osc/bsusurrogate/step_register_omi.go
+++ b/builder/osc/bsusurrogate/step_register_omi.go
@@ -114,7 +114,7 @@ func (s *StepRegisterOMI) Cleanup(state multistep.StateBag) {
 	}
 }
 
-func (s *StepRegisterOMI) combineDevices(snapshotIds map[string]string) []osc.BlockDeviceMappingImage {
+func (s *StepRegisterOMI) combineDevices(snapshotIDs map[string]string) []osc.BlockDeviceMappingImage {
 	devices := map[string]osc.BlockDeviceMappingImage{}
 
 	for _, device := range s.OMIDevices {
@@ -125,12 +125,20 @@ func (s *StepRegisterOMI) combineDevices(snapshotIds map[string]string) []osc.Bl
 	// the same name in ami_block_device_mappings, except for the
 	// one designated as the root device in ami_root_device
 	for _, device := range s.LaunchDevices {
-		snapshotId, ok := snapshotIds[device.DeviceName]
+		snapshotID, ok := snapshotIDs[device.DeviceName]
 		if ok {
-			device.Bsu.SnapshotId = snapshotId
+			device.Bsu.SnapshotId = snapshotID
 		}
 		if device.DeviceName == s.RootDevice.SourceDeviceName {
 			device.DeviceName = s.RootDevice.DeviceName
+
+			if device.Bsu.VolumeType != "" {
+				device.Bsu.VolumeType = s.RootDevice.VolumeType
+				if device.Bsu.VolumeType != "io1" {
+					device.Bsu.Iops = 0
+				}
+			}
+
 		}
 		devices[device.DeviceName] = copyToDeviceMappingImage(device)
 	}


### PR DESCRIPTION
**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer PR:

https://github.com/hashicorp/packer/blob/master/.github/CONTRIBUTING.md#opening-an-pull-request

Describe the change you are making here!

Please include tests. Check out these examples:

- https://github.com/hashicorp/packer/blob/master/builder/virtualbox/common/ssh_config_test.go#L19-L37
- https://github.com/hashicorp/packer/blob/master/post-processor/compress/post-processor_test.go#L153-L182

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #10465 
