### PR TITLE
Add retry strategies to oci calls

### DIFF
--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net/http"
 	"regexp"
 	"sync/atomic"
 	"time"
@@ -28,7 +29,8 @@ var retryPolicy = &common.RetryPolicy{
 	ShouldRetryOperation: func(res common.OCIOperationResponse) bool {
 		var e common.ServiceError
 		if errors.As(res.Error, &e) {
-			if e.GetHTTPStatusCode() == 429 || e.GetHTTPStatusCode() == 500 || e.GetHTTPStatusCode() == 503 {
+			switch e.GetHTTPStatusCode() {
+			case http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable:
 				return true
 			}
 		}


### PR DESCRIPTION
The oci api returns 429, among others, in case a per-user rate limit is
hit. Currently our only mechanism to deal with this is to wait 5s
between the requests that poll for image availability (and export).

With a custom retry strategy we can handle more error situations while
putting less load on the api.

