### PR TITLE
Remove remote plugin docs for exoscale

### DIFF
--- a/website/content/partials/builders/community_builders.mdx
+++ b/website/content/partials/builders/community_builders.mdx
@@ -5,6 +5,8 @@
   - [packer-builder-arm-image](https://github.com/solo-io/packer-builder-arm-image) - simple builder lets you extend on existing system images.
   - [packer-builder-arm](https://github.com/mkaczanowski/packer-builder-arm) - flexible builder lets you extend or build images from scratch with variety of options (ie. custom partition table).
 
+- [Exoscale builder](https://github.com/exoscale/packer-plugin-exoscale) - A builder to create Exoscale custom templates based on a Compute instance snapshot.
+
 - [Huawei Cloud ECS builder](https://github.com/huaweicloud/packer-builder-huaweicloud-ecs) - Plugin for creating [Huawei Cloud ECS](https://www.huaweicloud.com/intl/en-us/) images.
 
 - [UpCloud builder](https://github.com/UpCloudLtd/packer-plugin-upcloud) - A suite of Packer plugins for provisioning Upcloud servers.

--- a/website/content/partials/post-processors/community_post-processors.mdx
+++ b/website/content/partials/post-processors/community_post-processors.mdx
@@ -1,2 +1,4 @@
 ### Community Post-Processors
 
+- [Exoscale Import post-processor](https://github.com/exoscale/packer-plugin-exoscale) - A post-processor to import Exoscale custom templates from disk image files.
+

--- a/website/data/docs-remote-plugins.json
+++ b/website/data/docs-remote-plugins.json
@@ -3,10 +3,5 @@
     "title": "Docker",
     "path": "docker",
     "repo": "hashicorp/packer-plugin-docker"
-  },
-  {
-    "title": "Exoscale",
-    "path":  "exoscale",
-    "repo":  "exoscale/packer-plugin-exoscale"
   }
 ]


### PR DESCRIPTION
The Exoscale team would like to hold on pulling in remote docs at this time. Instead they would like to encourage users to reference the docs from their GitHub repository as it is closer to the source of the plugins. They will revisit when the remote-plugin registry is a bit more flushed out.

Open question: 
How should we best list multi-component plugins on packer.io that have not registered their documentation with us? Maybe we create a new community supported page to list out all the plugins as opposed to having separate pages for each component. 