### PR TITLE
website: fix edit links for remote plugins

### DIFF
--- a/website/components/plugin-tier-label/style.module.css
+++ b/website/components/plugin-tier-label/style.module.css
@@ -29,12 +29,6 @@ to match Terraform Registry tier labels.
   }
 }
 
-/* add margin-top to separate from the adjacent
-search bar present on docs pages */
-:global(.g-search) + .root {
-  margin-top: 40px;
-}
-
 .text {
   /* composes */
   composes: g-type-body-small-strong from global;

--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -54,7 +54,7 @@ async function generateStaticProps({
   // (current options are "Official" or "Community")
   function mdxContentHook(mdxContent) {
     if (pluginTier) {
-      const tierMdx = `<br /><br/><PluginTierLabel tier="${pluginTier}" />\n\n`
+      const tierMdx = `<br/><PluginTierLabel tier="${pluginTier}" />\n\n`
       mdxContent = tierMdx + mdxContent
     }
     return mdxContent

--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -54,7 +54,7 @@ async function generateStaticProps({
   // (current options are "Official" or "Community")
   function mdxContentHook(mdxContent) {
     if (pluginTier) {
-      const tierMdx = `<PluginTierLabel tier="${pluginTier}" />\n\n`
+      const tierMdx = `<br /><br/><PluginTierLabel tier="${pluginTier}" />\n\n`
       mdxContent = tierMdx + mdxContent
     }
     return mdxContent

--- a/website/components/remote-plugin-docs/utils/resolve-nav-data.js
+++ b/website/components/remote-plugin-docs/utils/resolve-nav-data.js
@@ -132,7 +132,13 @@ async function mergeRemotePlugins(remotePluginsFile, navData, currentPath) {
 // which contains { filePath, fileString } data for the remote
 // plugin doc .mdx file
 async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
-  const { title, path: slug, repo, version } = pluginConfigEntry
+  const {
+    title,
+    path: slug,
+    repo,
+    version,
+    sourceBranch = 'main',
+  } = pluginConfigEntry
   const docsMdxFiles = await fetchPluginDocs({ repo, tag: version })
   // We construct a special kind of "NavLeaf" node, with a remoteFile property,
   // consisting of a { filePath, fileString, sourceUrl }, where:
@@ -155,7 +161,7 @@ async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
     const { nav_title, sidebar_title } = frontmatter
     const title = nav_title || sidebar_title || basename
     // construct sourceUrl (used for "Edit this page" link)
-    const sourceUrl = `https://github.com/${repo}/blob/${version}/${filePath}`
+    const sourceUrl = `https://github.com/${repo}/blob/${sourceBranch}/${filePath}`
     // determine pluginTier
     const pluginOwner = repo.split('/')[0]
     const pluginTier = pluginOwner === 'hashicorp' ? 'official' : 'community'

--- a/website/content/docs/plugins/creation/index.mdx
+++ b/website/content/docs/plugins/creation/index.mdx
@@ -276,7 +276,7 @@ This is done by adding the block below for the respective plugin to the file [we
 
 If a plugin maintainer wishes to only include a specific version of released docs, then the `"version"` key in the above configuration should be set to a released version of the plugin. Otherwise it should be set to `"latest"`.
 
-The `"sourceBranch"` key in the above configuration ensures potential contributors can link back to the plugin repository from the Packer docs site.
+The `"sourceBranch"` key in the above configuration ensures potential contributors can link back to source files in the plugin repository from the Packer docs site. If a `"sourceBranch"` value is not present, it will default to `"main"`.
 
 ### Plugin Development Tips and FAQs
 

--- a/website/content/docs/plugins/creation/index.mdx
+++ b/website/content/docs/plugins/creation/index.mdx
@@ -247,21 +247,6 @@ To include plugin docs on Packer.io a global pre-hook has been added to the main
 
 The `docs.zip` file will contain all of the `.mdx` files under the plugins root `docs/` directory that can be consumed remotely by Packer.io.
 
-Once the first `docs.zip` file has been included into a release you will need to open a one time pull-request against [hashicorp/packer](https://github.com/hashicorp/packer) to register the plugin docs.
-
-This is done by adding the block below for the respective plugin to the file [website/data/docs-remote-navigation.js](https://github.com/hashicorp/packer/blob/master/website/data/docs-remote-plugins.json).
-
-```json
-{
-   "title": "Scaffolding",
-   "path": "scaffolding",
-   "repo": "hashicorp/packer-plugin-scaffolding",
-   "version": "latest"
- }
-```
-
-If a plugin maintainer wishes to only include a specific version of released docs then the `"version"` key in the above configuration should be set to a released version of the plugin. Otherwise it should be set to "latest".
-
 </Tab>
 
 <Tab heading="Manually generating docs.zip">
@@ -272,23 +257,26 @@ The documentation structure needed for Packer.io can be generated manually, by c
 [[ -d docs/ ]] && zip -r docs.zip docs/
 ```
 
+</Tab>
+</Tabs>
+
 Once the first `docs.zip` file has been included into a release you will need to open a one time pull-request against [hashicorp/packer](https://github.com/hashicorp/packer) to register the plugin docs.
 
-This is done by adding the block below for the respective plugin to the file [website/data/docs-remote-navigation.js](https://github.com/hashicorp/packer/blob/master/website/data/docs-remote-plugins.json).
+This is done by adding the block below for the respective plugin to the file [website/data/docs-remote-plugins.json](https://github.com/hashicorp/packer/blob/master/website/data/docs-remote-plugins.json).
 
 ```json
 {
-   "title": "Scaffolding",
-   "path": "scaffolding",
-   "repo": "hashicorp/packer-plugin-scaffolding",
-   "version": "latest"
- }
+  "title": "Scaffolding",
+  "path": "scaffolding",
+  "repo": "hashicorp/packer-plugin-scaffolding",
+  "version": "latest",
+  "sourceBranch": "main"
+}
 ```
 
-If a plugin maintainer wishes to only include a specific version of released docs then the `"version"` key in the above configuration should be set to a released version of the plugin. Otherwise it should be set to "latest".
+If a plugin maintainer wishes to only include a specific version of released docs, then the `"version"` key in the above configuration should be set to a released version of the plugin. Otherwise it should be set to `"latest"`.
 
-</Tab>
-</Tabs>
+The `"sourceBranch"` key in the above configuration ensures potential contributors can link back to the plugin repository from the Packer docs site.
 
 ### Plugin Development Tips and FAQs
 


### PR DESCRIPTION
👀 [Preview](https://packer-git-fork-zchsh-zsfix-plugin-latest-edit-links-hashicorp.vercel.app/docs/builders/amazon/chroot) (vs [live page](https://www.packer.io/docs/builders/amazon/chroot), where "Edit" link leads to 404)

This PR fixes an issue with `Edit this page` links, where the links would lead to 404s.

The cause of this issue was that links were being generated from the plugin release `version`, which does not necessarily correspond to a GitHub link (for example, where `version` is `latest`, `https://github.com/hashicorp/packer-plugin-amazon/blob/latest/docs/builders/chroot.mdx` is not a valid link).

To fix this, the configuration in `website/content/docs-remote-plugins.json` now supports an additional attribute `"sourceBranch"`. If not present in configuration, `sourceBranch` will default to `main`. The `"Edit this page"` links are constructed using this source branch.

This PR also includes a smaller patch related to global styling on the plugin tier tags. Previously, the global styles seemed to be causing layout shift. With the revised approach, this layout shift is no longer present.

<details>
<summary><strong>Before</strong> - plugin tier causes layout shift</summary>

![before](https://user-images.githubusercontent.com/4624598/113934307-98a06f00-97c3-11eb-81d3-384b57e9bf14.gif)

</details>

<details>
<summary><strong>After</strong> - plugin tier does not cause layout shift</summary>

![after](https://user-images.githubusercontent.com/4624598/113934314-9a6a3280-97c3-11eb-9738-8b387e4c6411.gif)

</details>