### PR TITLE
Add Vultr remote docs

### DIFF
--- a/website/data/docs-remote-plugins.json
+++ b/website/data/docs-remote-plugins.json
@@ -10,5 +10,11 @@
     "path": "amazon",
     "repo": "hashicorp/packer-plugin-amazon",
     "version": "latest"
+  },
+  {
+    "title": "Vultr",
+    "path": "vultr",
+    "repo": "vultr/packer-plugin-vultr",
+    "version": "latest"
   }
 ]


### PR DESCRIPTION
The Vultr packer plugin was updated this morning to support `packer init`. 

PR is to submit the docs.zip for remote docs

https://github.com/vultr/packer-plugin-vultr/releases/tag/v2.3.0