### PR TITLE
Update diagnostic detail to display list of PostProcessors

### DIFF
--- a/hcl2template/plugin.go
+++ b/hcl2template/plugin.go
@@ -167,7 +167,7 @@ func (cfg *PackerConfig) initializeBlocks() hcl.Diagnostics {
 					diags = append(diags, &hcl.Diagnostic{
 						Summary:  fmt.Sprintf("Unknown "+buildPostProcessorLabel+" type %q", ppBlock.PType),
 						Subject:  ppBlock.HCL2Ref.TypeRange.Ptr(),
-						Detail:   fmt.Sprintf("known "+buildPostProcessorLabel+"s: %v", cfg.parser.PluginConfig.Provisioners.List()),
+						Detail:   fmt.Sprintf("known "+buildPostProcessorLabel+"s: %v", cfg.parser.PluginConfig.PostProcessors.List()),
 						Severity: hcl.DiagError,
 					})
 				}


### PR DESCRIPTION
Before change
```
known post-processors: [inspec breakpoint converge windows-shell
chef-solo powershell sleep puppet-server salt-masterless shell file
azure-dtlartifact chef-client windows-restart ansible shell-local ansible-local
puppet-masterless]

```

After change
```
known post-processors: [compress alicloud-import checksum docker-import
amazon-import exoscale-import artifice shell-local vagrant ucloud-import
yandex-export manifest yandex-import googlecompute-export vsphere
digitalocean-import docker-save docker-push vagrant-cloud
vsphere-template googlecompute-import docker-tag]

```