### PR TITLE
fix(azure): rename Shared Gallery Image to Shared Image Gallery

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -178,7 +178,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	if b.config.isManagedImage() && b.config.SharedGalleryDestination.SigDestinationGalleryName != "" {
 		_, err = azureClient.GalleryImagesClient.Get(ctx, b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationImageName)
 		if err != nil {
-			return nil, fmt.Errorf("the Shared Gallery Image to which to publish the managed image version to does not exist in the resource group %s", b.config.SharedGalleryDestination.SigDestinationResourceGroup)
+			return nil, fmt.Errorf("the Shared Image Gallery to which to publish the managed image version to does not exist in the resource group %s", b.config.SharedGalleryDestination.SigDestinationResourceGroup)
 		}
 		// SIG requires that replication regions include the region in which the Managed Image resides
 		managedImageLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))

--- a/builder/azure/dtl/builder.go
+++ b/builder/azure/dtl/builder.go
@@ -138,7 +138,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	if b.config.isManagedImage() && b.config.SharedGalleryDestination.SigDestinationGalleryName != "" {
 		_, err = azureClient.GalleryImagesClient.Get(ctx, b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationImageName)
 		if err != nil {
-			return nil, fmt.Errorf("The Shared Gallery Image to which to publish the managed image version to does not exist in the resource group %s", b.config.SharedGalleryDestination.SigDestinationResourceGroup)
+			return nil, fmt.Errorf("The Shared Image Gallery to which to publish the managed image version to does not exist in the resource group %s", b.config.SharedGalleryDestination.SigDestinationResourceGroup)
 		}
 		// SIG requires that replication regions include the region in which the Managed Image resides
 		managedImageLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))


### PR DESCRIPTION
Fixes a naming error where an Azure Shared Image Gallery was called Shared Gallery Image.