### PR TITLE
Added a fallback to both the player and workstation drivers from the vmware builder when trying to determine the network-mapping configuration

### DIFF
--- a/builder/vmware/common/driver_player5.go
+++ b/builder/vmware/common/driver_player5.go
@@ -205,11 +205,28 @@ func (d *Player5Driver) Verify() error {
 	d.VmwareDriver.NetworkMapper = func() (NetworkNameMapper, error) {
 		pathNetmap := playerNetmapConfPath()
 		if _, err := os.Stat(pathNetmap); err != nil {
-			return nil, fmt.Errorf("Could not find netmap conf file: %s", pathNetmap)
+			log.Printf("Located networkmapper configuration file using Player: %s", pathNetmap)
+			return ReadNetmapConfig(pathNetmap)
 		}
-		log.Printf("Located networkmapper configuration file using Player: %s", pathNetmap)
 
-		return ReadNetmapConfig(pathNetmap)
+		// If we weren't able to find the networkmapper configuration file, then fall back
+		// to the networking file which might also be in the configuration directory.
+		libpath, _ := playerVMwareRoot()
+		pathNetworking := filepath.Join(libpath, "networking")
+		if _, err := os.Stat(pathNetworking); err != nil {
+			return nil, fmt.Errorf("Could not determine network mappings from files in path: %s", libpath)
+		}
+
+		// We were able to successfully stat the file.. So, now we can open a handle to it.
+		log.Printf("Located networking configuration file using Player: %s", pathNetworking)
+		fd, err := os.Open(pathNetworking)
+		if err != nil {
+			return nil, err
+		}
+		defer fd.Close()
+
+		// Then we pass the handle to the networking configuration parser.
+		return ReadNetworkingConfig(fd)
 	}
 	return nil
 }

--- a/builder/vmware/common/driver_player5.go
+++ b/builder/vmware/common/driver_player5.go
@@ -204,7 +204,10 @@ func (d *Player5Driver) Verify() error {
 
 	d.VmwareDriver.NetworkMapper = func() (NetworkNameMapper, error) {
 		pathNetmap := playerNetmapConfPath()
-		if _, err := os.Stat(pathNetmap); err != nil {
+
+		// If we were able to find the file (no error), then we can proceed with reading
+		// the networkmapper configuration.
+		if _, err := os.Stat(pathNetmap); err == nil {
 			log.Printf("Located networkmapper configuration file using Player: %s", pathNetmap)
 			return ReadNetmapConfig(pathNetmap)
 		}

--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -165,12 +165,29 @@ func (d *Workstation9Driver) Verify() error {
 
 	d.VmwareDriver.NetworkMapper = func() (NetworkNameMapper, error) {
 		pathNetmap := workstationNetmapConfPath()
-		if _, err := os.Stat(pathNetmap); err != nil {
-			return nil, fmt.Errorf("Could not find netmap conf file: %s", pathNetmap)
+		if _, err := os.Stat(pathNetmap); err == nil {
+			log.Printf("Located networkmapper configuration file using Workstation: %s", pathNetmap)
+			return ReadNetmapConfig(pathNetmap)
 		}
-		log.Printf("Located networkmapper configuration file using Workstation: %s", pathNetmap)
 
-		return ReadNetmapConfig(pathNetmap)
+		// If we weren't able to find the networkmapper configuration file, then fall back
+		// to the networking file which might also be in the configuration directory.
+		libpath, _ := workstationVMwareRoot()
+		pathNetworking := filepath.Join(libpath, "networking")
+		if _, err := os.Stat(pathNetworking); err != nil {
+			return nil, fmt.Errorf("Could not determine network mappings from files in path: %s", libpath)
+		}
+
+		// We were able to successfully stat the file.. So, now we can open a handle to it.
+		log.Printf("Located networking configuration file using Workstation: %s", pathNetworking)
+		fd, err := os.Open(pathNetworking)
+		if err != nil {
+			return nil, err
+		}
+		defer fd.Close()
+
+		// Then we pass the handle to the networking configuration parser.
+		return ReadNetworkingConfig(fd)
 	}
 	return nil
 }

--- a/builder/vmware/common/driver_workstation9.go
+++ b/builder/vmware/common/driver_workstation9.go
@@ -165,6 +165,9 @@ func (d *Workstation9Driver) Verify() error {
 
 	d.VmwareDriver.NetworkMapper = func() (NetworkNameMapper, error) {
 		pathNetmap := workstationNetmapConfPath()
+
+		// Check that the file for the networkmapper configuration exists. If there's no
+		// error, then the file exists and we can proceed to read the configuration out of it.
 		if _, err := os.Stat(pathNetmap); err == nil {
 			log.Printf("Located networkmapper configuration file using Workstation: %s", pathNetmap)
 			return ReadNetmapConfig(pathNetmap)


### PR DESCRIPTION
When installing VMWare Workstation on Linux hosts, in some instances the installer will not generate the network-mapping configuration (netmap.conf) at the time of installation. As a workaround, users have suggested to explicitly run the network configuration and commit their changes in order for the network-mapping configuration to be written.

On my instance of VMWare Workstation (16.0.0 build-16894299) the installer actually creates a "networking" configuration file (which uses the syntax that the builders are parsing for for VMWare Fusion), and then after configuring the network the "netmap.conf" file is created. As this "networking" file contains similar information, it can also be used to infer the network-mapping configuration as a fallback in the situation where the "netmap.conf" file hasn't been created yet.

To take advantage of this, both the player and workstation drivers for the vmware builder were modified to determine which file is available. The original logic is still given priority in that if the original "netmap.conf" file is found, its parser is used to return type which implements the `NetworkNameMapper` interface. In this original logic, another case was added so that if the "netmap.conf" was not found, then the "networking" file is checked if it exists. If this file is found, then the parser for the "networking" file is used. If neither was found, an error is returned with a complaint and the paths that it checked for.

I'm not sure whether the symptoms reported in #10009 are the same as on Windows (as nobody had confirmed it), but I kind of figured that it'd be better to be defensive about it and check with both methods anyways in case the network-mapping configuration can't be determined. Thus, this affects both the Windows and Linux platforms.

This fixes issue #10009.