### PR TITLE
Test against deployment url

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -9,7 +9,7 @@ jobs:
       id: waitForVercelPreviewDeployment
       with:
        token: ${{ secrets.GITHUB_TOKEN }}
-       max_timeout: 180
+       max_timeout: 180 #seconds
     - name: Set Deployment URL Env
       run:
         echo "DEPLOYMENT_URL=${{ steps.waitForVercelPreviewDeployment.outputs.url }}" >> $GITHUB_ENV

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -3,7 +3,8 @@ name: Check Markdown links for modified files
 jobs:
   vercel-deployment-poll:
     runs-on: ubuntu-latest
-    timeout-minutes: 1 #cancel job if no deployment is found
+    timeout-minutes: 3 #cancel job if no deployment is found
+    continue-on-error: true
     outputs:
       url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,20 +1,29 @@
 on: [pull_request]
 name: Check Markdown links for modified files
 jobs:
-  markdown-link-check:
+  vercel-deployment-poll:
     runs-on: ubuntu-latest
+    timeout-minutes: 1 #cancel job if no deployment is found
+    outputs:
+      url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
     - name: Wait for Vercel preview deployment to be ready
       uses: patrickedqvist/wait-for-vercel-preview@master
       id: waitForVercelPreviewDeployment
       with:
        token: ${{ secrets.GITHUB_TOKEN }}
-       max_timeout: 180 #seconds
+       max_timeout: 600 # in seconds, set really high to leverage job timeout-minutes values
+  markdown-link-check:
+    needs: vercel-deployment-poll
+    runs-on: ubuntu-latest
+    steps:
     - name: Set Deployment URL Env
       run:
-        echo "DEPLOYMENT_URL=${{ steps.waitForVercelPreviewDeployment.outputs.url }}" >> $GITHUB_ENV
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        echo "DEPLOYMENT_URL=${{ needs.vercel-deployment-poll.outputs.url }}" >> $GITHUB_ENV
+    - name: Checkout source branch
+      uses: actions/checkout@master
+    - name: Check links
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         file-extension: 'mdx'

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -16,6 +16,7 @@ jobs:
        max_timeout: 600 # in seconds, set really high to leverage job timeout-minutes values
   markdown-link-check:
     needs: vercel-deployment-poll
+    if: ${{ needs.vercel-deployment-poll.outputs.url != '' }}
     runs-on: ubuntu-latest
     steps:
     - name: Set Deployment URL Env

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -12,11 +12,12 @@ jobs:
       url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
     - name: Wait for Vercel preview deployment to be ready
-      uses: patrickedqvist/wait-for-vercel-preview@master
+      uses: nywilken/wait-for-vercel-preview@master
       id: waitForVercelPreviewDeployment
       with:
        token: ${{ secrets.GITHUB_TOKEN }}
        max_timeout: 600 # in seconds, set really high to leverage job timeout-minutes values
+       allow_inactive: true # needed to ensure we get a URL for a previously released deployment
   markdown-link-check:
     needs: vercel-deployment-poll
     if: ${{ needs.vercel-deployment-poll.outputs.url != '' }}

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
     paths:
-      - 'website/content/**'
+      - 'website/**'
 
 name: Check markdown links on modified website files
 jobs:

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -7,7 +7,7 @@ name: Check markdown links on modified website files
 jobs:
   vercel-deployment-poll:
     runs-on: ubuntu-latest
-    timeout-minutes: 3 #cancel job if no deployment is found
+    timeout-minutes: 3 #cancel job if no deployment is found within x minutes
     outputs:
       url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,10 +1,13 @@
-on: [pull_request]
-name: Check Markdown links for modified files
+on:
+  pull_request:
+    paths:
+      - 'website/content/**'
+
+name: Check markdown links on modified website files
 jobs:
   vercel-deployment-poll:
     runs-on: ubuntu-latest
     timeout-minutes: 3 #cancel job if no deployment is found
-    continue-on-error: true
     outputs:
       url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
