### PR TITLE
WIP use io.fs instead of os 

### DIFF
--- a/builder/vsphere/common/output_config.go
+++ b/builder/vsphere/common/output_config.go
@@ -5,7 +5,7 @@ package common
 
 import (
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/hashicorp/packer-plugin-sdk/common"
@@ -27,7 +27,7 @@ type OutputConfig struct {
 	// leading zero such as "0755" in JSON file, because JSON does not support
 	// octal value. In Unix-like OS, the actual permission may differ from
 	// this value because of umask.
-	DirPerm os.FileMode `mapstructure:"directory_permission" required:"false"`
+	DirPerm fs.FileMode `mapstructure:"directory_permission" required:"false"`
 }
 
 func (c *OutputConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig) []error {
@@ -45,7 +45,7 @@ func (c *OutputConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 func (c *OutputConfig) ListFiles() ([]string, error) {
 	files := make([]string, 0, 10)
 
-	visit := func(path string, info os.FileInfo, err error) error {
+	visit := func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/builder/vsphere/common/output_config.hcl2spec.go
+++ b/builder/vsphere/common/output_config.hcl2spec.go
@@ -3,7 +3,7 @@
 package common
 
 import (
-	"os"
+	"io/fs"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
@@ -13,7 +13,7 @@ import (
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatOutputConfig struct {
 	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	DirPerm   *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 }
 
 // FlatMapstructure returns a new FlatOutputConfig.

--- a/builder/vsphere/common/step_export.hcl2spec.go
+++ b/builder/vsphere/common/step_export.hcl2spec.go
@@ -3,7 +3,7 @@
 package common
 
 import (
-	"os"
+	"io/fs"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
@@ -17,7 +17,7 @@ type FlatExportConfig struct {
 	Images    *bool        `mapstructure:"images" cty:"images" hcl:"images"`
 	Manifest  *string      `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
 	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	DirPerm   *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 	Options   []string     `mapstructure:"options" cty:"options" hcl:"options"`
 }
 


### PR DESCRIPTION
golang 1.16 changes the FileInfo etc structs to be aliases. See if we can just update it. If this fails for 1.15 we're gonna have to figure out how to support both golang versions or just pin Packer to go 1.16.