### PR TITLE
Fix invalid link for env function docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
     [GH-10377]
 * **New function** `env` allows users to set the default value of a variable to
     the value of an environment variable. Please see [env function
-    docs](https://www.packer.io/docs/templates/hcl_templates/functions/contextual/env") for
+    docs](https://www.packer.io/docs/templates/hcl_templates/functions/contextual/env) for
     more details. [GH-10240]
 * **Future Scaffolding** This release contains a large number of no-op
     refactoring changes. The Packer team at HashiCorp is preparing to split the


### PR DESCRIPTION
The changelog for version 1.6.6 has an invalid link for the env function docs, this fixes that.
