### PR TITLE
init: show successful installs in cyan

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
+	"github.com/hashicorp/packer/packer"
 	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
 	"github.com/hashicorp/packer/packer/plugin-getter/github"
 	"github.com/hashicorp/packer/version"
@@ -94,6 +95,11 @@ func (c *InitCommand) RunContext(buildCtx context.Context, cla *InitArgs) int {
 		},
 	}
 
+	ui := &packer.ColoredUi{
+		Color: packer.UiColorCyan,
+		Ui:    c.Ui,
+	}
+
 	for _, pluginRequirement := range reqs {
 		// Get installed plugins that match requirement
 
@@ -119,7 +125,7 @@ func (c *InitCommand) RunContext(buildCtx context.Context, cla *InitArgs) int {
 		}
 		if newInstall != nil {
 			msg := fmt.Sprintf("Installed plugin %s %s in %q", pluginRequirement.Identifier.ForDisplay(), newInstall.Version, newInstall.BinaryPath)
-			c.Ui.Say(msg)
+			ui.Say(msg)
 		}
 	}
 	return ret


### PR DESCRIPTION
I had this commit in my packer-init branch but I think it's better to make a PR so we can all think about it, here's a demo with my terminal ( colors might differ from terminal to terminal )
![Screenshot 2021-02-03 at 11 17 53](https://user-images.githubusercontent.com/1024852/106732845-78143700-6611-11eb-8a34-babc93e6d395.png)
