### PR TITLE
Add missing provisioner override hcl docs

### DIFF
--- a/website/content/docs/templates/hcl_templates/blocks/build/provisioner.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/provisioner.mdx
@@ -76,6 +76,66 @@ build {
 
 The values within `only` or `except` are _build names_, not builder types.
 
+## Build-Specific Overrides
+
+While the goal of Packer is to produce identical machine images, it sometimes
+requires periods of time where the machines are different before they
+eventually converge to be identical. In these cases, different configurations
+for provisioners may be necessary depending on the build. This can be done
+using build-specific overrides.
+
+An example of where this might be necessary is when building both an EC2 AMI
+and a VMware machine. The source EC2 AMI may setup a user with administrative
+privileges by default, whereas the VMware machine doesn't have these
+privileges. In this case, the shell script may need to be executed differently.
+Of course, the goal is that hopefully the shell script converges these two
+images to be identical. However, they may initially need to be run differently.
+
+This example is shown below:
+
+```hcl
+source "null" "example1" {
+  communicator = "none"
+}
+
+source "null" "example2" {
+  communicator = "none"
+}
+
+source "null" "example3" {
+  communicator = "none"
+}
+
+build {
+  sources = ["source.null.example2", "source.null.example3"]
+
+  source "source.null.example1" {
+    // Give a name to this source
+    name = "renamed"
+  }
+
+  provisioner "shell-local" {
+    inline = ["echo not overridden"]
+    override = {
+      example3 = {
+        inline = ["echo overrides for example3"]
+      }
+      // Refer to the source with the given name
+      renamed = {
+        inline = ["echo overrides for renamed"]
+      }
+    }
+  }
+}
+```
+
+As you can see, the `override` key is used. The value of this key is another
+HCL attribute map where the key is the name of a [builder
+definition](/docs/templates/hcl_templates/blocks/source). The value of this is in turn
+another HCL attribute map. This HCL attribute map simply contains the provisioner
+configuration as normal. This configuration is merged into the default
+provisioner configuration.
+
 ## On Error Provisioner
 
 You can optionally create a single specialized provisioner called an

--- a/website/content/partials/provisioners/common-config.mdx
+++ b/website/content/partials/provisioners/common-config.mdx
@@ -10,6 +10,30 @@ Parameters common to all provisioners:
 - `override` (object) - Override the builder with different settings for a
   specific builder, eg :
 
+  In HCL2:
+
+  ```hcl
+  source "null" "example1" {
+    communicator = "none"
+  }
+
+  source "null" "example2" {
+    communicator = "none"
+  }
+
+  build {
+    sources = ["source.null.example1", "source.null.example2"]
+    provisioner "shell-local" {
+      inline = ["echo not overridden"]
+      override = {
+        example1 = {
+          inline = ["echo yes overridden"]
+        }
+      }
+    }
+  }
+  ```
+
   In JSON:
 
   ```json
@@ -37,30 +61,6 @@ Parameters common to all provisioners:
         }
       }
     ]
-  }
-  ```
-
-  In HCL2:
-
-  ```hcl
-  source "null" "example1" {
-    communicator = "none"
-  }
-
-  source "null" "example2" {
-    communicator = "none"
-  }
-
-  build {
-    sources = ["source.null.example1", "source.null.example2"]
-    provisioner "shell-local" {
-      inline = ["echo not overridden"]
-      override = {
-        example1 = {
-          inline = ["echo yes overridden"]
-        }
-      }
-    }
   }
   ```
 


### PR DESCRIPTION
I noticed the `override` docs were missing from the hcl2 provisioner block. 
