### PR TITLE
Hcl2 upgrade fix

### DIFF
--- a/builder/amazon/common/step_run_source_instance.go
+++ b/builder/amazon/common/step_run_source_instance.go
@@ -258,7 +258,7 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		if resp, e := ec2conn.DescribeInstances(describeInstance); e == nil {
 			if len(resp.Reservations) > 0 && len(resp.Reservations[0].Instances) > 0 {
 				instance := resp.Reservations[0].Instances[0]
-				if instance.StateTransitionReason != nil && instance.StateReason.Message != nil {
+				if instance.StateTransitionReason != nil && instance.StateReason != nil && instance.StateReason.Message != nil {
 					ui.Error(fmt.Sprintf("Instance state change details: %s: %s",
 						*instance.StateTransitionReason, *instance.StateReason.Message))
 				}

--- a/command/hcl2_upgrade.go
+++ b/command/hcl2_upgrade.go
@@ -292,14 +292,9 @@ func transposeTemplatingCalls(s []byte) []byte {
 	}
 
 	str := &bytes.Buffer{}
-	v := struct {
-		HTTPIP   string
-		HTTPPort string
-	}{
-		HTTPIP:   "{{ .HTTPIP }}",
-		HTTPPort: "{{ .HTTPPort }}",
-	}
-	if err := tpl.Execute(str, v); err != nil {
+	// PASSTHROUGHS is a map of variable-specific golang text template fields
+	// that should remain in the text template format.
+	if err := tpl.Execute(str, PASSTHROUGHS); err != nil {
 		return fallbackReturn(err)
 	}
 
@@ -453,14 +448,9 @@ func variableTransposeTemplatingCalls(s []byte) (isLocal bool, body []byte) {
 	}
 
 	str := &bytes.Buffer{}
-	v := struct {
-		HTTPIP   string
-		HTTPPort string
-	}{
-		HTTPIP:   "{{ .HTTPIP }}",
-		HTTPPort: "{{ .HTTPPort }}",
-	}
-	if err := tpl.Execute(str, v); err != nil {
+	// PASSTHROUGHS is a map of variable-specific golang text template fields
+	// that should remain in the text template format.
+	if err := tpl.Execute(str, PASSTHROUGHS); err != nil {
 		return isLocal, fallbackReturn(err)
 	}
 
@@ -1020,4 +1010,108 @@ func (p *PostProcessorParser) Write(out *bytes.Buffer) {
 	if len(p.out) > 0 {
 		out.Write(p.out)
 	}
+}
+
+var PASSTHROUGHS = map[string]string{"NVME_Present": "{{ .NVME_Present }}",
+	"Usb_Present":                "{{ .Usb_Present }}",
+	"Serial_Type":                "{{ .Serial_Type }}",
+	"MapKey":                     "{{ .MapKey }}",
+	"HostAlias":                  "{{ .HostAlias }}",
+	"BoxName":                    "{{ .BoxName }}",
+	"Port":                       "{{ .Port }}",
+	"Header":                     "{{ .Header }}",
+	"HTTPIP":                     "{{ .HTTPIP }}",
+	"Host":                       "{{ .Host }}",
+	"PACKER_TEST_TEMP":           "{{ .PACKER_TEST_TEMP }}",
+	"SCSI_diskAdapterType":       "{{ .SCSI_diskAdapterType }}",
+	"VHDBlockSizeBytes":          "{{ .VHDBlockSizeBytes }}",
+	"Parallel_Auto":              "{{ .Parallel_Auto }}",
+	"KTyp":                       "{{ .KTyp }}",
+	"MemorySize":                 "{{ .MemorySize }}",
+	"APIURL":                     "{{ .APIURL }}",
+	"SourcePath":                 "{{ .SourcePath }}",
+	"CDROMType":                  "{{ .CDROMType }}",
+	"Parallel_Present":           "{{ .Parallel_Present }}",
+	"HTTPPort":                   "{{ .HTTPPort }}",
+	"BuildName":                  "{{ .BuildName }}",
+	"Network_Device":             "{{ .Network_Device }}",
+	"Flavor":                     "{{ .Flavor }}",
+	"Image":                      "{{ .Image }}",
+	"Os":                         "{{ .Os }}",
+	"Network_Type":               "{{ .Network_Type }}",
+	"SourceOMIName":              "{{ .SourceOMIName }}",
+	"Serial_Yield":               "{{ .Serial_Yield }}",
+	"SourceAMI":                  "{{ .SourceAMI }}",
+	"SSHHostPort":                "{{ .SSHHostPort }}",
+	"Vars":                       "{{ .Vars }}",
+	"Slice":                      "{{ .Slice }}",
+	"Version":                    "{{ .Version }}",
+	"Parallel_Bidirectional":     "{{ .Parallel_Bidirectional }}",
+	"Serial_Auto":                "{{ .Serial_Auto }}",
+	"VHDX":                       "{{ .VHDX }}",
+	"WinRMPassword":              "{{ .WinRMPassword }}",
+	"DefaultOrganizationID":      "{{ .DefaultOrganizationID }}",
+	"HTTPDir":                    "{{ .HTTPDir }}",
+	"SegmentPath":                "{{ .SegmentPath }}",
+	"NewVHDSizeBytes":            "{{ .NewVHDSizeBytes }}",
+	"CTyp":                       "{{ .CTyp }}",
+	"VMName":                     "{{ .VMName }}",
+	"Serial_Present":             "{{ .Serial_Present }}",
+	"Varname":                    "{{ .Varname }}",
+	"DiskNumber":                 "{{ .DiskNumber }}",
+	"SecondID":                   "{{ .SecondID }}",
+	"Typ":                        "{{ .Typ }}",
+	"SourceAMIName":              "{{ .SourceAMIName }}",
+	"ActiveProfile":              "{{ .ActiveProfile }}",
+	"Primitive":                  "{{ .Primitive }}",
+	"Elem":                       "{{ .Elem }}",
+	"Network_Adapter":            "{{ .Network_Adapter }}",
+	"Minor":                      "{{ .Minor }}",
+	"ProjectName":                "{{ .ProjectName }}",
+	"Generation":                 "{{ .Generation }}",
+	"User":                       "{{ .User }}",
+	"Size":                       "{{ .Size }}",
+	"Parallel_Filename":          "{{ .Parallel_Filename }}",
+	"ID":                         "{{ .ID }}",
+	"FastpathLen":                "{{ .FastpathLen }}",
+	"Tag":                        "{{ .Tag }}",
+	"Serial_Endpoint":            "{{ .Serial_Endpoint }}",
+	"GuestOS":                    "{{ .GuestOS }}",
+	"Major":                      "{{ .Major }}",
+	"Serial_Filename":            "{{ .Serial_Filename }}",
+	"Name":                       "{{ .Name }}",
+	"SourceOMI":                  "{{ .SourceOMI }}",
+	"SCSI_Present":               "{{ .SCSI_Present }}",
+	"CpuCount":                   "{{ .CpuCount }}",
+	"DefaultProjectID":           "{{ .DefaultProjectID }}",
+	"CDROMType_PrimarySecondary": "{{ .CDROMType_PrimarySecondary }}",
+	"Arch":                       "{{ .Arch }}",
+	"ImageFile":                  "{{ .ImageFile }}",
+	"SATA_Present":               "{{ .SATA_Present }}",
+	"Serial_Host":                "{{ .Serial_Host }}",
+	"BuildRegion":                "{{ .BuildRegion }}",
+	"Id":                         "{{ .Id }}",
+	"SyncedFolder":               "{{ .SyncedFolder }}",
+	"Network_Name":               "{{ .Network_Name }}",
+	"AccountID":                  "{{ .AccountID }}",
+	"OPTION":                     "{{ .OPTION }}",
+	"Type":                       "{{ .Type }}",
+	"CustomVagrantfile":          "{{ .CustomVagrantfile }}",
+	"SendTelemetry":              "{{ .SendTelemetry }}",
+	"DiskType":                   "{{ .DiskType }}",
+	"Password":                   "{{ .Password }}",
+	"HardDrivePath":              "{{ .HardDrivePath }}",
+	"ISOPath":                    "{{ .ISOPath }}",
+	"Insecure":                   "{{ .Insecure }}",
+	"Region":                     "{{ .Region }}",
+	"SecretKey":                  "{{ .SecretKey }}",
+	"DefaultRegion":              "{{ .DefaultRegion }}",
+	"MemoryStartupBytes":         "{{ .MemoryStartupBytes }}",
+	"SwitchName":                 "{{ .SwitchName }}",
+	"Path":                       "{{ .Path }}",
+	"Username":                   "{{ .Username }}",
+	"OutputDir":                  "{{ .OutputDir }}",
+	"DiskName":                   "{{ .DiskName }}",
+	"ProviderVagrantfile":        "{{ .ProviderVagrantfile }}",
+	"Sound_Present":              "{{ .Sound_Present }}",
 }


### PR DESCRIPTION
This creates a "passthrough" map of all the variable fields used in our various built-in template options. This allows hcl2_upgrade to not choke on fields that are probably correct. 

example source json: 

```
{
    "builders": [
        {
            "type": "amazon-ebs",
            "ami_name": "packer-whee",
            "force_deregister": true,
            "instance_type": "t3.nano",
            "source_ami_filter": {
              "filters": {
                "virtualization-type": "hvm",
                "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
                "root-device-type": "ebs"
              },
              "owners": ["099720109477"],
              "most_recent": true
            },
            "region": "us-west-2",
            "tags": {
              "source": "{{.SourceAMI}}"
            },
            "ssh_username": "ubuntu"
        }
    ],
  "provisioners": [
    {
        "type": "shell",
        "execute_command": "{{.Path}}",
        "script": "./script.sh",
        "remote_path": "~/script.sh"
    }
  ]
}
```
example output hcl (before):

```

data "amazon-ami" "autogenerated_1" {
  filters = {
    name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
    root-device-type    = "ebs"
    virtualization-type = "hvm"
  }
  most_recent = true
  owners      = ["099720109477"]
}

# could not parse template for following block: "template: hcl2_upgrade:10:16: executing \"hcl2_upgrade\" at <.SourceAMI>: can't evaluate field SourceAMI in type struct { HTTPIP string; HTTPPort string }"

source "amazon-ebs" "autogenerated_1" {
  ami_name         = "packer-whee"
  force_deregister = true
  instance_type    = "t3.nano"
  region           = "us-west-2"
  source_ami       = "{{ data `amazon-ami.autogenerated_1.id` }}"
  ssh_username     = "ubuntu"
  tags = {
    source = "{{.SourceAMI}}"
  }
}

build {
  sources = ["source.amazon-ebs.autogenerated_1"]


  # could not parse template for following block: "template: hcl2_upgrade:2:23: executing \"hcl2_upgrade\" at <.Path>: can't evaluate field Path in type struct { HTTPIP string; HTTPPort string }"
  provisioner "shell" {
    execute_command = "{{.Path}}"
    remote_path     = "~/script.sh"
    script          = "./script.sh"
  }

}

```

example output hcl (after):

```

data "amazon-ami" "autogenerated_1" {
  filters = {
    name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
    root-device-type    = "ebs"
    virtualization-type = "hvm"
  }
  most_recent = true
  owners      = ["099720109477"]
}

source "amazon-ebs" "autogenerated_1" {
  ami_name         = "packer-whee"
  force_deregister = true
  instance_type    = "t3.nano"
  region           = "us-west-2"
  source_ami       = "${data.amazon-ami.autogenerated_1.id}"
  ssh_username     = "ubuntu"
  tags = {
    source = "{{ .SourceAMI }}"
  }
}

build {
  sources = ["source.amazon-ebs.autogenerated_1"]

  provisioner "shell" {
    execute_command = "{{ .Path }}"
    remote_path     = "~/script.sh"
    script          = "./script.sh"
  }

}

```