### PR TITLE
Update vagrant.mdx

### DIFF
--- a/website/content/docs/builders/vagrant.mdx
+++ b/website/content/docs/builders/vagrant.mdx
@@ -183,6 +183,25 @@ build {
 </Tab>
 </Tabs>
 
+## Regarding output directory and new box
+
+After Packer completes building and provisioning a new Vagrant Box file, it is worth 
+noting that the new box file will need to be added to Vagrant. For a beginner to Packer 
+and Vagrant, it may seem as if a simple 'vagrant up' in the output directory will run the
+the newly created Box. This is not the case. 
+
+Rather, create a new directory (to avoid Vagarant init collisions), add the new 
+package.box to Vagrant and init. Then run vagrant up to bring up the new box created 
+by Packer. You will now be able to connect to the new box with provisioned changes.
+
+```
+'mkdir output2'
+'cp package.box ./output2'
+'vagrant box add new-box name-of-the-packer-box.box'
+'vagrant init new-box'
+'vagrant up'
+```
+
 ## A note on SSH connections
 
 Currently this builder only works for SSH connections, and automatically fills


### PR DESCRIPTION
Add newbie friendly reminder that just running a 'vagrant up' in the Packer Vagrant builder output directory does not run the newly built and provisioned .box file.
