### PR TITLE
Add outscale-mgo to osc codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,8 +68,8 @@
 /builder/yandex/                      @GennadySpb @alexanderKhaustov @seukyaso
 /website/pages/docs/builders/yandex* @GennadySpb @alexanderKhaustov @seukyaso
 
-/builder/osc/                      @marinsalinas @Hakujou
-/website/pages/docs/builders/osc* @marinsalinas @Hakujou
+/builder/osc/                      @marinsalinas @Hakujou @outscale-mgo
+/website/pages/docs/builders/osc* @marinsalinas @Hakujou @outscale-mgo
 
 /examples/tencentcloud/                      @likexian
 /builder/tencentcloud/                      @likexian


### PR DESCRIPTION
Hello,

@outscale-mgo is part of Outscale and will also handle Outscale provider for Packer.
This PR adds him to osc builders and doc codeowners.

Thanks :)
