### PR TITLE
Add new disk to existingDevices list

### DIFF
--- a/builder/vsphere/driver/disk.go
+++ b/builder/vsphere/driver/disk.go
@@ -59,6 +59,7 @@ func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceLi
 		}
 
 		existingDevices.AssignController(disk, controllers[dc.ControllerIndex])
+		existingDevices = append(existingDevices, disk)
 		newDevices = append(newDevices, disk)
 	}
 

--- a/builder/vsphere/driver/disk_test.go
+++ b/builder/vsphere/driver/disk_test.go
@@ -1,0 +1,46 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/object"
+)
+
+func TestAddStorageDevices(t *testing.T) {
+	config := &StorageConfig{
+		DiskControllerType: []string{"pvscsi"},
+		Storage: []Disk{
+			{
+				DiskSize:            3072,
+				DiskThinProvisioned: true,
+				ControllerIndex:     0,
+			},
+			{
+				DiskSize:            20480,
+				DiskThinProvisioned: true,
+				ControllerIndex:     0,
+			},
+		},
+	}
+
+	noExistingDevices := object.VirtualDeviceList{}
+	storageConfigSpec, err := config.AddStorageDevices(noExistingDevices)
+	if err != nil {
+		t.Fatalf("unexpected erro: %q", err.Error())
+	}
+	if len(storageConfigSpec) != 3 {
+		t.Fatalf("Expecting VirtualDeviceList to have 3 storage devices but had %d", len(storageConfigSpec))
+	}
+
+	existingDevices := object.VirtualDeviceList{}
+	device, err := existingDevices.CreateNVMEController()
+	existingDevices = append(existingDevices, device)
+
+	storageConfigSpec, err = config.AddStorageDevices(existingDevices)
+	if err != nil {
+		t.Fatalf("unexpected erro: %q", err.Error())
+	}
+	if len(storageConfigSpec) != 3 {
+		t.Fatalf("Expecting VirtualDeviceList to have 3 storage devices but had %d", len(storageConfigSpec))
+	}
+}

--- a/builder/vsphere/driver/vm_test.go
+++ b/builder/vsphere/driver/vm_test.go
@@ -60,3 +60,46 @@ func TestVirtualMachineDriver_Configure(t *testing.T) {
 		t.Fatalf("Configure should fail")
 	}
 }
+
+func TestVirtualMachineDriver_CreateVM(t *testing.T) {
+	sim, err := NewVCenterSimulator()
+	if err != nil {
+		t.Fatalf("should not fail: %s", err.Error())
+	}
+	defer sim.Close()
+
+	_, datastore := sim.ChooseSimulatorPreCreatedDatastore()
+
+	config := &CreateConfig{
+		Annotation: "mock annotation",
+		Name:       "mock name",
+		Host:       "DC0_H0",
+		Datastore:  datastore.Name,
+		NICs: []NIC{
+			{
+				Network:     "VM Network",
+				NetworkCard: "vmxnet3",
+			},
+		},
+		StorageConfig: StorageConfig{
+			DiskControllerType: []string{"pvscsi"},
+			Storage: []Disk{
+				{
+					DiskSize:            3072,
+					DiskThinProvisioned: true,
+					ControllerIndex:     0,
+				},
+				{
+					DiskSize:            20480,
+					DiskThinProvisioned: true,
+					ControllerIndex:     0,
+				},
+			},
+		},
+	}
+
+	_, err = sim.driver.CreateVM(config)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err.Error())
+	}
+}


### PR DESCRIPTION
The newly created devices weren't being added to the existingDevices list. This was causing devices to be created with the same key.  

Closes https://github.com/hashicorp/packer/issues/10430