### PR TITLE
[WIP]: Add ability to rescale instance on hcloud

### DIFF
--- a/builder/hcloud/config.go
+++ b/builder/hcloud/config.go
@@ -28,11 +28,12 @@ type Config struct {
 
 	PollInterval time.Duration `mapstructure:"poll_interval"`
 
-	ServerName  string       `mapstructure:"server_name"`
-	Location    string       `mapstructure:"location"`
-	ServerType  string       `mapstructure:"server_type"`
-	Image       string       `mapstructure:"image"`
-	ImageFilter *imageFilter `mapstructure:"image_filter"`
+	ServerName      string       `mapstructure:"server_name"`
+	Location        string       `mapstructure:"location"`
+	ServerType      string       `mapstructure:"server_type"`
+	ScaleServerType string       `mapstructure:"scale_server_type"`
+	Image           string       `mapstructure:"image"`
+	ImageFilter     *imageFilter `mapstructure:"image_filter"`
 
 	SnapshotName   string            `mapstructure:"snapshot_name"`
 	SnapshotLabels map[string]string `mapstructure:"snapshot_labels"`


### PR DESCRIPTION
This allows to build a snapshot with smallest image size (20GB) using a more powerful instance type for the actual build. The subsequently produced snapshot can then be used with all instance types on hcloud.

Note: This also removes a reboot that was required before, when using rescue previously. Instead it create the instance without starting it and only calling the start once all settings had been made