### PR TITLE
Fix syntax in BlockDevice JSON example

### DIFF
--- a/builder/amazon/common/block_device.go
+++ b/builder/amazon/common/block_device.go
@@ -42,7 +42,7 @@ const (
 //
 // JSON example:
 // ```json
-// launch_block_device_mappings: [
+// "launch_block_device_mappings": [
 //   {
 //      "device_name": "/dev/sda1",
 //      "encrypted": true,

--- a/website/content/partials/builder/amazon/common/BlockDevice.mdx
+++ b/website/content/partials/builder/amazon/common/BlockDevice.mdx
@@ -20,7 +20,7 @@ launch_block_device_mappings {
 
 JSON example:
 ```json
-launch_block_device_mappings: [
+"launch_block_device_mappings": [
   {
      "device_name": "/dev/sda1",
      "encrypted": true,


### PR DESCRIPTION
Keys must be quoted in JSON. Fixed syntax in BlockDevice JSON example.