### PR TITLE
add AWS API call retries on AMIGetFilteredImage

### DIFF
--- a/builder/amazon/common/ami_filter.go
+++ b/builder/amazon/common/ami_filter.go
@@ -51,7 +51,10 @@ func (d *AmiFilterOptions) GetFilteredImage(params *ec2.DescribeImagesInput, ec2
 	}
 
 	log.Printf("Using AMI Filters %v", params)
-	imageResp, err := ec2conn.DescribeImages(params)
+	req, imageResp := ec2conn.DescribeImagesRequest(params)
+	req.RetryCount = 11
+
+	err := req.Send()
 	if err != nil {
 		err := fmt.Errorf("Error querying AMI: %s", err)
 		return nil, err


### PR DESCRIPTION
Mostly a copy paste from https://github.com/hashicorp/packer/pull/8034

Since we are using filters on our source ami's I think this is the correct place where this happens. This doesn't happen too often for us, but enough that its an annoyance.

> amazon-ebs: output will be in this color.
==> amazon-ebs: Prevalidating any provided VPC information
==> amazon-ebs: Prevalidating AMI Name: XXXXXXXXX
==> amazon-ebs: Error querying AMI: RequestLimitExceeded: Request limit exceeded.
==> amazon-ebs: 	status code: 503, request id: XXXXXXXXX
Build 'amazon-ebs' errored after 74 milliseconds 398 microseconds: Error querying AMI: RequestLimitExceeded: Request limit exceeded.
	status code: 503, request id: XXXXXXXXX
==> Wait completed after 74 milliseconds 474 microseconds
==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Error querying AMI: RequestLimitExceeded: Request limit exceeded.
	status code: 503, request id: XXXXXXXXX
==> Builds finished but no artifacts were created.