### PR TITLE
fixes typo in Vagrant Cloud post-processor

### DIFF
--- a/post-processor/vagrant-cloud/post-processor.go
+++ b/post-processor/vagrant-cloud/post-processor.go
@@ -112,7 +112,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}
 
 	if p.config.VagrantCloudUrl == VAGRANT_CLOUD_URL && p.config.AccessToken == "" {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("access_token must be set if vagrant_cloud_url has not been overriden"))
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("access_token must be set if vagrant_cloud_url has not been overridden"))
 	}
 
 	// Create the HTTP client


### PR DESCRIPTION
Hello maintainers 👋🏼 

This fixes a typo in the Vagrant Cloud post-processor: `overriden` -> `overridden`

