### PR TITLE
Fix omi_description that was ignored in Osc builder

### DIFF
--- a/builder/osc/bsu/step_create_omi.go
+++ b/builder/osc/bsu/step_create_omi.go
@@ -32,6 +32,9 @@ func (s *stepCreateOMI) Run(ctx context.Context, state multistep.StateBag) multi
 		ImageName:           omiName,
 		BlockDeviceMappings: config.BlockDevices.BuildOscOMIDevices(),
 	}
+	if config.OMIDescription != "" {
+		createOpts.Description = config.OMIDescription
+	}
 
 	resp, _, err := oscconn.ImageApi.CreateImage(context.Background(), &osc.CreateImageOpts{
 		CreateImageRequest: optional.NewInterface(createOpts),

--- a/builder/osc/bsusurrogate/step_register_omi.go
+++ b/builder/osc/bsusurrogate/step_register_omi.go
@@ -37,6 +37,9 @@ func (s *StepRegisterOMI) Run(ctx context.Context, state multistep.StateBag) mul
 		BlockDeviceMappings: blockDevices,
 	}
 
+	if config.OMIDescription != "" {
+		registerOpts.Description = config.OMIDescription
+	}
 	registerResp, _, err := oscconn.ImageApi.CreateImage(context.Background(), &osc.CreateImageOpts{
 		CreateImageRequest: optional.NewInterface(registerOpts),
 	})

--- a/builder/osc/chroot/step_create_omi.go
+++ b/builder/osc/chroot/step_create_omi.go
@@ -75,6 +75,10 @@ func (s *StepCreateOMI) Run(ctx context.Context, state multistep.StateBag) multi
 		registerOpts = buildRegisterOpts(config, image, newMappings)
 	}
 
+	if config.OMIDescription != "" {
+		registerOpts.Description = config.OMIDescription
+	}
+
 	registerResp, _, err := osconn.ImageApi.CreateImage(context.Background(), &osc.CreateImageOpts{
 		CreateImageRequest: optional.NewInterface(registerOpts),
 	})


### PR DESCRIPTION
Hello, it seems omi_description field  wasn't set at VM creation.
This PR try to fix that.

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>
