### PR TITLE
salt-masterless: Add Execute Command Override Comparable to Shell Provisioner

### DIFF
--- a/provisioner/salt-masterless/provisioner.go
+++ b/provisioner/salt-masterless/provisioner.go
@@ -30,7 +30,8 @@ type Config struct {
 	SkipBootstrap bool   `mapstructure:"skip_bootstrap"`
 	BootstrapArgs string `mapstructure:"bootstrap_args"`
 
-	DisableSudo bool `mapstructure:"disable_sudo"`
+	DisableSudo    bool   `mapstructure:"disable_sudo"`
+	ExecuteCommand string `mapstructure:"execute_command"`
 
 	// Custom state to run instead of highstate
 	CustomState string `mapstructure:"custom_state"`
@@ -469,7 +470,12 @@ func (p *Provisioner) sudo(cmd string) string {
 		return cmd
 	}
 
-	return "sudo " + cmd
+	executeCommand := "sudo"
+	if p.config.ExecuteCommand != "" {
+		executeCommand = p.config.ExecuteCommand
+	}
+
+	return fmt.Sprintf("%s %s", executeCommand, cmd)
 }
 
 func validateDirConfig(path string, name string, required bool) error {

--- a/provisioner/salt-masterless/provisioner.hcl2spec.go
+++ b/provisioner/salt-masterless/provisioner.hcl2spec.go
@@ -21,6 +21,7 @@ type FlatConfig struct {
 	SkipBootstrap       *bool             `mapstructure:"skip_bootstrap" cty:"skip_bootstrap" hcl:"skip_bootstrap"`
 	BootstrapArgs       *string           `mapstructure:"bootstrap_args" cty:"bootstrap_args" hcl:"bootstrap_args"`
 	DisableSudo         *bool             `mapstructure:"disable_sudo" cty:"disable_sudo" hcl:"disable_sudo"`
+	ExecuteCommand      *string           `mapstructure:"execute_command" cty:"execute_command" hcl:"execute_command"`
 	CustomState         *string           `mapstructure:"custom_state" cty:"custom_state" hcl:"custom_state"`
 	MinionConfig        *string           `mapstructure:"minion_config" cty:"minion_config" hcl:"minion_config"`
 	GrainsFile          *string           `mapstructure:"grains_file" cty:"grains_file" hcl:"grains_file"`
@@ -60,6 +61,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"skip_bootstrap":             &hcldec.AttrSpec{Name: "skip_bootstrap", Type: cty.Bool, Required: false},
 		"bootstrap_args":             &hcldec.AttrSpec{Name: "bootstrap_args", Type: cty.String, Required: false},
 		"disable_sudo":               &hcldec.AttrSpec{Name: "disable_sudo", Type: cty.Bool, Required: false},
+		"execute_command":            &hcldec.AttrSpec{Name: "execute_command", Type: cty.String, Required: false},
 		"custom_state":               &hcldec.AttrSpec{Name: "custom_state", Type: cty.String, Required: false},
 		"minion_config":              &hcldec.AttrSpec{Name: "minion_config", Type: cty.String, Required: false},
 		"grains_file":                &hcldec.AttrSpec{Name: "grains_file", Type: cty.String, Required: false},

--- a/provisioner/salt-masterless/provisioner.hcl2spec.go
+++ b/provisioner/salt-masterless/provisioner.hcl2spec.go
@@ -20,7 +20,6 @@ type FlatConfig struct {
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
 	SkipBootstrap       *bool             `mapstructure:"skip_bootstrap" cty:"skip_bootstrap" hcl:"skip_bootstrap"`
 	BootstrapArgs       *string           `mapstructure:"bootstrap_args" cty:"bootstrap_args" hcl:"bootstrap_args"`
-	DisableSudo         *bool             `mapstructure:"disable_sudo" cty:"disable_sudo" hcl:"disable_sudo"`
 	ExecuteCommand      *string           `mapstructure:"execute_command" cty:"execute_command" hcl:"execute_command"`
 	CustomState         *string           `mapstructure:"custom_state" cty:"custom_state" hcl:"custom_state"`
 	MinionConfig        *string           `mapstructure:"minion_config" cty:"minion_config" hcl:"minion_config"`
@@ -60,7 +59,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"skip_bootstrap":             &hcldec.AttrSpec{Name: "skip_bootstrap", Type: cty.Bool, Required: false},
 		"bootstrap_args":             &hcldec.AttrSpec{Name: "bootstrap_args", Type: cty.String, Required: false},
-		"disable_sudo":               &hcldec.AttrSpec{Name: "disable_sudo", Type: cty.Bool, Required: false},
 		"execute_command":            &hcldec.AttrSpec{Name: "execute_command", Type: cty.String, Required: false},
 		"custom_state":               &hcldec.AttrSpec{Name: "custom_state", Type: cty.String, Required: false},
 		"minion_config":              &hcldec.AttrSpec{Name: "minion_config", Type: cty.String, Required: false},

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -177,31 +177,6 @@ func TestProvisionerPrepare_LocalPillarRoots(t *testing.T) {
 	}
 }
 
-func TestProvisionerSudo(t *testing.T) {
-	var p Provisioner
-	config := testConfig()
-
-	err := p.Prepare(config)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	withSudo := p.sudo("echo hello")
-	if withSudo != "sudo echo hello" {
-		t.Fatalf("sudo command not generated correctly")
-	}
-
-	config["disable_sudo"] = true
-	err = p.Prepare(config)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	withoutSudo := p.sudo("echo hello")
-	if withoutSudo != "echo hello" {
-		t.Fatalf("sudo-less command not generated correctly")
-	}
-}
-
 func TestProvisionerExecuteCommand(t *testing.T) {
 	var p Provisioner
 	config := testConfig()

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -202,6 +202,31 @@ func TestProvisionerSudo(t *testing.T) {
 	}
 }
 
+func TestProvisionerExecuteCommand(t *testing.T) {
+	var p Provisioner
+	config := testConfig()
+
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	withoutOverride := p.sudo("echo hello")
+	if withoutOverride != "sudo echo hello" {
+		t.Fatalf("execute command not generated correctly")
+	}
+
+	config["execute_command"] = "echo 'testing' | sudo -S -E"
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	withOverride := p.sudo("echo hello")
+	if withOverride != "echo 'testing' | sudo -S -E echo hello" {
+		t.Fatalf("execute command not generated correctly")
+	}
+}
+
 func TestProvisionerPrepare_RemoteStateTree(t *testing.T) {
 	var p Provisioner
 	config := testConfig()

--- a/provisioner/salt-masterless/provisioner_test.go
+++ b/provisioner/salt-masterless/provisioner_test.go
@@ -187,7 +187,7 @@ func TestProvisionerExecuteCommand(t *testing.T) {
 	}
 
 	withoutOverride := p.sudo("echo hello")
-	if withoutOverride != "sudo echo hello" {
+	if withoutOverride != "sudo -S echo hello" {
 		t.Fatalf("execute command not generated correctly")
 	}
 

--- a/website/content/docs/provisioners/salt-masterless.mdx
+++ b/website/content/docs/provisioners/salt-masterless.mdx
@@ -61,13 +61,9 @@ Optional:
   has more detailed usage instructions. By default, no arguments are sent to
   the script.
 
-- `disable_sudo` (boolean) - By default, the bootstrap install command is
-  prefixed with `sudo`. When using a Docker builder, you will likely want to
-  pass `true` since `sudo` is often not pre-installed.
-
-- `execute_command` (string) - By default certain commands require sudo on linux
-  based systems, if necessary this allows overriding the default `sudo -S`. When
-  the SSH user is not in the sudoers file with no password, you will have to use this.
+- `execute_command` (string) - The command to use to execute salt-call with. Like the
+  shell executor this is prefixed to the actual salt-call command. The default value
+  for unix is `sudo -S` and the default on windows is empty.
 
 - `remote_pillar_roots` (string) - The path to your remote [pillar
   roots](http://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-configuration).

--- a/website/content/docs/provisioners/salt-masterless.mdx
+++ b/website/content/docs/provisioners/salt-masterless.mdx
@@ -65,6 +65,10 @@ Optional:
   prefixed with `sudo`. When using a Docker builder, you will likely want to
   pass `true` since `sudo` is often not pre-installed.
 
+- `execute_command` (string) - By default certain commands require sudo on linux
+  based systems, if necessary this allows overriding the default `sudo -S`. When
+  the SSH user is not in the sudoers file with no password, you will have to use this.
+
 - `remote_pillar_roots` (string) - The path to your remote [pillar
   roots](http://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-configuration).
   default: `/srv/pillar`. This option cannot be used with `minion_config`.


### PR DESCRIPTION
This adds the same `execute_command` capability from the shell provisioner to the salt-masterless provisioner. 

The current implementation of sudo will not work in most situations unless the user has sudo without password prior to running saltstack.

This allows for the ability to pass `execute_command` to the provisioner to obtain `sudo` privileges properly or to alter the command any way you would with the shell provisioner.

```
  provisioner "salt-masterless" {
    local_state_tree = "${path.root}/saltstack"
    skip_bootstrap   = true
    execute_command  = "echo '${var.password}' | sudo -S -E"
    custom_state     = "template.server"
    salt_call_args   = "--state-output=terse"
  }
```

This also includes documentation updates for the new option.