### PR TITLE
website: fix issue with bloated static props

### DIFF
--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -28,11 +28,16 @@ async function generateStaticProps({
   product,
   remotePluginsFile,
 }) {
+  // Build the currentPath from page parameters
+  const currentPath = params.page ? params.page.join('/') : ''
+  // Resolve navData, including the possibility that this
+  // page is a remote plugin docs, in which case we'll provide
+  // the MDX fileString in the resolved navData
   const navData = await resolveNavData(navDataFile, localContentDir, {
     remotePluginsFile,
+    currentPath,
   })
-  const pathToMatch = params.page ? params.page.join('/') : ''
-  const navNode = getNodeFromPath(pathToMatch, navData, localContentDir)
+  const navNode = getNodeFromPath(currentPath, navData, localContentDir)
   const { filePath, remoteFile, pluginTier } = navNode
   //  Fetch the MDX file content
   const mdxString = remoteFile
@@ -59,8 +64,6 @@ async function generateStaticProps({
     productName: product.name,
     mdxContentHook,
   })
-  // Build the currentPath from page parameters
-  const currentPath = !params.page ? '' : params.page.join('/')
 
   return {
     currentPath,

--- a/website/scripts/log-docs-static-props-size.sh
+++ b/website/scripts/log-docs-static-props-size.sh
@@ -1,6 +1,0 @@
-cd .next/server/pages/docs
-find . -name "*.json" -print0 | while read -d $'\0' file; do
-    size_kb=$(du -k "$file" | cut -f1)
-    basename=${file##*/}
-    printf "%4s kB | $basename\n" "$size_kb"
-done

--- a/website/scripts/log-docs-static-props-size.sh
+++ b/website/scripts/log-docs-static-props-size.sh
@@ -1,0 +1,6 @@
+cd .next/server/pages/docs
+find . -name "*.json" -print0 | while read -d $'\0' file; do
+    size_kb=$(du -k "$file" | cut -f1)
+    basename=${file##*/}
+    printf "%4s kB | $basename\n" "$size_kb"
+done


### PR DESCRIPTION
This PR fixes an issue where bundle sizes for individual `/docs` pages were bloated with additional MDX content.

### Details

In summary, the addition of remote plugin docs meant we enhanced our `navData` with MDX `fileString` values for remote files. We added `fileString` values for _every_ remote file. In certain contexts, such as our search indexing script, this behaviour is necessary and desirable. However, in `getStaticProps`, it means we return many more `fileString` values than we need - for each page we really only need a single `fileString`, for the current page.

This PR resolves this issue by adding a `currentPath` option to the `resolveNavData` function. When included, this option ensures the returned `navData` includes at most one `fileString`, on the matching remote file node. If the matching node is a local file, then all `fileString` values are removed.