### PR TITLE
Allow using API tokens for Proxmox authentication

### DIFF
--- a/builder/proxmox/clone/config.hcl2spec.go
+++ b/builder/proxmox/clone/config.hcl2spec.go
@@ -81,6 +81,7 @@ type FlatConfig struct {
 	SkipCertValidation        *bool                              `mapstructure:"insecure_skip_tls_verify" cty:"insecure_skip_tls_verify" hcl:"insecure_skip_tls_verify"`
 	Username                  *string                            `mapstructure:"username" cty:"username" hcl:"username"`
 	Password                  *string                            `mapstructure:"password" cty:"password" hcl:"password"`
+	Token                     *string                            `mapstructure:"token" cty:"token" hcl:"token"`
 	Node                      *string                            `mapstructure:"node" cty:"node" hcl:"node"`
 	Pool                      *string                            `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
@@ -190,6 +191,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"insecure_skip_tls_verify":     &hcldec.AttrSpec{Name: "insecure_skip_tls_verify", Type: cty.Bool, Required: false},
 		"username":                     &hcldec.AttrSpec{Name: "username", Type: cty.String, Required: false},
 		"password":                     &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
+		"token":                        &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"node":                         &hcldec.AttrSpec{Name: "node", Type: cty.String, Required: false},
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},

--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -2,7 +2,6 @@ package proxmox
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 
@@ -35,15 +34,7 @@ type Builder struct {
 
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook, state multistep.StateBag) (packersdk.Artifact, error) {
 	var err error
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: b.config.SkipCertValidation,
-	}
-	b.proxmoxClient, err = proxmox.NewClient(b.config.proxmoxURL.String(), nil, tlsConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	err = b.proxmoxClient.Login(b.config.Username, b.config.Password, "")
+	b.proxmoxClient, err = NewProxmoxClient(b.config)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -34,7 +34,7 @@ type Builder struct {
 
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook, state multistep.StateBag) (packersdk.Artifact, error) {
 	var err error
-	b.proxmoxClient, err = NewProxmoxClient(b.config)
+	b.proxmoxClient, err = newProxmoxClient(b.config)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -1,0 +1,62 @@
+package proxmox
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/Telmate/proxmox-api-go/proxmox"
+)
+
+type authenticatedTransport struct {
+	rt    http.RoundTripper
+	user  string
+	token string
+}
+
+func newAuthenticatedTransport(rt http.RoundTripper, user, token string) *authenticatedTransport {
+	return &authenticatedTransport{rt, user, token}
+}
+
+func (t *authenticatedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	auth := fmt.Sprintf("PVEAPIToken=%s=%s", t.user, t.token)
+	req.Header.Set("Authorization", auth)
+	return t.rt.RoundTrip(req)
+}
+
+func NewProxmoxClient(config Config) (*proxmox.Client, error) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: config.SkipCertValidation,
+	}
+
+	wantsTokenAuth := config.Token != ""
+
+	var httpClient *http.Client
+	if wantsTokenAuth {
+		// setup a HTTP client which adds the token auth header
+		log.Print("using token auth")
+		baseTransport := &http.Transport{
+			TLSClientConfig:    tlsConfig,
+			DisableCompression: true,
+		}
+		authTransport := newAuthenticatedTransport(baseTransport, config.Username, config.Token)
+		httpClient = &http.Client{Transport: authTransport}
+	}
+
+	client, err := proxmox.NewClient(config.proxmoxURL.String(), httpClient, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if !wantsTokenAuth {
+		// fallback to login if not using tokens
+		log.Print("using password auth")
+		err = client.Login(config.Username, config.Password, "")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
+}

--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
+
+const defaultTaskTimeout = 30 * time.Second
 
 type authenticatedTransport struct {
 	rt    http.RoundTripper
@@ -44,7 +47,7 @@ func NewProxmoxClient(config Config) (*proxmox.Client, error) {
 		httpClient = &http.Client{Transport: authTransport}
 	}
 
-	client, err := proxmox.NewClient(config.proxmoxURL.String(), httpClient, tlsConfig)
+	client, err := proxmox.NewClient(config.proxmoxURL.String(), httpClient, tlsConfig, int(defaultTaskTimeout.Seconds()))
 	if err != nil {
 		return nil, err
 	}

--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -2,31 +2,13 @@ package proxmox
 
 import (
 	"crypto/tls"
-	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
 const defaultTaskTimeout = 30 * time.Second
-
-type authenticatedTransport struct {
-	rt    http.RoundTripper
-	user  string
-	token string
-}
-
-func newAuthenticatedTransport(rt http.RoundTripper, user, token string) *authenticatedTransport {
-	return &authenticatedTransport{rt, user, token}
-}
-
-func (t *authenticatedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	auth := fmt.Sprintf("PVEAPIToken=%s=%s", t.user, t.token)
-	req.Header.Set("Authorization", auth)
-	return t.rt.RoundTrip(req)
-}
 
 func NewProxmoxClient(config Config) (*proxmox.Client, error) {
 	tlsConfig := &tls.Config{

--- a/builder/proxmox/common/client.go
+++ b/builder/proxmox/common/client.go
@@ -10,7 +10,7 @@ import (
 
 const defaultTaskTimeout = 30 * time.Second
 
-func NewProxmoxClient(config Config) (*proxmox.Client, error) {
+func newProxmoxClient(config Config) (*proxmox.Client, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: config.SkipCertValidation,
 	}

--- a/builder/proxmox/common/client_test.go
+++ b/builder/proxmox/common/client_test.go
@@ -30,7 +30,7 @@ func TestTokenAuth(t *testing.T) {
 		Token:              "ac5293bf-15e2-477f-b04c-a6dfa7a46b80",
 	}
 
-	client, err := NewProxmoxClient(config)
+	client, err := newProxmoxClient(config)
 	require.NoError(t, err)
 
 	ref := proxmox.NewVmRef(110)
@@ -80,7 +80,7 @@ func TestLogin(t *testing.T) {
 		Token:              "",
 	}
 
-	client, err := NewProxmoxClient(config)
+	client, err := newProxmoxClient(config)
 	require.NoError(t, err)
 
 	ref := proxmox.NewVmRef(110)

--- a/builder/proxmox/common/client_test.go
+++ b/builder/proxmox/common/client_test.go
@@ -53,7 +53,7 @@ func TestLogin(t *testing.T) {
 				return
 			}
 
-			json.NewEncoder(rw).Encode(map[string]interface{}{
+			_ = json.NewEncoder(rw).Encode(map[string]interface{}{
 				"data": map[string]string{
 					"username":            user,
 					"ticket":              "dummy-ticket",

--- a/builder/proxmox/common/client_test.go
+++ b/builder/proxmox/common/client_test.go
@@ -1,0 +1,91 @@
+package proxmox
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenAuth(t *testing.T) {
+	mockAPI := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") != "PVEAPIToken=dummy@vmhost!test-token=ac5293bf-15e2-477f-b04c-a6dfa7a46b80" {
+			rw.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+	}))
+	defer mockAPI.Close()
+
+	pmURL, _ := url.Parse(mockAPI.URL)
+	config := Config{
+		proxmoxURL:         pmURL,
+		SkipCertValidation: false,
+		Username:           "dummy@vmhost!test-token",
+		Password:           "not-used",
+		Token:              "ac5293bf-15e2-477f-b04c-a6dfa7a46b80",
+	}
+
+	client, err := NewProxmoxClient(config)
+	require.NoError(t, err)
+
+	ref := proxmox.NewVmRef(110)
+	ref.SetNode("node1")
+	ref.SetVmType("qemu")
+	err = client.Sendkey(ref, "ping")
+	require.NoError(t, err)
+}
+
+func TestLogin(t *testing.T) {
+	mockAPI := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// mock ticketing api
+		if req.Method == http.MethodPost && req.URL.Path == "/access/ticket" {
+			body, _ := ioutil.ReadAll(req.Body)
+			values, _ := url.ParseQuery(string(body))
+			user := values.Get("username")
+			pass := values.Get("password")
+			if user != "dummy@vmhost" || pass != "correct-horse-battery-staple" {
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			json.NewEncoder(rw).Encode(map[string]interface{}{
+				"data": map[string]string{
+					"username":            user,
+					"ticket":              "dummy-ticket",
+					"CSRFPreventionToken": "random-token",
+				},
+			})
+			return
+		}
+
+		// validate ticket
+		if val, err := req.Cookie("PVEAuthCookie"); err != nil || val.Value != "dummy-ticket" {
+			rw.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+	}))
+	defer mockAPI.Close()
+
+	pmURL, _ := url.Parse(mockAPI.URL)
+	config := Config{
+		proxmoxURL:         pmURL,
+		SkipCertValidation: false,
+		Username:           "dummy@vmhost",
+		Password:           "correct-horse-battery-staple",
+		Token:              "",
+	}
+
+	client, err := NewProxmoxClient(config)
+	require.NoError(t, err)
+
+	ref := proxmox.NewVmRef(110)
+	ref.SetNode("node1")
+	ref.SetVmType("qemu")
+	err = client.Sendkey(ref, "ping")
+	require.NoError(t, err)
+}

--- a/builder/proxmox/common/config.go
+++ b/builder/proxmox/common/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	SkipCertValidation bool   `mapstructure:"insecure_skip_tls_verify"`
 	Username           string `mapstructure:"username"`
 	Password           string `mapstructure:"password"`
+	Token              string `mapstructure:"token"`
 	Node               string `mapstructure:"node"`
 	Pool               string `mapstructure:"pool"`
 
@@ -135,6 +136,9 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	if c.Password == "" {
 		c.Password = os.Getenv("PROXMOX_PASSWORD")
 	}
+	if c.Token == "" {
+		c.Token = os.Getenv("PROXMOX_TOKEN")
+	}
 	if c.BootKeyInterval == 0 && os.Getenv(bootcommand.PackerKeyEnv) != "" {
 		var err error
 		c.BootKeyInterval, err = time.ParseDuration(os.Getenv(bootcommand.PackerKeyEnv))
@@ -220,8 +224,8 @@ func (c *Config) Prepare(upper interface{}, raws ...interface{}) ([]string, []st
 	if c.Username == "" {
 		errs = packersdk.MultiErrorAppend(errs, errors.New("username must be specified"))
 	}
-	if c.Password == "" {
-		errs = packersdk.MultiErrorAppend(errs, errors.New("password must be specified"))
+	if c.Password == "" && c.Token == "" {
+		errs = packersdk.MultiErrorAppend(errs, errors.New("password or token must be specified"))
 	}
 	if c.ProxmoxURLRaw == "" {
 		errs = packersdk.MultiErrorAppend(errs, errors.New("proxmox_url must be specified"))

--- a/builder/proxmox/common/config.hcl2spec.go
+++ b/builder/proxmox/common/config.hcl2spec.go
@@ -80,6 +80,7 @@ type FlatConfig struct {
 	SkipCertValidation        *bool                      `mapstructure:"insecure_skip_tls_verify" cty:"insecure_skip_tls_verify" hcl:"insecure_skip_tls_verify"`
 	Username                  *string                    `mapstructure:"username" cty:"username" hcl:"username"`
 	Password                  *string                    `mapstructure:"password" cty:"password" hcl:"password"`
+	Token                     *string                    `mapstructure:"token" cty:"token" hcl:"token"`
 	Node                      *string                    `mapstructure:"node" cty:"node" hcl:"node"`
 	Pool                      *string                    `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	VMName                    *string                    `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
@@ -187,6 +188,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"insecure_skip_tls_verify":     &hcldec.AttrSpec{Name: "insecure_skip_tls_verify", Type: cty.Bool, Required: false},
 		"username":                     &hcldec.AttrSpec{Name: "username", Type: cty.String, Required: false},
 		"password":                     &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
+		"token":                        &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"node":                         &hcldec.AttrSpec{Name: "node", Type: cty.String, Required: false},
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},

--- a/builder/proxmox/iso/config.hcl2spec.go
+++ b/builder/proxmox/iso/config.hcl2spec.go
@@ -81,6 +81,7 @@ type FlatConfig struct {
 	SkipCertValidation        *bool                              `mapstructure:"insecure_skip_tls_verify" cty:"insecure_skip_tls_verify" hcl:"insecure_skip_tls_verify"`
 	Username                  *string                            `mapstructure:"username" cty:"username" hcl:"username"`
 	Password                  *string                            `mapstructure:"password" cty:"password" hcl:"password"`
+	Token                     *string                            `mapstructure:"token" cty:"token" hcl:"token"`
 	Node                      *string                            `mapstructure:"node" cty:"node" hcl:"node"`
 	Pool                      *string                            `mapstructure:"pool" cty:"pool" hcl:"pool"`
 	VMName                    *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
@@ -196,6 +197,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"insecure_skip_tls_verify":     &hcldec.AttrSpec{Name: "insecure_skip_tls_verify", Type: cty.Bool, Required: false},
 		"username":                     &hcldec.AttrSpec{Name: "username", Type: cty.String, Required: false},
 		"password":                     &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
+		"token":                        &hcldec.AttrSpec{Name: "token", Type: cty.String, Required: false},
 		"node":                         &hcldec.AttrSpec{Name: "node", Type: cty.String, Required: false},
 		"pool":                         &hcldec.AttrSpec{Name: "pool", Type: cty.String, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022
 	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.0
-	github.com/Telmate/proxmox-api-go v0.0.0-20200715182505-ec97c70ba887
+	github.com/Telmate/proxmox-api-go v0.0.0-20210320143302-fea68269e6b0
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190418113227-25233c783f4e
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20170113022742-e6dbea820a9f
 	github.com/antihax/optional v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,9 @@ github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.0 h1:0nxjOH7NurPGUWNG5BCrASW
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.0/go.mod h1:P+3VS0ETiQPyWOx3vB/oeC8J3qd7jnVZLYAFwWgGRt8=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/Telmate/proxmox-api-go v0.0.0-20200715182505-ec97c70ba887 h1:Q65o4V0g/KR1sSUZIMf4m1rShb7f1tVHuEt30hfnh2A=
 github.com/Telmate/proxmox-api-go v0.0.0-20200715182505-ec97c70ba887/go.mod h1:OGWyIMJ87/k/GCz8CGiWB2HOXsOVDM6Lpe/nFPkC4IQ=
+github.com/Telmate/proxmox-api-go v0.0.0-20210320143302-fea68269e6b0 h1:LeBf+Ex12uqA6dWZp73Qf3dzpV/LvB9SRmHgPBwnXrQ=
+github.com/Telmate/proxmox-api-go v0.0.0-20210320143302-fea68269e6b0/go.mod h1:ayPkdmEKnlssqLQ9K1BE1jlsaYhXVwkoduXI30oQF0I=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=

--- a/vendor/github.com/Telmate/proxmox-api-go/proxmox/config_qemu.go
+++ b/vendor/github.com/Telmate/proxmox-api-go/proxmox/config_qemu.go
@@ -15,6 +15,10 @@ import (
 	"time"
 )
 
+// Currently ZFS local, LVM, Ceph RBD, CephFS, Directory and virtio-scsi-pci are considered.
+// Other formats are not verified, but could be added if they're needed.
+const rxStorageTypes = `(zfspool|lvm|rbd|cephfs|dir|virtio-scsi-pci)`
+
 type (
 	QemuDevices     map[int]map[string]interface{}
 	QemuDevice      map[string]interface{}
@@ -23,33 +27,35 @@ type (
 
 // ConfigQemu - Proxmox API QEMU options
 type ConfigQemu struct {
-	VmID         int         `json:"vmid"`
-	Name         string      `json:"name"`
-	Description  string      `json:"desc"`
-	Pool         string      `json:"pool,omitempty"`
-	Bios         string      `json:"bios"`
-	Onboot       bool        `json:"onboot"`
-	Agent        int         `json:"agent"`
-	Memory       int         `json:"memory"`
-	Balloon      int         `json:"balloon"`
-	QemuOs       string      `json:"os"`
-	QemuCores    int         `json:"cores"`
-	QemuSockets  int         `json:"sockets"`
-	QemuVcpus    int         `json:"vcpus"`
-	QemuCpu      string      `json:"cpu"`
-	QemuNuma     bool        `json:"numa"`
-	QemuKVM      bool        `json:"kvm"`
-	Hotplug      string      `json:"hotplug"`
-	QemuIso      string      `json:"iso"`
-	FullClone    *int        `json:"fullclone"`
-	Boot         string      `json:"boot"`
-	BootDisk     string      `json:"bootdisk,omitempty"`
-	Scsihw       string      `json:"scsihw,omitempty"`
-	QemuDisks    QemuDevices `json:"disk"`
-	QemuVga      QemuDevice  `json:"vga,omitempty"`
-	QemuNetworks QemuDevices `json:"network"`
-	QemuSerials  QemuDevices `json:"serial,omitempty"`
-	HaState      string      `json:"hastate,omitempty"`
+	VmID            int         `json:"vmid"`
+	Name            string      `json:"name"`
+	Description     string      `json:"desc"`
+	Pool            string      `json:"pool,omitempty"`
+	Bios            string      `json:"bios"`
+	Onboot          bool        `json:"onboot"`
+	Agent           int         `json:"agent"`
+	Memory          int         `json:"memory"`
+	Balloon         int         `json:"balloon"`
+	QemuOs          string      `json:"os"`
+	QemuCores       int         `json:"cores"`
+	QemuSockets     int         `json:"sockets"`
+	QemuVcpus       int         `json:"vcpus"`
+	QemuCpu         string      `json:"cpu"`
+	QemuNuma        bool        `json:"numa"`
+	QemuKVM         bool        `json:"kvm"`
+	Hotplug         string      `json:"hotplug"`
+	QemuIso         string      `json:"iso"`
+	FullClone       *int        `json:"fullclone"`
+	Boot            string      `json:"boot"`
+	BootDisk        string      `json:"bootdisk,omitempty"`
+	Scsihw          string      `json:"scsihw,omitempty"`
+	QemuDisks       QemuDevices `json:"disk"`
+	QemuUnusedDisks QemuDevices `json:"unused_disk"`
+	QemuVga         QemuDevice  `json:"vga,omitempty"`
+	QemuNetworks    QemuDevices `json:"network"`
+	QemuSerials     QemuDevices `json:"serial,omitempty"`
+	HaState         string      `json:"hastate,omitempty"`
+	Tags            string      `json:"tags"`
 
 	// Deprecated single disk.
 	DiskSize    float64 `json:"diskGB"`
@@ -100,6 +106,7 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"memory":      config.Memory,
 		"boot":        config.Boot,
 		"description": config.Description,
+		"tags":        config.Tags,
 	}
 
 	if config.Bios != "" {
@@ -127,7 +134,10 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 	}
 
 	// Create disks config.
-	config.CreateQemuDisksParams(vmr.vmId, params, false)
+	err = config.CreateQemuDisksParams(vmr.vmId, params, false)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
 
 	// Create vga config.
 	vgaParam := QemuDeviceParam{}
@@ -137,17 +147,26 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 	}
 
 	// Create networks config.
-	config.CreateQemuNetworksParams(vmr.vmId, params)
+	err = config.CreateQemuNetworksParams(vmr.vmId, params)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
 
 	// Create serial interfaces
-	config.CreateQemuSerialsParams(vmr.vmId, params)
+	err = config.CreateQemuSerialsParams(vmr.vmId, params)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
 
 	exitStatus, err := client.CreateQemuVm(vmr.node, params)
 	if err != nil {
 		return fmt.Errorf("Error creating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
 	}
 
-	client.UpdateVMHA(vmr, config.HaState)
+	_, err = client.UpdateVMHA(vmr, config.HaState)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
 
 	return
 }
@@ -210,6 +229,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	configParams := map[string]interface{}{
 		"name":        config.Name,
 		"description": config.Description,
+		"tags":        config.Tags,
 		"onboot":      config.Onboot,
 		"agent":       config.Agent,
 		"sockets":     config.QemuSockets,
@@ -253,8 +273,16 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	configParamsDisk := map[string]interface{}{
 		"vmid": vmr.vmId,
 	}
-	config.CreateQemuDisksParams(vmr.vmId, configParamsDisk, false)
-	client.createVMDisks(vmr.node, configParamsDisk)
+	// TODO keep going if error=
+	err = config.CreateQemuDisksParams(vmr.vmId, configParamsDisk, false)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
+	// TODO keep going if error=
+	_, err = client.createVMDisks(vmr.node, configParamsDisk)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
 	//Copy the disks to the global configParams
 	for key, value := range configParamsDisk {
 		//vmid is only required in createVMDisks
@@ -264,7 +292,10 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	}
 
 	// Create networks config.
-	config.CreateQemuNetworksParams(vmr.vmId, configParams)
+	err = config.CreateQemuNetworksParams(vmr.vmId, configParams)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
 
 	// Create vga config.
 	vgaParam := QemuDeviceParam{}
@@ -276,7 +307,10 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	}
 
 	// Create serial interfaces
-	config.CreateQemuSerialsParams(vmr.vmId, configParams)
+	err = config.CreateQemuSerialsParams(vmr.vmId, configParams)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
 
 	// cloud-init options
 	if config.CIuser != "" {
@@ -321,7 +355,10 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		return err
 	}
 
-	client.UpdateVMHA(vmr, config.HaState)
+	_, err = client.UpdateVMHA(vmr, config.HaState)
+	if err != nil {
+		log.Printf("[ERROR] %q", err)
+	}
 
 	_, err = client.UpdateVMPool(vmr, config.Pool)
 
@@ -340,13 +377,14 @@ func NewConfigQemuFromJson(io io.Reader) (config *ConfigQemu, err error) {
 }
 
 var (
-	rxIso        = regexp.MustCompile(`(.*?),media`)
-	rxDeviceID   = regexp.MustCompile(`\d+`)
-	rxDiskName   = regexp.MustCompile(`(virtio|scsi)\d+`)
-	rxDiskType   = regexp.MustCompile(`\D+`)
-	rxNicName    = regexp.MustCompile(`net\d+`)
-	rxMpName     = regexp.MustCompile(`mp\d+`)
-	rxSerialName = regexp.MustCompile(`serial\d+`)
+	rxIso            = regexp.MustCompile(`(.*?),media`)
+	rxDeviceID       = regexp.MustCompile(`\d+`)
+	rxDiskName       = regexp.MustCompile(`(virtio|scsi)\d+`)
+	rxDiskType       = regexp.MustCompile(`\D+`)
+	rxUnusedDiskName = regexp.MustCompile(`^(unused)\d+`)
+	rxNicName        = regexp.MustCompile(`net\d+`)
+	rxMpName         = regexp.MustCompile(`mp\d+`)
+	rxSerialName     = regexp.MustCompile(`serial\d+`)
 )
 
 func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err error) {
@@ -386,6 +424,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	description := ""
 	if _, isSet := vmConfig["description"]; isSet {
 		description = vmConfig["description"].(string)
+	}
+	tags := ""
+	if _, isSet := vmConfig["tags"]; isSet {
+		tags = vmConfig["tags"].(string)
 	}
 	bios := "seabios"
 	if _, isSet := vmConfig["bios"]; isSet {
@@ -466,28 +508,30 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	}
 
 	config = &ConfigQemu{
-		Name:         name,
-		Description:  strings.TrimSpace(description),
-		Bios:         bios,
-		Onboot:       onboot,
-		Agent:        agent,
-		QemuOs:       ostype,
-		Memory:       int(memory),
-		QemuCores:    int(cores),
-		QemuSockets:  int(sockets),
-		QemuCpu:      cpu,
-		QemuNuma:     numa,
-		QemuKVM:      kvm,
-		Hotplug:      hotplug,
-		QemuVlanTag:  -1,
-		Boot:         boot,
-		BootDisk:     bootdisk,
-		Scsihw:       scsihw,
-		HaState:      hastate,
-		QemuDisks:    QemuDevices{},
-		QemuVga:      QemuDevice{},
-		QemuNetworks: QemuDevices{},
-		QemuSerials:  QemuDevices{},
+		Name:            name,
+		Description:     strings.TrimSpace(description),
+		Tags:            strings.TrimSpace(tags),
+		Bios:            bios,
+		Onboot:          onboot,
+		Agent:           agent,
+		QemuOs:          ostype,
+		Memory:          int(memory),
+		QemuCores:       int(cores),
+		QemuSockets:     int(sockets),
+		QemuCpu:         cpu,
+		QemuNuma:        numa,
+		QemuKVM:         kvm,
+		Hotplug:         hotplug,
+		QemuVlanTag:     -1,
+		Boot:            boot,
+		BootDisk:        bootdisk,
+		Scsihw:          scsihw,
+		HaState:         hastate,
+		QemuDisks:       QemuDevices{},
+		QemuUnusedDisks: QemuDevices{},
+		QemuVga:         QemuDevice{},
+		QemuNetworks:    QemuDevices{},
+		QemuSerials:     QemuDevices{},
 	}
 
 	if balloon >= 1 {
@@ -533,32 +577,66 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	// Add disks.
 	diskNames := []string{}
 
-	for k, _ := range vmConfig {
+	for k := range vmConfig {
 		if diskName := rxDiskName.FindStringSubmatch(k); len(diskName) > 0 {
 			diskNames = append(diskNames, diskName[0])
 		}
 	}
 
 	for _, diskName := range diskNames {
-		diskConfStr := vmConfig[diskName]
-		diskConfList := strings.Split(diskConfStr.(string), ",")
+		diskConfStr := vmConfig[diskName].(string)
 
-		//
 		id := rxDeviceID.FindStringSubmatch(diskName)
 		diskID, _ := strconv.Atoi(id[0])
 		diskType := rxDiskType.FindStringSubmatch(diskName)[0]
-		storageName, fileName := ParseSubConf(diskConfList[0], ":")
 
-		//
-		diskConfMap := QemuDevice{
-			"id":      diskID,
-			"type":    diskType,
-			"storage": storageName,
-			"file":    fileName,
+		diskConfMap := ParsePMConf(diskConfStr, "volume")
+		diskConfMap["slot"] = diskID
+		diskConfMap["type"] = diskType
+
+		storageName, fileName := ParseSubConf(diskConfMap["volume"].(string), ":")
+		diskConfMap["storage"] = storageName
+		diskConfMap["file"] = fileName
+
+		filePath := diskConfMap["volume"]
+
+		// Get disk format
+		storageContent, err := client.GetStorageContent(vmr, storageName)
+		if err != nil {
+			log.Fatal(err)
+			return nil, err
 		}
+		var storageFormat string
+		contents := storageContent["data"].([]interface{})
+		for content := range contents {
+			storageContentMap := contents[content].(map[string]interface{})
+			if storageContentMap["volid"] == filePath {
+				storageFormat = storageContentMap["format"].(string)
+				break
+			}
+		}
+		diskConfMap["format"] = storageFormat
 
-		// Add rest of device config.
-		diskConfMap.readDeviceConfig(diskConfList[1:])
+		// Get storage type for disk
+		var storageStatus map[string]interface{}
+		storageStatus, err = client.GetStorageStatus(vmr, storageName)
+		if err != nil {
+			log.Fatal(err)
+			return nil, err
+		}
+		storageType := storageStatus["type"]
+
+		diskConfMap["storage_type"] = storageType
+
+		// Convert to gigabytes if disk size was received in terabytes
+		sizeIsInTerabytes, err := regexp.MatchString("[0-9]+T", diskConfMap["size"].(string))
+		if err != nil {
+			log.Fatal(err)
+			return nil, err
+		}
+		if sizeIsInTerabytes {
+			diskConfMap["size"] = fmt.Sprintf("%.0fG", DiskSizeGB(diskConfMap["size"]))
+		}
 
 		// And device config to disks map.
 		if len(diskConfMap) > 0 {
@@ -566,11 +644,49 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		}
 	}
 
+	// Add unused disks
+	// unused0:local:100/vm-100-disk-1.qcow2
+	unusedDiskNames := []string{}
+	for k := range vmConfig {
+		// look for entries from the config in the format "unusedX:<storagepath>" where X is an integer
+		if unusedDiskName := rxUnusedDiskName.FindStringSubmatch(k); len(unusedDiskName) > 0 {
+			unusedDiskNames = append(unusedDiskNames, unusedDiskName[0])
+		}
+	}
+
+	fmt.Println(fmt.Sprintf("unusedDiskNames: %v", unusedDiskNames))
+	for _, unusedDiskName := range unusedDiskNames {
+		unusedDiskConfStr := vmConfig[unusedDiskName].(string)
+		finalDiskConfMap := QemuDevice{}
+
+		// parse "unused0" to get the id '0' as an int
+		id := rxDeviceID.FindStringSubmatch(unusedDiskName)
+		diskID, err := strconv.Atoi(id[0])
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Unable to parse unused disk id from input string '%v' tried to convert '%v' to integer.", unusedDiskName, diskID))
+		}
+		finalDiskConfMap["slot"] = diskID
+
+		// parse the attributes from the unused disk
+		// extract the storage and file path from the unused disk entry
+		parsedUnusedDiskMap := ParsePMConf(unusedDiskConfStr, "storage+file")
+		storageName, fileName := ParseSubConf(parsedUnusedDiskMap["storage+file"].(string), ":")
+		finalDiskConfMap["storage"] = storageName
+		finalDiskConfMap["file"] = fileName
+
+		config.QemuUnusedDisks[diskID] = finalDiskConfMap
+	}
+
 	//Display
 	if vga, isSet := vmConfig["vga"]; isSet {
 		vgaList := strings.Split(vga.(string), ",")
 		vgaMap := QemuDevice{}
-		vgaMap.readDeviceConfig(vgaList)
+
+		// TODO: keep going if error?
+		err = vgaMap.readDeviceConfig(vgaList)
+		if err != nil {
+			log.Printf("[ERROR] %q", err)
+		}
 		if len(vgaMap) > 0 {
 			config.QemuVga = vgaMap
 		}
@@ -579,7 +695,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	// Add networks.
 	nicNames := []string{}
 
-	for k, _ := range vmConfig {
+	for k := range vmConfig {
 		if nicName := rxNicName.FindStringSubmatch(k); len(nicName) > 0 {
 			nicNames = append(nicNames, nicName[0])
 		}
@@ -601,7 +717,15 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		}
 
 		// Add rest of device config.
-		nicConfMap.readDeviceConfig(nicConfList[1:])
+		err = nicConfMap.readDeviceConfig(nicConfList[1:])
+		if err != nil {
+			log.Printf("[ERROR] %q", err)
+		}
+		if nicConfMap["firewall"] == 1 {
+			nicConfMap["firewall"] = true
+		} else if nicConfMap["firewall"] == 0 {
+			nicConfMap["firewall"] = false
+		}
 
 		// And device config to networks.
 		if len(nicConfMap) > 0 {
@@ -612,7 +736,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	// Add serials
 	serialNames := []string{}
 
-	for k, _ := range vmConfig {
+	for k := range vmConfig {
 		if serialName := rxSerialName.FindStringSubmatch(k); len(serialName) > 0 {
 			serialNames = append(serialNames, serialName[0])
 		}
@@ -773,6 +897,52 @@ func SendKeysString(vmr *VmRef, client *Client, keys string) (err error) {
 	return nil
 }
 
+// Given a QemuDevice, return a param string to give to ProxMox
+func formatDeviceParam(device QemuDevice) string {
+	deviceConfParams := QemuDeviceParam{}
+	deviceConfParams = deviceConfParams.createDeviceParam(device, nil)
+	return strings.Join(deviceConfParams, ",")
+}
+
+// Given a QemuDevice (represesting a disk), return a param string to give to ProxMox
+func FormatDiskParam(disk QemuDevice) string {
+	diskConfParam := QemuDeviceParam{}
+
+	if volume, ok := disk["volume"]; ok && volume != "" {
+		diskConfParam = append(diskConfParam, volume.(string))
+		diskConfParam = append(diskConfParam, fmt.Sprintf("size=%v", disk["size"]))
+	} else {
+		volumeInit := fmt.Sprintf("%v:%v", disk["storage"], DiskSizeGB(disk["size"]))
+		diskConfParam = append(diskConfParam, volumeInit)
+	}
+
+	// Set cache if not none (default).
+	if cache, ok := disk["cache"]; ok && cache != "none" {
+		diskCache := fmt.Sprintf("cache=%v", disk["cache"])
+		diskConfParam = append(diskConfParam, diskCache)
+	}
+
+	// Mountoptions
+	if mountoptions, ok := disk["mountoptions"]; ok {
+		options := []string{}
+		for opt, enabled := range mountoptions.(map[string]interface{}) {
+			if enabled.(bool) {
+				options = append(options, opt)
+			}
+		}
+		diskMountOpts := fmt.Sprintf("mountoptions=%v", strings.Join(options, ";"))
+		diskConfParam = append(diskConfParam, diskMountOpts)
+	}
+
+	// Keys that are not used as real/direct conf.
+	ignoredKeys := []string{"key", "slot", "type", "storage", "file", "size", "cache", "volume", "container", "vm", "mountoptions", "storage_type", "format"}
+
+	// Rest of config.
+	diskConfParam = diskConfParam.createDeviceParam(disk, ignoredKeys)
+
+	return strings.Join(diskConfParam, ",")
+}
+
 // Create parameters for each Nic device.
 func (c ConfigQemu) CreateQemuNetworksParams(vmID int, params map[string]interface{}) error {
 
@@ -873,57 +1043,41 @@ func (c ConfigQemu) CreateQemuDisksParams(
 
 	// For new style with multi disk device.
 	for diskID, diskConfMap := range c.QemuDisks {
-
 		// skip the first disk for clones (may not always be right, but a template probably has at least 1 disk)
 		if diskID == 0 && cloned {
 			continue
-		}
-		diskConfParam := QemuDeviceParam{
-			"media=disk",
 		}
 
 		// Device name.
 		deviceType := diskConfMap["type"].(string)
 		qemuDiskName := deviceType + strconv.Itoa(diskID)
 
-		// Set disk storage.
-		// Disk size.
-		diskSizeGB := fmt.Sprintf("size=%v", diskConfMap["size"])
-		diskConfParam = append(diskConfParam, diskSizeGB)
-
-		// Disk name.
-		var diskFile string
-		// Currently ZFS local, LVM, Ceph RBD, CephFS and Directory are considered.
-		// Other formats are not verified, but could be added if they're needed.
-		rxStorageTypes := `(zfspool|lvm|rbd|cephfs)`
-		storageType := diskConfMap["storage_type"].(string)
-		if matched, _ := regexp.MatchString(rxStorageTypes, storageType); matched {
-			diskFile = fmt.Sprintf("file=%v:vm-%v-disk-%v", diskConfMap["storage"], vmID, diskID)
-		} else {
-			diskFile = fmt.Sprintf("file=%v:%v/vm-%v-disk-%v.%v", diskConfMap["storage"], vmID, vmID, diskID, diskConfMap["format"])
-		}
-		diskConfParam = append(diskConfParam, diskFile)
-
-		// Set cache if not none (default).
-		if diskConfMap["cache"].(string) != "none" {
-			diskCache := fmt.Sprintf("cache=%v", diskConfMap["cache"])
-			diskConfParam = append(diskConfParam, diskCache)
-		}
-
-		// Keys that are not used as real/direct conf.
-		ignoredKeys := []string{"id", "type", "storage", "storage_type", "size", "cache"}
-
-		// Rest of config.
-		diskConfParam = diskConfParam.createDeviceParam(diskConfMap, ignoredKeys)
-
 		// Add back to Qemu prams.
-		params[qemuDiskName] = strings.Join(diskConfParam, ",")
+		params[qemuDiskName] = FormatDiskParam(diskConfMap)
 	}
 
 	return nil
 }
 
-// Create the parameters for each device that will be sent to Proxmox API.
+// Create parameters for serial interface
+func (c ConfigQemu) CreateQemuSerialsParams(
+	vmID int,
+	params map[string]interface{},
+) error {
+
+	// For new style with multi disk device.
+	for serialID, serialConfMap := range c.QemuSerials {
+		// Device name.
+		deviceType := serialConfMap["type"].(string)
+		qemuSerialName := "serial" + strconv.Itoa(serialID)
+
+		// Add back to Qemu prams.
+		params[qemuSerialName] = deviceType
+	}
+
+	return nil
+}
+
 func (p QemuDeviceParam) createDeviceParam(
 	deviceConfMap QemuDevice,
 	ignoredKeys []string,
@@ -962,43 +1116,6 @@ func (confMap QemuDevice) readDeviceConfig(confList []string) error {
 func (c ConfigQemu) String() string {
 	jsConf, _ := json.Marshal(c)
 	return string(jsConf)
-}
-
-// Create parameters for serial interface
-func (c ConfigQemu) CreateQemuSerialsParams(
-	vmID int,
-	params map[string]interface{},
-) error {
-
-	// For new style with multi disk device.
-	for serialID, serialConfMap := range c.QemuSerials {
-		// Device name.
-		deviceType := serialConfMap["type"].(string)
-		qemuSerialName := "serial" + strconv.Itoa(serialID)
-
-		// Add back to Qemu prams.
-		params[qemuSerialName] = deviceType
-	}
-
-	return nil
-}
-
-// NextId - Get next free VMID
-func (c *Client) NextId() (id int, err error) {
-	var data map[string]interface{}
-	_, err = c.session.GetJSON("/cluster/nextid", nil, nil, &data)
-	if err != nil {
-		return -1, err
-	}
-	if data["data"] == nil || data["errors"] != nil {
-		return -1, fmt.Errorf(data["errors"].(string))
-	}
-
-	i, err := strconv.Atoi(data["data"].(string))
-	if err != nil {
-		return -1, err
-	}
-	return i, nil
 }
 
 // VMIdExists - If you pass an VMID that exists it will raise an error otherwise it will return the vmID

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server
 # github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 github.com/StackExchange/wmi
-# github.com/Telmate/proxmox-api-go v0.0.0-20200715182505-ec97c70ba887
+# github.com/Telmate/proxmox-api-go v0.0.0-20210320143302-fea68269e6b0
 ## explicit
 github.com/Telmate/proxmox-api-go/proxmox
 # github.com/agext/levenshtein v1.2.1

--- a/website/content/docs/builders/proxmox/clone.mdx
+++ b/website/content/docs/builders/proxmox/clone.mdx
@@ -43,10 +43,20 @@ in the image's Cloud-Init settings for provisioning.
 
 - `username` (string) - Username when authenticating to Proxmox, including
   the realm. For example `user@pve` to use the local Proxmox realm.
+  When used with `token`, it would look like this: `user@pve!token`
   Can also be set via the `PROXMOX_USERNAME` environment variable.
 
 - `password` (string) - Password for the user.
+  For API tokens please use `token`.
   Can also be set via the `PROXMOX_PASSWORD` environment variable.
+  Either `password` or `token` must be specifed. If both are set,
+  `token` takes precedence.
+
+- `token` (string) - Token for authenticating API calls.
+  This allows the API client to work with API tokens instead of user passwords.
+  Can also be set via the `PROXMOX_TOKEN` environment variable.
+  Either `password` or `token` must be specifed. If both are set,
+  `token` takes precedence.
 
 - `node` (string) - Which node in the Proxmox cluster to start the virtual
   machine on during creation.

--- a/website/content/docs/builders/proxmox/iso.mdx
+++ b/website/content/docs/builders/proxmox/iso.mdx
@@ -40,10 +40,20 @@ builder.
 
 - `username` (string) - Username when authenticating to Proxmox, including
   the realm. For example `user@pve` to use the local Proxmox realm.
+  When used with `token`, it would look like this: `user@pve!token`
   Can also be set via the `PROXMOX_USERNAME` environment variable.
 
 - `password` (string) - Password for the user.
+  For API tokens please use `token`.
   Can also be set via the `PROXMOX_PASSWORD` environment variable.
+  Either `password` or `token` must be specifed. If both are set,
+  `token` takes precedence.
+
+- `token` (string) - Token for authenticating API calls.
+  This allows the API client to work with API tokens instead of user passwords.
+  Can also be set via the `PROXMOX_TOKEN` environment variable.
+  Either `password` or `token` must be specifed. If both are set,
+  `token` takes precedence.
 
 - `node` (string) - Which node in the Proxmox cluster to start the virtual
   machine on during creation.


### PR DESCRIPTION
Proxmox allows people to create API tokens with limited privileges that can be rotated without deleting a user account. It is usually useful for giving automated systems specific access to parts of the Proxmox API, e.g. a single VM resource pool.

> API tokens allow stateless access to most parts of the REST API by another system, software or API client. Tokens can be generated for individual users and can be given separate permissions and expiration dates to limit the scope and duration of the access. Should the API token get compromised it can be revoked without disabling the user itself.
> _https://pve.proxmox.com/wiki/User_Management#pveum_tokens_

The current authentication flow used for the Proxmox client is not compatible though:
> `POST /api2/json/access/ticket`
> This API endpoint is not available for API tokens.
> _https://pve.proxmox.com/pve-docs/api-viewer/#/access/ticket (POST tab)_

Instead the required auth flow for API tokens is described here:
> To use an API token, set the HTTP header Authorization to the displayed value of the form `PVEAPIToken=USER@REALM!TOKENID=UUID` when making API requests
> _https://pve.proxmox.com/wiki/User_Management#pveum_tokens_

---

This PR introduces a new parameter `token` for the Proxmox builder which allows using the alternative API token flow.
It will take precedence over `password` if both are given.

Tests are provided, docs have been updated.
I tested a development build with a proxmox setup locally.