### PR TITLE
Add 'skip_create_ami' option to the amazon-ebs builder

### DIFF
--- a/builder/amazon/common/step_ami_region_copy.go
+++ b/builder/amazon/common/step_ami_region_copy.go
@@ -24,6 +24,7 @@ type StepAMIRegionCopy struct {
 
 	toDelete           string
 	getRegionConn      func(*AccessConfig, string) (ec2iface.EC2API, error)
+	AMISkipCreateImage bool
 	AMISkipBuildRegion bool
 }
 
@@ -63,6 +64,12 @@ func (s *StepAMIRegionCopy) DeduplicateRegions(intermediary bool) {
 
 func (s *StepAMIRegionCopy) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
+
+	if s.AMISkipCreateImage {
+		ui.Say("Skipping AMI region copy...")
+		return multistep.ActionContinue
+	}
+
 	amis := state.Get("amis").(map[string]string)
 	snapshots := state.Get("snapshots").(map[string][]string)
 	intermediary, _ := state.Get("intermediary_image").(bool)

--- a/builder/amazon/common/step_create_tags.go
+++ b/builder/amazon/common/step_create_tags.go
@@ -16,6 +16,8 @@ import (
 )
 
 type StepCreateTags struct {
+	AMISkipCreateImage bool
+
 	Tags         map[string]string
 	SnapshotTags map[string]string
 	Ctx          interpolate.Context
@@ -25,6 +27,12 @@ func (s *StepCreateTags) Run(ctx context.Context, state multistep.StateBag) mult
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	session := state.Get("awsSession").(*session.Session)
 	ui := state.Get("ui").(packersdk.Ui)
+
+	if s.AMISkipCreateImage {
+		ui.Say("Skipping AMI create tags...")
+		return multistep.ActionContinue
+	}
+
 	amis := state.Get("amis").(map[string]string)
 
 	if len(s.Tags) == 0 && len(s.SnapshotTags) == 0 {

--- a/builder/amazon/common/step_modify_ami_attributes.go
+++ b/builder/amazon/common/step_modify_ami_attributes.go
@@ -14,6 +14,8 @@ import (
 )
 
 type StepModifyAMIAttributes struct {
+	AMISkipCreateImage bool
+
 	Users          []string
 	Groups         []string
 	SnapshotUsers  []string
@@ -29,6 +31,12 @@ func (s *StepModifyAMIAttributes) Run(ctx context.Context, state multistep.State
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	session := state.Get("awsSession").(*session.Session)
 	ui := state.Get("ui").(packersdk.Ui)
+
+	if s.AMISkipCreateImage {
+		ui.Say("Skipping AMI modify attributes...")
+		return multistep.ActionContinue
+	}
+
 	amis := state.Get("amis").(map[string]string)
 	snapshots := state.Get("snapshots").(map[string][]string)
 

--- a/builder/amazon/ebs/builder.go
+++ b/builder/amazon/ebs/builder.go
@@ -34,6 +34,9 @@ type Config struct {
 	awscommon.AccessConfig `mapstructure:",squash"`
 	awscommon.AMIConfig    `mapstructure:",squash"`
 	awscommon.RunConfig    `mapstructure:",squash"`
+	// If true, Packer will not create the AMI. Useful for setting to `true`
+	// during a build test stage. Default `false`.
+	AMISkipCreateImage bool `mapstructure:"skip_create_ami" required:"false"`
 	// Add one or more block device mappings to the AMI. These will be attached
 	// when booting a new instance from your AMI. To add a block device during
 	// the Packer build see `launch_block_device_mappings` below. Your options
@@ -319,6 +322,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Regions:             b.config.AMIRegions,
 		},
 		&stepCreateAMI{
+			AMISkipCreateImage: b.config.AMISkipCreateImage,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 			PollingConfig:      b.config.PollingConfig,
 		},
@@ -330,22 +334,25 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			EncryptBootVolume:  b.config.AMIEncryptBootVolume,
 			Name:               b.config.AMIName,
 			OriginalRegion:     *ec2conn.Config.Region,
+			AMISkipCreateImage: b.config.AMISkipCreateImage,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 		},
 		&awscommon.StepModifyAMIAttributes{
-			Description:    b.config.AMIDescription,
-			Users:          b.config.AMIUsers,
-			Groups:         b.config.AMIGroups,
-			ProductCodes:   b.config.AMIProductCodes,
-			SnapshotUsers:  b.config.SnapshotUsers,
-			SnapshotGroups: b.config.SnapshotGroups,
-			Ctx:            b.config.ctx,
-			GeneratedData:  generatedData,
+			AMISkipCreateImage: b.config.AMISkipCreateImage,
+			Description:        b.config.AMIDescription,
+			Users:              b.config.AMIUsers,
+			Groups:             b.config.AMIGroups,
+			ProductCodes:       b.config.AMIProductCodes,
+			SnapshotUsers:      b.config.SnapshotUsers,
+			SnapshotGroups:     b.config.SnapshotGroups,
+			Ctx:                b.config.ctx,
+			GeneratedData:      generatedData,
 		},
 		&awscommon.StepCreateTags{
-			Tags:         b.config.AMITags,
-			SnapshotTags: b.config.SnapshotTags,
-			Ctx:          b.config.ctx,
+			AMISkipCreateImage: b.config.AMISkipCreateImage,
+			Tags:               b.config.AMITags,
+			SnapshotTags:       b.config.SnapshotTags,
+			Ctx:                b.config.ctx,
 		},
 	}
 

--- a/builder/amazon/ebs/builder.hcl2spec.go
+++ b/builder/amazon/ebs/builder.hcl2spec.go
@@ -142,6 +142,7 @@ type FlatConfig struct {
 	SSHInterface                              *string                                `mapstructure:"ssh_interface" cty:"ssh_interface" hcl:"ssh_interface"`
 	PauseBeforeSSM                            *string                                `mapstructure:"pause_before_ssm" cty:"pause_before_ssm" hcl:"pause_before_ssm"`
 	SessionManagerPort                        *int                                   `mapstructure:"session_manager_port" cty:"session_manager_port" hcl:"session_manager_port"`
+	AMISkipCreateImage                        *bool                                  `mapstructure:"skip_create_ami" required:"false" cty:"skip_create_ami" hcl:"skip_create_ami"`
 	AMIMappings                               []common.FlatBlockDevice               `mapstructure:"ami_block_device_mappings" required:"false" cty:"ami_block_device_mappings" hcl:"ami_block_device_mappings"`
 	LaunchMappings                            []common.FlatBlockDevice               `mapstructure:"launch_block_device_mappings" required:"false" cty:"launch_block_device_mappings" hcl:"launch_block_device_mappings"`
 	VolumeRunTags                             map[string]string                      `mapstructure:"run_volume_tags" cty:"run_volume_tags" hcl:"run_volume_tags"`
@@ -291,6 +292,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ssh_interface":                         &hcldec.AttrSpec{Name: "ssh_interface", Type: cty.String, Required: false},
 		"pause_before_ssm":                      &hcldec.AttrSpec{Name: "pause_before_ssm", Type: cty.String, Required: false},
 		"session_manager_port":                  &hcldec.AttrSpec{Name: "session_manager_port", Type: cty.Number, Required: false},
+		"skip_create_ami":                       &hcldec.AttrSpec{Name: "skip_create_ami", Type: cty.Bool, Required: false},
 		"ami_block_device_mappings":             &hcldec.BlockListSpec{TypeName: "ami_block_device_mappings", Nested: hcldec.ObjectSpec((*common.FlatBlockDevice)(nil).HCL2Spec())},
 		"launch_block_device_mappings":          &hcldec.BlockListSpec{TypeName: "launch_block_device_mappings", Nested: hcldec.ObjectSpec((*common.FlatBlockDevice)(nil).HCL2Spec())},
 		"run_volume_tags":                       &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},

--- a/builder/amazon/ebs/step_create_ami.go
+++ b/builder/amazon/ebs/step_create_ami.go
@@ -19,6 +19,7 @@ import (
 type stepCreateAMI struct {
 	PollingConfig      *awscommon.AWSPollingConfig
 	image              *ec2.Image
+	AMISkipCreateImage bool
 	AMISkipBuildRegion bool
 }
 
@@ -27,6 +28,11 @@ func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	instance := state.Get("instance").(*ec2.Instance)
 	ui := state.Get("ui").(packersdk.Ui)
+
+	if s.AMISkipCreateImage {
+		ui.Say("Skipping AMI creation...")
+		return multistep.ActionContinue
+	}
 
 	// Create the image
 	amiName := config.AMIName

--- a/website/content/partials/builder/amazon/ebs/Config-not-required.mdx
+++ b/website/content/partials/builder/amazon/ebs/Config-not-required.mdx
@@ -1,5 +1,8 @@
 <!-- Code generated from the comments of the Config struct in builder/amazon/ebs/builder.go; DO NOT EDIT MANUALLY -->
 
+- `skip_create_ami` (bool) - If true, Packer will not create the AMI. Useful for setting to `true`
+  during a build test stage. Default `false`.
+
 - `ami_block_device_mappings` (awscommon.BlockDevices) - Add one or more block device mappings to the AMI. These will be attached
   when booting a new instance from your AMI. To add a block device during
   the Packer build see `launch_block_device_mappings` below. Your options


### PR DESCRIPTION
Hi,

This chage allows to skip the AMI creation in the `amazon-ebs` builder to verify packer can build an AMI without actually
creating the AMI as a result. This is useful to test the builder and provisioner in CI.

Implementation is very similar to some merged PRs in the last weeks: 

- https://github.com/hashicorp/packer/pull/10115
- https://github.com/hashicorp/packer/pull/10496



Packer output:

```shell
==> amazon-ebs.default: Stopping the source instance...
    amazon-ebs.default: Stopping instance
==> amazon-ebs.default: Waiting for the instance to stop...
==> amazon-ebs.default: Skipping AMI creation...
==> amazon-ebs.default: Skipping AMI region copy...
==> amazon-ebs.default: Skipping AMI modify attributes...
==> amazon-ebs.default: Skipping AMI create tags...
==> amazon-ebs.default: Terminating the source AWS instance...
==> amazon-ebs.default: Cleaning up any extra volumes...
==> amazon-ebs.default: Destroying volume (vol-0c7258q48c606818p)...
==> amazon-ebs.default: Deleting temporary security group...
==> amazon-ebs.default: Deleting temporary keypair...
```