### PR TITLE
modify logging to make overrides clearer in face of vagrant always st…

### DIFF
--- a/builder/vagrant/step_ssh_config.go
+++ b/builder/vagrant/step_ssh_config.go
@@ -41,17 +41,23 @@ func (s *StepSSHConfig) Run(ctx context.Context, state multistep.StateBag) multi
 		return multistep.ActionHalt
 	}
 
-	config.Comm.SSHHost = sshConfig.Hostname
-	port, err := strconv.Atoi(sshConfig.Port)
-	if err != nil {
-		state.Put("error", err)
-		return multistep.ActionHalt
+	if config.Comm.SSHHost == "" {
+		config.Comm.SSHHost = sshConfig.Hostname
 	}
-	config.Comm.SSHPort = port
+	if config.Comm.SSHPort == 0 {
+		port, err := strconv.Atoi(sshConfig.Port)
+		if err != nil {
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
+		config.Comm.SSHPort = port
+	}
 
 	if config.Comm.SSHUsername != "" {
 		// If user has set the username within the communicator, use the
-		// auth provided there.
+		// username, password, and/or keyfile auth provided there.
+		log.Printf("Overriding SSH config from Vagrant with the username, " +
+			"password, and private key information provided to the Packer template.")
 		return multistep.ActionContinue
 	}
 	log.Printf("identity file is %s", sshConfig.IdentityFile)

--- a/builder/vagrant/step_ssh_config_test.go
+++ b/builder/vagrant/step_ssh_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 )
 
@@ -12,6 +13,83 @@ func TestStepSSHConfig_Impl(t *testing.T) {
 	raw = new(StepSSHConfig)
 	if _, ok := raw.(multistep.Step); !ok {
 		t.Fatalf("initialize should be a step")
+	}
+}
+
+func TestPrepStepSSHConfig_sshOverrides(t *testing.T) {
+	type testcase struct {
+		name              string
+		inputSSHConfig    communicator.SSH
+		expectedSSHConfig communicator.SSH
+	}
+	tcs := []testcase{
+		{
+			// defaults to overriding with the ssh config from vagrant\
+			name:           "default",
+			inputSSHConfig: communicator.SSH{},
+			expectedSSHConfig: communicator.SSH{
+				SSHHost:     "127.0.0.1",
+				SSHPort:     2222,
+				SSHUsername: "vagrant",
+				SSHPassword: "",
+			},
+		},
+		{
+			// respects SSH host and port overrides independent of credential
+			// overrides
+			name: "host_override",
+			inputSSHConfig: communicator.SSH{
+				SSHHost: "123.45.67.8",
+				SSHPort: 1234,
+			},
+			expectedSSHConfig: communicator.SSH{
+				SSHHost:     "123.45.67.8",
+				SSHPort:     1234,
+				SSHUsername: "vagrant",
+				SSHPassword: "",
+			},
+		},
+		{
+			// respects credential overrides
+			name: "credential_override",
+			inputSSHConfig: communicator.SSH{
+				SSHUsername: "megan",
+				SSHPassword: "SoSecure",
+			},
+			expectedSSHConfig: communicator.SSH{
+				SSHHost:     "127.0.0.1",
+				SSHPort:     2222,
+				SSHUsername: "megan",
+				SSHPassword: "SoSecure",
+			},
+		},
+	}
+	for _, tc := range tcs {
+		driver := &MockVagrantDriver{}
+		config := &Config{
+			Comm: communicator.Config{
+				SSH: tc.inputSSHConfig,
+			},
+		}
+		state := new(multistep.BasicStateBag)
+		state.Put("driver", driver)
+		state.Put("config", config)
+
+		step := StepSSHConfig{}
+		_ = step.Run(context.Background(), state)
+
+		if config.Comm.SSHHost != tc.expectedSSHConfig.SSHHost {
+			t.Fatalf("unexpected sshconfig host: name: %s, recieved %s", tc.name, config.Comm.SSHHost)
+		}
+		if config.Comm.SSHPort != tc.expectedSSHConfig.SSHPort {
+			t.Fatalf("unexpected sshconfig port: name: %s, recieved %d", tc.name, config.Comm.SSHPort)
+		}
+		if config.Comm.SSHUsername != tc.expectedSSHConfig.SSHUsername {
+			t.Fatalf("unexpected sshconfig SSHUsername: name: %s, recieved %s", tc.name, config.Comm.SSHUsername)
+		}
+		if config.Comm.SSHPassword != tc.expectedSSHConfig.SSHPassword {
+			t.Fatalf("unexpected sshconfig SSHUsername: name: %s, recieved %s", tc.name, config.Comm.SSHPassword)
+		}
 	}
 }
 


### PR DESCRIPTION
Clarify messaging around vagrant ssh overrides. Make sure we respect user overrides not only of username and password, but also host and port (though I don't know why you'd want to override those)

Add tests. 

Closes #10547
