### PR TITLE
VirtualBox builder: support for "virtio" storage and ISO drive

### DIFF
--- a/builder/virtualbox/common/driver.go
+++ b/builder/virtualbox/common/driver.go
@@ -22,6 +22,9 @@ type Driver interface {
 	// Create a SCSI controller.
 	CreateSCSIController(vm string, controller string) error
 
+	// Create a VirtIO controller.
+	CreateVirtIOController(vm string, controller string) error
+
 	// Create an NVME controller
 	CreateNVMeController(vm string, controller string, portcount int) error
 

--- a/builder/virtualbox/common/driver_4_2.go
+++ b/builder/virtualbox/common/driver_4_2.go
@@ -64,12 +64,22 @@ func (d *VBox42Driver) CreateNVMeController(vmName string, name string, portcoun
 }
 
 func (d *VBox42Driver) CreateSCSIController(vmName string, name string) error {
-
 	command := []string{
 		"storagectl", vmName,
 		"--name", name,
 		"--add", "scsi",
 		"--controller", "LSILogic",
+	}
+
+	return d.VBoxManage(command...)
+}
+
+func (d *VBox42Driver) CreateVirtIOController(vmName string, name string) error {
+	command := []string{
+		"storagectl", vmName,
+		"--name", name,
+		"--add", "VirtIO",
+		"--controller", "VirtIO",
 	}
 
 	return d.VBoxManage(command...)

--- a/builder/virtualbox/common/driver_mock.go
+++ b/builder/virtualbox/common/driver_mock.go
@@ -13,6 +13,10 @@ type DriverMock struct {
 	CreateSCSIControllerController string
 	CreateSCSIControllerErr        error
 
+	CreateVirtIOControllerVM         string
+	CreateVirtIOControllerController string
+	CreateVirtIOControllerErr        error
+
 	CreateNVMeControllerVM         string
 	CreateNVMeControllerController string
 	CreateNVMeControllerErr        error
@@ -76,6 +80,12 @@ func (d *DriverMock) CreateSCSIController(vm string, controller string) error {
 	d.CreateSCSIControllerVM = vm
 	d.CreateSCSIControllerController = vm
 	return d.CreateSCSIControllerErr
+}
+
+func (d *DriverMock) CreateVirtIOController(vm string, controller string) error {
+	d.CreateVirtIOControllerVM = vm
+	d.CreateVirtIOControllerController = vm
+	return d.CreateVirtIOControllerErr
 }
 
 func (d *DriverMock) CreateNVMeController(vm string, controller string, portcount int) error {

--- a/builder/virtualbox/common/step_attach_isos.go
+++ b/builder/virtualbox/common/step_attach_isos.go
@@ -80,6 +80,10 @@ func (s *StepAttachISOs) Run(ctx context.Context, state multistep.StateBag) mult
 				controllerName = "SATA Controller"
 				port = "1"
 				device = "0"
+			} else if s.ISOInterface == "virtio" {
+				controllerName = "VirtIO Controller"
+				port = "1"
+				device = "0"
 			}
 			ui.Message("Mounting boot ISO...")
 		case "guest_additions":
@@ -88,6 +92,10 @@ func (s *StepAttachISOs) Run(ctx context.Context, state multistep.StateBag) mult
 			device = "0"
 			if s.GuestAdditionsInterface == "sata" {
 				controllerName = "SATA Controller"
+				port = "2"
+				device = "0"
+			} else if s.GuestAdditionsInterface == "virtio" {
+				controllerName = "VirtIO Controller"
 				port = "2"
 				device = "0"
 			}
@@ -100,7 +108,11 @@ func (s *StepAttachISOs) Run(ctx context.Context, state multistep.StateBag) mult
 				controllerName = "SATA Controller"
 				port = "3"
 				device = "0"
-			}
+			} else if s.ISOInterface == "virtio" {
+				controllerName = "VirtIO Controller"
+				port = "3"
+				device = "0"
+         }
 			ui.Message("Mounting cd_files ISO...")
 		}
 

--- a/builder/virtualbox/common/step_attach_isos.go
+++ b/builder/virtualbox/common/step_attach_isos.go
@@ -112,7 +112,7 @@ func (s *StepAttachISOs) Run(ctx context.Context, state multistep.StateBag) mult
 				controllerName = "VirtIO Controller"
 				port = "3"
 				device = "0"
