### PR TITLE
Fix markdown link checker issues

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -8,33 +8,6 @@
     },
     {
       "pattern": "^https://www.linode.com"
-    },
-    {
-      "pattern": "^https://github.com/hashicorp/packer-plugin-scaffolding"
-    },
-    {
-      "pattern": "^https://www.packer.io/docs/templates/hcl_templates/"
-    },
-    {
-      "pattern": "^https://packer.io/docs/templates/hcl_templates/"
-    },
-    {
-      "pattern": "^/docs/templates/hcl_templates/"
-    },
-    {
-      "pattern": "^/commands/init"
-    },
-    {
-      "pattern": "^/docs/datasources"
-    },
-    {
-      "pattern": "^/docs/extending/custom-datasources"
-    },
-    {
-      "pattern": "^/docs/templates/legacy_json_templates"
-    },
-    {
-      "pattern": "^https://packer.io/docs/templates/legacy_json_templates"
     }
   ],
   "replacementPatterns": [

--- a/website/content/docs/provisioners/salt-masterless.mdx
+++ b/website/content/docs/provisioners/salt-masterless.mdx
@@ -50,7 +50,7 @@ required element is "local_state_tree".
 Required:
 
 - `local_state_tree` (string) - The path to your local [state
-  tree](http://docs.saltstack.com/ref/states/highstate.html#the-salt-state-tree).
+  tree](http://docs.saltproject.io/en/latest/ref/states/highstate.html#the-salt-state-tree).
   This will be uploaded to the `remote_state_tree` on the remote.
 
 Optional:
@@ -67,27 +67,27 @@ Optional:
   pass `true` since `sudo` is often not pre-installed.
 
 - `remote_pillar_roots` (string) - The path to your remote [pillar
-  roots](http://docs.saltstack.com/ref/configuration/master.html#pillar-configuration).
+  roots](http://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-configuration).
   default: `/srv/pillar`. This option cannot be used with `minion_config`.
 
 - `remote_state_tree` (string) - The path to your remote [state
-  tree](http://docs.saltstack.com/ref/states/highstate.html#the-salt-state-tree).
+  tree](http://docs.saltproject.io/en/latest/ref/states/highstate.html#the-salt-state-tree).
   default: `/srv/salt`. This option cannot be used with `minion_config`.
 
 - `local_pillar_roots` (string) - The path to your local [pillar
-  roots](http://docs.saltstack.com/ref/configuration/master.html#pillar-configuration).
+  roots](http://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-configuration).
   This will be uploaded to the `remote_pillar_roots` on the remote.
 
 - `custom_state` (string) - A state to be run instead of `state.highstate`.
   Defaults to `state.highstate` if unspecified.
 
 - `minion_config` (string) - The path to your local [minion config
-  file](http://docs.saltstack.com/ref/configuration/minion.html). This will
+  file](http://docs.saltproject.io/en/latest/ref/configuration/minion.html). This will
   be uploaded to the `/etc/salt` on the remote. This option overrides the
   `remote_state_tree` or `remote_pillar_roots` options.
 
 - `grains_file` (string) - The path to your local [grains
-  file](https://docs.saltstack.com/en/latest/topics/grains). This will be
+  file](https://docs.saltproject.io/en/latest/topics/grains). This will be
   uploaded to `/etc/salt/grains` on the remote.
 
 - `skip_bootstrap` (boolean) - By default the salt provisioner runs [salt
@@ -104,7 +104,7 @@ Optional:
 
 - `salt_call_args` (string) - Additional arguments to pass directly to
   `salt-call`. See
-  [salt-call](https://docs.saltstack.com/ref/cli/salt-call.html)
+  [salt-call](https://docs.saltproject.io/en/latest/ref/cli/salt-call.html)
   documentation for more information. By default no additional arguments
   (besides the ones Packer generates) are passed to `salt-call`.
 

--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -31,17 +31,37 @@ module.exports = [
   },
   {
     source: '/docs/extend/developing-plugins',
-    destination: '/docs/extending/plugins',
+    destination: '/docs/plugins',
     permanent: true,
   },
   {
     source: '/docs/extending/developing-plugins',
-    destination: '/docs/extending/plugins',
+    destination: '/docs/plugins',
+    permanent: true,
+  },
+  {
+    source: '/docs/extending/plugins',
+    destination: '/docs/plugins',
     permanent: true,
   },
   {
     source: '/docs/extend/builder',
     destination: '/docs/extending/custom-builders',
+    permanent: true,
+  },
+  {
+    source: '/docs/extending/custom-builders',
+    destination: '/docs/plugins/creation/custom-builders',
+    permanent: true,
+  },
+  {
+    source: '/docs/extending/custom-provisioners',
+    destination: '/docs/plugins/creation/custom-provisioners',
+    permanent: true,
+  },
+  {
+    source: '/docs/extending/custom-post-processors',
+    destination: '/docs/plugins/creation/custom-post-processors',
     permanent: true,
   },
   {
@@ -82,11 +102,6 @@ module.exports = [
   {
     source: '/docs/command-line/:path*',
     destination: '/docs/commands/:path*',
-    permanent: true,
-  },
-  {
-    source: '/docs/extend/:path*',
-    destination: '/docs/extending/:path*',
     permanent: true,
   },
   {


### PR DESCRIPTION
Addresses the reported failures report on https://github.com/hashicorp/packer/runs/1835542158?check_suite_focus=true

* Update extending redirects with new page locations
* Update documentation links for SaltStack
* Remove exclusions for docs on master