### PR TITLE
Fix logic for checking for KMS keys

### DIFF
--- a/builder/amazon/common/ami_config.go
+++ b/builder/amazon/common/ami_config.go
@@ -172,7 +172,7 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 
 	// Prevent sharing of default KMS key encrypted volumes with other aws users
 	if len(c.AMIUsers) > 0 {
-		if len(c.AMIKmsKeyId) == 0 && c.AMIEncryptBootVolume.True() {
+		if len(c.AMIKmsKeyId) == 0 && len(c.AMIRegionKMSKeyIDs) == 0 && c.AMIEncryptBootVolume.True() {
 			errs = append(errs, fmt.Errorf("Cannot share AMI encrypted with default KMS key"))
 		}
 		if len(c.AMIRegionKMSKeyIDs) > 0 {


### PR DESCRIPTION
Fix logic that is causing multi-region AMI builds to fail when encrypting with KMS and sharing with other accounts.

Closes #10233 
