### PR TITLE
Fix tiny typo in `hcl2_upgrade.mdx`

### DIFF
--- a/website/content/docs/commands/hcl2_upgrade.mdx
+++ b/website/content/docs/commands/hcl2_upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 description: |
   The `packer hcl2_upgrade` Packer command is used to transpile a JSON
-  configuration template to it's formatted HCL2 counterpart. The command will
+  configuration template to its formatted HCL2 counterpart. The command will
   return a zero exit status on success, and a non-zero exit status on failure.
 page_title: packer hcl2_upgrade - Commands
 ---


### PR DESCRIPTION
Just a tiny typo that was bugging me -- it should read "its formatted HCL2 counterpart", not "it's".