### PR TITLE
[WIP] Check for Linode account image limit before starting.

### DIFF
--- a/builder/linode/builder.go
+++ b/builder/linode/builder.go
@@ -52,6 +52,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("ui", ui)
 
 	steps := []multistep.Step{
+		&stepCheckAccountImageLimit{ client },
 		&StepCreateSSHKey{
 			Debug:        b.config.PackerDebug,
 			DebugKeyPath: fmt.Sprintf("linode_%s.pem", b.config.PackerBuildName),

--- a/builder/linode/builder_acc_test.go
+++ b/builder/linode/builder_acc_test.go
@@ -1,17 +1,25 @@
 package linode
 
 import (
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"os"
 	"testing"
 
 	builderT "github.com/hashicorp/packer-plugin-sdk/acctest"
 )
 
-func TestBuilderAcc_basic(t *testing.T) {
+func TestBuilderAcc_multiple(t *testing.T) {
 	builderT.Test(t, builderT.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		Builder:  &Builder{},
 		Template: testBuilderAccBasic,
+		SkipArtifactTeardown: true,
+	})
+	builderT.Test(t, builderT.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Builder:  &Builder{},
+		Template: testBuilderAccLimited,
+		Teardown: func () { cleanTestImages(t) },
 	})
 }
 
@@ -19,6 +27,9 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("LINODE_TOKEN"); v == "" {
 		t.Fatal("LINODE_TOKEN must be set for acceptance tests")
 	}
+}
+
+func cleanTestImages(t *testing.T) {
 }
 
 const testBuilderAccBasic = `
@@ -30,5 +41,19 @@ const testBuilderAccBasic = `
 		"image": "linode/alpine3.9",
 		"ssh_username": "root"
 	}]
