### PR TITLE
Set BootVolumeSizeInGBs only when image size is not 0 and is valid

### DIFF
--- a/builder/oracle/oci/config.go
+++ b/builder/oracle/oci/config.go
@@ -362,9 +362,7 @@ func (c *Config) Prepare(raws ...interface{}) error {
 
 	// Set default boot volume size to 50 if not set
 	// Check if size set is allowed by OCI
-	if c.BootVolumeSizeInGBs == 0 {
-		c.BootVolumeSizeInGBs = 50
-	} else if c.BootVolumeSizeInGBs < 50 || c.BootVolumeSizeInGBs > 16384 {
+	if c.BootVolumeSizeInGBs != 0 && (c.BootVolumeSizeInGBs < 50 || c.BootVolumeSizeInGBs > 16384) {
 		errs = packersdk.MultiErrorAppend(
 			errs, errors.New("'disk_size' must be between 50 and 16384 GBs"))
 	}

--- a/builder/oracle/oci/driver_oci.go
+++ b/builder/oracle/oci/driver_oci.go
@@ -140,9 +140,10 @@ func (d *driverOCI) CreateInstance(ctx context.Context, publicKey string) (strin
 	}
 
 	// Create Source details which will be used to Launch Instance
-	InstanceSourceDetails := core.InstanceSourceViaImageDetails{
-		ImageId:             imageId,
-		BootVolumeSizeInGBs: &d.cfg.BootVolumeSizeInGBs,
+	InstanceSourceDetails := core.InstanceSourceViaImageDetails{ImageId: imageId}
+
+	if d.cfg.BootVolumeSizeInGBs != 0 {
+		InstanceSourceDetails.BootVolumeSizeInGBs = &d.cfg.BootVolumeSizeInGBs
 	}
 
 	// Build instance details


### PR DESCRIPTION
When disk_size was first supported by our packer implementation, it broke existing users since it defaulted to 50 when unset (or 0). This means that where base images are larger than 50 validation would fail. This commit removes the defaulting and removes BootVolumeSizeInGBs from ImageSourceDetails when unset or 0.

Closes https://github.com/hashicorp/packer/issues/10399

NOTE: I WILL TEST THIS TOMORROW.
