### PR TITLE
Fix issue when loading single plugin type `packer-provisioner-comment` built with latest SDK

### DIFF
--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -178,7 +178,6 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 	if len(externallyUsed) > 0 {
 		sort.Strings(externallyUsed)
 		log.Printf("using external datasource %v", externallyUsed)
-		externallyUsed = nil
 	}
 
 	pluginPaths, err = c.discoverSingle(filepath.Join(path, "packer-plugin-*"))

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -121,7 +121,9 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 	}
 	for pluginName, pluginPath := range pluginPaths {
 		newPath := pluginPath // this needs to be stored in a new variable for the func below
-		c.Builders.Set(pluginName, c.Client(newPath).Builder)
+		c.Builders.Set(pluginName, func() (packersdk.Builder, error) {
+			return c.Client(newPath).Builder()
+		})
 		externallyUsed = append(externallyUsed, pluginName)
 	}
 	if len(externallyUsed) > 0 {
@@ -136,7 +138,9 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 	}
 	for pluginName, pluginPath := range pluginPaths {
 		newPath := pluginPath // this needs to be stored in a new variable for the func below
-		c.PostProcessors.Set(pluginName, c.Client(newPath).PostProcessor)
+		c.PostProcessors.Set(pluginName, func() (packersdk.PostProcessor, error) {
+			return c.Client(newPath).PostProcessor()
+		})
 		externallyUsed = append(externallyUsed, pluginName)
 	}
 	if len(externallyUsed) > 0 {
@@ -151,12 +155,15 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 	}
 	for pluginName, pluginPath := range pluginPaths {
 		newPath := pluginPath // this needs to be stored in a new variable for the func below
-		c.Provisioners.Set(pluginName, c.Client(newPath).Provisioner)
+		c.Provisioners.Set(pluginName, func() (packersdk.Provisioner, error) {
+			return c.Client(newPath).Provisioner()
+		})
 		externallyUsed = append(externallyUsed, pluginName)
 	}
 	if len(externallyUsed) > 0 {
 		sort.Strings(externallyUsed)
 		log.Printf("using external provisioners %v", externallyUsed)
+		externallyUsed = nil
 	}
 
 	pluginPaths, err = c.discoverSingle(filepath.Join(path, "packer-datasource-*"))
@@ -171,6 +178,7 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 	if len(externallyUsed) > 0 {
 		sort.Strings(externallyUsed)
 		log.Printf("using external datasource %v", externallyUsed)
+		externallyUsed = nil
 	}
 
 	pluginPaths, err = c.discoverSingle(filepath.Join(path, "packer-plugin-*"))


### PR DESCRIPTION
This changes wraps the plugin client start call with an anonymous function so that Packer starts a
new plugin for each occurrence of a particular plugin block.

Before only one subprocess was being created causing subsquent calls to fail as it was trying start
an already started plugin subprocess.

```
source "null" "basic-example" {
  communicator = "none"
}

build {
  sources = ["sources.null.basic-example"]

  provisioner "comment" {
    comment     = "Begin"
    ui          = true
    bubble_text = true
  }

  provisioner "shell-local" {
    inline = ["echo \"This is a shell script\""]
  }

  provisioner "breakpoint" {}

  provisioner "comment" {
    comment = "In the middle of Provisioning run"
    ui      = true
  }

  provisioner "shell-local" {
    inline = ["echo \"This is another shell script\""]
  }

  provisioner "comment" {
    comment = "this comment is invisible and won't go to the UI"
  }

  provisioner "comment" {
    comment     = "End"
    ui          = true
    bubble_text = true
  }
}
```



Before Change
```
???????: failed loading comment: error dial unix /tmp/packer-plugin358226172: connect: no such file or directory
2021/02/05 16:09:13 On error:
2021/02/05 16:09:13 Waiting on builds to complete...

2021/02/05 16:09:13 Starting build run: null.basic-example
2021/02/05 16:09:13 Running builder:
2021/02/05 16:09:13 [INFO] (telemetry) Starting builder
  on examples/basic-example.pkr.hcl line 29:
  (source code not available)

dial unix /tmp/packer-plugin358226172: connect: no such file or directory

???????: failed loading comment: error dial unix /tmp/packer-plugin358226172: connect: no such file or directory

2021/02/05 16:09:13 packer.test plugin: [INFO] communicator disabled, will not connect
2021/02/05 16:09:13 packer.test plugin: Unable to load communicator config from state to populate provisionHookData
  on examples/basic-example.pkr.hcl line 38:
2021/02/05 16:09:13 packer.test plugin: Running the provision hook
  (source code not available)

dial unix /tmp/packer-plugin358226172: connect: no such file or directory

???????: failed loading comment: error dial unix /tmp/packer-plugin358226172: connect: no such file or directory

  on examples/basic-example.pkr.hcl line 42:
  (source code not available)

2021/02/05 16:09:13 [INFO] (telemetry) Starting provisioner comment
dial unix /tmp/packer-plugin358226172: connect: no such file or directory
```

After change
```

null.basic-example: output will be in this color.

==> null.basic-example:   ____                   _
==> null.basic-example:  | __ )    ___    __ _  (_)  _ __
==> null.basic-example:  |  _ \   / _ \  / _` | | | | '_ \
==> null.basic-example:  | |_) | |  __/ | (_| | | | | | | |
==> null.basic-example:  |____/   \___|  \__, | |_| |_| |_|
==> null.basic-example:                  |___/
==> null.basic-example:
==> null.basic-example: Running local shell script: /tmp/packer-shell646549657
    null.basic-example: This is a shell script
==> null.basic-example: Pausing at breakpoint provisioner.
==> null.basic-example: Press enter to continue.
==> null.basic-example: In the middle of Provisioning run
==> null.basic-example: Running local shell script: /tmp/packer-shell177279484
    null.basic-example: This is another shell script
==> null.basic-example:   _____               _
==> null.basic-example:  | ____|  _ __     __| |
==> null.basic-example:  |  _|   | '_ \   / _` |
==> null.basic-example:  | |___  | | | | | (_| |
==> null.basic-example:  |_____| |_| |_|  \__,_|
==> null.basic-example:
Build 'null.basic-example' finished after 1 second 32 milliseconds.

==> Wait completed after 1 second 32 milliseconds

==> Builds finished. The artifacts of successful builds are:
--> null.basic-example: Did not export anything. This is the null builder
 Please enter the commit message for your changes. Lines starting
```