### PR TITLE
HCL2 variables: split validation from getting value

### DIFF
--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -291,7 +291,7 @@ func filterVarsFromLogs(inputOrLocal Variables) {
 		if !variable.Sensitive {
 			continue
 		}
-		value, _ := variable.Value()
+		value := variable.Value()
 		_ = cty.Walk(value, func(_ cty.Path, nested cty.Value) (bool, error) {
 			if nested.IsWhollyKnown() && !nested.IsNull() && nested.Type().Equals(cty.String) {
 				packersdk.LogSecretFilter.Set(nested.AsString())
@@ -311,9 +311,9 @@ func (cfg *PackerConfig) Initialize(opts packer.InitializeOptions) hcl.Diagnosti
 		return diags
 	}
 
-	_, moreDiags = cfg.InputVariables.Values()
+	moreDiags = cfg.InputVariables.ValidateValues()
 	diags = append(diags, moreDiags...)
-	_, moreDiags = cfg.LocalVariables.Values()
+	moreDiags = cfg.LocalVariables.ValidateValues()
 	diags = append(diags, moreDiags...)
 	diags = append(diags, cfg.evaluateDatasources(opts.SkipDatasourcesExecution)...)
 	diags = append(diags, cfg.evaluateLocalVariables(cfg.LocalBlocks)...)

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -91,8 +91,8 @@ const (
 // decoder in order to tell what is the actual value of a var or a local and
 // the list of defined functions.
 func (cfg *PackerConfig) EvalContext(ctx BlockContext, variables map[string]cty.Value) *hcl.EvalContext {
-	inputVariables, _ := cfg.InputVariables.Values()
-	localVariables, _ := cfg.LocalVariables.Values()
+	inputVariables := cfg.InputVariables.Values()
+	localVariables := cfg.LocalVariables.Values()
 	ectx := &hcl.EvalContext{
 		Functions: Functions(cfg.Basedir),
 		Variables: map[string]cty.Value{
@@ -594,7 +594,7 @@ func (p *PackerConfig) printVariables() string {
 	sort.Strings(keys)
 	for _, key := range keys {
 		v := p.InputVariables[key]
-		val, _ := v.Value()
+		val := v.Value()
 		fmt.Fprintf(out, "var.%s: %q\n", v.Name, PrintableCtyValue(val))
 	}
 	out.WriteString("\n> local-variables:\n\n")
@@ -602,7 +602,7 @@ func (p *PackerConfig) printVariables() string {
 	sort.Strings(keys)
 	for _, key := range keys {
 		v := p.LocalVariables[key]
-		val, _ := v.Value()
+		val := v.Value()
 		fmt.Fprintf(out, "local.%s: %q\n", v.Name, PrintableCtyValue(val))
 	}
 	return out.String()

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -868,7 +868,7 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			}
 			values := map[string]cty.Value{}
 			for k, v := range tt.variables {
-				value, diag := v.Value()
+				value, diag := v.Value(), v.ValidateValue()
 				if diag != nil {
 					t.Fatalf("Value %s: %v", k, diag)
 				}


### PR DESCRIPTION
This way we do this only once and log this only once. The errors were being ignored anyway.

Before:  (here every time a variable value was accessed it would also be validated, which would cause this noisy TRACE log, but once we're done parsing its value should never change, so we can actually validate it only once).
```
2021/03/30 15:03:36 [INFO] Setting cache directory: /Users/azr/packer_cache
2021/03/30 15:03:36 [TRACE] validateValue: not active for headless, so skipping
2021/03/30 15:03:36 [TRACE] validateValue: not active for ubuntu_2004_patch_version, so skipping
2021/03/30 15:03:36 [TRACE] validateValue: not active for headless, so skipping
2021/03/30 15:03:36 [TRACE] validateValue: not active for ubuntu_2004_patch_version, so skipping
2021/03/30 15:03:36 [TRACE] validateValue: not active for headless, so skipping
2021/03/30 15:03:36 [TRACE] validateValue: not active for ubuntu_2004_patch_version, so skipping
2021/03/30 15:03:36 [TRACE] validateValue: not active for headless, so skipping
2021/03/30 15:03:37 [TRACE] validateValue: not active for ubuntu_2004_patch_version, so skipping
2021/03/30 15:03:37 [TRACE] validateValue: not active for ubuntu_2004_patch_version, so skipping
2021/03/30 15:03:37 [TRACE] validateValue: not active for headless, so skipping
[...]
```

After:
```
2021/03/30 15:03:36 [INFO] Setting cache directory: /Users/azr/packer_cache
2021/03/30 15:03:36 [TRACE] validateValue: not active for headless, so skipping
2021/03/30 15:03:36 [TRACE] validateValue: not active for ubuntu_2004_patch_version, so skipping

  on build.ubuntu.pkr.hcl line 7:
```

Help with #10818