### PR TITLE
Fix the version parsing in ChecksumFileEntry.init() so that plugins whose name contain v's can `packer init`

### DIFF
--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -305,12 +305,12 @@ func (e ChecksumFileEntry) Arch() string        { return e.arch }
 //
 func (e *ChecksumFileEntry) init(req *Requirement) (err error) {
 	filename := e.Filename
-	res := strings.TrimLeft(filename, req.FilenamePrefix())
+	res := strings.TrimPrefix(filename, req.FilenamePrefix())
 	// res now looks like v0.2.12_x5.0_freebsd_amd64.zip
 
 	e.ext = filepath.Ext(res)
 
-	res = strings.TrimRight(res, e.ext)
+	res = strings.TrimSuffix(res, e.ext)
 	// res now looks like v0.2.12_x5.0_freebsd_amd64
 
 	parts := strings.Split(res, "_")
@@ -326,7 +326,7 @@ func (e *ChecksumFileEntry) init(req *Requirement) (err error) {
 
 func (e *ChecksumFileEntry) validate(expectedVersion string, installOpts BinaryInstallationOptions) error {
 	if e.binVersion != expectedVersion {
-		return fmt.Errorf("wrong version, expected %s ", expectedVersion)
+		return fmt.Errorf("wrong version: '%s' does not match expected %s ", e.binVersion, expectedVersion)
 	}
 	if e.os != installOpts.OS || e.arch != installOpts.ARCH {
 		return fmt.Errorf("wrong system, expected %s_%s ", installOpts.OS, installOpts.ARCH)

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -27,6 +27,28 @@ var (
 	pluginFolderWrongChecksums = filepath.Join("testdata", "wrong_checksums")
 )
 
+func TestChecksumFileEntry_init(t *testing.T) {
+	expectedVersion := "v0.3.0"
+	req := &Requirement{
+		Identifier: &addrs.Plugin{
+			Hostname:  "github.com/ddelnano/packer-plugin-xenserver",
+			Namespace: "",
+			Type:      "xenserver",
+		},
+	}
+
+	checkSum := &ChecksumFileEntry{
+		Filename: fmt.Sprintf("packer-plugin-xenserver_%s_x5.0_darwin_amd64.zip", expectedVersion),
+		Checksum: "0f5969b069b9c0a58f2d5786c422341c70dfe17bd68f896fcbd46677e8c913f1",
+	}
+
+	checkSum.init(req)
+
+	if checkSum.binVersion != expectedVersion {
+		t.Errorf("failed to parse ChecksumFileEntry properly expected version '%s' but found '%s'", expectedVersion, checkSum.binVersion)
+	}
+}
+
 func TestPlugin_ListInstallations(t *testing.T) {
 
 	type fields struct {

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -31,8 +31,8 @@ func TestChecksumFileEntry_init(t *testing.T) {
 	expectedVersion := "v0.3.0"
 	req := &Requirement{
 		Identifier: &addrs.Plugin{
-			Hostname:  "github.com/ddelnano/packer-plugin-xenserver",
-			Namespace: "",
+			Hostname:  "github.com",
+			Namespace: "ddelnano",
 			Type:      "xenserver",
 		},
 	}

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -42,7 +42,11 @@ func TestChecksumFileEntry_init(t *testing.T) {
 		Checksum: "0f5969b069b9c0a58f2d5786c422341c70dfe17bd68f896fcbd46677e8c913f1",
 	}
 
-	checkSum.init(req)
+	err := checkSum.init(req)
+
+	if err != nil {
+		t.Fatalf("ChecksumFileEntry.init failure: %v", err)
+	}
 
 	if checkSum.binVersion != expectedVersion {
 		t.Errorf("failed to parse ChecksumFileEntry properly expected version '%s' but found '%s'", expectedVersion, checkSum.binVersion)


### PR DESCRIPTION
This change addresses #10759 and allows me to get the [packer-plugin-xenserver](https://github.com/ddelnano/packer-plugin-xenserver/) (which was recently migrated to the packer-pluginsdk) working with `packer init`.

`TrimLeft` and `TrimRight` remove all leading and trailing occurrences of cutset (see [golang docs](https://golang.org/pkg/strings/#TrimLeft)). This creates problems where the packer plugin name contains a "v" because that is [passed into](https://github.com/hashicorp/packer/blob/4bbeec4733a51a0e90c4d42cc45782d4c72ce01b/packer/plugin-getter/plugins.go#L65) the "cutset" parameter and means that the leading "v" of the plugin version is stripped off on the [TrimLeft](https://github.com/hashicorp/packer/blob/4bbeec4733a51a0e90c4d42cc45782d4c72ce01b/packer/plugin-getter/plugins.go#L308). What we really want is to trim the suffix or prefix.

## Testing
- [x] Included a unit test for this change. I tried to avoid testing the private `init` function direclty but the other tests have a bunch of plugin files checked into the repo so that seemed like too much work for testing this simple logic
- [x] Verified that building packer from this branch fixes the issue reported in #10759
```
# See that I'm on this branch
ddelnano@ddelnano-desktop:~/code/packer$ git log --name-status HEAD^..HEAD
commit 2f28a9c34cad4f56490d9e65e05a99bb822892f4 (HEAD -> fix-packer-init-for-plugins-with-v-in-name, origin/fix-packer-init-for-plugins-with-v-in-name)
Author: Dom Del Nano <ddelnano@gmail.com>
Date:   Fri Mar 12 23:24:42 2021 -0800

    Fix the version parsing in ChecksumFileEntry.init() so that plugins whose name contains a 'v' work with packer init

M       packer/plugin-getter/plugins.go
M       packer/plugin-getter/plugins_test.go

# compile packer with this change
ddelnano@ddelnano-desktop:~/code/packer$ go build -o bin/packer

# See that packer successfully install the plugin
ddelnano@ddelnano-desktop:~/code/packer$  ./bin/packer init test.pkr.hcl
Installed plugin github.com/ddelnano/xenserver v0.3.0 in "/home/ddelnano/.packer.d/plugins/github.com/ddelnano/xenserver/packer-plugin-xenserver_v0.3.0_x5.0_linux_amd64"
```
- [x] See that packer 1.7 is unable to install the xenserver v0.3.0 plugin installed in the previous step
```
ddelnano@ddelnano-desktop:~/code/packer$ /usr/local/bin/packer1.7 version
Packer v1.7.0
ddelnano@ddelnano-desktop:~/code/packer$ /usr/local/bin/packer1.7 init test.pkr.hcl
could not find a local nor a remote checksum for plugin "github.com/ddelnano/xenserver" ">= 0.3.0"

``` 

Closes #10759
