### PR TITLE
WIP Add a flag to skip the plugin requirement check on packer build

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -145,7 +145,10 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	if ret != 0 {
 		return ret
 	}
-	diags := packerStarter.Initialize(packer.InitializeOptions{})
+
+	diags := packerStarter.Initialize(packer.InitializeOptions{
+		SkipPluginRequirements: cla.SkipPluginCheck,
+	})
 	ret = writeDiags(c.Ui, nil, diags)
 	if ret != 0 {
 		return ret
@@ -388,6 +391,7 @@ Options:
   -only=foo,bar,baz             Build only the specified builds.
   -force                        Force a build to continue if artifacts exist, deletes existing artifacts.
   -machine-readable             Produce machine-readable output.
+  -skip-plugin-check            Skip check for required plugins and continue with any manually installed version of the plugins.
   -on-error=[cleanup|abort|ask|run-cleanup-provisioner] If the build fails do: clean up (default), abort, ask, or run-cleanup-provisioner.
   -parallel-builds=1            Number of builds to run in parallel. 1 disables parallelization. 0 means no limit (Default: 0)
   -timestamp-ui                 Enable prefixing of each ui output with an RFC3339 timestamp.

--- a/command/cli.go
+++ b/command/cli.go
@@ -76,6 +76,7 @@ func (ba *BuildArgs) AddFlagSets(flags *flag.FlagSet) {
 	flags.BoolVar(&ba.Force, "force", false, "")
 	flags.BoolVar(&ba.TimestampUi, "timestamp-ui", false, "")
 	flags.BoolVar(&ba.MachineReadable, "machine-readable", false, "")
+	flags.BoolVar(&ba.SkipPluginCheck, "skip-plugin-check", false, "")
 
 	flags.Int64Var(&ba.ParallelBuilds, "parallel-builds", 0, "")
 
@@ -88,9 +89,9 @@ func (ba *BuildArgs) AddFlagSets(flags *flag.FlagSet) {
 // BuildArgs represents a parsed cli line for a `packer build`
 type BuildArgs struct {
 	MetaArgs
-	Color, Debug, Force, TimestampUi, MachineReadable bool
-	ParallelBuilds                                    int64
-	OnError                                           string
+	Color, Debug, Force, TimestampUi, MachineReadable, SkipPluginCheck bool
+	ParallelBuilds                                                     int64
+	OnError                                                            string
 }
 
 func (ia *InitArgs) AddFlagSets(flags *flag.FlagSet) {

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -298,7 +298,7 @@ func (cfg *PackerConfig) Initialize(opts packer.InitializeOptions) hcl.Diagnosti
 	var diags hcl.Diagnostics
 
 	// enable packer to start plugins requested in required_plugins.
-	moreDiags := cfg.detectPluginBinaries()
+	moreDiags := cfg.detectPluginBinaries(opts.SkipPluginRequirements)
 	diags = append(diags, moreDiags...)
 	if moreDiags.HasErrors() {
 		return diags

--- a/hcl2template/plugin.go
+++ b/hcl2template/plugin.go
@@ -50,7 +50,13 @@ func (cfg *PackerConfig) PluginRequirements() (plugingetter.Requirements, hcl.Di
 	return reqs, diags
 }
 
-func (cfg *PackerConfig) detectPluginBinaries() hcl.Diagnostics {
+func (cfg *PackerConfig) detectPluginBinaries(useLocalInstallations bool) hcl.Diagnostics {
+
+	if useLocalInstallations {
+		log.Print("[DEBUG] Running with plugin detection off; continuing with currently installed plugins.")
+		return nil
+	}
+
 	opts := plugingetter.ListInstallationsOptions{
 		FromFolders: cfg.parser.PluginConfig.KnownPluginFolders,
 		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{

--- a/packer/run_interfaces.go
+++ b/packer/run_interfaces.go
@@ -32,6 +32,7 @@ type InitializeOptions struct {
 	// When set, the execution of datasources will be skipped and the datasource will provide
 	// a output spec that will be used for validation only.
 	SkipDatasourcesExecution bool
+	SkipPluginRequirements   bool
 }
 
 // The Handler handles all Packer things. This interface reflects the Packer


### PR DESCRIPTION
Marking this a WIP because I would like to discuss further the implications of this change,
and figure out if there is a different approach we should take.


This changes introduces a flat `skip-plugin-check` that when executed
with a Packer build will not execute a plugin requirements check and
continue with the locally installed versions of a plugin listed in the
required plugins block.

After change
```
~>  PACKER_LOG=1 packer.test build --skip-plugin-check docker_centos_shell_provisioner.pkr.hcl                                                    
2021/02/12 15:29:29 [INFO] Packer version: 1.7.0-dev [go1.15.2 linux amd64]                                                                       
2021/02/12 15:29:29 [DEBUG] Discovered plugin: comment = /home/wilken/.packer.d/plugins/packer-provisioner-comment                                
2021/02/12 15:29:29 using external provisioners [comment]                                                                                         
2021/02/12 15:29:29 [DEBUG] Discovered plugin: compress = /home/wilken/.packer.d/plugins/packer-plugin-compress                                   
2021/02/12 15:29:29 [DEBUG] Discovered plugin: docker = /home/wilken/.packer.d/plugins/packer-plugin-docker                                       
2021/02/12 15:29:29 [INFO] found external [-packer-default-plugin-name-] builders from docker plugin                                              
2021/02/12 15:29:29 [INFO] found external [import push save tag] post-processors from docker plugin                                               
2021/02/12 15:29:29 [INFO] found external [-packer-default-plugin-name-] post-processors from compress plugin                                     
2021/02/12 15:29:29 [INFO] PACKER_CONFIG env var not set; checking the default config file path                                                   
2021/02/12 15:29:29 [INFO] PACKER_CONFIG env var set; attempting to open config file: /home/wilken/.packerconfig                                  
2021/02/12 15:29:29 [WARN] Config file doesn't exist: /home/wilken/.packerconfig                                                                  
2021/02/12 15:29:29 [INFO] Setting cache directory: /home/wilken/Development/packer-templates/docker/packer_cache                                 
2021/02/12 15:29:29 [TRACE] validateValue: not active for source_image, so skipping                                                               
2021/02/12 15:29:29 [TRACE] validateValue: not active for username, so skipping                                                                   
2021/02/12 15:29:29 [TRACE] validateValue: not active for source_image, so skipping                                                               
2021/02/12 15:29:29 [TRACE] validateValue: not active for username, so skipping                                                                   
2021/02/12 15:29:29 [DEBUG] Running with plugin detection off; continuing with currently installed plugins.      
```

Closes #10617