### PR TITLE
Fix for build issue (https://github.com/hashicorp/packer/issues/10740)

### DIFF
--- a/builder/vsphere/common/output_config.hcl2spec.go
+++ b/builder/vsphere/common/output_config.hcl2spec.go
@@ -3,7 +3,7 @@
 package common
 
 import (
-	"io/fs"
+	"os"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
@@ -13,7 +13,7 @@ import (
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatOutputConfig struct {
 	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm   *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 }
 
 // FlatMapstructure returns a new FlatOutputConfig.

--- a/builder/vsphere/common/step_export.hcl2spec.go
+++ b/builder/vsphere/common/step_export.hcl2spec.go
@@ -3,7 +3,7 @@
 package common
 
 import (
-	"io/fs"
+	"os"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
@@ -17,7 +17,7 @@ type FlatExportConfig struct {
 	Images    *bool        `mapstructure:"images" cty:"images" hcl:"images"`
 	Manifest  *string      `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
 	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm   *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 	Options   []string     `mapstructure:"options" cty:"options" hcl:"options"`
 }
 


### PR DESCRIPTION
Fix for build issue (https://github.com/hashicorp/packer/issues/10740): using "os" instead of "io/fs", to also work with less recent releases of Go.