### PR TITLE
website: add huaweicloud remote plugin

### DIFF
--- a/website/data/docs-remote-plugins.json
+++ b/website/data/docs-remote-plugins.json
@@ -66,6 +66,14 @@
     "pluginTier": "community"
   },
   {
+    "title": "HuaweiCloud",
+    "path": "huaweicloud",
+    "repo": "huaweicloud/packer-plugin-huaweicloud",
+    "version": "latest",
+    "pluginTier": "community",
+    "sourceBranch": "master"
+  },
+  {
     "title": "HyperOne",
     "path": "hyperone",
     "repo": "hashicorp/packer-plugin-hyperone",


### PR DESCRIPTION
Hi, Team

The [HuaweiCloud plugin](https://github.com/huaweicloud/packer-plugin-huaweicloud) can be installed by `packer init` command since [v0.4.0](https://github.com/huaweicloud/packer-plugin-huaweicloud/releases/tag/v0.4.0) which includes the  `docs.zip` file archive.

According to [Packer Documentation](https://packer-git-extracttencentcloud-hashicorp.vercel.app/docs/plugins/creation#registering-plugin-documentation), this pull request registers the HuaweiCloud plugin.
