### PR TITLE
github/getter: Adds a hostname check to Get function

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -291,6 +291,32 @@ func TestInitCommand_Run(t *testing.T) {
 				testBuild{want: 1}.fn,
 			},
 		},
+		{
+			"unsupported-non-github-source-address",
+			[]func(t *testing.T, tc testCaseInit){
+				skipInitTestUnlessEnVar(acctest.TestEnvVar).fn,
+			},
+			testMetaFile(t),
+			nil,
+			"h1:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+			map[string]string{
+				`cfg.pkr.hcl`: `
+					packer {
+						required_plugins {
+							comment = {
+								source  = "example.com/sylviamoss/comment"
+								version = "v0.2.19"
+							}
+						}
+					}`,
+			},
+			cfg.dir("6_pkr_config"),
+			cfg.dir("6_pkr_user_folder"),
+			1,
+			nil,
+			"h1:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/packer/plugin-getter/github/getter.go
+++ b/packer/plugin-getter/github/getter.go
@@ -23,6 +23,7 @@ import (
 const (
 	ghTokenAccessor  = "PACKER_GITHUB_API_TOKEN"
 	defaultUserAgent = "packer-plugin-getter"
+	defaultHostname  = "github.com"
 )
 
 type Getter struct {
@@ -154,6 +155,11 @@ func (t *HostSpecificTokenAuthTransport) base() http.RoundTripper {
 }
 
 func (g *Getter) Get(what string, opts plugingetter.GetOptions) (io.ReadCloser, error) {
+	if opts.PluginRequirement.Identifier.Hostname != defaultHostname {
+		s := opts.PluginRequirement.Identifier.String() + " doesn't appear to be a valid " + defaultHostname + " source address; check source and try again."
+		return nil, errors.New(s)
+	}
+
 	ctx := context.TODO()
 	if g.Client == nil {
 		var tc *http.Client

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -345,7 +345,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 	getters := opts.Getters
 	fail := fmt.Errorf("could not find a local nor a remote checksum for plugin %q %q", pr.Identifier, pr.VersionConstraints)
 
-	log.Printf("[TRACE] getting available versions for the the %s plugin", pr.Identifier)
+	log.Printf("[TRACE] getting available versions for the %s plugin", pr.Identifier)
 	versions := version.Collection{}
 	for _, getter := range getters {
 


### PR DESCRIPTION
This change adds a simple hostname validation check to validate that a plugins source address is github.com before continuing with the Get call. An issue was encountered when using a hostname different from github.com, where the getter would continue to pull a plugin from GitHub even if the hostname was something like "example.com". See log details below.           
                                                                                                                                                                                                                                                                      
Before change                                                                                                                                                                                                                                                                                          
```                                                                                                                                                                                                                                                                                                    
2021/02/16 12:49:41 [TRACE] fetching checksums file for the "0.0.2" version of the example.com/hashicorp/docker plugin in                                                                                                                                                                              
"/home/wilken/.packer.d/plugins/example.com/hashicorp/docker"...                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                       
2021/02/16 12:49:41 [DEBUG] github-getter: getting "https://github.com/hashicorp/packer-plugin-docker/releases/download/v0.0.2/packer-plugin-docker_v0.0.2_SHA256SUMS"                                                                                                                                 
2021/02/16 12:49:42 [TRACE] Ignoring remote binary packer-plugin-docker_v0.0.2_x5.0_linux_arm64.zip, wrong system, expected                                                                                                                                                                            
2021/02/16 12:49:42 [TRACE] About to get: packer-plugin-docker_v0.0.2_x5.0_linux_amd64.zip                                                                                                                                                                                                             
2021/02/16 12:49:42 [DEBUG] github-getter: getting "https://github.com/hashicorp/packer-plugin-docker/releases/download/v0.0.2/packer-plugin-docker_v0.0.2_x5.0_linux_amd64.zip"                                                                                                                       
```                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                       
After change                                                                                                                                                                                                                                                                                           
```                                                                                                                                                                                                                                                                                                    
2021/02/16 13:36:32 [TRACE] for plugin example.com/hashicorp/docker found 0 matching installation(s)                                                                                                                                                                                                   
2021/02/16 13:36:32 [TRACE] getting available versions for the the example.com/hashicorp/docker plugin                                                                                                                                                                                                 
2021/02/16 13:36:32 [TRACE] &{%!q(*github.Client=<nil>) "packer-getter-github-1.7.0-dev"} getter could not get release: example.com/hashicorp/docker doesn't appear to be a valid github.com source address; check source and try again.                                                               
2021/02/16 13:36:32 [DEBUG] will try to install: []                                                                                                                                                                                                                                                    
2021/02/16 13:36:32 [INFO] (telemetry) Finalizing.  no release version found for the example.com/hashicorp/docker plugin matching the constraint(s): ">=v0.0.2"                                                                                                                                        
2021/02/16 13:36:32 waiting for all plugin processes to complete...                                                                                                                                                                                                                                    
``` 