### PR TITLE
website: enable plugin tier override

### DIFF
--- a/.github/workflows/check-plugin-docs.js
+++ b/.github/workflows/check-plugin-docs.js
@@ -20,6 +20,7 @@ async function checkPluginDocs() {
     console.log(`\n${COLOR_BLUE}${repo}${COLOR_RESET} | ${title}`);
     console.log(`Fetching docs from release "${version}" …`);
     try {
+      // Validate that all required properties are present
       const undefinedProps = ["title", "repo", "version", "path"].filter(
         (key) => typeof pluginEntry[key] == "undefined"
       );
@@ -34,6 +35,22 @@ async function checkPluginDocs() {
           )} are defined. Additional information on this configuration can be found in "website/README.md".`
         );
       }
+      // Validate pluginTier property
+      const { pluginTier } = pluginEntry;
+      if (typeof pluginTier !== "undefined") {
+        const validPluginTiers = ["official", "community"];
+        const isValid = validPluginTiers.indexOf(pluginTier) !== -1;
+        if (!isValid) {
+          throw new Error(
+            `Failed to validate plugin docs config. Invalid pluginTier "${pluginTier}" found for "${
+              title || pluginEntry.path || repo
+            }". In "website/data/docs-remote-plugins.json", the optional pluginTier property must be one of ${JSON.stringify(
+              validPluginTiers
+            )}. The pluginTier property can also be omitted, in which case it will be determined from the plugin repository owner.`
+          );
+        }
+      }
+      // Attempt to fetch plugin docs files
       const docsMdxFiles = await fetchPluginDocs({ repo, tag: version });
       const mdxFilesByComponent = docsMdxFiles.reduce((acc, mdxFile) => {
         const componentType = mdxFile.filePath.split("/")[1];

--- a/website/components/remote-plugin-docs/utils/resolve-nav-data.js
+++ b/website/components/remote-plugin-docs/utils/resolve-nav-data.js
@@ -137,6 +137,7 @@ async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
     path: slug,
     repo,
     version,
+    pluginTier,
     sourceBranch = 'main',
   } = pluginConfigEntry
   const docsMdxFiles = await fetchPluginDocs({ repo, tag: version })
@@ -164,13 +165,14 @@ async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
     const sourceUrl = `https://github.com/${repo}/blob/${sourceBranch}/${filePath}`
     // determine pluginTier
     const pluginOwner = repo.split('/')[0]
-    const pluginTier = pluginOwner === 'hashicorp' ? 'official' : 'community'
+    const parsedPluginTier =
+      pluginTier || (pluginOwner === 'hashicorp' ? 'official' : 'community')
     // Construct and return a NavLeafRemote node
     return {
       title,
       path: urlPath,
       remoteFile: { filePath, fileString, sourceUrl },
-      pluginTier,
+      pluginTier: parsedPluginTier,
     }
   })
   //


### PR DESCRIPTION
🔍 [Preview](https://packer-git-fork-zchsh-zsallow-plugin-tier-override-hashicorp.vercel.app/docs/builders/amazon)

Currently, a plugin's tier is strictly based on its repository owner:

```js
const pluginOwner = repo.split('/')[0]
const pluginTier = pluginOwner === 'hashicorp' ? 'official' : 'community'
```

This PR enables an optional `pluginTier` property to be specified for plugin entries in `website/data/remote-plugin-docs.json`. This property accepts either `"official"` or `"community"`.

When provided, the `pluginTier` property will be used directly, regardless of the plugin repository owner. When omitted, the `pluginTier` will be determined  based on the owner (as in the snippet above).
