### PR TITLE
Correct the spelling of heirarchical/hierarchical

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/collection/setproduct.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/setproduct.mdx
@@ -214,7 +214,7 @@ elements in the input variables.
 
 - [`contains`](/docs/templates/hcl_templates/functions/collection/contains) tests whether a given list or set contains
   a given element value.
-- [`flatten`](/docs/templates/hcl_templates/functions/collection/flatten) is useful for flattening heirarchical data
+- [`flatten`](/docs/templates/hcl_templates/functions/collection/flatten) is useful for flattening hierarchical data
   into a single list, for situations where the relationships between two
   object types are defined explicitly.
 - [`setintersection`](/docs/templates/hcl_templates/functions/collection/setintersection) computes the _intersection_ of


### PR DESCRIPTION
A follow-up to https://github.com/hashicorp/terraform/pull/27692