### PR TITLE
[WIP] vsphere-iso bugfix invalid conf device 2 https://github.com/hashic…

### DIFF
--- a/builder/vsphere/driver/disk.go
+++ b/builder/vsphere/driver/disk.go
@@ -48,7 +48,7 @@ func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceLi
 	for _, dc := range c.Storage {
 		disk := &types.VirtualDisk{
 			VirtualDevice: types.VirtualDevice{
-				Key: existingDevices.NewKey(),
+				Key: newDevices.NewKey(),
 				Backing: &types.VirtualDiskFlatVer2BackingInfo{
 					DiskMode:        string(types.VirtualDiskModePersistent),
 					ThinProvisioned: types.NewBool(dc.DiskThinProvisioned),
@@ -58,7 +58,7 @@ func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceLi
 			CapacityInKB: dc.DiskSize * 1024,
 		}
 
-		existingDevices.AssignController(disk, controllers[dc.ControllerIndex])
+		newDevices.AssignController(disk, controllers[dc.ControllerIndex])
 		newDevices = append(newDevices, disk)
 	}
 


### PR DESCRIPTION
bug fix : for vsphere-iso builder issue : https://github.com/hashicorp/packer/issues/10430
when specifying more than one disk in the template configuration it now gives the error: Invalid configuration for device '2'

Closes 10430
