### PR TITLE
Added custom nicname and osdiskname

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -402,7 +402,7 @@ type Config struct {
 	// temporary name assigned to the OSDisk. If this
 	// value is not set, a random value will be assigned. Being able to assign a custom
 	// osDiskName could ease deployment if naming conventions are used..
-	OsDiskName string `mapstructure:"os_disk_name" required:"false"`
+	TempOSDiskName string `mapstructure:"temp_os_disk_name" required:"false"`
 	// Specify the size of the OS disk in GB
 	// (gigabytes). Values of zero or less than zero are ignored.
 	OSDiskSizeGB int32 `mapstructure:"os_disk_size_gb" required:"false"`

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -719,7 +719,6 @@ func setRuntimeValues(c *Config) {
 	}
 	c.tmpNicName = tempName.NicName
 	c.tmpPublicIPAddressName = tempName.PublicIPAddressName
-	c.tmpOSDiskName = tempName.OSDiskName
 	if c.TempOSDiskName == "" {
 		c.tmpOSDiskName = tempName.OSDiskName
 	} else {	

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -304,7 +304,7 @@ type Config struct {
 	TempComputeName string `mapstructure:"temp_compute_name" required:"false"`
 	// temporary name assigned to the Nic. If this
 	// value is not set, a random value will be assigned. Being able to assign a custom
-	// nicname could ease deployment if naming conventions are used..
+	// nicname could ease deployment if naming conventions are used.
 	TempNicName string `mapstructure:"temp_nic_name" required:"false"`
 	// name assigned to the temporary resource group created during the build.
 	// If this value is not set, a random value will be assigned. This resource
@@ -401,7 +401,7 @@ type Config struct {
 	OSType string `mapstructure:"os_type" required:"false"`
 	// temporary name assigned to the OSDisk. If this
 	// value is not set, a random value will be assigned. Being able to assign a custom
-	// osDiskName could ease deployment if naming conventions are used..
+	// osDiskName could ease deployment if naming conventions are used.
 	TempOSDiskName string `mapstructure:"temp_os_disk_name" required:"false"`
 	// Specify the size of the OS disk in GB
 	// (gigabytes). Values of zero or less than zero are ignored.

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -721,7 +721,7 @@ func setRuntimeValues(c *Config) {
 	c.tmpPublicIPAddressName = tempName.PublicIPAddressName
 	if c.TempOSDiskName == "" {
 		c.tmpOSDiskName = tempName.OSDiskName
-	} else {	
+	} else {
 		c.tmpOSDiskName = c.TempOSDiskName
 	}
 	c.tmpDataDiskName = tempName.DataDiskName

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -302,6 +302,10 @@ type Config struct {
 	// group and VM name allows one to execute commands to update the VM during a
 	// Packer build, e.g. attach a resource disk to the VM.
 	TempComputeName string `mapstructure:"temp_compute_name" required:"false"`
+	// temporary name assigned to the Nic. If this
+	// value is not set, a random value will be assigned. Being able to assign a custom
+	// nicname could ease deployment if naming conventions are used..
+	TempNicName string `mapstructure:"temp_nic_name" required:"false"`
 	// name assigned to the temporary resource group created during the build.
 	// If this value is not set, a random value will be assigned. This resource
 	// group is deleted at the end of the build.
@@ -395,6 +399,10 @@ type Config struct {
 	// machine. For Linux this configures an SSH authorized key. For Windows
 	// this configures a WinRM certificate.
 	OSType string `mapstructure:"os_type" required:"false"`
+	// temporary name assigned to the OSDisk. If this
+	// value is not set, a random value will be assigned. Being able to assign a custom
+	// osDiskName could ease deployment if naming conventions are used..
+	OsDiskName string `mapstructure:"os_disk_name" required:"false"`
 	// Specify the size of the OS disk in GB
 	// (gigabytes). Values of zero or less than zero are ignored.
 	OSDiskSizeGB int32 `mapstructure:"os_disk_size_gb" required:"false"`
@@ -704,9 +712,19 @@ func setRuntimeValues(c *Config) {
 	} else if c.TempResourceGroupName != "" && c.BuildResourceGroupName == "" {
 		c.tmpResourceGroupName = c.TempResourceGroupName
 	}
+	if c.TempNicName == "" {
+		c.tmpNicName = tempName.NicName
+	} else {
+		c.tmpNicName = c.TempNicName
+	}
 	c.tmpNicName = tempName.NicName
 	c.tmpPublicIPAddressName = tempName.PublicIPAddressName
 	c.tmpOSDiskName = tempName.OSDiskName
+	if c.TempOSDiskName == "" {
+		c.tmpOSDiskName = tempName.OSDiskName
+	} else {	
+		c.tmpOSDiskName = c.TempOSDiskName
+	}
 	c.tmpDataDiskName = tempName.DataDiskName
 	c.tmpSubnetName = tempName.SubnetName
 	c.tmpVirtualNetworkName = tempName.VirtualNetworkName

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -58,6 +58,7 @@ type FlatConfig struct {
 	ResourceGroupName                          *string                            `mapstructure:"resource_group_name" cty:"resource_group_name" hcl:"resource_group_name"`
 	StorageAccount                             *string                            `mapstructure:"storage_account" cty:"storage_account" hcl:"storage_account"`
 	TempComputeName                            *string                            `mapstructure:"temp_compute_name" required:"false" cty:"temp_compute_name" hcl:"temp_compute_name"`
+	TempNicName                                *string                            `mapstructure:"temp_nic_name" required:"false" cty:"temp_nic_name" hcl:"temp_nic_name"`
 	TempResourceGroupName                      *string                            `mapstructure:"temp_resource_group_name" cty:"temp_resource_group_name" hcl:"temp_resource_group_name"`
 	BuildResourceGroupName                     *string                            `mapstructure:"build_resource_group_name" cty:"build_resource_group_name" hcl:"build_resource_group_name"`
 	BuildKeyVaultName                          *string                            `mapstructure:"build_key_vault_name" cty:"build_key_vault_name" hcl:"build_key_vault_name"`
@@ -70,6 +71,7 @@ type FlatConfig struct {
 	PlanInfo                                   *FlatPlanInformation               `mapstructure:"plan_info" required:"false" cty:"plan_info" hcl:"plan_info"`
 	PollingDurationTimeout                     *string                            `mapstructure:"polling_duration_timeout" required:"false" cty:"polling_duration_timeout" hcl:"polling_duration_timeout"`
 	OSType                                     *string                            `mapstructure:"os_type" required:"false" cty:"os_type" hcl:"os_type"`
+	TempOSDiskName                             *string                            `mapstructure:"temp_os_disk_name" required:"false" cty:"temp_os_disk_name" hcl:"temp_os_disk_name"`
 	OSDiskSizeGB                               *int32                             `mapstructure:"os_disk_size_gb" required:"false" cty:"os_disk_size_gb" hcl:"os_disk_size_gb"`
 	AdditionalDiskSize                         []int32                            `mapstructure:"disk_additional_size" required:"false" cty:"disk_additional_size" hcl:"disk_additional_size"`
 	DiskCachingType                            *string                            `mapstructure:"disk_caching_type" required:"false" cty:"disk_caching_type" hcl:"disk_caching_type"`
@@ -187,6 +189,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"resource_group_name":                              &hcldec.AttrSpec{Name: "resource_group_name", Type: cty.String, Required: false},
 		"storage_account":                                  &hcldec.AttrSpec{Name: "storage_account", Type: cty.String, Required: false},
 		"temp_compute_name":                                &hcldec.AttrSpec{Name: "temp_compute_name", Type: cty.String, Required: false},
+		"temp_nic_name":                                    &hcldec.AttrSpec{Name: "temp_nic_name", Type: cty.String, Required: false},
 		"temp_resource_group_name":                         &hcldec.AttrSpec{Name: "temp_resource_group_name", Type: cty.String, Required: false},
 		"build_resource_group_name":                        &hcldec.AttrSpec{Name: "build_resource_group_name", Type: cty.String, Required: false},
 		"build_key_vault_name":                             &hcldec.AttrSpec{Name: "build_key_vault_name", Type: cty.String, Required: false},
@@ -199,6 +202,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"plan_info":                                        &hcldec.BlockSpec{TypeName: "plan_info", Nested: hcldec.ObjectSpec((*FlatPlanInformation)(nil).HCL2Spec())},
 		"polling_duration_timeout":                         &hcldec.AttrSpec{Name: "polling_duration_timeout", Type: cty.String, Required: false},
 		"os_type":                                          &hcldec.AttrSpec{Name: "os_type", Type: cty.String, Required: false},
+		"temp_os_disk_name":                                &hcldec.AttrSpec{Name: "temp_os_disk_name", Type: cty.String, Required: false},
 		"os_disk_size_gb":                                  &hcldec.AttrSpec{Name: "os_disk_size_gb", Type: cty.Number, Required: false},
 		"disk_additional_size":                             &hcldec.AttrSpec{Name: "disk_additional_size", Type: cty.List(cty.Number), Required: false},
 		"disk_caching_type":                                &hcldec.AttrSpec{Name: "disk_caching_type", Type: cty.String, Required: false},

--- a/website/content/partials/builder/azure/arm/Config-not-required.mdx
+++ b/website/content/partials/builder/azure/arm/Config-not-required.mdx
@@ -156,6 +156,10 @@
   group and VM name allows one to execute commands to update the VM during a
   Packer build, e.g. attach a resource disk to the VM.
 
+- `temp_nic_name` (string) - temporary name assigned to the Nic. If this
+  value is not set, a random value will be assigned. Being able to assign a custom
+  nicname could ease deployment if naming conventions are used.
+
 - `temp_resource_group_name` (string) - name assigned to the temporary resource group created during the build.
   If this value is not set, a random value will be assigned. This resource
   group is deleted at the end of the build.
@@ -245,6 +249,10 @@
   automatically configure authentication credentials for the provisioned
   machine. For Linux this configures an SSH authorized key. For Windows
   this configures a WinRM certificate.
+
+- `temp_os_disk_name` (string) - temporary name assigned to the OSDisk. If this
+  value is not set, a random value will be assigned. Being able to assign a custom
+  osDiskName could ease deployment if naming conventions are used.
 
 - `os_disk_size_gb` (int32) - Specify the size of the OS disk in GB
   (gigabytes). Values of zero or less than zero are ignored.


### PR DESCRIPTION
Added the posibility to define custom nic and osdisk name when using Azure-ARM, instead of only being able to have them randomized.
This will help when using naming convention on Azure Resources.


