### PR TITLE
Update public GCP image project as gce-uefi-images is be deprecated

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -253,7 +253,6 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		"ubuntu-os-cloud",
 		"windows-cloud",
 		"windows-sql-cloud",
-		"gce-uefi-images",
 		"gce-nvme",
 		// misc
 		"google-containers",


### PR DESCRIPTION
gce-uefi-images is being deprecated. Users should just use normal prod image projects (e.g. ubuntu-os-cloud for Ubuntu images)