### PR TITLE
Add Vultr remote docs

### DIFF
--- a/website/data/docs-remote-plugins.json
+++ b/website/data/docs-remote-plugins.json
@@ -223,6 +223,13 @@
     "version": "latest"
   },
   {
+    "title": "Vultr",
+    "path": "vultr",
+    "repo": "vultr/packer-plugin-vultr",
+    "pluginTier": "community",
+    "version": "latest"
+  },
+  {
     "title": "Yandex",
     "path": "yandex",
     "repo": "hashicorp/packer-plugin-yandex",


### PR DESCRIPTION
PR is to submit the docs.zip for the vultr packer plugin https://github.com/vultr/packer-plugin-vultr

docs.zip on latest release
https://github.com/vultr/packer-plugin-vultr/releases/tag/v2.3.1