### PR TITLE
Update Oracle Go SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/mitchellh/prefixedio v0.0.0-20151214002211-6e6954073784
 	github.com/mitchellh/reflectwalk v1.0.0
 	github.com/olekukonko/tablewriter v0.0.0-20180105111133-96aac992fc8b
-	github.com/oracle/oci-go-sdk v18.0.0+incompatible
+	github.com/oracle/oci-go-sdk v24.3.0+incompatible
 	github.com/outscale/osc-sdk-go/osc v0.0.0-20200722135656-d654809d0699
 	github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -532,6 +532,7 @@ github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZX
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
 github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
@@ -562,6 +563,8 @@ github.com/olekukonko/tablewriter v0.0.0-20180105111133-96aac992fc8b/go.mod h1:v
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/oracle/oci-go-sdk v18.0.0+incompatible h1:FLV4KixsVfF3rwyVTMI6Ryp/Q+OSb9sR5TawbfjFLN4=
 github.com/oracle/oci-go-sdk v18.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
+github.com/oracle/oci-go-sdk v24.3.0+incompatible h1:x4mcfb4agelf1O4/1/auGlZ1lr97jXRSSN5MxTgG/zU=
+github.com/oracle/oci-go-sdk v24.3.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
 github.com/outscale/osc-sdk-go/osc v0.0.0-20200722135656-d654809d0699 h1:SHe9i7h5cHe+cB77fQ6lsEgIwKg3ckNU90P03CjGMnI=
 github.com/outscale/osc-sdk-go/osc v0.0.0-20200722135656-d654809d0699/go.mod h1:5AqqNH1X8zCHescKVlpSHRzrat1KCKDXqZoQPe8fY3A=
 github.com/packer-community/winrmcp v0.0.0-20180921204643-0fd363d6159a h1:A3QMuteviunoaY/8ex+RKFqwhcZJ/Cf3fCW3IwL2wx4=

--- a/vendor/github.com/oracle/oci-go-sdk/NOTICE.txt
+++ b/vendor/github.com/oracle/oci-go-sdk/NOTICE.txt
@@ -1,0 +1,1 @@
+Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.

--- a/vendor/github.com/oracle/oci-go-sdk/common/auth/dispatcher_modifier.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/auth/dispatcher_modifier.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
 package auth
 
 import "github.com/oracle/oci-go-sdk/common"

--- a/vendor/github.com/oracle/oci-go-sdk/common/auth/resouce_principal_key_provider.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/auth/resouce_principal_key_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
 package auth
 
 import (

--- a/vendor/github.com/oracle/oci-go-sdk/common/common.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/common.go
@@ -4,18 +4,26 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
 	"regexp"
 	"strings"
+	"time"
 )
 
 //Region type for regions
 type Region string
 
 const (
+	instanceMetadataRegionInfoURLV2 = "http://169.254.169.254/opc/v2/instance/regionInfo"
+
 	//RegionSEA region SEA
 	RegionSEA Region = "sea"
-	//RegionCAToronto1 region for toronto
+	//RegionCAToronto1 region for Toronto
 	RegionCAToronto1 Region = "ca-toronto-1"
 	//RegionCAMontreal1 region for Montreal
 	RegionCAMontreal1 Region = "ca-montreal-1"
@@ -23,18 +31,26 @@ const (
 	RegionPHX Region = "us-phoenix-1"
 	//RegionIAD region IAD
 	RegionIAD Region = "us-ashburn-1"
+	//RegionSJC1 region SJC
+	RegionSJC1 Region = "us-sanjose-1"
 	//RegionFRA region FRA
 	RegionFRA Region = "eu-frankfurt-1"
 	//RegionLHR region LHR
 	RegionLHR Region = "uk-london-1"
-	//RegionAPTokyo1 region for tokyo
+	//RegionAPTokyo1 region for Tokyo
 	RegionAPTokyo1 Region = "ap-tokyo-1"
 	//RegionAPOsaka1 region for Osaka
 	RegionAPOsaka1 Region = "ap-osaka-1"
-	//RegionAPSeoul1 region for seoul
+	//RegionAPChiyoda1 region for Chiyoda
+	RegionAPChiyoda1 Region = "ap-chiyoda-1"
+	//RegionAPSeoul1 region for Seoul
 	RegionAPSeoul1 Region = "ap-seoul-1"
-	//RegionAPMumbai1 region for mumbai
+	//RegionAPChuncheon1 region for Chuncheon
+	RegionAPChuncheon1 Region = "ap-chuncheon-1"
+	//RegionAPMumbai1 region for Mumbai
 	RegionAPMumbai1 Region = "ap-mumbai-1"
+	//RegionAPHyderabad1 region for Hyderabad
+	RegionAPHyderabad1 Region = "ap-hyderabad-1"
 	//RegionAPMelbourne1 region for Melbourne
 	RegionAPMelbourne1 Region = "ap-melbourne-1"
 	//RegionAPSydney1 region for Sydney
@@ -47,26 +63,69 @@ const (
 	RegionEUAmsterdam1 Region = "eu-amsterdam-1"
 	//RegionSASaopaulo1 region for Sao Paulo
 	RegionSASaopaulo1 Region = "sa-saopaulo-1"
-	//RegionUSLangley1 region for langley
+
+	//RegionUSLangley1 region for Langley
 	RegionUSLangley1 Region = "us-langley-1"
-	//RegionUSLuke1 region for luke
+	//RegionUSLuke1 region for Luke
 	RegionUSLuke1 Region = "us-luke-1"
 
-	//RegionUSGovAshburn1 region for langley
+	//RegionUSGovAshburn1 gov region Ashburn
 	RegionUSGovAshburn1 Region = "us-gov-ashburn-1"
-	//RegionUSGovChicago1 region for luke
+	//RegionUSGovChicago1 gov region Chicago
 	RegionUSGovChicago1 Region = "us-gov-chicago-1"
-	//RegionUSGovPhoenix1 region for luke
+	//RegionUSGovPhoenix1 region for Phoenix
 	RegionUSGovPhoenix1 Region = "us-gov-phoenix-1"
 	//RegionUKGovLondon1 gov region London
 	RegionUKGovLondon1 Region = "uk-gov-london-1"
+	//RegionUKGovCardiff1 gov region Cardiff
+	RegionUKGovCardiff1 Region = "uk-gov-cardiff-1"
+
+	// Region Metadata Configuration File
+	regionMetadataCfgDirName  = ".oci"
+	regionMetadataCfgFileName = "regions-config.json"
+
+	// Region Metadata Environment Variable
+	regionMetadataEnvVarName = "OCI_REGION_METADATA"
+
+	// Region Metadata
+	regionIdentifierPropertyName     = "regionIdentifier"     // e.g. "ap-sydney-1"
+	realmKeyPropertyName             = "realmKey"             // e.g. "oc1"
+	realmDomainComponentPropertyName = "realmDomainComponent" // e.g. "oraclecloud.com"
+	regionKeyPropertyName            = "regionKey"            // e.g. "SYD"
 )
+
+var shortNameRegion = map[string]Region{
+	"sea": RegionSEA,
+	"phx": RegionPHX,
+	"iad": RegionIAD,
+	"fra": RegionFRA,
+	"lhr": RegionLHR,
+	"ams": RegionEUAmsterdam1,
+	"zrh": RegionEUZurich1,
+	"mel": RegionAPMelbourne1,
+	"bom": RegionAPMumbai1,
+	"hyd": RegionAPHyderabad1,
+	"icn": RegionAPSeoul1,
+	"yny": RegionAPChuncheon1,
+	"nrt": RegionAPTokyo1,
+	"kix": RegionAPOsaka1,
+	"nja": RegionAPChiyoda1,
+	"syd": RegionAPSydney1,
+	"yul": RegionCAMontreal1,
+	"yyz": RegionCAToronto1,
+	"sjc": RegionSJC1,
+	"gru": RegionSASaopaulo1,
+	"jed": RegionMEJeddah1,
+	"ltn": RegionUKGovLondon1,
+	"brs": RegionUKGovCardiff1,
+}
 
 var realm = map[string]string{
 	"oc1": "oraclecloud.com",
 	"oc2": "oraclegovcloud.com",
 	"oc3": "oraclegovcloud.com",
 	"oc4": "oraclegovcloud.uk",
+	"oc8": "oraclecloud8.com",
 }
 
 var regionRealm = map[Region]string{
@@ -76,11 +135,14 @@ var regionRealm = map[Region]string{
 	RegionLHR:          "oc1",
 	RegionCAToronto1:   "oc1",
 	RegionCAMontreal1:  "oc1",
+	RegionSJC1:         "oc1",
 	RegionAPTokyo1:     "oc1",
 	RegionAPOsaka1:     "oc1",
 	RegionAPSeoul1:     "oc1",
+	RegionAPChuncheon1: "oc1",
 	RegionAPSydney1:    "oc1",
 	RegionAPMumbai1:    "oc1",
+	RegionAPHyderabad1: "oc1",
 	RegionAPMelbourne1: "oc1",
 	RegionMEJeddah1:    "oc1",
 	RegionEUZurich1:    "oc1",
@@ -92,15 +154,24 @@ var regionRealm = map[Region]string{
 	RegionUSGovAshburn1: "oc3",
 	RegionUSGovChicago1: "oc3",
 	RegionUSGovPhoenix1: "oc3",
+	RegionUKGovCardiff1: "oc4",
 	RegionUKGovLondon1:  "oc4",
+
+	RegionAPChiyoda1: "oc8",
 }
+
+// External region metadata info flag, used to control adding these metadata region info only once.
+var readCfgFile, readEnvVar, visitIMDS bool = true, true, false
+
+// getRegionInfoFromInstanceMetadataService gets the region information
+var getRegionInfoFromInstanceMetadataService = getRegionInfoFromInstanceMetadataServiceProd
 
 // Endpoint returns a endpoint for a service
 func (region Region) Endpoint(service string) string {
 	return fmt.Sprintf("%s.%s.%s", service, region, region.secondLevelDomain())
 }
 
-// EndpointForTemplate returns a endpoint for a service based on template
+// EndpointForTemplate returns a endpoint for a service based on template, only unknown region name can fall back to "oc1", but not short code region name.
 func (region Region) EndpointForTemplate(service string, serviceEndpointTemplate string) string {
 	if serviceEndpointTemplate == "" {
 		return region.Endpoint(service)
@@ -131,57 +202,22 @@ func (region Region) secondLevelDomain() string {
 
 //StringToRegion convert a string to Region type
 func StringToRegion(stringRegion string) (r Region) {
-	switch strings.ToLower(stringRegion) {
-	case "sea":
-		r = RegionSEA
-	case "yyz", "ca-toronto-1":
-		r = RegionCAToronto1
-	case "yul", "ca-montreal-1":
-		r = RegionCAMontreal1
-	case "phx", "us-phoenix-1":
-		r = RegionPHX
-	case "iad", "us-ashburn-1":
-		r = RegionIAD
-	case "fra", "eu-frankfurt-1":
-		r = RegionFRA
-	case "lhr", "uk-london-1":
-		r = RegionLHR
-	case "nrt", "ap-tokyo-1":
-		r = RegionAPTokyo1
-	case "kix", "ap-osaka-1":
-		r = RegionAPOsaka1
-	case "icn", "ap-seoul-1":
-		r = RegionAPSeoul1
-	case "bom", "ap-mumbai-1":
-		r = RegionAPMumbai1
-	case "mel", "ap-melbourne-1":
-		r = RegionAPMelbourne1
-	case "syd", "ap-sydney-1":
-		r = RegionAPSydney1
-	case "jed", "me-jeddah-1":
-		r = RegionMEJeddah1
-	case "zrh", "eu-zurich-1":
-		r = RegionEUZurich1
-	case "ams", "eu-amsterdam-1":
-		r = RegionEUAmsterdam1
-	case "gru", "sa-saopaulo-1":
-		r = RegionSASaopaulo1
-	case "us-langley-1":
-		r = RegionUSLangley1
-	case "us-luke-1":
-		r = RegionUSLuke1
-	case "us-gov-ashburn-1":
-		r = RegionUSGovAshburn1
-	case "us-gov-chicago-1":
-		r = RegionUSGovChicago1
-	case "us-gov-phoenix-1":
-		r = RegionUSGovPhoenix1
-	case "ltn", "uk-gov-london-1":
-		r = RegionUKGovLondon1
-	default:
-		r = Region(stringRegion)
-		Debugf("region named: %s, is not recognized", stringRegion)
+	regionStr := strings.ToLower(stringRegion)
+	// check if short region name provided
+	if region, ok := shortNameRegion[regionStr]; ok {
+		r = region
+		return
 	}
+	// check if normal region name provided
+	potentialRegion := Region(regionStr)
+	if _, ok := regionRealm[potentialRegion]; ok {
+		r = potentialRegion
+		return
+	}
+
+	Debugf("region named: %s, is not recognized from hard-coded region list, will check Region metadata info", stringRegion)
+	r = checkAndAddRegionMetadata(stringRegion)
+
 	return
 }
 
@@ -194,4 +230,221 @@ func canStringBeRegion(stringRegion string) (region string, err error) {
 		return "", fmt.Errorf("region can not be empty or have spaces")
 	}
 	return stringRegion, nil
+}
+
+// check region info from original map
+func checkAndAddRegionMetadata(region string) Region {
+	switch {
+	case setRegionMetadataFromCfgFile(&region):
+	case setRegionMetadataFromEnvVar(&region):
+	case setRegionFromInstanceMetadataService(&region):
+	default:
+		//err := fmt.Errorf("failed to get region metadata information.")
+		return Region(region)
+	}
+	return Region(region)
+}
+
+// EnableInstanceMetadataServiceLookup provides the interface to lookup IMDS region info
+func EnableInstanceMetadataServiceLookup() {
+	Debugf("Set visitIMDS 'true' to enable IMDS Lookup.")
+	visitIMDS = true
+}
+
+// setRegionMetadataFromEnvVar checks if region metadata env variable is provided, once it's there, parse and added it
+// to region map, and it can make sure the env var can only be visited once.
+// Once successfully find the expected region(region name or short code), return true, region name will be stored in
+// the input pointer.
+func setRegionMetadataFromEnvVar(region *string) bool {
+	if readEnvVar == false {
+		Debugf("metadata region env variable had already been checked, no need to check again.")
+		return false //no need to check it again.
+	}
+	// Mark readEnvVar Flag as false since it has already been visited.
+	readEnvVar = false
+	// check from env variable
+	if jsonStr, existed := os.LookupEnv(regionMetadataEnvVarName); existed {
+		Debugf("Raw content of region metadata env var:", jsonStr)
+		var regionSchema map[string]string
+		if err := json.Unmarshal([]byte(jsonStr), &regionSchema); err != nil {
+			Debugf("Can't unmarshal env var, the error info is", err)
+			return false
+		}
+		// check if the specified region is in the env var.
+		if checkSchemaItems(regionSchema) {
+			// set mapping table
+			addRegionSchema(regionSchema)
+			if regionSchema[regionKeyPropertyName] == *region ||
+				regionSchema[regionIdentifierPropertyName] == *region {
+				*region = regionSchema[regionIdentifierPropertyName]
+				return true
+			}
+		}
+		return false
+	}
+	Debugf("The Region Metadata Schema wasn't set in env variable - OCI_REGION_METADATA.")
+	return false
+}
+
+// setRegionMetadataFromCfgFile checks if region metadata config file is provided, once it's there, parse and add all
+// the valid regions to region map, the configuration file can only be visited once.
+// Once successfully find the expected region(region name or short code), return true, region name will be stored in
+// the input pointer.
+func setRegionMetadataFromCfgFile(region *string) bool {
+	if readCfgFile == false {
+		Debugf("metadata region config file had already been checked, no need to check again.")
+		return false //no need to check it again.
+	}
+	// Mark readCfgFile Flag as false since it has already been visited.
+	readCfgFile = false
+	homeFolder := getHomeFolder()
+	configFile := path.Join(homeFolder, regionMetadataCfgDirName, regionMetadataCfgFileName)
+	if jsonArr, ok := readAndParseConfigFile(&configFile); ok {
+		added := false
+		for _, jsonItem := range jsonArr {
+			if checkSchemaItems(jsonItem) {
+				addRegionSchema(jsonItem)
+				if jsonItem[regionKeyPropertyName] == *region ||
+					jsonItem[regionIdentifierPropertyName] == *region {
+					*region = jsonItem[regionIdentifierPropertyName]
+					added = true
+				}
+			}
+		}
+		return added
+	}
+	return false
+}
+
+func readAndParseConfigFile(configFileName *string) (fileContent []map[string]string, ok bool) {
+
+	if content, err := ioutil.ReadFile(*configFileName); err == nil {
+		Debugf("Raw content of region metadata config file content:", string(content[:]))
+		if err := json.Unmarshal(content, &fileContent); err != nil {
+			Debugf("Can't unmarshal config file, the error info is", err)
+			return
+		}
+		ok = true
+		return
+	}
+	Debugf("No Region Metadata Config File provided.")
+	return
+
+}
+
+// check map regionRealm's region name, if it's already there, no need to add it.
+func addRegionSchema(regionSchema map[string]string) {
+	r := Region(strings.ToLower(regionSchema[regionIdentifierPropertyName]))
+	if _, ok := regionRealm[r]; !ok {
+		// set mapping table
+		shortNameRegion[regionSchema[regionKeyPropertyName]] = r
+		realm[regionSchema[realmKeyPropertyName]] = regionSchema[realmDomainComponentPropertyName]
+		regionRealm[r] = regionSchema[realmKeyPropertyName]
+		return
+	}
+	Debugf("Region {} has already been added, no need to add again.", regionSchema[regionIdentifierPropertyName])
+}
+
+// check region schema content if all the required contents are provided
+func checkSchemaItems(regionSchema map[string]string) bool {
+	if checkSchemaItem(regionSchema, regionIdentifierPropertyName) &&
+		checkSchemaItem(regionSchema, realmKeyPropertyName) &&
+		checkSchemaItem(regionSchema, realmDomainComponentPropertyName) &&
+		checkSchemaItem(regionSchema, regionKeyPropertyName) {
+		return true
+	}
+	return false
+}
+
+// check region schema item is valid, if so, convert it to lower case.
+func checkSchemaItem(regionSchema map[string]string, key string) bool {
+	if val, ok := regionSchema[key]; ok {
+		if val != "" {
+			regionSchema[key] = strings.ToLower(val)
+			return true
+		}
+		Debugf("Region metadata schema {} is provided,but content is empty.", key)
+		return false
+	}
+	Debugf("Region metadata schema {} is not provided, please update the content", key)
+	return false
+}
+
+// setRegionFromInstanceMetadataService checks if region metadata can be provided from InstanceMetadataService.
+// Once successfully find the expected region(region name or short code), return true, region name will be stored in
+// the input pointer.
+// setRegionFromInstanceMetadataService will only be checked on the instance, by default it will not be enabled unless
+// user explicitly enable it.
+func setRegionFromInstanceMetadataService(region *string) bool {
+	// example of content:
+	// {
+	// 	"realmKey" : "oc1",
+	// 	"realmDomainComponent" : "oraclecloud.com",
+	// 	"regionKey" : "YUL",
+	// 	"regionIdentifier" : "ca-montreal-1"
+	// }
+	// Mark visitIMDS Flag as false since it has already been visited.
+	if visitIMDS == false {
+		Debugf("check from IMDS is disabled or IMDS had already been successfully visited, no need to check again.")
+		return false
+	}
+	content, err := getRegionInfoFromInstanceMetadataService()
+	if err != nil {
+		Debugf("Failed to get instance metadata. Error: %v", err)
+		return false
+	}
+
+	// Mark visitIMDS Flag as false since we have already successfully get the region info from IMDS.
+	visitIMDS = false
+
+	var regionInfo map[string]string
+	err = json.Unmarshal(content, &regionInfo)
+	if err != nil {
+		Debugf("Failed to unmarshal the response content: %v \nError: %v", string(content), err)
+		return false
+	}
+
+	if checkSchemaItems(regionInfo) {
+		addRegionSchema(regionInfo)
+		if regionInfo[regionKeyPropertyName] == *region ||
+			regionInfo[regionIdentifierPropertyName] == *region {
+			*region = regionInfo[regionIdentifierPropertyName]
+		}
+	} else {
+		Debugf("Region information is not valid.")
+		return false
+	}
+
+	return true
+}
+
+// getRegionInfoFromInstanceMetadataServiceProd calls instance metadata service and get the region information
+func getRegionInfoFromInstanceMetadataServiceProd() ([]byte, error) {
+	request, err := http.NewRequest(http.MethodGet, instanceMetadataRegionInfoURLV2, nil)
+	request.Header.Add("Authorization", "Bearer Oracle")
+
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+	resp, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to call instance metadata service. Error: %v", err)
+	}
+
+	statusCode := resp.StatusCode
+
+	defer resp.Body.Close()
+
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get region information from response body. Error: %v", err)
+	}
+
+	if statusCode != http.StatusOK {
+		err = fmt.Errorf("HTTP Get failed: URL: %s, Status: %s, Message: %s",
+			instanceMetadataRegionInfoURLV2, resp.Status, string(content))
+		return nil, err
+	}
+
+	return content, nil
 }

--- a/vendor/github.com/oracle/oci-go-sdk/common/configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/configuration.go
@@ -241,8 +241,8 @@ func ConfigurationProviderFromFileWithProfile(configFilePath, profile, privateKe
 }
 
 type configFileInfo struct {
-	UserOcid, Fingerprint, KeyFilePath, TenancyOcid, Region, Passphrase string
-	PresentConfiguration                                                byte
+	UserOcid, Fingerprint, KeyFilePath, TenancyOcid, Region, Passphrase, SecurityTokenFilePath string
+	PresentConfiguration                                                                       byte
 }
 
 const (
@@ -252,6 +252,7 @@ const (
 	hasRegion
 	hasKeyFile
 	hasPassphrase
+	hasSecurityTokenFile
 	none
 )
 
@@ -310,6 +311,9 @@ func parseConfigAtLine(start int, content []string) (info *configFileInfo, err e
 		case "region":
 			configurationPresent = configurationPresent | hasRegion
 			info.Region = value
+		case "security_token_file":
+			configurationPresent = configurationPresent | hasSecurityTokenFile
+			info.SecurityTokenFilePath = value
 		}
 	}
 	info.PresentConfiguration = configurationPresent
@@ -387,7 +391,13 @@ func (p fileConfigurationProvider) UserOCID() (value string, err error) {
 		return
 	}
 
-	value, err = presentOrError(info.UserOcid, hasUser, info.PresentConfiguration, "user")
+	if value, err = presentOrError(info.UserOcid, hasUser, info.PresentConfiguration, "user"); err != nil {
+		// need to check if securityTokenPath is provided, if security token is provided, userOCID can be "".
+		if _, stErr := presentOrError(info.SecurityTokenFilePath, hasSecurityTokenFile, info.PresentConfiguration,
+			"securityTokenPath"); stErr == nil {
+			err = nil
+		}
+	}
 	return
 }
 
@@ -407,8 +417,14 @@ func (p fileConfigurationProvider) KeyID() (keyID string, err error) {
 		err = fmt.Errorf("can not read tenancy configuration due to: %s", err.Error())
 		return
 	}
-
-	return fmt.Sprintf("%s/%s/%s", info.TenancyOcid, info.UserOcid, info.Fingerprint), nil
+	if info.PresentConfiguration&hasUser == hasUser {
+		return fmt.Sprintf("%s/%s/%s", info.TenancyOcid, info.UserOcid, info.Fingerprint), nil
+	}
+	if filePath, err := presentOrError(info.SecurityTokenFilePath, hasSecurityTokenFile, info.PresentConfiguration, "securityTokenFilePath"); err == nil {
+		return getSecurityToken(filePath)
+	}
+	err = fmt.Errorf("can not read SecurityTokenFilePath from configuration file due to: %s", err.Error())
+	return
 }
 
 func (p fileConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, err error) {
@@ -449,10 +465,25 @@ func (p fileConfigurationProvider) Region() (value string, err error) {
 
 	value, err = presentOrError(info.Region, hasRegion, info.PresentConfiguration, "region")
 	if err != nil {
-		return
+		val, error := getRegionFromEnvVar()
+		if error != nil {
+			err = fmt.Errorf("region configuration is missing from file, nor for OCI_REGION env var")
+			return
+		}
+		value = val
 	}
 
 	return canStringBeRegion(value)
+}
+
+func getSecurityToken(filePath string) (string, error) {
+	expandedPath := expandPath(filePath)
+	tokenFileContent, err := ioutil.ReadFile(expandedPath)
+	if err != nil {
+		err = fmt.Errorf("can not read PrivateKey  from configuration file due to: %s", err.Error())
+		return "", err
+	}
+	return fmt.Sprintf("ST$%s", tokenFileContent), nil
 }
 
 // A configuration provider that look for information in  multiple configuration providers
@@ -512,7 +543,10 @@ func (c composingConfigurationProvider) Region() (string, error) {
 			return val, nil
 		}
 	}
-	return "", fmt.Errorf("did not find a proper configuration for region")
+	if val, err := getRegionFromEnvVar(); err == nil {
+		return val, nil
+	}
+	return "", fmt.Errorf("did not find a proper configuration for region, nor for OCI_REGION env var")
 }
 
 func (c composingConfigurationProvider) KeyID() (string, error) {
@@ -533,4 +567,12 @@ func (c composingConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKey, error)
 		}
 	}
 	return nil, fmt.Errorf("did not find a proper configuration for private key")
+}
+
+func getRegionFromEnvVar() (string, error) {
+	regionEnvVar := "OCI_REGION"
+	if region, existed := os.LookupEnv(regionEnvVar); existed {
+		return region, nil
+	}
+	return "", fmt.Errorf("did not find OCI_REGION env var")
 }

--- a/vendor/github.com/oracle/oci-go-sdk/common/http.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/http.go
@@ -449,8 +449,17 @@ func addToHeader(request *http.Request, value reflect.Value, field reflect.Struc
 		return
 	}
 
-	request.Header.Add(headerName, headerValue)
+	if isUniqueHeaderRequired(headerName) {
+		request.Header.Set(headerName, headerValue)
+	} else {
+		request.Header.Add(headerName, headerValue)
+	}
 	return
+}
+
+// Check if the header is required to be unique
+func isUniqueHeaderRequired(headerName string) bool {
+	return strings.EqualFold(headerName, requestHeaderContentType)
 }
 
 // Header collection is a map of string to string that gets rendered as individual headers with a given prefix

--- a/vendor/github.com/oracle/oci-go-sdk/common/log.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/log.go
@@ -5,11 +5,13 @@ package common
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
 	"sync"
+	"time"
 )
 
 //sdkLogger an interface for logging in the SDK
