### PR TITLE
Set default for the parameter client_cert_token_timeout

### DIFF
--- a/builder/azure/common/client/config.go
+++ b/builder/azure/common/client/config.go
@@ -165,7 +165,7 @@ func (c Config) Validate(errs *packersdk.MultiError) {
 		if _, err := os.Stat(c.ClientCertPath); err != nil {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("client_cert_path is not an accessible file: %v", err))
 		}
-		if c.ClientCertExpireTimeout < 5*time.Minute {
+		if c.ClientCertExpireTimeout != 0 && c.ClientCertExpireTimeout < 5*time.Minute {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("client_cert_token_timeout will expire within 5 minutes, please set a value greater than 5 minutes"))
 		}
 		return


### PR DESCRIPTION
This fix will address the issue when the parameter `client_cert_token_timeout` is not set.  The default should be 1h but due to the test case it failed as the default time gets set after the testing is completed.

# Tests
## client_cert_token_timeout not set:
$~/go/src/github.com/hashicorp/packer/bin/packer build .
azure-arm.timeouttest: output will be in this color.

==> azure-arm.timeouttest: Running builder ...
==> azure-arm.timeouttest: Getting tokens using client certificate
==> azure-arm.timeouttest: Getting tokens using client certificate
    azure-arm.timeouttest: Creating Azure Resource Manager (ARM) client ...
...

## client_cert_token_timeout = "3m":
$ ~/go/src/github.com/hashicorp/packer/bin/packer build .
Error: 1 error(s) occurred:

* client_cert_token_timeout will expire within 5 minutes, please set a value greater than 5 minutes

  on azurefx.pkr.hcl line 44:
  (source code not available)

## client_cert_token_timeout = "4h":
$ ~/go/src/github.com/hashicorp/packer/bin/packer build .
azure-arm.timeouttest: output will be in this color.

==> azure-arm.timeouttest: Running builder ...
==> azure-arm.timeouttest: Getting tokens using client certificate
==> azure-arm.timeouttest: Getting tokens using client certificate
    azure-arm.timeouttest: Creating Azure Resource Manager (ARM) client ...


==> Wait completed after 4 microseconds

## retest the feature
$ make test TEST=./builder/azure/common/client TESTARGS="-run Test_ClientConfig_ClientCert"
==> Checking that only certain files are executable...
Check passed.
ok      github.com/hashicorp/packer/builder/azure/common/client 0.007s

I didin't open an issue for this issue but was testing 1.7.1 prior to it being released and realized the issue.
