### PR TITLE
Fix vault function docs example

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/contextual/vault.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/vault.mdx
@@ -17,7 +17,7 @@ can access it using the following:
 
 ```hcl
 locals {
-    foo = vault("/secret/data/hello" "foo")
+    foo = vault("/secret/data/hello", "foo")
 }
 ```
 


### PR DESCRIPTION
The given example is missing a `,`.