### PR TITLE
Change PKR_GITHUB_API_TOKEN to PACKER_GITHUB_API_TOKEN to stay consistent

### DIFF
--- a/packer/plugin-getter/github/getter.go
+++ b/packer/plugin-getter/github/getter.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	ghTokenAccessor  = "PKR_GITHUB_API_TOKEN"
+	ghTokenAccessor  = "PACKER_GITHUB_API_TOKEN"
 	defaultUserAgent = "packer-plugin-getter"
 )
 

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -27,7 +27,7 @@ per hour one IP can
 do](https://docs.github.com/en/developers/apps/rate-limits-for-github-apps#normal-user-to-server-rate-limits).
 Packer will do its best to avoid hitting those limits and in an average local
 usage this should not be an issue. Otherwise you can set the
-`PKR_GITHUB_API_TOKEN` env var in order to get more requests per hour. Go to
+`PACKER_GITHUB_API_TOKEN` env var in order to get more requests per hour. Go to
 your personal [access token page](https://github.com/settings/tokens) to
 generate a new token.
 

--- a/website/content/docs/configure.mdx
+++ b/website/content/docs/configure.mdx
@@ -110,9 +110,9 @@ each can be found below:
 - `PACKER_CONFIG_DIR` - The location for the home directory of Packer. See
   [Packer's home directory](#packer-s-home-directory) for more.
 
-- `PKR_GITHUB_API_TOKEN` - When using Packer init on HCL2 templates, Packer
+- `PACKER_GITHUB_API_TOKEN` - When using Packer init on HCL2 templates, Packer
   queries the public API from Github which limits the ammount of queries on can
-  set the `PKR_GITHUB_API_TOKEN` with a Github Token to make it higher.
+  set the `PACKER_GITHUB_API_TOKEN` with a Github Token to make it higher.
 
 - `PACKER_LOG` - Setting this to any value other than "" (empty string) or
   "0" will enable the logger. See the [debugging


### PR DESCRIPTION
Whilst adding the `PKR_GITHUB_API_TOKEN` to the "configuring packer" env part, I realised all other env var setting started with `PACKER_`, which made the docs page look weird and inconsistent.

I really prefer pkr because it's also what's in a config file suffix but I think that for consistency this will make things better.

What do you think ?


![Screenshot 2021-02-08 at 11 40 07](https://user-images.githubusercontent.com/1024852/107208851-69a79000-6a02-11eb-8070-a17285869bef.png)
