### PR TITLE
Fix wrong link in post-processor docs

### DIFF
--- a/website/content/docs/templates/hcl_templates/blocks/build/post-processor.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/post-processor.mdx
@@ -89,6 +89,6 @@ about and see some examples of how to use them.
 
 ### Related
 
-- The [`post-processors` block](/docs/templates/hcl_templates/blocks/build/post-processor)
+- The [`post-processors` block](/docs/templates/hcl_templates/blocks/build/post-processors)
   allows to define one or more chain of `post-processor`s that will take the
   output from the build and provision steps.


### PR DESCRIPTION
Should be self-explanatory looking at the one-liner change.