### PR TITLE
fix: correct SIG timout

### DIFF
--- a/builder/azure/dtl/azure_client.go
+++ b/builder/azure/dtl/azure_client.go
@@ -181,7 +181,6 @@ func NewAzureClient(subscriptionID, resourceGroupName string,
 	azureClient.GalleryImageVersionsClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GalleryImageVersionsClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImageVersionsClient.UserAgent)
 	azureClient.GalleryImageVersionsClient.Client.PollingDuration = SharedGalleryTimeout
-	azureClient.GalleryImageVersionsClient.Client.PollingDuration = PollingDuration
 
 	azureClient.GalleryImagesClient = newCompute.NewGalleryImagesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.GalleryImagesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)


### PR DESCRIPTION
`shared_image_gallery_timeout` is overwritten by `PollingDuration` for publishing an image to SIG, this change correct the code to use `shared_image_gallery_timeout` as the expected timeout.