### PR TITLE
website: remove obselete nav data

### DIFF
--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -7,19 +7,27 @@ import {
 import renderPageMdx from '@hashicorp/react-docs-page/render-page-mdx'
 import resolveNavData from './utils/resolve-nav-data'
 
-async function generateStaticPaths(navDataFile, contentDir, options = {}) {
-  const navData = await resolveNavData(navDataFile, contentDir, options)
+async function generateStaticPaths({
+  navDataFile,
+  localContentDir,
+  remotePluginsFile,
+}) {
+  const navData = await resolveNavData(navDataFile, localContentDir, {
+    remotePluginsFile,
+  })
   const paths = await getPathsFromNavData(navData)
   return paths
 }
 
-async function generateStaticProps(
-  navDataFile,
+async function generateStaticProps({
+  additionalComponents,
   localContentDir,
+  mainBranch = 'main',
+  navDataFile,
   params,
   product,
-  { remotePluginsFile, additionalComponents, mainBranch = 'main' } = {}
-) {
+  remotePluginsFile,
+}) {
   const navData = await resolveNavData(navDataFile, localContentDir, {
     remotePluginsFile,
   })

--- a/website/content/docs/builders/alicloud-ecs.mdx
+++ b/website/content/docs/builders/alicloud-ecs.mdx
@@ -3,7 +3,6 @@ description: |
   The `alicloud-ecs` Packer builder plugin provide the capability to build
   customized images based on an existing base images.
 page_title: Alicloud Image Builder
-sidebar_title: Alicloud ECS
 ---
 
 # Alicloud Image Builder

--- a/website/content/docs/builders/azure/arm.mdx
+++ b/website/content/docs/builders/azure/arm.mdx
@@ -1,7 +1,6 @@
 ---
 description: Packer supports building VHDs in Azure Resource manager.
 page_title: Azure arm - Builders
-sidebar_title: ARM
 ---
 
 # Azure Resource Manager Builder

--- a/website/content/docs/builders/azure/chroot.mdx
+++ b/website/content/docs/builders/azure/chroot.mdx
@@ -5,7 +5,6 @@ description: >
 
   a VM in Azure.
 page_title: Azure chroot - Builders
-sidebar_title: chroot
 ---
 
 # Azure Builder (chroot)
@@ -261,36 +260,36 @@ build {
 </Tab>
 <Tab heading="JSON">
 
-  ```json
-  {
-    "variables": {
-      "client_id": "{{env `ARM_CLIENT_ID`}}",
-      "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
-      "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
-      "resource_group": "{{env `ARM_IMAGE_RESOURCEGROUP_ID`}}"
-    },
-    "builders": [
-      {
-        "type": "azure-chroot",
+```json
+{
+  "variables": {
+    "client_id": "{{env `ARM_CLIENT_ID`}}",
+    "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+    "resource_group": "{{env `ARM_IMAGE_RESOURCEGROUP_ID`}}"
+  },
+  "builders": [
+    {
+      "type": "azure-chroot",
 
-        "client_id": "{{user `client_id`}}",
-        "client_secret": "{{user `client_secret`}}",
-        "subscription_id": "{{user `subscription_id`}}",
+      "client_id": "{{user `client_id`}}",
+      "client_secret": "{{user `client_secret`}}",
+      "subscription_id": "{{user `subscription_id`}}",
 
-        "image_resource_id": "/subscriptions/{{user `subscription_id`}}/resourceGroups/{{user `resource_group`}}/providers/Microsoft.Compute/images/MyDebianOSImage-{{timestamp}}",
+      "image_resource_id": "/subscriptions/{{user `subscription_id`}}/resourceGroups/{{user `resource_group`}}/providers/Microsoft.Compute/images/MyDebianOSImage-{{timestamp}}",
 
-        "source": "credativ:Debian:9:latest"
-      }
-    ],
-    "provisioners": [
-      {
-        "inline": ["apt-get update", "apt-get upgrade -y"],
-        "inline_shebang": "/bin/sh -x",
-        "type": "shell"
-      }
-    ]
-  }
-  ```
+      "source": "credativ:Debian:9:latest"
+    }
+  ],
+  "provisioners": [
+    {
+      "inline": ["apt-get update", "apt-get upgrade -y"],
+      "inline_shebang": "/bin/sh -x",
+      "type": "shell"
+    }
+  ]
+}
+```
 
 </Tab>
 </Tabs>

--- a/website/content/docs/builders/azure/index.mdx
+++ b/website/content/docs/builders/azure/index.mdx
@@ -5,7 +5,6 @@ description: >
   multiple builders depending on the strategy you want to use to build the
   images.
 page_title: Azure images - Builders
-sidebar_title: Azure
 ---
 
 # Azure Virtual Machine Image Builders

--- a/website/content/docs/builders/cloudstack.mdx
+++ b/website/content/docs/builders/cloudstack.mdx
@@ -5,7 +5,6 @@ description: |
   source, runs any provisioning necessary on the instance after launching it and
   then creates a new template from that instance.
 page_title: CloudStack - Builders
-sidebar_title: CloudStack
 ---
 
 # CloudStack Builder

--- a/website/content/docs/builders/community-supported.mdx
+++ b/website/content/docs/builders/community-supported.mdx
@@ -3,7 +3,6 @@ description: |
   Community-maintained builders are not part of the core Packer binary, but
   can run alongside Packer with minimal extra effort.
 page_title: Community - Builders
-sidebar_title: Community-Supported
 ---
 
 # Community Builders

--- a/website/content/docs/builders/custom.mdx
+++ b/website/content/docs/builders/custom.mdx
@@ -4,7 +4,6 @@ description: |
   modify the core source code of Packer itself. Documentation for creating new
   builders is covered in the custom builders page of the Packer plugin section.
 page_title: Custom - Builders
-sidebar_title: Custom
 ---
 
 # Custom Builder

--- a/website/content/docs/builders/digitalocean.mdx
+++ b/website/content/docs/builders/digitalocean.mdx
@@ -11,7 +11,6 @@ description: >
 
   launched within DigitalOcean.
 page_title: DigitalOcean - Builders
-sidebar_title: DigitalOcean
 ---
 
 # DigitalOcean Builder

--- a/website/content/docs/builders/file.mdx
+++ b/website/content/docs/builders/file.mdx
@@ -4,7 +4,6 @@ description: |
   from a file. It can be used to debug post-processors without incurring high
   wait times.
 page_title: File - Builders
-sidebar_title: File
 ---
 
 # File Builder

--- a/website/content/docs/builders/googlecompute.mdx
+++ b/website/content/docs/builders/googlecompute.mdx
@@ -3,7 +3,6 @@ description: |
   The googlecompute Packer builder is able to create images for use with Google
   Cloud Compute Engine (GCE) based on existing images.
 page_title: Google Compute - Builders
-sidebar_title: Google Cloud
 ---
 
 # Google Compute Builder

--- a/website/content/docs/builders/hetzner-cloud.mdx
+++ b/website/content/docs/builders/hetzner-cloud.mdx
@@ -6,7 +6,6 @@ description: |
   image. This reusable image can then be used as the foundation of new servers
   that are launched within the Hetzner Cloud.
 page_title: Hetzner Cloud - Builders
-sidebar_title: Hetzner Cloud
 ---
 
 # Hetzner Cloud Builder

--- a/website/content/docs/builders/hyperone.mdx
+++ b/website/content/docs/builders/hyperone.mdx
@@ -4,7 +4,6 @@ description: |
   The builder takes a source image, runs any provisioning necessary on
   the image after launching it, then creates a reusable image.
 page_title: HyperOne - Builders
-sidebar_title: HyperOne
 ---
 
 # HyperOne Builder

--- a/website/content/docs/builders/hyperv/index.mdx
+++ b/website/content/docs/builders/hyperv/index.mdx
@@ -3,7 +3,6 @@ description: |
   The Hyper-V Packer builder is able to create Hyper-V virtual machines and
   export them.
 page_title: Hyper-V - Builders
-sidebar_title: Hyper-V
 ---
 
 # HyperV Builder

--- a/website/content/docs/builders/hyperv/iso.mdx
+++ b/website/content/docs/builders/hyperv/iso.mdx
@@ -5,7 +5,6 @@ description: |
   The Hyper-V Packer builder is able to create Hyper-V virtual machines and
   export them.
 page_title: Hyper-V ISO - Builders
-sidebar_title: ISO
 ---
 
 # Hyper-V Builder (from an ISO)

--- a/website/content/docs/builders/hyperv/vmcx.mdx
+++ b/website/content/docs/builders/hyperv/vmcx.mdx
@@ -5,7 +5,6 @@ description: >-
   The Hyper-V Packer builder is able to clone an existing Hyper-V virtual
   machine and export them.
 page_title: Hyper-V Builder (from a vmcx)
-sidebar_title: VMCX
 ---
 
 # Hyper-V Builder (from a vmcx)

--- a/website/content/docs/builders/index.mdx
+++ b/website/content/docs/builders/index.mdx
@@ -3,7 +3,6 @@ description: |
   Builders are responsible for creating machines and generating images from them
   for various platforms.
 page_title: Builders
-sidebar_title: Builders
 ---
 
 # Builders
@@ -17,4 +16,3 @@ See the [`source`](/docs/templates/hcl_templates/blocks/source) block documentat
 about configuring builders in the Packer language.
 For information on an individual builder, choose it from the sidebar. Each
 builder has its own configuration options and parameters.
-

--- a/website/content/docs/builders/jdcloud.mdx
+++ b/website/content/docs/builders/jdcloud.mdx
@@ -3,7 +3,6 @@ description: |
   The `jdcloud` Packer builder helps you to build instance images
   based on an existing image
 page_title: JDCloud Image Builder
-sidebar_title: JDCloud
 ---
 
 # JDCloud Image Builder

--- a/website/content/docs/builders/linode.mdx
+++ b/website/content/docs/builders/linode.mdx
@@ -11,7 +11,6 @@ description: >
 
   within all Linode regions.
 page_title: Linode - Builders
-sidebar_title: Linode
 ---
 
 # Linode Builder
@@ -48,6 +47,7 @@ can also be supplied to override the typical auto-generated key:
 
   See https://github.com/tcort/markdown-link-check/issues/109
 -->
+
 ### Required
 
 - `linode_token` (string) - The client TOKEN to use to access your account.

--- a/website/content/docs/builders/lxc.mdx
+++ b/website/content/docs/builders/lxc.mdx
@@ -4,7 +4,6 @@ description: |
   container, runs provisioners within this container, then exports the container
   as a tar.gz of the root file system.
 page_title: LXC - Builders
-sidebar_title: LXC
 ---
 
 # LXC Builder

--- a/website/content/docs/builders/lxd.mdx
+++ b/website/content/docs/builders/lxd.mdx
@@ -7,7 +7,6 @@ description: >
 
   an LXD image.
 page_title: LXD - Builders
-sidebar_title: LXD
 ---
 
 # LXD Builder

--- a/website/content/docs/builders/ncloud.mdx
+++ b/website/content/docs/builders/ncloud.mdx
@@ -3,7 +3,6 @@ description: |
   The ncloud builder allows you to create server images using the NAVER Cloud
   Platform.
 page_title: Naver Cloud Platform - Builders
-sidebar_title: NAVER Cloud
 ---
 
 # NAVER CLOUD PLATFORM Builder

--- a/website/content/docs/builders/null.mdx
+++ b/website/content/docs/builders/null.mdx
@@ -5,7 +5,6 @@ description: |
   without incurring high wait times. It does not create any kind of image or
   artifact.
 page_title: Null - Builders
-sidebar_title: 'Null'
 ---
 
 # Null Builder

--- a/website/content/docs/builders/oneandone.mdx
+++ b/website/content/docs/builders/oneandone.mdx
@@ -1,7 +1,6 @@
 ---
 description: The 1&1 builder is able to create images for 1&1 cloud.
 page_title: 1&1 - Builders
-sidebar_title: 1&amp;1
 ---
 
 # 1&1 Builder
@@ -47,8 +46,9 @@ can also be supplied to override the typical auto-generated key:
   while waiting for the build to complete. Default value "600".
 
 <!-- markdown-link-check-disable -->
+
 - `url` (string) - Endpoint for the 1&1 REST API. Default URL
-  "<https://cloudpanel-api.1and1.com/v1>"
+"<https://cloudpanel-api.1and1.com/v1>"
 <!-- markdown-link-check-enable -->
 
 ## Example

--- a/website/content/docs/builders/openstack.mdx
+++ b/website/content/docs/builders/openstack.mdx
@@ -11,7 +11,6 @@ description: >
 
   within OpenStack.
 page_title: OpenStack - Builders
-sidebar_title: OpenStack
 ---
 
 # OpenStack Builder
@@ -132,6 +131,7 @@ builders "openstack" {
   insecure = "true"
 }
 ```
+
 </Tab>
 </Tabs>
 
@@ -155,6 +155,7 @@ Here is a basic example. This is a working example to build a Ubuntu 12.04 LTS
   "flavor": "2"
 }
 ```
+
 </Tab>
 
 <Tab heading="HCL2">
@@ -170,6 +171,7 @@ builders "openstack" {
   flavor = "2"
 }
 ```
+
 </Tab>
 </Tabs>
 
@@ -190,6 +192,7 @@ by Metacloud.
   "flavor": "2"
 }
 ```
+
 </Tab>
 
 <Tab heading="HCL2">
@@ -202,9 +205,9 @@ builders "openstack" {
   flavor = "2"
 }
 ```
+
 </Tab>
 </Tabs>
-
 
 In this case, the connection information for connecting to OpenStack doesn't
 appear in the template. That is because I source a standard OpenStack script
@@ -266,6 +269,7 @@ by Selectel VPC.
   "volume_type": "fast.ru-3a"
 }
 ```
+
 </Tab>
 
 <Tab heading="HCL2">
@@ -287,9 +291,9 @@ builders "openstack" {
   volume_type = "fast.ru-3a"
 }
 ```
+
 </Tab>
 </Tabs>
-
 
 ## Notes on OpenStack Authorization
 

--- a/website/content/docs/builders/oracle/classic.mdx
+++ b/website/content/docs/builders/oracle/classic.mdx
@@ -3,7 +3,6 @@ description: |
   The oracle-classic builder is able to create new custom images for use with
   Oracle Cloud Infrastructure Classic Compute.
 page_title: Oracle Cloud Infrastructure Classic - Builders
-sidebar_title: Oracle Classic
 ---
 
 # Oracle Cloud Infrastructure Classic Compute Builder

--- a/website/content/docs/builders/oracle/index.mdx
+++ b/website/content/docs/builders/oracle/index.mdx
@@ -1,7 +1,6 @@
 ---
 description: Packer is able to create custom images using Oracle Cloud Infrastructure.
 page_title: Oracle - Builders
-sidebar_title: Oracle
 ---
 
 # Oracle Builder

--- a/website/content/docs/builders/oracle/oci.mdx
+++ b/website/content/docs/builders/oracle/oci.mdx
@@ -3,7 +3,6 @@ description: |
   The oracle-oci builder is able to create new custom images for use with Oracle
   Cloud Infrastructure (OCI).
 page_title: Oracle OCI - Builders
-sidebar_title: Oracle OCI
 ---
 
 # Oracle Cloud Infrastructure (OCI) Builder
@@ -189,18 +188,19 @@ can also be supplied to override the typical auto-generated key:
 - `use_private_ip` (boolean) - Use private ip addresses to connect to the
   instance via ssh.
 
-- `shape_config` (object) - The shape configuration for an instance. The shape configuration determines the resources 
+- `shape_config` (object) - The shape configuration for an instance. The shape configuration determines the resources
   allocated to an instance. Options:
   - `ocpus` (required when using flexible shapes or memory_in_gbs is set) (float32) - The total number of OCPUs available to the instance.
   - `memory_in_gbs` (optional) (float32) - The total amount of memory, in gigabytes, available to the instance.
 
 <!-- markdown-link-check-disable -->
+
 - `metadata` (map of strings) - Metadata optionally contains custom metadata
-  key/value pairs provided in the configuration. While this can be used to
-  set metadata\["user_data"\] the explicit "user_data" and
-  "user_data_file" values will have precedence. An instance's metadata can
-  be obtained from at [http://169.254.169.254](http://169.254.169.254) on
-  the launched instance.
+key/value pairs provided in the configuration. While this can be used to
+set metadata\["user_data"\] the explicit "user_data" and
+"user_data_file" values will have precedence. An instance's metadata can
+be obtained from at [http://169.254.169.254](http://169.254.169.254) on
+the launched instance.
 <!-- markdown-link-check-enable -->
 
 - `user_data` (string) - User data to be used by cloud-init. See [the Oracle

--- a/website/content/docs/builders/outscale/bsu.mdx
+++ b/website/content/docs/builders/outscale/bsu.mdx
@@ -7,7 +7,6 @@ description: >
 
   the root device section in the Outscale documentation.
 page_title: Outscale BSU - Builders
-sidebar_title: BSU
 ---
 
 # OMI Builder (BSU backed)

--- a/website/content/docs/builders/outscale/bsusurrogate.mdx
+++ b/website/content/docs/builders/outscale/bsusurrogate.mdx
@@ -3,7 +3,6 @@ description: |
   The osc-bsusurrogate Packer builder is like the chroot builder, but does not
   require running inside an Outscale virtual machine.
 page_title: Outscale BSU Surrogate - Builders
-sidebar_title: BSU Surrogate
 ---
 
 # BSU Surrogate Builder

--- a/website/content/docs/builders/outscale/bsuvolume.mdx
+++ b/website/content/docs/builders/outscale/bsuvolume.mdx
@@ -3,7 +3,6 @@ description: |
   The osc-bsuvolume Packer builder is like the BSU builder, but is intended to
   create BSU volumes rather than a machine image.
 page_title: Outscale BSU Volume - Builders
-sidebar_title: BSU Volume
 ---
 
 # BSU Volume Builder

--- a/website/content/docs/builders/outscale/chroot.mdx
+++ b/website/content/docs/builders/outscale/chroot.mdx
@@ -9,7 +9,6 @@ description: >
 
   in the Outscale documentation.
 page_title: Outscale chroot - Builders
-sidebar_title: chroot
 ---
 
 # OMI Builder (chroot)

--- a/website/content/docs/builders/outscale/index.mdx
+++ b/website/content/docs/builders/outscale/index.mdx
@@ -5,7 +5,6 @@ description: >
 
   multiple builders depending on the strategy you want to use to build the OMI.
 page_title: Outscale OMI - Builders
-sidebar_title: Outscale
 ---
 
 # Outscale OMI Builder

--- a/website/content/docs/builders/parallels/index.mdx
+++ b/website/content/docs/builders/parallels/index.mdx
@@ -3,7 +3,6 @@ description: |
   The Parallels Packer builder is able to create Parallels Desktop for Mac
   virtual machines and export them in the PVM format.
 page_title: Parallels - Builders
-sidebar_title: Parallels
 ---
 
 # Parallels Builder

--- a/website/content/docs/builders/parallels/iso.mdx
+++ b/website/content/docs/builders/parallels/iso.mdx
@@ -6,7 +6,6 @@ description: |
   virtual machines and export them in the PVM format, starting from an ISO
   image.
 page_title: Parallels ISO - Builders
-sidebar_title: ISO
 ---
 
 # Parallels Builder (from an ISO)

--- a/website/content/docs/builders/parallels/pvm.mdx
+++ b/website/content/docs/builders/parallels/pvm.mdx
@@ -6,7 +6,6 @@ description: |
   machines and export them in the PVM format, starting from an existing PVM
   (exported virtual machine image).
 page_title: Parallels PVM - Builders
-sidebar_title: PVM
 ---
 
 # Parallels Builder (from a PVM)

--- a/website/content/docs/builders/profitbricks.mdx
+++ b/website/content/docs/builders/profitbricks.mdx
@@ -1,7 +1,6 @@
 ---
 description: The ProfitBricks builder is able to create images for ProfitBricks cloud.
 page_title: ProfitBricks - Builders
-sidebar_title: ProfitBricks
 ---
 
 # ProfitBricks Builder
@@ -63,7 +62,7 @@ can also be supplied to override the typical auto-generated key:
 - `snapshot_password` (string) - Password for the snapshot.
 <!-- markdown-link-check-disable -->
 - `url` (string) - Endpoint for the ProfitBricks REST API. Default URL
-  "<https://api.profitbricks.com/rest/v2>"
+"<https://api.profitbricks.com/rest/v2>"
 <!-- markdown-link-check-enable -->
 
 ## Example

--- a/website/content/docs/builders/proxmox/clone.mdx
+++ b/website/content/docs/builders/proxmox/clone.mdx
@@ -5,7 +5,6 @@ description: |
   template name, runs any provisioning necessary on the image after
   launching it, then creates a virtual machine template.
 page_title: Proxmox Clone - Builders
-sidebar_title: Clone
 ---
 
 # Proxmox Builder (from an image)

--- a/website/content/docs/builders/proxmox/index.mdx
+++ b/website/content/docs/builders/proxmox/index.mdx
@@ -3,7 +3,6 @@ description: >
   The Proxmox Packer builder is able to create Cloud-Init virtual machine images
   on a Proxmox server.
 page_title: Proxmox - Builders
-sidebar_title: Proxmox
 ---
 
 # Proxmox Builder

--- a/website/content/docs/builders/proxmox/iso.mdx
+++ b/website/content/docs/builders/proxmox/iso.mdx
@@ -5,7 +5,6 @@ description: |
   necessary on the image after launching it, then creates a virtual machine
   template.
 page_title: Proxmox ISO - Builders
-sidebar_title: ISO
 ---
 
 # Proxmox Builder (from an ISO)
@@ -223,7 +222,7 @@ builder.
   Defaults to `lsi`.
 
 - `cloud_init` (bool) - If true, add a Cloud-Init CDROM drive after the virtual machine has been converted to a template.
-   Defaults to `false`.
+  Defaults to `false`.
 
 - `cloud_init_storage_pool` - (string) - Name of the Proxmox storage pool
   to store the Cloud-Init CDROM on. If not given, the storage pool of the boot device will be used.

--- a/website/content/docs/builders/qemu.mdx
+++ b/website/content/docs/builders/qemu.mdx
@@ -4,7 +4,6 @@ modeline: |
 description: |
   The Qemu Packer builder is able to create KVM virtual machine images.
 page_title: QEMU - Builders
-sidebar_title: QEMU
 ---
 
 # QEMU Builder

--- a/website/content/docs/builders/scaleway.mdx
+++ b/website/content/docs/builders/scaleway.mdx
@@ -11,7 +11,6 @@ description: >
 
   servers that are launched within Scaleway.
 page_title: Scaleway - Builders
-sidebar_title: Scaleway
 ---
 
 # Scaleway Builder
@@ -70,6 +69,7 @@ access tokens:
   "ssh_private_key_file": "~/.ssh/id_rsa"
 }
 ```
+
 </Tab>
 
 <Tab heading="HCL2">
@@ -86,9 +86,9 @@ builders "scaleway" {
   ssh_private_key_file = "~/.ssh/id_rsa"
 }
 ```
+
 </Tab>
 </Tabs>
-
 
 When you do not specify the `ssh_private_key_file`, a temporary SSH keypair
 is generated to connect the server. This key will only allow the `root` user to

--- a/website/content/docs/builders/tencentcloud-cvm.mdx
+++ b/website/content/docs/builders/tencentcloud-cvm.mdx
@@ -3,7 +3,6 @@ description: |
   The `tencentcloud-cvm` Packer builder plugin provide the capability to build
   customized images based on an existing base images.
 page_title: Tencentcloud Image Builder
-sidebar_title: Tencent Cloud
 ---
 
 # Tencentcloud Image Builder

--- a/website/content/docs/builders/triton.mdx
+++ b/website/content/docs/builders/triton.mdx
@@ -10,7 +10,6 @@ description: >
 
   Cloud API to create images.
 page_title: Triton - Builders
-sidebar_title: Triton
 ---
 
 # Triton Builder

--- a/website/content/docs/builders/ucloud-uhost.mdx
+++ b/website/content/docs/builders/ucloud-uhost.mdx
@@ -3,7 +3,6 @@ description: |
   The `ucloud-uhost` Packer builder plugin provides the capability to build
   customized images based on an existing base image for use in UHost Instance.
 page_title: UCloud Image Builder
-sidebar_title: UCloud
 ---
 
 # UCloud Image Builder

--- a/website/content/docs/builders/vagrant.mdx
+++ b/website/content/docs/builders/vagrant.mdx
@@ -3,7 +3,6 @@ description: |
   The Vagrant Packer builder is able to launch Vagrant boxes and
   re-package them into .box files
 page_title: Vagrant - Builders
-sidebar_title: Vagrant
 ---
 
 # Vagrant Builder
@@ -185,13 +184,13 @@ build {
 
 ## Regarding output directory and new box
 
-After Packer completes building and provisioning a new Vagrant Box file, it is worth 
-noting that the new box file will need to be added to Vagrant. For a beginner to Packer 
+After Packer completes building and provisioning a new Vagrant Box file, it is worth
+noting that the new box file will need to be added to Vagrant. For a beginner to Packer
 and Vagrant, it may seem as if a simple 'vagrant up' in the output directory will run the
-the newly created Box. This is not the case. 
+the newly created Box. This is not the case.
 
-Rather, create a new directory (to avoid Vagarant init collisions), add the new 
-package.box to Vagrant and init. Then run vagrant up to bring up the new box created 
+Rather, create a new directory (to avoid Vagarant init collisions), add the new
+package.box to Vagrant and init. Then run vagrant up to bring up the new box created
 by Packer. You will now be able to connect to the new box with provisioned changes.
 
 ```

--- a/website/content/docs/builders/virtualbox/index.mdx
+++ b/website/content/docs/builders/virtualbox/index.mdx
@@ -5,7 +5,6 @@ description: >
 
   export them in the OVA or OVF format.
 page_title: VirtualBox - Builders
-sidebar_title: VirtualBox
 ---
 
 # VirtualBox Builder

--- a/website/content/docs/builders/virtualbox/iso.mdx
+++ b/website/content/docs/builders/virtualbox/iso.mdx
@@ -5,7 +5,6 @@ description: |
   The VirtualBox Packer builder is able to create VirtualBox virtual machines
   and export them in the OVF format, starting from an ISO image.
 page_title: VirtualBox ISO - Builders
-sidebar_title: ISO
 ---
 
 # VirtualBox Builder (from an ISO)

--- a/website/content/docs/builders/virtualbox/ovf.mdx
+++ b/website/content/docs/builders/virtualbox/ovf.mdx
@@ -6,7 +6,6 @@ description: |
   and export them in the OVF format, starting from an existing OVF/OVA (exported
   virtual machine image).
 page_title: VirtualBox OVF/OVA - Builders
-sidebar_title: OVF
 ---
 
 # VirtualBox Builder (from an OVF/OVA)

--- a/website/content/docs/builders/virtualbox/vm.mdx
+++ b/website/content/docs/builders/virtualbox/vm.mdx
@@ -7,7 +7,6 @@ description: >
 
   and export them in the OVF format, starting from an ISO image.
 page_title: VirtualBox Snapshot - Builders
-sidebar_title: VM
 ---
 
 # VirtualBox Builder (from an existing VM)

--- a/website/content/docs/builders/vmware/index.mdx
+++ b/website/content/docs/builders/vmware/index.mdx
@@ -3,7 +3,6 @@ description: |
   The VMware Packer builder is able to create VMware virtual machines for use
   with any VMware product.
 page_title: VMware - Builders
-sidebar_title: VMware
 ---
 
 # VMware Builder

--- a/website/content/docs/builders/vmware/iso.mdx
+++ b/website/content/docs/builders/vmware/iso.mdx
@@ -8,7 +8,6 @@ description: |
   VMware Player on Linux. It can also build machines directly on VMware vSphere
   Hypervisor using SSH as opposed to the vSphere API.
 page_title: VMware ISO - Builders
-sidebar_title: VMWare ISO
 ---
 
 # VMware Builder (from ISO)

--- a/website/content/docs/builders/vmware/vmx.mdx
+++ b/website/content/docs/builders/vmware/vmx.mdx
@@ -7,7 +7,6 @@ description: |
   virtual machines on hosts running VMware Fusion Professional for OS X, VMware
   Workstation for Linux and Windows, and VMware Player on Linux.
 page_title: VMware VMX - Builders
-sidebar_title: VMWare VMX
 ---
 
 # VMware Builder (from VMX)

--- a/website/content/docs/builders/vmware/vsphere-clone.mdx
+++ b/website/content/docs/builders/vmware/vsphere-clone.mdx
@@ -5,7 +5,6 @@ description: >
   This VMware Packer builder uses the vSphere API to clone an existing vSphere
   template and create a new virtual machine remotely.
 page_title: VSphere Clone - Builders
-sidebar_title: VSphere Clone
 ---
 
 # VMWare Vsphere Clone Builder

--- a/website/content/docs/builders/vmware/vsphere-iso.mdx
+++ b/website/content/docs/builders/vmware/vsphere-iso.mdx
@@ -5,7 +5,6 @@ description: |
   This VMware Packer builder starts from an ISO and creates a vm using the
   vSphere API to build on a remote VMWare machine.
 page_title: VSphere ISO - Builders
-sidebar_title: VSphere ISO
 ---
 
 # Packer Builder for VMware vSphere

--- a/website/content/docs/builders/yandex.mdx
+++ b/website/content/docs/builders/yandex.mdx
@@ -3,7 +3,6 @@ description: |
   The yandex Packer builder is able to create images for use with
   Yandex.Cloud based on existing images.
 page_title: Yandex Compute - Builders
-sidebar_title: Yandex.Cloud
 ---
 
 # Yandex Compute Builder

--- a/website/content/docs/commands/build.mdx
+++ b/website/content/docs/commands/build.mdx
@@ -5,7 +5,6 @@ description: |
   template are executed in parallel, unless otherwise specified. And the
   artifacts that are created will be outputted at the end of the build.
 page_title: packer build - Commands
-sidebar_title: <tt>build</tt>
 ---
 
 # `build` Command

--- a/website/content/docs/commands/console.mdx
+++ b/website/content/docs/commands/console.mdx
@@ -3,7 +3,6 @@ description: |
   The `packer console` command allows you to experiment with Packer variable
   interpolations.
 page_title: packer console - Commands
-sidebar_title: <tt>console</tt>
 ---
 
 # `console` Command

--- a/website/content/docs/commands/fix.mdx
+++ b/website/content/docs/commands/fix.mdx
@@ -5,7 +5,6 @@ description: |
   of Packer. After you update to a new Packer release, you should run the fix
   command to make sure your templates work with the new release.
 page_title: packer fix - Commands
-sidebar_title: <tt>fix</tt>
 ---
 
 # `fix` Command

--- a/website/content/docs/commands/fmt.mdx
+++ b/website/content/docs/commands/fmt.mdx
@@ -3,7 +3,6 @@ description: |
   The `packer fmt` Packer command is used to format HCL2
   configuration files to a canonical format and style.
 page_title: packer fmt - Commands
-sidebar_title: <tt>fmt</tt>
 ---
 
 # `fmt` Command

--- a/website/content/docs/commands/hcl2_upgrade.mdx
+++ b/website/content/docs/commands/hcl2_upgrade.mdx
@@ -4,7 +4,6 @@ description: |
   configuration template to it's formatted HCL2 counterpart. The command will
   return a zero exit status on success, and a non-zero exit status on failure.
 page_title: packer hcl2_upgrade - Commands
-sidebar_title: <tt>hcl2_upgrade</tt>
 ---
 
 -> **Note:** This command is Beta, and currently being improved upon; do not
@@ -35,16 +34,13 @@ From **v1.7.1**, the `hcl2_upgrade` command can upgrade a variables file.
 
 ```json
 {
-    "variables": {
-        "aws_region": null,
-        "aws_secondary_region": "{{ env `AWS_DEFAULT_REGION` }}",
-        "aws_secret_key": "",
-        "aws_access_key": "",
-    },
-    "sensitive-variables": [
-        "aws_secret_key",
-        "aws_access_key",
-    ]
+  "variables": {
+    "aws_region": null,
+    "aws_secondary_region": "{{ env `AWS_DEFAULT_REGION` }}",
+    "aws_secret_key": "",
+    "aws_access_key": ""
+  },
+  "sensitive-variables": ["aws_secret_key", "aws_access_key"]
 }
 ```
 

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -6,7 +6,6 @@ description: |
   additional options as well. Subcommands are executed with `packer SUBCOMMAND`,
   where "SUBCOMMAND" is the actual command you wish to execute.
 page_title: Commands
-sidebar_title: Commands (CLI)
 ---
 
 # Packer Commands (CLI)

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -2,7 +2,6 @@
 description: |
   The `packer init` Packer command is used to download Packer plugin binaries.
 page_title: packer init - Commands
-sidebar_title: <tt>init</tt>
 ---
 
 # `init` Command
@@ -37,7 +36,6 @@ for the ones that are missing.
 
 `packer init -upgrade` will try to get the latest versions for all plugins.
 
-
 Import a plugin using the [`required_plugin`](/docs/templates/hcl_templates/blocks/packer#specifying-plugin-requirements)
 block :
 
@@ -55,6 +53,7 @@ packer {
 HashiCorp does not officially verify third party Packer plugins, plugins not under the HashiCorp namespace `hashicorp/*`; as with all open source tools, please do your own due diligence when using a new tool.
 
 ## Plugin Selection
+
 Plugin selection depends on the source and version constraints defined within the `required_plugins` block.
 For each of the required plugins Packer will query the source repository `github.com/azr/happycloud` whose fully qualified address
 is `https://github.com/azr/packer-plugin-happycloud` for a plugin matching the version constraints for the host operating system.

--- a/website/content/docs/commands/inspect.mdx
+++ b/website/content/docs/commands/inspect.mdx
@@ -11,7 +11,6 @@ description: >
 
   provisioners it defines and the order they'll run, and more.
 page_title: packer inspect - Commands
-sidebar_title: <tt>inspect</tt>
 ---
 
 # `inspect` Command

--- a/website/content/docs/commands/validate.mdx
+++ b/website/content/docs/commands/validate.mdx
@@ -5,7 +5,6 @@ description: |
   success, and a non-zero exit status on failure. Additionally, if a template
   doesn't validate, any error messages will be outputted.
 page_title: packer validate - Commands
-sidebar_title: <tt>validate</tt>
 ---
 
 # `validate` Command

--- a/website/content/docs/communicators/index.mdx
+++ b/website/content/docs/communicators/index.mdx
@@ -3,7 +3,6 @@ description: |
   Communicators are the mechanism Packer uses to upload files, execute
   scripts, etc. with the machine being created.
 page_title: Communicators
-sidebar_title: Communicators
 ---
 
 # Communicators

--- a/website/content/docs/communicators/ssh.mdx
+++ b/website/content/docs/communicators/ssh.mdx
@@ -3,7 +3,6 @@ description: |
   The SSH communicator uses SSH to upload files, execute scripts, etc. on
   the machine being created.
 page_title: Communicators - SSH
-sidebar_title: SSH
 ---
 
 # SSH Communicator

--- a/website/content/docs/communicators/winrm.mdx
+++ b/website/content/docs/communicators/winrm.mdx
@@ -3,7 +3,6 @@ description: |
   Communicators are the mechanism Packer uses to upload files, execute scripts,
   etc. with the machine being created.
 page_title: Communicators - Templates
-sidebar_title: WINRM
 ---
 
 # WinRM Communicator

--- a/website/content/docs/configure.mdx
+++ b/website/content/docs/configure.mdx
@@ -3,7 +3,6 @@ description: |
   There are various ways to configure Packer. By default Packer will use known folders,
   which can be changed by using environment variables.
 page_title: Configuring Packer
-sidebar_title: Configuring Packer
 ---
 
 # Configuring Packer
@@ -21,7 +20,7 @@ The home directory of packer will be the first one of the following env values
 to be set :
 
 | unix                   | windows               |
-|------------------------|-----------------------|
+| ---------------------- | --------------------- |
 | `${PACKER_CONFIG_DIR}` | `%PACKER_CONFIG_DIR%` |
 | `${APPDATA}`           | `%APPDATA%`           |
 | `${HOME}`              | `%HOME%`              |
@@ -36,7 +35,7 @@ Packer can optionally read a JSON file for the end user to set core settings.
 The config file of packer will be looked up on the following paths:
 
 | unix                            | windows                          |
-|---------------------------------|----------------------------------|
+| ------------------------------- | -------------------------------- |
 | `${PACKER_CONFIG}`              | `%PACKER_CONFIG%`                |
 | `PACKER_HOME_DIR/.packerconfig` | `PACKER_HOME_DIR/packer.config/` |
 
@@ -48,17 +47,18 @@ Packer's configuration directory can potentialy contain plugins and internal
 Packer files. The config dir of packer will be looked up on the following paths:
 
 | unix                        | windows                     |
-|-----------------------------|-----------------------------|
+| --------------------------- | --------------------------- |
 | `PACKER_HOME_DIR/.packer.d` | `PACKER_HOME_DIR/packer.d/` |
 
-Examples: 
-* On a 'unix' system, if the `$PACKER_CONFIG_DIR` env var is set to
-`/home/packer`, the config directory will be: `/home/packer/.packer.d/` and
-other values will not be checked.
-* On a 'unix' system, if the `HOME` env var is `/home/azr` or the `USER` env var
-is `azr`, then the config directory will default to `/home/azr/.packer.d/`.
-* On a 'windows' system, if the `PACKER_CONFIG_DIR` env var is set to `C:/`,the
-config directory will be: `C:/packer.d/` and other values will not be checked.
+Examples:
+
+- On a 'unix' system, if the `$PACKER_CONFIG_DIR` env var is set to
+  `/home/packer`, the config directory will be: `/home/packer/.packer.d/` and
+  other values will not be checked.
+- On a 'unix' system, if the `HOME` env var is `/home/azr` or the `USER` env var
+  is `azr`, then the config directory will default to `/home/azr/.packer.d/`.
+- On a 'windows' system, if the `PACKER_CONFIG_DIR` env var is set to `C:/`,the
+  config directory will be: `C:/packer.d/` and other values will not be checked.
 
 ## Packer's plugin directory
 

--- a/website/content/docs/datasources/index.mdx
+++ b/website/content/docs/datasources/index.mdx
@@ -3,7 +3,6 @@ description: |
   Data sources allow data to be fetched for use in Packer configuration. Use of data sources
   allows a build to use information defined outside of Packer.
 page_title: Data Sources
-sidebar_title: Data Sources
 ---
 
 # Data Sources

--- a/website/content/docs/debugging.mdx
+++ b/website/content/docs/debugging.mdx
@@ -4,7 +4,6 @@ description: |
   certain things may not work entirely correctly, or may not appear to work
   correctly.
 page_title: Debugging - Other
-sidebar_title: Debugging
 ---
 
 # Debugging Packer Builds

--- a/website/content/docs/install.mdx
+++ b/website/content/docs/install.mdx
@@ -3,7 +3,6 @@ description: |
   Installing Packer is simple. You can download a precompiled binary or compile
   from source. This page details both methods.
 page_title: Install
-sidebar_title: Installing Packer
 ---
 
 # Install Packer

--- a/website/content/docs/plugins/creation/custom-builders.mdx
+++ b/website/content/docs/plugins/creation/custom-builders.mdx
@@ -3,7 +3,6 @@ description: |
   It is possible to write custom builders using the Packer plugin interface, and
   this page documents how to do that.
 page_title: Custom Builders - Extending
-sidebar_title: Custom Builders
 ---
 
 # Custom Builders
@@ -24,7 +23,6 @@ basics](/docs/extending/plugins).
 ~> **Warning!** This is an advanced topic. If you're new to Packer, we
 recommend getting comfortable with using Packer and its officially maintained
 plugins before you dive into writing plugins of your own.
-
 
 Custom plugins are written in [golang](https://golang.org/), so this guide
 assumes that you have some familiarity with that programming language.
@@ -53,8 +51,7 @@ function, check our
 
 The `Prepare` method for each builder will be called by the Packer core
 at the beginning of the build. Its purpose is to parse and validate the
-configuration template provided to Packer with `packer build
-your_packer_template.json`, but not to execute API calls or begin creating any
+configuration template provided to Packer with `packer build your_packer_template.json`, but not to execute API calls or begin creating any
 resources or artifacts.
 
 The configuration from your Packer template is passed into the Prepare() method
@@ -107,7 +104,7 @@ the machine, provision it, and create the resulting machine image, which is
 returned as an implementation of the `packer.Artifact` interface.
 
 The `Run` method takes three parameters. The context.Context used to cancel the
-build.  The `packer.Ui` object is used to send output to the console.
+build. The `packer.Ui` object is used to send output to the console.
 `packer.Hook` is used to execute hooks, which are covered in more detail in the
 Provisioning section below.
 
@@ -143,7 +140,6 @@ is a rare use case.
 The `Cancel` method can be called at any time and requests cancellation of any
 builder run in progress. This method should block until the run actually stops.
 Note that the Cancel method will not be called by Packer versions >= 1.4.0.
-
 
 #### Context cancellation ( from Packer v1.4 )
 

--- a/website/content/docs/plugins/creation/custom-datasources.mdx
+++ b/website/content/docs/plugins/creation/custom-datasources.mdx
@@ -3,7 +3,6 @@ description: >
   Packer Data Sources are the components of Packer that allow data to be fetched for use within the Packer configuration.
   Use of data sources allows a build to use information defined outside of Packer.
 page_title: Custom Data Sources - Extending
-sidebar_title: Custom Data Sources
 ---
 
 # Custom Data Sources
@@ -86,7 +85,6 @@ Execute command will fetch the data and return it as a cty.Value.
 
 To get the equivalent cty.Value from an output config, we suggest using our
 [packer-plugin-sdk hcl2helper functions](https://github.com/hashicorp/packer-plugin-sdk/blob/v0.0.7/hcl2helper/values.go).
-
 
 ## Scaffolding template
 

--- a/website/content/docs/plugins/creation/custom-post-processors.mdx
+++ b/website/content/docs/plugins/creation/custom-post-processors.mdx
@@ -5,7 +5,6 @@ description: >
 
   into another, for example by compressing files, or uploading them.
 page_title: Custom Post-Processors - Extending
-sidebar_title: Custom Post-Processors
 ---
 
 # Custom Post-Processors

--- a/website/content/docs/plugins/creation/custom-provisioners.mdx
+++ b/website/content/docs/plugins/creation/custom-provisioners.mdx
@@ -9,7 +9,6 @@ description: >
 
   within the machines.
 page_title: Custom Provisioners - Extending
-sidebar_title: Custom Provisioners
 ---
 
 # Custom Provisioners

--- a/website/content/docs/plugins/creation/index.mdx
+++ b/website/content/docs/plugins/creation/index.mdx
@@ -4,7 +4,6 @@ description: |
   infinite, Packer supports plugins for builders, provisioners, and
   post-processors.
 page_title: Extending
-sidebar_title: Extending Packer
 ---
 
 # Extending Packer
@@ -43,8 +42,9 @@ provisioners, post-processors, and data sources.
 Each of these components has a corresponding [interface](https://golang.org/doc/effective_go.html#interfaces_and_types).
 
 All you need to do to create a plugin is:
-  1. create an implementation of the desired interface, and
-  2. serve it using the server provided in the [packer-plugin-sdk](https://github.com/hashicorp/packer-plugin-sdk).
+
+1. create an implementation of the desired interface, and
+2. serve it using the server provided in the [packer-plugin-sdk](https://github.com/hashicorp/packer-plugin-sdk).
 
 The core and the SDK handle all of the communication details inside the server.
 
@@ -110,10 +110,10 @@ be referenced by using only the plugin name. For example:
 If your plugin is named `packer-plugin-my`, the above set definition would make
 the following components available:
 
-* the `my-example` builder
-* the `my` builder
-* the `my-foo` post-processor
-* the `my-bar` provisioner
+- the `my-example` builder
+- the `my` builder
+- the `my-foo` post-processor
+- the `my-bar` provisioner
 
 </Tab>
 
@@ -152,7 +152,6 @@ because the `packer init` command only supports multi-component plugins.
 </Tab>
 </Tabs>
 
-
 Next, build your plugin as you would any other Go application. The resulting
 binary is the plugin that can be installed using
 [standard installation procedures](/docs/plugins#installing-plugins).
@@ -190,7 +189,7 @@ the logs to be helpful.
 
 `packer init` does not work using a centralized registry. Instead, it requires
 you to publish your plugin in a GitHub repo with the name
-`packer-plugin-*` where * represents the name of your plugin. You also need to
+`packer-plugin-*` where \* represents the name of your plugin. You also need to
 create a GitHub release of your plugin with specific assets for the
 `packer init` download to work. We provide a pre-defined release workflow
 configuration using
@@ -200,28 +199,29 @@ release contains the right assets with the right names for Packer to leverage
 `packer init` installation.
 
 Here's what you need to create releases using GitHub Actions:
+
 1. Generate a GPG key to be used when signing releases (See [GitHub's detailed instructions](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/generating-a-new-gpg-key)
-for help with this step)
+   for help with this step)
 2. Copy the [GoReleaser configuration from the packer-plugin-scaffolding repository](https://github.com/hashicorp/packer-plugin-scaffolding/blob/main/.goreleaser.yml) to the root of your repository.
-	```sh
-	curl -L -o .goreleaser.yml \
-	https://raw.githubusercontent.com/hashicorp/packer-plugin-scaffolding/main/.goreleaser.yml
-	```
+   ```sh
+   curl -L -o .goreleaser.yml \
+   https://raw.githubusercontent.com/hashicorp/packer-plugin-scaffolding/main/.goreleaser.yml
+   ```
 3. Copy the [GitHub Actions workflow from the packer-plugin-scaffolding repository](https://github.com/hashicorp/packer-plugin-scaffolding/blob/main/.github/workflows/release.yml) to `.github/workflows/release.yml` in your repository.
-	```sh
-  mkdir -p .github/workflows &&
-  curl -L -o .github/workflows/release.yml \
-  https://raw.githubusercontent.com/hashicorp/packer-plugin-scaffolding/main/.github/workflows/release.yml
-	```
+   ```sh
+   mkdir -p .github/workflows &&
+   curl -L -o .github/workflows/release.yml \
+   https://raw.githubusercontent.com/hashicorp/packer-plugin-scaffolding/main/.github/workflows/release.yml
+   ```
 4. Go to your repository page on GitHub and navigate to Settings > Secrets. Add
-	the following secrets:
-    - `GPG_PRIVATE_KEY` - Your ASCII-armored GPG private key. You can export this with `gpg --armor --export-secret-keys [key ID or email]`.
-    - `PASSPHRASE` - The passphrase for your GPG private key.
+   the following secrets:
+   - `GPG_PRIVATE_KEY` - Your ASCII-armored GPG private key. You can export this with `gpg --armor --export-secret-keys [key ID or email]`.
+   - `PASSPHRASE` - The passphrase for your GPG private key.
 5. Push a new valid version tag (e.g. `v1.2.3`) to test that the GitHub Actions
-releaser is working. The tag must be a valid
-[Semantic Version](https://semver.org/) preceded with a `v`. Once the tag is pushed, the github actions you just configured will automatically build release binaries that Packer can download using `packer init`. For more details on how
-to install a plugin using `packer init`, see the
-[init docs](/docs/commands/init).
+   releaser is working. The tag must be a valid
+   [Semantic Version](https://semver.org/) preceded with a `v`. Once the tag is pushed, the github actions you just configured will automatically build release binaries that Packer can download using `packer init`. For more details on how
+   to install a plugin using `packer init`, see the
+   [init docs](/docs/commands/init).
 
 ### Registering Plugin Documentation
 
@@ -245,7 +245,7 @@ To register a plugin follow one of the following setups
 Documentation for a plugin is maintained within the `docs` directory and served on GitHub.
 
 A GitHub workflow has been added to [packer-plugin-scaffolding](https://github.com/hashicorp/packer-plugin-scaffolding/tree/main/docs) that
-can be used generate a documentation structure that can be consumed remotely by https://packer.io.  See the full workflow at [generated-docs-artifacts.yml](https://github.com/hashicorp/packer-plugin-scaffolding/blob/main/.github/workflows/generate-docs-artifacts.yml)
+can be used generate a documentation structure that can be consumed remotely by https://packer.io. See the full workflow at [generated-docs-artifacts.yml](https://github.com/hashicorp/packer-plugin-scaffolding/blob/main/.github/workflows/generate-docs-artifacts.yml)
 
 The GitHub workflow will automatically create the `.docs-artifacts` directory with the generated sidebar navigation file, and open a new pull-request against the default configured branch to be merged by the maintainer.
 
@@ -258,19 +258,19 @@ This is done by adding the block below for the respective plugin to the file [do
 
 ```json
 {
-   "title": "Docker",
-   "path": "docker",
-   "repo": "hashicorp/packer-plugin-docker",
- }
+  "title": "Docker",
+  "path": "docker",
+  "repo": "hashicorp/packer-plugin-docker"
+}
 ```
 
 #### Required fields
 
 `title`: The name of the plugin to be displayed in the sidebar - See [naming conventions](#naming-conventions)
 
-`path`:  The path name for the documentation page, which is usually the lower case version of `title` (e.g https
+`path`: The path name for the documentation page, which is usually the lower case version of `title` (e.g https
 
-`repo`:  The full name of the GitHub repository (i.e org/repo-name)
+`repo`: The full name of the GitHub repository (i.e org/repo-name)
 
 #### Optional fields
 
@@ -278,17 +278,14 @@ This is done by adding the block below for the respective plugin to the file [do
 
 `artifactDir`: The location of the docs artifacts directory in the remote repository. Defaults to `.doc-artifacts`.
 
-
 </Tab>
 <Tab heading="Registering Manually">
-
 
 The documentation structure needed for registering a plugin's documentation can be generated manually, but it is
 encouraged to use the action on release events so that documentation stays up to date.
 
 If your local development environment has a supported version (v10.0.0+) of [node](https://nodejs.org/en/) and a
 supported version (>=5.2.0) [npm](https://www.npmjs.com/) installed, in the plugin root directory, you can run:
-
 
 ```shell-session
 > npx -p @hashicorp/packer-docs-artifacts generate
@@ -304,26 +301,25 @@ This is done by adding the block below for the respective plugin to the file [do
 
 ```json
 {
-   "title": "Docker",
-   "path": "docker",
-   "repo": "hashicorp/packer-plugin-docker",
- }
+  "title": "Docker",
+  "path": "docker",
+  "repo": "hashicorp/packer-plugin-docker"
+}
 ```
 
 #### Required fields
 
 `title`: The name of the plugin to be displayed in the sidebar - See [naming conventions](#naming-conventions)
 
-`path`:  The path name for the documentation page, which is usually the lower case version of `title` (e.g https
+`path`: The path name for the documentation page, which is usually the lower case version of `title` (e.g https
 
-`repo`:  The full name of the GitHub repository (i.e org/repo-name)
+`repo`: The full name of the GitHub repository (i.e org/repo-name)
 
 #### Optional fields
 
 `branch`: The name of the default branch of the repository. Defaults to main.
 
 `artifactDir`: The location of the docs artifacts directory in the remote repository. Defaults to `.doc-artifacts`.
-
 
 </Tab>
 </Tabs>
@@ -334,9 +330,9 @@ This is done by adding the block below for the respective plugin to the file [do
 
 Here's a non exaustive list of Packer plugins that you can check out:
 
-* [github.com/hashicorp/packer-plugin-docker](https://github.com/hashicorp/packer-plugin-docker)
-* [github.com/exoscale/packer-plugin-exoscale](https://github.com/exoscale/packer-plugin-exoscale)
-* [github.com/sylviamoss/packer-plugin-comment](https://github.com/sylviamoss/packer-plugin-comment)
+- [github.com/hashicorp/packer-plugin-docker](https://github.com/hashicorp/packer-plugin-docker)
+- [github.com/exoscale/packer-plugin-exoscale](https://github.com/exoscale/packer-plugin-exoscale)
+- [github.com/sylviamoss/packer-plugin-comment](https://github.com/sylviamoss/packer-plugin-comment)
 
 Looking at their code will give you good examples.
 
@@ -352,8 +348,8 @@ scope of a plugin.
 
 Making your unpublished plugin available to Packer is possible by either:
 
-* Starting Packer from the directory where the plugin binary is located.
-* Putting the plugin binary in the same directory as Packer.
+- Starting Packer from the directory where the plugin binary is located.
+- Putting the plugin binary in the same directory as Packer.
 
 In both these cases, if the binary is called `packer-plugin-myawesomecloud` and
 defines an `ebs` builder then you will be able to use an `myawesomecloud-ebs`

--- a/website/content/docs/plugins/creation/index.mdx
+++ b/website/content/docs/plugins/creation/index.mdx
@@ -230,37 +230,17 @@ Here's what you need to create releases using GitHub Actions:
 `packer init` allows users to require and install remote Packer plugins, those not bundled with Packer core, that have been published to GitHub automatically.
 To help with the discovery of remote Packer plugins on GitHub, plugins maintainers can choose to register plugin documentation for each component directly on the [Packer Documentation Page](https://packer.io/docs).
 
-The registration process requires the creation of a `.docs-artifacts` directory and a sidebar navigation file `docs-nav.json` for each of the plugin
-components in the remote plugin's repository. A working example can be seen at the [packer-plugin-docker repository](https://github.com/hashicorp/packer-plugin-docker/tree/main/.docs-artifacts).
+The registration process involves the creation of an additional `docs.zip` asset as part of the [`goreleaser.yml` workflow](https://github.com/hashicorp/packer-plugin-docker/blob/main/.goreleaser.yml). For details on this workflow, see [the "registering documentation" section of the packer-plugin-scaffolding README](https://github.com/hashicorp/packer-plugin-scaffolding#registering-documentation-on-packerio).
 
-Once in place the remote plugin can be added to Packer's website builds by opening a pull-request against [hashicorp/packer](https://github.com/packer), which the needed configuration pulling in the remote documentation.
-
-Remote plugins will have their components listed under the respected types (i.e builders, provisioners, etc) using the names specified in the remote block configuration, and labeled with their respective [tier and namespace](/docs/plugins#tiers-and-namespaces).
-
-To register a plugin follow one of the following setups
-
-<Tabs>
-<Tab heading="Registering Using GitHub Actions">
-
-Documentation for a plugin is maintained within the `docs` directory and served on GitHub.
-
-A GitHub workflow has been added to [packer-plugin-scaffolding](https://github.com/hashicorp/packer-plugin-scaffolding/tree/main/docs) that
-can be used generate a documentation structure that can be consumed remotely by https://packer.io. See the full workflow at [generated-docs-artifacts.yml](https://github.com/hashicorp/packer-plugin-scaffolding/blob/main/.github/workflows/generate-docs-artifacts.yml)
-
-The GitHub workflow will automatically create the `.docs-artifacts` directory with the generated sidebar navigation file, and open a new pull-request against the default configured branch to be merged by the maintainer.
-
-By default the workflow is configured to trigger on the creation of tags beginning with `'v*` to ensure that documentation gets updated for each release. Updates to the plugin documentation will get pulled in at the time of the next Packer website deployment.
-
-After merging the generated files to the default branch for the plugin repository.
-
-Open a one time pull-request against [hashicorp/packer](https://github.com/hashicorp/packer) to register the plugin docs.
-This is done by adding the block below for the respective plugin to the file [docs-remote-navigation.js](https://github.com/hashicorp/packer/blob/master/website/data/docs-remote-plugins.json).
+After publishing a release from the plugin repository, open a pull-request against [hashicorp/packer](https://github.com/hashicorp/packer) to register the plugin documentation.
+This is done by adding the block below for the respective plugin to the file [docs-remote-plugins.json](https://github.com/hashicorp/packer/blob/master/website/data/docs-remote-plugins.json).
 
 ```json
 {
   "title": "Docker",
   "path": "docker",
-  "repo": "hashicorp/packer-plugin-docker"
+  "repo": "hashicorp/packer-plugin-docker",
+  "version": "1.0.0"
 }
 ```
 
@@ -268,61 +248,11 @@ This is done by adding the block below for the respective plugin to the file [do
 
 `title`: The name of the plugin to be displayed in the sidebar - See [naming conventions](#naming-conventions)
 
-`path`: The path name for the documentation page, which is usually the lower case version of `title` (e.g https
+`path`: The path name for the documentation page, which is usually the lower case version of `title` (e.g https)
 
 `repo`: The full name of the GitHub repository (i.e org/repo-name)
 
-#### Optional fields
-
-`branch`: The name of the default branch of the repository. Defaults to main.
-
-`artifactDir`: The location of the docs artifacts directory in the remote repository. Defaults to `.doc-artifacts`.
-
-</Tab>
-<Tab heading="Registering Manually">
-
-The documentation structure needed for registering a plugin's documentation can be generated manually, but it is
-encouraged to use the action on release events so that documentation stays up to date.
-
-If your local development environment has a supported version (v10.0.0+) of [node](https://nodejs.org/en/) and a
-supported version (>=5.2.0) [npm](https://www.npmjs.com/) installed, in the plugin root directory, you can run:
-
-```shell-session
-> npx -p @hashicorp/packer-docs-artifacts generate
-```
-
-The generated files will be placed under `PLUGIN_ROOT/.doc-artifacts`; this directory contains all the docs
-and respective navigation information needed for including the plugin docs under [packer.io/docs/](https://packer.io/docs).
-
-After merging the generated files to the default branch for the plugin repository.
-
-Open a one time pull-request against [hashicorp/packer](https://github.com/hashicorp/packer) to register the plugin docs.
-This is done by adding the block below for the respective plugin to the file [docs-remote-navigation.js](https://github.com/hashicorp/packer/blob/master/website/data/docs-remote-plugins.json).
-
-```json
-{
-  "title": "Docker",
-  "path": "docker",
-  "repo": "hashicorp/packer-plugin-docker"
-}
-```
-
-#### Required fields
-
-`title`: The name of the plugin to be displayed in the sidebar - See [naming conventions](#naming-conventions)
-
-`path`: The path name for the documentation page, which is usually the lower case version of `title` (e.g https
-
-`repo`: The full name of the GitHub repository (i.e org/repo-name)
-
-#### Optional fields
-
-`branch`: The name of the default branch of the repository. Defaults to main.
-
-`artifactDir`: The location of the docs artifacts directory in the remote repository. Defaults to `.doc-artifacts`.
-
-</Tab>
-</Tabs>
+`version`: The release version from which docs will be pulled (e.g. `1.0.0`)
 
 ### Plugin Development Tips and FAQs
 

--- a/website/content/docs/plugins/index.mdx
+++ b/website/content/docs/plugins/index.mdx
@@ -4,7 +4,6 @@ description: |
   the core source code. Packer plugins are able to add new builders,
   provisioners, hooks, and more.
 page_title: Plugins
-sidebar_title: Packer Plugins
 ---
 
 # Packer Plugins
@@ -40,11 +39,10 @@ build.
 
 Packer plugins are published and maintained by a variety of sources, including HashiCorp, and the Packer community. The Packer website uses tiers and badges to denote the source of a provider. Additionally, namespaces are used to help users identify the organization or publisher responsible for the integration, as shown in the table below.
 
-
-| Tier     | Description | Namespace |
-| ---------| ------------| ----------|
-| <PluginTierLabel tier="official" /> |Official plugins are owned and maintained by HashiCorp. | hashicorp |
-| <PluginTierLabel tier="community" /> | Community providers are published by individual maintainers, groups of maintainers, or other members of the Packer community.| Third-party organization or maintainer's individual account |
+| Tier                                 | Description                                                                                                                   | Namespace                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| <PluginTierLabel tier="official" />  | Official plugins are owned and maintained by HashiCorp.                                                                       | hashicorp                                                   |
+| <PluginTierLabel tier="community" /> | Community providers are published by individual maintainers, groups of maintainers, or other members of the Packer community. | Third-party organization or maintainer's individual account |
 
 ## Installing Plugins
 
@@ -65,7 +63,7 @@ it is a single-component plugin.
 <Tab heading="Packer init (from Packer v1.7.0)">
 
 ~> **Note**: Only _multi-component plugin binaries_ -- that is plugins named
-packer-plugin-*, like the `packer-plugin-amazon` -- are expected to work with
+packer-plugin-\*, like the `packer-plugin-amazon` -- are expected to work with
 Packer init. The legacy `builder`, `post-processor` and `provisioner` plugin
 types will keep on being detected but Packer cannot install them automatically.
 If a plugin you use has not been upgraded to use the multi-component plugin
@@ -74,39 +72,40 @@ architecture, contact your maintainer to request an upgrade.
 ### Create a required_plugins block
 
 1. Add a
-[`required_plugins`](/docs/templates/hcl_templates/blocks/packer#specifying-plugin-requirements)
-block to your [packer block](/docs/templates/hcl_templates/blocks/packer). Each block will tell Packer what version(s) of a
-particular plugin can be installed. Make sure to set a valid [version
-constraint string](/docs/templates/hcl_templates/blocks/packer#version-constraints).
+   [`required_plugins`](/docs/templates/hcl_templates/blocks/packer#specifying-plugin-requirements)
+   block to your [packer block](/docs/templates/hcl_templates/blocks/packer). Each block will tell Packer what version(s) of a
+   particular plugin can be installed. Make sure to set a valid [version
+   constraint string](/docs/templates/hcl_templates/blocks/packer#version-constraints).
 
 Here is an example `required_plugins` block:
 
-  ```hcl
-  packer {
-    required_plugins {
-      myawesomecloud = {
-        version = ">= 2.7.0"
-        source = "github.com/azr/myawesomecloud"
-      }
-      happycloud = {
-        version = ">= 1.1.3"
-        source = "github.com/azr/happycloud"
-      }
+```hcl
+packer {
+  required_plugins {
+    myawesomecloud = {
+      version = ">= 2.7.0"
+      source = "github.com/azr/myawesomecloud"
+    }
+    happycloud = {
+      version = ">= 1.1.3"
+      source = "github.com/azr/happycloud"
     }
   }
-  ```
+}
+```
 
 2. Run [`packer init`](/docs/commands/init) from your project directory (the
-directory containing your Packer templates) to install all missing plugin
-binaries. Given the above example, Packer will try to look for a GitHub
-repository owned by user or organization `azr` named
-`packer-plugin-myawesomecloud` and `packer-plugin-happycloud`.
+   directory containing your Packer templates) to install all missing plugin
+   binaries. Given the above example, Packer will try to look for a GitHub
+   repository owned by user or organization `azr` named
+   `packer-plugin-myawesomecloud` and `packer-plugin-happycloud`.
 
 ## Names and Addresses
+
 Each plugin has two identifiers:
 
-* A `source` address, which is only necessary when requiring a plugin outside the HashiCorp domain.
-* A unique **local name**, which is used everywhere else in a Packer
+- A `source` address, which is only necessary when requiring a plugin outside the HashiCorp domain.
+- A unique **local name**, which is used everywhere else in a Packer
   configuration.
 
 ### Local Names
@@ -163,14 +162,14 @@ follows:
 
 `<HOSTNAME>/<NAMESPACE>/<TYPE>`
 
-* **Hostname:** The hostname of the location/service that
+- **Hostname:** The hostname of the location/service that
   distributes the plugin. Currently, the only valid "hostname" is github.com,
   but we plan to eventually support plugins downloaded from other domains.
 
-* **Namespace:** An organizational namespace within the specified host.
+- **Namespace:** An organizational namespace within the specified host.
   This often is the organization that publishes the plugin.
 
-* **Type:** A short name for the platform or system the plugin manages. The
+- **Type:** A short name for the platform or system the plugin manages. The
   type is usually the plugin's preferred local name.
 
 For example, the fictional `myawesomecloud` plugin could belong to the
@@ -192,6 +191,7 @@ various outputs, like error messages.
 ## Implicit Github urls
 
 Using the following example :
+
 ```hcl
     required_plugins {
       happycloud = {
@@ -202,7 +202,8 @@ Using the following example :
 ```
 
 The plugin getter will look for plugins located at:
-* github.com/azr/packer-plugin-happycloud
+
+- github.com/azr/packer-plugin-happycloud
 
 Packer will error if you set the `packer-plugin-` prefix in a `source`. This
 will avoid conflicting with other plugins for other tools, like Terraform.

--- a/website/content/docs/post-processors/alicloud-import.mdx
+++ b/website/content/docs/post-processors/alicloud-import.mdx
@@ -3,7 +3,6 @@ description: |
   The Packer Alicloud Import post-processor takes a RAW or VHD artifact from
   various builders and imports it to an Alicloud customized image list.
 page_title: Alicloud Import Post-Processor
-sidebar_title: Alicloud Import
 ---
 
 # Alicloud Import Post-Processor

--- a/website/content/docs/post-processors/artifice.mdx
+++ b/website/content/docs/post-processors/artifice.mdx
@@ -13,7 +13,6 @@ description: >
 
   instance.
 page_title: Artifice - Post-Processors
-sidebar_title: Artifice
 ---
 
 # Artifice Post-Processor

--- a/website/content/docs/post-processors/checksum.mdx
+++ b/website/content/docs/post-processors/checksum.mdx
@@ -7,7 +7,6 @@ description: >
   artifact, compute it checksum and pass to next post-processor original
   artifacts and checksum files.
 page_title: Checksum - Post-Processors
-sidebar_title: Checksum
 ---
 
 # Checksum Post-Processor

--- a/website/content/docs/post-processors/checksum.mdx
+++ b/website/content/docs/post-processors/checksum.mdx
@@ -23,7 +23,7 @@ After computes checksum for artifacts, you can use new artifacts with other
 post-processors like
 [artifice](/docs/post-processors/artifice),
 [compress](/docs/post-processors/compress),
-[docker-push](/docs/post-processors/docker-push), or
+[docker-push](/docs/post-processors/docker/docker-push), or
 a third-party post-processor.
 
 ## Basic example

--- a/website/content/docs/post-processors/community-supported.mdx
+++ b/website/content/docs/post-processors/community-supported.mdx
@@ -5,7 +5,6 @@ description: >
 
   can run alongside Packer with minimal extra effort.
 page_title: Community - Post-Processors
-sidebar_title: Community-Supported
 ---
 
 # Community Post-Processors

--- a/website/content/docs/post-processors/compress.mdx
+++ b/website/content/docs/post-processors/compress.mdx
@@ -3,7 +3,6 @@ description: |
   The Packer compress post-processor takes an artifact with files (such as from
   VMware or VirtualBox) and compresses the artifact into a single archive.
 page_title: Compress - Post-Processors
-sidebar_title: Compress
 ---
 
 # Compress Post-Processor

--- a/website/content/docs/post-processors/digitalocean-import.mdx
+++ b/website/content/docs/post-processors/digitalocean-import.mdx
@@ -3,7 +3,6 @@ description: |
   The Packer DigitalOcean Import post-processor takes an image artifact
   from various builders and imports it to DigitalOcean.
 page_title: DigitalOcean Import - Post-Processors
-sidebar_title: DigitalOcean Import
 ---
 
 # DigitalOcean Import Post-Processor

--- a/website/content/docs/post-processors/googlecompute-export.mdx
+++ b/website/content/docs/post-processors/googlecompute-export.mdx
@@ -5,7 +5,6 @@ description: >
   exported images can be easily shared and uploaded to other Google Cloud
   Projects.
 page_title: Google Compute Image Exporter - Post-Processors
-sidebar_title: Google Compute Export
 ---
 
 # Google Compute Image Exporter Post-Processor

--- a/website/content/docs/post-processors/googlecompute-import.mdx
+++ b/website/content/docs/post-processors/googlecompute-import.mdx
@@ -3,7 +3,6 @@ description: |
   The Google Compute Image Import post-processor takes a compressed raw disk
   image and imports it to a GCE image available to Google Compute Engine.
 page_title: Google Compute Image Import - Post-Processors
-sidebar_title: Google Compute Import
 ---
 
 # Google Compute Image Import Post-Processor
@@ -145,64 +144,64 @@ build {
 </Tab>
   <Tab heading="JSON">
 
-  ```json
-  {
-    "variables": {
-      "account_file": "account.json",
-      "bucket": "my-bucket",
-      "project": "my-project",
-      "serial": ""
-    },
-    "builders": [
-      {
-        "type": "qemu",
-        "accelerator": "kvm",
-        "boot_command": [
-          "<tab> console=ttyS0,115200n8 inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-31-ks.cfg rd.live.check=0<enter><wait>"
-        ],
-        "disk_size": "15000",
-        "format": "raw",
-        "iso_checksum": "sha256:225ebc160e40bb43c5de28bad9680e3a78a9db40c9e3f4f42f3ee3f10f95dbeb",
-        "iso_url": "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/31/Server/x86_64/iso/Fedora-Server-dvd-x86_64-31-1.9.iso",
-        "headless": "true",
-        "http_directory": "http",
-        "http_port_max": "10089",
-        "http_port_min": "10082",
-        "output_directory": "output",
-        "shutdown_timeout": "30m",
-        "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-        "ssh_username": "vagrant",
-        "ssh_password": "vagrant",
-        "vm_name": "disk.raw",
-        "qemu_binary": "/usr/bin/kvm",
-        "qemuargs": [
-          ["-m", "1024"],
-          ["-cpu", "host"],
-          ["-chardev", "tty,id=pts,path={{user `serial`}}"],
-          ["-device", "isa-serial,chardev=pts"],
-          ["-device", "virtio-net,netdev=user.0"]
-        ]
-      }
-    ],
-    "post-processors": [
-      [
-        {
-          "type": "compress",
-          "output": "output/disk.raw.tar.gz"
-        },
-        {
-          "type": "googlecompute-import",
-          "project_id": "{{user `project`}}",
-          "account_file": "{{user `account_file`}}",
-          "bucket": "{{user `bucket`}}",
-          "image_name": "fedora31-server-packertest",
-          "image_description": "Fedora 31 Server",
-          "image_family": "fedora31-server"
-        }
+```json
+{
+  "variables": {
+    "account_file": "account.json",
+    "bucket": "my-bucket",
+    "project": "my-project",
+    "serial": ""
+  },
+  "builders": [
+    {
+      "type": "qemu",
+      "accelerator": "kvm",
+      "boot_command": [
+        "<tab> console=ttyS0,115200n8 inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-31-ks.cfg rd.live.check=0<enter><wait>"
+      ],
+      "disk_size": "15000",
+      "format": "raw",
+      "iso_checksum": "sha256:225ebc160e40bb43c5de28bad9680e3a78a9db40c9e3f4f42f3ee3f10f95dbeb",
+      "iso_url": "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/31/Server/x86_64/iso/Fedora-Server-dvd-x86_64-31-1.9.iso",
+      "headless": "true",
+      "http_directory": "http",
+      "http_port_max": "10089",
+      "http_port_min": "10082",
+      "output_directory": "output",
+      "shutdown_timeout": "30m",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "vm_name": "disk.raw",
+      "qemu_binary": "/usr/bin/kvm",
+      "qemuargs": [
+        ["-m", "1024"],
+        ["-cpu", "host"],
+        ["-chardev", "tty,id=pts,path={{user `serial`}}"],
+        ["-device", "isa-serial,chardev=pts"],
+        ["-device", "virtio-net,netdev=user.0"]
       ]
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "compress",
+        "output": "output/disk.raw.tar.gz"
+      },
+      {
+        "type": "googlecompute-import",
+        "project_id": "{{user `project`}}",
+        "account_file": "{{user `account_file`}}",
+        "bucket": "{{user `bucket`}}",
+        "image_name": "fedora31-server-packertest",
+        "image_description": "Fedora 31 Server",
+        "image_family": "fedora31-server"
+      }
     ]
-  }
-  ```
+  ]
+}
+```
 
 </Tab>
 </Tabs>

--- a/website/content/docs/post-processors/index.mdx
+++ b/website/content/docs/post-processors/index.mdx
@@ -3,7 +3,6 @@ description: |
   Post-processors run after the image is built by the builder and provisioned by
   the provisioner(s).
 page_title: Post-Processors
-sidebar_title: Post-Processors
 ---
 
 # Post-Processors

--- a/website/content/docs/post-processors/manifest.mdx
+++ b/website/content/docs/post-processors/manifest.mdx
@@ -3,7 +3,6 @@ description: >
   The manifest post-processor writes a JSON file with the build artifacts and
   IDs from a packer run.
 page_title: Manifest - Post-Processors
-sidebar_title: Manifest
 ---
 
 # Manifest Post-Processor

--- a/website/content/docs/post-processors/shell-local.mdx
+++ b/website/content/docs/post-processors/shell-local.mdx
@@ -3,7 +3,6 @@ description: |
   The shell-local Packer post processor enables users to do some post processing
   after artifacts have been built.
 page_title: Local Shell - Post-Processors
-sidebar_title: Shell (Local)
 ---
 
 # Local Shell Post Processor

--- a/website/content/docs/post-processors/ucloud-import.mdx
+++ b/website/content/docs/post-processors/ucloud-import.mdx
@@ -4,7 +4,6 @@ description: >
   artifact from various builders and imports it to UCloud customized image list
   for UHost Instance.
 page_title: UCloud Import Post-Processors
-sidebar_title: UCloud Import
 ---
 
 # UCloud Import Post-Processor

--- a/website/content/docs/post-processors/vagrant-cloud.mdx
+++ b/website/content/docs/post-processors/vagrant-cloud.mdx
@@ -3,7 +3,6 @@ description: |
   The Vagrant Cloud post-processor enables the upload of Vagrant boxes to
   Vagrant Cloud.
 page_title: Vagrant Cloud - Post-Processors
-sidebar_title: Vagrant Cloud
 ---
 
 # Vagrant Cloud Post-Processor

--- a/website/content/docs/post-processors/vagrant.mdx
+++ b/website/content/docs/post-processors/vagrant.mdx
@@ -9,7 +9,6 @@ description: >
 
   distributed by Vagrant are created.
 page_title: Vagrant - Post-Processors
-sidebar_title: Vagrant
 ---
 
 # Vagrant Post-Processor

--- a/website/content/docs/post-processors/vsphere-template.mdx
+++ b/website/content/docs/post-processors/vsphere-template.mdx
@@ -5,7 +5,6 @@ description: >
   [vSphere](/docs/post-processors/vsphere) post-processor, marks the VM as a
   template, and leaves it in the path of your choice.
 page_title: vSphere Template - Post-Processors
-sidebar_title: vSphere Template
 ---
 
 # vSphere Template Post-Processor

--- a/website/content/docs/post-processors/vsphere.mdx
+++ b/website/content/docs/post-processors/vsphere.mdx
@@ -3,7 +3,6 @@ description: >
   The Packer vSphere post-processor takes an artifact and uploads it to a
   vSphere endpoint.
 page_title: vSphere - Post-Processors
-sidebar_title: vSphere
 ---
 
 # vSphere Post-Processor

--- a/website/content/docs/post-processors/yandex-export.mdx
+++ b/website/content/docs/post-processors/yandex-export.mdx
@@ -7,7 +7,6 @@ description: >
 
   images can be easily shared and uploaded to other Yandex.Cloud Cloud folders.
 page_title: Yandex.Cloud Compute Image Exporter - Post-Processors
-sidebar_title: Yandex.Cloud Compute Export
 ---
 
 # Yandex.Cloud Compute Image Exporter Post-Processor

--- a/website/content/docs/post-processors/yandex-import.mdx
+++ b/website/content/docs/post-processors/yandex-import.mdx
@@ -4,7 +4,6 @@ description: >
   qcow2 image (or from provided Storage object in near future). It uploads qcow2
   to Yandex Object Storage and create new one Compute Image in target folder.
 page_title: Yandex.Cloud Compute Image Import - Post-Processors
-sidebar_title: Yandex.Cloud Compute Import
 ---
 
 # Yandex.Cloud Compute Image Import Post-Processor

--- a/website/content/docs/provisioners/ansible-local.mdx
+++ b/website/content/docs/provisioners/ansible-local.mdx
@@ -6,7 +6,6 @@ description: >
   Playbooks and Roles can be uploaded from your build machine (the one running
   Packer) to the vm.
 page_title: Ansible Local - Provisioners
-sidebar_title: Ansible Local
 ---
 
 # Ansible Local Provisioner

--- a/website/content/docs/provisioners/ansible.mdx
+++ b/website/content/docs/provisioners/ansible.mdx
@@ -3,7 +3,6 @@ description: |
   The ansible Packer provisioner allows Ansible playbooks to be run to provision
   the machine.
 page_title: Ansible - Provisioners
-sidebar_title: Ansible (Remote)
 ---
 
 # Ansible Provisioner

--- a/website/content/docs/provisioners/breakpoint.mdx
+++ b/website/content/docs/provisioners/breakpoint.mdx
@@ -7,7 +7,6 @@ description: >
 
   particular part of the provisioning process.
 page_title: breakpoint - Provisioners
-sidebar_title: Breakpoint
 ---
 
 # Breakpoint Provisioner

--- a/website/content/docs/provisioners/chef-client.mdx
+++ b/website/content/docs/provisioners/chef-client.mdx
@@ -8,7 +8,6 @@ description: >
 
   remote Chef Server to provision the machine.
 page_title: Chef Client - Provisioners
-sidebar_title: Chef Client
 ---
 
 # Chef Client Provisioner

--- a/website/content/docs/provisioners/chef-solo.mdx
+++ b/website/content/docs/provisioners/chef-solo.mdx
@@ -4,7 +4,6 @@ description: |
   built by Packer using chef-solo. Cookbooks can be uploaded from your local
   machine to the remote machine or remote paths can be used.
 page_title: Chef Solo - Provisioners
-sidebar_title: Chef Solo
 ---
 
 # Chef Solo Provisioner
@@ -134,7 +133,7 @@ configuration is actually required, but at least `run_list` is recommended.
 
 @include 'provisioners/common-config.mdx'
 
-#####  Node Attribute Mapping
+##### Node Attribute Mapping
 
 An arbitrary mapping of JSON that will be available as node attributes while running Chef.
 
@@ -142,7 +141,7 @@ An arbitrary mapping of JSON that will be available as node attributes while run
 <Tab heading="HCL2">
 
 - `json_string` (string) - The JSON string can be encoded using the [jsonencode](/docs/templates/hcl_templates/functions/encoding/jsonencode)
-template function.
+  template function.
 
 ```hcl
 provisioner "chef-solo" {

--- a/website/content/docs/provisioners/community-supported.mdx
+++ b/website/content/docs/provisioners/community-supported.mdx
@@ -3,7 +3,6 @@ description: |
   Community-maintained provisioners are not part of the core Packer binary, but
   can run alongside Packer with minimal extra effort.
 page_title: Community - Provisioners
-sidebar_title: Community-Supported
 ---
 
 # Community Provisioners

--- a/website/content/docs/provisioners/converge.mdx
+++ b/website/content/docs/provisioners/converge.mdx
@@ -3,7 +3,6 @@ description: >-
   The converge Packer provisioner uses Converge modules to provision the
   machine.
 page_title: Converge - Provisioners
-sidebar_title: Converge
 ---
 
 # Converge Provisioner

--- a/website/content/docs/provisioners/custom.mdx
+++ b/website/content/docs/provisioners/custom.mdx
@@ -5,7 +5,6 @@ description: |
   provisioners is covered in the custom provisioners page of the Packer plugin
   section.
 page_title: Custom - Provisioners
-sidebar_title: Custom
 ---
 
 # Custom Provisioner

--- a/website/content/docs/provisioners/file.mdx
+++ b/website/content/docs/provisioners/file.mdx
@@ -5,7 +5,6 @@ description: |
   then use shell provisioner to move them to the proper place, set permissions,
   etc.
 page_title: File - Provisioners
-sidebar_title: File
 ---
 
 # File Provisioner

--- a/website/content/docs/provisioners/index.mdx
+++ b/website/content/docs/provisioners/index.mdx
@@ -3,7 +3,6 @@ description: |
   Provisioners use builtin and third-party software to install and configure the
   machine image after booting.
 page_title: Provisioners
-sidebar_title: Provisioners
 ---
 
 # Provisioners

--- a/website/content/docs/provisioners/inspec.mdx
+++ b/website/content/docs/provisioners/inspec.mdx
@@ -3,7 +3,6 @@ description: |
   The inspec Packer provisioner allows inspec profiles to be run to test the
   machine.
 page_title: InSpec - Provisioners
-sidebar_title: InSpec
 ---
 
 # InSpec Provisioner
@@ -159,7 +158,7 @@ Optional Parameters:
 
 - `user` (string) - The `--user` to use. Defaults to the user running Packer.
 
-- `valid_exit_codes` (list of ints) - A list of valid exit codes returned by 
+- `valid_exit_codes` (list of ints) - A list of valid exit codes returned by
   inspec to be accepted by the provisioner. The default is (0,101) (accept
   skipped tests). See [inspec exit codes](https://docs.chef.io/inspec/cli/#exec)
   for a list and explanation of inspec exit codes.

--- a/website/content/docs/provisioners/powershell.mdx
+++ b/website/content/docs/provisioners/powershell.mdx
@@ -3,7 +3,6 @@ description: |
   The PowerShell Packer provisioner runs PowerShell scripts on Windows machines.
   It assumes that the communicator in use is WinRM.
 page_title: PowerShell - Provisioners
-sidebar_title: PowerShell
 ---
 
 # PowerShell Provisioner

--- a/website/content/docs/provisioners/puppet-masterless.mdx
+++ b/website/content/docs/provisioners/puppet-masterless.mdx
@@ -12,7 +12,6 @@ description: >
 
   to a Puppet master.
 page_title: Puppet Masterless - Provisioners
-sidebar_title: Puppet Masterless
 ---
 
 # Puppet (Masterless) Provisioner

--- a/website/content/docs/provisioners/puppet-server.mdx
+++ b/website/content/docs/provisioners/puppet-server.mdx
@@ -3,7 +3,6 @@ description: |
   The puppet-server Packer provisioner provisions Packer machines with Puppet by
   connecting to a Puppet master.
 page_title: Puppet Server - Provisioners
-sidebar_title: Puppet Server
 ---
 
 # Puppet Server Provisioner

--- a/website/content/docs/provisioners/salt-masterless.mdx
+++ b/website/content/docs/provisioners/salt-masterless.mdx
@@ -3,7 +3,6 @@ description: |
   The salt-masterless Packer provisioner provisions machines built by Packer
   using Salt states, without connecting to a Salt master.
 page_title: Salt Masterless - Provisioners
-sidebar_title: Salt Masterless
 ---
 
 # Salt Masterless Provisioner

--- a/website/content/docs/provisioners/shell-local.mdx
+++ b/website/content/docs/provisioners/shell-local.mdx
@@ -5,7 +5,6 @@ description: |
   your build server, or your desktop, etc., rather than the remote/guest machine
   being provisioned by Packer.
 page_title: Shell (Local) - Provisioners
-sidebar_title: Shell (Local)
 ---
 
 # Local Shell Provisioner

--- a/website/content/docs/provisioners/shell.mdx
+++ b/website/content/docs/provisioners/shell.mdx
@@ -4,7 +4,6 @@ description: |
   scripts. Shell provisioning is the easiest way to get software installed and
   configured on a machine.
 page_title: Shell - Provisioners
-sidebar_title: Shell
 ---
 
 # Shell Provisioner

--- a/website/content/docs/provisioners/windows-restart.mdx
+++ b/website/content/docs/provisioners/windows-restart.mdx
@@ -3,7 +3,6 @@ description: |
   The Windows restart provisioner restarts a Windows machine and waits for it to
   come back up.
 page_title: Windows Restart - Provisioners
-sidebar_title: Windows Restart
 ---
 
 # Windows Restart Provisioner

--- a/website/content/docs/provisioners/windows-shell.mdx
+++ b/website/content/docs/provisioners/windows-shell.mdx
@@ -3,7 +3,6 @@ description: |
   The windows-shell Packer provisioner runs commands on Windows using the cmd
   shell.
 page_title: Windows Shell - Provisioners
-sidebar_title: Windows Shell
 ---
 
 # Windows Shell Provisioner

--- a/website/content/docs/templates/hcl_templates/blocks/build/index.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/index.mdx
@@ -2,7 +2,6 @@
 description: |
   The source block defines what builders are started.
 page_title: build - Blocks
-sidebar_title: <tt>build</tt>
 ---
 
 # The `build` block

--- a/website/content/docs/templates/hcl_templates/blocks/build/post-processor.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/post-processor.mdx
@@ -2,7 +2,6 @@
 description: |
   The post-processor block defines how a post-processor is configured.
 page_title: post-processor - build - Blocks
-sidebar_title: <tt>post-processor</tt>
 ---
 
 # The `post-processor` block

--- a/website/content/docs/templates/hcl_templates/blocks/build/post-processors.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/post-processors.mdx
@@ -3,7 +3,6 @@ description: >
   The post-processors block allows to define lists of post-processors to apply
   to an artifact.
 page_title: post-processors - build - Blocks
-sidebar_title: <tt>post-processors</tt>
 ---
 
 # The `post-processors` block

--- a/website/content/docs/templates/hcl_templates/blocks/build/provisioner.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/provisioner.mdx
@@ -2,7 +2,6 @@
 description: |
   The provisioner block defines how a provisioner is configured.
 page_title: provisioner - build - Blocks
-sidebar_title: <tt>provisioner</tt>
 ---
 
 # The `provisioner` block

--- a/website/content/docs/templates/hcl_templates/blocks/build/source.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/source.mdx
@@ -4,7 +4,6 @@ description: >
   source and to set specific fields which aren't already set in the top-level
   source block.
 page_title: source - build - Blocks
-sidebar_title: <tt>source</tt>
 ---
 
 # The `source` block

--- a/website/content/docs/templates/hcl_templates/blocks/data.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/data.mdx
@@ -2,7 +2,6 @@
 description: >
   The data block defines data sources within your Packer configuration.
 page_title: data - Blocks
-sidebar_title: <tt>data</tt>
 ---
 
 # The `data` block

--- a/website/content/docs/templates/hcl_templates/blocks/index.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/index.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Blocks - Configuration Language
-sidebar_title: Blocks
 description: The HCL language has a number of blocks that can be used to configure builds.
 ---
 
@@ -12,20 +11,21 @@ The Packer - HCL2 language includes a number of built-in blocks that you can
 use to configure builds. A block is a container for configuration.
 
 The most important blocks can be broken into a couple of major types:
- * `build` blocks contain configuration for a specific combination of builders,
- 	provisioners, and post-processors used to create a specific image artifact.
- * `source` blocks contain configuration for builder plugins. Once defined,
- 	sources can be used and further configured by the "build" block.
- * `provisioner` blocks contain configuration for provisioner plugins. These
- 	blocks are nested inside of a build block.
- * `post-processor` and `post-processors` blocks contain configuration for
- 	post-processor plugins and post-processor plugin sequences. They are also
- 	nested within `build` blocks.
- * `variable` blocks contain configuration for variables that can either be
- 	defaulted in configuration or set by the user at runtime.
- * `locals` blocks contain configuration for variables that can be created using
- 	HCL functions or data sources, or composited from variables created in the
- 	variables blocks.
+
+- `build` blocks contain configuration for a specific combination of builders,
+  provisioners, and post-processors used to create a specific image artifact.
+- `source` blocks contain configuration for builder plugins. Once defined,
+  sources can be used and further configured by the "build" block.
+- `provisioner` blocks contain configuration for provisioner plugins. These
+  blocks are nested inside of a build block.
+- `post-processor` and `post-processors` blocks contain configuration for
+  post-processor plugins and post-processor plugin sequences. They are also
+  nested within `build` blocks.
+- `variable` blocks contain configuration for variables that can either be
+  defaulted in configuration or set by the user at runtime.
+- `locals` blocks contain configuration for variables that can be created using
+  HCL functions or data sources, or composited from variables created in the
+  variables blocks.
 
 Use the sidebar to navigate to detailed documentation for each of these blocks.
 

--- a/website/content/docs/templates/hcl_templates/blocks/locals.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/locals.mdx
@@ -3,7 +3,6 @@ description: >
   The locals block also called the local-variable block defines locals within
   your Packer configuration.
 page_title: locals - Blocks
-sidebar_title: <tt>locals</tt>
 ---
 
 # The `locals` block

--- a/website/content/docs/templates/hcl_templates/blocks/packer.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/packer.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: packer - Blocks
-sidebar_title: <tt>packer</tt>
 description: |-
   The "packer" configuration section is used to configure some behaviors
   of Packer itself.

--- a/website/content/docs/templates/hcl_templates/blocks/source.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/source.mdx
@@ -2,7 +2,6 @@
 description: |
   The top-level source block defines reusable builder configuration blocks
 page_title: source - Blocks
-sidebar_title: <tt>source</tt>
 ---
 
 # The `source` block

--- a/website/content/docs/templates/hcl_templates/blocks/variable.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/variable.mdx
@@ -3,7 +3,6 @@ description: >
   The variable block, also called the input-variable block, defines variables
   within your Packer configuration.
 page_title: variable - Blocks
-sidebar_title: <tt>variable</tt>
 ---
 
 # The `variable` block

--- a/website/content/docs/templates/hcl_templates/contextual-variables.mdx
+++ b/website/content/docs/templates/hcl_templates/contextual-variables.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Contextual Variables - HCL Configuration Language
-sidebar_title: Contextual Variables
 description: >-
   Special variables provide connection information and basic instance state
   information.

--- a/website/content/docs/templates/hcl_templates/datasources.mdx
+++ b/website/content/docs/templates/hcl_templates/datasources.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Data Sources
-sidebar_title: Data Sources
 description: >-
   Data sources allow data to be fetched or computed for use elsewhere in local variables and
   build sources configuration. Use of data sources
@@ -46,6 +45,7 @@ identifier, like `data.<TYPE>.<NAME>.<ATTRIBUTE>`.
 The output from the `amazon-ami.example` above can be accessed as follows:
 
 Output data:
+
 ```
 "data.amazon-ami.example" {
   id = "ami12345"

--- a/website/content/docs/templates/hcl_templates/expressions.mdx
+++ b/website/content/docs/templates/hcl_templates/expressions.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Expressions - Configuration Language
-sidebar_title: Expressions
 description: |-
   HCL allows the use of expressions to access data exported
   by sources and to transform and combine that data to produce other values.

--- a/website/content/docs/templates/hcl_templates/functions/collection/chunklist.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/chunklist.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: chunklist - Functions - Configuration Language
-sidebar_title: chunklist
 description: |-
   The chunklist function splits a single list into fixed-size chunks, returning
   a list of lists.

--- a/website/content/docs/templates/hcl_templates/functions/collection/coalesce.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/coalesce.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: coalesce - Functions - Configuration Language
-sidebar_title: coalesce
 description: |-
   The coalesce function takes any number of arguments and returns the
   first one that isn't null nor empty.

--- a/website/content/docs/templates/hcl_templates/functions/collection/coalescelist.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/coalescelist.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: coalescelist - Functions - Configuration Language
-sidebar_title: coalescelist
 description: |-
   The coalescelist function takes any number of list arguments and returns the
   first one that isn't empty.

--- a/website/content/docs/templates/hcl_templates/functions/collection/compact.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/compact.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: compact - Functions - Configuration Language
-sidebar_title: compact
 description: The compact function removes empty string elements from a list.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/concat.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/concat.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: concat - Functions - Configuration Language
-sidebar_title: concat
 description: The concat function combines two or more lists into a single list.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/contains.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/contains.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: contains - Functions - Configuration Language
-sidebar_title: contains
 description: The contains function determines whether a list or set contains a given value.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/distinct.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/distinct.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: distinct - Functions - Configuration Language
-sidebar_title: distinct
 description: The distinct function removes duplicate elements from a list.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/element.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/element.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: element - Functions - Configuration Language
-sidebar_title: element
 description: The element function retrieves a single element from a list.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/flatten.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/flatten.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: flatten - Functions - Configuration Language
-sidebar_title: flatten
 description: The flatten function eliminates nested lists from a list.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/index-fn.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/index-fn.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: index - Functions - Configuration Language
-sidebar_title: index
 description: The index function finds the element index for a given value in a list.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: Collection - Functions - Configuration Language
-sidebar_title: Collection Functions
 description: Overview of available collection functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/collection/keys.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/keys.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: keys - Functions - Configuration Language
-sidebar_title: keys
 description: The keys function returns a list of the keys in a given map.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/length.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/length.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: length - Functions - Configuration Language
-sidebar_title: length
 description: The length function determines the length of a collection or string.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/lookup.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/lookup.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: lookup - Functions - Configuration Language
-sidebar_title: lookup
 description: The lookup function retrieves an element value from a map given its key.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/merge.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/merge.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: merge - Functions - Configuration Language
-sidebar_title: merge
 description: |-
   The merge function takes an arbitrary number of maps and returns a single
   map after merging the keys from each argument.

--- a/website/content/docs/templates/hcl_templates/functions/collection/range.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/range.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: range - Functions - Configuration Language
-sidebar_title: range
 description: The range function generates sequences of numbers.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/reverse.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/reverse.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: reverse - Functions - Configuration Language
-sidebar_title: reverse
 description: The reverse function reverses a sequence.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/setintersection.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/setintersection.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: setintersection - Functions - Configuration Language
-sidebar_title: setintersection
 description: |-
   The setintersection function takes multiple sets and produces a single set
   containing only the elements that all of the given sets have in common.

--- a/website/content/docs/templates/hcl_templates/functions/collection/setproduct.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/setproduct.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: setproduct - Functions - Configuration Language
-sidebar_title: setproduct
 description: |-
   The setproduct function finds all of the possible combinations of elements
   from all of the given sets by computing the cartesian product.

--- a/website/content/docs/templates/hcl_templates/functions/collection/setunion.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/setunion.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: setunion - Functions - Configuration Language
-sidebar_title: setunion
 description: |-
   The setunion function takes multiple sets and produces a single set
   containing the elements from all of the given sets.

--- a/website/content/docs/templates/hcl_templates/functions/collection/slice.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/slice.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: slice - Functions - Configuration Language
-sidebar_title: slice
 description: The slice function extracts some consecutive elements from within a list.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/sort.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/sort.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: sort - Functions - Configuration Language
-sidebar_title: sort
 description: |-
   The sort function takes a list of strings and returns a new list with those
   strings sorted lexicographically.

--- a/website/content/docs/templates/hcl_templates/functions/collection/values.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/values.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: values - Functions - Configuration Language
-sidebar_title: values
 description: The values function returns a list of the element values in a given map.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/collection/zipmap.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/zipmap.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: zipmap - Functions - Configuration Language
-sidebar_title: zipmap
 description: |-
   The zipmap function constructs a map from a list of keys and a corresponding
   list of values.

--- a/website/content/docs/templates/hcl_templates/functions/contextual/aws_secretsmanager.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/aws_secretsmanager.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: aws_secretsmanager - Functions - Configuration Language
-sidebar_title: aws_secretsmanager
 description: >-
   The aws_secretsmanager function retrieves secrets from Amazon secretsmanager
   stores.

--- a/website/content/docs/templates/hcl_templates/functions/contextual/consul.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/consul.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: consul - Functions - Configuration Language
-sidebar_title: consul
 description: The consul function retrieves secrets from HashiCorp consul KV stores.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/contextual/env.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/env.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: env - Functions - Configuration Language
-sidebar_title: env
 description: The env function retrieves environment values for input variables.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/contextual/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: Contextual - Functions - Configuration Language
-sidebar_title: Contextual Functions
 description: Overview of available Contextual functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/contextual/vault.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/vault.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: vault - Functions - Configuration Language
-sidebar_title: vault
 description: The vault function retrieves secrets from HashiCorp Vault KV stores.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: can - Functions - Configuration Language
-sidebar_title: can
 description: |-
   The can function tries to evaluate an expression given as an argument and
   indicates whether the evaluation succeeded.

--- a/website/content/docs/templates/hcl_templates/functions/conversion/convert.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/convert.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: convert - Functions - Configuration Language
-sidebar_title: convert
 description: 'The convert function converts a value or an expression to a given type. '
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/conversion/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: conversion - Functions - Configuration Language
-sidebar_title: Type Conversion Functions
 description: Overview of available conversion functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: try - Functions - Configuration Language
-sidebar_title: try
 description: |-
   The try function tries to evaluate a sequence of expressions given as
   arguments and returns the result of the first one that does not produce

--- a/website/content/docs/templates/hcl_templates/functions/crypto/bcrypt.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/crypto/bcrypt.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: bcrypt - Functions - Configuration Language
-sidebar_title: bcrypt
 description: |-
   The bcrypt function computes a hash of the given string using the Blowfish
   cipher.

--- a/website/content/docs/templates/hcl_templates/functions/crypto/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/crypto/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: crypto - Functions - Configuration Language
-sidebar_title: Hash and Crypto Functions
 description: Overview of available crypto functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/crypto/md5.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/crypto/md5.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: md5 - Functions - Configuration Language
-sidebar_title: md5
 description: |-
   The md5 function computes the MD5 hash of a given string and encodes it
   with hexadecimal digits.

--- a/website/content/docs/templates/hcl_templates/functions/crypto/rsadecrypt.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/crypto/rsadecrypt.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: rsadecrypt - Functions - Configuration Language
-sidebar_title: rsadecrypt
 description: The rsadecrypt function decrypts an RSA-encrypted message.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/crypto/sha1.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/crypto/sha1.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: sha1 - Functions - Configuration Language
-sidebar_title: sha1
 description: |-
   The sha1 function computes the SHA1 hash of a given string and encodes it
   with hexadecimal digits.

--- a/website/content/docs/templates/hcl_templates/functions/crypto/sha256.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/crypto/sha256.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: sha256 - Functions - Configuration Language
-sidebar_title: sha256
 description: |-
   The sha256 function computes the SHA256 hash of a given string and encodes it
   with hexadecimal digits.

--- a/website/content/docs/templates/hcl_templates/functions/crypto/sha512.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/crypto/sha512.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: sha512 - Functions - Configuration Language
-sidebar_title: sha512
 description: |-
   The sha512 function computes the SHA512 hash of a given string and encodes it
   with hexadecimal digits.

--- a/website/content/docs/templates/hcl_templates/functions/datetime/formatdate.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/datetime/formatdate.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: formatdate - Functions - Configuration Language
-sidebar_title: formatdate
 description: The formatdate function converts a timestamp into a different time format.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/datetime/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/datetime/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: datetime - Functions - Configuration Language
-sidebar_title: Date and Time Functions
 description: Overview of available datetime functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/datetime/timeadd.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/datetime/timeadd.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: timeadd - Functions - Configuration Language
-sidebar_title: timeadd
 description: |-
   The timeadd function adds a duration to a timestamp, returning a new
   timestamp.

--- a/website/content/docs/templates/hcl_templates/functions/datetime/timestamp.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/datetime/timestamp.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: timestamp - Functions - Configuration Language
-sidebar_title: timestamp
 description: |-
   The timestamp function returns a string representation of the current date
   and time.

--- a/website/content/docs/templates/hcl_templates/functions/encoding/base64decode.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/base64decode.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: base64decode - Functions - Configuration Language
-sidebar_title: base64decode
 description: The base64decode function decodes a string containing a base64 sequence.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/encoding/base64encode.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/base64encode.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: base64encode - Functions - Configuration Language
-sidebar_title: base64encode
 description: The base64encode function applies Base64 encoding to a string.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/encoding/csvdecode.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/csvdecode.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: csvdecode - Functions - Configuration Language
-sidebar_title: csvdecode
 description: The csvdecode function decodes CSV data into a list of maps.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/encoding/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: encoding - Functions - Configuration Language
-sidebar_title: Encoding Functions
 description: Overview of available encoding functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/encoding/jsondecode.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/jsondecode.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: jsondecode - Functions - Configuration Language
-sidebar_title: jsondecode
 description: |-
   The jsondecode function decodes a JSON string into a representation of its
   value.

--- a/website/content/docs/templates/hcl_templates/functions/encoding/jsonencode.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/jsonencode.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: jsonencode - Functions - Configuration Language
-sidebar_title: jsonencode
 description: The jsonencode function encodes a given value as a JSON string.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/encoding/urlencode.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/urlencode.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: urlencode - Functions - Configuration Language
-sidebar_title: urlencode
 description: The urlencode function applies URL encoding to a given string.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/encoding/yamldecode.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/yamldecode.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: yamldecode - Functions - Configuration Language
-sidebar_title: yamldecode
 description: |-
   The yamldecode function decodes a YAML string into a representation of its
   value.

--- a/website/content/docs/templates/hcl_templates/functions/encoding/yamlencode.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/yamlencode.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: yamlencode - Functions - Configuration Language
-sidebar_title: yamlencode
 description: The yamlencode function encodes a given value as a YAML string.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/file/abspath.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/abspath.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: abspath - Functions - Configuration Language
-sidebar_title: abspath
 description: The abspath function converts the argument to an absolute filesystem path.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/file/basename.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/basename.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: basename - Functions - Configuration Language
-sidebar_title: basename
 description: |-
   The basename function removes all except the last portion from a filesystem
   path.

--- a/website/content/docs/templates/hcl_templates/functions/file/dirname.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/dirname.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: dirname - Functions - Configuration Language
-sidebar_title: dirname
 description: The dirname function removes the last portion from a filesystem path.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/file/file.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/file.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: file - Functions - Configuration Language
-sidebar_title: file
 description: |-
   The file function reads the contents of the file at the given path and
   returns them as a string.

--- a/website/content/docs/templates/hcl_templates/functions/file/fileexists.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/fileexists.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: fileexists - Functions - Configuration Language
-sidebar_title: fileexists
 description: The fileexists function determines whether a file exists at a given path.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/file/fileset.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/fileset.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: fileset - Functions - Configuration Language
-sidebar_title: fileset
 description: The fileset function enumerates a set of regular file names given a pattern.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/file/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: filesystem - Functions - Configuration Language
-sidebar_title: Filesystem Functions
 description: Overview of available filesystem functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/file/pathexpand.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/pathexpand.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: pathexpand - Functions - Configuration Language
-sidebar_title: pathexpand
 description: |-
   The pathexpand function expands a leading ~ character to the current user's
   home directory.

--- a/website/content/docs/templates/hcl_templates/functions/file/templatefile.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/templatefile.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: templatefile - Functions - Configuration Language
-sidebar_title: templatefile
 description: |-
   The templatefile function reads the file at the given path and renders its
   content as a template using a supplied set of template variables.
@@ -8,8 +7,8 @@ description: |-
 
 # `templatefile` Function
 
--> *Recommendation:* we recommend using the `.pkrtpl.hcl` file extension when
-using the `templatefile` function. Template files *are* hcl treated as files but
+-> _Recommendation:_ we recommend using the `.pkrtpl.hcl` file extension when
+using the `templatefile` function. Template files _are_ hcl treated as files but
 also templates and therefore have slightly different set of features
 than the ones offered in a `.pkr.hcl` Packer template. While you are not
 required to use this extension, doing so will enable syntax highlighters to
@@ -52,6 +51,7 @@ Given a template file backends.tpl with the following content:
 backend ${addr}:${port}
 %{ endfor ~}
 ```
+
 The templatefile function renders the template:
 
 ```shell-session
@@ -63,12 +63,15 @@ backend 10.0.0.2:8080
 ### Maps
 
 Given a template file config.tmpl with the following content:
+
 ```hcl
 %{ for config_key, config_value in config }
 set ${config_key} = ${config_value}
 %{ endfor ~}
 ```
+
 The templatefile function renders the template:
+
 ```shell-session
 > templatefile(
                "${path.root}/config.tmpl",
@@ -114,12 +117,13 @@ by using a for expression rather than by using template directives.
 ```
 {"backends":["10.0.0.1:8080","10.0.0.2:8080"]}
 ```
+
 If the resulting template is small, you can choose instead to write jsonencode or yamlencode calls inline in your main configuration files, and avoid creating separate template files at all:
 
 locals {
-  backend_config_json = jsonencode({
-    "backends": [for addr in ip_addrs : "${addr}:${port}"],
-  })
+backend_config_json = jsonencode({
+"backends": [for addr in ip_addrs : "${addr}:${port}"],
+})
 }
 For more information, see the main documentation for jsonencode and yamlencode.
 

--- a/website/content/docs/templates/hcl_templates/functions/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/index.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Functions - Configuration Language
-sidebar_title: Functions
 description: |-
   The HCL language has a number of built-in functions that can be called
   from within expressions to transform and combine values.

--- a/website/content/docs/templates/hcl_templates/functions/ipnet/cidrhost.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/ipnet/cidrhost.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: cidrhost - Functions - Configuration Language
-sidebar_title: cidrhost
 description: |-
   The cidrhost function calculates a full host IP address within a given
   IP network address prefix.

--- a/website/content/docs/templates/hcl_templates/functions/ipnet/cidrnetmask.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/ipnet/cidrnetmask.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: cidrnetmask - Functions - Configuration Language
-sidebar_title: cidrnetmask
 description: |-
   The cidrnetmask function converts an IPv4 address prefix given in CIDR
   notation into a subnet mask address.

--- a/website/content/docs/templates/hcl_templates/functions/ipnet/cidrsubnet.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/ipnet/cidrsubnet.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: cidrsubnet - Functions - Configuration Language
-sidebar_title: cidrsubnet
 description: |-
   The cidrsubnet function calculates a subnet address within a given IP network
   address prefix.

--- a/website/content/docs/templates/hcl_templates/functions/ipnet/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/ipnet/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: ipnet - Functions - Configuration Language
-sidebar_title: IP Network Functions
 description: Overview of available ipnet functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/numeric/abs.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/abs.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: abs - Functions - Configuration Language
-sidebar_title: abs
 description: The abs function returns the absolute value of the given number.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/numeric/ceil.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/ceil.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: ceil - Functions - Configuration Language
-sidebar_title: ceil
 description: |-
   The ceil function returns the closest whole number greater than or equal to
   the given value.

--- a/website/content/docs/templates/hcl_templates/functions/numeric/floor.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/floor.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: floor - Functions - Configuration Language
-sidebar_title: floor
 description: |-
   The floor function returns the closest whole number less than or equal to
   the given value.

--- a/website/content/docs/templates/hcl_templates/functions/numeric/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: Numeric - Functions - Configuration Language
-sidebar_title: Numeric Functions
 description: Overview of available numeric functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/numeric/log.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/log.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: log - Functions - Configuration Language
-sidebar_title: log
 description: The log function returns the logarithm of a given number in a given base.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/numeric/max.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/max.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: max - Functions - Configuration Language
-sidebar_title: max
 description: The max function takes one or more numbers and returns the greatest number.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/numeric/min.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/min.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: min - Functions - Configuration Language
-sidebar_title: min
 description: The min function takes one or more numbers and returns the smallest number.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/numeric/parseint.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/parseint.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: parseint - Functions - Configuration Language
-sidebar_title: parseint
 description: >-
   The parseint function parses the given string as a representation of an
   integer.

--- a/website/content/docs/templates/hcl_templates/functions/numeric/pow.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/pow.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: pow - Functions - Configuration Language
-sidebar_title: pow
 description: The pow function raises a number to a power.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/numeric/signum.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/signum.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: signum - Functions - Configuration Language
-sidebar_title: signum
 description: The signum function determines the sign of a number.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/string/chomp.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/chomp.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: chomp - Functions - Configuration Language
-sidebar_title: chomp
 description: The chomp function removes newline characters at the end of a string.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/string/format.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/format.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: format - Functions - Configuration Language
-sidebar_title: format
 description: |-
   The format function produces a string by formatting a number of other values
   according to a specification string.

--- a/website/content/docs/templates/hcl_templates/functions/string/formatlist.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/formatlist.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: formatlist - Functions - Configuration Language
-sidebar_title: formatlist
 description: |-
   The formatlist function produces a list of strings by formatting a number of
   other values according to a specification string.

--- a/website/content/docs/templates/hcl_templates/functions/string/indent.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/indent.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: indent - Functions - Configuration Language
-sidebar_title: indent
 description: |-
   The indent function adds a number of spaces to the beginnings of all but the
   first line of a given multi-line string.

--- a/website/content/docs/templates/hcl_templates/functions/string/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: string - Functions - Configuration Language
-sidebar_title: String Functions
 description: Overview of available string functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/string/join.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/join.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: join - Functions - Configuration Language
-sidebar_title: join
 description: |-
   The join function produces a string by concatenating the elements of a list
   with a given delimiter.

--- a/website/content/docs/templates/hcl_templates/functions/string/lower.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/lower.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: lower - Functions - Configuration Language
-sidebar_title: lower
 description: >-
   The lower function converts all cased letters in the given string to
   lowercase.

--- a/website/content/docs/templates/hcl_templates/functions/string/regex.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/regex.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: regex - Functions - Configuration Language
-sidebar_title: regex
 description: |-
   The regex function applies a regular expression to a string and returns the
   matching substrings.
@@ -41,54 +40,54 @@ language, the quoted string itself already uses backslash `\` as an escape
 character for the string, so any backslashes intended to be recognized as part
 of the pattern must be escaped as `\\`.
 
-| Sequence       | Matches                                                                          |
-| -------------- | -------------------------------------------------------------------------------- |
-| `.`            | Any character except newline                                                     |
-| `[xyz]`        | Any character listed between the brackets (`x`, `y`, and `z` in this example)    |
-| `[a-z]`        | Any character between `a` and `z`, inclusive                                     |
-| `[^xyz]`       | The opposite of `[xyz]`                                                          |
-| `\d`           | ASCII digits (0 through 9, inclusive)                                            |
-| `\D`           | Anything except ASCII digits                                                     |
-| `\s`           | ASCII spaces (space, tab, newline, carriage return, form feed)                   |
-| `\S`           | Anything except ASCII spaces                                                     |
-| `\w`           | The same as `[0-9A-Za-z_]`                                                       |
-| `\W`           | Anything except the characters matched by `\w`                                   |
-| `[[:alnum:]]`  | The same as `[0-9A-Za-z]`                                                        |
-| `[[:alpha:]]`  | The same as `[A-Za-z]`                                                           |
-| `[[:ascii:]]`  | Any ASCII character                                                              |
-| `[[:blank:]]`  | ASCII tab or space                                                               |
-| `[[:cntrl:]]`  | ASCII/Unicode control characters                                                 |
-| `[[:digit:]]`  | The same as `[0-9]`                                                              |
-| `[[:graph:]]`  | All "graphical" (printable) ASCII characters                                     |
-| `[[:lower:]]`  | The same as `[a-z]`                                                              |
-| `[[:print:]]`  | The same as `[[:graph:]]`                                                        |
-| `[[:punct:]]`  | The same as `` [!-/:-@[-`{-~] ``                                                 |
-| `[[:space:]]`  | The same as `[\t\n\v\f\r ]`                                                      |
-| `[[:upper:]]`  | The same as `[A-Z]`                                                              |
-| `[[:word:]]`   | The same as `\w`                                                                 |
-| `[[:xdigit:]]` | The same as `[0-9A-Fa-f]`                                                        |
-| `\pN`          | Unicode character class by using single-letter class names ("N" in this example) |
-| `\p{Greek}`    | Unicode character class by unicode name ("Greek" in this example)                |
-| `\PN`          | The opposite of `\pN`                                                            |
-| `\P{Greek}`    | The opposite of `\p{Greek}`                                                      |
-| `xy`           | `x` followed immediately by `y`                                                  |
-| <code>x&#124;y</code> | either `x` or `y`, preferring `x`                                         |
-| `x*`           | zero or more `x`, preferring more                                                |
-| `x*?`          | zero or more `x`, preferring fewer                                               |
-| `x+`           | one or more `x`, preferring more                                                 |
-| `x+?`          | one or more `x`, preferring fewer                                                |
-| `x?`           | zero or one `x`, preferring one                                                  |
-| `x??`          | zero or one `x`, preferring zero                                                 |
-| `x{n,m}`       | between `n` and `m` repetitions of `x`, preferring more                          |
-| `x{n,m}?`      | between `n` and `m` repetitions of `x`, preferring fewer                         |
-| `x{n,}`        | at least `n` repetitions of `x`, preferring more                                 |
-| `x{n,}?`       | at least `n` repetitions of `x`, preferring fewer                                |
-| `x{n}`         | exactly `n` repetitions of `x`                                                   |
-| `(x)`          | unnamed capture group for sub-pattern `x`                                        |
-| `(?P<name>x)`  | named capture group, named `name`, for sub-pattern `x`                           |
-| `(?:x)`        | non-capturing sub-pattern `x`                                                    |
-| `\*`           | Literal `*` for any punctuation character `*`                                    |
-| `\Q...\E`      | Literal `...` for any text `...` as long as it does not include literally `\E`   |
+| Sequence              | Matches                                                                          |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `.`                   | Any character except newline                                                     |
+| `[xyz]`               | Any character listed between the brackets (`x`, `y`, and `z` in this example)    |
+| `[a-z]`               | Any character between `a` and `z`, inclusive                                     |
+| `[^xyz]`              | The opposite of `[xyz]`                                                          |
+| `\d`                  | ASCII digits (0 through 9, inclusive)                                            |
+| `\D`                  | Anything except ASCII digits                                                     |
+| `\s`                  | ASCII spaces (space, tab, newline, carriage return, form feed)                   |
+| `\S`                  | Anything except ASCII spaces                                                     |
+| `\w`                  | The same as `[0-9A-Za-z_]`                                                       |
+| `\W`                  | Anything except the characters matched by `\w`                                   |
+| `[[:alnum:]]`         | The same as `[0-9A-Za-z]`                                                        |
+| `[[:alpha:]]`         | The same as `[A-Za-z]`                                                           |
+| `[[:ascii:]]`         | Any ASCII character                                                              |
+| `[[:blank:]]`         | ASCII tab or space                                                               |
+| `[[:cntrl:]]`         | ASCII/Unicode control characters                                                 |
+| `[[:digit:]]`         | The same as `[0-9]`                                                              |
+| `[[:graph:]]`         | All "graphical" (printable) ASCII characters                                     |
+| `[[:lower:]]`         | The same as `[a-z]`                                                              |
+| `[[:print:]]`         | The same as `[[:graph:]]`                                                        |
+| `[[:punct:]]`         | The same as `` [!-/:-@[-`{-~] ``                                                 |
+| `[[:space:]]`         | The same as `[\t\n\v\f\r ]`                                                      |
+| `[[:upper:]]`         | The same as `[A-Z]`                                                              |
+| `[[:word:]]`          | The same as `\w`                                                                 |
+| `[[:xdigit:]]`        | The same as `[0-9A-Fa-f]`                                                        |
+| `\pN`                 | Unicode character class by using single-letter class names ("N" in this example) |
+| `\p{Greek}`           | Unicode character class by unicode name ("Greek" in this example)                |
+| `\PN`                 | The opposite of `\pN`                                                            |
+| `\P{Greek}`           | The opposite of `\p{Greek}`                                                      |
+| `xy`                  | `x` followed immediately by `y`                                                  |
+| <code>x&#124;y</code> | either `x` or `y`, preferring `x`                                                |
+| `x*`                  | zero or more `x`, preferring more                                                |
+| `x*?`                 | zero or more `x`, preferring fewer                                               |
+| `x+`                  | one or more `x`, preferring more                                                 |
+| `x+?`                 | one or more `x`, preferring fewer                                                |
+| `x?`                  | zero or one `x`, preferring one                                                  |
+| `x??`                 | zero or one `x`, preferring zero                                                 |
+| `x{n,m}`              | between `n` and `m` repetitions of `x`, preferring more                          |
+| `x{n,m}?`             | between `n` and `m` repetitions of `x`, preferring fewer                         |
+| `x{n,}`               | at least `n` repetitions of `x`, preferring more                                 |
+| `x{n,}?`              | at least `n` repetitions of `x`, preferring fewer                                |
+| `x{n}`                | exactly `n` repetitions of `x`                                                   |
+| `(x)`                 | unnamed capture group for sub-pattern `x`                                        |
+| `(?P<name>x)`         | named capture group, named `name`, for sub-pattern `x`                           |
+| `(?:x)`               | non-capturing sub-pattern `x`                                                    |
+| `\*`                  | Literal `*` for any punctuation character `*`                                    |
+| `\Q...\E`             | Literal `...` for any text `...` as long as it does not include literally `\E`   |
 
 In addition to the above matching operators that consume the characters they
 match, there are some additional operators that _only_ match, but consume

--- a/website/content/docs/templates/hcl_templates/functions/string/regex.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/regex.mdx
@@ -30,7 +30,7 @@ It's not valid to mix both named and unnamed capture groups in the same pattern.
 
 If the given pattern does not match at all, the `regex` raises an error. To
 _test_ whether a given pattern matches a string, use
-[`regexall`](./regexall) and test that the result has length greater than
+[`regexall`](/docs/templates/hcl_templates/functions/string/regexall) and test that the result has length greater than
 zero.
 
 The pattern is a string containing a mixture of literal characters and special
@@ -152,8 +152,8 @@ string.
 
 ## Related Functions
 
-- [`regexall`](./regexall) searches for potentially multiple matches of a given pattern in a string.
-- [`replace`](./replace) replaces a substring of a string with another string, optionally matching using the same regular expression syntax as `regex`.
+- [`regexall`](/docs/templates/hcl_templates/functions/string/regexall) searches for potentially multiple matches of a given pattern in a string.
+- [`replace`](/docs/templates/hcl_templates/functions/string/replace) replaces a substring of a string with another string, optionally matching using the same regular expression syntax as `regex`.
 
 If Packer already has a more specialized function to parse the syntax you
 are trying to match, prefer to use that function instead. Regular expressions

--- a/website/content/docs/templates/hcl_templates/functions/string/regex_replace.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/regex_replace.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: regex_replace - Functions - Configuration Language
-sidebar_title: regex_replace
 description: >-
   The regex_replace function searches a given string for another given
   substring,

--- a/website/content/docs/templates/hcl_templates/functions/string/regexall.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/regexall.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: regexall - Functions - Configuration Language
-sidebar_title: regexall
 description: |-
   The regexall function applies a regular expression to a string and returns a list of all matches.
 ---

--- a/website/content/docs/templates/hcl_templates/functions/string/regexall.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/regexall.mdx
@@ -14,7 +14,7 @@ to a string and returns a list of all matches.
 regexall(pattern, string)
 ```
 
-`regexall` is a variant of [`regex`](./regex) and uses the same pattern
+`regexall` is a variant of [`regex`](/docs/templates/hcl_templates/functions/string/regex) and uses the same pattern
 syntax. For any given input to `regex`, `regexall` returns a list of whatever
 type `regex` would've returned, with one element per match. That is:
 
@@ -47,7 +47,7 @@ false
 
 ## Related Functions
 
-- [`regex`](./regex) searches for a single match of a given pattern, and
+- [`regex`](/docs/templates/hcl_templates/functions/string/regex) searches for a single match of a given pattern, and
   returns an error if no match is found.
 
 If Packer already has a more specialized function to parse the syntax you

--- a/website/content/docs/templates/hcl_templates/functions/string/replace.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/replace.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: replace - Functions - Configuration Language
-sidebar_title: replace
 description: |-
   The replace function searches a given string for another given substring,
   and replaces all occurrences with a given replacement string.

--- a/website/content/docs/templates/hcl_templates/functions/string/split.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/split.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: split - Functions - Configuration Language
-sidebar_title: split
 description: |-
   The split function produces a list by dividing a given string at all
   occurrences of a given separator.

--- a/website/content/docs/templates/hcl_templates/functions/string/strrev.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/strrev.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: strrev - Functions - Configuration Language
-sidebar_title: strrev
 description: The strrev function reverses a string.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/string/substr.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/substr.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: substr - Functions - Configuration Language
-sidebar_title: substr
 description: |-
   The substr function extracts a substring from a given string by offset and
   length.

--- a/website/content/docs/templates/hcl_templates/functions/string/title.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/title.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: title - Functions - Configuration Language
-sidebar_title: title
 description: |-
   The title function converts the first letter of each word in a given string
   to uppercase.

--- a/website/content/docs/templates/hcl_templates/functions/string/trim.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/trim.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: trim - Functions - Configuration Language
-sidebar_title: trim
 description: |-
   The trim function removes the specified characters from the start and end of
   a given string.

--- a/website/content/docs/templates/hcl_templates/functions/string/trimprefix.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/trimprefix.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: trimprefix - Functions - Configuration Language
-sidebar_title: trimprefix
 description: |-
   The trimprefix function removes the specified prefix from the start of a
   given string.

--- a/website/content/docs/templates/hcl_templates/functions/string/trimspace.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/trimspace.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: trimspace - Functions - Configuration Language
-sidebar_title: trimspace
 description: |-
   The trimspace function removes space characters from the start and end of
   a given string.

--- a/website/content/docs/templates/hcl_templates/functions/string/trimsuffix.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/trimsuffix.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: trimsuffix - Functions - Configuration Language
-sidebar_title: trimsuffix
 description: |-
   The trimsuffix function removes the specified suffix from the end of a
   given string.

--- a/website/content/docs/templates/hcl_templates/functions/string/upper.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/upper.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: upper - Functions - Configuration Language
-sidebar_title: upper
 description: >-
   The upper function converts all cased letters in the given string to
   uppercase.

--- a/website/content/docs/templates/hcl_templates/functions/uuid/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/uuid/index.mdx
@@ -1,5 +1,4 @@
 ---
 page_title: uuid - Functions - Configuration Language
-sidebar_title: UUID Functions
 description: Overview of available uuid functions
 ---

--- a/website/content/docs/templates/hcl_templates/functions/uuid/uuidv4.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/uuid/uuidv4.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: v4 - uuid - Functions - Configuration Language
-sidebar_title: uuidv4
 description: The uuidv4 function generates a unique id.
 ---
 

--- a/website/content/docs/templates/hcl_templates/functions/uuid/uuidv5.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/uuid/uuidv5.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: uuidv5 - Functions - Configuration Language
-sidebar_title: uuidv5
 description: |-
   The uuidv5 function generates a uuid v5 string representation of the value in
   the specified namespace.

--- a/website/content/docs/templates/hcl_templates/index.mdx
+++ b/website/content/docs/templates/hcl_templates/index.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: HCL Templates
-sidebar_title: HCL Templates
 description: |-
   Packer uses text files to describe infrastructure and to set variables.
   These text files are called Packer _configurations_ and are

--- a/website/content/docs/templates/hcl_templates/locals.mdx
+++ b/website/content/docs/templates/hcl_templates/locals.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Local Values - HCL Configuration Language
-sidebar_title: Locals
 description: >-
   Local values assign a name to an expression that can then be used multiple
   times within a folder.

--- a/website/content/docs/templates/hcl_templates/onlyexcept.mdx
+++ b/website/content/docs/templates/hcl_templates/onlyexcept.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Only Except - HCL Configuration Language
-sidebar_title: Only Except
 description: >-
   Only and Except can be used as a command line argument to selectively run
   builds. Only and Except can also be used in a provisioner to not run it for a

--- a/website/content/docs/templates/hcl_templates/path-variables.mdx
+++ b/website/content/docs/templates/hcl_templates/path-variables.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Path Variables - HCL Configuration Language
-sidebar_title: Path Variables
 description: |-
   Special variables provide directory information. This page covers all path
   variables.

--- a/website/content/docs/templates/hcl_templates/syntax-json.mdx
+++ b/website/content/docs/templates/hcl_templates/syntax-json.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: JSON Configuration Syntax - Configuration Language
-sidebar_title: JSON Syntax
 description: |-
   In addition to the native syntax that is most commonly used with Packer,
   the HCL language can also be expressed in a JSON-compatible syntax.
@@ -117,14 +116,14 @@ Since JSON grammar is not able to represent all of the Packer language
 [expression syntax](/docs/templates/hcl_templates/expressions), JSON values interpreted as expressions
 are mapped as follows:
 
-| JSON    | Packer Language Interpretation                                                                                    |
-| ------- | ----------------------------------------------------------------------------------------------------------------- |
-| Boolean | A literal `bool` value.                                                                                           |
-| Number  | A literal `number` value.                                                                                         |
+| JSON    | Packer Language Interpretation                                                                                                   |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Boolean | A literal `bool` value.                                                                                                          |
+| Number  | A literal `number` value.                                                                                                        |
 | String  | Parsed as a [string template](/docs/templates/hcl_templates/expressions#string-templates) and then evaluated as described below. |
-| Object  | Each property value is mapped per this table, producing an `object(...)` value with suitable attribute types.     |
-| Array   | Each element is mapped per this table, producing a `tuple(...)` value with suitable element types.                |
-| Null    | A literal `null`.                                                                                                 |
+| Object  | Each property value is mapped per this table, producing an `object(...)` value with suitable attribute types.                    |
+| Array   | Each element is mapped per this table, producing a `tuple(...)` value with suitable element types.                               |
+| Null    | A literal `null`.                                                                                                                |
 
 When a JSON string is encountered in a location where arbitrary expressions are
 expected, its value is first parsed as a [string template](/docs/templates/hcl_templates/expressions#string-templates)

--- a/website/content/docs/templates/hcl_templates/syntax.mdx
+++ b/website/content/docs/templates/hcl_templates/syntax.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Syntax - Configuration Language
-sidebar_title: Syntax
 description: |-
   HCL has its own syntax, intended to combine declarative
   structure with expressions in a way that is easy for humans to read and

--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Input Variables - HCL Configuration Language
-sidebar_title: Variables
 description: |-
   Input variables are parameters for Packer modules.
   This page covers configuration syntax for variables.

--- a/website/content/docs/templates/legacy_json_templates/builders.mdx
+++ b/website/content/docs/templates/legacy_json_templates/builders.mdx
@@ -5,7 +5,6 @@ description: >
 
   that Packer should use to generate machine images for the template.
 page_title: Builders - Templates
-sidebar_title: Builders
 ---
 
 `@include 'from-1.5/legacy-json-warning.mdx'`

--- a/website/content/docs/templates/legacy_json_templates/communicator.mdx
+++ b/website/content/docs/templates/legacy_json_templates/communicator.mdx
@@ -3,7 +3,6 @@ description: |
   Communicators are the mechanism Packer uses to upload files, execute scripts,
   etc. with the machine being created.
 page_title: Communicators - Templates
-sidebar_title: Communicators
 ---
 
 `@include 'from-1.5/legacy-json-warning.mdx'`

--- a/website/content/docs/templates/legacy_json_templates/engine.mdx
+++ b/website/content/docs/templates/legacy_json_templates/engine.mdx
@@ -4,7 +4,6 @@ description: |
   engine, where variables and functions can be used to modify the value of a
   configuration parameter at runtime.
 page_title: Template Engine - Templates
-sidebar_title: Engine
 ---
 
 `@include 'from-1.5/legacy-json-warning.mdx'`

--- a/website/content/docs/templates/legacy_json_templates/index.mdx
+++ b/website/content/docs/templates/legacy_json_templates/index.mdx
@@ -7,7 +7,6 @@ description: >
   templates by hand, but also write scripts to dynamically create or modify
   templates.
 page_title: JSON Templates
-sidebar_title: JSON Templates
 ---
 
 `@include 'from-1.5/legacy-json-warning.mdx'`

--- a/website/content/docs/templates/legacy_json_templates/post-processors.mdx
+++ b/website/content/docs/templates/legacy_json_templates/post-processors.mdx
@@ -4,7 +4,6 @@ description: |
   that will be done to images built by the builders. Examples of post-processing
   would be compressing files, uploading artifacts, etc.
 page_title: Post-Processors - Templates
-sidebar_title: Post-Processors
 ---
 
 `@include 'from-1.5/legacy-json-warning.mdx'`

--- a/website/content/docs/templates/legacy_json_templates/provisioners.mdx
+++ b/website/content/docs/templates/legacy_json_templates/provisioners.mdx
@@ -4,7 +4,6 @@ description: |
   provisioners that Packer should use to install and configure software within
   running machines prior to turning them into machine images.
 page_title: Provisioners - Templates
-sidebar_title: Provisioners
 ---
 
 `@include 'from-1.5/legacy-json-warning.mdx'`

--- a/website/content/docs/templates/legacy_json_templates/user-variables.mdx
+++ b/website/content/docs/templates/legacy_json_templates/user-variables.mdx
@@ -6,7 +6,6 @@ description: |
   environment-specific data, and other types of information out of your
   templates. This maximizes the portability and shareability of the template.
 page_title: User Variables - Templates
-sidebar_title: User Variables
 ---
 
 `@include 'from-1.5/legacy-json-warning.mdx'`

--- a/website/content/docs/terminology.mdx
+++ b/website/content/docs/terminology.mdx
@@ -12,7 +12,6 @@ description: >
 
   for quick referencing.
 page_title: Terminology
-sidebar_title: Terminology
 ---
 
 # Packer Terminology

--- a/website/content/guides/1.7-plugin-upgrade.mdx
+++ b/website/content/guides/1.7-plugin-upgrade.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Upgrading your plugin to use the Packer plugin sdk
-sidebar_title: Upgrade Your Plugin to use the Packer plugin sdk
 ---
 
 # Upgrading your plugin to be compatible with Packer v1.7.0 and later
@@ -57,7 +56,6 @@ func main() {
 ```
 
 With this single-component plugin binary you'd install it by putting it into the plugin directory with the name `packer-provisioner-foo`, and to access your provisioner in your Packer template, you would use the type `foo`.
-
 
 To use the new multi-component server, you'll want to use the NewSet() function to create a server:
 
@@ -116,4 +114,3 @@ Once a plugin has been migrated to use the `packer-plugin-sdk` it can be release
 If you want Packer to be able to automatically install your plugin for your users via`packer init` -- the preferred method of installation -- you need to make the plugin available on GitHub in a repository named after the multi-component plugin. `https://github.com/<yourorg>/packer-plugin-name`. We recognize that this may require you to rename or fork your plugin repository, but we think that it is worth the inconvenience to reduce ambiguity in the `init` call.
 
 See our documentation on [Creating a GitHub Release](/docs/plugins/creation#creating-a-github-release) for details on the recommended practice for releasing Packer plugins on GitHub.
-

--- a/website/content/guides/1.7-template-upgrade.mdx
+++ b/website/content/guides/1.7-template-upgrade.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Upgrading your template to use Packer init
-sidebar_title: Upgrade Your Template to use Packer init
 ---
 
 # Upgrading your template to be compatible with `packer init`
@@ -28,7 +27,6 @@ We strongly encourage you to upgrade and start using `required_plugins` block wi
 installation, but if you prefer not to use the `required_plugins` block you can continue to
 [install plugins manually](/docs/plugins#installing-plugins).
 
-
 ### What if you only use components that are built into the Packer core?
 
 You don't need `packer init` for this, as of v1.7.0. But it's a good idea to get familiar with the required_plugins
@@ -44,8 +42,8 @@ version v5.0. The plugin repository on GitHub also needs to use a specific relea
 the plugin you use fits those requirements, you can reach out to your maintainer to ask. You can also look for clues
 that the plugin is ready for use with `packer init`:
 
-* Check the plugin's CHANGELOG for notes about migrating to the packer-plugin-sdk.
-* Check the name of the repository the plugin resides in. Chances are that if the repository follows the naming
+- Check the plugin's CHANGELOG for notes about migrating to the packer-plugin-sdk.
+- Check the name of the repository the plugin resides in. Chances are that if the repository follows the naming
   convention `packer-plugin-*` (e.g. `packer-plugin-comment`), then the plugin has been upgraded to be compatible with
   `packer init`. If the repository has a name that references a specific Packer component (for example,
   `packer-provisioner-*`, `packer-builder-*`, or `packer-post-processor-*`) then the plugin likely still needs to be
@@ -67,8 +65,8 @@ maintainer-focused guide [here](/guides/1.7-plugin-upgrade).
 Check the table below to better understand whether your plugin is compatible with `packer init`, with manual
 installation, or with both for the the Packer version you are using.
 
-| Packer Core Version | Single Component Plugin - API v4                  | Single Component Plugin - API v5.0                | Multi Component Plugin - API v5.0                        |
-| ------------------- | ------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------------- |
+| Packer Core Version | Single Component Plugin - API v4                  | Single Component Plugin - API v5.0                | Multi Component Plugin - API v5.0                         |
+| ------------------- | ------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------- |
 | v1.5.0 to v1.6.6    | ✋ Plugin must be manually installed              | ⛔ Plugin cannot be used with this Packer version | ⛔ Plugin cannot be used with this Packer version         |
 | v1.7.0              | ⛔ Plugin cannot be used with this Packer version | ✋ Plugin must be manually installed              | 📦 Plugin can be installed manually or with `packer init` |
 
@@ -134,34 +132,36 @@ than `v0.2.23`. Finally, the local_name of the plugin will be `comment`, which m
 in the rest of the template.
 
 Here it is a brief explanation of each field:
+
 - `version` - Should follow the [version constraints](/docs/templates/hcl_templates/blocks/packer#version-constraints).
-- `source` - Should have the GitHub hostname, the plugin's organizational namespace, and its short name. 
-Packer will be responsible for determining the full GitHub
+- `source` - Should have the GitHub hostname, the plugin's organizational namespace, and its short name.
+  Packer will be responsible for determining the full GitHub
   address. For example, if the source is `github.com/sylviamoss/comment`, Packer
   will download the binaries from `github.com/sylviamoss/packer-plugin-comment`.
   To learn more about the source field, check out the [Source
   Address](/docs/plugins#source-addresses) documentation.
 - `local_name`- Can be replaced with whatever you want, and the new value will become the name of the plugin.
   For example:
-    ```hcl
-    packer {
-        required_plugins {
-            bubbled_up = {
-                # ...
-            }
-        }
-    }
 
-    # ...
+  ```hcl
+  packer {
+      required_plugins {
+          bubbled_up = {
+              # ...
+          }
+      }
+  }
 
-    build {
-        # ...
+  # ...
 
-        provisioner "bubbled_up" {
-            # ...
-        }
-    }
-    ```
+  build {
+      # ...
+
+      provisioner "bubbled_up" {
+          # ...
+      }
+  }
+  ```
 
 Once the template is upgraded, you can run `packer init example.pkr.hcl` and the output should tell you the installed
 plugin, and the place where it was installed.
@@ -181,4 +181,3 @@ and won't need to run `init` again unless you want to upgrade the plugin version
 
 A template with a `required_plugins` block should **always** be initialised at least once with `packer init` before
 `packer build`. If the template is built before init, Packer will fail and ask for initialisation.
-

--- a/website/content/guides/automatic-operating-system-installs/autounattend_windows.mdx
+++ b/website/content/guides/automatic-operating-system-installs/autounattend_windows.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Unattended Windows Installation
-sidebar_title: Unattended Installation for Windows
 description: |-
   Learn how to use an autounattend file to automatically answer installation
   questions and enable Packer to connect to your windows instnace.

--- a/website/content/guides/automatic-operating-system-installs/index.mdx
+++ b/website/content/guides/automatic-operating-system-installs/index.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Automatic OS Installs
-sidebar_title: Automatic OS Installs
 description: |-
   Learn how to use preseed, kickstart, and autounattend files to automatically
   answer installation questions and enable Packer to connect to your instnace.

--- a/website/content/guides/automatic-operating-system-installs/preseed_ubuntu.mdx
+++ b/website/content/guides/automatic-operating-system-installs/preseed_ubuntu.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Unattended Debian/Ubuntu Installation
-sidebar_title: Unattended Installation for Debian
 description: |-
   Learn how to use a preseed file to automatically answer installation
   questions and enable Packer to connect to your Debian instnace.

--- a/website/content/guides/hcl/component-object-spec.mdx
+++ b/website/content/guides/hcl/component-object-spec.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Generating code for config spec.
-sidebar_title: Making a plugin HCL2 enabled
 description: Learn how to generate the HCL2 configuration of your component easily.
 ---
 

--- a/website/content/guides/hcl/from-json-v1.mdx
+++ b/website/content/guides/hcl/from-json-v1.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Transforming Packer v1 files for Packer v1.5.0
-sidebar_title: From JSON v1
 description: |-
   Learn how to manually move from a Packer v1 working JSON build file to a
   working v1.5.0 HCL file.

--- a/website/content/guides/hcl/index.mdx
+++ b/website/content/guides/hcl/index.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Getting started configuring Packer with HCL2 files
-sidebar_title: HCL guides
 ---
 
 # Introduction to Packer HCL2

--- a/website/content/guides/hcl/variables.mdx
+++ b/website/content/guides/hcl/variables.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Input and Local Variables guide
-sidebar_title: Variables
 description: |-
   This page introduces input variables and local variables as a way to
   parameterize a configuration.

--- a/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
+++ b/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Build Images in CI/CD
-sidebar_title: Build Images in CI/CD
 ---
 
 # Build Images in CI/CD

--- a/website/content/guides/packer-on-cicd/build-virtualbox-image.mdx
+++ b/website/content/guides/packer-on-cicd/build-virtualbox-image.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Build a VirtualBox Image with Packer in TeamCity
-sidebar_title: Build a VirtualBox Image with Packer in TeamCity
 ---
 
 # Build a VirtualBox Image with Packer in TeamCity

--- a/website/content/guides/packer-on-cicd/index.mdx
+++ b/website/content/guides/packer-on-cicd/index.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Build Immutable Infrastructure with Packer in CI/CD
-sidebar_title: Build Immutable Infrastructure with Packer in CI/CD
 ---
 
 # Build Immutable Infrastructure with Packer in CI/CD

--- a/website/content/guides/packer-on-cicd/pipelineing-builds.mdx
+++ b/website/content/guides/packer-on-cicd/pipelineing-builds.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Packer Build Pipelines
-sidebar_title: Pipelineing Builds
 description: |-
   Here we explore how to break your builds into discrete steps so that your
   builds can be shorter and more reliable.

--- a/website/content/guides/packer-on-cicd/trigger-tfe.mdx
+++ b/website/content/guides/packer-on-cicd/trigger-tfe.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Trigger Terraform Enterprise runs
-sidebar_title: Trigger Terraform Enterprise runs
 ---
 
 # Create Terraform Enterprise Runs

--- a/website/content/guides/packer-on-cicd/upload-images-to-artifact.mdx
+++ b/website/content/guides/packer-on-cicd/upload-images-to-artifact.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Upload VirtualBox Image to S3
-sidebar_title: Upload a VirtualBox Image to S3
 ---
 
 # Upload VirtualBox Image to S3

--- a/website/content/guides/workflow-tips-and-tricks/index.mdx
+++ b/website/content/guides/workflow-tips-and-tricks/index.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Tips and Tricks
-sidebar_title: Workflow Tips and Tricks
 description: |-
   The guides stored in this section are miscellanious tips and tricks that might
   make your experience of using Packer easier

--- a/website/content/guides/workflow-tips-and-tricks/isotime-template-function.mdx
+++ b/website/content/guides/workflow-tips-and-tricks/isotime-template-function.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Using the isotime template function - Guides
-sidebar_title: Isotime Template Function
 description: |-
   It can be a bit confusing to figure out how to format your isotime using the
   golang reference date string. Here is a small guide and some examples.

--- a/website/content/guides/workflow-tips-and-tricks/use-packer-with-comment.mdx
+++ b/website/content/guides/workflow-tips-and-tricks/use-packer-with-comment.mdx
@@ -1,13 +1,11 @@
 ---
 page_title: Use jq and Packer to comment your templates - Guides
-sidebar_title: Use jq to strip comments from a Packer template
 description: |-
   You can add detailed comments beyond the root-level underscore-prefixed field
   supported by Packer, and remove them using jq.
 ---
 
 # How to use jq to strip unsupported comments from a Packer template
-
 
 -> **Note:** Packer supports HCL2 from version 1.6.0, the Hashicorp Configuration
 Language allows to comment directly in template files. Consider upgrading your

--- a/website/content/guides/workflow-tips-and-tricks/veewee-to-packer.mdx
+++ b/website/content/guides/workflow-tips-and-tricks/veewee-to-packer.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Convert Veewee Definitions to Packer Templates - Guides
-sidebar_title: Veewee to Packer
 description: |-
   If you are or were a user of Veewee, then there is an official tool called
   veewee-to-packer that will convert your Veewee definition into an equivalent

--- a/website/content/intro/use-cases.mdx
+++ b/website/content/intro/use-cases.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Use Cases - Introduction
-sidebar_title: Use Cases
 description: |-
   By now you should know what Packer does and what the benefits of image
   creation are. In this section, we'll enumerate *some* of the use cases for

--- a/website/content/intro/why.mdx
+++ b/website/content/intro/why.mdx
@@ -1,6 +1,5 @@
 ---
 page_title: Why Packer - Introduction
-sidebar_title: Why Use Packer?
 description: |-
   Pre-baked machine images have a lot of advantages, but most have been unable
   to benefit from them because images have been too tedious to create and

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -321,6 +321,10 @@
                     "path": "templates/hcl_templates/functions/collection/flatten"
                   },
                   {
+                    "title": "index",
+                    "path": "templates/hcl_templates/functions/collection/index-fn"
+                  },
+                  {
                     "title": "keys",
                     "path": "templates/hcl_templates/functions/collection/keys"
                   },
@@ -545,6 +549,10 @@
                   {
                     "title": "cidrsubnet",
                     "path": "templates/hcl_templates/functions/ipnet/cidrsubnet"
+                  },
+                  {
+                    "title": "cidrsubnets",
+                    "path": "templates/hcl_templates/functions/ipnet/cidrsubnets"
                   }
                 ]
               },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2852,14 +2852,14 @@
       "integrity": "sha512-AYIe6tcOxlKPe5Sq89o/Vk0rGE6Z1dCzf+N3ynECTh5L2A1zusf9xeM659QEh/edE/Ll9EBBLmq49sQXLNDxTw=="
     },
     "@hashicorp/react-docs-page": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-11.0.1.tgz",
-      "integrity": "sha512-BZ746Qm97OQTyMPI7calYDb+LAQQZGTn/vZ8FaMXbVCF+X9Bvs1xYyWRDV6gV0mtgmlkCwYqIrmqneOZdd6PcA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-12.0.0.tgz",
+      "integrity": "sha512-t5HpVsENkUSpbs8Eb5odTVt+Ke2z/LDKiJgC9Jq3+mVtRDXZ0+w5X6XQic8xVRP5McmOKPqoSeqBmgLwIBm1WQ==",
       "requires": {
         "@hashicorp/react-content": "^6.3.0",
         "@hashicorp/react-docs-sidenav": "^7.0.0",
         "@hashicorp/react-head": "^1.2.0",
-        "@hashicorp/react-search": "^4.1.0",
+        "@hashicorp/react-search": "^4.2.0",
         "fs-exists-sync": "0.1.0",
         "gray-matter": "4.0.2",
         "js-yaml": "3.14.0",
@@ -2877,28 +2877,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-1.2.0.tgz",
           "integrity": "sha512-6BNmhsrzVwJFOAcT3WhSeDlCdtlD3d7vzhXOGfkpPYVnYRaIpLLC6seemAr/wqZhYB87W+KvFilz8vZcpDAZzQ=="
-        },
-        "@hashicorp/react-inline-svg": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-1.0.2.tgz",
-          "integrity": "sha512-AAFnBslSTgnEr++dTbMn3sybAqvn7myIj88ijGigF6u11eSRiV64zqEcyYLQKWTV6dF4AvYoxiYC6GSOgiM0Yw=="
-        },
-        "@hashicorp/react-search": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-4.1.0.tgz",
-          "integrity": "sha512-TZChez9q/4bn/flQXRo0h/9B0kDMvin759hd8+vRrt1M3Qhz2C1TKpfZRKrX6dFZI8w4obGm1EzUzR130gdFfQ==",
-          "requires": {
-            "@hashicorp/react-inline-svg": "^1.0.2",
-            "@hashicorp/remark-plugins": "^3.0.0",
-            "algoliasearch": "^4.8.4",
-            "dotenv": "^8.2.0",
-            "glob": "^7.1.6",
-            "gray-matter": "^4.0.2",
-            "react-instantsearch-dom": "^6.9.0",
-            "remark": "^12.0.1",
-            "search-insights": "^1.6.0",
-            "unist-util-visit": "^2.0.3"
-          }
         }
       }
     },

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "@hashicorp/mktg-global-styles": "2.1.0",
     "@hashicorp/nextjs-scripts": "16.3.0",
     "@hashicorp/react-button": "4.0.0",
-    "@hashicorp/react-docs-page": "11.0.1",
+    "@hashicorp/react-docs-page": "12.0.0",
     "@hashicorp/react-hashi-stack-menu": "^1.1.0",
     "@hashicorp/react-head": "1.1.6",
     "@hashicorp/react-inline-svg": "5.0.0",

--- a/website/pages/docs/[[...page]].jsx
+++ b/website/pages/docs/[[...page]].jsx
@@ -8,17 +8,14 @@ import {
   generateStaticProps,
 } from 'components/remote-plugin-docs/server'
 
-//  Configure the docs path
-const BASE_ROUTE = 'docs'
-const NAV_DATA = 'data/docs-nav-data.json'
-const CONTENT_DIR = 'content/docs'
-const PRODUCT = { name: productName, slug: productSlug }
-// add remote plugin docs loading
-const OPTIONS = {
-  remotePluginsFile: 'data/docs-remote-plugins.json',
-  additionalComponents: { PluginTierLabel },
-  mainBranch: 'master',
-}
+//  Configure the docs path and remote plugin docs loading
+const additionalComponents = { PluginTierLabel }
+const baseRoute = 'docs'
+const localContentDir = 'content/docs'
+const mainBranch = 'master'
+const navDataFile = 'data/docs-nav-data.json'
+const product = { name: productName, slug: productSlug }
+const remotePluginsFile = 'data/docs-remote-plugins.json'
 
 function DocsLayout({ isDevMissingRemotePlugins, ...props }) {
   return (
@@ -47,9 +44,9 @@ function DocsLayout({ isDevMissingRemotePlugins, ...props }) {
         </DevAlert>
       ) : null}
       <DocsPage
-        additionalComponents={OPTIONS.additionalComponents}
-        baseRoute={BASE_ROUTE}
-        product={PRODUCT}
+        additionalComponents={additionalComponents}
+        baseRoute={baseRoute}
+        product={product}
         staticProps={props}
       />
     </>
@@ -57,18 +54,24 @@ function DocsLayout({ isDevMissingRemotePlugins, ...props }) {
 }
 
 export async function getStaticPaths() {
-  const paths = await generateStaticPaths(NAV_DATA, CONTENT_DIR, OPTIONS)
+  const paths = await generateStaticPaths({
+    localContentDir,
+    navDataFile,
+    remotePluginsFile,
+  })
   return { paths, fallback: false }
 }
 
 export async function getStaticProps({ params }) {
-  const props = await generateStaticProps(
-    NAV_DATA,
-    CONTENT_DIR,
+  const props = await generateStaticProps({
+    additionalComponents,
+    localContentDir,
+    mainBranch,
+    navDataFile,
     params,
-    PRODUCT,
-    OPTIONS
-  )
+    product,
+    remotePluginsFile,
+  })
   return { props }
 }
 

--- a/website/pages/guides/[[...page]].jsx
+++ b/website/pages/guides/[[...page]].jsx
@@ -7,30 +7,30 @@ import {
 } from '@hashicorp/react-docs-page/server'
 
 //  Configure the docs path
-const BASE_ROUTE = 'guides'
-const NAV_DATA = 'data/guides-nav-data.json'
-const CONTENT_DIR = 'content/guides'
-const MAIN_BRANCH = 'master'
-const PRODUCT = { name: productName, slug: productSlug }
+const baseRoute = 'guides'
+const navDataFile = 'data/guides-nav-data.json'
+const localContentDir = 'content/guides'
+const mainBranch = 'master'
+const product = { name: productName, slug: productSlug }
 
 export default function GuidesLayout(props) {
   return (
-    <DocsPage baseRoute={BASE_ROUTE} product={PRODUCT} staticProps={props} />
+    <DocsPage baseRoute={baseRoute} product={product} staticProps={props} />
   )
 }
 
 export async function getStaticPaths() {
-  const paths = await generateStaticPaths(NAV_DATA, CONTENT_DIR)
+  const paths = await generateStaticPaths({ localContentDir, navDataFile })
   return { paths, fallback: false }
 }
 
 export async function getStaticProps({ params }) {
-  const props = await generateStaticProps(
-    NAV_DATA,
-    CONTENT_DIR,
+  const props = await generateStaticProps({
+    localContentDir,
+    mainBranch,
+    navDataFile,
     params,
-    PRODUCT,
-    { mainBranch: MAIN_BRANCH }
-  )
+    product,
+  })
   return { props }
 }

--- a/website/pages/intro/[[...page]].jsx
+++ b/website/pages/intro/[[...page]].jsx
@@ -7,30 +7,30 @@ import {
 } from '@hashicorp/react-docs-page/server'
 
 //  Configure the docs path
-const BASE_ROUTE = 'intro'
-const NAV_DATA = 'data/intro-nav-data.json'
-const CONTENT_DIR = 'content/intro'
-const MAIN_BRANCH = 'master'
-const PRODUCT = { name: productName, slug: productSlug }
+const baseRoute = 'intro'
+const navDataFile = 'data/intro-nav-data.json'
+const localContentDir = 'content/intro'
+const mainBranch = 'master'
+const product = { name: productName, slug: productSlug }
 
 export default function IntroLayout(props) {
   return (
-    <DocsPage baseRoute={BASE_ROUTE} product={PRODUCT} staticProps={props} />
+    <DocsPage baseRoute={baseRoute} product={product} staticProps={props} />
   )
 }
 
 export async function getStaticPaths() {
-  const paths = await generateStaticPaths(NAV_DATA, CONTENT_DIR)
+  const paths = await generateStaticPaths({ localContentDir, navDataFile })
   return { paths, fallback: false }
 }
 
 export async function getStaticProps({ params }) {
-  const props = await generateStaticProps(
-    NAV_DATA,
-    CONTENT_DIR,
+  const props = await generateStaticProps({
+    localContentDir,
+    mainBranch,
+    navDataFile,
     params,
-    PRODUCT,
-    { mainBranch: MAIN_BRANCH }
-  )
+    product,
+  })
   return { props }
 }


### PR DESCRIPTION
🔍  [Preview](https://packer-git-fork-zchsh-zsfixup-docs-nav-data-hashicorp.vercel.app/)

## Background

The `website/data/docs-navigation.js` data file and the `sidebar_title` frontmatter properties in all `.mdx` files are now ignored - they have been replaced by the revised `website/data/docs-nav-data.json` navigation data format, per [RFC MKTG-032](https://docs.google.com/document/d/1FPyWid2NmNI9E_6lH2UIMuEPqjqDCGe3F8wraPRQHQ8/edit#).

## Changes

This PR removes the now obselete `website/data/docs-navigation.js` file.

It also removes all `sidebar_title` frontmatter attributes from all `website/content/**/*.mdx` files.
