### PR TITLE
Fix issue when loading datasource single plugin type

### DIFF
--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -172,7 +172,9 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 	}
 	for pluginName, pluginPath := range pluginPaths {
 		newPath := pluginPath // this needs to be stored in a new variable for the func below
-		c.DataSources.Set(pluginName, c.Client(newPath).Datasource)
+		c.DataSources.Set(pluginName, func() (packersdk.Datasource, error) {
+			return c.Client(newPath).Datasource()
+		})
 		externallyUsed = append(externallyUsed, pluginName)
 	}
 	if len(externallyUsed) > 0 {


### PR DESCRIPTION
Just applying the changes from https://github.com/hashicorp/packer/pull/10579 to data sources. We don't expect to have data sources in single plugins but it is better to be safe. 