-         }
+			}
 			ui.Message("Mounting cd_files ISO...")
 		}
 

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -62,6 +62,7 @@ type Config struct {
 	// defaults to ide. When set to sata, the drive is attached to an AHCI SATA
 	// controller. When set to scsi, the drive is attached to an LsiLogic SCSI
 	// controller. When set to pcie, the drive is attached to an NVMe
+	// controller. When set to virtio, the drive is attached to a VirtIO
 	// controller. Please note that when you use "pcie", you'll need to have
 	// Virtualbox 6, install an [extension
 	// pack](https://www.virtualbox.org/wiki/Downloads#VirtualBox6.0.14OracleVMVirtualBoxExtensionPack)
@@ -98,6 +99,7 @@ type Config struct {
 	HardDriveNonrotational bool `mapstructure:"hard_drive_nonrotational" required:"false"`
 	// The type of controller that the ISO is attached to, defaults to ide.
 	// When set to sata, the drive is attached to an AHCI SATA controller.
+	// When set to virtio, the drive is attached to a VirtIO controller.
 	ISOInterface string `mapstructure:"iso_interface" required:"false"`
 	// Set this to true if you would like to keep the VM registered with
 	// virtualbox. Defaults to false.

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -186,11 +186,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	}
 
 	switch b.config.HardDriveInterface {
-	case "ide", "sata", "scsi", "pcie":
+	case "ide", "sata", "scsi", "pcie", "virtio":
 		// do nothing
 	default:
 		errs = packersdk.MultiErrorAppend(
-			errs, errors.New("hard_drive_interface can only be ide, sata, pcie or scsi"))
+			errs, errors.New("hard_drive_interface can only be ide, sata, pcie, scsi or virtio"))
 	}
 
 	if b.config.SATAPortCount == 0 {

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -211,9 +211,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			errs, errors.New("nvme_port_count cannot be greater than 255"))
 	}
 
-	if b.config.ISOInterface != "ide" && b.config.ISOInterface != "sata" {
+	if b.config.ISOInterface != "ide" && b.config.ISOInterface != "sata" && b.config.ISOInterface != "virtio" {
 		errs = packersdk.MultiErrorAppend(
-			errs, errors.New("iso_interface can only be ide or sata"))
+			errs, errors.New("iso_interface can only be ide, sata or virtio"))
 	}
 
 	// Warnings

--- a/builder/virtualbox/iso/step_create_disk.go
+++ b/builder/virtualbox/iso/step_create_disk.go
@@ -73,6 +73,13 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
+	} else if config.HardDriveInterface == "virtio" {
+		if err := driver.CreateVirtIOController(vmName, "VirtIO Controller"); err != nil {
+			err := fmt.Errorf("Error creating disk controller: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
 	} else if config.HardDriveInterface == "pcie" {
 		if err := driver.CreateNVMeController(vmName, "NVMe Controller", config.NVMePortCount); err != nil {
 			err := fmt.Errorf("Error creating NVMe controller: %s", err)
@@ -86,13 +93,11 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	controllerName := "IDE Controller"
 	if config.HardDriveInterface == "sata" {
 		controllerName = "SATA Controller"
-	}
-
-	if config.HardDriveInterface == "scsi" {
+	} else if config.HardDriveInterface == "scsi" {
 		controllerName = "SCSI Controller"
-	}
-
-	if config.HardDriveInterface == "pcie" {
+	} else if config.HardDriveInterface == "virtio" {
+		controllerName = "VirtIO Controller"
+	} else if config.HardDriveInterface == "pcie" {
 		controllerName = "NVMe Controller"
 	}
 

--- a/builder/virtualbox/iso/step_create_disk.go
+++ b/builder/virtualbox/iso/step_create_disk.go
@@ -66,15 +66,20 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 		}
 	}
 
-	if config.HardDriveInterface == "scsi" {
-		if err := driver.CreateSCSIController(vmName, "SCSI Controller"); err != nil {
+	// Add a VirtIO controller if we were asked to use VirtIO. We still attach
+	// the VirtIO controller above because some other things (disks) require
+	// that.
+	if config.HardDriveInterface == "virtio" || config.ISOInterface == "virtio" {
+		if err := driver.CreateVirtIOController(vmName, "VirtIO Controller"); err != nil {
 			err := fmt.Errorf("Error creating disk controller: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
-	} else if config.HardDriveInterface == "virtio" {
-		if err := driver.CreateVirtIOController(vmName, "VirtIO Controller"); err != nil {
+	}
+
+	if config.HardDriveInterface == "scsi" {
+		if err := driver.CreateSCSIController(vmName, "SCSI Controller"); err != nil {
 			err := fmt.Errorf("Error creating disk controller: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())

--- a/website/content/partials/builder/virtualbox/iso/Config-not-required.mdx
+++ b/website/content/partials/builder/virtualbox/iso/Config-not-required.mdx
@@ -18,6 +18,7 @@
   defaults to ide. When set to sata, the drive is attached to an AHCI SATA
   controller. When set to scsi, the drive is attached to an LsiLogic SCSI
   controller. When set to pcie, the drive is attached to an NVMe
+  controller. When set to virtio, the drive is attached to a VirtIO
   controller. Please note that when you use "pcie", you'll need to have
   Virtualbox 6, install an [extension
   pack](https://www.virtualbox.org/wiki/Downloads#VirtualBox6.0.14OracleVMVirtualBoxExtensionPack)
@@ -53,6 +54,7 @@
 
 - `iso_interface` (string) - The type of controller that the ISO is attached to, defaults to ide.
   When set to sata, the drive is attached to an AHCI SATA controller.
+  When set to virtio, the drive is attached to a VirtIO controller.
 
 - `keep_registered` (bool) - Set this to true if you would like to keep the VM registered with
   virtualbox. Defaults to false.


### PR DESCRIPTION
The VirtualBox builder did not support "virtio" for storage and ISO drive. This pull request adds the missing support.