### PR TITLE
add hpet to vmawre-iso builder default template

### DIFF
--- a/builder/vmware/iso/step_create_vmx.go
+++ b/builder/vmware/iso/step_create_vmx.go
@@ -467,6 +467,8 @@ vmci0.present = "TRUE"
 vmci0.id = "1861462627"
 vmci0.pciSlotNumber = "35"
 
+hpet0.present = "TRUE"
+
 // Network Adapter
 ethernet0.addressType = "generated"
 ethernet0.bsdName = "en0"


### PR DESCRIPTION
the VM created by VMware Product will add hpet by default.

VMware recommends enabling hpet to all VMware machine by setting

hpet0.present = "True"

in the vmx.

Closes #10824