+}
+`
+const testBuilderAccLimited = `
+{
+	"builders": [
+		{
+			"type": "test",
+			"region": "us-east",
+			"instance_type": "g6-nanode-1",
+			"image": "linode/alpine3.9",
+			"ssh_username": "root",
+			"account_image_limit": 1
+		}
+	]
 }
 `

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -25,17 +25,18 @@ type Config struct {
 
 	PersonalAccessToken string `mapstructure:"linode_token"`
 
-	Region       string        `mapstructure:"region"`
-	InstanceType string        `mapstructure:"instance_type"`
-	Label        string        `mapstructure:"instance_label"`
-	Tags         []string      `mapstructure:"instance_tags"`
-	Image        string        `mapstructure:"image"`
-	SwapSize     int           `mapstructure:"swap_size"`
-	RootPass     string        `mapstructure:"root_pass"`
-	RootSSHKey   string        `mapstructure:"root_ssh_key"`
-	ImageLabel   string        `mapstructure:"image_label"`
-	Description  string        `mapstructure:"image_description"`
-	StateTimeout time.Duration `mapstructure:"state_timeout" required:"false"`
+	Region            string        `mapstructure:"region"`
+	InstanceType      string        `mapstructure:"instance_type"`
+	Label             string        `mapstructure:"instance_label"`
+	Tags              []string      `mapstructure:"instance_tags"`
+	Image             string        `mapstructure:"image"`
+	SwapSize          int           `mapstructure:"swap_size"`
+	RootPass          string        `mapstructure:"root_pass"`
+	RootSSHKey        string        `mapstructure:"root_ssh_key"`
+	ImageLabel        string        `mapstructure:"image_label"`
+	Description       string        `mapstructure:"image_description"`
+	StateTimeout      time.Duration `mapstructure:"state_timeout" required:"false"`
+	AccountImageLimit int           `mapstructure:"account_image_limit" required:"false"`
 }
 
 func createRandomRootPassword() (string, error) {

--- a/builder/linode/linode.go
+++ b/builder/linode/linode.go
@@ -22,8 +22,8 @@ func newLinodeClient(pat string) linodego.Client {
 	client := linodego.NewClient(oauth2Client)
 
 	projectURL := "https://www.packer.io"
-	userAgent := fmt.Sprintf("Packer/%s (+%s) linodego/%s",
-		version.LinodePluginVersion.FormattedVersion(), projectURL, linodego.Version)
+	userAgent := fmt.Sprintf("Packer/%s (+%s)",
+		version.LinodePluginVersion.FormattedVersion(), projectURL)
 
 	client.SetUserAgent(userAgent)
 	return client

--- a/builder/linode/step_check_account_image_limit.go
+++ b/builder/linode/step_check_account_image_limit.go
@@ -1,0 +1,42 @@
+package linode
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/linode/linodego"
+)
+
+type stepCheckAccountImageLimit struct {
+	client linodego.Client
+}
+
+func (s *stepCheckAccountImageLimit) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	c := state.Get("config").(*Config)
+	ui := state.Get("ui").(packersdk.Ui)
+	accountImageLimit := c.AccountImageLimit
+
+	if accountImageLimit > 0 {
+		ui.Say("Checking image count...")
+		images, err := s.client.ListImages(ctx, nil)
+		if err != nil {
+			err = errors.New("Error listing Images: " + err.Error())
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		if len(images) >= accountImageLimit {
+			err = errors.New("Account Image Limit reached.")
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepCheckAccountImageLimit) Cleanup(state multistep.StateBag) {}

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/jdcloud-api/jdcloud-sdk-go v1.9.1-0.20190605102154-3d81a50ca961
 	github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62
 	github.com/klauspost/pgzip v0.0.0-20151221113845-47f36e165cec
-	github.com/linode/linodego v0.14.0
+	github.com/linode/linodego v0.24.3
 	github.com/masterzen/winrm v0.0.0-20201030141608-56ca5c5f2380
 	github.com/mattn/go-tty v0.0.0-20191112051231-74040eebce08
 	github.com/mitchellh/cli v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3v
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/linode/linodego v0.14.0 h1:0APKMjiVGyry2TTUVDiok72H6cWpFNMMrFWBFn14aFU=
 github.com/linode/linodego v0.14.0/go.mod h1:2ce3S00NrDqJfp4i55ZuSlT0U3cKNELNYACWBPI8Tnw=
+github.com/linode/linodego v0.24.3 h1:9U/I66zouHIU1tZCFgYK/U4IPJj9ShVu4WqgdGcXcyw=
+github.com/linode/linodego v0.24.3/go.mod h1:GSBKPpjoQfxEfryoCRcgkuUOCuVtGHWhzI8OMdycNTE=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 h1:2ZKn+w/BJeL43sCxI2jhPLRv73oVVOjEKZjKkflyqxg=
 github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=

--- a/website/content/docs/builders/linode.mdx
+++ b/website/content/docs/builders/linode.mdx
@@ -86,6 +86,10 @@ can also be supplied to override the typical auto-generated key:
   Linode instance to enter a desired state (such as "running") before timing
   out. The default state timeout is "5m".
 
+- `account_image_limit` (int) - If provided, halt before building if the
+  number of images for the account exceeds the limit. Recommended to
+  be set at 3.
+
 ## Basic Example
 
 Here is a Linode builder example. The `linode_token` should be replaced with an
@@ -100,10 +104,9 @@ Token](https://www.linode.com/docs/platform/api/getting-started-with-the-linode-
   "region": "us-east",
   "instance_type": "g6-nanode-1",
   "instance_label": "temporary-linode-{{timestamp}}",
-
   "image_label": "private-image-{{timestamp}}",
   "image_description": "My Private Image",
-
-  "ssh_username": "root"
+  "ssh_username": "root",
+  "account_image_limit": 3
 }
 ```


### PR DESCRIPTION
A Linode account is only allowed limited to a certain number of Images, typically 3, before receiving an error that they have reached that limit.

This work is an attempt to address feedback on the frustration of not finding out that they have hit this limit until the very end of the build process, potentially 10+ minutes after they started the script. Instead, if configured, check the number of images already on the account.

I am not hard coding `3` in favor of this being an opt in feature, to make it backwards compatible, and to be resistant to any changes Linode may make against this number.

I still need to add documentation, and will mention that `3` is the typical setting.

I have also updated our linodego module while I am here.

I need help with the integration test. My intent is to build an image (exactly as the original test did), then build another image with an assumption of the account limit being 1, which should error. I have looked at many of the other builder tests, and cannot find an example of asserting that there is a failure. I also cannot figure out how to properly clean the artifacts after the test, as I have set SkipArtifactTeardown on the first run to be able to exert the failure condition. Perhaps there is a different way to achieve this.

Thank you.