### PR TITLE
Update script to exit on immediate failure

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -126,7 +126,7 @@ if [ -n "${PACKER_DEV+x}" ]; then
 fi
 
 export CGO_ENABLED=0
-set +e
+
 ${GOX:?command not found} \
     -os="${XC_OS:-$ALL_XC_OS}" \
     -arch="${XC_ARCH:-$ALL_XC_ARCH}" \
@@ -134,7 +134,6 @@ ${GOX:?command not found} \
     -ldflags "${GOLDFLAGS}" \
     -output "pkg/{{.OS}}_{{.Arch}}/packer" \
     .
-set -e
 
 # trim GOPATH to first element
 IFS="${PATHSEP}"


### PR DESCRIPTION
This change removes the temporary ignore error property around GOX to capture issues with builds. Before this change the builds on CircrlCI for nightly releases was failing silently because the error generated by GOX were being ignored. This can be reproduced by running `make bin` using Go1.15. 

Before Change
```
[go-1.15.10] [3] $$$ in ~/Development/packer/ on master
~>  make bin
WARN: 'make bin' is for debug / test builds only. Use 'make release' for release builds.
==> Checking for necessary tools...
==> Entering Packer source dir...
==> Ensuring output directories are present...
==> Removing old builds...
==> Building...
Number of parallel builds: 15

-->    darwin/amd64: github.com/hashicorp/packer
-->      darwin/386: github.com/hashicorp/packer

2 errors occurred:
--> darwin/386 error: exit status 2
Stderr: cmd/go: unsupported GOOS/GOARCH pair darwin/386

--> darwin/amd64 error: exit status 1
Stderr: builder/vsphere/common/output_config.hcl2spec.go:6:2: cannot find package "." in:
        /Users/wilken/Development/packer/vendor/io/fs

==> Copying binaries for this platform...
find: ./pkg/darwin_amd64: No such file or directory

==> Results:


[go-1.15.10] [3] $$$ in ~/Development/packer/ on master
~>  echo $?
0
```

After change
```
[go-1.15.10] [3] $$$ in ~/Development/packer/ on master
~>  make bin
WARN: 'make bin' is for debug / test builds only. Use 'make release' for release builds.
==> Checking for necessary tools...
==> Entering Packer source dir...
==> Ensuring output directories are present...
==> Removing old builds...
==> Building...
Number of parallel builds: 15

make: *** [bin] Error 1

[go-1.15.10] [0] wilken@lotus in ~/Development/packer/ on upate-build-scripts (ahead 1)
~>  echo $?
2
```