### PR TITLE
Update index.mdx

### DIFF
--- a/website/content/docs/builders/amazon/index.mdx
+++ b/website/content/docs/builders/amazon/index.mdx
@@ -257,6 +257,17 @@ work, but specifics will depend on your use-case.
 }
 ```
 
+If using an existing instance profile with spot instances/spot pricing, the `iam:CreateServiceLinkedRole` action is also required:
+
+```json
+{
+  "Sid": "PackerIAMPassRole",
+  "Effect": "Allow",
+  "Action": ["iam:PassRole", "iam:GetInstanceProfile", "iam:CreateServiceLinkedRole"],
+  "Resource": ["*"]
+}
+```
+
 In case when you're creating a temporary instance profile you will require to have following
 IAM policies.
 


### PR DESCRIPTION
While trying to get packer to:

1. Assume a role
2. use `auto` price for spot instances
2. Assign an instance profile to the provisioned instance, I hit this error:

```
The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances.
```

Adding the `iam:CreateServiceLinkedRole` entitlement to the role that packer assumes was all I needed to do.

I didn't see the specific use case of "assumed role + spot pricing + instance profile" covered explicitly, so I opened this up.
