### PR TITLE
clarify onlyexcept docs further

### DIFF
--- a/website/content/docs/commands/validate.mdx
+++ b/website/content/docs/commands/validate.mdx
@@ -33,16 +33,20 @@ Errors validating build 'vmware'. 1 error(s) occurred:
   configuration is not validated.
 
 - `-except=foo,bar,baz` - Validates all the builds except those with the
-  comma-separated names. Name is a required block label in HCL, but in legacy
-  JSON, build names default to the types of their builders (e.g. `docker` or
+  comma-separated names. In legacy JSON templates, build names default to the
+  types of their builders (e.g. `docker` or
   `amazon-ebs` or `virtualbox-iso`, unless a specific `name` attribute is
-  specified within the configuration.
+  specified within the configuration. In HCL2 templates, the "name" is the
+  source block's "name" label, unless an in-build source definition adds the
+  "name" configuration option.
 
 - `-only=foo,bar,baz` - Only validate the builds with the given comma-separated
-  names. Name is a required block label in HCL, but in legacy
-  JSON, build names default to the types of their builders (e.g. `docker` or
+  names. In legacy JSON templates, build names default to the
+  types of their builders (e.g. `docker` or
   `amazon-ebs` or `virtualbox-iso`, unless a specific `name` attribute is
-  specified within the configuration.
+  specified within the configuration. In HCL2 templates, the "name" is the
+  source block's "name" label, unless an in-build source definition adds the
+  "name" configuration option.
 
 - `-machine-readable` Sets all output to become machine-readable on stdout.
   Logging, if enabled, continues to appear on stderr.

--- a/website/content/docs/commands/validate.mdx
+++ b/website/content/docs/commands/validate.mdx
@@ -33,12 +33,16 @@ Errors validating build 'vmware'. 1 error(s) occurred:
   configuration is not validated.
 
 - `-except=foo,bar,baz` - Validates all the builds except those with the
-  comma-separated names. Build names by default are the names of their
-  builders, unless a specific `name` attribute is specified within the configuration.
+  comma-separated names. Name is a required block label in HCL, but in legacy
+  JSON, build names default to the types of their builders (e.g. `docker` or
+  `amazon-ebs` or `virtualbox-iso`, unless a specific `name` attribute is
+  specified within the configuration.
 
 - `-only=foo,bar,baz` - Only validate the builds with the given comma-separated
-  names. Build names by default are the names of their builders, unless a
-  specific `name` attribute is specified within the configuration.
+  names. Name is a required block label in HCL, but in legacy
+  JSON, build names default to the types of their builders (e.g. `docker` or
+  `amazon-ebs` or `virtualbox-iso`, unless a specific `name` attribute is
+  specified within the configuration.
 
 - `-machine-readable` Sets all output to become machine-readable on stdout.
   Logging, if enabled, continues to appear on stderr.

--- a/website/content/docs/templates/hcl_templates/onlyexcept.mdx
+++ b/website/content/docs/templates/hcl_templates/onlyexcept.mdx
@@ -25,9 +25,10 @@ build {
   sources [
     "source.amazon-ebs.first-example",
   ]
-  source "source.amazon-ebs.second-example" {
-    // setting the name field allows to rename the source only for this build
-    // section.
+  source "source.amazon-ebs.second-example"
+    // setting the name field allows you to rename the source only for this
+    // build section. To match this builder, you need to use
+    // second-example-local-name, not second-example
     name = "second-example-local-name"
   }
 
@@ -68,4 +69,4 @@ configuration:
 
 -> Note: In the cli `only` and `except` will match agains **build names** (for
 example:`my_build.amazon-ebs.first-example`) but in a provisioner they will
-match on the **source type** (for example:`source.amazon-ebs.third-example`).
+match on the **source name** (for example:`amazon-ebs.third-example`).

--- a/website/content/docs/templates/legacy_json_templates/post-processors.mdx
+++ b/website/content/docs/templates/legacy_json_templates/post-processors.mdx
@@ -169,7 +169,8 @@ option _ignores_ post-processors.
 ])
 ```
 
-The values within `only` or `except` are _build names_, not builder types. If
-you recall, build names by default are just their builder type, but if you
-specify a custom `name` parameter, then you should use that as the value
-instead of the type.
+The values within `only` or `except` are _build names_, not builder types.
+Name is a required block label in HCL, but in legacy JSON, build names default
+to the types of their builders (e.g. `docker` or `amazon-ebs` or
+`virtualbox-iso`, unless a specific `name` attribute is specified within the
+configuration.

--- a/website/content/partials/commands/except.mdx
+++ b/website/content/partials/commands/except.mdx
@@ -1,8 +1,10 @@
 - `-except=foo,bar,baz` - Run all the builds and post-processors except those
-  with the given comma-separated names. Name is a required block label in HCL,
-  but in legacy JSON, build names default to the types of their builders (e.g.
-  `docker` or `amazon-ebs` or `virtualbox-iso`, unless a specific `name`
-  attribute is specified within the configuration. Any post-processor following
+  with the given comma-separated names. In legacy JSON templates, build names default to the
+  types of their builders (e.g. `docker` or
+  `amazon-ebs` or `virtualbox-iso`, unless a specific `name` attribute is
+  specified within the configuration. In HCL2 templates, the "name" is the
+  source block's "name" label, unless an in-build source definition adds the
+  "name" configuration option.Any post-processor following
   a skipped post-processor will not run. Because post-processors can be nested
   in arrays a different post-processor chain can still run. A post-processor
   with an empty name will be ignored.

--- a/website/content/partials/commands/except.mdx
+++ b/website/content/partials/commands/except.mdx
@@ -1,7 +1,8 @@
 - `-except=foo,bar,baz` - Run all the builds and post-processors except those
-  with the given comma-separated names. Build and post-processor names by
-  default are their type, unless a specific `name` attribute is specified
-  within the configuration. Any post-processor following a skipped
-  post-processor will not run. Because post-processors can be nested in
-  arrays a different post-processor chain can still run. A post-processor
+  with the given comma-separated names. Name is a required block label in HCL,
+  but in legacy JSON, build names default to the types of their builders (e.g.
+  `docker` or `amazon-ebs` or `virtualbox-iso`, unless a specific `name`
+  attribute is specified within the configuration. Any post-processor following
+  a skipped post-processor will not run. Because post-processors can be nested
+  in arrays a different post-processor chain can still run. A post-processor
   with an empty name will be ignored.

--- a/website/content/partials/commands/only.mdx
+++ b/website/content/partials/commands/only.mdx
@@ -1,4 +1,5 @@
 - `-only=foo,bar,baz` - Only run the builds with the given comma-separated
-  names. Build names by default are their type, unless a specific `name`
-  attribute is specified within the configuration. `-only` does not apply to
-  post-processors.
+  names. Name is a required block label in HCL, but in legacy
+  JSON, build names default to the types of their builders (e.g. `docker` or
+  `amazon-ebs` or `virtualbox-iso`, unless a specific `name` attribute is
+  specified within the configuration.

--- a/website/content/partials/commands/only.mdx
+++ b/website/content/partials/commands/only.mdx
@@ -1,5 +1,7 @@
 - `-only=foo,bar,baz` - Only run the builds with the given comma-separated
-  names. Name is a required block label in HCL, but in legacy
-  JSON, build names default to the types of their builders (e.g. `docker` or
+  names. In legacy JSON templates, build names default to the
+  types of their builders (e.g. `docker` or
   `amazon-ebs` or `virtualbox-iso`, unless a specific `name` attribute is
-  specified within the configuration.
+  specified within the configuration. In HCL2 templates, the "name" is the
+  source block's "name" label, unless an in-build source definition adds the
+  "name" configuration option.


### PR DESCRIPTION
Clarify that "name" is not defaulted to type for hcl sources the way it is for JSON because you _have to_ have a name in HCL. 

Closes #10677