### PR TITLE
Fix force flag for hcl2 provisioners and post-processors

### DIFF
--- a/command/test-fixtures/build-only/template.pkr.hcl
+++ b/command/test-fixtures/build-only/template.pkr.hcl
@@ -42,13 +42,13 @@ build {
   }
 
   post-processor "shell-local" {
-    only = ["sources.file.vanilla"]
+    only = ["file.vanilla"]
     name = "tomato"
     inline = [ "echo apple > tomato.txt" ]
   }
 
   post-processor "shell-local" {
-    only = ["sources.file.chocolate"]
+    only = ["file.chocolate"]
     inline = [ "echo apple > unnamed.txt" ]
   }
 }

--- a/command/test-fixtures/hcl/force.pkr.hcl
+++ b/command/test-fixtures/hcl/force.pkr.hcl
@@ -1,0 +1,12 @@
+source "null" "potato" {
+    communicator = "none"
+}
+
+build {
+    sources = ["sources.null.potato"]
+
+    post-processor "manifest" {
+        output = "manifest.json"
+        strip_time = true
+    }
+}

--- a/hcl2template/types.build.post-processor.go
+++ b/hcl2template/types.build.post-processor.go
@@ -2,6 +2,7 @@ package hcl2template
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -64,11 +65,17 @@ func (cfg *PackerConfig) startPostProcessor(source SourceUseBlock, pp *PostProce
 		})
 		return nil, diags
 	}
