### PR TITLE
fix GetConfig .pkr.json configType

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -56,6 +56,14 @@ func TestBuild(t *testing.T) {
 			fileCheck: fileCheck{expected: []string{"apple.txt"}},
 		},
 		{
+			name: "var-args: pkr json - arg sets an apple env var",
+			args: []string{
+				"-var", "fruit=apple",
+				filepath.Join(testFixture("var-arg"), "fruit_builder.pkr.json"),
+			},
+			fileCheck: fileCheck{expected: []string{"apple.txt"}},
+		},
+		{
 			name: "json - json varfile sets an apple env var, " +
 				"override with banana cli var",
 			args: []string{

--- a/command/cli.go
+++ b/command/cli.go
@@ -38,8 +38,7 @@ func (ma *MetaArgs) GetConfigType() (configType, error) {
 		// will need to add a setting that says "this is an HCL config".
 		return ma.ConfigType, nil
 	}
-	if strings.HasSuffix(name, ".pkr.hcl") ||
-		strings.HasSuffix(name, ".pkr.json") {
+	if strings.HasSuffix(name, ".pkr.hcl") {
 		return ConfigTypeHCL2, nil
 	}
 	isDir, err := isDir(name)

--- a/command/cli_test.go
+++ b/command/cli_test.go
@@ -1,0 +1,55 @@
+package command
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestCliConfigType(t *testing.T) {
+	tc := []struct {
+		args     []string
+		expected configType
+		name     string
+	}{
+		{
+			args: []string{
+				filepath.Join(testFixture("build-only"), "template.pkr.json"),
+			},
+			expected: ConfigTypeJSON,
+			name:     "configType: pkr JSON file",
+		},
+		{
+			args: []string{
+				filepath.Join(testFixture("build-only"), "template.json"),
+			},
+			expected: ConfigTypeJSON,
+			name:     "configType: JSON file",
+		},
+		{
+			args: []string{
+				filepath.Join(testFixture("build-only"), "template.pkr.hcl"),
+			},
+			expected: ConfigTypeHCL2,
+			name:     "configType: HCL2 file",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &BuildCommand{
+				Meta: testMetaFile(t),
+			}
+			cla, _ := c.ParseArgs(tt.args)
+
+			configType, err := cla.MetaArgs.GetConfigType()
+			t.Logf("cla: %v", cla)
+			if err != nil {
+				t.Errorf("Failed to get configType: %v", err)
+			}
+
+			if configType != tt.expected {
+				t.Errorf("Expected configType: %v; received: %v", ConfigTypeJSON, configType)
+			}
+		})
+	}
+}

--- a/command/test-fixtures/var-arg/fruit_builder.pkr.json
+++ b/command/test-fixtures/var-arg/fruit_builder.pkr.json
@@ -1,0 +1,20 @@
+{
+    "variables": {
+        "fruit": null
+    },
+    "builders": [
+        {
+            "communicator": "none",
+            "type": "null"
+        }
+    ],
+    "post-processors": [
+        [
+            {
+                "name": "apple",
+                "type": "shell-local",
+                "inline": [ "echo {{ user `fruit` }} > {{ user `fruit` }}.txt" ]
+            }
+        ]
+    ]
+}


### PR DESCRIPTION
Current packer state only allows *.pkr.json files for configuration. Trying to build with a `.pkr.json` config file fails because `BuildCommand.GetConfig()` tries to parse the json as HCL2. 

This PR updates `MetaArgs.GetConfigType()` to return ConfigTypeJSON from `.pkr.json` config files. Note that if path arg is a dir, this will still return ConfigTypeHCL2 by default.