### PR TITLE
Adding support for private DTL VMs

### DIFF
--- a/builder/azure/dtl/azure_client.go
+++ b/builder/azure/dtl/azure_client.go
@@ -132,7 +132,7 @@ func byConcatDecorators(decorators ...autorest.RespondDecorator) autorest.Respon
 }
 
 func NewAzureClient(subscriptionID, resourceGroupName string,
-	cloud *azure.Environment, SharedGalleryTimeout time.Duration, PollingDuration time.Duration,
+	cloud *azure.Environment, SharedGalleryTimeout time.Duration, CustomImageCaptureTimeout time.Duration, PollingDuration time.Duration,
 	servicePrincipalToken *adal.ServicePrincipalToken) (*AzureClient, error) {
 
 	var azureClient = &AzureClient{}
@@ -166,7 +166,7 @@ func NewAzureClient(subscriptionID, resourceGroupName string,
 	azureClient.DtlCustomImageClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
 	azureClient.DtlCustomImageClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DtlCustomImageClient.UserAgent)
 	azureClient.DtlCustomImageClient.PollingDuration = autorest.DefaultPollingDuration
-	azureClient.DtlCustomImageClient.Client.PollingDuration = PollingDuration
+	azureClient.DtlCustomImageClient.Client.PollingDuration = CustomImageCaptureTimeout
 
 	azureClient.DtlVirtualNetworksClient = dtl.NewVirtualNetworksClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DtlVirtualNetworksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
@@ -188,6 +188,13 @@ func NewAzureClient(subscriptionID, resourceGroupName string,
 	azureClient.GalleryImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImagesClient.UserAgent)
 	azureClient.GalleryImagesClient.Client.PollingDuration = PollingDuration
+
+	azureClient.InterfacesClient = network.NewInterfacesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
+	azureClient.InterfacesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
+	azureClient.InterfacesClient.RequestInspector = withInspection(maxlen)
+	azureClient.InterfacesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
+	azureClient.InterfacesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.InterfacesClient.UserAgent)
+	azureClient.InterfacesClient.Client.PollingDuration = PollingDuration
 
 	return azureClient, nil
 }

--- a/builder/azure/dtl/builder.go
+++ b/builder/azure/dtl/builder.go
@@ -75,12 +75,13 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		return nil, err
 	}
 
-	ui.Message("Creating Azure Resource Manager (ARM) client ...")
+	ui.Message("Creating Azure DevTestLab (DTL) client ...")
 	azureClient, err := NewAzureClient(
 		b.config.ClientConfig.SubscriptionID,
 		b.config.LabResourceGroupName,
 		b.config.ClientConfig.CloudEnvironment(),
 		b.config.SharedGalleryTimeout,
+		b.config.CustomImageCaptureTimeout,
 		b.config.PollingDurationTimeout,
 		spnCloud)
 
