### PR TITLE
Simplify error message when config file can't be "stat'd"

### DIFF
--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -90,6 +90,11 @@ func (p *Parser) Parse(filename string, varFiles []string, argVars map[string]st
 	if filename != "" {
 		hclFiles, jsonFiles, moreDiags := GetHCL2Files(filename, hcl2FileExt, hcl2JsonFileExt)
 		diags = append(diags, moreDiags...)
+		if moreDiags.HasErrors() {
+			// here this probably means that the file was not found, let's
+			// simply leave early.
+			return nil, diags
+		}
 		if len(hclFiles)+len(jsonFiles) == 0 {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,

--- a/hcl2template/utils.go
+++ b/hcl2template/utils.go
@@ -57,7 +57,6 @@ func GetHCL2Files(filename, hclSuffix, jsonSuffix string) (hclFiles, jsonFiles [
 	if err != nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Cannot tell wether " + filename + " is a directory",
 			Detail:   err.Error(),
 		})
 		return nil, nil, diags


### PR DESCRIPTION
Simplify error management when a file doesn't exist. From:

```shell-session
❯ packerdev build nope.pkr.hcl
Error: 

stat nope.pkr.hcl: no such file or directory

Error: Could not find any config file in nope.pkr.hcl

A config file must be suffixed with `.pkr.hcl` or `.pkr.json`. A folder can be
referenced.


exit status 1
```

To:
```shell-session
❯ packerdev build nope.pkr.hcl
Error: 

stat nope.pkr.hcl: no such file or directory

exit status 1
```