### PR TITLE
pin packer to golang 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     resource_class: medium+
   darwin:
     macos:
@@ -61,13 +61,11 @@ jobs:
           file: coverage.txt
   test-darwin:
     executor: darwin
-    working_directory: ~/go/src/github.com/hashicorp/packer
-    environment:
-      GO111MODULE: "off"
+    working_directory: ~/go/github.com/hashicorp/packer
     steps:
       - install-go-run-tests-unix:
           GOOS: darwin
-          GOVERSION: "1.15"
+          GOVERSION: "1.16"
       - codecov/upload:
           file: coverage.txt
   test-windows:
@@ -76,7 +74,7 @@ jobs:
       shell: bash.exe
     steps:
       - install-go-run-tests-windows:
-          GOVERSION: "1.15"
+          GOVERSION: "1.16"
       - codecov/upload:
           file: coverage.txt
   check-lint:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,9 @@ can quickly merge or address your contributions.
 If you have never worked with Go before, you will have to install its
 runtime in order to build packer.
 
-1. This project always releases from the latest version of golang. [Install go](https://golang.org/doc/install#install)
+1. This project always releases from the latest version of golang.
+[Install go](https://golang.org/doc/install#install) To properly build from
+source, you need to have golang >= v1.16
 
 ## Setting up Packer for dev
 
@@ -72,7 +74,6 @@ If/when you have go installed you can already `go get` packer and `make` in
 order to compile and test Packer. These instructions target
 POSIX-like environments (macOS, Linux, Cygwin, etc.) so you may need to
 adjust them for Windows or other shells.
-The instructions below are for go 1.7. or later.
 
 1. Download the Packer source (and its dependencies) by running
    `go get github.com/hashicorp/packer`. This will download the Packer source to

--- a/builder/vsphere/common/output_config.hcl2spec.go
+++ b/builder/vsphere/common/output_config.hcl2spec.go
@@ -3,7 +3,7 @@
 package common
 
 import (
-	"os"
+	"io/fs"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
@@ -13,7 +13,7 @@ import (
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatOutputConfig struct {
 	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	DirPerm   *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 }
 
 // FlatMapstructure returns a new FlatOutputConfig.

--- a/builder/vsphere/common/step_export.hcl2spec.go
+++ b/builder/vsphere/common/step_export.hcl2spec.go
@@ -3,7 +3,7 @@
 package common
 
 import (
-	"os"
+	"io/fs"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
@@ -17,7 +17,7 @@ type FlatExportConfig struct {
 	Images    *bool        `mapstructure:"images" cty:"images" hcl:"images"`
 	Manifest  *string      `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
 	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	DirPerm   *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 	Options   []string     `mapstructure:"options" cty:"options" hcl:"options"`
 }
 

--- a/command/build_cancellation_test.go
+++ b/command/build_cancellation_test.go
@@ -64,7 +64,8 @@ func TestBuildCommand_RunContext_CtxCancel(t *testing.T) {
 				defer close(codeC)
 				cfg, ret := c.ParseArgs(tt.args)
 				if ret != 0 {
-					t.Fatal("ParseArgs failed.")
+					t.Error("ParseArgs failed.")
+					return
 				}
 				codeC <- c.RunContext(ctx, cfg)
 			}()

--- a/go.mod
+++ b/go.mod
@@ -99,4 +99,4 @@ require (
 	google.golang.org/grpc v1.32.0
 )
 
-go 1.13
+go 1.16

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # cloud.google.com/go v0.66.0
+## explicit
 cloud.google.com/go
 cloud.google.com/go/compute/metadata
 cloud.google.com/go/iam
@@ -9,8 +10,10 @@ cloud.google.com/go/internal/version
 # cloud.google.com/go/storage v1.10.0
 cloud.google.com/go/storage
 # github.com/1and1/oneandone-cloudserver-sdk-go v1.0.1
+## explicit
 github.com/1and1/oneandone-cloudserver-sdk-go
 # github.com/Azure/azure-sdk-for-go v40.5.0+incompatible
+## explicit
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute
@@ -26,17 +29,23 @@ github.com/Azure/azure-sdk-for-go/version
 # github.com/Azure/go-autorest v14.2.0+incompatible
 github.com/Azure/go-autorest
 # github.com/Azure/go-autorest/autorest v0.10.0
+## explicit
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/azure
 # github.com/Azure/go-autorest/autorest/adal v0.8.2
+## explicit
 github.com/Azure/go-autorest/autorest/adal
 # github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
+## explicit
 github.com/Azure/go-autorest/autorest/azure/auth
 # github.com/Azure/go-autorest/autorest/azure/cli v0.3.1
+## explicit
 github.com/Azure/go-autorest/autorest/azure/cli
 # github.com/Azure/go-autorest/autorest/date v0.2.0
+## explicit
 github.com/Azure/go-autorest/autorest/date
 # github.com/Azure/go-autorest/autorest/to v0.3.0
+## explicit
 github.com/Azure/go-autorest/autorest/to
 # github.com/Azure/go-autorest/autorest/validation v0.3.1
 github.com/Azure/go-autorest/autorest/validation
@@ -47,6 +56,7 @@ github.com/Azure/go-autorest/tracing
 # github.com/Azure/go-ntlmssp v0.0.0-20191115201650-bad6df29494a
 github.com/Azure/go-ntlmssp
 # github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022
+## explicit
 github.com/ChrisTrenkamp/goxpath
 github.com/ChrisTrenkamp/goxpath/internal/execxp
 github.com/ChrisTrenkamp/goxpath/internal/execxp/findutil
@@ -62,16 +72,19 @@ github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlele
 github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlnode
 github.com/ChrisTrenkamp/goxpath/xconst
 # github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.0
+## explicit
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2/hmac
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server
 # github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 github.com/StackExchange/wmi
 # github.com/Telmate/proxmox-api-go v0.0.0-20200715182505-ec97c70ba887
+## explicit
 github.com/Telmate/proxmox-api-go/proxmox
 # github.com/agext/levenshtein v1.2.1
 github.com/agext/levenshtein
 # github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190418113227-25233c783f4e
+## explicit
 github.com/aliyun/alibaba-cloud-sdk-go/sdk
 github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth
 github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials
@@ -85,14 +98,17 @@ github.com/aliyun/alibaba-cloud-sdk-go/sdk/utils
 github.com/aliyun/alibaba-cloud-sdk-go/services/ecs
 github.com/aliyun/alibaba-cloud-sdk-go/services/ram
 # github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20170113022742-e6dbea820a9f
+## explicit
 github.com/aliyun/aliyun-oss-go-sdk/oss
 # github.com/antihax/optional v1.0.0
+## explicit
 github.com/antihax/optional
 # github.com/apparentlymart/go-cidr v1.0.1
 github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v12 v12.0.0
 github.com/apparentlymart/go-textseg/v12/textseg
 # github.com/approvals/go-approval-tests v0.0.0-20160714161514-ad96e53bea43
+## explicit
 github.com/approvals/go-approval-tests
 github.com/approvals/go-approval-tests/reporters
 github.com/approvals/go-approval-tests/utils
@@ -101,6 +117,7 @@ github.com/armon/go-metrics
 # github.com/armon/go-radix v1.0.0
 github.com/armon/go-radix
 # github.com/aws/aws-sdk-go v1.37.15
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -166,18 +183,23 @@ github.com/bgentry/go-netrc/netrc
 # github.com/bgentry/speakeasy v0.1.0
 github.com/bgentry/speakeasy
 # github.com/biogo/hts v0.0.0-20160420073057-50da7d4131a3
+## explicit
 github.com/biogo/hts/bgzf
 # github.com/bmatcuk/doublestar v1.1.5
 github.com/bmatcuk/doublestar
 # github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee
+## explicit
 github.com/c2h5oh/datasize
 # github.com/cheggaaa/pb v1.0.27
+## explicit
 github.com/cheggaaa/pb
 # github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+## explicit
 github.com/chzyer/readline
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
+## explicit
 github.com/dgrijalva/jwt-go
 # github.com/digitalocean/go-libvirt v0.0.0-20210112203132-25518eb2c840
 github.com/digitalocean/go-libvirt
@@ -185,31 +207,39 @@ github.com/digitalocean/go-libvirt/internal/constants
 github.com/digitalocean/go-libvirt/internal/event
 github.com/digitalocean/go-libvirt/internal/go-xdr/xdr2
 # github.com/digitalocean/go-qemu v0.0.0-20201211181942-d361e7b4965f
+## explicit
 github.com/digitalocean/go-qemu/qmp
 # github.com/digitalocean/godo v1.11.1
+## explicit
 github.com/digitalocean/godo
 # github.com/dimchansky/utfbom v1.1.0
 github.com/dimchansky/utfbom
 # github.com/dylanmei/iso8601 v0.1.0
 github.com/dylanmei/iso8601
 # github.com/exoscale/egoscale v0.18.1
+## explicit
 github.com/exoscale/egoscale
 # github.com/fatih/camelcase v1.0.0
+## explicit
 github.com/fatih/camelcase
 # github.com/fatih/color v1.9.0
 github.com/fatih/color
 # github.com/fatih/structtag v1.0.0
+## explicit
 github.com/fatih/structtag
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml
 # github.com/go-ini/ini v1.25.4
+## explicit
 github.com/go-ini/ini
 # github.com/go-ole/go-ole v1.2.5
 github.com/go-ole/go-ole
 github.com/go-ole/go-ole/oleutil
 # github.com/go-resty/resty/v2 v2.3.0
+## explicit
 github.com/go-resty/resty/v2
 # github.com/gobwas/glob v0.2.3
+## explicit
 github.com/gobwas/glob
 github.com/gobwas/glob/compiler
 github.com/gobwas/glob/match
@@ -223,6 +253,7 @@ github.com/gofrs/flock
 # github.com/gofrs/uuid v3.2.0+incompatible
 github.com/gofrs/uuid
 # github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
+## explicit
 github.com/golang-collections/collections/stack
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
@@ -241,6 +272,7 @@ github.com/golang/protobuf/ptypes/wrappers
 # github.com/golang/snappy v0.0.1
 github.com/golang/snappy
 # github.com/google/go-cmp v0.5.2
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -248,16 +280,19 @@ github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/google/go-github/v33 v33.0.1-0.20210113204525-9318e629ec69
+## explicit
 github.com/google/go-github/v33/github
 # github.com/google/go-querystring v1.0.0
 github.com/google/go-querystring/query
 # github.com/google/shlex v0.0.0-20150127133951-6f45313302b9
 github.com/google/shlex
 # github.com/google/uuid v1.1.2
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
 # github.com/gophercloud/gophercloud v0.12.0
+## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
@@ -286,25 +321,33 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/subnets
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gophercloud/utils v0.0.0-20200508015959-b0167b94122c
+## explicit
 github.com/gophercloud/utils/env
 github.com/gophercloud/utils/openstack/clientconfig
 github.com/gophercloud/utils/openstack/compute/v2/flavors
 # github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
+## explicit
 github.com/grpc-ecosystem/go-grpc-middleware
 # github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026
+## explicit
 github.com/hako/durafmt
 # github.com/hashicorp/aws-sdk-go-base v0.6.0
+## explicit
 github.com/hashicorp/aws-sdk-go-base
 github.com/hashicorp/aws-sdk-go-base/tfawserr
 # github.com/hashicorp/consul/api v1.4.0
 github.com/hashicorp/consul/api
 # github.com/hashicorp/errwrap v1.0.0
+## explicit
 github.com/hashicorp/errwrap
 # github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de
+## explicit
 github.com/hashicorp/go-checkpoint
 # github.com/hashicorp/go-cleanhttp v0.5.1
+## explicit
 github.com/hashicorp/go-cleanhttp
 # github.com/hashicorp/go-cty-funcs v0.0.0-20200930094925-2721b1e36840
+## explicit
 github.com/hashicorp/go-cty-funcs/cidr
 github.com/hashicorp/go-cty-funcs/collection
 github.com/hashicorp/go-cty-funcs/crypto
@@ -316,6 +359,7 @@ github.com/hashicorp/go-getter/gcs/v2
 # github.com/hashicorp/go-getter/s3/v2 v2.0.0-20200604122502-a6995fa1edad
 github.com/hashicorp/go-getter/s3/v2
 # github.com/hashicorp/go-getter/v2 v2.0.0-20200604122502-a6995fa1edad
+## explicit
 github.com/hashicorp/go-getter/v2
 github.com/hashicorp/go-getter/v2/helper/url
 # github.com/hashicorp/go-hclog v0.12.0
@@ -323,8 +367,10 @@ github.com/hashicorp/go-hclog
 # github.com/hashicorp/go-immutable-radix v1.1.0
 github.com/hashicorp/go-immutable-radix
 # github.com/hashicorp/go-multierror v1.1.0
+## explicit
 github.com/hashicorp/go-multierror
 # github.com/hashicorp/go-oracle-terraform v0.0.0-20181016190316-007121241b79
+## explicit
 github.com/hashicorp/go-oracle-terraform/client
 github.com/hashicorp/go-oracle-terraform/compute
 github.com/hashicorp/go-oracle-terraform/opc
@@ -337,8 +383,10 @@ github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-sockaddr v1.0.2
 github.com/hashicorp/go-sockaddr
 # github.com/hashicorp/go-uuid v1.0.2
+## explicit
 github.com/hashicorp/go-uuid
 # github.com/hashicorp/go-version v1.2.0
+## explicit
 github.com/hashicorp/go-version
 # github.com/hashicorp/golang-lru v0.5.3
 github.com/hashicorp/golang-lru/simplelru
@@ -353,6 +401,7 @@ github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/hashicorp/hcl/v2 v2.8.0
+## explicit
 github.com/hashicorp/hcl/v2
 github.com/hashicorp/hcl/v2/ext/customdecode
 github.com/hashicorp/hcl/v2/ext/dynblock
@@ -365,6 +414,7 @@ github.com/hashicorp/hcl/v2/hclsyntax
 github.com/hashicorp/hcl/v2/hclwrite
 github.com/hashicorp/hcl/v2/json
 # github.com/hashicorp/packer-plugin-sdk v0.0.14
+## explicit
 github.com/hashicorp/packer-plugin-sdk/acctest
 github.com/hashicorp/packer-plugin-sdk/acctest/provisioneracc
 github.com/hashicorp/packer-plugin-sdk/acctest/testutils
@@ -407,6 +457,7 @@ github.com/hashicorp/packer-plugin-sdk/version
 # github.com/hashicorp/serf v0.9.2
 github.com/hashicorp/serf/coordinate
 # github.com/hashicorp/vault/api v1.0.4
+## explicit
 github.com/hashicorp/vault/api
 # github.com/hashicorp/vault/sdk v0.1.13
 github.com/hashicorp/vault/sdk/helper/compressutil
@@ -418,11 +469,14 @@ github.com/hashicorp/vault/sdk/helper/strutil
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
 # github.com/hetznercloud/hcloud-go v1.15.1
+## explicit
 github.com/hetznercloud/hcloud-go/hcloud
 github.com/hetznercloud/hcloud-go/hcloud/schema
 # github.com/hyperonecom/h1-client-go v0.0.0-20191203060043-b46280e4c4a4
+## explicit
 github.com/hyperonecom/h1-client-go
 # github.com/jdcloud-api/jdcloud-sdk-go v1.9.1-0.20190605102154-3d81a50ca961
+## explicit
 github.com/jdcloud-api/jdcloud-sdk-go/core
 github.com/jdcloud-api/jdcloud-sdk-go/services/charge/models
 github.com/jdcloud-api/jdcloud-sdk-go/services/common/models
@@ -438,6 +492,7 @@ github.com/jehiah/go-strftime
 # github.com/jmespath/go-jmespath v0.4.0
 github.com/jmespath/go-jmespath
 # github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62
+## explicit
 github.com/joyent/triton-go
 github.com/joyent/triton-go/authentication
 github.com/joyent/triton-go/client
@@ -455,18 +510,21 @@ github.com/klauspost/compress/flate
 # github.com/klauspost/crc32 v1.2.0
 github.com/klauspost/crc32
 # github.com/klauspost/pgzip v0.0.0-20151221113845-47f36e165cec
+## explicit
 github.com/klauspost/pgzip
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/kr/fs v0.1.0
 github.com/kr/fs
 # github.com/linode/linodego v0.14.0
+## explicit
 github.com/linode/linodego
 github.com/linode/linodego/internal/duration
 github.com/linode/linodego/internal/parseabletime
 # github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786
 github.com/masterzen/simplexml/dom
 # github.com/masterzen/winrm v0.0.0-20201030141608-56ca5c5f2380
+## explicit
 github.com/masterzen/winrm
 github.com/masterzen/winrm/soap
 # github.com/mattn/go-colorable v0.1.6
@@ -476,29 +534,37 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 github.com/mattn/go-runewidth
 # github.com/mattn/go-tty v0.0.0-20191112051231-74040eebce08
+## explicit
 github.com/mattn/go-tty
 # github.com/mitchellh/cli v1.1.0
+## explicit
 github.com/mitchellh/cli
 # github.com/mitchellh/go-fs v0.0.0-20180402234041-7b48fa161ea7
 github.com/mitchellh/go-fs
 github.com/mitchellh/go-fs/fat
 # github.com/mitchellh/go-homedir v1.1.0
+## explicit
 github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-testing-interface v1.0.3
 github.com/mitchellh/go-testing-interface
 # github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
+## explicit
 github.com/mitchellh/go-vnc
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/iochan v1.0.0
 github.com/mitchellh/iochan
 # github.com/mitchellh/mapstructure v1.4.0
+## explicit
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/panicwrap v1.0.0
+## explicit
 github.com/mitchellh/panicwrap
 # github.com/mitchellh/prefixedio v0.0.0-20151214002211-6e6954073784
+## explicit
 github.com/mitchellh/prefixedio
 # github.com/mitchellh/reflectwalk v1.0.0
+## explicit
 github.com/mitchellh/reflectwalk
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
@@ -507,29 +573,36 @@ github.com/modern-go/reflect2
 # github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 github.com/nu7hatch/gouuid
 # github.com/olekukonko/tablewriter v0.0.0-20180105111133-96aac992fc8b
+## explicit
 github.com/olekukonko/tablewriter
 # github.com/oracle/oci-go-sdk v24.3.0+incompatible
+## explicit
 github.com/oracle/oci-go-sdk/common
 github.com/oracle/oci-go-sdk/common/auth
 github.com/oracle/oci-go-sdk/core
 # github.com/outscale/osc-sdk-go/osc v0.0.0-20200722135656-d654809d0699
+## explicit
 github.com/outscale/osc-sdk-go/osc
 # github.com/packer-community/winrmcp v0.0.0-20180921204643-0fd363d6159a
 github.com/packer-community/winrmcp/winrmcp
 # github.com/pierrec/lz4 v2.0.5+incompatible
+## explicit
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pkg/sftp v0.0.0-20160118190721-e84cc8c755ca
 github.com/pkg/sftp
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/posener/complete v1.2.3
+## explicit
 github.com/posener/complete
 github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
 # github.com/profitbricks/profitbricks-sdk-go v4.0.2+incompatible
+## explicit
 github.com/profitbricks/profitbricks-sdk-go
 # github.com/rivo/uniseg v0.1.0
 github.com/rivo/uniseg
@@ -538,6 +611,7 @@ github.com/ryanuber/go-glob
 # github.com/satori/go.uuid v1.2.0
 github.com/satori/go.uuid
 # github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7
+## explicit
 github.com/scaleway/scaleway-sdk-go/api/instance/v1
 github.com/scaleway/scaleway-sdk-go/api/marketplace/v1
 github.com/scaleway/scaleway-sdk-go/internal/async
@@ -550,6 +624,7 @@ github.com/scaleway/scaleway-sdk-go/namegenerator
 github.com/scaleway/scaleway-sdk-go/scw
 github.com/scaleway/scaleway-sdk-go/validation
 # github.com/shirou/gopsutil v2.18.12+incompatible
+## explicit
 github.com/shirou/gopsutil/cpu
 github.com/shirou/gopsutil/host
 github.com/shirou/gopsutil/internal/common
@@ -561,9 +636,11 @@ github.com/shirou/w32
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
 # github.com/stretchr/testify v1.6.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/tencentcloud/tencentcloud-sdk-go v3.0.222+incompatible
+## explicit
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/http
@@ -571,6 +648,7 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc/v20170312
 # github.com/ucloud/ucloud-sdk-go v0.16.3
+## explicit
 github.com/ucloud/ucloud-sdk-go/external
 github.com/ucloud/ucloud-sdk-go/private/protocol/http
 github.com/ucloud/ucloud-sdk-go/private/utils
@@ -588,15 +666,18 @@ github.com/ucloud/ucloud-sdk-go/ucloud/request
 github.com/ucloud/ucloud-sdk-go/ucloud/response
 github.com/ucloud/ucloud-sdk-go/ucloud/version
 # github.com/ufilesdk-dev/ufile-gosdk v0.0.0-20190830075812-b4dbc4ef43a6
+## explicit
 github.com/ufilesdk-dev/ufile-gosdk
 # github.com/ugorji/go/codec v1.2.4
 github.com/ugorji/go/codec
 # github.com/ulikunitz/xz v0.5.5
+## explicit
 github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 # github.com/vmware/govmomi v0.23.1
+## explicit
 github.com/vmware/govmomi
 github.com/vmware/govmomi/find
 github.com/vmware/govmomi/list
@@ -624,8 +705,10 @@ github.com/vmware/govmomi/vim25/soap
 github.com/vmware/govmomi/vim25/types
 github.com/vmware/govmomi/vim25/xml
 # github.com/xanzy/go-cloudstack v0.0.0-20190526095453-42f262b63ed0
+## explicit
 github.com/xanzy/go-cloudstack/cloudstack
 # github.com/yandex-cloud/go-genproto v0.0.0-20200915125933-33de72a328bd
+## explicit
 github.com/yandex-cloud/go-genproto/yandex/cloud
 github.com/yandex-cloud/go-genproto/yandex/cloud/access
 github.com/yandex-cloud/go-genproto/yandex/cloud/ai/stt/v2
@@ -662,6 +745,7 @@ github.com/yandex-cloud/go-genproto/yandex/cloud/serverless/functions/v1
 github.com/yandex-cloud/go-genproto/yandex/cloud/serverless/triggers/v1
 github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1
 # github.com/yandex-cloud/go-sdk v0.0.0-20200921111412-ef15ded2014c
+## explicit
 github.com/yandex-cloud/go-sdk
 github.com/yandex-cloud/go-sdk/dial
 github.com/yandex-cloud/go-sdk/gen/ai/stt
@@ -701,6 +785,7 @@ github.com/yandex-cloud/go-sdk/pkg/sdkerrors
 github.com/yandex-cloud/go-sdk/pkg/singleflight
 github.com/yandex-cloud/go-sdk/sdkresolvers
 # github.com/zclconf/go-cty v1.7.0
+## explicit
 github.com/zclconf/go-cty/cty
 github.com/zclconf/go-cty/cty/convert
 github.com/zclconf/go-cty/cty/function
@@ -709,6 +794,7 @@ github.com/zclconf/go-cty/cty/gocty
 github.com/zclconf/go-cty/cty/json
 github.com/zclconf/go-cty/cty/set
 # github.com/zclconf/go-cty-yaml v1.0.1
+## explicit
 github.com/zclconf/go-cty-yaml
 # go.opencensus.io v0.22.4
 go.opencensus.io
@@ -728,6 +814,7 @@ go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
 go.opencensus.io/trace/tracestate
 # golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
+## explicit
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5
@@ -755,12 +842,15 @@ golang.org/x/crypto/ssh/terminal
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/mobile v0.0.0-20201208152944-da85bec010a2
+## explicit
 golang.org/x/mobile/event/key
 # golang.org/x/mod v0.3.0
+## explicit
 golang.org/x/mod/module
 golang.org/x/mod/semver
 golang.org/x/mod/sumdb/dirhash
 # golang.org/x/net v0.0.0-20201209123823-ac852fbbde11
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/html
@@ -778,15 +868,18 @@ golang.org/x/net/publicsuffix
 golang.org/x/net/trace
 golang.org/x/net/websocket
 # golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/plan9
@@ -818,6 +911,7 @@ golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20201111133315-69daaf961d65
+## explicit
 golang.org/x/tools/cmd/goimports
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/gcexportdata
@@ -839,6 +933,7 @@ golang.org/x/tools/internal/typesinternal
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
 # google.golang.org/api v0.32.0
+## explicit
 google.golang.org/api/compute/v1
 google.golang.org/api/googleapi
 google.golang.org/api/googleapi/transport
@@ -877,6 +972,7 @@ google.golang.org/genproto/googleapis/type/expr
 google.golang.org/genproto/googleapis/type/timeofday
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.32.0
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff


### PR DESCRIPTION
code generation is failing between v1.15 and v1.16 because of some changes to the os and io/fs libs. Move Packer requirement to v1.16. 