@@ -19,7 +22,7 @@ jobs:
     if: ${{ needs.vercel-deployment-poll.outputs.url != '' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Set Deployment URL Env
+    - name: Get Deployment URL
       run:
         echo "DEPLOYMENT_URL=${{ needs.vercel-deployment-poll.outputs.url }}" >> $GITHUB_ENV
     - name: Checkout source branch

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -4,6 +4,15 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
+    - name: Wait for Vercel preview deployment to be ready
+      uses: patrickedqvist/wait-for-vercel-preview@master
+      id: waitForVercelPreviewDeployment
+      with:
+       token: ${{ secrets.GITHUB_TOKEN }}
+       max_timeout: 180
+    - name: Set Deployment URL Env
+      run:
+        echo "DEPLOYMENT_URL=${{ steps.waitForVercelPreviewDeployment.outputs.url }}" >> $GITHUB_ENV
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
@@ -11,4 +20,3 @@ jobs:
         file-extension: 'mdx'
         check-modified-files-only: 'yes'
         folder-path: 'website/content'
-

--- a/.github/workflows/scheduled-link-checker.yml
+++ b/.github/workflows/scheduled-link-checker.yml
@@ -6,6 +6,9 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
+    - name: Set deployment URL env
+      run:
+        echo "DEPLOYMENT_URL=https://packer-git-master.hashicorp.vercel.app" >> $GITHUB_ENV
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -37,7 +37,7 @@
   "replacementPatterns": [
     {
       "pattern": "^/",
-      "replacement": "https://packer.io/"
+      "replacement": "{{env.DEPLOYMENT_URL}}/"
     }
   ],
   "timeout": "20s",

--- a/website/README.md
+++ b/website/README.md
@@ -379,7 +379,9 @@ You may customize the parameters in any way you'd like. To remove a prerelease f
 
 ## Link Validation
 
-The Packer GitHub repository is configured to run a [Markdown Link Check](https://github.com/gaurav-nelson/github-action-markdown-link-check#github-action---markdown-link-check-%EF%B8%8F) on a nightly basis to check for potential broken links within the Packer documentation. There is also a GitHub action that will check any modified `.mdx` files on new pull-requests.
+The Packer GitHub repository is configured to run a [Markdown Link Check](https://github.com/gaurav-nelson/github-action-markdown-link-check#github-action---markdown-link-check-%EF%B8%8F) on a nightly basis to check for potential broken links within the Packer documentation. All checks on master will be executed using the BASE_URL set to https://packer.io/.
+
+There is also a GitHub action that will check any modified `.mdx` files on new pull-requests. The link checker action for pull-requests will only run when there is a new Vercel deployment; checks will be executed against the Vercel deployment URL. If no deployment is made the check will run but will timeout after 3 minutes since it needs a valid Vercel deployment URL.
 
 The master configuration file for the markdown-link-checker is called `mlc_config.json` and is located under the project's root directory.
 The configuration helps with relative links in the documentation that will be valid once deployed, and configures a few ignored URLs which are valid but may not return a valid 200 HTTP response code due to permissions or DDoS protection settings on the domain.

--- a/website/README.md
+++ b/website/README.md
@@ -381,7 +381,7 @@ You may customize the parameters in any way you'd like. To remove a prerelease f
 
 The Packer GitHub repository is configured to run a [Markdown Link Check](https://github.com/gaurav-nelson/github-action-markdown-link-check#github-action---markdown-link-check-%EF%B8%8F) on a nightly basis to check for potential broken links within the Packer documentation. All checks on master will be executed using the BASE_URL set to https://packer.io/.
 
-There is also a GitHub action that will check any modified `.mdx` files on new pull-requests. The link checker action for pull-requests will only run when there is a new Vercel deployment; checks will be executed against the Vercel deployment URL. If no deployment is made the check will run but will timeout after 3 minutes since it needs a valid Vercel deployment URL.
+There is also a GitHub action that will check any modified `website/content/**/*.mdx` files on new pull-requests. The link checker action for pull-requests will only run when there is a new Vercel deployment; checks will be executed against the Vercel deployment URL. If no deployment is made the check will run but will timeout after 3 minutes since it needs a valid Vercel deployment URL.
 
 The master configuration file for the markdown-link-checker is called `mlc_config.json` and is located under the project's root directory.
 The configuration helps with relative links in the documentation that will be valid once deployed, and configures a few ignored URLs which are valid but may not return a valid 200 HTTP response code due to permissions or DDoS protection settings on the domain.

--- a/website/content/guides/packer-on-cicd/pipelineing-builds.mdx
+++ b/website/content/guides/packer-on-cicd/pipelineing-builds.mdx
@@ -118,7 +118,7 @@ build {
 
 In order to build using this template, create a directory named "http" in your
 current working directory. Copy the minimal example from our
-[preseed guide](https://www.packer.io/guides/automatic-operating-system-installs/preseed_ubuntu#examples)
+[preseed guide](https://packer.io/guides/automatic-operating-system-installs/preseed_ubuntu#examples)
 into a file in your http directory and name it "ubuntu_preseed.cfg". Copy the
 above json template into your current working directory and save it as
 "example_virtualbox_iso.json"

--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -147,11 +147,6 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/docs/templates/hcl_templates/:path*',
-    destination: '/docs/templates/hcl_templates/:path*',
-    permanent: true,
-  },
-  {
     source: '/docs/templates/hcl_templates/:path*/overview',
     destination: '/docs/templates/hcl_templates/:path*',
     permanent: true,


### PR DESCRIPTION
This change  updates the link checker to use an updated GitHub action that will inject the Vercel deployment url, via `env.DEPLOYMENT_URL` into the markdown link checker config as the main BASE_URL.

This change will ensure that newly added documentation gets validated on the Vercel preview site as opposed to https://packer.io/.

The check on master will have its BASE_URL set to `https://packer-git-master.hashicorp.vercel.app/`