### PR TITLE
Improve cloud init error logging for proxmox builder

### DIFF
--- a/builder/proxmox/common/step_finalize_template_config.go
+++ b/builder/proxmox/common/step_finalize_template_config.go
@@ -72,6 +72,11 @@ func (s *stepFinalizeTemplateConfig) Run(ctx context.Context, state multistep.St
 				ui.Error(err.Error())
 				return multistep.ActionHalt
 			}
+		} else {
+			err := fmt.Errorf("cloud_init is set to true, but cloud_init_storage_pool is empty and could not be set automatically. set cloud_init_storage_pool in your configuration")
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
 		}
 	}
 


### PR DESCRIPTION
Hi all!

If you're using the proxmox builder and setting `cloud_init` to `true` there are two ways how `cloudInitStoragePool` gets a vaule.
Either from the configuration option `cloud_init_storage_pool` or extracted from the VM parameter `bootdisk`.

I had the case that I haven't set the configuration option and the `bootdisk` parameter was also empty.
In that case the code in the current master silently fails. You don't get an error, but you also don't have cloud init afterwards.

I would like to see and error message for this.
I propose to let it fail with `ActionHalt`, as the result would anyways not be what the user had expected.
But I'm open for changes on the severity.