### PR TITLE
Proxmox builder return first ipv4 address

### DIFF
--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -155,10 +155,10 @@ func getVMIP(state multistep.StateBag) (string, error) {
 
 	for _, iface := range ifs {
 		for _, addr := range iface.IPAddresses {
-			if addr.To4() == nil {
+			if addr.IsLoopback() {
 				continue
 			}
-			if addr.IsLoopback() {
+			if addr.To4() == nil {
 				continue
 			}
 			return addr.String(), nil

--- a/builder/proxmox/common/builder.go
+++ b/builder/proxmox/common/builder.go
@@ -155,6 +155,9 @@ func getVMIP(state multistep.StateBag) (string, error) {
 
 	for _, iface := range ifs {
 		for _, addr := range iface.IPAddresses {
+			if addr.To4() == nil {
+				continue
+			}
 			if addr.IsLoopback() {
 				continue
 			}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022
 	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.0
-	github.com/Telmate/proxmox-api-go v0.0.0-20210320143302-fea68269e6b0
+	github.com/Telmate/proxmox-api-go v0.0.0-20210331182840-ff89a0cebcfa
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190418113227-25233c783f4e
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20170113022742-e6dbea820a9f
 	github.com/antihax/optional v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.0/go.mod h1:P+3VS0ETiQPyWOx3
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Telmate/proxmox-api-go v0.0.0-20200715182505-ec97c70ba887/go.mod h1:OGWyIMJ87/k/GCz8CGiWB2HOXsOVDM6Lpe/nFPkC4IQ=
-github.com/Telmate/proxmox-api-go v0.0.0-20210320143302-fea68269e6b0 h1:LeBf+Ex12uqA6dWZp73Qf3dzpV/LvB9SRmHgPBwnXrQ=
-github.com/Telmate/proxmox-api-go v0.0.0-20210320143302-fea68269e6b0/go.mod h1:ayPkdmEKnlssqLQ9K1BE1jlsaYhXVwkoduXI30oQF0I=
+github.com/Telmate/proxmox-api-go v0.0.0-20210331182840-ff89a0cebcfa h1:n4g0+o4DDX6WGTRfdj1Ux+49vSwtxtqFGB5XtxoDphI=
+github.com/Telmate/proxmox-api-go v0.0.0-20210331182840-ff89a0cebcfa/go.mod h1:ayPkdmEKnlssqLQ9K1BE1jlsaYhXVwkoduXI30oQF0I=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=

--- a/vendor/github.com/Telmate/proxmox-api-go/proxmox/client.go
+++ b/vendor/github.com/Telmate/proxmox-api-go/proxmox/client.go
@@ -301,7 +301,7 @@ func (a *AgentNetworkInterface) UnmarshalJSON(b []byte) error {
 
 	a.IPAddresses = make([]net.IP, len(intermediate.IPAddresses))
 	for idx, ip := range intermediate.IPAddresses {
-		a.IPAddresses[idx] = net.ParseIP(ip.IPAddress)
+		a.IPAddresses[idx] = net.ParseIP((strings.Split(ip.IPAddress, "%"))[0])
 		if a.IPAddresses[idx] == nil {
 			return fmt.Errorf("Could not parse %s as IP", ip.IPAddress)
 		}

--- a/vendor/github.com/Telmate/proxmox-api-go/proxmox/config_qemu.go
+++ b/vendor/github.com/Telmate/proxmox-api-go/proxmox/config_qemu.go
@@ -628,6 +628,11 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 
 		diskConfMap["storage_type"] = storageType
 
+		// cloud-init disks not always have the size sent by the API, which results in a crash
+		if diskConfMap["size"] == nil && strings.Contains(fileName.(string), "cloudinit") {
+			diskConfMap["size"] = "4M" // default cloud-init disk size
+		}
+
 		// Convert to gigabytes if disk size was received in terabytes
 		sizeIsInTerabytes, err := regexp.MatchString("[0-9]+T", diskConfMap["size"].(string))
 		if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server
 # github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 github.com/StackExchange/wmi
-# github.com/Telmate/proxmox-api-go v0.0.0-20210320143302-fea68269e6b0
+# github.com/Telmate/proxmox-api-go v0.0.0-20210331182840-ff89a0cebcfa
 ## explicit
 github.com/Telmate/proxmox-api-go/proxmox
 # github.com/agext/levenshtein v1.2.1


### PR DESCRIPTION
This fix is a 2-way fix. I've updated the Telmate/proxmox-api-go and my fix was merged yesterday.
Secondly the proxmox builder was updated to filter the returned IPs and return the first non-loopback IPv4 address.

I've run tests and all works as expected now.

This fix closes #10227 
