### PR TITLE
actually use the partials created in code generation inside the digit…

### DIFF
--- a/website/content/docs/builders/digitalocean.mdx
+++ b/website/content/docs/builders/digitalocean.mdx
@@ -34,78 +34,13 @@ There are many configuration options available for the builder. They are
 segmented below into two categories: required and optional parameters. Within
 each category, the available configuration keys are alphabetized.
 
-### Communicator Config
-
-In addition to the builder options, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this builder.
-
-@include 'packer-plugin-sdk/communicator/Config-not-required.mdx'
-
-@include 'packer-plugin-sdk/communicator/SSH-not-required.mdx'
-
-@include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'
-
 ### Required:
 
-- `api_token` (string) - The client TOKEN to use to access your account. It
-  can also be specified via environment variable `DIGITALOCEAN_API_TOKEN`, if
-  set.
-
-- `image` (string) - The name (or slug) of the base image to use. This is the
-  image that will be used to launch a new droplet and provision it. See
-  [here](https://developers.digitalocean.com/documentation/v2/#list-all-images)
-  for details on how to get a list of the accepted image names/slugs.
-
-- `region` (string) - The name (or slug) of the region to launch the droplet
-  in. Consequently, this is the region where the snapshot will be available.
-  See [here](https://developers.digitalocean.com/documentation/v2/#list-all-regions)
-  for the accepted region names/slugs.
-
-- `size` (string) - The name (or slug) of the droplet size to use. See
-  [here](https://developers.digitalocean.com/documentation/v2/#list-all-sizes)
-  for the accepted size names/slugs.
+@include 'builder/digitalocean/Config-required.mdx'
 
 ### Optional:
 
-- `api_url` (string) - Non standard api endpoint URL. Set this if you are
-  using a DigitalOcean API compatible service. It can also be specified via
-  environment variable `DIGITALOCEAN_API_URL`.
-
-- `droplet_name` (string) - The name assigned to the droplet. DigitalOcean
-  sets the hostname of the machine to this value.
-
-- `private_networking` (boolean) - Set to `true` to enable private networking
-  for the droplet being created. This defaults to `false`, or not enabled.
-
-- `monitoring` (boolean) - Set to `true` to enable monitoring for the droplet
-  being created. This defaults to `false`, or not enabled.
-
-- `ipv6` (boolean) - Set to `true` to enable ipv6 for the droplet being
-  created. This defaults to `false`, or not enabled.
-
-- `snapshot_name` (string) - The name of the resulting snapshot that will
-  appear in your account. Defaults to `packer-{{timestamp}}` (see
-  [configuration templates](/docs/templates/legacy_json_templates/engine) for more info).
-
-- `snapshot_regions` (array of strings) - The regions of the resulting
-  snapshot that will appear in your account.
-
-- `state_timeout` (string) - The time to wait, as a duration string, for a
-  droplet to enter a desired state (such as "active") before timing out. The
-  default state timeout is "6m".
-
-- `snapshot_timeout` (string) - The time to wait, as a duration string, for a
-  snapshot action to complete (e.g snapshot creation) before timing out. The
-  default snapshot timeout is "60m".
-
-- `user_data` (string) - User data to launch with the Droplet. Packer will
-  not automatically wait for a user script to finish before shutting down the
-  instance this must be handled in a provisioner.
-
-- `user_data_file` (string) - Path to a file that will be used for the user
-  data when launching the Droplet.
-
-- `tags` (list) - Tags to apply to the droplet when it is created
+@include 'builder/digitalocean/Config-not-required.mdx'
 
 ## Basic Example
 
@@ -122,3 +57,14 @@ access tokens:
   "ssh_username": "root"
 }
 ```
+
+### Communicator Config
+
+In addition to the builder options, a
+[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this builder.
+
+@include 'packer-plugin-sdk/communicator/Config-not-required.mdx'
+
+@include 'packer-plugin-sdk/communicator/SSH-not-required.mdx'
+
+@include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'


### PR DESCRIPTION
Digitalocean builder generated partials, but partials weren't actually being used in the .mdx docs file. This meant the docs were getting out of sync with the config struct. This fixes that. 

Closes #10694 