### PR TITLE
change template parsing error to include warning about file extensions

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -126,7 +126,11 @@ func (m *Meta) GetConfigFromJSON(cla *MetaArgs) (packer.Handler, int) {
 	}
 
 	if err != nil {
-		m.Ui.Error(fmt.Sprintf("Failed to parse template: %s", err))
+		m.Ui.Error(fmt.Sprintf("Failed to parse file as legacy JSON template: "+
+			"if you are using an HCL template, check your file extensions; they "+
+			"should be either *.pkr.hcl or *.pkr.json; see the docs for more "+
+			"details: https://www.packer.io/docs/templates/hcl_templates. \n"+
+			"Original error: %s", err))
 		return nil, 1
 	}
 


### PR DESCRIPTION
Now that users are transferring to HCL templates, add message to legacy json parse error with hint about valid HCL extensions. 

Closes #10606