### PR TITLE
website: fix issue with .mdx in plugin docs URL paths

### DIFF
--- a/website/components/remote-plugin-docs/utils/resolve-nav-data.js
+++ b/website/components/remote-plugin-docs/utils/resolve-nav-data.js
@@ -139,7 +139,7 @@ async function resolvePluginEntryDocs(pluginConfigEntry) {
     // Process into a NavLeaf, with a remoteFile attribute
     const dirs = path.dirname(filePath).split('/')
     const dirUrl = dirs.slice(2).join('/')
-    const basename = path.basename(filePath)
+    const basename = path.basename(filePath, path.extname(filePath))
     // build urlPath
     // note that this will be prefixed to get to our final path
     const isIndexFile = basename === 'index'


### PR DESCRIPTION
This PR fixes an issue where nested docs files rendered from remote plugin repos would have `.mdx` in their URL.