@@ -45,6 +47,7 @@ type defaultSDKLogger struct {
 //defaultLogger is the defaultLogger in the SDK
 var defaultLogger sdkLogger
 var loggerLock sync.Mutex
+var file *os.File
 
 //initializes the SDK defaultLogger as a defaultLogger
 func init() {
@@ -81,6 +84,7 @@ func newSDKLogger() (defaultSDKLogger, error) {
 	if !isLogEnabled {
 		logger.currentLoggingLevel = noLogging
 	} else {
+		logOutputModeConfig(logger)
 
 		switch strings.ToLower(configured) {
 		case "null":
@@ -122,6 +126,54 @@ func (l defaultSDKLogger) getLoggerForLevel(logLevel int) *log.Logger {
 	default:
 		return l.nullLogger
 	}
+}
+
+// Set SDK Log output mode
+// Output mode is switched based on environment variable "OCI_GO_SDK_LOG_OUPUT_MODE"
+// "file" outputs log to a specific file
+// "combine" outputs log to both stderr and specific file
+// other unsupported value ouputs log to stderr
+// output file can be set via environment variable "OCI_GO_SDK_LOG_FILE"
+// if this environment variable is not set, a default log file will be created under project root path
+func logOutputModeConfig(logger defaultSDKLogger) {
+	logMode, isLogOutputModeEnabled := os.LookupEnv("OCI_GO_SDK_LOG_OUTPUT_MODE")
+	if !isLogOutputModeEnabled {
+		return
+	}
+	fileName, isLogFileNameProvided := os.LookupEnv("OCI_GO_SDK_LOG_FILE")
+	if !isLogFileNameProvided {
+		fileName = fmt.Sprintf("logging_%v%s", time.Now().Unix(), ".log")
+	}
+
+	switch strings.ToLower(logMode) {
+	case "file", "f":
+		file = openLogOutputFile(logger, fileName)
+		logger.infoLogger.SetOutput(file)
+		logger.debugLogger.SetOutput(file)
+		logger.verboseLogger.SetOutput(file)
+		break
+	case "combine", "c":
+		file = openLogOutputFile(logger, fileName)
+		wrt := io.MultiWriter(os.Stderr, file)
+
+		logger.infoLogger.SetOutput(wrt)
+		logger.debugLogger.SetOutput(wrt)
+		logger.verboseLogger.SetOutput(wrt)
+		break
+	}
+}
+
+func openLogOutputFile(logger defaultSDKLogger, fileName string) *os.File {
+	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		logger.verboseLogger.Fatal(err)
+	}
+	return file
+}
+
+//CloseLogFile close the logging file and return error
+func CloseLogFile() error {
+	return file.Close()
 }
 
 //LogLevel returns the current debug level

--- a/vendor/github.com/oracle/oci-go-sdk/common/retry.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/retry.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+
 package common
 
 import (

--- a/vendor/github.com/oracle/oci-go-sdk/common/version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/common/version.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	major = "18"
-	minor = "0"
+	major = "24"
+	minor = "3"
 	patch = "0"
 	tag   = ""
 )

--- a/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_listing.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_listing.go
@@ -32,7 +32,7 @@ type AppCatalogListing struct {
 	// Name of the listing.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Date and time the listing was published, in RFC3339 format.
+	// Date and time the listing was published, in RFC3339 (https://tools.ietf.org/html/rfc3339) format.
 	// Example: `2018-03-20T12:32:53.532Z`
 	TimePublished *common.SDKTime `mandatory:"false" json:"timePublished"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_listing_resource_version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_listing_resource_version.go
@@ -23,7 +23,7 @@ type AppCatalogListingResourceVersion struct {
 	// The OCID of the listing this resource version belongs to.
 	ListingId *string `mandatory:"false" json:"listingId"`
 
-	// Date and time the listing resource version was published, in RFC3339 format.
+	// Date and time the listing resource version was published, in RFC3339 (https://tools.ietf.org/html/rfc3339) format.
 	// Example: `2018-03-20T12:32:53.532Z`
 	TimePublished *common.SDKTime `mandatory:"false" json:"timePublished"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_listing_resource_version_agreements.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_listing_resource_version_agreements.go
@@ -32,7 +32,7 @@ type AppCatalogListingResourceVersionAgreements struct {
 	// EULA link
 	EulaLink *string `mandatory:"false" json:"eulaLink"`
 
-	// Date and time the agreements were retrieved, in RFC3339 format.
+	// Date and time the agreements were retrieved, in RFC3339 (https://tools.ietf.org/html/rfc3339) format.
 	// Example: `2018-03-20T12:32:53.532Z`
 	TimeRetrieved *common.SDKTime `mandatory:"false" json:"timeRetrieved"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_listing_resource_version_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_listing_resource_version_summary.go
@@ -23,7 +23,7 @@ type AppCatalogListingResourceVersionSummary struct {
 	// The OCID of the listing this resource version belongs to.
 	ListingId *string `mandatory:"false" json:"listingId"`
 
-	// Date and time the listing resource version was published, in RFC3339 format.
+	// Date and time the listing resource version was published, in RFC3339 (https://tools.ietf.org/html/rfc3339) format.
 	// Example: `2018-03-20T12:32:53.532Z`
 	TimePublished *common.SDKTime `mandatory:"false" json:"timePublished"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_subscription.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_subscription.go
@@ -41,7 +41,7 @@ type AppCatalogSubscription struct {
 	// The compartmentID of the subscription.
 	CompartmentId *string `mandatory:"false" json:"compartmentId"`
 
-	// Date and time at which the subscription was created, in RFC3339 format.
+	// Date and time at which the subscription was created, in RFC3339 (https://tools.ietf.org/html/rfc3339) format.
 	// Example: `2018-03-20T12:32:53.532Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_subscription_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/app_catalog_subscription_summary.go
@@ -41,7 +41,7 @@ type AppCatalogSubscriptionSummary struct {
 	// The compartmentID of the subscription.
 	CompartmentId *string `mandatory:"false" json:"compartmentId"`
 
-	// Date and time at which the subscription was created, in RFC3339 format.
+	// Date and time at which the subscription was created, in RFC3339 (https://tools.ietf.org/html/rfc3339) format.
 	// Example: `2018-03-20T12:32:53.532Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/boolean_image_capability_schema_descriptor.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/boolean_image_capability_schema_descriptor.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// BooleanImageCapabilitySchemaDescriptor Boolean type ImageCapabilitySchemaDescriptor
+type BooleanImageCapabilitySchemaDescriptor struct {
+
+	// the default value
+	DefaultValue *bool `mandatory:"false" json:"defaultValue"`
+
+	Source ImageCapabilitySchemaDescriptorSourceEnum `mandatory:"true" json:"source"`
+}
+
+//GetSource returns Source
+func (m BooleanImageCapabilitySchemaDescriptor) GetSource() ImageCapabilitySchemaDescriptorSourceEnum {
+	return m.Source
+}
+
+func (m BooleanImageCapabilitySchemaDescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m BooleanImageCapabilitySchemaDescriptor) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeBooleanImageCapabilitySchemaDescriptor BooleanImageCapabilitySchemaDescriptor
+	s := struct {
+		DiscriminatorParam string `json:"descriptorType"`
+		MarshalTypeBooleanImageCapabilitySchemaDescriptor
+	}{
+		"boolean",
+		(MarshalTypeBooleanImageCapabilitySchemaDescriptor)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/boot_volume.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/boot_volume.go
@@ -44,7 +44,8 @@ type BootVolume struct {
 	// This field is deprecated. Please use sizeInGBs.
 	SizeInMBs *int64 `mandatory:"true" json:"sizeInMBs"`
 
-	// The date and time the boot volume was created. Format defined by RFC3339.
+	// The date and time the boot volume was created. Format defined
+	// by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a
@@ -91,6 +92,12 @@ type BootVolume struct {
 
 	// The OCID of the Key Management master encryption key assigned to the boot volume.
 	KmsKeyId *string `mandatory:"false" json:"kmsKeyId"`
+
+	// Specifies whether the auto-tune performance is enabled for this boot volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
+
+	// The number of Volume Performance Units per GB that this boot volume is effectively tuned to when it's idle.
+	AutoTunedVpusPerGB *int64 `mandatory:"false" json:"autoTunedVpusPerGB"`
 }
 
 func (m BootVolume) String() string {
@@ -111,6 +118,8 @@ func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 		SourceDetails      bootvolumesourcedetails           `json:"sourceDetails"`
 		VolumeGroupId      *string                           `json:"volumeGroupId"`
 		KmsKeyId           *string                           `json:"kmsKeyId"`
+		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
+		AutoTunedVpusPerGB *int64                            `json:"autoTunedVpusPerGB"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 		Id                 *string                           `json:"id"`
@@ -154,6 +163,10 @@ func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 
 	m.KmsKeyId = model.KmsKeyId
 
+	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
+
+	m.AutoTunedVpusPerGB = model.AutoTunedVpusPerGB
+
 	m.AvailabilityDomain = model.AvailabilityDomain
 
 	m.CompartmentId = model.CompartmentId
@@ -165,6 +178,7 @@ func (m *BootVolume) UnmarshalJSON(data []byte) (e error) {
 	m.SizeInMBs = model.SizeInMBs
 
 	m.TimeCreated = model.TimeCreated
+
 	return
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/boot_volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/boot_volume_attachment.go
@@ -41,7 +41,7 @@ type BootVolumeAttachment struct {
 	// The current state of the boot volume attachment.
 	LifecycleState BootVolumeAttachmentLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The date and time the boot volume was created, in the format defined by RFC3339.
+	// The date and time the boot volume was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/boot_volume_backup.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/boot_volume_backup.go
@@ -42,7 +42,7 @@ type BootVolumeBackup struct {
 	LifecycleState BootVolumeBackupLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
 	// The date and time the boot volume backup was created. This is the time the actual point-in-time image
-	// of the volume data was taken. Format defined by RFC3339.
+	// of the volume data was taken. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// The OCID of the boot volume.
@@ -58,7 +58,7 @@ type BootVolumeBackup struct {
 	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
 
 	// The date and time the volume backup will expire and be automatically deleted.
-	// Format defined by RFC3339. This parameter will always be present for backups that
+	// Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339). This parameter will always be present for backups that
 	// were created automatically by a scheduled-backup policy. For manually created backups,
 	// it will be absent, signifying that there is no expiration time and the backup will
 	// last forever until manually deleted.
@@ -87,7 +87,7 @@ type BootVolumeBackup struct {
 	// Specifies whether the backup was created manually, or via scheduled backup policy.
 	SourceType BootVolumeBackupSourceTypeEnum `mandatory:"false" json:"sourceType,omitempty"`
 
-	// The date and time the request to create the boot volume backup was received. Format defined by RFC3339.
+	// The date and time the request to create the boot volume backup was received. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeRequestReceived *common.SDKTime `mandatory:"false" json:"timeRequestReceived"`
 
 	// The type of a volume backup.

--- a/vendor/github.com/oracle/oci-go-sdk/core/change_compute_image_capability_schema_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/change_compute_image_capability_schema_compartment_details.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeComputeImageCapabilitySchemaCompartmentDetails The configuration details for the move operation.
+type ChangeComputeImageCapabilitySchemaCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to
+	// move the instance configuration to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeComputeImageCapabilitySchemaCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/change_compute_image_capability_schema_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/change_compute_image_capability_schema_compartment_request_response.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeComputeImageCapabilitySchemaCompartmentRequest wrapper for the ChangeComputeImageCapabilitySchemaCompartment operation
+type ChangeComputeImageCapabilitySchemaCompartmentRequest struct {
+
+	// The id of the compute image capability schema or the image ocid
+	ComputeImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeImageCapabilitySchemaId"`
+
+	// Compute Image Capability Schema change compartment details
+	ChangeComputeImageCapabilitySchemaCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeComputeImageCapabilitySchemaCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeComputeImageCapabilitySchemaCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeComputeImageCapabilitySchemaCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeComputeImageCapabilitySchemaCompartmentResponse wrapper for the ChangeComputeImageCapabilitySchemaCompartment operation
+type ChangeComputeImageCapabilitySchemaCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ChangeComputeImageCapabilitySchemaCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeComputeImageCapabilitySchemaCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/change_vlan_compartment_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/change_vlan_compartment_details.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ChangeVlanCompartmentDetails The configuration details for the move operation.
+type ChangeVlanCompartmentDetails struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the VLAN to.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+}
+
+func (m ChangeVlanCompartmentDetails) String() string {
+	return common.PointerString(m)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/change_vlan_compartment_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/change_vlan_compartment_request_response.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ChangeVlanCompartmentRequest wrapper for the ChangeVlanCompartment operation
+type ChangeVlanCompartmentRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+	VlanId *string `mandatory:"true" contributesTo:"path" name:"vlanId"`
+
+	// Request to change the compartment of a given VLAN.
+	ChangeVlanCompartmentDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ChangeVlanCompartmentRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ChangeVlanCompartmentRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ChangeVlanCompartmentRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ChangeVlanCompartmentResponse wrapper for the ChangeVlanCompartment operation
+type ChangeVlanCompartmentResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+
+	// The OCID of the work request. Use GetWorkRequest (https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+	// with this ID to track the status of the request.
+	OpcWorkRequestId *string `presentIn:"header" name:"opc-work-request-id"`
+}
+
+func (response ChangeVlanCompartmentResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ChangeVlanCompartmentResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/cluster_network.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/cluster_network.go
@@ -31,11 +31,11 @@ type ClusterNetwork struct {
 	// The current state of the cluster network.
 	LifecycleState ClusterNetworkLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The date and time the resource was created, in the format defined by RFC3339.
+	// The date and time the resource was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// The date and time the resource was updated, in the format defined by RFC3339.
+	// The date and time the resource was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/cluster_network_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/cluster_network_summary.go
@@ -30,11 +30,11 @@ type ClusterNetworkSummary struct {
 	// The current state of the cluster network.
 	LifecycleState ClusterNetworkSummaryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The date and time the resource was created, in the format defined by RFC3339.
+	// The date and time the resource was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// The date and time the resource was updated, in the format defined by RFC3339.
+	// The date and time the resource was updated, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeUpdated *common.SDKTime `mandatory:"true" json:"timeUpdated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/compute_global_image_capability_schema.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/compute_global_image_capability_schema.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeGlobalImageCapabilitySchema Compute Global Image Capability Schema is a container for a set of compute global image capability schema versions
+type ComputeGlobalImageCapabilitySchema struct {
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+	Id *string `mandatory:"true" json:"id"`
+
+	// A user-friendly name for the compute global image capability schema
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The date and time the compute global image capability schema was created, in the format defined by
+	// RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The OCID of the compartment that contains the resource.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The name of the global capabilities version resource that is considered the current version.
+	CurrentVersionName *string `mandatory:"false" json:"currentVersionName"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m ComputeGlobalImageCapabilitySchema) String() string {
+	return common.PointerString(m)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/compute_global_image_capability_schema_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/compute_global_image_capability_schema_summary.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeGlobalImageCapabilitySchemaSummary Summary information for a compute global image capability schema
+type ComputeGlobalImageCapabilitySchemaSummary struct {
+
+	// The compute global image capability schema OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	Id *string `mandatory:"true" json:"id"`
+
+	// A user-friendly name for the compute global image capability schema.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The date and time the compute global image capability schema was created, in the format defined by
+	// RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The OCID of the compartment containing the compute global image capability schema
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// The name of the global capabilities version resource that is considered the current version.
+	CurrentVersionName *string `mandatory:"false" json:"currentVersionName"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m ComputeGlobalImageCapabilitySchemaSummary) String() string {
+	return common.PointerString(m)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/compute_global_image_capability_schema_version.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/compute_global_image_capability_schema_version.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeGlobalImageCapabilitySchemaVersion Compute Global Image Capability Schema Version is a set of all possible capabilities for a collection of images.
+type ComputeGlobalImageCapabilitySchemaVersion struct {
+
+	// The name of the compute global image capability schema version
+	Name *string `mandatory:"true" json:"name"`
+
+	// The ocid of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaId"`
+
+	// A user-friendly name for the compute global image capability schema
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The map of each capability name to its ImageCapabilityDescriptor.
+	SchemaData map[string]ImageCapabilitySchemaDescriptor `mandatory:"true" json:"schemaData"`
+
+	// The date and time the compute global image capability schema version was created, in the format defined by
+	// RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+}
+
+func (m ComputeGlobalImageCapabilitySchemaVersion) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ComputeGlobalImageCapabilitySchemaVersion) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		Name                                 *string                                    `json:"name"`
+		ComputeGlobalImageCapabilitySchemaId *string                                    `json:"computeGlobalImageCapabilitySchemaId"`
+		DisplayName                          *string                                    `json:"displayName"`
+		SchemaData                           map[string]imagecapabilityschemadescriptor `json:"schemaData"`
+		TimeCreated                          *common.SDKTime                            `json:"timeCreated"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.Name = model.Name
+
+	m.ComputeGlobalImageCapabilitySchemaId = model.ComputeGlobalImageCapabilitySchemaId
+
+	m.DisplayName = model.DisplayName
+
+	m.SchemaData = make(map[string]ImageCapabilitySchemaDescriptor)
+	for k, v := range model.SchemaData {
+		nn, e = v.UnmarshalPolymorphicJSON(v.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.SchemaData[k] = nn.(ImageCapabilitySchemaDescriptor)
+		} else {
+			m.SchemaData[k] = nil
+		}
+	}
+
+	m.TimeCreated = model.TimeCreated
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/compute_global_image_capability_schema_version_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/compute_global_image_capability_schema_version_summary.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeGlobalImageCapabilitySchemaVersionSummary Summary information for a compute global image capability schema
+type ComputeGlobalImageCapabilitySchemaVersionSummary struct {
+
+	// The compute global image capability schema version name
+	Name *string `mandatory:"true" json:"name"`
+
+	// The OCID of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaId"`
+
+	// The date and time the compute global image capability schema version was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The display name of the version
+	DisplayName *string `mandatory:"false" json:"displayName"`
+}
+
+func (m ComputeGlobalImageCapabilitySchemaVersionSummary) String() string {
+	return common.PointerString(m)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/compute_image_capability_schema.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/compute_image_capability_schema.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeImageCapabilitySchema Compute Image Capability Schema is a set of capabilities that filter the compute global capability schema
+// version for an image.
+type ComputeImageCapabilitySchema struct {
+
+	// The id of the compute global image capability schema version
+	Id *string `mandatory:"true" json:"id"`
+
+	// The ocid of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaId"`
+
+	// The name of the compute global image capability schema version
+	ComputeGlobalImageCapabilitySchemaVersionName *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaVersionName"`
+
+	// The OCID of the image associated with this compute image capability schema
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// A user-friendly name for the compute global image capability schema
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The map of each capability name to its ImageCapabilityDescriptor.
+	SchemaData map[string]ImageCapabilitySchemaDescriptor `mandatory:"true" json:"schemaData"`
+
+	// The date and time the compute image capability schema was created, in the format defined by
+	// RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The OCID of the compartment that contains the resource.
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m ComputeImageCapabilitySchema) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *ComputeImageCapabilitySchema) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		CompartmentId                                 *string                                    `json:"compartmentId"`
+		DefinedTags                                   map[string]map[string]interface{}          `json:"definedTags"`
+		FreeformTags                                  map[string]string                          `json:"freeformTags"`
+		Id                                            *string                                    `json:"id"`
+		ComputeGlobalImageCapabilitySchemaId          *string                                    `json:"computeGlobalImageCapabilitySchemaId"`
+		ComputeGlobalImageCapabilitySchemaVersionName *string                                    `json:"computeGlobalImageCapabilitySchemaVersionName"`
+		ImageId                                       *string                                    `json:"imageId"`
+		DisplayName                                   *string                                    `json:"displayName"`
+		SchemaData                                    map[string]imagecapabilityschemadescriptor `json:"schemaData"`
+		TimeCreated                                   *common.SDKTime                            `json:"timeCreated"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.CompartmentId = model.CompartmentId
+
+	m.DefinedTags = model.DefinedTags
+
+	m.FreeformTags = model.FreeformTags
+
+	m.Id = model.Id
+
+	m.ComputeGlobalImageCapabilitySchemaId = model.ComputeGlobalImageCapabilitySchemaId
+
+	m.ComputeGlobalImageCapabilitySchemaVersionName = model.ComputeGlobalImageCapabilitySchemaVersionName
+
+	m.ImageId = model.ImageId
+
+	m.DisplayName = model.DisplayName
+
+	m.SchemaData = make(map[string]ImageCapabilitySchemaDescriptor)
+	for k, v := range model.SchemaData {
+		nn, e = v.UnmarshalPolymorphicJSON(v.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.SchemaData[k] = nn.(ImageCapabilitySchemaDescriptor)
+		} else {
+			m.SchemaData[k] = nil
+		}
+	}
+
+	m.TimeCreated = model.TimeCreated
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/compute_image_capability_schema_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/compute_image_capability_schema_summary.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ComputeImageCapabilitySchemaSummary Summary information for a compute image capability schema
+type ComputeImageCapabilitySchemaSummary struct {
+
+	// The compute image capability schema OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+	Id *string `mandatory:"true" json:"id"`
+
+	// The name of the compute global image capability schema version
+	ComputeGlobalImageCapabilitySchemaVersionName *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaVersionName"`
+
+	// The OCID of the image associated with this compute image capability schema
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// A user-friendly name for the compute image capability schema.
+	DisplayName *string `mandatory:"true" json:"displayName"`
+
+	// The date and time the compute image capability schema was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
+
+	// The OCID of the compartment containing the compute global image capability schema
+	CompartmentId *string `mandatory:"false" json:"compartmentId"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+}
+
+func (m ComputeImageCapabilitySchemaSummary) String() string {
+	return common.PointerString(m)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/console_history.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/console_history.go
@@ -40,7 +40,7 @@ type ConsoleHistory struct {
 	// The current state of the console history.
 	LifecycleState ConsoleHistoryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The date and time the history was created, in the format defined by RFC3339.
+	// The date and time the history was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/core_compute_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/core_compute_client.go
@@ -350,6 +350,60 @@ func (client ComputeClient) captureConsoleHistory(ctx context.Context, request c
 	return response, err
 }
 
+// ChangeComputeImageCapabilitySchemaCompartment Moves a compute image capability schema into a different compartment within the same tenancy.
+// For information about moving resources between compartments, see
+//         Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+func (client ComputeClient) ChangeComputeImageCapabilitySchemaCompartment(ctx context.Context, request ChangeComputeImageCapabilitySchemaCompartmentRequest) (response ChangeComputeImageCapabilitySchemaCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeComputeImageCapabilitySchemaCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeComputeImageCapabilitySchemaCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeComputeImageCapabilitySchemaCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeComputeImageCapabilitySchemaCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeComputeImageCapabilitySchemaCompartmentResponse")
+	}
+	return
+}
+
+// changeComputeImageCapabilitySchemaCompartment implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) changeComputeImageCapabilitySchemaCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeComputeImageCapabilitySchemaCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ChangeDedicatedVmHostCompartment Moves a dedicated virtual machine host from one compartment to another.
 func (client ComputeClient) ChangeDedicatedVmHostCompartment(ctx context.Context, request ChangeDedicatedVmHostCompartmentRequest) (response ChangeDedicatedVmHostCompartmentResponse, err error) {
 	var ociResponse common.OCIResponse
@@ -552,6 +606,58 @@ func (client ComputeClient) createAppCatalogSubscription(ctx context.Context, re
 	}
 
 	var response CreateAppCatalogSubscriptionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// CreateComputeImageCapabilitySchema Creates compute image capability schema.
+func (client ComputeClient) CreateComputeImageCapabilitySchema(ctx context.Context, request CreateComputeImageCapabilitySchemaRequest) (response CreateComputeImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createComputeImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateComputeImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateComputeImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateComputeImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateComputeImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// createComputeImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) createComputeImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/computeImageCapabilitySchemas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateComputeImageCapabilitySchemaResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -777,6 +883,53 @@ func (client ComputeClient) deleteAppCatalogSubscription(ctx context.Context, re
 	}
 
 	var response DeleteAppCatalogSubscriptionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteComputeImageCapabilitySchema Deletes the specified Compute Image Capability Schema
+func (client ComputeClient) DeleteComputeImageCapabilitySchema(ctx context.Context, request DeleteComputeImageCapabilitySchemaRequest) (response DeleteComputeImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteComputeImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteComputeImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteComputeImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteComputeImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteComputeImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// deleteComputeImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) deleteComputeImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteComputeImageCapabilitySchemaResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -1378,6 +1531,147 @@ func (client ComputeClient) getBootVolumeAttachment(ctx context.Context, request
 	return response, err
 }
 
+// GetComputeGlobalImageCapabilitySchema Gets the specified Compute Global Image Capability Schema
+func (client ComputeClient) GetComputeGlobalImageCapabilitySchema(ctx context.Context, request GetComputeGlobalImageCapabilitySchemaRequest) (response GetComputeGlobalImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getComputeGlobalImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetComputeGlobalImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetComputeGlobalImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetComputeGlobalImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetComputeGlobalImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// getComputeGlobalImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) getComputeGlobalImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetComputeGlobalImageCapabilitySchemaResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetComputeGlobalImageCapabilitySchemaVersion Gets the specified Compute Global Image Capability Schema Version
+func (client ComputeClient) GetComputeGlobalImageCapabilitySchemaVersion(ctx context.Context, request GetComputeGlobalImageCapabilitySchemaVersionRequest) (response GetComputeGlobalImageCapabilitySchemaVersionResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getComputeGlobalImageCapabilitySchemaVersion, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetComputeGlobalImageCapabilitySchemaVersionResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetComputeGlobalImageCapabilitySchemaVersionResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetComputeGlobalImageCapabilitySchemaVersionResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetComputeGlobalImageCapabilitySchemaVersionResponse")
+	}
+	return
+}
+
+// getComputeGlobalImageCapabilitySchemaVersion implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) getComputeGlobalImageCapabilitySchemaVersion(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}/versions/{computeGlobalImageCapabilitySchemaVersionName}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetComputeGlobalImageCapabilitySchemaVersionResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// GetComputeImageCapabilitySchema Gets the specified Compute Image Capability Schema
+func (client ComputeClient) GetComputeImageCapabilitySchema(ctx context.Context, request GetComputeImageCapabilitySchemaRequest) (response GetComputeImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getComputeImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetComputeImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetComputeImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetComputeImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetComputeImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// getComputeImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) getComputeImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetComputeImageCapabilitySchemaResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetConsoleHistory Shows the metadata for the specified console history.
 // See CaptureConsoleHistory
 // for details about using the console history operations.
@@ -1940,6 +2234,13 @@ func (client ComputeClient) instanceAction(ctx context.Context, request common.O
 // GetVnic with the VNIC ID.
 // You can later add secondary VNICs to an instance. For more information, see
 // Virtual Network Interface Cards (VNICs) (https://docs.cloud.oracle.com/Content/Network/Tasks/managingVNICs.htm).
+// To launch an instance from a Marketplace image listing, you must provide the image ID of the
+// listing resource version that you want, but you also must subscribe to the listing before you try
+// to launch the instance. To subscribe to the listing, use the GetAppCatalogListingAgreements
+// operation to get the signature for the terms of use agreement for the desired listing resource version.
+// Then, call CreateAppCatalogSubscription
+// with the signature. To get the image ID for the LaunchInstance operation, call
+// GetAppCatalogListingResourceVersion.
 func (client ComputeClient) LaunchInstance(ctx context.Context, request LaunchInstanceRequest) (response LaunchInstanceResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -2168,6 +2469,147 @@ func (client ComputeClient) listBootVolumeAttachments(ctx context.Context, reque
 	}
 
 	var response ListBootVolumeAttachmentsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListComputeGlobalImageCapabilitySchemaVersions Lists Compute Global Image Capability Schema versions in the specified compartment.
+func (client ComputeClient) ListComputeGlobalImageCapabilitySchemaVersions(ctx context.Context, request ListComputeGlobalImageCapabilitySchemaVersionsRequest) (response ListComputeGlobalImageCapabilitySchemaVersionsResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeGlobalImageCapabilitySchemaVersions, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeGlobalImageCapabilitySchemaVersionsResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeGlobalImageCapabilitySchemaVersionsResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeGlobalImageCapabilitySchemaVersionsResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeGlobalImageCapabilitySchemaVersionsResponse")
+	}
+	return
+}
+
+// listComputeGlobalImageCapabilitySchemaVersions implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeGlobalImageCapabilitySchemaVersions(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeGlobalImageCapabilitySchemas/{computeGlobalImageCapabilitySchemaId}/versions")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeGlobalImageCapabilitySchemaVersionsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListComputeGlobalImageCapabilitySchemas Lists Compute Global Image Capability Schema in the specified compartment.
+func (client ComputeClient) ListComputeGlobalImageCapabilitySchemas(ctx context.Context, request ListComputeGlobalImageCapabilitySchemasRequest) (response ListComputeGlobalImageCapabilitySchemasResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeGlobalImageCapabilitySchemas, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeGlobalImageCapabilitySchemasResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeGlobalImageCapabilitySchemasResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeGlobalImageCapabilitySchemasResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeGlobalImageCapabilitySchemasResponse")
+	}
+	return
+}
+
+// listComputeGlobalImageCapabilitySchemas implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeGlobalImageCapabilitySchemas(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeGlobalImageCapabilitySchemas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeGlobalImageCapabilitySchemasResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListComputeImageCapabilitySchemas Lists Compute Image Capability Schema in the specified compartment. You can also query by a specific imageId.
+func (client ComputeClient) ListComputeImageCapabilitySchemas(ctx context.Context, request ListComputeImageCapabilitySchemasRequest) (response ListComputeImageCapabilitySchemasResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listComputeImageCapabilitySchemas, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListComputeImageCapabilitySchemasResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListComputeImageCapabilitySchemasResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListComputeImageCapabilitySchemasResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListComputeImageCapabilitySchemasResponse")
+	}
+	return
+}
+
+// listComputeImageCapabilitySchemas implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) listComputeImageCapabilitySchemas(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/computeImageCapabilitySchemas")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListComputeImageCapabilitySchemasResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -2418,7 +2860,7 @@ func (client ComputeClient) listDedicatedVmHosts(ctx context.Context, request co
 	return response, err
 }
 
-// ListImageShapeCompatibilityEntries Lists the shape compatibilities for the image.
+// ListImageShapeCompatibilityEntries Lists the compatible shapes for the specified image.
 func (client ComputeClient) ListImageShapeCompatibilityEntries(ctx context.Context, request ListImageShapeCompatibilityEntriesRequest) (response ListImageShapeCompatibilityEntriesResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -2911,6 +3353,53 @@ func (client ComputeClient) terminateInstance(ctx context.Context, request commo
 	}
 
 	var response TerminateInstanceResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateComputeImageCapabilitySchema Updates the specified Compute Image Capability Schema
+func (client ComputeClient) UpdateComputeImageCapabilitySchema(ctx context.Context, request UpdateComputeImageCapabilitySchemaRequest) (response UpdateComputeImageCapabilitySchemaResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateComputeImageCapabilitySchema, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateComputeImageCapabilitySchemaResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateComputeImageCapabilitySchemaResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateComputeImageCapabilitySchemaResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateComputeImageCapabilitySchemaResponse")
+	}
+	return
+}
+
+// updateComputeImageCapabilitySchema implements the OCIOperation interface (enables retrying operations)
+func (client ComputeClient) updateComputeImageCapabilitySchema(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/computeImageCapabilitySchemas/{computeImageCapabilitySchemaId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateComputeImageCapabilitySchemaResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/vendor/github.com/oracle/oci-go-sdk/core/core_computemanagement_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/core_computemanagement_client.go
@@ -1304,6 +1304,11 @@ func (client ComputeManagementClient) terminateClusterNetwork(ctx context.Contex
 }
 
 // TerminateInstancePool Terminate the specified instance pool.
+// **Warning:** When you delete an instance pool, the resources that were created by the pool are permanently
+// deleted, including associated instances, attached boot volumes, and block volumes.
+// If an autoscaling configuration applies to the instance pool, the autoscaling configuration will be deleted
+// asynchronously after the pool is deleted. You can also manually delete the autoscaling configuration using
+// the `DeleteAutoScalingConfiguration` operation in the Autoscaling API.
 func (client ComputeManagementClient) TerminateInstancePool(ctx context.Context, request TerminateInstancePoolRequest) (response TerminateInstancePoolResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()

--- a/vendor/github.com/oracle/oci-go-sdk/core/core_virtualnetwork_client.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/core_virtualnetwork_client.go
@@ -1244,6 +1244,60 @@ func (client VirtualNetworkClient) changeVirtualCircuitCompartment(ctx context.C
 	return response, err
 }
 
+// ChangeVlanCompartment Moves a VLAN into a different compartment within the same tenancy.
+// For information about moving resources between compartments, see
+// Moving Resources to a Different Compartment (https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+func (client VirtualNetworkClient) ChangeVlanCompartment(ctx context.Context, request ChangeVlanCompartmentRequest) (response ChangeVlanCompartmentResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.changeVlanCompartment, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ChangeVlanCompartmentResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ChangeVlanCompartmentResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ChangeVlanCompartmentResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ChangeVlanCompartmentResponse")
+	}
+	return
+}
+
+// changeVlanCompartment implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) changeVlanCompartment(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/vlans/{vlanId}/actions/changeCompartment")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChangeVlanCompartmentResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // ConnectLocalPeeringGateways Connects this local peering gateway (LPG) to another one in the same region.
 // This operation must be called by the VCN administrator who is designated as
 // the *requestor* in the peering relationship. The *acceptor* must implement
@@ -2655,6 +2709,58 @@ func (client VirtualNetworkClient) createVirtualCircuit(ctx context.Context, req
 	return response, err
 }
 
+// CreateVlan Creates a VLAN in the specified VCN and the specified compartment.
+func (client VirtualNetworkClient) CreateVlan(ctx context.Context, request CreateVlanRequest) (response CreateVlanResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+
+	if !(request.OpcRetryToken != nil && *request.OpcRetryToken != "") {
+		request.OpcRetryToken = common.String(common.RetryToken())
+	}
+
+	ociResponse, err = common.Retry(ctx, request, client.createVlan, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = CreateVlanResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = CreateVlanResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(CreateVlanResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into CreateVlanResponse")
+	}
+	return
+}
+
+// createVlan implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) createVlan(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPost, "/vlans")
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateVlanResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // DeleteCpe Deletes the specified CPE object. The CPE must not be connected to a DRG. This is an asynchronous
 // operation. The CPE's `lifecycleState` will change to TERMINATING temporarily until the CPE is completely
 // removed.
@@ -3698,6 +3804,53 @@ func (client VirtualNetworkClient) deleteVirtualCircuit(ctx context.Context, req
 	}
 
 	var response DeleteVirtualCircuitResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// DeleteVlan Deletes the specified VLAN, but only if there are no VNICs in the VLAN.
+func (client VirtualNetworkClient) DeleteVlan(ctx context.Context, request DeleteVlanRequest) (response DeleteVlanResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.deleteVlan, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = DeleteVlanResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = DeleteVlanResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(DeleteVlanResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into DeleteVlanResponse")
+	}
+	return
+}
+
+// deleteVlan implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) deleteVlan(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodDelete, "/vlans/{vlanId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response DeleteVlanResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -4999,7 +5152,7 @@ func (client VirtualNetworkClient) getPrivateIp(ctx context.Context, request com
 
 // GetPublicIp Gets the specified public IP. You must specify the object's OCID.
 // Alternatively, you can get the object by using GetPublicIpByIpAddress
-// with the public IP address (for example, 129.146.2.1).
+// with the public IP address (for example, 203.0.113.2).
 // Or you can use GetPublicIpByPrivateIpId
 // with the OCID of the private IP that the public IP is assigned to.
 // **Note:** If you're fetching a reserved public IP that is in the process of being
@@ -5051,7 +5204,7 @@ func (client VirtualNetworkClient) getPublicIp(ctx context.Context, request comm
 	return response, err
 }
 
-// GetPublicIpByIpAddress Gets the public IP based on the public IP address (for example, 129.146.2.1).
+// GetPublicIpByIpAddress Gets the public IP based on the public IP address (for example, 203.0.113.2).
 // **Note:** If you're fetching a reserved public IP that is in the process of being
 // moved to a different private IP, the service returns the public IP object with
 // `lifecycleState` = ASSIGNING and `assignedEntityId` = OCID of the target private IP.
@@ -5644,6 +5797,53 @@ func (client VirtualNetworkClient) getVirtualCircuit(ctx context.Context, reques
 	return response, err
 }
 
+// GetVlan Gets the specified VLAN's information.
+func (client VirtualNetworkClient) GetVlan(ctx context.Context, request GetVlanRequest) (response GetVlanResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.getVlan, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = GetVlanResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = GetVlanResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(GetVlanResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into GetVlanResponse")
+	}
+	return
+}
+
+// getVlan implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) getVlan(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/vlans/{vlanId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetVlanResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
 // GetVnic Gets the information for the specified virtual network interface card (VNIC).
 // You can get the VNIC OCID from the
 // ListVnicAttachments
@@ -6038,6 +6238,7 @@ func (client VirtualNetworkClient) listCrossconnectPortSpeedShapes(ctx context.C
 }
 
 // ListDhcpOptions Lists the sets of DHCP options in the specified VCN and specified compartment.
+// If the VCN ID is not provided, then the list includes the sets of DHCP options from all VCNs in the specified compartment.
 // The response includes the default set of options that automatically comes with each VCN,
 // plus any other sets you've created.
 func (client VirtualNetworkClient) ListDhcpOptions(ctx context.Context, request ListDhcpOptionsRequest) (response ListDhcpOptionsResponse, err error) {
@@ -6377,6 +6578,7 @@ func (client VirtualNetworkClient) listIPSecConnections(ctx context.Context, req
 }
 
 // ListInternetGateways Lists the internet gateways in the specified VCN and the specified compartment.
+// If the VCN ID is not provided, then the list includes the internet gateways from all VCNs in the specified compartment.
 func (client VirtualNetworkClient) ListInternetGateways(ctx context.Context, request ListInternetGatewaysRequest) (response ListInternetGatewaysResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -6476,8 +6678,8 @@ func (client VirtualNetworkClient) listIpv6s(ctx context.Context, request common
 	return response, err
 }
 
-// ListLocalPeeringGateways Lists the local peering gateways (LPGs) for the specified VCN and compartment
-// (the LPG's compartment).
+// ListLocalPeeringGateways Lists the local peering gateways (LPGs) for the specified VCN and specified compartment.
+// If the VCN ID is not provided, then the list includes the LPGs from all VCNs in the specified compartment.
 func (client VirtualNetworkClient) ListLocalPeeringGateways(ctx context.Context, request ListLocalPeeringGatewaysRequest) (response ListLocalPeeringGatewaysResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -6724,6 +6926,8 @@ func (client VirtualNetworkClient) listNetworkSecurityGroups(ctx context.Context
 //   requires the OCID.
 // If you're listing all the private IPs associated with a given subnet
 // or VNIC, the response includes both primary and secondary private IPs.
+// If you are an Oracle Cloud VMware Solution customer and have VLANs
+// in your VCN, you can filter the list by VLAN OCID. See Vlan.
 func (client VirtualNetworkClient) ListPrivateIps(ctx context.Context, request ListPrivateIpsRequest) (response ListPrivateIpsResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -6880,9 +7084,10 @@ func (client VirtualNetworkClient) listRemotePeeringConnections(ctx context.Cont
 	return response, err
 }
 
-// ListRouteTables Lists the route tables in the specified VCN and specified compartment. The response
-// includes the default route table that automatically comes with each VCN, plus any route tables
-// you've created.
+// ListRouteTables Lists the route tables in the specified VCN and specified compartment.
+// If the VCN ID is not provided, then the list includes the route tables from all VCNs in the specified compartment.
+// The response includes the default route table that automatically comes with
+// each VCN in the specified compartment, plus any route tables you've created.
 func (client VirtualNetworkClient) ListRouteTables(ctx context.Context, request ListRouteTablesRequest) (response ListRouteTablesResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -6930,6 +7135,7 @@ func (client VirtualNetworkClient) listRouteTables(ctx context.Context, request 
 }
 
 // ListSecurityLists Lists the security lists in the specified VCN and compartment.
+// If the VCN ID is not provided, then the list includes the security lists from all VCNs in the specified compartment.
 func (client VirtualNetworkClient) ListSecurityLists(ctx context.Context, request ListSecurityListsRequest) (response ListSecurityListsResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -7073,6 +7279,7 @@ func (client VirtualNetworkClient) listServices(ctx context.Context, request com
 }
 
 // ListSubnets Lists the subnets in the specified VCN and the specified compartment.
+// If the VCN ID is not provided, then the list includes the subnets from all VCNs in the specified compartment.
 func (client VirtualNetworkClient) ListSubnets(ctx context.Context, request ListSubnetsRequest) (response ListSubnetsResponse, err error) {
 	var ociResponse common.OCIResponse
 	policy := common.NoRetryPolicy()
@@ -7296,6 +7503,53 @@ func (client VirtualNetworkClient) listVirtualCircuits(ctx context.Context, requ
 	}
 
 	var response ListVirtualCircuitsResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// ListVlans Lists the VLANs in the specified VCN and the specified compartment.
+func (client VirtualNetworkClient) ListVlans(ctx context.Context, request ListVlansRequest) (response ListVlansResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.listVlans, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = ListVlansResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = ListVlansResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(ListVlansResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into ListVlansResponse")
+	}
+	return
+}
+
+// listVlans implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) listVlans(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodGet, "/vlans")
+	if err != nil {
+		return nil, err
+	}
+
+	var response ListVlansResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)
@@ -8624,6 +8878,55 @@ func (client VirtualNetworkClient) updateVirtualCircuit(ctx context.Context, req
 	}
 
 	var response UpdateVirtualCircuitResponse
+	var httpResponse *http.Response
+	httpResponse, err = client.Call(ctx, &httpRequest)
+	defer common.CloseBodyIfValid(httpResponse)
+	response.RawResponse = httpResponse
+	if err != nil {
+		return response, err
+	}
+
+	err = common.UnmarshalResponse(httpResponse, &response)
+	return response, err
+}
+
+// UpdateVlan Updates the specified VLAN. This could result in changes to all
+// the VNICs in the VLAN, which can take time. During that transition
+// period, the VLAN will be in the UPDATING state.
+func (client VirtualNetworkClient) UpdateVlan(ctx context.Context, request UpdateVlanRequest) (response UpdateVlanResponse, err error) {
+	var ociResponse common.OCIResponse
+	policy := common.NoRetryPolicy()
+	if request.RetryPolicy() != nil {
+		policy = *request.RetryPolicy()
+	}
+	ociResponse, err = common.Retry(ctx, request, client.updateVlan, policy)
+	if err != nil {
+		if ociResponse != nil {
+			if httpResponse := ociResponse.HTTPResponse(); httpResponse != nil {
+				opcRequestId := httpResponse.Header.Get("opc-request-id")
+				response = UpdateVlanResponse{RawResponse: httpResponse, OpcRequestId: &opcRequestId}
+			} else {
+				response = UpdateVlanResponse{}
+			}
+		}
+		return
+	}
+	if convertedResponse, ok := ociResponse.(UpdateVlanResponse); ok {
+		response = convertedResponse
+	} else {
+		err = fmt.Errorf("failed to convert OCIResponse into UpdateVlanResponse")
+	}
+	return
+}
+
+// updateVlan implements the OCIOperation interface (enables retrying operations)
+func (client VirtualNetworkClient) updateVlan(ctx context.Context, request common.OCIRequest) (common.OCIResponse, error) {
+	httpRequest, err := request.HTTPRequest(http.MethodPut, "/vlans/{vlanId}")
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateVlanResponse
 	var httpResponse *http.Response
 	httpResponse, err = client.Call(ctx, &httpRequest)
 	defer common.CloseBodyIfValid(httpResponse)

--- a/vendor/github.com/oracle/oci-go-sdk/core/cpe.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/cpe.go
@@ -66,7 +66,7 @@ type Cpe struct {
 	//   * GetTunnelCpeDeviceConfig
 	CpeDeviceShapeId *string `mandatory:"false" json:"cpeDeviceShapeId"`
 
-	// The date and time the CPE was created, in the format defined by RFC3339.
+	// The date and time the CPE was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_app_catalog_subscription_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_app_catalog_subscription_details.go
@@ -32,7 +32,7 @@ type CreateAppCatalogSubscriptionDetails struct {
 	// Oracle TOU link
 	OracleTermsOfUseLink *string `mandatory:"true" json:"oracleTermsOfUseLink"`
 
-	// Date and time the agreements were retrieved, in RFC3339 format.
+	// Date and time the agreements were retrieved, in RFC3339 (https://tools.ietf.org/html/rfc3339) format.
 	// Example: `2018-03-20T12:32:53.532Z`
 	TimeRetrieved *common.SDKTime `mandatory:"true" json:"timeRetrieved"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_boot_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_boot_volume_details.go
@@ -64,6 +64,9 @@ type CreateBootVolumeDetails struct {
 	//   * `10`: Represents Balanced option.
 	//   * `20`: Represents Higher Performance option.
 	VpusPerGB *int64 `mandatory:"false" json:"vpusPerGB"`
+
+	// Specifies whether the auto-tune performance is enabled for this boot volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
 func (m CreateBootVolumeDetails) String() string {
@@ -80,6 +83,7 @@ func (m *CreateBootVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 		KmsKeyId           *string                           `json:"kmsKeyId"`
 		SizeInGBs          *int64                            `json:"sizeInGBs"`
 		VpusPerGB          *int64                            `json:"vpusPerGB"`
+		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 		SourceDetails      bootvolumesourcedetails           `json:"sourceDetails"`
@@ -104,6 +108,8 @@ func (m *CreateBootVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 
 	m.VpusPerGB = model.VpusPerGB
 
+	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
+
 	m.AvailabilityDomain = model.AvailabilityDomain
 
 	m.CompartmentId = model.CompartmentId
@@ -117,5 +123,6 @@ func (m *CreateBootVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 	} else {
 		m.SourceDetails = nil
 	}
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_compute_image_capability_schema_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_compute_image_capability_schema_details.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateComputeImageCapabilitySchemaDetails Create Image Capability Schema for an image.
+type CreateComputeImageCapabilitySchemaDetails struct {
+
+	// The OCID of the compartment that contains the resource.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The name of the compute global image capability schema version
+	ComputeGlobalImageCapabilitySchemaVersionName *string `mandatory:"true" json:"computeGlobalImageCapabilitySchemaVersionName"`
+
+	// The ocid of the image
+	ImageId *string `mandatory:"true" json:"imageId"`
+
+	// The map of each capability name to its ImageCapabilitySchemaDescriptor.
+	SchemaData map[string]ImageCapabilitySchemaDescriptor `mandatory:"true" json:"schemaData"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// A user-friendly name for the compute image capability schema
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m CreateComputeImageCapabilitySchemaDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *CreateComputeImageCapabilitySchemaDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		FreeformTags                                  map[string]string                          `json:"freeformTags"`
+		DisplayName                                   *string                                    `json:"displayName"`
+		DefinedTags                                   map[string]map[string]interface{}          `json:"definedTags"`
+		CompartmentId                                 *string                                    `json:"compartmentId"`
+		ComputeGlobalImageCapabilitySchemaVersionName *string                                    `json:"computeGlobalImageCapabilitySchemaVersionName"`
+		ImageId                                       *string                                    `json:"imageId"`
+		SchemaData                                    map[string]imagecapabilityschemadescriptor `json:"schemaData"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.FreeformTags = model.FreeformTags
+
+	m.DisplayName = model.DisplayName
+
+	m.DefinedTags = model.DefinedTags
+
+	m.CompartmentId = model.CompartmentId
+
+	m.ComputeGlobalImageCapabilitySchemaVersionName = model.ComputeGlobalImageCapabilitySchemaVersionName
+
+	m.ImageId = model.ImageId
+
+	m.SchemaData = make(map[string]ImageCapabilitySchemaDescriptor)
+	for k, v := range model.SchemaData {
+		nn, e = v.UnmarshalPolymorphicJSON(v.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.SchemaData[k] = nn.(ImageCapabilitySchemaDescriptor)
+		} else {
+			m.SchemaData[k] = nil
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_compute_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_compute_image_capability_schema_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateComputeImageCapabilitySchemaRequest wrapper for the CreateComputeImageCapabilitySchema operation
+type CreateComputeImageCapabilitySchemaRequest struct {
+
+	// Compute Image Capability Schema creation details
+	CreateComputeImageCapabilitySchemaDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateComputeImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateComputeImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateComputeImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateComputeImageCapabilitySchemaResponse wrapper for the CreateComputeImageCapabilitySchema operation
+type CreateComputeImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeImageCapabilitySchema instance
+	ComputeImageCapabilitySchema `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateComputeImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateComputeImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_cpe_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_cpe_details.go
@@ -24,7 +24,7 @@ type CreateCpeDetails struct {
 	CompartmentId *string `mandatory:"true" json:"compartmentId"`
 
 	// The public IP address of the on-premises router.
-	// Example: `143.19.23.16`
+	// Example: `203.0.113.2`
 	IpAddress *string `mandatory:"true" json:"ipAddress"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_dhcp_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_dhcp_details.go
@@ -86,5 +86,6 @@ func (m *CreateDhcpDetails) UnmarshalJSON(data []byte) (e error) {
 	}
 
 	m.VcnId = model.VcnId
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_image_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_image_details.go
@@ -49,7 +49,7 @@ type CreateImageDetails struct {
 	// Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
 	// * `NATIVE` - VM instances launch with paravirtualized boot and VFIO devices. The default value for Oracle-provided images.
 	// * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	// * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 	LaunchMode CreateImageDetailsLaunchModeEnum `mandatory:"false" json:"launchMode,omitempty"`
 }
@@ -96,6 +96,7 @@ func (m *CreateImageDetails) UnmarshalJSON(data []byte) (e error) {
 	m.LaunchMode = model.LaunchMode
 
 	m.CompartmentId = model.CompartmentId
+
 	return
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_instance_configuration_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_instance_configuration_details.go
@@ -112,5 +112,6 @@ func (m *CreateInstanceConfigurationDetails) UnmarshalJSON(data []byte) (e error
 	} else {
 		m.InstanceDetails = nil
 	}
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_ip_sec_connection_tunnel_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_ip_sec_connection_tunnel_details.go
@@ -34,7 +34,6 @@ type CreateIpSecConnectionTunnelDetails struct {
 	// spaces are allowed. If you don't provide a value,
 	// Oracle generates a value for you. You can specify your own shared secret later if
 	// you like with UpdateIPSecConnectionTunnelSharedSecret.
-	// Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 	SharedSecret *string `mandatory:"false" json:"sharedSecret"`
 
 	// Information for establishing a BGP session for the IPSec tunnel. Required if the tunnel uses

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_ipv6_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_ipv6_details.go
@@ -42,7 +42,7 @@ type CreateIpv6Details struct {
 	// the subnet's CIDR. If you don't specify a value, Oracle automatically
 	// assigns an IPv6 address from the subnet. The subnet is the one that
 	// contains the VNIC you specify in `vnicId`.
-	// Example: `2001:0db8:0123:1111:abcd:ef01:2345:6789`
+	// Example: `2001:DB8::`
 	IpAddress *string `mandatory:"false" json:"ipAddress"`
 
 	// Whether the IPv6 can be used for internet communication. Allowed by default for an IPv6 in

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_private_ip_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_private_ip_details.go
@@ -20,10 +20,6 @@ import (
 // CreatePrivateIpDetails The representation of CreatePrivateIpDetails
 type CreatePrivateIpDetails struct {
 
-	// The OCID of the VNIC to assign the private IP to. The VNIC and private IP
-	// must be in the same subnet.
-	VnicId *string `mandatory:"true" json:"vnicId"`
-
 	// Defined tags for this resource. Each key is predefined and scoped to a
 	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
 	// Example: `{"Operations": {"CostCenter": "42"}}`
@@ -54,6 +50,15 @@ type CreatePrivateIpDetails struct {
 	// assigns a private IP address from the subnet.
 	// Example: `10.0.3.3`
 	IpAddress *string `mandatory:"false" json:"ipAddress"`
+
+	// The OCID of the VNIC to assign the private IP to. The VNIC and private IP
+	// must be in the same subnet.
+	VnicId *string `mandatory:"false" json:"vnicId"`
+
+	// Use this attribute only with the Oracle Cloud VMware Solution.
+	// The OCID of the VLAN from which the private IP is to be drawn. The IP address,
+	// *if supplied*, must be valid for the given VLAN. See Vlan.
+	VlanId *string `mandatory:"false" json:"vlanId"`
 }
 
 func (m CreatePrivateIpDetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_subnet_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_subnet_details.go
@@ -20,8 +20,10 @@ import (
 // CreateSubnetDetails The representation of CreateSubnetDetails
 type CreateSubnetDetails struct {
 
-	// The CIDR IP address range of the subnet.
-	// Example: `172.16.1.0/24`
+	// The CIDR IP address range of the subnet. The CIDR must maintain the following rules -
+	// a. The CIDR block is valid and correctly formatted.
+	// b. The new range is within one of the parent VCN ranges.
+	// Example: `10.0.1.0/24`
 	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
 
 	// The OCID of the compartment to contain the subnet.

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_vcn_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_vcn_details.go
@@ -21,7 +21,7 @@ import (
 type CreateVcnDetails struct {
 
 	// The CIDR IP address block of the VCN.
-	// Example: `172.16.0.0/16`
+	// Example: `10.0.0.0/16`
 	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
 
 	// The OCID of the compartment to contain the VCN.

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_vlan_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_vlan_details.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// CreateVlanDetails The representation of CreateVlanDetails
+type CreateVlanDetails struct {
+
+	// The availability domain of the VLAN.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"true" json:"availabilityDomain"`
+
+	// The range of IPv4 addresses that will be used for layer 3 communication with
+	// hosts outside the VLAN. The CIDR must maintain the following rules -
+	// a. The CIDR block is valid and correctly formatted.
+	// Example: `192.0.2.0/24`
+	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
+
+	// The OCID of the compartment to contain the VLAN.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The OCID of the VCN to contain the VLAN.
+	VcnId *string `mandatory:"true" json:"vcnId"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A descriptive name. Does not have to be unique, and it's changeable. Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// A list of the OCIDs of the network security groups (NSGs) to add all VNICs in the VLAN to. For more
+	// information about NSGs, see
+	// NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The OCID of the route table the VLAN will use. If you don't provide a value,
+	// the VLAN uses the VCN's default route table.
+	RouteTableId *string `mandatory:"false" json:"routeTableId"`
+
+	// The IEEE 802.1Q VLAN tag for this VLAN. The value must be unique across all
+	// VLANs in the VCN. If you don't provide a value, Oracle assigns one.
+	// You cannot change the value later. VLAN tag 0 is reserved for use by Oracle.
+	VlanTag *int `mandatory:"false" json:"vlanTag"`
+}
+
+func (m CreateVlanDetails) String() string {
+	return common.PointerString(m)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_vlan_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_vlan_request_response.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// CreateVlanRequest wrapper for the CreateVlan operation
+type CreateVlanRequest struct {
+
+	// Details for creating a VLAN
+	CreateVlanDetails `contributesTo:"body"`
+
+	// A token that uniquely identifies a request so it can be retried in case of a timeout or
+	// server error without risk of executing that same action again. Retry tokens expire after 24
+	// hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+	// has been deleted and purged from the system, then a retry of the original creation request
+	// may be rejected).
+	OpcRetryToken *string `mandatory:"false" contributesTo:"header" name:"opc-retry-token"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request CreateVlanRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request CreateVlanRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request CreateVlanRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// CreateVlanResponse wrapper for the CreateVlan operation
+type CreateVlanResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Vlan instance
+	Vlan `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response CreateVlanResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response CreateVlanResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_vnic_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_vnic_details.go
@@ -23,12 +23,6 @@ import (
 // Virtual Network Interface Cards (VNICs) (https://docs.cloud.oracle.com/Content/Network/Tasks/managingVNICs.htm).
 type CreateVnicDetails struct {
 
-	// The OCID of the subnet to create the VNIC in. When launching an instance,
-	// use this `subnetId` instead of the deprecated `subnetId` in
-	// LaunchInstanceDetails.
-	// At least one of them is required; if you provide both, the values must match.
-	SubnetId *string `mandatory:"true" json:"subnetId"`
-
 	// Whether the VNIC should be assigned a public IP address. Defaults to whether
 	// the subnet is public or private. If not set and the VNIC is being created
 	// in a private subnet (that is, where `prohibitPublicIpOnVnic` = true in the
@@ -46,6 +40,8 @@ type CreateVnicDetails struct {
 	// about the public IP limits, see
 	// Public IP Addresses (https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
 	// Example: `false`
+	// If you specify a `vlanId`, the `assignPublicIp` is required to be set to false. See
+	// Vlan.
 	AssignPublicIp *bool `mandatory:"false" json:"assignPublicIp"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a
@@ -79,11 +75,17 @@ type CreateVnicDetails struct {
 	// LaunchInstanceDetails.
 	// If you provide both, the values must match.
 	// Example: `bminstance-1`
+	// If you specify a `vlanId`, the `hostnameLabel` cannot be specified. vnics on a Vlan
+	// can not be assigned a hostname  See Vlan.
 	HostnameLabel *string `mandatory:"false" json:"hostnameLabel"`
 
 	// A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. For more
 	// information about NSGs, see
 	// NetworkSecurityGroup.
+	// If a `vlanId` is specified, the `nsgIds` cannot be specified. The `vlanId`
+	// indicates that the VNIC will belong to a VLAN instead of a subnet. With VLANs,
+	// all VNICs in the VLAN belong to the NSGs that are associated with the VLAN.
+	// See Vlan.
 	NsgIds []string `mandatory:"false" json:"nsgIds"`
 
 	// A private IP address of your choice to assign to the VNIC. Must be an
@@ -94,6 +96,9 @@ type CreateVnicDetails struct {
 	// PrivateIp object returned by
 	// ListPrivateIps and
 	// GetPrivateIp.
+	//
+	// If you specify a `vlanId`, the `privateIp` cannot be specified.
+	// See Vlan.
 	// Example: `10.0.3.3`
 	PrivateIp *string `mandatory:"false" json:"privateIp"`
 
@@ -101,8 +106,28 @@ type CreateVnicDetails struct {
 	// Defaults to `false`, which means the check is performed. For information
 	// about why you would skip the source/destination check, see
 	// Using a Private IP as a Route Target (https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip).
+	//
+	// If you specify a `vlanId`, the `skipSourceDestCheck` cannot be specified because the
+	// source/destination check is always disabled for VNICs in a VLAN. See
+	// Vlan.
 	// Example: `true`
 	SkipSourceDestCheck *bool `mandatory:"false" json:"skipSourceDestCheck"`
+
+	// The OCID of the subnet to create the VNIC in. When launching an instance,
+	// use this `subnetId` instead of the deprecated `subnetId` in
+	// LaunchInstanceDetails.
+	// At least one of them is required; if you provide both, the values must match.
+	// If you are an Oracle Cloud VMware Solution customer and creating a secondary
+	// VNIC in a VLAN instead of a subnet, provide a `vlanId` instead of a `subnetId`.
+	// If you provide both a `vlanId` and `subnetId`, the request fails.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// Provide this attribute only if you are an Oracle Cloud VMware Solution
+	// customer and creating a secondary VNIC in a VLAN. The value is the OCID of the VLAN.
+	// See Vlan.
+	// Provide a `vlanId` instead of a `subnetId`. If you provide both a
+	// `vlanId` and `subnetId`, the request fails.
+	VlanId *string `mandatory:"false" json:"vlanId"`
 }
 
 func (m CreateVnicDetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_volume_backup_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_volume_backup_policy_details.go
@@ -30,7 +30,8 @@ type CreateVolumeBackupPolicyDetails struct {
 	// Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example: `us-ashburn-1`
+	// The paired destination region for copying scheduled backups to. Example: `us-ashburn-1`.
+	// See Region Pairs (https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs) for details about paired regions.
 	DestinationRegion *string `mandatory:"false" json:"destinationRegion"`
 
 	// The collection of schedules for the volume backup policy. See

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_volume_details.go
@@ -75,6 +75,9 @@ type CreateVolumeDetails struct {
 	// This field is deprecated. Use the sourceDetails field instead to specify the
 	// backup for the volume.
 	VolumeBackupId *string `mandatory:"false" json:"volumeBackupId"`
+
+	// Specifies whether the auto-tune performance is enabled for this volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
 func (m CreateVolumeDetails) String() string {
@@ -94,6 +97,7 @@ func (m *CreateVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 		SizeInMBs          *int64                            `json:"sizeInMBs"`
 		SourceDetails      volumesourcedetails               `json:"sourceDetails"`
 		VolumeBackupId     *string                           `json:"volumeBackupId"`
+		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 	}{}
@@ -131,8 +135,11 @@ func (m *CreateVolumeDetails) UnmarshalJSON(data []byte) (e error) {
 
 	m.VolumeBackupId = model.VolumeBackupId
 
+	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
+
 	m.AvailabilityDomain = model.AvailabilityDomain
 
 	m.CompartmentId = model.CompartmentId
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/create_volume_group_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/create_volume_group_details.go
@@ -84,5 +84,6 @@ func (m *CreateVolumeGroupDetails) UnmarshalJSON(data []byte) (e error) {
 	} else {
 		m.SourceDetails = nil
 	}
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/cross_connect.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/cross_connect.go
@@ -74,7 +74,7 @@ type CrossConnect struct {
 	// uses.
 	CustomerReferenceName *string `mandatory:"false" json:"customerReferenceName"`
 
-	// The date and time the cross-connect was created, in the format defined by RFC3339.
+	// The date and time the cross-connect was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/cross_connect_group.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/cross_connect_group.go
@@ -59,7 +59,7 @@ type CrossConnectGroup struct {
 	// group uses.
 	CustomerReferenceName *string `mandatory:"false" json:"customerReferenceName"`
 
-	// The date and time the cross-connect group was created, in the format defined by RFC3339.
+	// The date and time the cross-connect group was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/dedicated_vm_host.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/dedicated_vm_host.go
@@ -43,7 +43,7 @@ type DedicatedVmHost struct {
 	// The current state of the dedicated VM host.
 	LifecycleState DedicatedVmHostLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The date and time the dedicated VM host was created, in the format defined by RFC3339.
+	// The date and time the dedicated VM host was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/dedicated_vm_host_instance_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/dedicated_vm_host_instance_summary.go
@@ -33,7 +33,7 @@ type DedicatedVmHostInstanceSummary struct {
 	// The shape of the VM instance.
 	Shape *string `mandatory:"true" json:"shape"`
 
-	// The date and time the virtual machine instance was created, in the format defined by RFC3339.
+	// The date and time the virtual machine instance was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/dedicated_vm_host_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/dedicated_vm_host_summary.go
@@ -42,7 +42,7 @@ type DedicatedVmHostSummary struct {
 	// The current state of the dedicated VM host.
 	LifecycleState DedicatedVmHostSummaryLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The date and time the dedicated VM host was created, in the format defined by RFC3339.
+	// The date and time the dedicated VM host was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/delete_compute_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/delete_compute_image_capability_schema_request_response.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteComputeImageCapabilitySchemaRequest wrapper for the DeleteComputeImageCapabilitySchema operation
+type DeleteComputeImageCapabilitySchemaRequest struct {
+
+	// The id of the compute image capability schema or the image ocid
+	ComputeImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeImageCapabilitySchemaId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteComputeImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteComputeImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteComputeImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteComputeImageCapabilitySchemaResponse wrapper for the DeleteComputeImageCapabilitySchema operation
+type DeleteComputeImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteComputeImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteComputeImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/delete_vlan_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/delete_vlan_request_response.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// DeleteVlanRequest wrapper for the DeleteVlan operation
+type DeleteVlanRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+	VlanId *string `mandatory:"true" contributesTo:"path" name:"vlanId"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request DeleteVlanRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request DeleteVlanRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request DeleteVlanRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// DeleteVlanResponse wrapper for the DeleteVlan operation
+type DeleteVlanResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response DeleteVlanResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response DeleteVlanResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/dhcp_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/dhcp_options.go
@@ -45,7 +45,7 @@ type DhcpOptions struct {
 	// The collection of individual DHCP options.
 	Options []DhcpOption `mandatory:"true" json:"options"`
 
-	// Date and time the set of DHCP options was created, in the format defined by RFC3339.
+	// Date and time the set of DHCP options was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
@@ -118,6 +118,7 @@ func (m *DhcpOptions) UnmarshalJSON(data []byte) (e error) {
 	m.TimeCreated = model.TimeCreated
 
 	m.VcnId = model.VcnId
+
 	return
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/drg.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/drg.go
@@ -52,7 +52,7 @@ type Drg struct {
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
-	// The date and time the DRG was created, in the format defined by RFC3339.
+	// The date and time the DRG was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/drg_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/drg_attachment.go
@@ -48,7 +48,7 @@ type DrgAttachment struct {
 	//   * Transit Routing: Private Access to Oracle Services (https://docs.cloud.oracle.com/Content/Network/Tasks/transitroutingoracleservices.htm)
 	RouteTableId *string `mandatory:"false" json:"routeTableId"`
 
-	// The date and time the DRG attachment was created, in the format defined by RFC3339.
+	// The date and time the DRG attachment was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/emulated_volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/emulated_volume_attachment.go
@@ -34,7 +34,7 @@ type EmulatedVolumeAttachment struct {
 	// The OCID of the instance the volume is attached to.
 	InstanceId *string `mandatory:"true" json:"instanceId"`
 
-	// The date and time the volume was created, in the format defined by RFC3339.
+	// The date and time the volume was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/enum_integer_image_capability_descriptor.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/enum_integer_image_capability_descriptor.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// EnumIntegerImageCapabilityDescriptor Enum Integer type CapabilityDescriptor
+type EnumIntegerImageCapabilityDescriptor struct {
+
+	// the list of values for the enum
+	Values []int `mandatory:"true" json:"values"`
+
+	// the default value
+	DefaultValue *int `mandatory:"false" json:"defaultValue"`
+
+	Source ImageCapabilitySchemaDescriptorSourceEnum `mandatory:"true" json:"source"`
+}
+
+//GetSource returns Source
+func (m EnumIntegerImageCapabilityDescriptor) GetSource() ImageCapabilitySchemaDescriptorSourceEnum {
+	return m.Source
+}
+
+func (m EnumIntegerImageCapabilityDescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m EnumIntegerImageCapabilityDescriptor) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeEnumIntegerImageCapabilityDescriptor EnumIntegerImageCapabilityDescriptor
+	s := struct {
+		DiscriminatorParam string `json:"descriptorType"`
+		MarshalTypeEnumIntegerImageCapabilityDescriptor
+	}{
+		"enuminteger",
+		(MarshalTypeEnumIntegerImageCapabilityDescriptor)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/enum_string_image_capability_schema_descriptor.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/enum_string_image_capability_schema_descriptor.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// EnumStringImageCapabilitySchemaDescriptor Enum String type of ImageCapabilitySchemaDescriptor
+type EnumStringImageCapabilitySchemaDescriptor struct {
+
+	// the list of values for the enum
+	Values []string `mandatory:"true" json:"values"`
+
+	// the default value
+	DefaultValue *string `mandatory:"false" json:"defaultValue"`
+
+	Source ImageCapabilitySchemaDescriptorSourceEnum `mandatory:"true" json:"source"`
+}
+
+//GetSource returns Source
+func (m EnumStringImageCapabilitySchemaDescriptor) GetSource() ImageCapabilitySchemaDescriptorSourceEnum {
+	return m.Source
+}
+
+func (m EnumStringImageCapabilitySchemaDescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// MarshalJSON marshals to json representation
+func (m EnumStringImageCapabilitySchemaDescriptor) MarshalJSON() (buff []byte, e error) {
+	type MarshalTypeEnumStringImageCapabilitySchemaDescriptor EnumStringImageCapabilitySchemaDescriptor
+	s := struct {
+		DiscriminatorParam string `json:"descriptorType"`
+		MarshalTypeEnumStringImageCapabilitySchemaDescriptor
+	}{
+		"enumstring",
+		(MarshalTypeEnumStringImageCapabilitySchemaDescriptor)(m),
+	}
+
+	return json.Marshal(&s)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/get_compute_global_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/get_compute_global_image_capability_schema_request_response.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetComputeGlobalImageCapabilitySchemaRequest wrapper for the GetComputeGlobalImageCapabilitySchema operation
+type GetComputeGlobalImageCapabilitySchemaRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeGlobalImageCapabilitySchemaId"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetComputeGlobalImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetComputeGlobalImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetComputeGlobalImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetComputeGlobalImageCapabilitySchemaResponse wrapper for the GetComputeGlobalImageCapabilitySchema operation
+type GetComputeGlobalImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeGlobalImageCapabilitySchema instance
+	ComputeGlobalImageCapabilitySchema `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetComputeGlobalImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetComputeGlobalImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/get_compute_global_image_capability_schema_version_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/get_compute_global_image_capability_schema_version_request_response.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetComputeGlobalImageCapabilitySchemaVersionRequest wrapper for the GetComputeGlobalImageCapabilitySchemaVersion operation
+type GetComputeGlobalImageCapabilitySchemaVersionRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeGlobalImageCapabilitySchemaId"`
+
+	// The name of the compute global image capability schema version
+	ComputeGlobalImageCapabilitySchemaVersionName *string `mandatory:"true" contributesTo:"path" name:"computeGlobalImageCapabilitySchemaVersionName"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetComputeGlobalImageCapabilitySchemaVersionRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetComputeGlobalImageCapabilitySchemaVersionRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetComputeGlobalImageCapabilitySchemaVersionRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetComputeGlobalImageCapabilitySchemaVersionResponse wrapper for the GetComputeGlobalImageCapabilitySchemaVersion operation
+type GetComputeGlobalImageCapabilitySchemaVersionResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeGlobalImageCapabilitySchemaVersion instance
+	ComputeGlobalImageCapabilitySchemaVersion `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetComputeGlobalImageCapabilitySchemaVersionResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetComputeGlobalImageCapabilitySchemaVersionResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/get_compute_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/get_compute_image_capability_schema_request_response.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetComputeImageCapabilitySchemaRequest wrapper for the GetComputeImageCapabilitySchema operation
+type GetComputeImageCapabilitySchemaRequest struct {
+
+	// The id of the compute image capability schema or the image ocid
+	ComputeImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeImageCapabilitySchemaId"`
+
+	// Merge the image capability schema with the global image capability schema
+	IsMergeEnabled *bool `mandatory:"false" contributesTo:"query" name:"isMergeEnabled"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetComputeImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetComputeImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetComputeImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetComputeImageCapabilitySchemaResponse wrapper for the GetComputeImageCapabilitySchema operation
+type GetComputeImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeImageCapabilitySchema instance
+	ComputeImageCapabilitySchema `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetComputeImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetComputeImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/get_public_ip_by_ip_address_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/get_public_ip_by_ip_address_details.go
@@ -21,7 +21,7 @@ import (
 type GetPublicIpByIpAddressDetails struct {
 
 	// The public IP address.
-	// Example: 129.146.2.1
+	// Example: 203.0.113.2
 	IpAddress *string `mandatory:"true" json:"ipAddress"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/get_vlan_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/get_vlan_request_response.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// GetVlanRequest wrapper for the GetVlan operation
+type GetVlanRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+	VlanId *string `mandatory:"true" contributesTo:"path" name:"vlanId"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request GetVlanRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request GetVlanRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request GetVlanRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// GetVlanResponse wrapper for the GetVlan operation
+type GetVlanResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Vlan instance
+	Vlan `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response GetVlanResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response GetVlanResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/i_scsi_volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/i_scsi_volume_attachment.go
@@ -34,7 +34,7 @@ type IScsiVolumeAttachment struct {
 	// The OCID of the instance the volume is attached to.
 	InstanceId *string `mandatory:"true" json:"instanceId"`
 
-	// The date and time the volume was created, in the format defined by RFC3339.
+	// The date and time the volume was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
@@ -45,11 +45,11 @@ type IScsiVolumeAttachment struct {
 	// Example: `169.254.0.2`
 	Ipv4 *string `mandatory:"true" json:"ipv4"`
 
-	// The target volume's iSCSI Qualified Name in the format defined by RFC 3720.
-	// Example: `iqn.2015-12.us.oracle.com:456b0391-17b8-4122-bbf1-f85fc0bb97d9`
+	// The target volume's iSCSI Qualified Name in the format defined by RFC 3720 (https://tools.ietf.org/html/rfc3720#page-32).
+	// Example: `iqn.2015-12.us.oracle.com:<CHAP_username>`
 	Iqn *string `mandatory:"true" json:"iqn"`
 
-	// The volume's iSCSI port.
+	// The volume's iSCSI port, usually port 860 or 3260.
 	// Example: `3260`
 	Port *int `mandatory:"true" json:"port"`
 
@@ -72,11 +72,10 @@ type IScsiVolumeAttachment struct {
 
 	// The Challenge-Handshake-Authentication-Protocol (CHAP) secret valid for the associated CHAP user name.
 	// (Also called the "CHAP password".)
-	// Example: `d6866c0d-298b-48ba-95af-309b4faux45e`
 	ChapSecret *string `mandatory:"false" json:"chapSecret"`
 
-	// The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name.
-	// Example: `ocid1.volume.oc1.phx.abyhqljrgvttnlx73nmrwfaux7kcvzfs3s66izvxf2h4lgvyndsdsnoiwr5q`
+	// The volume's system-generated Challenge-Handshake-Authentication-Protocol (CHAP) user name. See RFC 1994 (https://tools.ietf.org/html/rfc1994) for more on CHAP.
+	// Example: `ocid1.volume.oc1.phx.<unique_ID>`
 	ChapUsername *string `mandatory:"false" json:"chapUsername"`
 
 	// The current state of the volume attachment.

--- a/vendor/github.com/oracle/oci-go-sdk/core/image.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/image.go
@@ -47,7 +47,7 @@ type Image struct {
 	// Example: `7.2`
 	OperatingSystemVersion *string `mandatory:"true" json:"operatingSystemVersion"`
 
-	// The date and time the image was created, in the format defined by RFC3339.
+	// The date and time the image was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
@@ -73,7 +73,7 @@ type Image struct {
 	// Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
 	// * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
 	// * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	// * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 	LaunchMode ImageLaunchModeEnum `mandatory:"false" json:"launchMode,omitempty"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/image_capability_schema_descriptor.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/image_capability_schema_descriptor.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// ImageCapabilitySchemaDescriptor Image Capability Schema Descriptor is a type of capability for an image.
+type ImageCapabilitySchemaDescriptor interface {
+	GetSource() ImageCapabilitySchemaDescriptorSourceEnum
+}
+
+type imagecapabilityschemadescriptor struct {
+	JsonData       []byte
+	Source         ImageCapabilitySchemaDescriptorSourceEnum `mandatory:"true" json:"source"`
+	DescriptorType string                                    `json:"descriptorType"`
+}
+
+// UnmarshalJSON unmarshals json
+func (m *imagecapabilityschemadescriptor) UnmarshalJSON(data []byte) error {
+	m.JsonData = data
+	type Unmarshalerimagecapabilityschemadescriptor imagecapabilityschemadescriptor
+	s := struct {
+		Model Unmarshalerimagecapabilityschemadescriptor
+	}{}
+	err := json.Unmarshal(data, &s.Model)
+	if err != nil {
+		return err
+	}
+	m.Source = s.Model.Source
+	m.DescriptorType = s.Model.DescriptorType
+
+	return err
+}
+
+// UnmarshalPolymorphicJSON unmarshals polymorphic json
+func (m *imagecapabilityschemadescriptor) UnmarshalPolymorphicJSON(data []byte) (interface{}, error) {
+
+	if data == nil || string(data) == "null" {
+		return nil, nil
+	}
+
+	var err error
+	switch m.DescriptorType {
+	case "enumstring":
+		mm := EnumStringImageCapabilitySchemaDescriptor{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "enuminteger":
+		mm := EnumIntegerImageCapabilityDescriptor{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	case "boolean":
+		mm := BooleanImageCapabilitySchemaDescriptor{}
+		err = json.Unmarshal(data, &mm)
+		return mm, err
+	default:
+		return *m, nil
+	}
+}
+
+//GetSource returns Source
+func (m imagecapabilityschemadescriptor) GetSource() ImageCapabilitySchemaDescriptorSourceEnum {
+	return m.Source
+}
+
+func (m imagecapabilityschemadescriptor) String() string {
+	return common.PointerString(m)
+}
+
+// ImageCapabilitySchemaDescriptorSourceEnum Enum with underlying type: string
+type ImageCapabilitySchemaDescriptorSourceEnum string
+
+// Set of constants representing the allowable values for ImageCapabilitySchemaDescriptorSourceEnum
+const (
+	ImageCapabilitySchemaDescriptorSourceGlobal ImageCapabilitySchemaDescriptorSourceEnum = "GLOBAL"
+	ImageCapabilitySchemaDescriptorSourceImage  ImageCapabilitySchemaDescriptorSourceEnum = "IMAGE"
+)
+
+var mappingImageCapabilitySchemaDescriptorSource = map[string]ImageCapabilitySchemaDescriptorSourceEnum{
+	"GLOBAL": ImageCapabilitySchemaDescriptorSourceGlobal,
+	"IMAGE":  ImageCapabilitySchemaDescriptorSourceImage,
+}
+
+// GetImageCapabilitySchemaDescriptorSourceEnumValues Enumerates the set of values for ImageCapabilitySchemaDescriptorSourceEnum
+func GetImageCapabilitySchemaDescriptorSourceEnumValues() []ImageCapabilitySchemaDescriptorSourceEnum {
+	values := make([]ImageCapabilitySchemaDescriptorSourceEnum, 0)
+	for _, v := range mappingImageCapabilitySchemaDescriptorSource {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/image_shape_compatibility_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/image_shape_compatibility_summary.go
@@ -17,10 +17,10 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// ImageShapeCompatibilitySummary Summary information for an image shape compatibility entry.
+// ImageShapeCompatibilitySummary Summary information for a compatible image and shape.
 type ImageShapeCompatibilitySummary struct {
 
-	// The image OCID.
+	// The image OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
 	ImageId *string `mandatory:"true" json:"imageId"`
 
 	// The shape name.

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance.go
@@ -53,7 +53,7 @@ type Instance struct {
 	// ListShapes.
 	Shape *string `mandatory:"true" json:"shape"`
 
-	// The date and time the instance was created, in the format defined by RFC3339.
+	// The date and time the instance was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
@@ -70,8 +70,10 @@ type Instance struct {
 	// Example: `My bare metal instance`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
-	// They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+	// Additional metadata key/value pairs that you provide. They serve the same purpose and functionality
+	// as fields in the `metadata` object.
+	// They are distinguished from `metadata` fields in that these can be nested JSON objects (whereas `metadata`
+	// fields are string/string maps only).
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// The name of the fault domain the instance is running in.
@@ -80,8 +82,7 @@ type Instance struct {
 	// instances so that they are not on the same physical hardware within a single availability domain.
 	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
 	// instances in other fault domains.
-	// If you do not specify the fault domain, the system selects one for you. To change the fault
-	// domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+	// If you do not specify the fault domain, the system selects one for you.
 	// Example: `FAULT-DOMAIN-1`
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 
@@ -116,11 +117,14 @@ type Instance struct {
 	// Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
 	// * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
 	// * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	// * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 	LaunchMode InstanceLaunchModeEnum `mandatory:"false" json:"launchMode,omitempty"`
 
+	// Options for tuning the compatibility and performance of VM shapes. The values that you specify override any default values.
 	LaunchOptions *LaunchOptions `mandatory:"false" json:"launchOptions"`
+
+	AvailabilityConfig *InstanceAvailabilityConfig `mandatory:"false" json:"availabilityConfig"`
 
 	// Custom metadata that you provide.
 	Metadata map[string]string `mandatory:"false" json:"metadata"`
@@ -136,7 +140,7 @@ type Instance struct {
 
 	AgentConfig *InstanceAgentConfig `mandatory:"false" json:"agentConfig"`
 
-	// The date and time the instance is expected to be stopped / started,  in the format defined by RFC3339.
+	// The date and time the instance is expected to be stopped / started,  in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// After that time if instance hasn't been rebooted, Oracle will reboot the instance within 24 hours of the due time.
 	// Regardless of how the instance was stopped, the flag will be reset to empty as soon as instance reaches Stopped state.
 	// Example: `2018-05-25T21:10:29.600Z`
@@ -160,6 +164,7 @@ func (m *Instance) UnmarshalJSON(data []byte) (e error) {
 		IpxeScript               *string                           `json:"ipxeScript"`
 		LaunchMode               InstanceLaunchModeEnum            `json:"launchMode"`
 		LaunchOptions            *LaunchOptions                    `json:"launchOptions"`
+		AvailabilityConfig       *InstanceAvailabilityConfig       `json:"availabilityConfig"`
 		Metadata                 map[string]string                 `json:"metadata"`
 		ShapeConfig              *InstanceShapeConfig              `json:"shapeConfig"`
 		SourceDetails            instancesourcedetails             `json:"sourceDetails"`
@@ -200,6 +205,8 @@ func (m *Instance) UnmarshalJSON(data []byte) (e error) {
 
 	m.LaunchOptions = model.LaunchOptions
 
+	m.AvailabilityConfig = model.AvailabilityConfig
+
 	m.Metadata = model.Metadata
 
 	m.ShapeConfig = model.ShapeConfig
@@ -233,6 +240,7 @@ func (m *Instance) UnmarshalJSON(data []byte) (e error) {
 	m.Shape = model.Shape
 
 	m.TimeCreated = model.TimeCreated
+
 	return
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_action_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_action_request_response.go
@@ -84,19 +84,21 @@ type InstanceActionActionEnum string
 
 // Set of constants representing the allowable values for InstanceActionActionEnum
 const (
-	InstanceActionActionStop      InstanceActionActionEnum = "STOP"
-	InstanceActionActionStart     InstanceActionActionEnum = "START"
-	InstanceActionActionSoftreset InstanceActionActionEnum = "SOFTRESET"
-	InstanceActionActionReset     InstanceActionActionEnum = "RESET"
-	InstanceActionActionSoftstop  InstanceActionActionEnum = "SOFTSTOP"
+	InstanceActionActionStop                    InstanceActionActionEnum = "STOP"
+	InstanceActionActionStart                   InstanceActionActionEnum = "START"
+	InstanceActionActionSoftreset               InstanceActionActionEnum = "SOFTRESET"
+	InstanceActionActionReset                   InstanceActionActionEnum = "RESET"
+	InstanceActionActionSoftstop                InstanceActionActionEnum = "SOFTSTOP"
+	InstanceActionActionSenddiagnosticinterrupt InstanceActionActionEnum = "SENDDIAGNOSTICINTERRUPT"
 )
 
 var mappingInstanceActionAction = map[string]InstanceActionActionEnum{
-	"STOP":      InstanceActionActionStop,
-	"START":     InstanceActionActionStart,
-	"SOFTRESET": InstanceActionActionSoftreset,
-	"RESET":     InstanceActionActionReset,
-	"SOFTSTOP":  InstanceActionActionSoftstop,
+	"STOP":                    InstanceActionActionStop,
+	"START":                   InstanceActionActionStart,
+	"SOFTRESET":               InstanceActionActionSoftreset,
+	"RESET":                   InstanceActionActionReset,
+	"SOFTSTOP":                InstanceActionActionSoftstop,
+	"SENDDIAGNOSTICINTERRUPT": InstanceActionActionSenddiagnosticinterrupt,
 }
 
 // GetInstanceActionActionEnumValues Enumerates the set of values for InstanceActionActionEnum

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_availability_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_availability_config.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// InstanceAvailabilityConfig Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+type InstanceAvailabilityConfig struct {
+
+	// Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+	// * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+	// will be restored to the power state it was in before maintenance.
+	// * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+	RecoveryAction InstanceAvailabilityConfigRecoveryActionEnum `mandatory:"false" json:"recoveryAction,omitempty"`
+}
+
+func (m InstanceAvailabilityConfig) String() string {
+	return common.PointerString(m)
+}
+
+// InstanceAvailabilityConfigRecoveryActionEnum Enum with underlying type: string
+type InstanceAvailabilityConfigRecoveryActionEnum string
+
+// Set of constants representing the allowable values for InstanceAvailabilityConfigRecoveryActionEnum
+const (
+	InstanceAvailabilityConfigRecoveryActionRestoreInstance InstanceAvailabilityConfigRecoveryActionEnum = "RESTORE_INSTANCE"
+	InstanceAvailabilityConfigRecoveryActionStopInstance    InstanceAvailabilityConfigRecoveryActionEnum = "STOP_INSTANCE"
+)
+
+var mappingInstanceAvailabilityConfigRecoveryAction = map[string]InstanceAvailabilityConfigRecoveryActionEnum{
+	"RESTORE_INSTANCE": InstanceAvailabilityConfigRecoveryActionRestoreInstance,
+	"STOP_INSTANCE":    InstanceAvailabilityConfigRecoveryActionStopInstance,
+}
+
+// GetInstanceAvailabilityConfigRecoveryActionEnumValues Enumerates the set of values for InstanceAvailabilityConfigRecoveryActionEnum
+func GetInstanceAvailabilityConfigRecoveryActionEnumValues() []InstanceAvailabilityConfigRecoveryActionEnum {
+	values := make([]InstanceAvailabilityConfigRecoveryActionEnum, 0)
+	for _, v := range mappingInstanceAvailabilityConfigRecoveryAction {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration.go
@@ -30,7 +30,7 @@ type InstanceConfiguration struct {
 	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the instance configuration.
 	Id *string `mandatory:"true" json:"id"`
 
-	// The date and time the instance configuration was created, in the format defined by RFC3339.
+	// The date and time the instance configuration was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
@@ -103,5 +103,6 @@ func (m *InstanceConfiguration) UnmarshalJSON(data []byte) (e error) {
 	m.Id = model.Id
 
 	m.TimeCreated = model.TimeCreated
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_attach_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_attach_volume_details.go
@@ -26,12 +26,23 @@ type InstanceConfigurationAttachVolumeDetails interface {
 
 	// Whether the attachment should be created in read-only mode.
 	GetIsReadOnly() *bool
+
+	// The device name.
+	GetDevice() *string
+
+	// Whether the attachment should be created in shareable mode. If an attachment
+	// is created in shareable mode, then other instances can attach the same volume, provided
+	// that they also create their attachments in shareable mode. Only certain volume types can
+	// be attached in shareable mode. Defaults to false if not specified.
+	GetIsShareable() *bool
 }
 
 type instanceconfigurationattachvolumedetails struct {
 	JsonData    []byte
 	DisplayName *string `mandatory:"false" json:"displayName"`
 	IsReadOnly  *bool   `mandatory:"false" json:"isReadOnly"`
+	Device      *string `mandatory:"false" json:"device"`
+	IsShareable *bool   `mandatory:"false" json:"isShareable"`
 	Type        string  `json:"type"`
 }
 
@@ -48,6 +59,8 @@ func (m *instanceconfigurationattachvolumedetails) UnmarshalJSON(data []byte) er
 	}
 	m.DisplayName = s.Model.DisplayName
 	m.IsReadOnly = s.Model.IsReadOnly
+	m.Device = s.Model.Device
+	m.IsShareable = s.Model.IsShareable
 	m.Type = s.Model.Type
 
 	return err
@@ -83,6 +96,16 @@ func (m instanceconfigurationattachvolumedetails) GetDisplayName() *string {
 //GetIsReadOnly returns IsReadOnly
 func (m instanceconfigurationattachvolumedetails) GetIsReadOnly() *bool {
 	return m.IsReadOnly
+}
+
+//GetDevice returns Device
+func (m instanceconfigurationattachvolumedetails) GetDevice() *string {
+	return m.Device
+}
+
+//GetIsShareable returns IsShareable
+func (m instanceconfigurationattachvolumedetails) GetIsShareable() *bool {
+	return m.IsShareable
 }
 
 func (m instanceconfigurationattachvolumedetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_availability_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_availability_config.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// InstanceConfigurationAvailabilityConfig Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+type InstanceConfigurationAvailabilityConfig struct {
+
+	// Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+	// * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+	// will be restored to the power state it was in before maintenance.
+	// * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+	RecoveryAction InstanceConfigurationAvailabilityConfigRecoveryActionEnum `mandatory:"false" json:"recoveryAction,omitempty"`
+}
+
+func (m InstanceConfigurationAvailabilityConfig) String() string {
+	return common.PointerString(m)
+}
+
+// InstanceConfigurationAvailabilityConfigRecoveryActionEnum Enum with underlying type: string
+type InstanceConfigurationAvailabilityConfigRecoveryActionEnum string
+
+// Set of constants representing the allowable values for InstanceConfigurationAvailabilityConfigRecoveryActionEnum
+const (
+	InstanceConfigurationAvailabilityConfigRecoveryActionRestoreInstance InstanceConfigurationAvailabilityConfigRecoveryActionEnum = "RESTORE_INSTANCE"
+	InstanceConfigurationAvailabilityConfigRecoveryActionStopInstance    InstanceConfigurationAvailabilityConfigRecoveryActionEnum = "STOP_INSTANCE"
+)
+
+var mappingInstanceConfigurationAvailabilityConfigRecoveryAction = map[string]InstanceConfigurationAvailabilityConfigRecoveryActionEnum{
+	"RESTORE_INSTANCE": InstanceConfigurationAvailabilityConfigRecoveryActionRestoreInstance,
+	"STOP_INSTANCE":    InstanceConfigurationAvailabilityConfigRecoveryActionStopInstance,
+}
+
+// GetInstanceConfigurationAvailabilityConfigRecoveryActionEnumValues Enumerates the set of values for InstanceConfigurationAvailabilityConfigRecoveryActionEnum
+func GetInstanceConfigurationAvailabilityConfigRecoveryActionEnumValues() []InstanceConfigurationAvailabilityConfigRecoveryActionEnum {
+	values := make([]InstanceConfigurationAvailabilityConfigRecoveryActionEnum, 0)
+	for _, v := range mappingInstanceConfigurationAvailabilityConfigRecoveryAction {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_block_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_block_volume_details.go
@@ -58,5 +58,6 @@ func (m *InstanceConfigurationBlockVolumeDetails) UnmarshalJSON(data []byte) (e 
 	m.CreateDetails = model.CreateDetails
 
 	m.VolumeId = model.VolumeId
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_create_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_create_volume_details.go
@@ -119,5 +119,6 @@ func (m *InstanceConfigurationCreateVolumeDetails) UnmarshalJSON(data []byte) (e
 	} else {
 		m.SourceDetails = nil
 	}
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_iscsi_attach_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_iscsi_attach_volume_details.go
@@ -27,6 +27,15 @@ type InstanceConfigurationIscsiAttachVolumeDetails struct {
 	// Whether the attachment should be created in read-only mode.
 	IsReadOnly *bool `mandatory:"false" json:"isReadOnly"`
 
+	// The device name.
+	Device *string `mandatory:"false" json:"device"`
+
+	// Whether the attachment should be created in shareable mode. If an attachment
+	// is created in shareable mode, then other instances can attach the same volume, provided
+	// that they also create their attachments in shareable mode. Only certain volume types can
+	// be attached in shareable mode. Defaults to false if not specified.
+	IsShareable *bool `mandatory:"false" json:"isShareable"`
+
 	// Whether to use CHAP authentication for the volume attachment. Defaults to false.
 	UseChap *bool `mandatory:"false" json:"useChap"`
 }
@@ -39,6 +48,16 @@ func (m InstanceConfigurationIscsiAttachVolumeDetails) GetDisplayName() *string 
 //GetIsReadOnly returns IsReadOnly
 func (m InstanceConfigurationIscsiAttachVolumeDetails) GetIsReadOnly() *bool {
 	return m.IsReadOnly
+}
+
+//GetDevice returns Device
+func (m InstanceConfigurationIscsiAttachVolumeDetails) GetDevice() *string {
+	return m.Device
+}
+
+//GetIsShareable returns IsShareable
+func (m InstanceConfigurationIscsiAttachVolumeDetails) GetIsShareable() *bool {
+	return m.IsShareable
 }
 
 func (m InstanceConfigurationIscsiAttachVolumeDetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_launch_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_launch_instance_details.go
@@ -18,7 +18,9 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// InstanceConfigurationLaunchInstanceDetails See Instance launch details - LaunchInstanceDetails
+// InstanceConfigurationLaunchInstanceDetails Instance launch details for creating an instance from an instance configuration. Use the `sourceDetails`
+// parameter to specify whether a boot volume or an image should be used to launch a new instance.
+// See LaunchInstanceDetails for more information.
 type InstanceConfigurationLaunchInstanceDetails struct {
 
 	// The availability domain of the instance.
@@ -42,8 +44,12 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	// Example: `My bare metal instance`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
-	// They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+	// Additional metadata key/value pairs that you provide. They serve the same purpose and
+	// functionality as fields in the `metadata` object.
+	// They are distinguished from `metadata` fields in that these can be nested JSON objects
+	// (whereas `metadata` fields are string/string maps only).
+	// The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+	// 32,000 bytes.
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// Free-form tags for this resource. Each tag is a simple key-value pair with no
@@ -92,29 +98,21 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	//  Cloud-Init to run custom scripts or provide custom Cloud-Init configuration. For
 	//  information about how to take advantage of user data, see the
 	//  Cloud-Init Documentation (http://cloudinit.readthedocs.org/en/latest/topics/format.html).
-	//  **Note:** Cloud-Init does not pull this data from the `http://169.254.169.254/opc/v1/instance/metadata/`
-	//  path. When the instance launches and either of these keys are provided, the key values are formatted as
-	//  OpenStack metadata and copied to the following locations, which are recognized by Cloud-Init:
-	//  `http://169.254.169.254/openstack/latest/meta_data.json` - This JSON blob
-	//  contains, among other things, the SSH keys that you provided for
-	//   **"ssh_authorized_keys"**.
-	//  `http://169.254.169.254/openstack/latest/user_data` - Contains the
-	//  base64-decoded data that you provided for **"user_data"**.
 	//  **Metadata Example**
 	//       "metadata" : {
 	//          "quake_bot_level" : "Severe",
-	//          "ssh_authorized_keys" : "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCZ06fccNTQfq+xubFlJ5ZR3kt+uzspdH9tXL+lAejSM1NXM+CFZev7MIxfEjas06y80ZBZ7DUTQO0GxJPeD8NCOb1VorF8M4xuLwrmzRtkoZzU16umt4y1W0Q4ifdp3IiiU0U8/WxczSXcUVZOLqkz5dc6oMHdMVpkimietWzGZ4LBBsH/LjEVY7E0V+a0sNchlVDIZcm7ErReBLcdTGDq0uLBiuChyl6RUkX1PNhusquTGwK7zc8OBXkRuubn5UKXhI3Ul9Nyk4XESkVWIGNKmw8mSpoJSjR8P9ZjRmcZVo8S+x4KVPMZKQEor== ryan.smith@company.com
-	//          ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAzJSAtwEPoB3Jmr58IXrDGzLuDYkWAYg8AsLYlo6JZvKpjY1xednIcfEVQJm4T2DhVmdWhRrwQ8DmayVZvBkLt+zs2LdoAJEVimKwXcJFD/7wtH8Lnk17HiglbbbNXsemjDY0hea4JUE5CfvkIdZBITuMrfqSmA4n3VNoorXYdvtTMoGG8fxMub46RPtuxtqi9bG9Zqenordkg5FJt2mVNfQRqf83CWojcOkklUWq4CjyxaeLf5i9gv1fRoBo4QhiA8I6NCSppO8GnoV/6Ox6TNoh9BiifqGKC9VGYuC89RvUajRBTZSK2TK4DPfaT+2R+slPsFrwiT/oPEhhEK1S5Q== rsa-key-20160227",
-	//          "user_data" : "SWYgeW91IGNhbiBzZWUgdGhpcywgdGhlbiBpdCB3b3JrZWQgbWF5YmUuCg=="
+	//          "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227",
+	//          "user_data" : "<your_public_SSH_key>=="
 	//       }
 	//  **Getting Metadata on the Instance**
 	//  To get information about your instance, connect to the instance using SSH and issue any of the
 	//  following GET requests:
-	//      curl http://169.254.169.254/opc/v1/instance/
-	//      curl http://169.254.169.254/opc/v1/instance/metadata/
-	//      curl http://169.254.169.254/opc/v1/instance/metadata/<any-key-name>
+	//      curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/
+	//      curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/
+	//      curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
 	//  You'll get back a response that includes all the instance information; only the metadata information; or
 	//  the metadata information for the specified key name, respectively.
+	//  The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
 	Metadata map[string]string `mandatory:"false" json:"metadata"`
 
 	// The shape of an instance. The shape determines the number of CPUs, amount of memory,
@@ -133,8 +131,8 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	// instances so that they are not on the same physical hardware within a single availability domain.
 	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
 	// instances in other fault domains.
-	// If you do not specify the fault domain, the system selects one for you. To change the fault
-	// domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+	// If you do not specify the fault domain, the system selects one for you.
+	//
 	// To get a list of fault domains, use the
 	// ListFaultDomains operation in the
 	// Identity and Access Management Service API.
@@ -142,15 +140,18 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 
 	// The OCID of dedicated VM host.
+	// Dedicated VM hosts can be used when launching individual instances from an instance configuration. They
+	// cannot be used to launch instance pools.
 	DedicatedVmHostId *string `mandatory:"false" json:"dedicatedVmHostId"`
 
 	// Specifies the configuration mode for launching virtual machine (VM) instances. The configuration modes are:
 	// * `NATIVE` - VM instances launch with iSCSI boot and VFIO devices. The default value for Oracle-provided images.
 	// * `EMULATED` - VM instances launch with emulated devices, such as the E1000 network driver and emulated SCSI disk controller.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	// * `CUSTOM` - VM instances launch with custom configuration settings specified in the `LaunchOptions` parameter.
 	LaunchMode InstanceConfigurationLaunchInstanceDetailsLaunchModeEnum `mandatory:"false" json:"launchMode,omitempty"`
 
+	// Options for tuning the compatibility and performance of VM shapes. The values that you specify override any default values.
 	LaunchOptions *InstanceConfigurationLaunchOptions `mandatory:"false" json:"launchOptions"`
 
 	AgentConfig *InstanceConfigurationLaunchInstanceAgentConfigDetails `mandatory:"false" json:"agentConfig"`
@@ -162,6 +163,8 @@ type InstanceConfigurationLaunchInstanceDetails struct {
 	// * `LIVE_MIGRATE` - Run maintenance using a live migration.
 	// * `REBOOT` - Run maintenance using a reboot.
 	PreferredMaintenanceAction InstanceConfigurationLaunchInstanceDetailsPreferredMaintenanceActionEnum `mandatory:"false" json:"preferredMaintenanceAction,omitempty"`
+
+	AvailabilityConfig *InstanceConfigurationAvailabilityConfig `mandatory:"false" json:"availabilityConfig"`
 }
 
 func (m InstanceConfigurationLaunchInstanceDetails) String() string {
@@ -190,6 +193,7 @@ func (m *InstanceConfigurationLaunchInstanceDetails) UnmarshalJSON(data []byte) 
 		AgentConfig                    *InstanceConfigurationLaunchInstanceAgentConfigDetails                   `json:"agentConfig"`
 		IsPvEncryptionInTransitEnabled *bool                                                                    `json:"isPvEncryptionInTransitEnabled"`
 		PreferredMaintenanceAction     InstanceConfigurationLaunchInstanceDetailsPreferredMaintenanceActionEnum `json:"preferredMaintenanceAction"`
+		AvailabilityConfig             *InstanceConfigurationAvailabilityConfig                                 `json:"availabilityConfig"`
 	}{}
 
 	e = json.Unmarshal(data, &model)
@@ -242,6 +246,9 @@ func (m *InstanceConfigurationLaunchInstanceDetails) UnmarshalJSON(data []byte) 
 	m.IsPvEncryptionInTransitEnabled = model.IsPvEncryptionInTransitEnabled
 
 	m.PreferredMaintenanceAction = model.PreferredMaintenanceAction
+
+	m.AvailabilityConfig = model.AvailabilityConfig
+
 	return
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_launch_instance_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_launch_instance_shape_config_details.go
@@ -17,12 +17,15 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// InstanceConfigurationLaunchInstanceShapeConfigDetails The shape configuration requested for the instance. If provided, the instance will be created
-// with the resources specified. In the case where some properties are missing or
-// the entire parameter is not provided, the instance will be created with the default
-// configuration values for the provided `shape`.
-// Each shape only supports certain configurable values. If the values provided are invalid for the
-// provided `shape`, an error will be returned.
+// InstanceConfigurationLaunchInstanceShapeConfigDetails The shape configuration requested for the instance.
+// If the parameter is provided, the instance is created
+// with the resources that you specify. If some properties are missing or
+// the entire parameter is not provided, the instance is created with the default
+// configuration values for the `shape` that you specify.
+// Each shape only supports certain configurable values. If the values that you provid are not valid for the
+// specified `shape`, an error is returned.
+// For more information about customizing the resources that are allocated to a flexible shapes, see
+// Flexible Shapes (https://docs.cloud.oracle.com/Content/Compute/References/computeshapes.htm#flexible).
 type InstanceConfigurationLaunchInstanceShapeConfigDetails struct {
 
 	// The total number of OCPUs available to the instance.

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_launch_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_launch_options.go
@@ -17,44 +17,46 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// InstanceConfigurationLaunchOptions Options for tuning compatibility and performance of VM shapes.
+// InstanceConfigurationLaunchOptions Options for tuning the compatibility and performance of VM shapes. The values that you specify override any
+// default values.
 type InstanceConfigurationLaunchOptions struct {
 
-	// Emulation type for volume.
-	// * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-	// Storage volumes on Oracle provided images.
+	// Emulation type for the boot volume.
+	// * `ISCSI` - ISCSI attached block storage device.
 	// * `SCSI` - Emulated SCSI disk.
 	// * `IDE` - Emulated IDE disk.
-	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
 	// volumes on Oracle provided images.
-	// * `PARAVIRTUALIZED` - Paravirtualized disk.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided images.
 	BootVolumeType InstanceConfigurationLaunchOptionsBootVolumeTypeEnum `mandatory:"false" json:"bootVolumeType,omitempty"`
 
 	// Firmware used to boot VM.  Select the option that matches your operating system.
 	// * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
 	// systems that boot using MBR style bootloaders.
 	// * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-	// default for Oracle provided images.
+	// default for Oracle-provided images.
 	Firmware InstanceConfigurationLaunchOptionsFirmwareEnum `mandatory:"false" json:"firmware,omitempty"`
 
 	// Emulation type for the physical network interface card (NIC).
 	// * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
 	// * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
 	// when you launch an instance using hardware-assisted (SR-IOV) networking.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	NetworkType InstanceConfigurationLaunchOptionsNetworkTypeEnum `mandatory:"false" json:"networkType,omitempty"`
 
 	// Emulation type for volume.
-	// * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-	// Storage volumes on Oracle provided images.
+	// * `ISCSI` - ISCSI attached block storage device.
 	// * `SCSI` - Emulated SCSI disk.
 	// * `IDE` - Emulated IDE disk.
-	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
+	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
 	// volumes on Oracle provided images.
-	// * `PARAVIRTUALIZED` - Paravirtualized disk.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided images.
 	RemoteDataVolumeType InstanceConfigurationLaunchOptionsRemoteDataVolumeTypeEnum `mandatory:"false" json:"remoteDataVolumeType,omitempty"`
 
-	// Whether to enable in-transit encryption for the boot volume's paravirtualized attachment. The default value is false.
+	// Deprecated. Instead use `isPvEncryptionInTransitEnabled` in
+	// InstanceConfigurationLaunchInstanceDetails.
 	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
 
 	// Whether to enable consistent volume naming feature. Defaults to false.

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_paravirtualized_attach_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_paravirtualized_attach_volume_details.go
@@ -26,6 +26,18 @@ type InstanceConfigurationParavirtualizedAttachVolumeDetails struct {
 
 	// Whether the attachment should be created in read-only mode.
 	IsReadOnly *bool `mandatory:"false" json:"isReadOnly"`
+
+	// The device name.
+	Device *string `mandatory:"false" json:"device"`
+
+	// Whether the attachment should be created in shareable mode. If an attachment
+	// is created in shareable mode, then other instances can attach the same volume, provided
+	// that they also create their attachments in shareable mode. Only certain volume types can
+	// be attached in shareable mode. Defaults to false if not specified.
+	IsShareable *bool `mandatory:"false" json:"isShareable"`
+
+	// Whether to enable in-transit encryption for the data volume's paravirtualized attachment. The default value is false.
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
 }
 
 //GetDisplayName returns DisplayName
@@ -36,6 +48,16 @@ func (m InstanceConfigurationParavirtualizedAttachVolumeDetails) GetDisplayName(
 //GetIsReadOnly returns IsReadOnly
 func (m InstanceConfigurationParavirtualizedAttachVolumeDetails) GetIsReadOnly() *bool {
 	return m.IsReadOnly
+}
+
+//GetDevice returns Device
+func (m InstanceConfigurationParavirtualizedAttachVolumeDetails) GetDevice() *string {
+	return m.Device
+}
+
+//GetIsShareable returns IsShareable
+func (m InstanceConfigurationParavirtualizedAttachVolumeDetails) GetIsShareable() *bool {
+	return m.IsShareable
 }
 
 func (m InstanceConfigurationParavirtualizedAttachVolumeDetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_configuration_summary.go
@@ -26,7 +26,7 @@ type InstanceConfigurationSummary struct {
 	// The OCID of the instance configuration.
 	Id *string `mandatory:"true" json:"id"`
 
-	// The date and time the instance configuration was created, in the format defined by RFC3339.
+	// The date and time the instance configuration was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_pool.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_pool.go
@@ -42,7 +42,7 @@ type InstancePool struct {
 	// The number of instances that should be in the instance pool.
 	Size *int `mandatory:"true" json:"size"`
 
-	// The date and time the instance pool was created, in the format defined by RFC3339.
+	// The date and time the instance pool was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_pool_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_pool_summary.go
@@ -38,7 +38,7 @@ type InstancePoolSummary struct {
 	// The number of instances that should be in the instance pool.
 	Size *int `mandatory:"true" json:"size"`
 
-	// The date and time the instance pool was created, in the format defined by RFC3339.
+	// The date and time the instance pool was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_shape_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_shape_config.go
@@ -24,34 +24,34 @@ type InstanceShapeConfig struct {
 	// The total number of OCPUs available to the instance.
 	Ocpus *float32 `mandatory:"false" json:"ocpus"`
 
-	// The total amount of memory, in gigabytes, available to the instance.
+	// The total amount of memory available to the instance, in gigabytes.
 	MemoryInGBs *float32 `mandatory:"false" json:"memoryInGBs"`
 
-	// A short description of the processors available to the instance.
+	// A short description of the instance's processor (CPU).
 	ProcessorDescription *string `mandatory:"false" json:"processorDescription"`
 
-	// The networking bandwidth, in gigabits per second, available to the instance.
+	// The networking bandwidth available to the instance, in gigabits per second.
 	NetworkingBandwidthInGbps *float32 `mandatory:"false" json:"networkingBandwidthInGbps"`
 
 	// The maximum number of VNIC attachments for the instance.
 	MaxVnicAttachments *int `mandatory:"false" json:"maxVnicAttachments"`
 
-	// The number of GPUs available to this instance.
+	// The number of GPUs available to the instance.
 	Gpus *int `mandatory:"false" json:"gpus"`
 
-	// A short description of the GPUs available to this instance.
-	// This field is `null` if `gpus` is `0`.
+	// A short description of the instance's graphics processing unit (GPU).
+	// If the instance does not have any GPUs, this field is `null`.
 	GpuDescription *string `mandatory:"false" json:"gpuDescription"`
 
 	// The number of local disks available to the instance.
 	LocalDisks *int `mandatory:"false" json:"localDisks"`
 
-	// The size of the local disks, aggregated, in gigabytes.
-	// This field is `null` if `localDisks` is equal to `0`.
+	// The aggregate size of all local disks, in gigabytes.
+	// If the instance does not have any local disks, this field is `null`.
 	LocalDisksTotalSizeInGBs *float32 `mandatory:"false" json:"localDisksTotalSizeInGBs"`
 
 	// A short description of the local disks available to this instance.
-	// This field is `null` if `localDisks` is equal to `0`.
+	// If the instance does not have any local disks, this field is `null`.
 	LocalDiskDescription *string `mandatory:"false" json:"localDiskDescription"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/instance_summary.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/instance_summary.go
@@ -38,14 +38,14 @@ type InstanceSummary struct {
 	// The current state of the instance pool instance.
 	State *string `mandatory:"true" json:"state"`
 
-	// The date and time the instance pool instance was created, in the format defined by RFC3339.
+	// The date and time the instance pool instance was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// The user-friendly name.  Does not have to be unique.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// The name of the Fault Domain the instance is running in.
+	// The fault domain the instance is running in.
 	FaultDomain *string `mandatory:"false" json:"faultDomain"`
 
 	// The shape of an instance. The shape determines the number of CPUs, amount of memory,

--- a/vendor/github.com/oracle/oci-go-sdk/core/internet_gateway.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/internet_gateway.go
@@ -57,7 +57,7 @@ type InternetGateway struct {
 	// routed to/from the Internet, regardless of route rules.
 	IsEnabled *bool `mandatory:"false" json:"isEnabled"`
 
-	// The date and time the internet gateway was created, in the format defined by RFC3339.
+	// The date and time the internet gateway was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/ip_sec_connection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/ip_sec_connection.go
@@ -95,7 +95,7 @@ type IpSecConnection struct {
 	// for `cpeLocalIdentifier`.
 	CpeLocalIdentifierType IpSecConnectionCpeLocalIdentifierTypeEnum `mandatory:"false" json:"cpeLocalIdentifierType,omitempty"`
 
-	// The date and time the IPSec connection was created, in the format defined by RFC3339.
+	// The date and time the IPSec connection was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/ip_sec_connection_device_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/ip_sec_connection_device_status.go
@@ -27,7 +27,7 @@ type IpSecConnectionDeviceStatus struct {
 	// The IPSec connection's Oracle ID (OCID).
 	Id *string `mandatory:"true" json:"id"`
 
-	// The date and time the IPSec connection was created, in the format defined by RFC3339.
+	// The date and time the IPSec connection was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/ip_sec_connection_tunnel.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/ip_sec_connection_tunnel.go
@@ -32,11 +32,11 @@ type IpSecConnectionTunnel struct {
 	LifecycleState IpSecConnectionTunnelLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
 	// The IP address of Oracle's VPN headend.
-	// Example: `192.0.2.5`
+	// Example: `203.0.113.21`
 	VpnIp *string `mandatory:"false" json:"vpnIp"`
 
 	// The IP address of the CPE's VPN headend.
-	// Example: `192.0.2.157`
+	// Example: `203.0.113.22`
 	CpeIp *string `mandatory:"false" json:"cpeIp"`
 
 	// The status of the tunnel based on IPSec protocol characteristics.
@@ -55,11 +55,11 @@ type IpSecConnectionTunnel struct {
 	// The type of routing used for this tunnel (either BGP dynamic routing or static routing).
 	Routing IpSecConnectionTunnelRoutingEnum `mandatory:"false" json:"routing,omitempty"`
 
-	// The date and time the IPSec connection tunnel was created, in the format defined by RFC3339.
+	// The date and time the IPSec connection tunnel was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 
-	// When the status of the tunnel last changed, in the format defined by RFC3339.
+	// When the status of the tunnel last changed, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeStatusUpdated *common.SDKTime `mandatory:"false" json:"timeStatusUpdated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/ip_sec_connection_tunnel_shared_secret.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/ip_sec_connection_tunnel_shared_secret.go
@@ -21,7 +21,6 @@ import (
 type IpSecConnectionTunnelSharedSecret struct {
 
 	// The tunnel's shared secret (pre-shared key).
-	// Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 	SharedSecret *string `mandatory:"true" json:"sharedSecret"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/ipv6.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/ipv6.go
@@ -48,7 +48,7 @@ type Ipv6 struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the subnet the VNIC is in.
 	SubnetId *string `mandatory:"true" json:"subnetId"`
 
-	// The date and time the IPv6 was created, in the format defined by RFC3339.
+	// The date and time the IPv6 was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/launch_instance_availability_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/launch_instance_availability_config_details.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// LaunchInstanceAvailabilityConfigDetails Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+type LaunchInstanceAvailabilityConfigDetails struct {
+
+	// Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+	// * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+	// will be restored to the power state it was in before maintenance.
+	// * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+	RecoveryAction LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum `mandatory:"false" json:"recoveryAction,omitempty"`
+}
+
+func (m LaunchInstanceAvailabilityConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum Enum with underlying type: string
+type LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum string
+
+// Set of constants representing the allowable values for LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum
+const (
+	LaunchInstanceAvailabilityConfigDetailsRecoveryActionRestoreInstance LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum = "RESTORE_INSTANCE"
+	LaunchInstanceAvailabilityConfigDetailsRecoveryActionStopInstance    LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum = "STOP_INSTANCE"
+)
+
+var mappingLaunchInstanceAvailabilityConfigDetailsRecoveryAction = map[string]LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum{
+	"RESTORE_INSTANCE": LaunchInstanceAvailabilityConfigDetailsRecoveryActionRestoreInstance,
+	"STOP_INSTANCE":    LaunchInstanceAvailabilityConfigDetailsRecoveryActionStopInstance,
+}
+
+// GetLaunchInstanceAvailabilityConfigDetailsRecoveryActionEnumValues Enumerates the set of values for LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum
+func GetLaunchInstanceAvailabilityConfigDetailsRecoveryActionEnumValues() []LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum {
+	values := make([]LaunchInstanceAvailabilityConfigDetailsRecoveryActionEnum, 0)
+	for _, v := range mappingLaunchInstanceAvailabilityConfigDetailsRecoveryAction {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/launch_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/launch_instance_details.go
@@ -38,7 +38,7 @@ type LaunchInstanceDetails struct {
 	// the instance is launched.
 	CreateVnicDetails *CreateVnicDetails `mandatory:"false" json:"createVnicDetails"`
 
-	// The OCID of dedicated VM host.
+	// The OCID of the dedicated VM host.
 	DedicatedVmHostId *string `mandatory:"false" json:"dedicatedVmHostId"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a
@@ -51,8 +51,12 @@ type LaunchInstanceDetails struct {
 	// Example: `My bare metal instance`
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// Additional metadata key/value pairs that you provide. They serve the same purpose and functionality as fields in the 'metadata' object.
-	// They are distinguished from 'metadata' fields in that these can be nested JSON objects (whereas 'metadata' fields are string/string maps only).
+	// Additional metadata key/value pairs that you provide. They serve the same purpose and
+	// functionality as fields in the `metadata` object.
+	// They are distinguished from `metadata` fields in that these can be nested JSON objects
+	// (whereas `metadata` fields are string/string maps only).
+	// The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+	// 32,000 bytes.
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// A fault domain is a grouping of hardware and infrastructure within an availability domain.
@@ -60,8 +64,8 @@ type LaunchInstanceDetails struct {
 	// instances so that they are not on the same physical hardware within a single availability domain.
 	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
 	// instances in other fault domains.
-	// If you do not specify the fault domain, the system selects one for you. To change the fault
-	// domain for an instance, terminate it and launch a new instance in the preferred fault domain.
+	// If you do not specify the fault domain, the system selects one for you.
+	//
 	// To get a list of fault domains, use the
 	// ListFaultDomains operation in the
 	// Identity and Access Management Service API.
@@ -103,7 +107,11 @@ type LaunchInstanceDetails struct {
 	// For more information about iPXE, see http://ipxe.org.
 	IpxeScript *string `mandatory:"false" json:"ipxeScript"`
 
+	// Options for tuning the compatibility and performance of VM shapes. The values that you specify override any
+	// default values.
 	LaunchOptions *LaunchOptions `mandatory:"false" json:"launchOptions"`
+
+	AvailabilityConfig *LaunchInstanceAvailabilityConfigDetails `mandatory:"false" json:"availabilityConfig"`
 
 	// Custom metadata key/value pairs that you provide, such as the SSH public key
 	// required to connect to the instance.
@@ -125,29 +133,21 @@ type LaunchInstanceDetails struct {
 	//  Cloud-Init to run custom scripts or provide custom Cloud-Init configuration. For
 	//  information about how to take advantage of user data, see the
 	//  Cloud-Init Documentation (http://cloudinit.readthedocs.org/en/latest/topics/format.html).
-	//  **Note:** Cloud-Init does not pull this data from the `http://169.254.169.254/opc/v1/instance/metadata/`
-	//  path. When the instance launches and either of these keys are provided, the key values are formatted as
-	//  OpenStack metadata and copied to the following locations, which are recognized by Cloud-Init:
-	//  `http://169.254.169.254/openstack/latest/meta_data.json` - This JSON blob
-	//  contains, among other things, the SSH keys that you provided for
-	//   **"ssh_authorized_keys"**.
-	//  `http://169.254.169.254/openstack/latest/user_data` - Contains the
-	//  base64-decoded data that you provided for **"user_data"**.
 	//  **Metadata Example**
 	//       "metadata" : {
 	//          "quake_bot_level" : "Severe",
-	//          "ssh_authorized_keys" : "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCZ06fccNTQfq+xubFlJ5ZR3kt+uzspdH9tXL+lAejSM1NXM+CFZev7MIxfEjas06y80ZBZ7DUTQO0GxJPeD8NCOb1VorF8M4xuLwrmzRtkoZzU16umt4y1W0Q4ifdp3IiiU0U8/WxczSXcUVZOLqkz5dc6oMHdMVpkimietWzGZ4LBBsH/LjEVY7E0V+a0sNchlVDIZcm7ErReBLcdTGDq0uLBiuChyl6RUkX1PNhusquTGwK7zc8OBXkRuubn5UKXhI3Ul9Nyk4XESkVWIGNKmw8mSpoJSjR8P9ZjRmcZVo8S+x4KVPMZKQEor== ryan.smith@company.com
-	//          ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAzJSAtwEPoB3Jmr58IXrDGzLuDYkWAYg8AsLYlo6JZvKpjY1xednIcfEVQJm4T2DhVmdWhRrwQ8DmayVZvBkLt+zs2LdoAJEVimKwXcJFD/7wtH8Lnk17HiglbbbNXsemjDY0hea4JUE5CfvkIdZBITuMrfqSmA4n3VNoorXYdvtTMoGG8fxMub46RPtuxtqi9bG9Zqenordkg5FJt2mVNfQRqf83CWojcOkklUWq4CjyxaeLf5i9gv1fRoBo4QhiA8I6NCSppO8GnoV/6Ox6TNoh9BiifqGKC9VGYuC89RvUajRBTZSK2TK4DPfaT+2R+slPsFrwiT/oPEhhEK1S5Q== rsa-key-20160227",
-	//          "user_data" : "SWYgeW91IGNhbiBzZWUgdGhpcywgdGhlbiBpdCB3b3JrZWQgbWF5YmUuCg=="
+	//          "ssh_authorized_keys" : "ssh-rsa <your_public_SSH_key>== rsa-key-20160227",
+	//          "user_data" : "<your_public_SSH_key>=="
 	//       }
 	//  **Getting Metadata on the Instance**
 	//  To get information about your instance, connect to the instance using SSH and issue any of the
 	//  following GET requests:
-	//      curl http://169.254.169.254/opc/v1/instance/
-	//      curl http://169.254.169.254/opc/v1/instance/metadata/
-	//      curl http://169.254.169.254/opc/v1/instance/metadata/<any-key-name>
+	//      curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/
+	//      curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/
+	//      curl -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/instance/metadata/<any-key-name>
 	//  You'll get back a response that includes all the instance information; only the metadata information; or
 	//  the metadata information for the specified key name, respectively.
+	//  The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of 32,000 bytes.
 	Metadata map[string]string `mandatory:"false" json:"metadata"`
 
 	AgentConfig *LaunchInstanceAgentConfigDetails `mandatory:"false" json:"agentConfig"`
@@ -174,26 +174,27 @@ func (m LaunchInstanceDetails) String() string {
 // UnmarshalJSON unmarshals from json
 func (m *LaunchInstanceDetails) UnmarshalJSON(data []byte) (e error) {
 	model := struct {
-		CreateVnicDetails              *CreateVnicDetails                `json:"createVnicDetails"`
-		DedicatedVmHostId              *string                           `json:"dedicatedVmHostId"`
-		DefinedTags                    map[string]map[string]interface{} `json:"definedTags"`
-		DisplayName                    *string                           `json:"displayName"`
-		ExtendedMetadata               map[string]interface{}            `json:"extendedMetadata"`
-		FaultDomain                    *string                           `json:"faultDomain"`
-		FreeformTags                   map[string]string                 `json:"freeformTags"`
-		HostnameLabel                  *string                           `json:"hostnameLabel"`
-		ImageId                        *string                           `json:"imageId"`
-		IpxeScript                     *string                           `json:"ipxeScript"`
-		LaunchOptions                  *LaunchOptions                    `json:"launchOptions"`
-		Metadata                       map[string]string                 `json:"metadata"`
-		AgentConfig                    *LaunchInstanceAgentConfigDetails `json:"agentConfig"`
-		ShapeConfig                    *LaunchInstanceShapeConfigDetails `json:"shapeConfig"`
-		SourceDetails                  instancesourcedetails             `json:"sourceDetails"`
-		SubnetId                       *string                           `json:"subnetId"`
-		IsPvEncryptionInTransitEnabled *bool                             `json:"isPvEncryptionInTransitEnabled"`
-		AvailabilityDomain             *string                           `json:"availabilityDomain"`
-		CompartmentId                  *string                           `json:"compartmentId"`
-		Shape                          *string                           `json:"shape"`
+		CreateVnicDetails              *CreateVnicDetails                       `json:"createVnicDetails"`
+		DedicatedVmHostId              *string                                  `json:"dedicatedVmHostId"`
+		DefinedTags                    map[string]map[string]interface{}        `json:"definedTags"`
+		DisplayName                    *string                                  `json:"displayName"`
+		ExtendedMetadata               map[string]interface{}                   `json:"extendedMetadata"`
+		FaultDomain                    *string                                  `json:"faultDomain"`
+		FreeformTags                   map[string]string                        `json:"freeformTags"`
+		HostnameLabel                  *string                                  `json:"hostnameLabel"`
+		ImageId                        *string                                  `json:"imageId"`
+		IpxeScript                     *string                                  `json:"ipxeScript"`
+		LaunchOptions                  *LaunchOptions                           `json:"launchOptions"`
+		AvailabilityConfig             *LaunchInstanceAvailabilityConfigDetails `json:"availabilityConfig"`
+		Metadata                       map[string]string                        `json:"metadata"`
+		AgentConfig                    *LaunchInstanceAgentConfigDetails        `json:"agentConfig"`
+		ShapeConfig                    *LaunchInstanceShapeConfigDetails        `json:"shapeConfig"`
+		SourceDetails                  instancesourcedetails                    `json:"sourceDetails"`
+		SubnetId                       *string                                  `json:"subnetId"`
+		IsPvEncryptionInTransitEnabled *bool                                    `json:"isPvEncryptionInTransitEnabled"`
+		AvailabilityDomain             *string                                  `json:"availabilityDomain"`
+		CompartmentId                  *string                                  `json:"compartmentId"`
+		Shape                          *string                                  `json:"shape"`
 	}{}
 
 	e = json.Unmarshal(data, &model)
@@ -223,6 +224,8 @@ func (m *LaunchInstanceDetails) UnmarshalJSON(data []byte) (e error) {
 
 	m.LaunchOptions = model.LaunchOptions
 
+	m.AvailabilityConfig = model.AvailabilityConfig
+
 	m.Metadata = model.Metadata
 
 	m.AgentConfig = model.AgentConfig
@@ -248,5 +251,6 @@ func (m *LaunchInstanceDetails) UnmarshalJSON(data []byte) (e error) {
 	m.CompartmentId = model.CompartmentId
 
 	m.Shape = model.Shape
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/launch_instance_shape_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/launch_instance_shape_config_details.go
@@ -17,12 +17,14 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// LaunchInstanceShapeConfigDetails The shape configuration requested for the instance. If provided, the instance will be created
-// with the resources specified. In the case where some properties are missing or
-// the entire parameter is not provided, the instance will be created with the default
-// configuration values for the provided `shape`.
-// Each shape only supports certain configurable values. If the values provided are invalid for the
-// provided `shape`, an error will be returned.
+// LaunchInstanceShapeConfigDetails The shape configuration requested for the instance.
+// If the parameter is provided, the instance is created with the resources that you specify. If some
+// properties are missing or the entire parameter is not provided, the instance is created
+// with the default configuration values for the `shape` that you specify.
+// Each shape only supports certain configurable values. If the values that you provide are not valid for the
+// specified `shape`, an error is returned.
+// For more information about customizing the resources that are allocated to a flexible shapes,
+// see Flexible Shapes (https://docs.cloud.oracle.com/Content/Compute/References/computeshapes.htm#flexible).
 type LaunchInstanceShapeConfigDetails struct {
 
 	// The total number of OCPUs available to the instance.

--- a/vendor/github.com/oracle/oci-go-sdk/core/launch_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/launch_options.go
@@ -17,44 +17,46 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// LaunchOptions Options for tuning compatibility and performance of VM shapes.
+// LaunchOptions Options for tuning the compatibility and performance of VM shapes. The values that you specify override any
+// default values.
 type LaunchOptions struct {
 
-	// Emulation type for volume.
-	// * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-	// Storage volumes on Oracle provided images.
+	// Emulation type for the boot volume.
+	// * `ISCSI` - ISCSI attached block storage device.
 	// * `SCSI` - Emulated SCSI disk.
 	// * `IDE` - Emulated IDE disk.
-	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-	// volumes on Oracle provided images.
-	// * `PARAVIRTUALIZED` - Paravirtualized disk.
+	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+	// volumes on Oracle-provided images.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided images.
 	BootVolumeType LaunchOptionsBootVolumeTypeEnum `mandatory:"false" json:"bootVolumeType,omitempty"`
 
 	// Firmware used to boot VM.  Select the option that matches your operating system.
 	// * `BIOS` - Boot VM using BIOS style firmware.  This is compatible with both 32 bit and 64 bit operating
 	// systems that boot using MBR style bootloaders.
 	// * `UEFI_64` - Boot VM using UEFI style firmware compatible with 64 bit operating systems.  This is the
-	// default for Oracle provided images.
+	// default for Oracle-provided images.
 	Firmware LaunchOptionsFirmwareEnum `mandatory:"false" json:"firmware,omitempty"`
 
 	// Emulation type for the physical network interface card (NIC).
 	// * `E1000` - Emulated Gigabit ethernet controller.  Compatible with Linux e1000 network driver.
 	// * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
 	// when you launch an instance using hardware-assisted (SR-IOV) networking.
-	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using virtio drivers.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
 	NetworkType LaunchOptionsNetworkTypeEnum `mandatory:"false" json:"networkType,omitempty"`
 
 	// Emulation type for volume.
-	// * `ISCSI` - ISCSI attached block storage device. This is the default for Boot Volumes and Remote Block
-	// Storage volumes on Oracle provided images.
+	// * `ISCSI` - ISCSI attached block storage device.
 	// * `SCSI` - Emulated SCSI disk.
 	// * `IDE` - Emulated IDE disk.
-	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for Local data
-	// volumes on Oracle provided images.
-	// * `PARAVIRTUALIZED` - Paravirtualized disk.
+	// * `VFIO` - Direct attached Virtual Function storage.  This is the default option for local data
+	// volumes on Oracle-provided images.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided images.
 	RemoteDataVolumeType LaunchOptionsRemoteDataVolumeTypeEnum `mandatory:"false" json:"remoteDataVolumeType,omitempty"`
 
-	// Whether to enable in-transit encryption for the boot volume's paravirtualized attachment. The default value is false.
+	// Deprecated. Instead use `isPvEncryptionInTransitEnabled` in
+	// LaunchInstanceDetails.
 	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
 
 	// Whether to enable consistent volume naming feature. Defaults to false.

--- a/vendor/github.com/oracle/oci-go-sdk/core/letter_of_authority.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/letter_of_authority.go
@@ -36,10 +36,10 @@ type LetterOfAuthority struct {
 	// The meet-me room port for this cross-connect.
 	PortName *string `mandatory:"false" json:"portName"`
 
-	// The date and time when the Letter of Authority expires, in the format defined by RFC3339.
+	// The date and time when the Letter of Authority expires, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeExpires *common.SDKTime `mandatory:"false" json:"timeExpires"`
 
-	// The date and time the Letter of Authority was created, in the format defined by RFC3339.
+	// The date and time the Letter of Authority was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeIssued *common.SDKTime `mandatory:"false" json:"timeIssued"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_compute_global_image_capability_schema_versions_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_compute_global_image_capability_schema_versions_request_response.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListComputeGlobalImageCapabilitySchemaVersionsRequest wrapper for the ListComputeGlobalImageCapabilitySchemaVersions operation
+type ListComputeGlobalImageCapabilitySchemaVersionsRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compute global image capability schema
+	ComputeGlobalImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeGlobalImageCapabilitySchemaId"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeGlobalImageCapabilitySchemaVersionsRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeGlobalImageCapabilitySchemaVersionsRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeGlobalImageCapabilitySchemaVersionsRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListComputeGlobalImageCapabilitySchemaVersionsResponse wrapper for the ListComputeGlobalImageCapabilitySchemaVersions operation
+type ListComputeGlobalImageCapabilitySchemaVersionsResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ComputeGlobalImageCapabilitySchemaVersionSummary instances
+	Items []ComputeGlobalImageCapabilitySchemaVersionSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeGlobalImageCapabilitySchemaVersionsResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeGlobalImageCapabilitySchemaVersionsResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum Enum with underlying type: string
+type ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum
+const (
+	ListComputeGlobalImageCapabilitySchemaVersionsSortByTimecreated ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum = "TIMECREATED"
+	ListComputeGlobalImageCapabilitySchemaVersionsSortByDisplayname ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeGlobalImageCapabilitySchemaVersionsSortBy = map[string]ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum{
+	"TIMECREATED": ListComputeGlobalImageCapabilitySchemaVersionsSortByTimecreated,
+	"DISPLAYNAME": ListComputeGlobalImageCapabilitySchemaVersionsSortByDisplayname,
+}
+
+// GetListComputeGlobalImageCapabilitySchemaVersionsSortByEnumValues Enumerates the set of values for ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum
+func GetListComputeGlobalImageCapabilitySchemaVersionsSortByEnumValues() []ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum {
+	values := make([]ListComputeGlobalImageCapabilitySchemaVersionsSortByEnum, 0)
+	for _, v := range mappingListComputeGlobalImageCapabilitySchemaVersionsSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum Enum with underlying type: string
+type ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum
+const (
+	ListComputeGlobalImageCapabilitySchemaVersionsSortOrderAsc  ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum = "ASC"
+	ListComputeGlobalImageCapabilitySchemaVersionsSortOrderDesc ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum = "DESC"
+)
+
+var mappingListComputeGlobalImageCapabilitySchemaVersionsSortOrder = map[string]ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum{
+	"ASC":  ListComputeGlobalImageCapabilitySchemaVersionsSortOrderAsc,
+	"DESC": ListComputeGlobalImageCapabilitySchemaVersionsSortOrderDesc,
+}
+
+// GetListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnumValues Enumerates the set of values for ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum
+func GetListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnumValues() []ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum {
+	values := make([]ListComputeGlobalImageCapabilitySchemaVersionsSortOrderEnum, 0)
+	for _, v := range mappingListComputeGlobalImageCapabilitySchemaVersionsSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_compute_global_image_capability_schemas_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_compute_global_image_capability_schemas_request_response.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListComputeGlobalImageCapabilitySchemasRequest wrapper for the ListComputeGlobalImageCapabilitySchemas operation
+type ListComputeGlobalImageCapabilitySchemasRequest struct {
+
+	// A filter to return only resources that match the given compartment OCID exactly.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeGlobalImageCapabilitySchemasSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeGlobalImageCapabilitySchemasSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeGlobalImageCapabilitySchemasRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeGlobalImageCapabilitySchemasRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeGlobalImageCapabilitySchemasRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListComputeGlobalImageCapabilitySchemasResponse wrapper for the ListComputeGlobalImageCapabilitySchemas operation
+type ListComputeGlobalImageCapabilitySchemasResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ComputeGlobalImageCapabilitySchemaSummary instances
+	Items []ComputeGlobalImageCapabilitySchemaSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeGlobalImageCapabilitySchemasResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeGlobalImageCapabilitySchemasResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeGlobalImageCapabilitySchemasSortByEnum Enum with underlying type: string
+type ListComputeGlobalImageCapabilitySchemasSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeGlobalImageCapabilitySchemasSortByEnum
+const (
+	ListComputeGlobalImageCapabilitySchemasSortByTimecreated ListComputeGlobalImageCapabilitySchemasSortByEnum = "TIMECREATED"
+	ListComputeGlobalImageCapabilitySchemasSortByDisplayname ListComputeGlobalImageCapabilitySchemasSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeGlobalImageCapabilitySchemasSortBy = map[string]ListComputeGlobalImageCapabilitySchemasSortByEnum{
+	"TIMECREATED": ListComputeGlobalImageCapabilitySchemasSortByTimecreated,
+	"DISPLAYNAME": ListComputeGlobalImageCapabilitySchemasSortByDisplayname,
+}
+
+// GetListComputeGlobalImageCapabilitySchemasSortByEnumValues Enumerates the set of values for ListComputeGlobalImageCapabilitySchemasSortByEnum
+func GetListComputeGlobalImageCapabilitySchemasSortByEnumValues() []ListComputeGlobalImageCapabilitySchemasSortByEnum {
+	values := make([]ListComputeGlobalImageCapabilitySchemasSortByEnum, 0)
+	for _, v := range mappingListComputeGlobalImageCapabilitySchemasSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListComputeGlobalImageCapabilitySchemasSortOrderEnum Enum with underlying type: string
+type ListComputeGlobalImageCapabilitySchemasSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeGlobalImageCapabilitySchemasSortOrderEnum
+const (
+	ListComputeGlobalImageCapabilitySchemasSortOrderAsc  ListComputeGlobalImageCapabilitySchemasSortOrderEnum = "ASC"
+	ListComputeGlobalImageCapabilitySchemasSortOrderDesc ListComputeGlobalImageCapabilitySchemasSortOrderEnum = "DESC"
+)
+
+var mappingListComputeGlobalImageCapabilitySchemasSortOrder = map[string]ListComputeGlobalImageCapabilitySchemasSortOrderEnum{
+	"ASC":  ListComputeGlobalImageCapabilitySchemasSortOrderAsc,
+	"DESC": ListComputeGlobalImageCapabilitySchemasSortOrderDesc,
+}
+
+// GetListComputeGlobalImageCapabilitySchemasSortOrderEnumValues Enumerates the set of values for ListComputeGlobalImageCapabilitySchemasSortOrderEnum
+func GetListComputeGlobalImageCapabilitySchemasSortOrderEnumValues() []ListComputeGlobalImageCapabilitySchemasSortOrderEnum {
+	values := make([]ListComputeGlobalImageCapabilitySchemasSortOrderEnum, 0)
+	for _, v := range mappingListComputeGlobalImageCapabilitySchemasSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_compute_image_capability_schemas_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_compute_image_capability_schemas_request_response.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListComputeImageCapabilitySchemasRequest wrapper for the ListComputeImageCapabilitySchemas operation
+type ListComputeImageCapabilitySchemasRequest struct {
+
+	// A filter to return only resources that match the given compartment OCID exactly.
+	CompartmentId *string `mandatory:"false" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of an image.
+	ImageId *string `mandatory:"false" contributesTo:"query" name:"imageId"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListComputeImageCapabilitySchemasSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListComputeImageCapabilitySchemasSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListComputeImageCapabilitySchemasRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListComputeImageCapabilitySchemasRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListComputeImageCapabilitySchemasRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListComputeImageCapabilitySchemasResponse wrapper for the ListComputeImageCapabilitySchemas operation
+type ListComputeImageCapabilitySchemasResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []ComputeImageCapabilitySchemaSummary instances
+	Items []ComputeImageCapabilitySchemaSummary `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListComputeImageCapabilitySchemasResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListComputeImageCapabilitySchemasResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListComputeImageCapabilitySchemasSortByEnum Enum with underlying type: string
+type ListComputeImageCapabilitySchemasSortByEnum string
+
+// Set of constants representing the allowable values for ListComputeImageCapabilitySchemasSortByEnum
+const (
+	ListComputeImageCapabilitySchemasSortByTimecreated ListComputeImageCapabilitySchemasSortByEnum = "TIMECREATED"
+	ListComputeImageCapabilitySchemasSortByDisplayname ListComputeImageCapabilitySchemasSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListComputeImageCapabilitySchemasSortBy = map[string]ListComputeImageCapabilitySchemasSortByEnum{
+	"TIMECREATED": ListComputeImageCapabilitySchemasSortByTimecreated,
+	"DISPLAYNAME": ListComputeImageCapabilitySchemasSortByDisplayname,
+}
+
+// GetListComputeImageCapabilitySchemasSortByEnumValues Enumerates the set of values for ListComputeImageCapabilitySchemasSortByEnum
+func GetListComputeImageCapabilitySchemasSortByEnumValues() []ListComputeImageCapabilitySchemasSortByEnum {
+	values := make([]ListComputeImageCapabilitySchemasSortByEnum, 0)
+	for _, v := range mappingListComputeImageCapabilitySchemasSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListComputeImageCapabilitySchemasSortOrderEnum Enum with underlying type: string
+type ListComputeImageCapabilitySchemasSortOrderEnum string
+
+// Set of constants representing the allowable values for ListComputeImageCapabilitySchemasSortOrderEnum
+const (
+	ListComputeImageCapabilitySchemasSortOrderAsc  ListComputeImageCapabilitySchemasSortOrderEnum = "ASC"
+	ListComputeImageCapabilitySchemasSortOrderDesc ListComputeImageCapabilitySchemasSortOrderEnum = "DESC"
+)
+
+var mappingListComputeImageCapabilitySchemasSortOrder = map[string]ListComputeImageCapabilitySchemasSortOrderEnum{
+	"ASC":  ListComputeImageCapabilitySchemasSortOrderAsc,
+	"DESC": ListComputeImageCapabilitySchemasSortOrderDesc,
+}
+
+// GetListComputeImageCapabilitySchemasSortOrderEnumValues Enumerates the set of values for ListComputeImageCapabilitySchemasSortOrderEnum
+func GetListComputeImageCapabilitySchemasSortOrderEnumValues() []ListComputeImageCapabilitySchemasSortOrderEnum {
+	values := make([]ListComputeImageCapabilitySchemasSortOrderEnum, 0)
+	for _, v := range mappingListComputeImageCapabilitySchemasSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_dhcp_options_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_dhcp_options_request_response.go
@@ -16,7 +16,7 @@ type ListDhcpOptionsRequest struct {
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
-	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
+	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
 	// "List" call. For important details about how pagination works, see

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_internet_gateways_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_internet_gateways_request_response.go
@@ -16,7 +16,7 @@ type ListInternetGatewaysRequest struct {
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
-	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
+	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
 	// "List" call. For important details about how pagination works, see

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_local_peering_gateways_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_local_peering_gateways_request_response.go
@@ -15,9 +15,6 @@ type ListLocalPeeringGatewaysRequest struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
-	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
-
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
 	// "List" call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
@@ -28,6 +25,9 @@ type ListLocalPeeringGatewaysRequest struct {
 	// call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_private_ips_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_private_ips_request_response.go
@@ -33,6 +33,9 @@ type ListPrivateIpsRequest struct {
 	// The OCID of the VNIC.
 	VnicId *string `mandatory:"false" contributesTo:"query" name:"vnicId"`
 
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+	VlanId *string `mandatory:"false" contributesTo:"query" name:"vlanId"`
+
 	// Unique Oracle-assigned identifier for the request.
 	// If you need to contact Oracle about a particular request, please provide the request ID.
 	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_route_tables_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_route_tables_request_response.go
@@ -15,9 +15,6 @@ type ListRouteTablesRequest struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
-	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
-
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
 	// "List" call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
@@ -28,6 +25,9 @@ type ListRouteTablesRequest struct {
 	// call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// A filter to return only resources that match the given display name exactly.
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_security_lists_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_security_lists_request_response.go
@@ -15,9 +15,6 @@ type ListSecurityListsRequest struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
-	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
-
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
 	// "List" call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
@@ -28,6 +25,9 @@ type ListSecurityListsRequest struct {
 	// call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// A filter to return only resources that match the given display name exactly.
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_subnets_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_subnets_request_response.go
@@ -15,9 +15,6 @@ type ListSubnetsRequest struct {
 	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
 	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
 
-	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
-	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
-
 	// For list pagination. The maximum number of results per page, or items to return in a paginated
 	// "List" call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
@@ -28,6 +25,9 @@ type ListSubnetsRequest struct {
 	// call. For important details about how pagination works, see
 	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
 	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+	VcnId *string `mandatory:"false" contributesTo:"query" name:"vcnId"`
 
 	// A filter to return only resources that match the given display name exactly.
 	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`

--- a/vendor/github.com/oracle/oci-go-sdk/core/list_vlans_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/list_vlans_request_response.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// ListVlansRequest wrapper for the ListVlans operation
+type ListVlansRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+	CompartmentId *string `mandatory:"true" contributesTo:"query" name:"compartmentId"`
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+	VcnId *string `mandatory:"true" contributesTo:"query" name:"vcnId"`
+
+	// For list pagination. The maximum number of results per page, or items to return in a paginated
+	// "List" call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	// Example: `50`
+	Limit *int `mandatory:"false" contributesTo:"query" name:"limit"`
+
+	// For list pagination. The value of the `opc-next-page` response header from the previous "List"
+	// call. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	Page *string `mandatory:"false" contributesTo:"query" name:"page"`
+
+	// A filter to return only resources that match the given display name exactly.
+	DisplayName *string `mandatory:"false" contributesTo:"query" name:"displayName"`
+
+	// The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+	// TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+	// sort order is case sensitive.
+	// **Note:** In general, some "List" operations (for example, `ListInstances`) let you
+	// optionally filter by availability domain if the scope of the resource type is within a
+	// single availability domain. If you call one of these "List" operations without specifying
+	// an availability domain, the resources are grouped by availability domain, then sorted.
+	SortBy ListVlansSortByEnum `mandatory:"false" contributesTo:"query" name:"sortBy" omitEmpty:"true"`
+
+	// The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+	// is case sensitive.
+	SortOrder ListVlansSortOrderEnum `mandatory:"false" contributesTo:"query" name:"sortOrder" omitEmpty:"true"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// A filter to only return resources that match the given lifecycle state.  The state value is case-insensitive.
+	LifecycleState VlanLifecycleStateEnum `mandatory:"false" contributesTo:"query" name:"lifecycleState" omitEmpty:"true"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request ListVlansRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request ListVlansRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request ListVlansRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// ListVlansResponse wrapper for the ListVlans operation
+type ListVlansResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// A list of []Vlan instances
+	Items []Vlan `presentIn:"body"`
+
+	// For list pagination. When this header appears in the response, additional pages
+	// of results remain. For important details about how pagination works, see
+	// List Pagination (https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+	OpcNextPage *string `presentIn:"header" name:"opc-next-page"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response ListVlansResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response ListVlansResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}
+
+// ListVlansSortByEnum Enum with underlying type: string
+type ListVlansSortByEnum string
+
+// Set of constants representing the allowable values for ListVlansSortByEnum
+const (
+	ListVlansSortByTimecreated ListVlansSortByEnum = "TIMECREATED"
+	ListVlansSortByDisplayname ListVlansSortByEnum = "DISPLAYNAME"
+)
+
+var mappingListVlansSortBy = map[string]ListVlansSortByEnum{
+	"TIMECREATED": ListVlansSortByTimecreated,
+	"DISPLAYNAME": ListVlansSortByDisplayname,
+}
+
+// GetListVlansSortByEnumValues Enumerates the set of values for ListVlansSortByEnum
+func GetListVlansSortByEnumValues() []ListVlansSortByEnum {
+	values := make([]ListVlansSortByEnum, 0)
+	for _, v := range mappingListVlansSortBy {
+		values = append(values, v)
+	}
+	return values
+}
+
+// ListVlansSortOrderEnum Enum with underlying type: string
+type ListVlansSortOrderEnum string
+
+// Set of constants representing the allowable values for ListVlansSortOrderEnum
+const (
+	ListVlansSortOrderAsc  ListVlansSortOrderEnum = "ASC"
+	ListVlansSortOrderDesc ListVlansSortOrderEnum = "DESC"
+)
+
+var mappingListVlansSortOrder = map[string]ListVlansSortOrderEnum{
+	"ASC":  ListVlansSortOrderAsc,
+	"DESC": ListVlansSortOrderDesc,
+}
+
+// GetListVlansSortOrderEnumValues Enumerates the set of values for ListVlansSortOrderEnum
+func GetListVlansSortOrderEnumValues() []ListVlansSortOrderEnum {
+	values := make([]ListVlansSortOrderEnum, 0)
+	for _, v := range mappingListVlansSortOrder {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/local_peering_gateway.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/local_peering_gateway.go
@@ -51,7 +51,7 @@ type LocalPeeringGateway struct {
 	// LPG at the other end of the peering has been deleted.
 	PeeringStatus LocalPeeringGatewayPeeringStatusEnum `mandatory:"true" json:"peeringStatus"`
 
-	// The date and time the LPG was created, in the format defined by RFC3339.
+	// The date and time the LPG was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/nat_gateway.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/nat_gateway.go
@@ -47,7 +47,7 @@ type NatGateway struct {
 	// The IP address associated with the NAT gateway.
 	NatIp *string `mandatory:"true" json:"natIp"`
 
-	// The date and time the NAT gateway was created, in the format defined by RFC3339.
+	// The date and time the NAT gateway was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/network_security_group.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/network_security_group.go
@@ -58,7 +58,7 @@ type NetworkSecurityGroup struct {
 	// The network security group's current state.
 	LifecycleState NetworkSecurityGroupLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The date and time the network security group was created, in the format defined by RFC3339.
+	// The date and time the network security group was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/network_security_group_vnic.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/network_security_group_vnic.go
@@ -28,7 +28,7 @@ type NetworkSecurityGroupVnic struct {
 	ResourceId *string `mandatory:"false" json:"resourceId"`
 
 	// The date and time the VNIC was added to the network security group, in the format
-	// defined by RFC3339.
+	// defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeAssociated *common.SDKTime `mandatory:"false" json:"timeAssociated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/paravirtualized_volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/paravirtualized_volume_attachment.go
@@ -34,7 +34,7 @@ type ParavirtualizedVolumeAttachment struct {
 	// The OCID of the instance the volume is attached to.
 	InstanceId *string `mandatory:"true" json:"instanceId"`
 
-	// The date and time the volume was created, in the format defined by RFC3339.
+	// The date and time the volume was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/private_ip.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/private_ip.go
@@ -38,6 +38,10 @@ import (
 // LaunchInstance or
 // AttachVnic. To update the hostname
 // for a primary private IP, you use UpdateVnic.
+// `PrivateIp` objects that are created for use with the Oracle Cloud VMware Solution are
+// assigned to a VLAN and not a VNIC in a subnet. See the
+// descriptions of the relevant attributes in the `PrivateIp` object. Also see
+// Vlan.
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access, see
 // Getting Started with Policies (https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
@@ -83,6 +87,9 @@ type PrivateIp struct {
 
 	// The private IP address of the `privateIp` object. The address is within the CIDR
 	// of the VNIC's subnet.
+	// However, if the `PrivateIp` object is being used with a VLAN as part of
+	// the Oracle Cloud VMware Solution, the address is from the range specified by the
+	// `cidrBlock` attribute for the VLAN. See Vlan.
 	// Example: `10.0.3.3`
 	IpAddress *string `mandatory:"false" json:"ipAddress"`
 
@@ -91,15 +98,24 @@ type PrivateIp struct {
 	// Example: `true`
 	IsPrimary *bool `mandatory:"false" json:"isPrimary"`
 
+	// Applicable only if the `PrivateIp` object is being used with a VLAN as part of
+	// the Oracle Cloud VMware Solution. The `vlanId` is the OCID of the VLAN. See
+	// Vlan.
+	VlanId *string `mandatory:"false" json:"vlanId"`
+
 	// The OCID of the subnet the VNIC is in.
+	// However, if the `PrivateIp` object is being used with a VLAN as part of
+	// the Oracle Cloud VMware Solution, the `subnetId` is null.
 	SubnetId *string `mandatory:"false" json:"subnetId"`
 
-	// The date and time the private IP was created, in the format defined by RFC3339.
+	// The date and time the private IP was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 
 	// The OCID of the VNIC the private IP is assigned to. The VNIC and private IP
 	// must be in the same subnet.
+	// However, if the `PrivateIp` object is being used with a VLAN as part of
+	// the Oracle Cloud VMware Solution, the `vnicId` is null.
 	VnicId *string `mandatory:"false" json:"vnicId"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/public_ip.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/public_ip.go
@@ -66,7 +66,7 @@ type PublicIp struct {
 	Id *string `mandatory:"false" json:"id"`
 
 	// The public IP address of the `publicIp` object.
-	// Example: `129.146.2.1`
+	// Example: `203.0.113.2`
 	IpAddress *string `mandatory:"false" json:"ipAddress"`
 
 	// The public IP's current state.
@@ -102,7 +102,7 @@ type PublicIp struct {
 	// Ephemeral public IPs that are assigned to private IPs have `scope` = `AVAILABILITY_DOMAIN`.
 	Scope PublicIpScopeEnum `mandatory:"false" json:"scope,omitempty"`
 
-	// The date and time the public IP was created, in the format defined by RFC3339.
+	// The date and time the public IP was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/remote_peering_connection.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/remote_peering_connection.go
@@ -54,7 +54,7 @@ type RemotePeeringConnection struct {
 	// RPC at the other end of the peering has been deleted.
 	PeeringStatus RemotePeeringConnectionPeeringStatusEnum `mandatory:"true" json:"peeringStatus"`
 
-	// The date and time the RPC was created, in the format defined by RFC3339.
+	// The date and time the RPC was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/route_table.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/route_table.go
@@ -56,7 +56,7 @@ type RouteTable struct {
 	// Example: `{"Department": "Finance"}`
 	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
 
-	// The date and time the route table was created, in the format defined by RFC3339.
+	// The date and time the route table was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/security_list.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/security_list.go
@@ -55,7 +55,7 @@ type SecurityList struct {
 	// The security list's current state.
 	LifecycleState SecurityListLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The date and time the security list was created, in the format defined by RFC3339.
+	// The date and time the security list was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/security_rule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/security_rule.go
@@ -113,7 +113,7 @@ type SecurityRule struct {
 	// If you specify TCP as the protocol but omit this object, then all destination ports are allowed.
 	TcpOptions *TcpOptions `mandatory:"false" json:"tcpOptions"`
 
-	// The date and time the security rule was created. Format defined by RFC3339.
+	// The date and time the security rule was created. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 
 	// Optional and valid only for UDP. Use to specify particular destination ports for UDP rules.

--- a/vendor/github.com/oracle/oci-go-sdk/core/service_gateway.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/service_gateway.go
@@ -75,7 +75,7 @@ type ServiceGateway struct {
 	// Transit Routing: Private Access to Oracle Services (https://docs.cloud.oracle.com/Content/Network/Tasks/transitroutingoracleservices.htm).
 	RouteTableId *string `mandatory:"false" json:"routeTableId"`
 
-	// The date and time the service gateway was created, in the format defined by RFC3339.
+	// The date and time the service gateway was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/shape.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/shape.go
@@ -18,44 +18,45 @@ import (
 )
 
 // Shape A compute instance shape that can be used in LaunchInstance.
-// For more information, see Overview of the Compute Service (https://docs.cloud.oracle.com/Content/Compute/Concepts/computeoverview.htm).
+// For more information, see Overview of the Compute Service (https://docs.cloud.oracle.com/Content/Compute/Concepts/computeoverview.htm) and
+// Compute Shapes (https://docs.cloud.oracle.com/Content/Compute/References/computeshapes.htm).
 type Shape struct {
 
 	// The name of the shape. You can enumerate all available shapes by calling
 	// ListShapes.
 	Shape *string `mandatory:"true" json:"shape"`
 
-	// A short description of the processors available to an instance of this shape.
+	// A short description of the shape's processor (CPU).
 	ProcessorDescription *string `mandatory:"false" json:"processorDescription"`
 
-	// The default number of OCPUs available to an instance of this shape.
+	// The default number of OCPUs available for this shape.
 	Ocpus *float32 `mandatory:"false" json:"ocpus"`
 
-	// The default amount of memory, in gigabytes, available to an instance of this shape.
+	// The default amount of memory available for this shape, in gigabytes.
 	MemoryInGBs *float32 `mandatory:"false" json:"memoryInGBs"`
 
-	// The networking bandwidth, in gigabits per second, available to an instance of this shape.
+	// The networking bandwidth available for this shape, in gigabits per second.
 	NetworkingBandwidthInGbps *float32 `mandatory:"false" json:"networkingBandwidthInGbps"`
 
-	// The maximum number of VNIC attachments available to an instance of this shape.
+	// The maximum number of VNIC attachments available for this shape.
 	MaxVnicAttachments *int `mandatory:"false" json:"maxVnicAttachments"`
 
-	// The number of GPUs available to an instance of this shape.
+	// The number of GPUs available for this shape.
 	Gpus *int `mandatory:"false" json:"gpus"`
 
-	// A short description of the GPUs available to instances of this shape.
-	// This field is `null` if `gpus` is `0`.
+	// A short description of the graphics processing unit (GPU) available for this shape.
+	// If the shape does not have any GPUs, this field is `null`.
 	GpuDescription *string `mandatory:"false" json:"gpuDescription"`
 
-	// The number of local disks available to the instance.
+	// The number of local disks available for this shape.
 	LocalDisks *int `mandatory:"false" json:"localDisks"`
 
-	// The size of the local disks, aggregated, in gigabytes.
-	// This field is `null` if `localDisks` is equal to `0`.
+	// The aggregate size of the local disks available for this shape, in gigabytes.
+	// If the shape does not have any local disks, this field is `null`.
 	LocalDisksTotalSizeInGBs *float32 `mandatory:"false" json:"localDisksTotalSizeInGBs"`
 
-	// A short description of the local disks available to instances of this shape.
-	// This field is `null` if `localDisks` is equal to `0`.
+	// A short description of the local disks available for this shape.
+	// If the shape does not have any local disks, this field is `null`.
 	LocalDiskDescription *string `mandatory:"false" json:"localDiskDescription"`
 
 	OcpuOptions *ShapeOcpuOptions `mandatory:"false" json:"ocpuOptions"`

--- a/vendor/github.com/oracle/oci-go-sdk/core/shape_max_vnic_attachment_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/shape_max_vnic_attachment_options.go
@@ -17,7 +17,8 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// ShapeMaxVnicAttachmentOptions The possible configurations for the number of VNIC attachments available to an instance of this shape. If this field is null, then all instances of this shape have a fixed maximum number of VNIC attachments equal to `maxVnicAttachments`.
+// ShapeMaxVnicAttachmentOptions For a flexible shape, the number of VNIC attachments that are available for instances that use this shape.
+// If this field is null, then this shape has a fixed maximum number of VNIC attachments equal to `maxVnicAttachments`.
 type ShapeMaxVnicAttachmentOptions struct {
 
 	// The lowest maximum value of VNIC attachments.

--- a/vendor/github.com/oracle/oci-go-sdk/core/shape_memory_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/shape_memory_options.go
@@ -17,9 +17,8 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// ShapeMemoryOptions The possible configurations for the amount of memory available to an instance of this shape.
-// If this field is null, then all instances of this shape have a fixed
-// amount of memory equivalent to `memoryInGBs`.
+// ShapeMemoryOptions For a flexible shape, the amount of memory available for instances that use this shape.
+// If this field is null, then this shape has a fixed amount of memory equivalent to `memoryInGBs`.
 type ShapeMemoryOptions struct {
 
 	// The minimum amount of memory, in gigabytes.
@@ -28,8 +27,7 @@ type ShapeMemoryOptions struct {
 	// The maximum amount of memory, in gigabytes.
 	MaxInGBs *float32 `mandatory:"false" json:"maxInGBs"`
 
-	// The default amount of memory, in gigabytes, per OCPU available to an instance
-	// of this shape.
+	// The default amount of memory per OCPU available for this shape, in gigabytes.
 	DefaultPerOcpuInGBs *float32 `mandatory:"false" json:"defaultPerOcpuInGBs"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/shape_networking_bandwidth_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/shape_networking_bandwidth_options.go
@@ -17,7 +17,8 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// ShapeNetworkingBandwidthOptions The possible configurations for the amount of networking bandwidth available to an instance of this shape. If this field is null, then all instances of this shape have a fixed amount of bandwidth equivalent to `networkingBandwidthInGbps`.
+// ShapeNetworkingBandwidthOptions For a flexible shape, the amount of networking bandwidth available for instances that use this shape.
+// If this field is null, then this shape has a fixed amount of bandwidth equivalent to `networkingBandwidthInGbps`.
 type ShapeNetworkingBandwidthOptions struct {
 
 	// The minimum amount of networking bandwidth, in gigabits per second.
@@ -26,8 +27,7 @@ type ShapeNetworkingBandwidthOptions struct {
 	// The maximum amount of networking bandwidth, in gigabits per second.
 	MaxInGbps *float32 `mandatory:"false" json:"maxInGbps"`
 
-	// The default amount of networking bandwidth, in gigabits per second,
-	// per OCPU.
+	// The default amount of networking bandwidth per OCPU, in gigabits per second.
 	DefaultPerOcpuInGbps *float32 `mandatory:"false" json:"defaultPerOcpuInGbps"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/shape_ocpu_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/shape_ocpu_options.go
@@ -17,9 +17,8 @@ import (
 	"github.com/oracle/oci-go-sdk/common"
 )
 
-// ShapeOcpuOptions The possible configurations for the number of OCPUs available to an instance of this shape.
-// If this field is null, then all instances of this shape have a fixed
-// number of OCPUs equal to `ocpus`.
+// ShapeOcpuOptions For a flexible shape, the number of OCPUs available for instances that use this shape.
+// If this field is null, then this shape has a fixed number of OCPUs equal to `ocpus`.
 type ShapeOcpuOptions struct {
 
 	// The minimum number of OCPUs.

--- a/vendor/github.com/oracle/oci-go-sdk/core/subnet.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/subnet.go
@@ -30,7 +30,7 @@ import (
 type Subnet struct {
 
 	// The subnet's CIDR block.
-	// Example: `172.16.1.0/24`
+	// Example: `10.0.1.0/24`
 	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
 
 	// The OCID of the compartment containing the subnet.
@@ -53,7 +53,7 @@ type Subnet struct {
 	VirtualRouterIp *string `mandatory:"true" json:"virtualRouterIp"`
 
 	// The MAC address of the virtual router.
-	// Example: `00:00:17:B6:4D:DD`
+	// Example: `00:00:00:00:00:01`
 	VirtualRouterMac *string `mandatory:"true" json:"virtualRouterMac"`
 
 	// The subnet's availability domain. This attribute will be null if this is a regional subnet
@@ -131,7 +131,7 @@ type Subnet struct {
 	// Example: `subnet123.vcn1.oraclevcn.com`
 	SubnetDomainName *string `mandatory:"false" json:"subnetDomainName"`
 
-	// The date and time the subnet was created, in the format defined by RFC3339.
+	// The date and time the subnet was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/tunnel_config.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/tunnel_config.go
@@ -23,14 +23,13 @@ import (
 type TunnelConfig struct {
 
 	// The IP address of Oracle's VPN headend.
-	// Example: `129.146.17.50`
+	// Example: `203.0.113.50 `
 	IpAddress *string `mandatory:"true" json:"ipAddress"`
 
 	// The shared secret of the IPSec tunnel.
-	// Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 	SharedSecret *string `mandatory:"true" json:"sharedSecret"`
 
-	// The date and time the IPSec connection was created, in the format defined by RFC3339.
+	// The date and time the IPSec connection was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/tunnel_status.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/tunnel_status.go
@@ -21,17 +21,17 @@ import (
 type TunnelStatus struct {
 
 	// The IP address of Oracle's VPN headend.
-	// Example: `129.146.17.50`
+	// Example: `203.0.113.50`
 	IpAddress *string `mandatory:"true" json:"ipAddress"`
 
 	// The tunnel's current state.
 	LifecycleState TunnelStatusLifecycleStateEnum `mandatory:"false" json:"lifecycleState,omitempty"`
 
-	// The date and time the IPSec connection was created, in the format defined by RFC3339.
+	// The date and time the IPSec connection was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 
-	// When the state of the tunnel last changed, in the format defined by RFC3339.
+	// When the state of the tunnel last changed, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeStateModified *common.SDKTime `mandatory:"false" json:"timeStateModified"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_boot_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_boot_volume_details.go
@@ -44,6 +44,9 @@ type UpdateBootVolumeDetails struct {
 	//   * `10`: Represents Balanced option.
 	//   * `20`: Represents Higher Performance option.
 	VpusPerGB *int64 `mandatory:"false" json:"vpusPerGB"`
+
+	// Specifies whether the auto-tune performance is enabled for this boot volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
 func (m UpdateBootVolumeDetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_compute_image_capability_schema_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_compute_image_capability_schema_details.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateComputeImageCapabilitySchemaDetails Create Image Capability Schema for an image.
+type UpdateComputeImageCapabilitySchemaDetails struct {
+
+	// A user-friendly name for the compute image capability schema
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// The map of each capability name to its ImageCapabilitySchemaDescriptor.
+	SchemaData map[string]ImageCapabilitySchemaDescriptor `mandatory:"false" json:"schemaData"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+}
+
+func (m UpdateComputeImageCapabilitySchemaDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UnmarshalJSON unmarshals from json
+func (m *UpdateComputeImageCapabilitySchemaDetails) UnmarshalJSON(data []byte) (e error) {
+	model := struct {
+		DisplayName  *string                                    `json:"displayName"`
+		FreeformTags map[string]string                          `json:"freeformTags"`
+		SchemaData   map[string]imagecapabilityschemadescriptor `json:"schemaData"`
+		DefinedTags  map[string]map[string]interface{}          `json:"definedTags"`
+	}{}
+
+	e = json.Unmarshal(data, &model)
+	if e != nil {
+		return
+	}
+	var nn interface{}
+	m.DisplayName = model.DisplayName
+
+	m.FreeformTags = model.FreeformTags
+
+	m.SchemaData = make(map[string]ImageCapabilitySchemaDescriptor)
+	for k, v := range model.SchemaData {
+		nn, e = v.UnmarshalPolymorphicJSON(v.JsonData)
+		if e != nil {
+			return e
+		}
+		if nn != nil {
+			m.SchemaData[k] = nn.(ImageCapabilitySchemaDescriptor)
+		} else {
+			m.SchemaData[k] = nil
+		}
+	}
+
+	m.DefinedTags = model.DefinedTags
+
+	return
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_compute_image_capability_schema_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_compute_image_capability_schema_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateComputeImageCapabilitySchemaRequest wrapper for the UpdateComputeImageCapabilitySchema operation
+type UpdateComputeImageCapabilitySchemaRequest struct {
+
+	// The id of the compute image capability schema or the image ocid
+	ComputeImageCapabilitySchemaId *string `mandatory:"true" contributesTo:"path" name:"computeImageCapabilitySchemaId"`
+
+	// Updates the freeFormTags, definedTags, and display name of the image capability schema
+	UpdateComputeImageCapabilitySchemaDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique Oracle-assigned identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateComputeImageCapabilitySchemaRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateComputeImageCapabilitySchemaRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateComputeImageCapabilitySchemaRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateComputeImageCapabilitySchemaResponse wrapper for the UpdateComputeImageCapabilitySchema operation
+type UpdateComputeImageCapabilitySchemaResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The ComputeImageCapabilitySchema instance
+	ComputeImageCapabilitySchema `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateComputeImageCapabilitySchemaResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateComputeImageCapabilitySchemaResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_dhcp_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_dhcp_details.go
@@ -74,5 +74,6 @@ func (m *UpdateDhcpDetails) UnmarshalJSON(data []byte) (e error) {
 			m.Options[i] = nil
 		}
 	}
+
 	return
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_instance_availability_config_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_instance_availability_config_details.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateInstanceAvailabilityConfigDetails Options for customers to define the general policy of how compute service perform maintenance on VM instances.
+type UpdateInstanceAvailabilityConfigDetails struct {
+
+	// Actions customers can specify that would be applied to their instances after scheduled or unexpected host maintenance.
+	// * `RESTORE_INSTANCE` - This would be the default action if recoveryAction is not set. VM instances
+	// will be restored to the power state it was in before maintenance.
+	// * `STOP_INSTANCE` - This action allow customers to have their VM instances be stopped after maintenance.
+	RecoveryAction UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum `mandatory:"false" json:"recoveryAction,omitempty"`
+}
+
+func (m UpdateInstanceAvailabilityConfigDetails) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum Enum with underlying type: string
+type UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum string
+
+// Set of constants representing the allowable values for UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum
+const (
+	UpdateInstanceAvailabilityConfigDetailsRecoveryActionRestoreInstance UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum = "RESTORE_INSTANCE"
+	UpdateInstanceAvailabilityConfigDetailsRecoveryActionStopInstance    UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum = "STOP_INSTANCE"
+)
+
+var mappingUpdateInstanceAvailabilityConfigDetailsRecoveryAction = map[string]UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum{
+	"RESTORE_INSTANCE": UpdateInstanceAvailabilityConfigDetailsRecoveryActionRestoreInstance,
+	"STOP_INSTANCE":    UpdateInstanceAvailabilityConfigDetailsRecoveryActionStopInstance,
+}
+
+// GetUpdateInstanceAvailabilityConfigDetailsRecoveryActionEnumValues Enumerates the set of values for UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum
+func GetUpdateInstanceAvailabilityConfigDetailsRecoveryActionEnumValues() []UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum {
+	values := make([]UpdateInstanceAvailabilityConfigDetailsRecoveryActionEnum, 0)
+	for _, v := range mappingUpdateInstanceAvailabilityConfigDetailsRecoveryAction {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_instance_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_instance_details.go
@@ -39,28 +39,32 @@ type UpdateInstanceDetails struct {
 	AgentConfig *UpdateInstanceAgentConfigDetails `mandatory:"false" json:"agentConfig"`
 
 	// Custom metadata key/value string pairs that you provide. Any set of key/value pairs
-	// provided here will completely replace the current set of key/value pairs in the 'metadata'
+	// provided here will completely replace the current set of key/value pairs in the `metadata`
 	// field on the instance.
-	// Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-	// has launched. Any request which updates, removes, or adds either of these fields will be
-	// rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+	// The "user_data" field and the "ssh_authorized_keys" field cannot be changed after an instance
+	// has launched. Any request that updates, removes, or adds either of these fields will be
+	// rejected. You must provide the same values for "user_data" and "ssh_authorized_keys" that
 	// already exist on the instance.
+	// The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+	// 32,000 bytes.
 	Metadata map[string]string `mandatory:"false" json:"metadata"`
 
 	// Additional metadata key/value pairs that you provide. They serve the same purpose and
-	// functionality as fields in the 'metadata' object.
-	// They are distinguished from 'metadata' fields in that these can be nested JSON objects
-	// (whereas 'metadata' fields are string/string maps only).
-	// Both the 'user_data' and 'ssh_authorized_keys' fields cannot be changed after an instance
-	// has launched. Any request which updates, removes, or adds either of these fields will be
-	// rejected. You must provide the same values for 'user_data' and 'ssh_authorized_keys' that
+	// functionality as fields in the `metadata` object.
+	// They are distinguished from `metadata` fields in that these can be nested JSON objects
+	// (whereas `metadata` fields are string/string maps only).
+	// The "user_data" field and the "ssh_authorized_keys" field cannot be changed after an instance
+	// has launched. Any request that updates, removes, or adds either of these fields will be
+	// rejected. You must provide the same values for "user_data" and "ssh_authorized_keys" that
 	// already exist on the instance.
+	// The combined size of the `metadata` and `extendedMetadata` objects can be a maximum of
+	// 32,000 bytes.
 	ExtendedMetadata map[string]interface{} `mandatory:"false" json:"extendedMetadata"`
 
 	// The shape of the instance. The shape determines the number of CPUs and the amount of memory
 	// allocated to the instance. For more information about how to change shapes, and a list of
 	// shapes that are supported, see
-	// Changing the Shape of an Instance (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
+	// Editing an Instance (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
 	// For details about the CPUs, memory, and other properties of each shape, see
 	// Compute Shapes (https://docs.cloud.oracle.com/iaas/Content/Compute/References/computeshapes.htm).
 	// The new shape must be compatible with the image that was used to launch the instance. You
@@ -71,6 +75,22 @@ type UpdateInstanceDetails struct {
 	Shape *string `mandatory:"false" json:"shape"`
 
 	ShapeConfig *UpdateInstanceShapeConfigDetails `mandatory:"false" json:"shapeConfig"`
+
+	// A fault domain is a grouping of hardware and infrastructure within an availability domain.
+	// Each availability domain contains three fault domains. Fault domains let you distribute your
+	// instances so that they are not on the same physical hardware within a single availability domain.
+	// A hardware failure or Compute hardware maintenance that affects one fault domain does not affect
+	// instances in other fault domains.
+	// To get a list of fault domains, use the
+	// ListFaultDomains operation in the
+	// Identity and Access Management Service API.
+	// Example: `FAULT-DOMAIN-1`
+	FaultDomain *string `mandatory:"false" json:"faultDomain"`
+
+	// Options for tuning the compatibility and performance of VM shapes.
+	LaunchOptions *UpdateLaunchOptions `mandatory:"false" json:"launchOptions"`
+
+	AvailabilityConfig *UpdateInstanceAvailabilityConfigDetails `mandatory:"false" json:"availabilityConfig"`
 }
 
 func (m UpdateInstanceDetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_ip_sec_connection_tunnel_shared_secret_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_ip_sec_connection_tunnel_shared_secret_details.go
@@ -22,7 +22,6 @@ type UpdateIpSecConnectionTunnelSharedSecretDetails struct {
 
 	// The shared secret (pre-shared key) to use for the tunnel. Only numbers, letters, and spaces
 	// are allowed.
-	// Example: `EXAMPLEToUis6j1cp8GdVQxcmdfMO0yXMLilZTbYCMDGu4V8o`
 	SharedSecret *string `mandatory:"false" json:"sharedSecret"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_launch_options.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_launch_options.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateLaunchOptions Options for tuning the compatibility and performance of VM shapes.
+type UpdateLaunchOptions struct {
+
+	// Emulation type for the boot volume.
+	// * `ISCSI` - ISCSI attached block storage device.
+	// * `PARAVIRTUALIZED` - Paravirtualized disk. This is the default for boot volumes and remote block
+	// storage volumes on Oracle-provided plaform images.
+	// Before you change the boot volume attachment type, detach all block volumes and VNICs except for
+	// the boot volume and the primary VNIC.
+	// If the instance is running when you change the boot volume attachment type, it will be rebooted.
+	// **Note:** Some instances might not function properly if you change the boot volume attachment type. After
+	// the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+	// as expected, the changes are not supported. Revert the instance to the original boot volume attachment type.
+	BootVolumeType UpdateLaunchOptionsBootVolumeTypeEnum `mandatory:"false" json:"bootVolumeType,omitempty"`
+
+	// Emulation type for the physical network interface card (NIC).
+	// * `VFIO` - Direct attached Virtual Function network controller. This is the networking type
+	// when you launch an instance using hardware-assisted (SR-IOV) networking.
+	// * `PARAVIRTUALIZED` - VM instances launch with paravirtualized devices using VirtIO drivers.
+	// Before you change the networking type, detach all VNICs and block volumes except for the primary
+	// VNIC and the boot volume.
+	// The image must have paravirtualized drivers installed. For more information, see
+	// Editing an Instance (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/resizinginstances.htm).
+	// If the instance is running when you change the network type, it will be rebooted.
+	// **Note:** Some instances might not function properly if you change the networking type. After
+	// the instance reboots and is running, connect to it. If the connection fails or the OS doesn't behave
+	// as expected, the changes are not supported. Revert the instance to the original networking type.
+	NetworkType UpdateLaunchOptionsNetworkTypeEnum `mandatory:"false" json:"networkType,omitempty"`
+
+	// Whether to enable in-transit encryption for the boot volume's paravirtualized attachment.
+	// Data in transit is transferred over an internal and highly secure network. If you have specific
+	// compliance requirements related to the encryption of the data while it is moving between the
+	// instance and the boot volume, you can enable in-transit encryption. In-transit encryption is
+	// not enabled by default.
+	// All boot volumes are encrypted at rest.
+	// For more information, see Block Volume Encryption (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm#Encrypti).
+	IsPvEncryptionInTransitEnabled *bool `mandatory:"false" json:"isPvEncryptionInTransitEnabled"`
+}
+
+func (m UpdateLaunchOptions) String() string {
+	return common.PointerString(m)
+}
+
+// UpdateLaunchOptionsBootVolumeTypeEnum Enum with underlying type: string
+type UpdateLaunchOptionsBootVolumeTypeEnum string
+
+// Set of constants representing the allowable values for UpdateLaunchOptionsBootVolumeTypeEnum
+const (
+	UpdateLaunchOptionsBootVolumeTypeIscsi           UpdateLaunchOptionsBootVolumeTypeEnum = "ISCSI"
+	UpdateLaunchOptionsBootVolumeTypeParavirtualized UpdateLaunchOptionsBootVolumeTypeEnum = "PARAVIRTUALIZED"
+)
+
+var mappingUpdateLaunchOptionsBootVolumeType = map[string]UpdateLaunchOptionsBootVolumeTypeEnum{
+	"ISCSI":           UpdateLaunchOptionsBootVolumeTypeIscsi,
+	"PARAVIRTUALIZED": UpdateLaunchOptionsBootVolumeTypeParavirtualized,
+}
+
+// GetUpdateLaunchOptionsBootVolumeTypeEnumValues Enumerates the set of values for UpdateLaunchOptionsBootVolumeTypeEnum
+func GetUpdateLaunchOptionsBootVolumeTypeEnumValues() []UpdateLaunchOptionsBootVolumeTypeEnum {
+	values := make([]UpdateLaunchOptionsBootVolumeTypeEnum, 0)
+	for _, v := range mappingUpdateLaunchOptionsBootVolumeType {
+		values = append(values, v)
+	}
+	return values
+}
+
+// UpdateLaunchOptionsNetworkTypeEnum Enum with underlying type: string
+type UpdateLaunchOptionsNetworkTypeEnum string
+
+// Set of constants representing the allowable values for UpdateLaunchOptionsNetworkTypeEnum
+const (
+	UpdateLaunchOptionsNetworkTypeVfio            UpdateLaunchOptionsNetworkTypeEnum = "VFIO"
+	UpdateLaunchOptionsNetworkTypeParavirtualized UpdateLaunchOptionsNetworkTypeEnum = "PARAVIRTUALIZED"
+)
+
+var mappingUpdateLaunchOptionsNetworkType = map[string]UpdateLaunchOptionsNetworkTypeEnum{
+	"VFIO":            UpdateLaunchOptionsNetworkTypeVfio,
+	"PARAVIRTUALIZED": UpdateLaunchOptionsNetworkTypeParavirtualized,
+}
+
+// GetUpdateLaunchOptionsNetworkTypeEnumValues Enumerates the set of values for UpdateLaunchOptionsNetworkTypeEnum
+func GetUpdateLaunchOptionsNetworkTypeEnumValues() []UpdateLaunchOptionsNetworkTypeEnum {
+	values := make([]UpdateLaunchOptionsNetworkTypeEnum, 0)
+	for _, v := range mappingUpdateLaunchOptionsNetworkType {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_vlan_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_vlan_details.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// UpdateVlanDetails The representation of UpdateVlanDetails
+type UpdateVlanDetails struct {
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A descriptive name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// A list of the OCIDs of the network security groups (NSGs) to use with
+	// this VLAN. All VNICs in the VLAN will belong to these NSGs. For more
+	// information about NSGs, see
+	// NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The OCID of the route table the VLAN will use.
+	RouteTableId *string `mandatory:"false" json:"routeTableId"`
+}
+
+func (m UpdateVlanDetails) String() string {
+	return common.PointerString(m)
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_vlan_request_response.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_vlan_request_response.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+	"net/http"
+)
+
+// UpdateVlanRequest wrapper for the UpdateVlan operation
+type UpdateVlanRequest struct {
+
+	// The OCID (https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+	VlanId *string `mandatory:"true" contributesTo:"path" name:"vlanId"`
+
+	// Details object for updating a subnet.
+	UpdateVlanDetails `contributesTo:"body"`
+
+	// For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+	// parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+	// will be updated or deleted only if the etag you provide matches the resource's current etag value.
+	IfMatch *string `mandatory:"false" contributesTo:"header" name:"if-match"`
+
+	// Unique identifier for the request.
+	// If you need to contact Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `mandatory:"false" contributesTo:"header" name:"opc-request-id"`
+
+	// Metadata about the request. This information will not be transmitted to the service, but
+	// represents information that the SDK will consume to drive retry behavior.
+	RequestMetadata common.RequestMetadata
+}
+
+func (request UpdateVlanRequest) String() string {
+	return common.PointerString(request)
+}
+
+// HTTPRequest implements the OCIRequest interface
+func (request UpdateVlanRequest) HTTPRequest(method, path string) (http.Request, error) {
+	return common.MakeDefaultHTTPRequestWithTaggedStruct(method, path, request)
+}
+
+// RetryPolicy implements the OCIRetryableRequest interface. This retrieves the specified retry policy.
+func (request UpdateVlanRequest) RetryPolicy() *common.RetryPolicy {
+	return request.RequestMetadata.RetryPolicy
+}
+
+// UpdateVlanResponse wrapper for the UpdateVlan operation
+type UpdateVlanResponse struct {
+
+	// The underlying http response
+	RawResponse *http.Response
+
+	// The Vlan instance
+	Vlan `presentIn:"body"`
+
+	// For optimistic concurrency control. See `if-match`.
+	Etag *string `presentIn:"header" name:"etag"`
+
+	// Unique Oracle-assigned identifier for the request. If you need to contact
+	// Oracle about a particular request, please provide the request ID.
+	OpcRequestId *string `presentIn:"header" name:"opc-request-id"`
+}
+
+func (response UpdateVlanResponse) String() string {
+	return common.PointerString(response)
+}
+
+// HTTPResponse implements the OCIResponse interface
+func (response UpdateVlanResponse) HTTPResponse() *http.Response {
+	return response.RawResponse
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_vnic_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_vnic_details.go
@@ -50,14 +50,20 @@ type UpdateVnicDetails struct {
 
 	// A list of the OCIDs of the network security groups (NSGs) to add the VNIC to. Setting this as
 	// an empty array removes the VNIC from all network security groups.
+	// If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+	// belonging to a subnet), the value of the `nsgIds` attribute is ignored. Instead, the
+	// VNIC belongs to the NSGs that are associated with the VLAN itself. See Vlan.
 	// For more information about NSGs, see
 	// NetworkSecurityGroup.
 	NsgIds []string `mandatory:"false" json:"nsgIds"`
 
 	// Whether the source/destination check is disabled on the VNIC.
-	// Defaults to `false`, which means the check is performed.
-	// For information about why you would skip the source/destination check, see
+	// Defaults to `false`, which means the check is performed. For information about why you would
+	// skip the source/destination check, see
 	// Using a Private IP as a Route Target (https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip).
+	// If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+	// belonging to a subnet), the value of the `skipSourceDestCheck` attribute is ignored.
+	// This is because the source/destination check is always disabled for VNICs in a VLAN.
 	// Example: `true`
 	SkipSourceDestCheck *bool `mandatory:"false" json:"skipSourceDestCheck"`
 }

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_volume_backup_policy_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_volume_backup_policy_details.go
@@ -27,7 +27,9 @@ type UpdateVolumeBackupPolicyDetails struct {
 	// Avoid entering confidential information.
 	DisplayName *string `mandatory:"false" json:"displayName"`
 
-	// The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example: `us-ashburn-1`
+	// The paired destination region for copying scheduled backups to. Example: `us-ashburn-1`.
+	// Specify `none` to reset the `destinationRegion` parameter.
+	// See Region Pairs (https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs) for details about paired regions.
 	DestinationRegion *string `mandatory:"false" json:"destinationRegion"`
 
 	// The collection of schedules for the volume backup policy. See

--- a/vendor/github.com/oracle/oci-go-sdk/core/update_volume_details.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/update_volume_details.go
@@ -45,6 +45,9 @@ type UpdateVolumeDetails struct {
 
 	// The size to resize the volume to in GBs. Has to be larger than the current size.
 	SizeInGBs *int64 `mandatory:"false" json:"sizeInGBs"`
+
+	// Specifies whether the auto-tune performance is enabled for this volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
 }
 
 func (m UpdateVolumeDetails) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/vcn.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/vcn.go
@@ -91,7 +91,7 @@ type Vcn struct {
 	// Example: `2001:0db8:0123::/48`
 	Ipv6PublicCidrBlock *string `mandatory:"false" json:"ipv6PublicCidrBlock"`
 
-	// The date and time the VCN was created, in the format defined by RFC3339.
+	// The date and time the VCN was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/virtual_circuit.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/virtual_circuit.go
@@ -134,7 +134,7 @@ type VirtualCircuit struct {
 	ServiceType VirtualCircuitServiceTypeEnum `mandatory:"false" json:"serviceType,omitempty"`
 
 	// The date and time the virtual circuit was created,
-	// in the format defined by RFC3339.
+	// in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/vlan.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/vlan.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.  All rights reserved.
+// This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+// Code generated. DO NOT EDIT.
+
+// Core Services API
+//
+// API covering the Networking (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm),
+// Compute (https://docs.cloud.oracle.com/iaas/Content/Compute/Concepts/computeoverview.htm), and
+// Block Volume (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/overview.htm) services. Use this API
+// to manage resources such as virtual cloud networks (VCNs), compute instances, and
+// block storage volumes.
+//
+
+package core
+
+import (
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+// Vlan A resource to be used only with the Oracle Cloud VMware Solution.
+// Conceptually, a virtual LAN (VLAN) is a broadcast domain that is created
+// by partitioning and isolating a network at the data link layer (a *layer 2 network*).
+// VLANs work by using IEEE 802.1Q VLAN tags. Layer 2 traffic is forwarded within the
+// VLAN based on MAC learning.
+// In the Networking service, a VLAN is an object within a VCN. You use VLANs to
+// partition the VCN at the data link layer (layer 2). A VLAN is analagous to a subnet,
+// which is an object for partitioning the VCN at the IP layer (layer 3).
+type Vlan struct {
+
+	// The range of IPv4 addresses that will be used for layer 3 communication with
+	// hosts outside the VLAN.
+	// Example: `192.168.1.0/24`
+	CidrBlock *string `mandatory:"true" json:"cidrBlock"`
+
+	// The OCID of the compartment containing the VLAN.
+	CompartmentId *string `mandatory:"true" json:"compartmentId"`
+
+	// The VLAN's Oracle ID (OCID).
+	Id *string `mandatory:"true" json:"id"`
+
+	// The VLAN's current state.
+	LifecycleState VlanLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
+
+	// The OCID of the VCN the VLAN is in.
+	VcnId *string `mandatory:"true" json:"vcnId"`
+
+	// The availability domain of the VLAN.
+	// Example: `Uocm:PHX-AD-1`
+	AvailabilityDomain *string `mandatory:"false" json:"availabilityDomain"`
+
+	// Defined tags for this resource. Each key is predefined and scoped to a
+	// namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Operations": {"CostCenter": "42"}}`
+	DefinedTags map[string]map[string]interface{} `mandatory:"false" json:"definedTags"`
+
+	// A user-friendly name. Does not have to be unique, and it's changeable.
+	// Avoid entering confidential information.
+	DisplayName *string `mandatory:"false" json:"displayName"`
+
+	// Free-form tags for this resource. Each tag is a simple key-value pair with no
+	// predefined name, type, or namespace. For more information, see Resource Tags (https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+	// Example: `{"Department": "Finance"}`
+	FreeformTags map[string]string `mandatory:"false" json:"freeformTags"`
+
+	// A list of the OCIDs of the network security groups (NSGs) to use with this VLAN.
+	// All VNICs in the VLAN belong to these NSGs. For more
+	// information about NSGs, see
+	// NetworkSecurityGroup.
+	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// The IEEE 802.1Q VLAN tag of this VLAN.
+	// Example: `100`
+	VlanTag *int `mandatory:"false" json:"vlanTag"`
+
+	// The OCID of the route table that the VLAN uses.
+	RouteTableId *string `mandatory:"false" json:"routeTableId"`
+
+	// The date and time the VLAN was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
+	// Example: `2016-08-25T21:10:29.600Z`
+	TimeCreated *common.SDKTime `mandatory:"false" json:"timeCreated"`
+}
+
+func (m Vlan) String() string {
+	return common.PointerString(m)
+}
+
+// VlanLifecycleStateEnum Enum with underlying type: string
+type VlanLifecycleStateEnum string
+
+// Set of constants representing the allowable values for VlanLifecycleStateEnum
+const (
+	VlanLifecycleStateProvisioning VlanLifecycleStateEnum = "PROVISIONING"
+	VlanLifecycleStateAvailable    VlanLifecycleStateEnum = "AVAILABLE"
+	VlanLifecycleStateTerminating  VlanLifecycleStateEnum = "TERMINATING"
+	VlanLifecycleStateTerminated   VlanLifecycleStateEnum = "TERMINATED"
+	VlanLifecycleStateUpdating     VlanLifecycleStateEnum = "UPDATING"
+)
+
+var mappingVlanLifecycleState = map[string]VlanLifecycleStateEnum{
+	"PROVISIONING": VlanLifecycleStateProvisioning,
+	"AVAILABLE":    VlanLifecycleStateAvailable,
+	"TERMINATING":  VlanLifecycleStateTerminating,
+	"TERMINATED":   VlanLifecycleStateTerminated,
+	"UPDATING":     VlanLifecycleStateUpdating,
+}
+
+// GetVlanLifecycleStateEnumValues Enumerates the set of values for VlanLifecycleStateEnum
+func GetVlanLifecycleStateEnumValues() []VlanLifecycleStateEnum {
+	values := make([]VlanLifecycleStateEnum, 0)
+	for _, v := range mappingVlanLifecycleState {
+		values = append(values, v)
+	}
+	return values
+}

--- a/vendor/github.com/oracle/oci-go-sdk/core/vnic.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/vnic.go
@@ -27,6 +27,11 @@ import (
 // You can add *secondary private IPs* to a VNIC after it's created. For more
 // information, see CreatePrivateIp and
 // IP Addresses (https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPaddresses.htm).
+//
+// If you are an Oracle Cloud VMware Solution customer, you will have secondary VNICs
+// that reside in a VLAN instead of a subnet. These VNICs have other differences, which
+// are called out in the descriptions of the relevant attributes in the `Vnic` object.
+// Also see Vlan.
 // To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
 // talk to an administrator. If you're an administrator who needs to write policies to give users access, see
 // Getting Started with Policies (https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
@@ -47,10 +52,7 @@ type Vnic struct {
 	// The current state of the VNIC.
 	LifecycleState VnicLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The OCID of the subnet the VNIC is in.
-	SubnetId *string `mandatory:"true" json:"subnetId"`
-
-	// The date and time the VNIC was created, in the format defined by RFC3339.
+	// The date and time the VNIC was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
@@ -84,13 +86,24 @@ type Vnic struct {
 	IsPrimary *bool `mandatory:"false" json:"isPrimary"`
 
 	// The MAC address of the VNIC.
-	// Example: `00:00:17:B6:4D:DD`
+	// If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution,
+	// the MAC address is learned. If the VNIC belongs to a subnet, the
+	// MAC address is a static, Oracle-provided value.
+	// Example: `00:00:00:00:00:01`
 	MacAddress *string `mandatory:"false" json:"macAddress"`
 
-	// A list of the OCIDs of the network security groups that the VNIC belongs to. For more
-	// information about NSGs, see
+	// A list of the OCIDs of the network security groups that the VNIC belongs to.
+	// If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+	// belonging to a subnet), the value of the `nsgIds` attribute is ignored. Instead, the
+	// VNIC belongs to the NSGs that are associated with the VLAN itself. See Vlan.
+	// For more information about NSGs, see
 	// NetworkSecurityGroup.
 	NsgIds []string `mandatory:"false" json:"nsgIds"`
+
+	// If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+	// belonging to a subnet), the `vlanId` is the OCID of the VLAN the VNIC is in. See
+	// Vlan. If the VNIC is instead in a subnet, `subnetId` has a value.
+	VlanId *string `mandatory:"false" json:"vlanId"`
 
 	// The private IP address of the primary `privateIp` object on the VNIC.
 	// The address is within the CIDR of the VNIC's subnet.
@@ -104,8 +117,15 @@ type Vnic struct {
 	// Defaults to `false`, which means the check is performed. For information
 	// about why you would skip the source/destination check, see
 	// Using a Private IP as a Route Target (https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip).
+	//
+	// If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
+	// belonging to a subnet), the `skipSourceDestCheck` attribute is `true`.
+	// This is because the source/destination check is always disabled for VNICs in a VLAN.
 	// Example: `true`
 	SkipSourceDestCheck *bool `mandatory:"false" json:"skipSourceDestCheck"`
+
+	// The OCID of the subnet the VNIC is in.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
 }
 
 func (m Vnic) String() string {

--- a/vendor/github.com/oracle/oci-go-sdk/core/vnic_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/vnic_attachment.go
@@ -40,10 +40,7 @@ type VnicAttachment struct {
 	// The current state of the VNIC attachment.
 	LifecycleState VnicAttachmentLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
-	// The OCID of the subnet to create the VNIC in.
-	SubnetId *string `mandatory:"true" json:"subnetId"`
-
-	// The date and time the VNIC attachment was created, in the format defined by RFC3339.
+	// The date and time the VNIC attachment was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
@@ -58,8 +55,20 @@ type VnicAttachment struct {
 	// Virtual Network Interface Cards (VNICs) (https://docs.cloud.oracle.com/Content/Network/Tasks/managingVNICs.htm).
 	NicIndex *int `mandatory:"false" json:"nicIndex"`
 
+	// The OCID of the subnet to create the VNIC in.
+	SubnetId *string `mandatory:"false" json:"subnetId"`
+
+	// The OCID of the VLAN to create the VNIC in. Creating the VNIC in a VLAN (instead
+	// of a subnet) is possible only if you are an Oracle Cloud VMware Solution customer.
+	// See Vlan.
+	// An error is returned if the instance already has a VNIC attached to it from this VLAN.
+	VlanId *string `mandatory:"false" json:"vlanId"`
+
 	// The Oracle-assigned VLAN tag of the attached VNIC. Available after the
 	// attachment process is complete.
+	// However, if the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution,
+	// the `vlanTag` value is instead the value of the `vlanTag` attribute for the VLAN.
+	// See Vlan.
 	// Example: `0`
 	VlanTag *int `mandatory:"false" json:"vlanTag"`
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/volume.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/volume.go
@@ -48,7 +48,7 @@ type Volume struct {
 	// The size of the volume in MBs. This field is deprecated. Use sizeInGBs instead.
 	SizeInMBs *int64 `mandatory:"true" json:"sizeInMBs"`
 
-	// The date and time the volume was created. Format defined by RFC3339.
+	// The date and time the volume was created. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// Defined tags for this resource. Each key is predefined and scoped to a
@@ -89,6 +89,12 @@ type Volume struct {
 
 	// The OCID of the source volume group.
 	VolumeGroupId *string `mandatory:"false" json:"volumeGroupId"`
+
+	// Specifies whether the auto-tune performance is enabled for this volume.
+	IsAutoTuneEnabled *bool `mandatory:"false" json:"isAutoTuneEnabled"`
+
+	// The number of Volume Performance Units per GB that this volume is effectively tuned to when it's idle.
+	AutoTunedVpusPerGB *int64 `mandatory:"false" json:"autoTunedVpusPerGB"`
 }
 
 func (m Volume) String() string {
@@ -107,6 +113,8 @@ func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 		SizeInGBs          *int64                            `json:"sizeInGBs"`
 		SourceDetails      volumesourcedetails               `json:"sourceDetails"`
 		VolumeGroupId      *string                           `json:"volumeGroupId"`
+		IsAutoTuneEnabled  *bool                             `json:"isAutoTuneEnabled"`
+		AutoTunedVpusPerGB *int64                            `json:"autoTunedVpusPerGB"`
 		AvailabilityDomain *string                           `json:"availabilityDomain"`
 		CompartmentId      *string                           `json:"compartmentId"`
 		DisplayName        *string                           `json:"displayName"`
@@ -147,6 +155,10 @@ func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 
 	m.VolumeGroupId = model.VolumeGroupId
 
+	m.IsAutoTuneEnabled = model.IsAutoTuneEnabled
+
+	m.AutoTunedVpusPerGB = model.AutoTunedVpusPerGB
+
 	m.AvailabilityDomain = model.AvailabilityDomain
 
 	m.CompartmentId = model.CompartmentId
@@ -160,6 +172,7 @@ func (m *Volume) UnmarshalJSON(data []byte) (e error) {
 	m.SizeInMBs = model.SizeInMBs
 
 	m.TimeCreated = model.TimeCreated
+
 	return
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/volume_attachment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/volume_attachment.go
@@ -43,7 +43,7 @@ type VolumeAttachment interface {
 	// The current state of the volume attachment.
 	GetLifecycleState() VolumeAttachmentLifecycleStateEnum
 
-	// The date and time the volume was created, in the format defined by RFC3339.
+	// The date and time the volume was created, in the format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	// Example: `2016-08-25T21:10:29.600Z`
 	GetTimeCreated() *common.SDKTime
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/volume_backup.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/volume_backup.go
@@ -41,7 +41,7 @@ type VolumeBackup struct {
 	LifecycleState VolumeBackupLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
 	// The date and time the volume backup was created. This is the time the actual point-in-time image
-	// of the volume data was taken. Format defined by RFC3339.
+	// of the volume data was taken. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// The type of a volume backup.
@@ -57,7 +57,7 @@ type VolumeBackup struct {
 	SystemTags map[string]map[string]interface{} `mandatory:"false" json:"systemTags"`
 
 	// The date and time the volume backup will expire and be automatically deleted.
-	// Format defined by RFC3339. This parameter will always be present for backups that
+	// Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339). This parameter will always be present for backups that
 	// were created automatically by a scheduled-backup policy. For manually created backups,
 	// it will be absent, signifying that there is no expiration time and the backup will
 	// last forever until manually deleted.
@@ -87,7 +87,7 @@ type VolumeBackup struct {
 	// The OCID of the source volume backup.
 	SourceVolumeBackupId *string `mandatory:"false" json:"sourceVolumeBackupId"`
 
-	// The date and time the request to create the volume backup was received. Format defined by RFC3339.
+	// The date and time the request to create the volume backup was received. Format defined by [RFC3339]https://tools.ietf.org/html/rfc3339.
 	TimeRequestReceived *common.SDKTime `mandatory:"false" json:"timeRequestReceived"`
 
 	// The size used by the backup, in GBs. It is typically smaller than sizeInGBs, depending on the space

--- a/vendor/github.com/oracle/oci-go-sdk/core/volume_backup_policy.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/volume_backup_policy.go
@@ -34,10 +34,11 @@ type VolumeBackupPolicy struct {
 	// The collection of schedules that this policy will apply.
 	Schedules []VolumeBackupSchedule `mandatory:"true" json:"schedules"`
 
-	// The date and time the volume backup policy was created. Format defined by RFC3339.
+	// The date and time the volume backup policy was created. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
-	// The paired destination region (pre-defined by oracle) for scheduled cross region backup calls. Example `us-ashburn-1`
+	// The paired destination region for copying scheduled backups to. Example `us-ashburn-1`.
+	// See Region Pairs (https://docs.cloud.oracle.com/iaas/Content/Block/Tasks/schedulingvolumebackups.htm#RegionPairs) for details about paired regions.
 	DestinationRegion *string `mandatory:"false" json:"destinationRegion"`
 
 	// The OCID of the compartment that contains the volume backup.

--- a/vendor/github.com/oracle/oci-go-sdk/core/volume_backup_policy_assignment.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/volume_backup_policy_assignment.go
@@ -31,7 +31,7 @@ type VolumeBackupPolicyAssignment struct {
 	// The OCID of the volume backup policy that has been assigned to the volume.
 	PolicyId *string `mandatory:"true" json:"policyId"`
 
-	// The date and time the volume backup policy was assigned to the volume. The format is defined by RFC3339.
+	// The date and time the volume backup policy was assigned to the volume. The format is defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/volume_backup_schedule.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/volume_backup_schedule.go
@@ -224,7 +224,7 @@ const (
 )
 
 var mappingVolumeBackupScheduleTimeZone = map[string]VolumeBackupScheduleTimeZoneEnum{
-	"UTC":                       VolumeBackupScheduleTimeZoneUtc,
+	"UTC": VolumeBackupScheduleTimeZoneUtc,
 	"REGIONAL_DATA_CENTER_TIME": VolumeBackupScheduleTimeZoneRegionalDataCenterTime,
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/volume_group.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/volume_group.go
@@ -42,7 +42,7 @@ type VolumeGroup struct {
 	// The aggregate size of the volume group in MBs.
 	SizeInMBs *int64 `mandatory:"true" json:"sizeInMBs"`
 
-	// The date and time the volume group was created. Format defined by RFC3339.
+	// The date and time the volume group was created. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// OCIDs for the volumes in this volume group.
@@ -132,6 +132,7 @@ func (m *VolumeGroup) UnmarshalJSON(data []byte) (e error) {
 	for i, n := range model.VolumeIds {
 		m.VolumeIds[i] = n
 	}
+
 	return
 }
 

--- a/vendor/github.com/oracle/oci-go-sdk/core/volume_group_backup.go
+++ b/vendor/github.com/oracle/oci-go-sdk/core/volume_group_backup.go
@@ -39,7 +39,7 @@ type VolumeGroupBackup struct {
 	LifecycleState VolumeGroupBackupLifecycleStateEnum `mandatory:"true" json:"lifecycleState"`
 
 	// The date and time the volume group backup was created. This is the time the actual point-in-time image
-	// of the volume group data was taken. Format defined by RFC3339.
+	// of the volume group data was taken. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeCreated *common.SDKTime `mandatory:"true" json:"timeCreated"`
 
 	// The type of backup.
@@ -64,7 +64,7 @@ type VolumeGroupBackup struct {
 	// The aggregate size of the volume group backup, in GBs.
 	SizeInGBs *int64 `mandatory:"false" json:"sizeInGBs"`
 
-	// The date and time the request to create the volume group backup was received. Format defined by RFC3339.
+	// The date and time the request to create the volume group backup was received. Format defined by RFC3339 (https://tools.ietf.org/html/rfc3339).
 	TimeRequestReceived *common.SDKTime `mandatory:"false" json:"timeRequestReceived"`
 
 	// The aggregate size used by the volume group backup, in MBs.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -504,7 +504,7 @@ github.com/modern-go/reflect2
 github.com/nu7hatch/gouuid
 # github.com/olekukonko/tablewriter v0.0.0-20180105111133-96aac992fc8b
 github.com/olekukonko/tablewriter
-# github.com/oracle/oci-go-sdk v18.0.0+incompatible
+# github.com/oracle/oci-go-sdk v24.3.0+incompatible
 github.com/oracle/oci-go-sdk/common
 github.com/oracle/oci-go-sdk/common/auth
 github.com/oracle/oci-go-sdk/core


### PR DESCRIPTION
Currently, the oracle-oci builder is broken, because it is unable
to read the key file provided by Oracle cloud. Updating to the
latest compatible oci-go-sdk fixes the issue.
