### PR TITLE
Add .hashibot configuration for transferring issues

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -22,3 +22,21 @@ poll "closed_issue_locker" "locker" {
     If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
   EOF
 }
+
+poll "label_issue_migrater" "remote_plugin_migrater" {
+  schedule                = "0 20 * * * *"
+  new_owner               = "hashicorp"
+  repo_prefix             = "packer-plugin-"
+  label_prefix            = "remote-plugin/"
+  excluded_label_prefixes  = ["communicator/"]
+  excluded_labels         = ["build", "core", "new-plugin-contribution", "website"]
+
+  issue_header     = <<-EOF
+    _This issue was originally opened by @${var.user} as ${var.repository}#${var.issue_number}. It was migrated here as a result of the [Packer plugin split](###blog-post-url###). The original body of the issue is below._
+
+    <hr>
+
+    EOF
+  migrated_comment = "This issue has been automatically migrated to ${var.repository}#${var.issue_number} because it looks like an issue with that plugin. If you believe this is _not_ an issue with the plugin, please reply to ${var.repository}#${var.issue_number}."
+}
+


### PR DESCRIPTION
The added configuration will allow us to transfer open remote-plugin/* issues from hashicorp/packer to their new respective repos. HashiBot issue transfer only works with orgs it has write access to. Which is similar to how GitHub's issue transfer feature works.

The process works the following way: 
Hashibot will look for issues label `remote-plugin/<name>` for every issue found it will then open a new issue on the repo hashicorp/packer-plugin-name with the description of the originating issue, with a link back to the original issue. The issue in this repo will be closed but left intact for users who navigate to it.  


All remote-plugin/<name> labels are managed through Terraform along with the respective packer-plugin-<name> repo. When extracting a plugin please make sure to update the Terraform configuration under the packer-repositories project. 