### PR TITLE
fix packer interpolation of packer log path

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,10 +80,6 @@ func realMain() int {
 	defer os.Remove(logTempFile.Name())
 	defer logTempFile.Close()
 
-	// Tell the logger to log to this file
-	os.Setenv(EnvLog, "")
-	os.Setenv(EnvLogFile, "")
-
 	// Setup the prefixed readers that send data properly to
 	// stdout/stderr.
 	doneCh := make(chan struct{})


### PR DESCRIPTION
Unsetting these variables doesn't do anything except confuse the rare user who might want to interpolate the log path in their template. the panic wrapper is smart enough to behave correctly even if these values are set. 

Closes #10344