### PR TITLE
fix: specify a string for name rather than a variable which is not su…

### DIFF
--- a/website/content/partials/from-1.5/builds/example-block.mdx
+++ b/website/content/partials/from-1.5/builds/example-block.mdx
@@ -17,7 +17,7 @@ build {
         # Note that fields cannot be overwritten, in other words, you cannot
         # set the 'output' field from the top-level source block and here.
         output = "different value"
-        name = var.foo
+        name = "differentname"
     }
 
     provisioner "shell" {


### PR DESCRIPTION
Hi there!

This one-liner fixes an error in the builder documentation which implied that build source names can be interpolated when in actual fact they can't[1]. It's included in the build overview docs [source here](https://github.com/hashicorp/packer/blob/master/website/content/docs/templates/hcl_templates/blocks/build/index.mdx) and rendered in the docs [here](https://www.packer.io/docs/templates/hcl_templates/blocks/build).

IMO this code block is confusing and the documentation would probably be better without it, but I'm not a professional docs chap so wanted to suggest this fix rather than make changes above my pay grade ;)

[1] Consider:
```
variable "name" {
  type    = string
  default = "hello"
}

source "null" "this" {
  communicator = "none"
}

build {
  name = "build"

  source "source.null.this" {
    name   = var.name
  }
}
```
which results in 
```
Error: Variables not allowed

  on main.pkr.hcl line 14:
  (source code not available)

Variables may not be used here.

Error: Unsuitable value type

  on main.pkr.hcl line 14:
  (source code not available)

Unsuitable value: value must be known
```
