### PR TITLE
Support both role and collection installation in ansible-local provisioner

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -357,12 +357,11 @@ func (p *Provisioner) provisionPlaybookFile(ui packersdk.Ui, comm packersdk.Comm
 
 func (p *Provisioner) executeGalaxy(ui packersdk.Ui, comm packersdk.Communicator) error {
 	ctx := context.TODO()
-	rolesDir := filepath.ToSlash(filepath.Join(p.config.StagingDir, "roles"))
 	galaxyFile := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.GalaxyFile)))
 
 	// ansible-galaxy install -r requirements.yml -p roles/
-	command := fmt.Sprintf("cd %s && %s install -r %s -p %s",
-		p.config.StagingDir, p.config.GalaxyCommand, galaxyFile, rolesDir)
+	command := fmt.Sprintf("cd %s && %s install -r %s",
+		p.config.StagingDir, p.config.GalaxyCommand, galaxyFile)
 	ui.Message(fmt.Sprintf("Executing Ansible Galaxy: %s", command))
 	cmd := &packersdk.RemoteCmd{
 		Command: command,


### PR DESCRIPTION
Ansible Galaxy skips installation of collections when invoked with `-p`. Described in [this](https://github.com/ansible/ansible/pull/67843#issuecomment-629572885) upstream Ansible issue comment.
See [following bug report](https://github.com/hashicorp/packer/issues/10666) for further discussion.