### PR TITLE
skip credential validation if we are not exporting an image

### DIFF
--- a/builder/vmware/common/driver_esx5.go
+++ b/builder/vmware/common/driver_esx5.go
@@ -328,9 +328,19 @@ func (d *ESX5Driver) Verify() error {
 }
 
 func (d *ESX5Driver) VerifyOvfTool(SkipExport, skipValidateCredentials bool) error {
+	// We don't use ovftool if we aren't exporting a VM; return without error
+	// if ovftool isn't on path.
+	if SkipExport {
+		return nil
+	}
+
 	err := d.base.VerifyOvfTool(SkipExport, skipValidateCredentials)
 	if err != nil {
 		return err
+	}
+
+	if skipValidateCredentials {
+		return nil
 	}
 
 	log.Printf("Verifying that ovftool credentials are valid...")
@@ -338,10 +348,6 @@ func (d *ESX5Driver) VerifyOvfTool(SkipExport, skipValidateCredentials bool) err
 	// now, so that we don't fail for a simple mistake after a long
 	// build
 	ovftool := GetOVFTool()
-
-	if skipValidateCredentials {
-		return nil
-	}
 
 	if d.Password == "" {
 		return fmt.Errorf("exporting the vm from esxi with ovftool requires " +

--- a/builder/vmware/common/driver_esx5_test.go
+++ b/builder/vmware/common/driver_esx5_test.go
@@ -92,3 +92,13 @@ func TestESX5Driver_CommHost(t *testing.T) {
 		t.Errorf("bad vm_address: %s", address.(string))
 	}
 }
+
+func TestESX5Driver_VerifyOvfTool(t *testing.T) {
+	driver := ESX5Driver{}
+	// should always skip validation if export is skipped, so this should always
+	// pass even when ovftool is not installed.
+	err := driver.VerifyOvfTool(true, false)
+	if err != nil {
+		t.Fatalf("shouldn't fail ever because should always skip check")
+	}
+}


### PR DESCRIPTION
on esx5 we have an ovftool credentials check, but users who are not exporting any images shouldn't have to have ovftool installed. Skip this check if the skipexport is true. 

Closes #10392