### PR TITLE
scaleway: add support for timeout in shutdown step

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -74,8 +74,10 @@ type Config struct {
 
 	RemoveVolume bool `mapstructure:"remove_volume"`
 
-	UserAgent string `mapstructure-to-hcl2:",skip"`
-	ctx       interpolate.Context
+	// Shutdown timeout. Default to 5m
+	ShutdownTimeout string `mapstructure:"shutdown_timeout" required:"false"`
+	UserAgent       string `mapstructure-to-hcl2:",skip"`
+	ctx             interpolate.Context
 
 	// Deprecated configs
 
@@ -98,8 +100,6 @@ type Config struct {
 	// available.
 	// Deprecated, use Zone instead
 	Region string `mapstructure:"region" required:"false"`
-
-	Timeout string `mapstructure:"timeout" required:"false"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
@@ -257,8 +257,8 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 			errs, errors.New("image is required"))
 	}
 
-	if c.Timeout == "" {
-		c.Timeout = "5m"
+	if c.ShutdownTimeout == "" {
+		c.ShutdownTimeout = "5m"
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -98,6 +98,8 @@ type Config struct {
 	// available.
 	// Deprecated, use Zone instead
 	Region string `mapstructure:"region" required:"false"`
+
+	Timeout string `mapstructure:"timeout" required:"false"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {

--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -257,6 +257,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 			errs, errors.New("image is required"))
 	}
 
+	if c.Timeout == "" {
+		c.Timeout = "5m"
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return warnings, errs
 	}

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -83,6 +83,7 @@ type FlatConfig struct {
 	Token                     *string           `mapstructure:"api_token" required:"false" cty:"api_token" hcl:"api_token"`
 	Organization              *string           `mapstructure:"organization_id" required:"false" cty:"organization_id" hcl:"organization_id"`
 	Region                    *string           `mapstructure:"region" required:"false" cty:"region" hcl:"region"`
+	Timeout                   *string           `mapstructure:"timeout" required:"false" cty:"timeout" hcl:"timeout"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -170,6 +171,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"api_token":                    &hcldec.AttrSpec{Name: "api_token", Type: cty.String, Required: false},
 		"organization_id":              &hcldec.AttrSpec{Name: "organization_id", Type: cty.String, Required: false},
 		"region":                       &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
+		"timeout":                      &hcldec.AttrSpec{Name: "timeout", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -80,10 +80,10 @@ type FlatConfig struct {
 	Bootscript                *string           `mapstructure:"bootscript" required:"false" cty:"bootscript" hcl:"bootscript"`
 	BootType                  *string           `mapstructure:"boottype" required:"false" cty:"boottype" hcl:"boottype"`
 	RemoveVolume              *bool             `mapstructure:"remove_volume" cty:"remove_volume" hcl:"remove_volume"`
+	ShutdownTimeout           *string           `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
 	Token                     *string           `mapstructure:"api_token" required:"false" cty:"api_token" hcl:"api_token"`
 	Organization              *string           `mapstructure:"organization_id" required:"false" cty:"organization_id" hcl:"organization_id"`
 	Region                    *string           `mapstructure:"region" required:"false" cty:"region" hcl:"region"`
-	Timeout                   *string           `mapstructure:"timeout" required:"false" cty:"timeout" hcl:"timeout"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -168,10 +168,10 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"bootscript":                   &hcldec.AttrSpec{Name: "bootscript", Type: cty.String, Required: false},
 		"boottype":                     &hcldec.AttrSpec{Name: "boottype", Type: cty.String, Required: false},
 		"remove_volume":                &hcldec.AttrSpec{Name: "remove_volume", Type: cty.Bool, Required: false},
+		"shutdown_timeout":             &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"api_token":                    &hcldec.AttrSpec{Name: "api_token", Type: cty.String, Required: false},
 		"organization_id":              &hcldec.AttrSpec{Name: "organization_id", Type: cty.String, Required: false},
 		"region":                       &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
-		"timeout":                      &hcldec.AttrSpec{Name: "timeout", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/scaleway/step_shutdown.go
+++ b/builder/scaleway/step_shutdown.go
@@ -34,7 +34,8 @@ func (s *stepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	waitRequest := &instance.WaitForServerRequest{
 		ServerID: serverID,
 	}
-	timeout := state.Get("timeout").(string)
+	c := state.Get("config").(*Config)
+	timeout := c.Timeout
 	duration, err := time.ParseDuration(timeout)
 	if err != nil {
 		err := fmt.Errorf("error: %s could not parse string %s as a duration", err, timeout)

--- a/builder/scaleway/step_shutdown.go
+++ b/builder/scaleway/step_shutdown.go
@@ -35,7 +35,7 @@ func (s *stepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 		ServerID: serverID,
 	}
 	c := state.Get("config").(*Config)
-	timeout := c.Timeout
+	timeout := c.ShutdownTimeout
 	duration, err := time.ParseDuration(timeout)
 	if err != nil {
 		err := fmt.Errorf("error: %s could not parse string %s as a duration", err, timeout)

--- a/website/content/partials/builder/scaleway/Config-not-required.mdx
+++ b/website/content/partials/builder/scaleway/Config-not-required.mdx
@@ -21,6 +21,8 @@
 
 - `remove_volume` (bool) - Remove Volume
 
+- `shutdown_timeout` (string) - Shutdown timeout. Default to 5m
+
 - `api_token` (string) - The token to use to authenticate with your account.
   It can also be specified via environment variable SCALEWAY_API_TOKEN. You
   can see and generate tokens in the "Credentials"
@@ -39,5 +41,3 @@
   or ams1). Consequently, this is the region where the snapshot will be
   available.
   Deprecated, use Zone instead
-
-- `timeout` (string) - Timeout

--- a/website/content/partials/builder/scaleway/Config-not-required.mdx
+++ b/website/content/partials/builder/scaleway/Config-not-required.mdx
@@ -39,3 +39,5 @@
   or ams1). Consequently, this is the region where the snapshot will be
   available.
   Deprecated, use Zone instead
+
+- `timeout` (string) - Timeout


### PR DESCRIPTION
This PR adds support for configuring a timeout which by default is only 5 minutes. Which is a bit short for big instances.