+
+	builderVars := source.builderVariables()
+	builderVars["packer_debug"] = strconv.FormatBool(cfg.debug)
+	builderVars["packer_force"] = strconv.FormatBool(cfg.force)
+	builderVars["packer_on_error"] = cfg.onError
+
 	hclPostProcessor := &HCL2PostProcessor{
 		PostProcessor:      postProcessor,
 		postProcessorBlock: pp,
 		evalContext:        ectx,
-		builderVariables:   source.builderVariables(),
+		builderVariables:   builderVars,
 	}
 	err = hclPostProcessor.HCL2Prepare(nil)
 	if err != nil {

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -2,6 +2,7 @@ package hcl2template
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
@@ -152,11 +153,16 @@ func (cfg *PackerConfig) startProvisioner(source SourceUseBlock, pb *Provisioner
 		return nil, diags
 	}
 
+	builderVars := source.builderVariables()
+	builderVars["packer_debug"] = strconv.FormatBool(cfg.debug)
+	builderVars["packer_force"] = strconv.FormatBool(cfg.force)
+	builderVars["packer_on_error"] = cfg.onError
+
 	hclProvisioner := &HCL2Provisioner{
 		Provisioner:      provisioner,
 		provisionerBlock: pb,
 		evalContext:      ectx,
-		builderVariables: source.builderVariables(),
+		builderVariables: builderVars,
 	}
 
 	if pb.Override != nil {

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -52,12 +52,12 @@ type PackerConfig struct {
 	// Builds is the list of Build blocks defined in the config files.
 	Builds Builds
 
-	except []glob.Glob
-	only   []glob.Glob
-
 	parser *Parser
 	files  []*hcl.File
 
+	// Fields passed as command line flags
+	except  []glob.Glob
+	only    []glob.Glob
 	force   bool
 	debug   bool
 	onError string

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -57,6 +57,10 @@ type PackerConfig struct {
 
 	parser *Parser
 	files  []*hcl.File
+
+	force   bool
+	debug   bool
+	onError string
 }
 
 type ValidationOptions struct {
@@ -408,6 +412,10 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packersdk.Bu
 	res := []packersdk.Build{}
 	var diags hcl.Diagnostics
 
+	cfg.debug = opts.Debug
+	cfg.force = opts.Force
+	cfg.onError = opts.OnError
+
 	for _, build := range cfg.Builds {
 		for _, srcUsage := range build.Sources {
 			src, found := cfg.Sources[srcUsage.SourceRef]
@@ -466,7 +474,7 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packersdk.Bu
 				}
 			}
 
-			builder, moreDiags, generatedVars := cfg.startBuilder(srcUsage, cfg.EvalContext(BuildContext, nil), opts)
+			builder, moreDiags, generatedVars := cfg.startBuilder(srcUsage, cfg.EvalContext(BuildContext, nil))
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue

--- a/hcl2template/types.source.go
+++ b/hcl2template/types.source.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	hcl2shim "github.com/hashicorp/packer/hcl2template/shim"
-	"github.com/hashicorp/packer/packer"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -96,7 +95,7 @@ func (p *Parser) decodeSource(block *hcl.Block) (SourceBlock, hcl.Diagnostics) {
 	return source, diags
 }
 
-func (cfg *PackerConfig) startBuilder(source SourceUseBlock, ectx *hcl.EvalContext, opts packer.GetBuildsOptions) (packersdk.Builder, hcl.Diagnostics, []string) {
+func (cfg *PackerConfig) startBuilder(source SourceUseBlock, ectx *hcl.EvalContext) (packersdk.Builder, hcl.Diagnostics, []string) {
 	var diags hcl.Diagnostics
 
 	builder, err := cfg.parser.PluginConfig.Builders.Start(source.Type)
@@ -127,9 +126,9 @@ func (cfg *PackerConfig) startBuilder(source SourceUseBlock, ectx *hcl.EvalConte
 	// prepare at a later step, to make builds from different template types
 	// easier to reason about.
 	builderVars := source.builderVariables()
-	builderVars["packer_debug"] = strconv.FormatBool(opts.Debug)
-	builderVars["packer_force"] = strconv.FormatBool(opts.Force)
-	builderVars["packer_on_error"] = opts.OnError
+	builderVars["packer_debug"] = strconv.FormatBool(cfg.debug)
+	builderVars["packer_force"] = strconv.FormatBool(cfg.force)
+	builderVars["packer_on_error"] = cfg.onError
 
 	generatedVars, warning, err := builder.Prepare(builderVars, decoded)
 	moreDiags = warningErrorsToDiags(cfg.Sources[source.SourceRef].block, warning, err)

--- a/website/content/docs/templates/hcl_templates/blocks/build/post-processor.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/post-processor.mdx
@@ -72,7 +72,7 @@ build {
   post-processor "checksum" {
     checksum_types = [ "md5", "sha512" ]
     keep_input_artifact = true
-    only = ["source.amazon-ebs.example"]
+    only = ["amazon-ebs.example"]
   }
 }
 ```

--- a/website/content/docs/templates/hcl_templates/blocks/build/provisioner.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/provisioner.mdx
@@ -58,7 +58,7 @@ build {
   ]
   provisioner "shell" {
     # This provisioner only runs for the 'first-example' source.
-    only = ["source.amazon-ebs.first-example"]
+    only = ["amazon-ebs.first-example"]
 
     inline = [
       "echo provisioning all the things",

--- a/website/content/docs/templates/hcl_templates/onlyexcept.mdx
+++ b/website/content/docs/templates/hcl_templates/onlyexcept.mdx
@@ -32,12 +32,12 @@ build {
   }
 
   provisioner "shell-local" {
-    only = ["source.amazon-ebs.first-example"]
+    only = ["amazon-ebs.first-example"]
     inline = ["echo I will only run for the second example source"]
   }
 
   provisioner "shell-local" {
-    except = ["source.amazon-ebs.second-example-local-name"]
+    except = ["amazon-ebs.second-example-local-name"]
     inline = ["echo I will never run for the second example source"]
   }
 }


### PR DESCRIPTION
This PRs passes the config flags `force`, `debug`, and `on-error` to provisioners and post-processors for hcl2 config. Also, updates some only/except hcl2 examples that were wrong. 

Closes https://github.com/hashicorp/packer/issues/10536
Closes https://github.com/hashicorp/packer/issues/10555