### PR TITLE
make Packer respect winrm_host flag in virtualbox connect func

### DIFF
--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -294,7 +294,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		// configure the communicator ssh, winrm
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,
-			Host:      hypervcommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
+			Host:      hypervcommon.CommHost(b.config.SSHConfig.Comm.Host()),
 			SSHConfig: b.config.SSHConfig.Comm.SSHConfigFunc(),
 		},
 

--- a/builder/hyperv/vmcx/builder.go
+++ b/builder/hyperv/vmcx/builder.go
@@ -334,7 +334,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		// configure the communicator ssh, winrm
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,
-			Host:      hypervcommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
+			Host:      hypervcommon.CommHost(b.config.SSHConfig.Comm.Host()),
 			SSHConfig: b.config.SSHConfig.Comm.SSHConfigFunc(),
 		},
 

--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -151,7 +151,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,
 			Host: CommHost(
-				b.config.RunConfig.Comm.SSHHost,
+				b.config.RunConfig.Comm.Host(),
 				computeClient,
 				b.config.SSHInterface,
 				b.config.SSHIPVersion),

--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -238,7 +238,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,
-			Host:      parallelscommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
+			Host:      parallelscommon.CommHost(b.config.SSHConfig.Comm.Host()),
 			SSHConfig: b.config.SSHConfig.Comm.SSHConfigFunc(),
 		},
 		&parallelscommon.StepUploadVersion{

--- a/builder/parallels/pvm/builder.go
+++ b/builder/parallels/pvm/builder.go
@@ -87,7 +87,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.SSHConfig.Comm,
-			Host:      parallelscommon.CommHost(b.config.SSHConfig.Comm.SSHHost),
+			Host:      parallelscommon.CommHost(b.config.SSHConfig.Comm.Host()),
 			SSHConfig: b.config.SSHConfig.Comm.SSHConfigFunc(),
 		},
 		&parallelscommon.StepUploadVersion{

--- a/builder/qemu/comm_config.go
+++ b/builder/qemu/comm_config.go
@@ -48,6 +48,7 @@ func (c *CommConfig) Prepare(ctx *interpolate.Context) (warnings []string, errs 
 
 	if c.Comm.SSHHost == "" && c.SkipNatMapping {
 		c.Comm.SSHHost = "127.0.0.1"
+		c.Comm.WinRMHost = "127.0.0.1"
 	}
 
 	if c.HostPortMin == 0 {

--- a/builder/virtualbox/common/comm_config.go
+++ b/builder/virtualbox/common/comm_config.go
@@ -50,8 +50,9 @@ func (c *CommConfig) Prepare(ctx *interpolate.Context) []error {
 		c.SkipNatMapping = c.SSHSkipNatMapping
 	}
 
-	if c.Comm.SSHHost == "" {
+	if c.Comm.Host() == "" {
 		c.Comm.SSHHost = "127.0.0.1"
+		c.Comm.WinRMHost = "127.0.0.1"
 	}
 
 	if c.HostPortMin == 0 {

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -449,7 +449,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.CommConfig.Comm,
-			Host:      vboxcommon.CommHost(b.config.CommConfig.Comm.SSHHost),
+			Host:      vboxcommon.CommHost(b.config.CommConfig.Comm.Host()),
 			SSHConfig: b.config.CommConfig.Comm.SSHConfigFunc(),
 			SSHPort:   vboxcommon.CommPort,
 			WinRMPort: vboxcommon.CommPort,

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -130,7 +130,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.CommConfig.Comm,
-			Host:      vboxcommon.CommHost(b.config.CommConfig.Comm.SSHHost),
+			Host:      vboxcommon.CommHost(b.config.CommConfig.Comm.Host()),
 			SSHConfig: b.config.CommConfig.Comm.SSHConfigFunc(),
 			SSHPort:   vboxcommon.CommPort,
 			WinRMPort: vboxcommon.CommPort,

--- a/builder/virtualbox/vm/builder.go
+++ b/builder/virtualbox/vm/builder.go
@@ -114,7 +114,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&communicator.StepConnect{
 			Config:    &b.config.CommConfig.Comm,
-			Host:      vboxcommon.CommHost(b.config.CommConfig.Comm.SSHHost),
+			Host:      vboxcommon.CommHost(b.config.CommConfig.Comm.Host()),
 			SSHConfig: b.config.CommConfig.Comm.SSHConfigFunc(),
 			SSHPort:   vboxcommon.CommPort,
 			WinRMPort: vboxcommon.CommPort,


### PR DESCRIPTION
Fix the communicator step in all remaining builders to respect winrm_host, not just ssh_host. 

Closes #6140