### PR TITLE
Fix links to Learn

### DIFF
--- a/website/data/intro-nav-data.json
+++ b/website/data/intro-nav-data.json
@@ -29,10 +29,6 @@
       {
         "title": "Vagrant Boxes",
         "href": "/intro/getting-started/vagrant"
-      },
-      {
-        "title": "Next Steps",
-        "href": "/intro/getting-started/next"
       }
     ]
   }

--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -133,12 +133,14 @@ module.exports = [
   },
   {
     source: '/intro/getting-started/vagrant',
-    destination: 'https://learn.hashicorp.com/packer/getting-started/vagrant',
+    destination:
+      'https://learn.hashicorp.com/tutorials/packer/aws-get-started-post-processors-vagrant?in=packer/aws-get-started',
     permanent: true,
   },
   {
     source: '/intro/getting-started/next',
-    destination: 'https://learn.hashicorp.com/packer/getting-started/next   ',
+    destination:
+      'https://learn.hashicorp.com/collections/packer/docker-get-started',
     permanent: true,
   },
   {


### PR DESCRIPTION
Some links to introductory tutorials were incorrect after some URLs changed. This fixes the links and the redirects.

