### PR TITLE
commands/init: Fix binary detection match on Windows

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -76,7 +76,7 @@ func (c *InitCommand) RunContext(buildCtx context.Context, cla *InitArgs) int {
 	}
 
 	if runtime.GOOS == "windows" && opts.Ext == "" {
-		opts.Ext = ".exe"
+		opts.BinaryInstallationOptions.Ext = ".exe"
 	}
 
 	log.Printf("[TRACE] init: %#v", opts)

--- a/command/init.go
+++ b/command/init.go
@@ -75,6 +75,10 @@ func (c *InitCommand) RunContext(buildCtx context.Context, cla *InitArgs) int {
 		},
 	}
 
+	if runtime.GOOS == "windows" && opts.Ext == "" {
+		opts.Ext = ".exe"
+	}
+
 	log.Printf("[TRACE] init: %#v", opts)
 
 	getters := []plugingetter.Getter{

--- a/hcl2template/plugin.go
+++ b/hcl2template/plugin.go
@@ -64,6 +64,10 @@ func (cfg *PackerConfig) detectPluginBinaries() hcl.Diagnostics {
 		},
 	}
 
+	if runtime.GOOS == "windows" && opts.Ext == "" {
+		opts.BinaryInstallationOptions.Ext = ".exe"
+	}
+
 	pluginReqs, diags := cfg.PluginRequirements()
 	if diags.HasErrors() {
 		return diags

--- a/packer/plugin-getter/github/getter.go
+++ b/packer/plugin-getter/github/getter.go
@@ -185,20 +185,23 @@ func (g *Getter) Get(what string, opts plugingetter.GetOptions) (io.ReadCloser, 
 
 	switch what {
 	case "releases":
-		req, err = g.Client.NewRequest("GET", filepath.Join("/repos/", opts.PluginRequirement.Identifier.RealRelativePath(), "/git/matching-refs/tags"), nil)
+		u := filepath.ToSlash("/repos/" + opts.PluginRequirement.Identifier.RealRelativePath() + "/git/matching-refs/tags")
+		req, err = g.Client.NewRequest("GET", u, nil)
 		transform = transformVersionStream
 	case "sha256":
 		// something like https://github.com/sylviamoss/packer-plugin-comment/releases/download/v0.2.11/packer-plugin-comment_v0.2.11_x5_SHA256SUMS
+		u := filepath.ToSlash("https://github.com/" + opts.PluginRequirement.Identifier.RealRelativePath() + "/releases/download/" + opts.Version() + "/" + opts.PluginRequirement.FilenamePrefix() + opts.Version() + "_SHA256SUMS")
 		req, err = g.Client.NewRequest(
 			"GET",
-			"https://github.com/"+opts.PluginRequirement.Identifier.RealRelativePath()+"/releases/download/"+opts.Version()+"/"+opts.PluginRequirement.FilenamePrefix()+opts.Version()+"_SHA256SUMS",
+			u,
 			nil,
 		)
 		transform = tranformChecksumStream()
 	case "zip":
+		u := filepath.ToSlash("https://github.com/" + opts.PluginRequirement.Identifier.RealRelativePath() + "/releases/download/" + opts.Version() + "/" + opts.ExpectedZipFilename())
 		req, err = g.Client.NewRequest(
 			"GET",
-			"https://github.com/"+opts.PluginRequirement.Identifier.RealRelativePath()+"/releases/download/"+opts.Version()+"/"+opts.ExpectedZipFilename(),
+			u,
 			nil,
 		)
 

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -463,7 +463,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 						Checksummer: checksummer,
 					}
 					expectedZipFilename := checksum.Filename
-					expectedBinaryFilename := strings.TrimSuffix(expectedZipFilename, filepath.Ext(expectedZipFilename))
+					expectedBinaryFilename := strings.TrimSuffix(expectedZipFilename, filepath.Ext(expectedZipFilename)) + opts.BinaryInstallationOptions.Ext
 
 					for _, outputFolder := range opts.InFolders {
 						potentialOutputFilename := filepath.Join(


### PR DESCRIPTION
The binary detection logic search for completely binary names, including a file extension. On Posix based OSes there is no extension. But on Windows it must be set to ".exe".

This change also changes the generated binary request URL to GitHub. On Windows is was using Windows path separator, which were being escaped at the time of the request and causing plugin init to fail. 