### PR TITLE
website: fixes and tweaks for plugin docs

### DIFF
--- a/website/components/remote-plugin-docs/utils/fetch-plugin-docs.js
+++ b/website/components/remote-plugin-docs/utils/fetch-plugin-docs.js
@@ -13,7 +13,10 @@ const parseDocsZip = require('./parse-docs-zip')
 // docs files were missing or invalid, with a path to resolution
 async function fetchDocsFiles({ repo, tag }) {
   // If there's a docs.zip asset, we'll prefer that
-  const docsZipUrl = `https://github.com/${repo}/releases/download/${tag}/docs.zip`
+  const docsZipUrl =
+    tag === 'latest'
+      ? `https://github.com/${repo}/releases/latest/download/docs.zip`
+      : `https://github.com/${repo}/releases/download/${tag}/docs.zip`
   const docsZipResponse = await fetch(docsZipUrl, { method: 'GET' })
   const hasDocsZip = docsZipResponse.status === 200
   // Note: early return!

--- a/website/components/remote-plugin-docs/utils/resolve-nav-data.js
+++ b/website/components/remote-plugin-docs/utils/resolve-nav-data.js
@@ -95,16 +95,19 @@ async function mergeRemotePlugins(remotePluginsFile, navData) {
     // console.log(JSON.stringify(routesWithPlugins, null, 2))
     // Also, sort the child routes so the order is alphabetical
     routesWithPlugins.sort((a, b) => {
+      // ensure casing does not affect ordering
+      const aTitle = a.title.toLowerCase()
+      const bTitle = b.title.toLowerCase()
       // (exception: "Overview" comes first)
-      if (a.title == 'Overview') return -1
-      if (b.title === 'Overview') return 1
+      if (aTitle === 'overview') return -1
+      if (bTitle === 'overview') return 1
       // (exception: "Community-Supported" comes last)
-      if (a.title == 'Community-Supported') return 1
-      if (b.title === 'Community-Supported') return -1
+      if (aTitle === 'community-supported') return 1
+      if (bTitle === 'community-supported') return -1
       // (exception: "Custom" comes second-last)
-      if (a.title == 'Custom') return 1
-      if (b.title === 'Custom') return -1
-      return a.title < b.title ? -1 : a.title > b.title ? 1 : 0
+      if (aTitle === 'custom') return 1
+      if (bTitle === 'custom') return -1
+      return aTitle < bTitle ? -1 : aTitle > bTitle ? 1 : 0
     })
     // return n
     return { ...n, routes: routesWithPlugins }
@@ -157,6 +160,16 @@ async function resolvePluginEntryDocs(pluginConfigEntry) {
       remoteFile: { filePath, fileString, sourceUrl },
       pluginTier,
     }
+  })
+  //
+  navNodes.sort((a, b) => {
+    // ensure casing does not affect ordering
+    const aTitle = a.title.toLowerCase()
+    const bTitle = b.title.toLowerCase()
+    // (exception: "Overview" comes first)
+    if (aTitle === 'overview') return -1
+    if (bTitle === 'overview') return 1
+    return aTitle < bTitle ? -1 : aTitle > bTitle ? 1 : 0
   })
   //
   const navNodesByComponent = navNodes.reduce((acc, navLeaf) => {

--- a/website/components/remote-plugin-docs/utils/validate-plugin-docs-files.js
+++ b/website/components/remote-plugin-docs/utils/validate-plugin-docs-files.js
@@ -13,15 +13,23 @@ const COMPONENT_TYPES = [
 // with at least one .mdx file within it.
 function validatePluginDocsFiles(filePaths) {
   function isValidPath(filePath) {
+    // Allow the docs root folder
     const isDocsRoot = filePath === 'docs/'
+    // Allow component folders
     const isComponentRoot = COMPONENT_TYPES.reduce((acc, type) => {
       return acc || filePath === `docs/${type}/`
     }, false)
+    // Allow .mdx files in component folders
     const isComponentMdx = COMPONENT_TYPES.reduce((acc, type) => {
       const mdxPathRegex = new RegExp(`^docs/${type}/(.*).mdx$`)
       return acc || mdxPathRegex.test(filePath)
     }, false)
-    const isValidPath = isDocsRoot || isComponentRoot || isComponentMdx
+    // Allow arbitrary .md files
+    const mdPathRegex = new RegExp(`^docs/(.*).md$`)
+    const isMdFile = mdPathRegex.test(filePath)
+    // Combine all allowed types
+    const isValidPath =
+      isDocsRoot || isComponentRoot || isComponentMdx || isMdFile
     return isValidPath
   }
   const invalidPaths = filePaths.filter((f) => !isValidPath(f))

--- a/website/components/remote-plugin-docs/utils/validate-plugin-docs-files.js
+++ b/website/components/remote-plugin-docs/utils/validate-plugin-docs-files.js
@@ -24,12 +24,11 @@ function validatePluginDocsFiles(filePaths) {
       const mdxPathRegex = new RegExp(`^docs/${type}/(.*).mdx$`)
       return acc || mdxPathRegex.test(filePath)
     }, false)
-    // Allow arbitrary .md files
-    const mdPathRegex = new RegExp(`^docs/(.*).md$`)
-    const isMdFile = mdPathRegex.test(filePath)
+    // Allow docs/README.md files
+    const isDocsReadme = filePath == 'docs/README.md'
     // Combine all allowed types
     const isValidPath =
-      isDocsRoot || isComponentRoot || isComponentMdx || isMdFile
+      isDocsRoot || isComponentRoot || isComponentMdx || isDocsReadme
     return isValidPath
   }
   const invalidPaths = filePaths.filter((f) => !isValidPath(f))


### PR DESCRIPTION
This PR makes some minor tweaks and fixes to plugin docs consumption:

- **Fixes an issue with `latest` `docs.zip` links** - previously these were not constructed correctly, so would not resolve. This was preventing the use of `"latest"` tags in `docs-remote-plugins.json` config.
- **Sorts nested plugin docs** - previously we'd assumed docs would be sorted by file name. This was not the case. We've added a sort function so that plugin docs files are sorted by `title` (which is derived from either the frontmatter `nav_title`, the frontmatter `sidebar_title`, or the file basename, in that order).
- **Ignores `docs/README.md` files in plugin docs** - previously we would consider a plugin `docs` folder to be invalid if it contained anything other than the expected `.mdx` files. This PR updates to allow `docs/README.md` files in `docs` folders. **Note that this files are not included in our site build**, it just no longer throws a validation error.