### PR TITLE
Add legacy_isotime docs

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/datetime/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/datetime/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: datetime - Functions - Configuration Language
-description: Overview of available datetime functions
----

--- a/website/content/docs/templates/hcl_templates/functions/datetime/legacy_isotime.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/datetime/legacy_isotime.mdx
@@ -1,0 +1,41 @@
+---
+page_title: legacy_isotime - Functions - Configuration Language
+description: |-
+  The legacy_isotime function returns a string representation of the current date
+  and time.
+---
+
+# `legacy_isotime` Function
+
+The `legacy_isotime` function returns the current date and time using the given format string.
+The format string follows golang's datetime formatting. See
+[isotime-function-format-reference](/docs/templates/legacy_json_templates/engine#isotime-function-format-reference)
+for more details.
+
+This function has been provided to create backwards compatibility with
+Packer's legacy JSON templates. However, we recommend that you upgrade your
+HCL Packer template to use [`timestamp`](/docs/templates/hcl_templates/functions/datetime/timestamp)
+and [`formatdate`](/docs/templates/hcl_templates/functions/datetime/formatdate) together as soon as is convenient.
+
+-> **Note:** If you are using a large number of builders, provisioners
+or post-processors, the isotime may be slightly different for each one
+because it is from when the plugin is launched not the initial Packer
+process. In order to avoid this and make the timestamp consistent across all
+plugins, set it as a user variable and then access the user variable within
+your plugins.
+
+## Examples
+
+```shell-session
+> legacy_isotime("2006-01-02")
+2021-04-19
+```
+
+## Related Functions
+
+- [`format`](/docs/templates/hcl_templates/functions/string/format) is a more general formatting function for arbitrary
+data.
+- [`timestamp`](/docs/templates/hcl_templates/functions/datetime/timestamp) returns the current date and time in a format
+suitable for input to `formatdate`.
+- [`formatdate`](/docs/templates/hcl_templates/functions/datetime/formatdate) can convert the resulting timestamp to
+  other date and time formats.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -464,10 +464,6 @@
                 "title": "Date and Time Functions",
                 "routes": [
                   {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/datetime"
-                  },
-                  {
                     "title": "formatdate",
                     "path": "templates/hcl_templates/functions/datetime/formatdate"
                   },
@@ -478,6 +474,10 @@
                   {
                     "title": "timestamp",
                     "path": "templates/hcl_templates/functions/datetime/timestamp"
+                  },
+                  {
+                    "title": "legacy_isotime",
+                    "path": "templates/hcl_templates/functions/datetime/legacy_isotime"
                   }
                 ]
               },


### PR DESCRIPTION
I noticed there are no docs about this function. Even if it's something we don't want to encourage users to use, one might want to understand what it is if they get the upgrade from JSON.

I'm also removing the empty overview page: https://www.packer.io/docs/templates/hcl_templates/functions/datetime