### PR TITLE
Add skip_create_image option to the openstack builder

### DIFF
--- a/builder/openstack/builder.hcl2spec.go
+++ b/builder/openstack/builder.hcl2spec.go
@@ -46,6 +46,7 @@ type FlatConfig struct {
 	ImageDiskFormat               *string                 `mapstructure:"image_disk_format" required:"false" cty:"image_disk_format" hcl:"image_disk_format"`
 	ImageTags                     []string                `mapstructure:"image_tags" required:"false" cty:"image_tags" hcl:"image_tags"`
 	ImageMinDisk                  *int                    `mapstructure:"image_min_disk" required:"false" cty:"image_min_disk" hcl:"image_min_disk"`
+	SkipCreateImage               *bool                   `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 	Type                          *string                 `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect            *string                 `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                       *string                 `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -177,6 +178,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_disk_format":                &hcldec.AttrSpec{Name: "image_disk_format", Type: cty.String, Required: false},
 		"image_tags":                       &hcldec.AttrSpec{Name: "image_tags", Type: cty.List(cty.String), Required: false},
 		"image_min_disk":                   &hcldec.AttrSpec{Name: "image_min_disk", Type: cty.Number, Required: false},
+		"skip_create_image":                &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 		"communicator":                     &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":          &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                         &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},

--- a/builder/openstack/image_config.go
+++ b/builder/openstack/image_config.go
@@ -33,6 +33,8 @@ type ImageConfig struct {
 	ImageTags []string `mapstructure:"image_tags" required:"false"`
 	// Minimum disk size needed to boot image, in gigabytes.
 	ImageMinDisk int `mapstructure:"image_min_disk" required:"false"`
+	// Skip creating the image. Useful for setting to `true` during a build test stage. Defaults to `false`.
+	SkipCreateImage bool `mapstructure:"skip_create_image" required:"false"`
 }
 
 func (c *ImageConfig) Prepare(ctx *interpolate.Context) []error {

--- a/builder/openstack/step_add_image_members.go
+++ b/builder/openstack/step_add_image_members.go
@@ -12,9 +12,15 @@ import (
 type stepAddImageMembers struct{}
 
 func (s *stepAddImageMembers) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	imageId := state.Get("image").(string)
 	ui := state.Get("ui").(packersdk.Ui)
 	config := state.Get("config").(*Config)
+
+	if config.SkipCreateImage {
+		ui.Say("Skipping image add members...")
+		return multistep.ActionContinue
+	}
+
+	imageId := state.Get("image").(string)
 
 	if len(config.ImageMembers) == 0 {
 		return multistep.ActionContinue

--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -24,6 +24,11 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	server := state.Get("server").(*servers.Server)
 	ui := state.Get("ui").(packersdk.Ui)
 
+	if config.SkipCreateImage {
+		ui.Say("Skipping image creation...")
+		return multistep.ActionContinue
+	}
+
 	// We need the v2 compute client
 	computeClient, err := config.computeV2Client()
 	if err != nil {

--- a/builder/openstack/step_update_image_mindisk.go
+++ b/builder/openstack/step_update_image_mindisk.go
@@ -12,9 +12,15 @@ import (
 type stepUpdateImageMinDisk struct{}
 
 func (s *stepUpdateImageMinDisk) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	imageId := state.Get("image").(string)
 	ui := state.Get("ui").(packersdk.Ui)
 	config := state.Get("config").(*Config)
+
+	if config.SkipCreateImage {
+		ui.Say("Skipping image update mindisk...")
+		return multistep.ActionContinue
+	}
+
+	imageId := state.Get("image").(string)
 
 	if config.ImageMinDisk == 0 {
 		return multistep.ActionContinue

--- a/builder/openstack/step_update_image_tags.go
+++ b/builder/openstack/step_update_image_tags.go
@@ -13,9 +13,15 @@ import (
 type stepUpdateImageTags struct{}
 
 func (s *stepUpdateImageTags) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	imageId := state.Get("image").(string)
 	ui := state.Get("ui").(packersdk.Ui)
 	config := state.Get("config").(*Config)
+
+	if config.SkipCreateImage {
+		ui.Say("Skipping image update tags...")
+		return multistep.ActionContinue
+	}
+
+	imageId := state.Get("image").(string)
 
 	if len(config.ImageTags) == 0 {
 		return multistep.ActionContinue

--- a/builder/openstack/step_update_image_visibility.go
+++ b/builder/openstack/step_update_image_visibility.go
@@ -12,9 +12,15 @@ import (
 type stepUpdateImageVisibility struct{}
 
 func (s *stepUpdateImageVisibility) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	imageId := state.Get("image").(string)
 	ui := state.Get("ui").(packersdk.Ui)
 	config := state.Get("config").(*Config)
+
+	if config.SkipCreateImage {
+		ui.Say("Skipping image update visibility...")
+		return multistep.ActionContinue
+	}
+
+	imageId := state.Get("image").(string)
 
 	if config.ImageVisibility == "" {
 		return multistep.ActionContinue

--- a/website/content/partials/builder/openstack/ImageConfig-not-required.mdx
+++ b/website/content/partials/builder/openstack/ImageConfig-not-required.mdx
@@ -18,3 +18,5 @@
 - `image_tags` ([]string) - List of tags to add to the image after creation.
 
 - `image_min_disk` (int) - Minimum disk size needed to boot image, in gigabytes.
+
+- `skip_create_image` (bool) - Skip creating the image. Useful for setting to `true` during a build test stage. Defaults to `false`.


### PR DESCRIPTION
Hi Packer team,

i just wanted to have the possibility to verify packer builds in openstack without actually
creating the image as a result.

Then i found the  #7209 issue and searched the code base and realized that there is
already a implementation in the googlecloud builder.

https://github.com/hashicorp/packer/blob/master/builder/googlecompute/step_create_image.go#L26

Copied the main code and implemented a skip in all openstack builder steps that either
create an image or reference an already existing one.
* stepAddImageMembers
* stepCreateImage
* stepUpdateImageMinDisk
* stepUpdateImageTags
* stepUpdateImageVisibility

As i didn't found any test code for the googlecloud builder i also didn't
created some.

I performed manual tests with our onpremise Openstack installation.

Closes #7209
