### PR TITLE
update docs to use double quotes, which works on more shells

### DIFF
--- a/website/content/guides/hcl/variables.mdx
+++ b/website/content/guides/hcl/variables.mdx
@@ -155,9 +155,9 @@ You can set variables directly on the command-line with the
 
 ```shell-session
 $ packer build \
-  -var 'weekday=Sunday' \
-  -var 'flavor=chocolate' \
-  -var 'sudo_password=hunter42' .
+  -var "weekday=Sunday" \
+  -var "flavor=chocolate" \
+  -var "sudo_password=hunter42" .
 ```
 
 Once again, setting variables this way will not save them, and they'll


### PR DESCRIPTION
replace single with double quotes in variable example. It seems the single quote way doesn't work in all shells. 

closes #11007