### PR TITLE
Update urls for the bootstrap scripts used by salt-masterless provider

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -109,7 +109,7 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 		tempDir:           "C:/Windows/Temp/salt/",
 		stateRoot:         "C:/salt/state",
 		pillarRoot:        "C:/salt/pillar/",
-		bootstrapFetchCmd: "powershell Invoke-WebRequest -Uri 'https://winbootstrap.saltproject.io' -OutFile 'C:/Windows/Temp/bootstrap-salt.ps1'",
+		bootstrapFetchCmd: "powershell -Command \"[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'; Invoke-WebRequest -Uri 'https://winbootstrap.saltproject.io' -OutFile 'C:/Windows/Temp/bootstrap-salt.ps1'\"",
 		bootstrapRunCmd:   "Powershell C:/Windows/Temp/bootstrap-salt.ps1",
 	},
 }

--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -101,7 +101,7 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 		tempDir:           "/tmp/salt",
 		stateRoot:         "/srv/salt",
 		pillarRoot:        "/srv/pillar",
-		bootstrapFetchCmd: "curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh || wget -O /tmp/install_salt.sh https://bootstrap.saltstack.com",
+		bootstrapFetchCmd: "curl -L https://bootstrap.saltproject.io -o /tmp/install_salt.sh || wget -O /tmp/install_salt.sh https://bootstrap.saltproject.io",
 		bootstrapRunCmd:   "sh /tmp/install_salt.sh",
 	},
 	guestexec.WindowsOSType: {
@@ -109,7 +109,7 @@ var guestOSTypeConfigs = map[string]guestOSTypeConfig{
 		tempDir:           "C:/Windows/Temp/salt/",
 		stateRoot:         "C:/salt/state",
 		pillarRoot:        "C:/salt/pillar/",
-		bootstrapFetchCmd: "powershell Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.ps1' -OutFile 'C:/Windows/Temp/bootstrap-salt.ps1'",
+		bootstrapFetchCmd: "powershell Invoke-WebRequest -Uri 'https://winbootstrap.saltproject.io' -OutFile 'C:/Windows/Temp/bootstrap-salt.ps1'",
 		bootstrapRunCmd:   "Powershell C:/Windows/Temp/bootstrap-salt.ps1",
 	},
 }


### PR DESCRIPTION
Salt is changing its domain from saltstack.com to saltproject.io. This changes the url to reflect that change. There is also a subdomain for the Windows bootstrap script. This changes the windows bootstrap url to the shorter subdomain url.

Salt also requires Tls1.2 which is not enabled by default in powershell. This enables Tls1.2 before invoking the download.

Please include tests. Check out these examples:

- https://github.com/hashicorp/packer/blob/master/builder/virtualbox/common/ssh_config_test.go#L19-L37
- https://github.com/hashicorp/packer/blob/master/post-processor/compress/post-processor_test.go#L153-L182