### PR TITLE
Rough guide-doc update for QEMU KVM builds from within containers

### DIFF
--- a/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
+++ b/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
@@ -10,12 +10,14 @@ images with Packer.
 - [How to Build Immutable Infrastructure with Packer and CircleCI Workflows](https://circleci.com/blog/how-to-build-immutable-infrastructure-with-packer-and-circleci-workflows/)
 - [Using Packer and Ansible to Build Immutable Infrastructure in CodeShip](https://blog.codeship.com/packer-ansible/)
 
-The majority of the [Packer Builders](/docs/builders) can run in
-a container or VM, a common model used by most CI/CD services. However, some
-builders may take substantially longer without privilege escalation (like the
-[QEMU builder](/docs/builders/qemu) for
+The majority of the [Packer Builders](/docs/builders) can run just fine in a
+container, a common model used by most CI/CD services. However, while it is
+possible to run many builders in containers or nested virtualization, this may
+require advanced configuration; examples include the [QEMU
+builder](/docs/builders/qemu) for
 [KVM](https://www.linux-kvm.org/page/Main_Page) and
-[Xen](https://www.xenproject.org/)).
+[Xen](https://www.xenproject.org/)), or the [VirtualBox
+builder](/docs/builders/virtualbox) for OVA or OVF virtual machines.
 
 The [Building a VirtualBox Image with Packer in
 TeamCity](/guides/packer-on-cicd/build-virtualbox-image) guide shows

--- a/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
+++ b/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
@@ -18,8 +18,8 @@ builder](/docs/builders/qemu) for
 [KVM](https://www.linux-kvm.org/page/Main_Page) or
 [Xen](https://www.xenproject.org/)), the [VirtualBox
 builder](/docs/builders/virtualbox) for OVA or OVF virtual machines, and the
-[VMware builder](/docs/builders/vmware) for use with VMware products that
-require running on a bare-metal machine or in nested virtualization.
+[VMware builder](/docs/builders/vmware) for use with VMware products that are
+all designed to run on a bare-metal machine or within nested virtualization.
 
 The [Building a VirtualBox Image with Packer in
 TeamCity](/guides/packer-on-cicd/build-virtualbox-image) guide shows

--- a/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
+++ b/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
@@ -16,7 +16,7 @@ possible to run many builders in containers or nested virtualization, this may
 require advanced configuration; examples include the [QEMU
 builder](/docs/builders/qemu) for
 [KVM](https://www.linux-kvm.org/page/Main_Page) or
-[Xen](https://www.xenproject.org/)), the [VirtualBox
+[Xen](https://www.xenproject.org/), the [VirtualBox
 builder](/docs/builders/virtualbox) for OVA or OVF virtual machines, and the
 [VMware builder](/docs/builders/vmware) for use with VMware products that are
 all designed to run on a bare-metal machine or within nested virtualization.

--- a/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
+++ b/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
@@ -15,9 +15,11 @@ container, a common model used by most CI/CD services. However, while it is
 possible to run many builders in containers or nested virtualization, this may
 require advanced configuration; examples include the [QEMU
 builder](/docs/builders/qemu) for
-[KVM](https://www.linux-kvm.org/page/Main_Page) and
-[Xen](https://www.xenproject.org/)), or the [VirtualBox
-builder](/docs/builders/virtualbox) for OVA or OVF virtual machines.
+[KVM](https://www.linux-kvm.org/page/Main_Page) or
+[Xen](https://www.xenproject.org/)), the [VirtualBox
+builder](/docs/builders/virtualbox) for OVA or OVF virtual machines, and the
+[VMware builder](/docs/builders/vmware) for use with VMware products that
+require running on a bare-metal machine or in nested virtualization.
 
 The [Building a VirtualBox Image with Packer in
 TeamCity](/guides/packer-on-cicd/build-virtualbox-image) guide shows

--- a/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
+++ b/website/content/guides/packer-on-cicd/build-image-in-cicd.mdx
@@ -11,13 +11,11 @@ images with Packer.
 - [Using Packer and Ansible to Build Immutable Infrastructure in CodeShip](https://blog.codeship.com/packer-ansible/)
 
 The majority of the [Packer Builders](/docs/builders) can run in
-a container or VM, a common model used by most CI/CD services. However, the
+a container or VM, a common model used by most CI/CD services. However, some
+builders may take substantially longer without privilege escalation (like the
 [QEMU builder](/docs/builders/qemu) for
 [KVM](https://www.linux-kvm.org/page/Main_Page) and
-[Xen](https://www.xenproject.org/) virtual machine images, [VirtualBox
-builder](/docs/builders/virtualbox) for OVA or OVF virtual machines and
-[VMware builder](/docs/builders/vmware) for use with VMware products
-require running on a bare-metal machine or nested virtualization.
+[Xen](https://www.xenproject.org/)).
 
 The [Building a VirtualBox Image with Packer in
 TeamCity](/guides/packer-on-cicd/build-virtualbox-image) guide shows


### PR DESCRIPTION
Hello! This is a prospective doc update, so I don't have any test results etc. to share according to the PR template.

I noticed that [this Guide](https://www.packer.io/guides/packer-on-cicd/build-image-in-cicd) on the website says that Packer can't be used to build QEMU KVM/Xen or VirtualBox images, if run from within a container. So I set up [this Gist's contents](https://gist.github.com/ryapric/5ee69073acf0435d5b40075da2625a80) to show that it can, at least, be done for QEMU KVM images without anything special -- though running with `--privileged` escalation ***significantly*** reduces the build time. I have not tested the other VM types called out in that Guide, but wanted to be sure to call *this one* out -- perhaps a kernel version or KVM improvement that now enables the functionality? I've included log files in the Gist.

System specs that  I tested this on:

- Dell Latitude 7480, BIOS has everything enabled to let KVM etc. work *outside* of a container
- OS: Ubuntu 20.04
- Linux kernel 5.4.0
- Docker 20.10.6 for Client and Server version
- As indicated in the Gist's `Dockerfile`, base image is Docker Hub's `hashicorp/packer:light`

Also note that this specific doc change IS NOT what I'm proposing -- moreso looking for thoughts on what it SHOULD say instead.

Thanks!