### PR TITLE
Wrap more than one extra var in quotes.

### DIFF
--- a/website/content/docs/provisioners/ansible.mdx
+++ b/website/content/docs/provisioners/ansible.mdx
@@ -442,7 +442,7 @@ Platform:
         "--connection",
         "packer",
         "--extra-vars",
-        "ansible_shell_type=powershell ansible_shell_executable=None"
+        "\"ansible_shell_type=powershell ansible_shell_executable=None\""
       ]
     }
   ],


### PR DESCRIPTION
When multiple extra vars are passed the list of vars must be wrapped in "s. At least with ansible-local it will not parse correctly leading to an error stating the second extra var is a playbook file that cannot be found.

Updating docs to show that they need to be wrapped in "s. 

https://github.com/hashicorp/packer/issues/6493 lists several other issues surrounding this including some proposals to detect/fix this. You can also use multiple -e calls.

