### PR TITLE
[provisioners/file] Fix when multiple files downloading overwrite same file

### DIFF
--- a/provisioner/file/provisioner.go
+++ b/provisioner/file/provisioner.go
@@ -138,12 +138,12 @@ func (p *Provisioner) ProvisionDownload(ui packersdk.Ui, comm packersdk.Communic
 		return fmt.Errorf("Error interpolating destination: %s", err)
 	}
 	for _, src := range p.config.Sources {
+		dst := dst
 		src, err := interpolate.Render(src, &p.config.ctx)
 		if err != nil {
 			return fmt.Errorf("Error interpolating source: %s", err)
 		}
 
-		ui.Say(fmt.Sprintf("Downloading %s => %s", src, dst))
 		// ensure destination dir exists.  p.config.Destination may either be a file or a dir.
 		dir := dst
 		// if it doesn't end with a /, set dir as the parent dir
@@ -152,6 +152,8 @@ func (p *Provisioner) ProvisionDownload(ui packersdk.Ui, comm packersdk.Communic
 		} else if !strings.HasSuffix(src, "/") && !strings.HasSuffix(src, "*") {
 			dst = filepath.Join(dst, filepath.Base(src))
 		}
+		ui.Say(fmt.Sprintf("Downloading %s => %s", src, dst))
+
 		if dir != "" {
 			err := os.MkdirAll(dir, os.FileMode(0755))
 			if err != nil {


### PR DESCRIPTION
Seems when downloading multiple files to a directory using the file provisioner, the `dst` in the outer scope gets overwritten in the first iteration of the loop with the filename, causing subsequent files to be downloaded to the same file.

```
==> amazon-ebs.autogenerated_1: Downloading /tmp/oscap_base_cve_results.xml => ./
==> amazon-ebs.autogenerated_1: Downloading /tmp/oscap_base_cve_report.html => oscap_base_cve_results.xml
==> amazon-ebs.autogenerated_1: Downloading /tmp/oscap_base_standard_results.xml => oscap_base_cve_results.xml
==> amazon-ebs.autogenerated_1: Downloading /tmp/oscap_base_standard_report.html => oscap_base_cve_results.xml
==> amazon-ebs.autogenerated_1: Downloading /tmp/oscap_base_cis_results.xml => oscap_base_cve_results.xml
==> amazon-ebs.autogenerated_1: Downloading /tmp/oscap_base_cis_report.html => oscap_base_cve_results.xml
==> amazon-ebs.autogenerated_1: Downloading /tmp/packages_base.csv => oscap_base_cve_results.xml
==> amazon-ebs.autogenerated_1: Downloading /tmp/inspec_cis_base_junit.xml => oscap_base_cve_results.xml
==> amazon-ebs.autogenerated_1: Downloading /tmp/inspec_cis_base_index.html => oscap_base_cve_results.xml
```

This PR fixes that by preventing the `dst` var in the outer-scope from being overwritten.