### PR TITLE
Override direct upload based on box size

### DIFF
--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -188,10 +188,10 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		new(stepCreateProvider),
 	}
 	if p.config.BoxDownloadUrl == "" {
-		steps = append(steps, new(stepPrepareUpload), new(stepUpload))
-		if !p.config.NoDirectUpload {
-			steps = append(steps, new(stepConfirmUpload))
-		}
+		steps = append(steps,
+			new(stepPrepareUpload),
+			new(stepUpload),
+			new(stepConfirmUpload))
 	}
 	steps = append(steps, new(stepReleaseVersion))
 

--- a/post-processor/vagrant-cloud/step_confirm_upload.go
+++ b/post-processor/vagrant-cloud/step_confirm_upload.go
@@ -16,6 +16,11 @@ func (s *stepConfirmUpload) Run(ctx context.Context, state multistep.StateBag) m
 	ui := state.Get("ui").(packersdk.Ui)
 	upload := state.Get("upload").(*Upload)
 	url := upload.CallbackPath
+	config := state.Get("config").(*Config)
+
+	if config.NoDirectUpload {
+		return multistep.ActionContinue
+	}
 
 	ui.Say("Confirming direct box upload completion")
 
@@ -23,7 +28,7 @@ func (s *stepConfirmUpload) Run(ctx context.Context, state multistep.StateBag) m
 
 	if err != nil || resp.StatusCode != 200 {
 		if resp == nil || resp.Body == nil {
-			state.Put("error", "No response from server.")
+			state.Put("error", fmt.Errorf("No response from server."))
 		} else {
 			cloudErrors := &VagrantCloudErrors{}
 			err = decodeBody(resp, cloudErrors)

--- a/post-processor/vagrant-cloud/step_prepare_upload.go
+++ b/post-processor/vagrant-cloud/step_prepare_upload.go
@@ -9,7 +9,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-const VAGRANT_CLOUD_DIRECT_UPLOAD_LIMIT = 5000000000 // Upload limit is 5GB
+const VAGRANT_CLOUD_DIRECT_UPLOAD_LIMIT = 5368709120 // Upload limit is 5G
 
 type Upload struct {
 	UploadPath   string `json:"upload_path"`
@@ -52,7 +52,7 @@ func (s *stepPrepareUpload) Run(ctx context.Context, state multistep.StateBag) m
 
 	if err != nil || (resp.StatusCode != 200) {
 		if resp == nil || resp.Body == nil {
-			state.Put("error", "No response from server.")
+			state.Put("error", fmt.Errorf("No response from server."))
 		} else {
 			cloudErrors := &VagrantCloudErrors{}
 			err = decodeBody(resp, cloudErrors)


### PR DESCRIPTION
Direct upload support in Vagrant Cloud is limited to box files which
are 5GB or less. Anything over 5GB will result in a 400 Bad Request
response. This updates the post processor to check the file size
when configured `NoDirectUpload: false`. If the file size is greater
than 5GB, it will output a warning and automatically update the
`NoDirectUpload` option to `true`.

This resolves the underlying cause of errors reported in #10537
