### PR TITLE
document gotcha around third party plugins

### DIFF
--- a/website/content/docs/commands/hcl2_upgrade.mdx
+++ b/website/content/docs/commands/hcl2_upgrade.mdx
@@ -99,7 +99,7 @@ working on improving this part of the transformer.
 ## Options
 
 - `-output-file` - Filename of the hcl2 generated template. Defaults to
-  JSON_TEMPLATE.pkr.hcl; for example, if your template is called
+  JSON_TEMPLATE.pkr.hcl; for example, if the file is called
   "packerparty.json", the default output-file is "packerparty.json.pkr.hcl".
 - `-with-annotations` - Adds helpful comments to the HCL template with
   information about the generated HCL2 blocks.

--- a/website/content/docs/commands/hcl2_upgrade.mdx
+++ b/website/content/docs/commands/hcl2_upgrade.mdx
@@ -98,7 +98,7 @@ working on improving this part of the transformer.
 
 ## Options
 
-- `-output-file` - Filename of the hcl2 generated config. Defaults to
+- `-output-file` - Filename of the hcl2 generated template. Defaults to
   JSON_TEMPLATE.pkr.hcl; for example, if your template is called
   "packerparty.json", the default output-file is "packerparty.json.pkr.hcl".
 - `-with-annotations` - Adds helpful comments to the HCL template with

--- a/website/content/docs/commands/hcl2_upgrade.mdx
+++ b/website/content/docs/commands/hcl2_upgrade.mdx
@@ -98,9 +98,11 @@ working on improving this part of the transformer.
 
 ## Options
 
-- `-output-file` - File where to put the hcl2 generated config. Defaults to
-  JSON_TEMPLATE.pkr.hcl
-- `-with-annotations` - Adds helper annotations with information about the generated HCL2 blocks.
+- `-output-file` - Filename of the hcl2 generated config. Defaults to
+  JSON_TEMPLATE.pkr.hcl; for example, if your template is called
+  "packerparty.json", the default output-file is "packerparty.json.pkr.hcl".
+- `-with-annotations` - Adds helpful comments to the HCL template with
+  information about the generated HCL2 blocks.
 
 ## User variables using other user variables
 
@@ -128,3 +130,10 @@ locals {
   baz = "${var.foo} ${var.bar}"
 }
 ```
+
+## Upgrading templates that use third-party community plugins
+
+If your template references a plugin that is not bundled with the main Packer
+binary, you need to make sure that the [plugin is installed](/docs/plugins#installing-plugins)
+or you will get an `unknown builder type` error. Packer needs to load the plugin
+to transpose the template.


### PR DESCRIPTION
Document that Packer needs to have third party plugins installed if you want to use hcl2_upgrade on a template that references them.