### PR TITLE
azure client sig fix: don't overwrite subscription id if unset

### DIFF
--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -233,7 +233,9 @@ func NewAzureClient(subscriptionID, sigSubscriptionID, resourceGroupName, storag
 	azureClient.GalleryImageVersionsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GalleryImageVersionsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImageVersionsClient.UserAgent)
 	azureClient.GalleryImageVersionsClient.Client.PollingDuration = sharedGalleryTimeout
-	azureClient.GalleryImageVersionsClient.SubscriptionID = sigSubscriptionID
+	if sigSubscriptionID != "" {
+		azureClient.GalleryImageVersionsClient.SubscriptionID = sigSubscriptionID
+	}
 
 	azureClient.GalleryImagesClient = newCompute.NewGalleryImagesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.GalleryImagesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
@@ -241,7 +243,9 @@ func NewAzureClient(subscriptionID, sigSubscriptionID, resourceGroupName, storag
 	azureClient.GalleryImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImagesClient.UserAgent)
 	azureClient.GalleryImagesClient.Client.PollingDuration = pollingDuration
-	azureClient.GalleryImagesClient.SubscriptionID = sigSubscriptionID
+	if sigSubscriptionID != "" {
+		azureClient.GalleryImagesClient.SubscriptionID = sigSubscriptionID
+	}
 
 	keyVaultURL, err := url.Parse(cloud.KeyVaultEndpoint)
 	if err != nil {


### PR DESCRIPTION
This PR addresses an issue where building up the Azure client shared image gallery subscription ID was being overwritten causing GET to fail on `packer build`.
Fixes #10428 