@@ -168,12 +169,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	b.config.Location = *lab.Location
 
 	if b.config.LabVirtualNetworkName == "" || b.config.LabSubnetName == "" {
-		virtualNetowrk, subnet, err := b.getSubnetInformation(ctx, ui, *azureClient)
+		virtualNetwork, subnet, err := b.getSubnetInformation(ctx, ui, *azureClient)
 
 		if err != nil {
 			return nil, err
 		}
-		b.config.LabVirtualNetworkName = *virtualNetowrk
+		b.config.LabVirtualNetworkName = *virtualNetwork
 		b.config.LabSubnetName = *subnet
 
 		ui.Message(fmt.Sprintf("No lab network information provided. Using %s Virtual network and %s subnet for Virtual Machine creation", b.config.LabVirtualNetworkName, b.config.LabSubnetName))

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -285,9 +285,9 @@ type Config struct {
 	LabSubnetName         string `mapstructure:"lab_subnet_name"`
 	LabResourceGroupName  string `mapstructure:"lab_resource_group_name"`
 
-	DtlArtifacts []DtlArtifact `mapstructure:"dtl_artifacts"`
-	VMName       string        `mapstructure:"vm_name"`
-	DisallowPublicIP        bool `mapstructure:"disallow_public_ip" required:"false"`
+	DtlArtifacts     []DtlArtifact `mapstructure:"dtl_artifacts"`
+	VMName           string        `mapstructure:"vm_name"`
+	DisallowPublicIP bool          `mapstructure:"disallow_public_ip" required:"false"`
 
 	// Runtime Values
 	UserName                string

--- a/builder/azure/dtl/config.hcl2spec.go
+++ b/builder/azure/dtl/config.hcl2spec.go
@@ -60,6 +60,7 @@ type FlatConfig struct {
 	SharedGallery                       *FlatSharedImageGallery            `mapstructure:"shared_image_gallery" cty:"shared_image_gallery" hcl:"shared_image_gallery"`
 	SharedGalleryDestination            *FlatSharedImageGalleryDestination `mapstructure:"shared_image_gallery_destination" cty:"shared_image_gallery_destination" hcl:"shared_image_gallery_destination"`
 	SharedGalleryTimeout                *string                            `mapstructure:"shared_image_gallery_timeout" cty:"shared_image_gallery_timeout" hcl:"shared_image_gallery_timeout"`
+	CustomImageCaptureTimeout           *string                            `mapstructure:"custom_image_capture_timeout" cty:"custom_image_capture_timeout" hcl:"custom_image_capture_timeout"`
 	ImagePublisher                      *string                            `mapstructure:"image_publisher" cty:"image_publisher" hcl:"image_publisher"`
 	ImageOffer                          *string                            `mapstructure:"image_offer" cty:"image_offer" hcl:"image_offer"`
 	ImageSku                            *string                            `mapstructure:"image_sku" cty:"image_sku" hcl:"image_sku"`
@@ -86,6 +87,7 @@ type FlatConfig struct {
 	LabResourceGroupName                *string                            `mapstructure:"lab_resource_group_name" cty:"lab_resource_group_name" hcl:"lab_resource_group_name"`
 	DtlArtifacts                        []FlatDtlArtifact                  `mapstructure:"dtl_artifacts" cty:"dtl_artifacts" hcl:"dtl_artifacts"`
 	VMName                              *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
+	DisallowPublicIP                    *bool                              `mapstructure:"disallow_public_ip" required:"false" cty:"disallow_public_ip" hcl:"disallow_public_ip"`
 	UserName                            *string                            `cty:"user_name" hcl:"user_name"`
 	Password                            *string                            `cty:"password" hcl:"password"`
 	VMCreationResourceGroup             *string                            `cty:"vm_creation_resource_group" hcl:"vm_creation_resource_group"`
@@ -175,6 +177,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shared_image_gallery":                     &hcldec.BlockSpec{TypeName: "shared_image_gallery", Nested: hcldec.ObjectSpec((*FlatSharedImageGallery)(nil).HCL2Spec())},
 		"shared_image_gallery_destination":         &hcldec.BlockSpec{TypeName: "shared_image_gallery_destination", Nested: hcldec.ObjectSpec((*FlatSharedImageGalleryDestination)(nil).HCL2Spec())},
 		"shared_image_gallery_timeout":             &hcldec.AttrSpec{Name: "shared_image_gallery_timeout", Type: cty.String, Required: false},
+		"custom_image_capture_timeout":             &hcldec.AttrSpec{Name: "custom_image_capture_timeout", Type: cty.String, Required: false},
 		"image_publisher":                          &hcldec.AttrSpec{Name: "image_publisher", Type: cty.String, Required: false},
 		"image_offer":                              &hcldec.AttrSpec{Name: "image_offer", Type: cty.String, Required: false},
 		"image_sku":                                &hcldec.AttrSpec{Name: "image_sku", Type: cty.String, Required: false},
@@ -201,6 +204,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"lab_resource_group_name":                  &hcldec.AttrSpec{Name: "lab_resource_group_name", Type: cty.String, Required: false},
 		"dtl_artifacts":                            &hcldec.BlockListSpec{TypeName: "dtl_artifacts", Nested: hcldec.ObjectSpec((*FlatDtlArtifact)(nil).HCL2Spec())},
 		"vm_name":                                  &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
+		"disallow_public_ip":                       &hcldec.AttrSpec{Name: "disallow_public_ip", Type: cty.Bool, Required: false},
 		"user_name":                                &hcldec.AttrSpec{Name: "user_name", Type: cty.String, Required: false},
 		"password":                                 &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
 		"vm_creation_resource_group":               &hcldec.AttrSpec{Name: "vm_creation_resource_group", Type: cty.String, Required: false},

--- a/builder/azure/dtl/step_capture_image.go
+++ b/builder/azure/dtl/step_capture_image.go
@@ -77,6 +77,7 @@ func (s *StepCaptureImage) captureImageFromVM(ctx context.Context) error {
 
 	f, err := s.client.DtlCustomImageClient.CreateOrUpdate(ctx, s.config.LabResourceGroupName, s.config.LabName, s.config.ManagedImageName, *customImage)
 	if err == nil {
+		s.say("Waiting for Capture Image to complete")
 		err = f.WaitForCompletionRef(ctx, s.client.DtlCustomImageClient.Client)
 	}
 	if err != nil {

--- a/builder/azure/dtl/step_deploy_template.go
+++ b/builder/azure/dtl/step_deploy_template.go
@@ -7,10 +7,10 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2018-09-15/dtl"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/builder/azure/common/constants"
-	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2018-09-15/dtl"
 )
 
 type StepDeployTemplate struct {

--- a/builder/azure/dtl/step_deploy_template.go
+++ b/builder/azure/dtl/step_deploy_template.go
@@ -86,10 +86,9 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 		resp, err := s.client.InterfacesClient.Get(ctx, s.config.tmpResourceGroupName, s.config.tmpNicName, "")
 		if err != nil {
 			s.say(s.client.LastError.Error())
-			return  err
+			return err
 		}
-		PrivateIP := *(*resp.IPConfigurations)[0].PrivateIPAddress
-		s.config.tmpFQDN = PrivateIP
+		s.config.tmpFQDN = *(*resp.IPConfigurations)[0].PrivateIPAddress
 	} else {
 		s.config.tmpFQDN = *vm.Fqdn
 	}

--- a/builder/azure/dtl/step_deploy_template.go
+++ b/builder/azure/dtl/step_deploy_template.go
@@ -110,7 +110,7 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 		dp := &dtl.ArtifactParameterProperties{}
 		dp.Name = &hostname
 		dp.Value = &s.config.tmpFQDN
-		dparams := []dtl.ArtifactParameterProperties{ *dp }
+		dparams := []dtl.ArtifactParameterProperties{*dp}
 
 		winrmArtifact := &dtl.ArtifactInstallProperties{
 			ArtifactTitle: &winrma,
@@ -118,8 +118,8 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 			Parameters:    &dparams,
 		}
 
-		dtlArtifacts := []dtl.ArtifactInstallProperties{ *winrmArtifact }
-		dtlArtifactsRequest := dtl.ApplyArtifactsRequest{ Artifacts: &dtlArtifacts }
+		dtlArtifacts := []dtl.ArtifactInstallProperties{*winrmArtifact}
+		dtlArtifactsRequest := dtl.ApplyArtifactsRequest{Artifacts: &dtlArtifacts}
 		f, err := s.client.DtlVirtualMachineClient.ApplyArtifacts(ctx, s.config.tmpResourceGroupName, s.config.LabName, s.config.tmpComputeName, dtlArtifactsRequest)
 		if err == nil {
 			err = f.WaitForCompletionRef(ctx, s.client.DtlVirtualMachineClient.Client)

--- a/builder/azure/dtl/template_factory.go
+++ b/builder/azure/dtl/template_factory.go
@@ -2,7 +2,6 @@ package dtl
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2018-09-15/dtl"
 )
@@ -78,31 +77,6 @@ func GetVirtualMachineDeployment(config *Config) (*dtl.LabVirtualMachineCreation
 		}
 	}
 
-	if strings.ToLower(config.OSType) == "windows" {
-		// Add mandatory Artifact
-		var winrma = "windows-winrm"
-		var artifactid = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DevTestLab/labs/%s/artifactSources/public repo/artifacts/%s",
-			config.ClientConfig.SubscriptionID,
-			config.tmpResourceGroupName,
-			config.LabName,
-			winrma)
-
-		var hostname = "hostName"
-		//var hostNameValue = fmt.Sprintf("%s.%s.cloudapp.azure.com", config.VMName, config.Location)
-		dparams := []dtl.ArtifactParameterProperties{}
-		dp := &dtl.ArtifactParameterProperties{}
-		dp.Name = &hostname
-		dp.Value = &config.tmpFQDN
-		dparams = append(dparams, *dp)
-
-		winrmArtifact := &dtl.ArtifactInstallProperties{
-			ArtifactTitle: &winrma,
-			ArtifactID:    &artifactid,
-			Parameters:    &dparams,
-		}
-		dtlArtifacts = append(dtlArtifacts, *winrmArtifact)
-	}
-
 	labMachineProps := &dtl.LabVirtualMachineCreationParameterProperties{
 		CreatedByUserID:            &config.ClientConfig.ClientID,
 		OwnerObjectID:              &config.ClientConfig.ObjectID,
@@ -114,7 +88,7 @@ func GetVirtualMachineDeployment(config *Config) (*dtl.LabVirtualMachineCreation
 		IsAuthenticationWithSSHKey: newBool(true),
 		LabSubnetName:              &config.LabSubnetName,
 		LabVirtualNetworkID:        &labVirtualNetworkID,
-		DisallowPublicIPAddress:    newBool(false),
+		DisallowPublicIPAddress:    &config.DisallowPublicIP,
 		GalleryImageReference:      &galleryImageRef,
 		CustomImageID:              getCustomImageId(config),
 		PlanID:                     &config.PlanID,

--- a/provisioner/azure-dtlartifact/provisioner.go
+++ b/provisioner/azure-dtlartifact/provisioner.go
@@ -98,6 +98,8 @@ func (p *Provisioner) Communicator() packersdk.Communicator {
 
 func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packersdk.Communicator, _ map[string]interface{}) error {
 
+	ui.Say("Running provisioner ...")
+
 	p.communicator = comm
 
 	err := p.config.ClientConfig.SetDefaultValues()
@@ -123,11 +125,12 @@ func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 		return err
 	}
 
-	ui.Message("Creating Azure Resource Manager (ARM) client ...")
+	ui.Message("Creating Azure DevTestLab (DTL) client ...")
 	azureClient, err := dtlBuilder.NewAzureClient(
 		p.config.ClientConfig.SubscriptionID,
 		"",
 		p.config.ClientConfig.CloudEnvironment(),
+		p.config.PollingDurationTimeout,
 		p.config.PollingDurationTimeout,
 		p.config.PollingDurationTimeout,
 		spnCloud)

--- a/website/content/partials/builder/azure/dtl/Config-not-required.mdx
+++ b/website/content/partials/builder/azure/dtl/Config-not-required.mdx
@@ -45,6 +45,13 @@
   its default of "60m" (valid time units include `s` for seconds, `m` for
   minutes, and `h` for hours.)
 
+- `custom_image_capture_timeout` (duration string | ex: "1h5m2s") - How long to wait for an image to be captured before timing out
+  If your Packer build is failing on the Capture Image step with the
+  error `Original Error: context deadline exceeded`, but the image is
+  present when you check your custom image repository, then you probably
+  need to increase this timeout from its default of 30 minutes.
+  Units: minutes
+
 - `image_publisher` (string) - PublisherName for your base image. See
   [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
   for details.
@@ -165,5 +172,7 @@
 - `dtl_artifacts` ([]DtlArtifact) - Dtl Artifacts
 
 - `vm_name` (string) - VM Name
+
+- `disallow_public_ip` (bool) - Disallow Public IP
 
 <!-- End of code generated from the comments of the Config struct in builder/azure/dtl/config.go; -->


### PR DESCRIPTION
In Azure DTL builder, currently only VMs with public IP were taken into account. This PR adds support for private IP VMs also (through the addition of a config parameter), by setting the SSHHost to be the IP address in case a private IP is request or the tmpFQDN otherwise. Also, this PR introduces a specific timeout for the image capture step.
