### PR TITLE
enable Packer fmt to read from stdin

### DIFF
--- a/command/fmt.go
+++ b/command/fmt.go
@@ -75,8 +75,11 @@ Usage: packer fmt [options] [TEMPLATE]
   configuration files (.pkr.hcl) and variable files (.pkrvars.hcl) are updated.
   JSON files (.json) are not modified.
 
-  If TEMPATE is "." the current directory will be used. The given content must
-  be in Packer's HCL2 configuration language; JSON is not supported.
+  If TEMPATE is "." the current directory will be used.
+  If TEMPATE is "-" then content will be read from STDIN.
+
+  The given content must be in Packer's HCL2 configuration language; JSON is
+  not supported.
 
 Options:
   -check        Check if the input is formatted. Exit status will be 0 if all

--- a/hcl2template/formatter.go
+++ b/hcl2template/formatter.go
@@ -122,7 +122,7 @@ func (f *HCL2Formatter) processFile(filename string) ([]byte, error) {
 
 	if f.Write {
 		if filename == "-" {
-			f.Output.Write(outSrc)
+			_, _ = f.Output.Write(outSrc)
 		} else {
 			if err := ioutil.WriteFile(filename, outSrc, 0644); err != nil {
 				return nil, err

--- a/hcl2template/formatter.go
+++ b/hcl2template/formatter.go
@@ -117,8 +117,10 @@ func (f *HCL2Formatter) processFile(filename string) ([]byte, error) {
 		return nil, nil
 	}
 
-	s := []byte(fmt.Sprintf("%s\n", filename))
-	_, _ = f.Output.Write(s)
+	if filename != "-" {
+		s := []byte(fmt.Sprintf("%s\n", filename))
+		_, _ = f.Output.Write(s)
+	}
 
 	if f.Write {
 		if filename == "-" {


### PR DESCRIPTION
This allows the format 

```
cat base_aws.pkr.hcl | packer fmt - 
```

or for formatting validation 

```
cat base_aws.pkr.hcl | packer fmt --check -
```