### PR TITLE
Support for ansible collections in local ansible provisioner

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -80,13 +80,13 @@ type Config struct {
 	//  `false`.
 	GalaxyForceInstall bool `mapstructure:"galaxy_force_install"`
 
-	// The path to the directory on your local system in which to
+	// The path to the directory on the remote system in which to
 	//   install the roles. Adds `--roles-path /path/to/your/roles` to
 	//   `ansible-galaxy` command. By default, this will install to a 'galaxy_roles' subfolder in the
 	//   staging/roles directory.
 	GalaxyRolesPath string `mapstructure:"galaxy_roles_path"`
 
-	// The path to the directory on your local system in which to
+	// The path to the directory on the remote system in which to
 	//   install the collections. Adds `--collections-path /path/to/your/collections` to
 	//   `ansible-galaxy` command. By default, this will install to a 'galaxy_collections' subfolder in the
 	//   staging/collections directory.

--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -5,8 +5,10 @@ package ansiblelocal
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
@@ -51,6 +53,9 @@ type Config struct {
 	// An array of local paths of roles to upload.
 	RolePaths []string `mapstructure:"role_paths"`
 
+	// An array of local paths of collections to upload.
+	CollectionPaths []string `mapstructure:"collection_paths"`
+
 	// The directory where files will be uploaded. Packer requires write
 	// permissions in this directory.
 	StagingDir string `mapstructure:"staging_directory"`
@@ -69,6 +74,23 @@ type Config struct {
 
 	// The command to run ansible-galaxy
 	GalaxyCommand string `mapstructure:"galaxy_command"`
+
+	// Force overwriting an existing role.
+	//  Adds `--force` option to `ansible-galaxy` command. By default, this is
+	//  `false`.
+	GalaxyForceInstall bool `mapstructure:"galaxy_force_install"`
+
+	// The path to the directory on your local system in which to
+	//   install the roles. Adds `--roles-path /path/to/your/roles` to
+	//   `ansible-galaxy` command. By default, this will install to a 'galaxy_roles' subfolder in the
+	//   staging/roles directory.
+	GalaxyRolesPath string `mapstructure:"galaxy_roles_path"`
+
+	// The path to the directory on your local system in which to
+	//   install the collections. Adds `--collections-path /path/to/your/collections` to
+	//   `ansible-galaxy` command. By default, this will install to a 'galaxy_collections' subfolder in the
+	//   staging/collections directory.
+	GalaxyCollectionsPath string `mapstructure:"galaxy_collections_path"`
 }
 
 type Provisioner struct {
@@ -106,6 +128,14 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if p.config.StagingDir == "" {
 		p.config.StagingDir = filepath.ToSlash(filepath.Join(DefaultStagingDir, uuid.TimeOrderedUUID()))
+	}
+
+	if p.config.GalaxyRolesPath == "" {
+		p.config.GalaxyRolesPath = filepath.ToSlash(filepath.Join(p.config.StagingDir, "galaxy_roles"))
+	}
+
+	if p.config.GalaxyCollectionsPath == "" {
+		p.config.GalaxyCollectionsPath = filepath.ToSlash(filepath.Join(p.config.StagingDir, "galaxy_collections"))
 	}
 
 	// Validation
@@ -183,6 +213,11 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 	for _, path := range p.config.RolePaths {
 		if err := validateDirConfig(path, "role_paths"); err != nil {
+			errs = packersdk.MultiErrorAppend(errs, err)
+		}
+	}
+	for _, path := range p.config.CollectionPaths {
+		if err := validateDirConfig(path, "collection_paths"); err != nil {
 			errs = packersdk.MultiErrorAppend(errs, err)
 		}
 	}
@@ -290,6 +325,16 @@ func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 		}
 	}
 
+	if len(p.config.CollectionPaths) > 0 {
+		ui.Message("Uploading collection directories...")
+		for _, src := range p.config.CollectionPaths {
+			dst := filepath.ToSlash(filepath.Join(p.config.StagingDir, "collections", filepath.Base(src)))
+			if err := p.uploadDir(ui, comm, dst, src); err != nil {
+				return fmt.Errorf("Error uploading collections: %s", err)
+			}
+		}
+	}
+
 	if len(p.config.PlaybookPaths) > 0 {
 		ui.Message("Uploading additional Playbooks...")
 		playbookDir := filepath.ToSlash(filepath.Join(p.config.StagingDir, "playbooks"))
@@ -356,14 +401,53 @@ func (p *Provisioner) provisionPlaybookFile(ui packersdk.Ui, comm packersdk.Comm
 }
 
 func (p *Provisioner) executeGalaxy(ui packersdk.Ui, comm packersdk.Communicator) error {
-	ctx := context.TODO()
-	rolesDir := filepath.ToSlash(filepath.Join(p.config.StagingDir, "roles"))
 	galaxyFile := filepath.ToSlash(filepath.Join(p.config.StagingDir, filepath.Base(p.config.GalaxyFile)))
 
-	// ansible-galaxy install -r requirements.yml -p roles/
-	command := fmt.Sprintf("cd %s && %s install -r %s -p %s",
-		p.config.StagingDir, p.config.GalaxyCommand, galaxyFile, rolesDir)
+	// ansible-galaxy install -r requirements.yml
+	roleArgs := []string{"install", "-r", galaxyFile, "-p", filepath.ToSlash(p.config.GalaxyRolesPath)}
+
+	// Instead of modifying args depending on config values and removing or modifying values from
+	// the slice between role and collection installs, just use 2 slices and simplify everything
+	collectionArgs := []string{"collection", "install", "-r", galaxyFile, "-p", filepath.ToSlash(p.config.GalaxyCollectionsPath)}
+
+	// Add force to arguments
+	if p.config.GalaxyForceInstall {
+		roleArgs = append(roleArgs, "-f")
+		collectionArgs = append(collectionArgs, "-f")
+	}
+
+	// Search galaxy_file for roles and collections keywords
+	f, err := ioutil.ReadFile(p.config.GalaxyFile)
+	if err != nil {
+		return err
+	}
+	hasRoles, _ := regexp.Match(`(?m)^roles:`, f)
+	hasCollections, _ := regexp.Match(`(?m)^collections:`, f)
+
+	// If if roles keyword present (v2 format), or no collections keyword present (v1), install roles
+	if hasRoles || !hasCollections {
+		if roleInstallError := p.invokeGalaxyCommand(roleArgs, ui, comm); roleInstallError != nil {
+			return roleInstallError
+		}
+	}
+
+	// If collections keyword present (v2 format), install collections
+	if hasCollections {
+		if collectionInstallError := p.invokeGalaxyCommand(collectionArgs, ui, comm); collectionInstallError != nil {
+			return collectionInstallError
+		}
+	}
+
+	return nil
+}
+
+// Intended to be invoked from p.executeGalaxy depending on the Ansible Galaxy parameters passed to Packer
+func (p *Provisioner) invokeGalaxyCommand(args []string, ui packersdk.Ui, comm packersdk.Communicator) error {
+	ctx := context.TODO()
+	command := fmt.Sprintf("cd %s && %s %s",
+		p.config.StagingDir, p.config.GalaxyCommand, strings.Join(args, " "))
 	ui.Message(fmt.Sprintf("Executing Ansible Galaxy: %s", command))
+
 	cmd := &packersdk.RemoteCmd{
 		Command: command,
 	}
@@ -413,8 +497,43 @@ func (p *Provisioner) executeAnsiblePlaybook(
 	ui packersdk.Ui, comm packersdk.Communicator, playbookFile, extraArgs, inventory string,
 ) error {
 	ctx := context.TODO()
-	command := fmt.Sprintf("cd %s && %s %s%s -c local -i %s",
-		p.config.StagingDir, p.config.Command, playbookFile, extraArgs, inventory,
+	env_vars := ""
+	galaxyFileHasCollections := false
+	galaxyFileHasRoles := false
+
+	// Check if we have custom collections from either galaxy or locally. TODO: Abstract to function
+	// as we use the same check in executeGalaxy
+	if len(p.config.GalaxyFile) > 0 {
+		f, err := ioutil.ReadFile(p.config.GalaxyFile)
+		if err != nil {
+			return err
+		}
+		galaxyFileHasCollections, _ = regexp.Match(`(?m)^collections:`, f)
+		galaxyFileHasRoles, _ = regexp.Match(`(?m)^roles:`, f)
+	}
+
+	collections_path := []string{}
+
+	if galaxyFileHasCollections {
+		collections_path = append(collections_path, p.config.GalaxyCollectionsPath)
+	}
+
+	if len(p.config.CollectionPaths) > 0 {
+		collections_path = append(collections_path, filepath.ToSlash(filepath.Join(p.config.StagingDir, "collections")))
+	}
+
+	if len(collections_path) > 0 {
+		env_vars += fmt.Sprintf(" ANSIBLE_COLLECTIONS_PATH=$ANSIBLE_COLLECTIONS_PATH:%s",
+			strings.Join(collections_path, ":"))
+	}
+
+	if galaxyFileHasRoles {
+		env_vars += fmt.Sprintf(" ANSIBLE_ROLES_PATH=$ANSIBLE_ROLES_PATH:%s",
+			p.config.GalaxyRolesPath)
+	}
+
+	command := fmt.Sprintf("cd %s && %s %s %s%s -c local -i %s",
+		p.config.StagingDir, env_vars, p.config.Command, playbookFile, extraArgs, inventory,
 	)
 	ui.Message(fmt.Sprintf("Executing Ansible: %s", command))
 	cmd := &packersdk.RemoteCmd{

--- a/provisioner/ansible-local/provisioner.hcl2spec.go
+++ b/provisioner/ansible-local/provisioner.hcl2spec.go
@@ -10,29 +10,33 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
-	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
-	PackerCoreVersion   *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
-	PackerDebug         *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
-	PackerForce         *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
-	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
-	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
-	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	Command             *string           `cty:"command" hcl:"command"`
-	ExtraArguments      []string          `mapstructure:"extra_arguments" cty:"extra_arguments" hcl:"extra_arguments"`
-	GroupVars           *string           `mapstructure:"group_vars" cty:"group_vars" hcl:"group_vars"`
-	HostVars            *string           `mapstructure:"host_vars" cty:"host_vars" hcl:"host_vars"`
-	PlaybookDir         *string           `mapstructure:"playbook_dir" cty:"playbook_dir" hcl:"playbook_dir"`
-	PlaybookFile        *string           `mapstructure:"playbook_file" cty:"playbook_file" hcl:"playbook_file"`
-	PlaybookFiles       []string          `mapstructure:"playbook_files" cty:"playbook_files" hcl:"playbook_files"`
-	PlaybookPaths       []string          `mapstructure:"playbook_paths" cty:"playbook_paths" hcl:"playbook_paths"`
-	RolePaths           []string          `mapstructure:"role_paths" cty:"role_paths" hcl:"role_paths"`
-	StagingDir          *string           `mapstructure:"staging_directory" cty:"staging_directory" hcl:"staging_directory"`
-	CleanStagingDir     *bool             `mapstructure:"clean_staging_directory" cty:"clean_staging_directory" hcl:"clean_staging_directory"`
-	InventoryFile       *string           `mapstructure:"inventory_file" cty:"inventory_file" hcl:"inventory_file"`
-	InventoryGroups     []string          `mapstructure:"inventory_groups" cty:"inventory_groups" hcl:"inventory_groups"`
-	GalaxyFile          *string           `mapstructure:"galaxy_file" cty:"galaxy_file" hcl:"galaxy_file"`
-	GalaxyCommand       *string           `mapstructure:"galaxy_command" cty:"galaxy_command" hcl:"galaxy_command"`
+	PackerBuildName       *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
+	PackerBuilderType     *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion     *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
+	PackerDebug           *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
+	PackerForce           *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
+	PackerOnError         *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
+	PackerUserVars        map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
+	PackerSensitiveVars   []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	Command               *string           `cty:"command" hcl:"command"`
+	ExtraArguments        []string          `mapstructure:"extra_arguments" cty:"extra_arguments" hcl:"extra_arguments"`
+	GroupVars             *string           `mapstructure:"group_vars" cty:"group_vars" hcl:"group_vars"`
+	HostVars              *string           `mapstructure:"host_vars" cty:"host_vars" hcl:"host_vars"`
+	PlaybookDir           *string           `mapstructure:"playbook_dir" cty:"playbook_dir" hcl:"playbook_dir"`
+	PlaybookFile          *string           `mapstructure:"playbook_file" cty:"playbook_file" hcl:"playbook_file"`
+	PlaybookFiles         []string          `mapstructure:"playbook_files" cty:"playbook_files" hcl:"playbook_files"`
+	PlaybookPaths         []string          `mapstructure:"playbook_paths" cty:"playbook_paths" hcl:"playbook_paths"`
+	RolePaths             []string          `mapstructure:"role_paths" cty:"role_paths" hcl:"role_paths"`
+	CollectionPaths       []string          `mapstructure:"collection_paths" cty:"collection_paths" hcl:"collection_paths"`
+	StagingDir            *string           `mapstructure:"staging_directory" cty:"staging_directory" hcl:"staging_directory"`
+	CleanStagingDir       *bool             `mapstructure:"clean_staging_directory" cty:"clean_staging_directory" hcl:"clean_staging_directory"`
+	InventoryFile         *string           `mapstructure:"inventory_file" cty:"inventory_file" hcl:"inventory_file"`
+	InventoryGroups       []string          `mapstructure:"inventory_groups" cty:"inventory_groups" hcl:"inventory_groups"`
+	GalaxyFile            *string           `mapstructure:"galaxy_file" cty:"galaxy_file" hcl:"galaxy_file"`
+	GalaxyCommand         *string           `mapstructure:"galaxy_command" cty:"galaxy_command" hcl:"galaxy_command"`
+	GalaxyForceInstall    *bool             `mapstructure:"galaxy_force_install" cty:"galaxy_force_install" hcl:"galaxy_force_install"`
+	GalaxyRolesPath       *string           `mapstructure:"galaxy_roles_path" cty:"galaxy_roles_path" hcl:"galaxy_roles_path"`
+	GalaxyCollectionsPath *string           `mapstructure:"galaxy_collections_path" cty:"galaxy_collections_path" hcl:"galaxy_collections_path"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -64,12 +68,16 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"playbook_files":             &hcldec.AttrSpec{Name: "playbook_files", Type: cty.List(cty.String), Required: false},
 		"playbook_paths":             &hcldec.AttrSpec{Name: "playbook_paths", Type: cty.List(cty.String), Required: false},
 		"role_paths":                 &hcldec.AttrSpec{Name: "role_paths", Type: cty.List(cty.String), Required: false},
+		"collection_paths":           &hcldec.AttrSpec{Name: "collection_paths", Type: cty.List(cty.String), Required: false},
 		"staging_directory":          &hcldec.AttrSpec{Name: "staging_directory", Type: cty.String, Required: false},
 		"clean_staging_directory":    &hcldec.AttrSpec{Name: "clean_staging_directory", Type: cty.Bool, Required: false},
 		"inventory_file":             &hcldec.AttrSpec{Name: "inventory_file", Type: cty.String, Required: false},
 		"inventory_groups":           &hcldec.AttrSpec{Name: "inventory_groups", Type: cty.List(cty.String), Required: false},
 		"galaxy_file":                &hcldec.AttrSpec{Name: "galaxy_file", Type: cty.String, Required: false},
 		"galaxy_command":             &hcldec.AttrSpec{Name: "galaxy_command", Type: cty.String, Required: false},
+		"galaxy_force_install":       &hcldec.AttrSpec{Name: "galaxy_force_install", Type: cty.Bool, Required: false},
+		"galaxy_roles_path":          &hcldec.AttrSpec{Name: "galaxy_roles_path", Type: cty.String, Required: false},
+		"galaxy_collections_path":    &hcldec.AttrSpec{Name: "galaxy_collections_path", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/provisioner/ansible/provisioner.go
+++ b/provisioner/ansible/provisioner.go
@@ -662,7 +662,7 @@ func (p *Provisioner) executeGalaxy(ui packersdk.Ui, comm packersdk.Communicator
 	hasRoles, _ := regexp.Match(`(?m)^roles:`, f)
 	hasCollections, _ := regexp.Match(`(?m)^collections:`, f)
 
-	// If if roles keyword present (v2 format), or no collections keywork present (v1), install roles
+	// If roles keyword present (v2 format), or no collections keyword present (v1), install roles
 	if hasRoles || !hasCollections {
 		if roleInstallError := p.invokeGalaxyCommand(roleArgs, ui, comm); roleInstallError != nil {
 			return roleInstallError

--- a/website/content/docs/provisioners/ansible-local.mdx
+++ b/website/content/docs/provisioners/ansible-local.mdx
@@ -193,6 +193,18 @@ Optional:
 - `galaxy_command` (string) - The command to invoke ansible-galaxy. By
   default, this is ansible-galaxy.
 
+- `galaxy_force_install` (bool) - Force overwriting an existing role or collection.
+   Adds `--force` option to `ansible-galaxy` command. By default, this is
+   `false`.
+
+- `galax_roles_path` (string) - The path to the directory on the remote system in which to
+    install the roles. Adds `--roles-path /path/to/your/roles` to
+    `ansible-galaxy` command. By default, this is `staging_directory`/galaxy_roles
+
+- `galaxy_collections_path` (string) - The path to the directory on the remote system in which to
+    install the collections. Adds `--collections-path /path/to/your/collections` to
+    `ansible-galaxy` command. By default, this is `staging_directory`/galaxy_collections.
+
 - `group_vars` (string) - a path to the directory containing ansible group
   variables on your local system to be copied to the remote machine. By
   default, this is empty.
@@ -203,7 +215,11 @@ Optional:
 
 - `role_paths` (array of strings) - An array of paths to role directories on
   your local system. These will be uploaded to the remote machine under
-  `staging_directory`/roles. By default, this is empty.
+  `staging_directory`/roles/roles. By default, this is empty.
+
+- `collection_paths` (array of strings) - An array of paths to collection
+  directories on your local system. These will be uploaded to the remote
+  machine under `staging_directory`/collections. By default, this is empty.
 
 - `staging_directory` (string) - The directory where all the configuration of
   Ansible by Packer will be placed. By default this is

--- a/website/content/docs/provisioners/ansible-local.mdx
+++ b/website/content/docs/provisioners/ansible-local.mdx
@@ -197,7 +197,7 @@ Optional:
    Adds `--force` option to `ansible-galaxy` command. By default, this is
    `false`.
 
-- `galax_roles_path` (string) - The path to the directory on the remote system in which to
+- `galaxy_roles_path` (string) - The path to the directory on the remote system in which to
     install the roles. Adds `--roles-path /path/to/your/roles` to
     `ansible-galaxy` command. By default, this is `staging_directory`/galaxy_roles
 


### PR DESCRIPTION
https://github.com/hashicorp/packer/issues/10666
Alternative to https://github.com/hashicorp/packer/pull/10667

Sorry I'm not a go developer (I usually sit in Python/PHP langs) so if i'm doing anything really stupid or anything please do tell me (and obviously review this as if submitted by an idiot 😆).

But this reuses some code from the ansible provisioned to use collections from ansible galaxy. It addresses some of the comments in #10667. Note as a difference from the remote provisioner I've added defaults for the role and collection paths so as to try and keep b/c the best I can with the existing code base (which has an opinionated roles path)

## What's different to the other PR
By default we don't install roles + collections globally but into the staging folder allowing them to be cleaned up fully at the end of a packer run.
By pulling in some of the code from #9903 we gain consistency with the ansible remote provisioner (including the force flag on the galaxy command)