### PR TITLE
Add redirect for Docker post-processor pages

### DIFF
--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -211,6 +211,11 @@ module.exports = [
     destination: '/docs/builders/vmware/vsphere-:path*',
     permanent: true,
   },
+  {
+    source: '/docs/post-processors/docker-:path',
+    destination: '/docs/post-processors/docker/docker-:path*',
+    permanent: true,
+  },
   // disallow '.html' or '/index.html' in favor of cleaner, simpler paths
   { source: '/:path*/index', destination: '/:path*', permanent: true },
   { source: '/:path*.html', destination: '/:path*', permanent: true },


### PR DESCRIPTION
Remote plugin docs such as Docker now fall under a top level path named
after the provider (e.g https://packer.io/docs/docker/...). This change
adds a redirect for the old URLs to the new location.
