### PR TITLE
Re-add dynamic blocks in a build block + add tests

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -383,6 +383,18 @@ func TestBuild(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "hcl - dynamic source block in a build block",
+			args: []string{
+				testFixture("hcl", "dynamic", "build.pkr.hcl"),
+			},
+			fileCheck: fileCheck{
+				expectedContent: map[string]string{
+					"dummy":       "layers/base/main/files",
+					"postgres/13": "layers/base/main/files\nlayers/base/init/files\nlayers/postgres/files",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/test-fixtures/hcl/dynamic/build.pkr.hcl
+++ b/command/test-fixtures/hcl/dynamic/build.pkr.hcl
@@ -1,0 +1,28 @@
+
+source "file" "base" {
+}
+
+variables {
+  images = {
+    dummy = {
+      image      = "dummy"
+      layers     = ["base/main"]
+    }
+    postgres = {
+      image      = "postgres/13"
+      layers     = ["base/main", "base/init", "postgres"]
+    }
+  }
+}
+
+build {
+  dynamic "source" {
+    for_each = var.images
+    labels   = ["file.base"]
+    content {
+      name         = source.key
+      target       = source.value.image
+      content      = join("\n", formatlist("layers/%s/files", var.images[source.key].layers))
+    }
+  }
+}

--- a/hcl2template/plugin.go
+++ b/hcl2template/plugin.go
@@ -132,8 +132,7 @@ func (cfg *PackerConfig) initializeBlocks() hcl.Diagnostics {
 					Summary:  "Unknown " + sourceLabel + " " + srcUsage.SourceRef.String(),
 					Subject:  build.HCL2Ref.DefRange.Ptr(),
 					Severity: hcl.DiagError,
-					Detail:   fmt.Sprintf("Known: %v", cfg.Sources),
-					// TODO: show known sources as a string slice here ^.
+					Detail:   fmt.Sprintf("Known: %v", listAvailableSourceNames(cfg.Sources)),
 				})
 				continue
 			}

--- a/hcl2template/plugin.go
+++ b/hcl2template/plugin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/dynblock"
+	"github.com/hashicorp/packer-plugin-sdk/didyoumean"
 	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
 	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
 )
@@ -128,11 +129,16 @@ func (cfg *PackerConfig) initializeBlocks() hcl.Diagnostics {
 
 			sourceDefinition, found := cfg.Sources[srcUsage.SourceRef]
 			if !found {
+				availableSrcs := listAvailableSourceNames(cfg.Sources)
+				detail := fmt.Sprintf("Known: %v", availableSrcs)
+				if sugg := didyoumean.NameSuggestion(srcUsage.SourceRef.String(), availableSrcs); sugg != "" {
+					detail = fmt.Sprintf("Did you mean to use %q?", sugg)
+				}
 				diags = append(diags, &hcl.Diagnostic{
 					Summary:  "Unknown " + sourceLabel + " " + srcUsage.SourceRef.String(),
 					Subject:  build.HCL2Ref.DefRange.Ptr(),
 					Severity: hcl.DiagError,
-					Detail:   fmt.Sprintf("Known: %v", listAvailableSourceNames(cfg.Sources)),
+					Detail:   detail,
 				})
 				continue
 			}

--- a/hcl2template/plugin.go
+++ b/hcl2template/plugin.go
@@ -129,7 +129,7 @@ func (cfg *PackerConfig) initializeBlocks() hcl.Diagnostics {
 			sourceDefinition, found := cfg.Sources[srcUsage.SourceRef]
 			if !found {
 				diags = append(diags, &hcl.Diagnostic{
-					Summary:  "Unknown " + sourceLabel + " " + srcUsage.String(),
+					Summary:  "Unknown " + sourceLabel + " " + srcUsage.SourceRef.String(),
 					Subject:  build.HCL2Ref.DefRange.Ptr(),
 					Severity: hcl.DiagError,
 					Detail:   fmt.Sprintf("Known: %v", cfg.Sources),

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/dynblock"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
@@ -118,7 +119,8 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		build.Sources = append(build.Sources, SourceUseBlock{SourceRef: ref})
 	}
 
-	content, moreDiags := b.Config.Content(buildSchema)
+	body := dynblock.Expand(b.Config, cfg.EvalContext(BuildContext, nil))
+	content, moreDiags := body.Content(buildSchema)
 	diags = append(diags, moreDiags...)
 	if diags.HasErrors() {
 		return nil, diags

--- a/hcl2template/types.source.go
+++ b/hcl2template/types.source.go
@@ -170,3 +170,11 @@ var NoSource SourceRef
 func (r SourceRef) String() string {
 	return fmt.Sprintf("%s.%s", r.Type, r.Name)
 }
+
+func listAvailableSourceNames(srcs map[SourceRef]SourceBlock) []string {
+	res := make([]string, 0, len(srcs))
+	for k := range srcs {
+		res = append(res, k.String())
+	}
+	return res
+}

--- a/hcl2template/types.source.go
+++ b/hcl2template/types.source.go
@@ -2,6 +2,7 @@ package hcl2template
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/hashicorp/hcl/v2"
@@ -176,5 +177,6 @@ func listAvailableSourceNames(srcs map[SourceRef]SourceBlock) []string {
 	for k := range srcs {
 		res = append(res, k.String())
 	}
+	sort.Strings(res)
 	return res
 }


### PR DESCRIPTION
This :
* allows to have a build.dynamic block
* add tests
* makes sure to show a correct message when a source was not found
  * display only name of source ( instead of a weird map printout ) 
  * use a "Did you mean %q" feature where possible 