### PR TITLE
Added firmware option for QEMU builder

### DIFF
--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -108,6 +108,12 @@ type Config struct {
 	// The number of cpus to use when building the VM.
 	//  The default is `1` CPU.
 	CpuCount int `mapstructure:"cpus" required:"false"`
+	// The firmware file to be used by QEMU, which is to be set by the -bios
+	// option of QEMU. Particularly, this option can be set to use EFI instead
+	// of BIOS, by using "OVMF.fd" from OpenFirmware.
+	// If unset, no -bios option is passed to QEMU, using the default of QEMU.
+	// Also see the QEMU documentation.
+	Firmware string `mapstructure:"firmware" required:"false"`
 	// The interface to use for the disk. Allowed values include any of `ide`,
 	// `scsi`, `virtio` or `virtio-scsi`^\*. Note also that any boot commands
 	// or kickstart type scripts must have proper adjustments for resulting

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -98,6 +98,7 @@ type FlatConfig struct {
 	Accelerator               *string           `mapstructure:"accelerator" required:"false" cty:"accelerator" hcl:"accelerator"`
 	AdditionalDiskSize        []string          `mapstructure:"disk_additional_size" required:"false" cty:"disk_additional_size" hcl:"disk_additional_size"`
 	CpuCount                  *int              `mapstructure:"cpus" required:"false" cty:"cpus" hcl:"cpus"`
+	Firmware                  *string           `mapstructure:"firmware" required:"false" cty:"firmware" hcl:"firmware"`
 	DiskInterface             *string           `mapstructure:"disk_interface" required:"false" cty:"disk_interface" hcl:"disk_interface"`
 	DiskSize                  *string           `mapstructure:"disk_size" required:"false" cty:"disk_size" hcl:"disk_size"`
 	SkipResizeDisk            *bool             `mapstructure:"skip_resize_disk" required:"false" cty:"skip_resize_disk" hcl:"skip_resize_disk"`
@@ -231,6 +232,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"accelerator":                  &hcldec.AttrSpec{Name: "accelerator", Type: cty.String, Required: false},
 		"disk_additional_size":         &hcldec.AttrSpec{Name: "disk_additional_size", Type: cty.List(cty.String), Required: false},
 		"cpus":                         &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
+		"firmware":                     &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"disk_interface":               &hcldec.AttrSpec{Name: "disk_interface", Type: cty.String, Required: false},
 		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.String, Required: false},
 		"skip_resize_disk":             &hcldec.AttrSpec{Name: "skip_resize_disk", Type: cty.Bool, Required: false},

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -104,6 +104,11 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 			config.MachineType, config.Accelerator)
 	}
 
+	// Firmware
+	if config.Firmware != "" {
+		defaultArgs["-bios"] = config.Firmware
+	}
+
 	// Configure "-netdev" arguments
 	defaultArgs["-netdev"] = fmt.Sprintf("bridge,id=user.0,br=%s", config.NetBridge)
 	if config.NetBridge == "" {

--- a/website/content/partials/builder/qemu/Config-not-required.mdx
+++ b/website/content/partials/builder/qemu/Config-not-required.mdx
@@ -35,6 +35,12 @@
 - `cpus` (int) - The number of cpus to use when building the VM.
    The default is `1` CPU.
 
+- `firmware` (string) - The firmware file to be used by QEMU, which is to be set by the -bios
+  option of QEMU. Particularly, this option can be set to use EFI instead
+  of BIOS, by using "OVMF.fd" from OpenFirmware.
+  If unset, no -bios option is passed to QEMU, using the default of QEMU.
+  Also see the QEMU documentation.
+
 - `disk_interface` (string) - The interface to use for the disk. Allowed values include any of `ide`,
   `scsi`, `virtio` or `virtio-scsi`^\*. Note also that any boot commands
   or kickstart type scripts must have proper adjustments for resulting


### PR DESCRIPTION
Added option to specify the firmware to the QEMU builder (-bios option of QEMU). This is particularly necessary to boot with EFI instead of BIOS.