### PR TITLE
HCL2 example syntax changes

### DIFF
--- a/website/content/docs/builders/googlecompute.mdx
+++ b/website/content/docs/builders/googlecompute.mdx
@@ -215,13 +215,13 @@ source "googlecompute" "windows-example" {
   project_id = "MY_PROJECT"
   source_image = "windows-server-2019-dc-v20200813"
   zone = "us-central1-a"
-  disk_size = 50,
-  machine_type = "n1-standard-2",
-  communicator ="winrm",
-  winrm_username = "packer_user",
-  winrm_insecure = true,
-  winrm_use_ssl = true,
-  metadata {
+  disk_size = 50
+  machine_type = "n1-standard-2"
+  communicator = "winrm"
+  winrm_username = "packer_user"
+  winrm_insecure = true
+  winrm_use_ssl = true
+  metadata = {
     windows-startup-script-cmd = "winrm quickconfig -quiet & net user /add packer_user & net localgroup administrators packer_user /add & winrm set winrm/config/service/auth @{Basic=\"true\"}"
   }
 }


### PR DESCRIPTION
Documentation fix:

An HCL2 example contained commas to separate the lines, and the metadata block did not have the equals sign, which is not valid.