### PR TITLE
fix: print unchanged formatted file when using stdin

### DIFF
--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -156,6 +156,7 @@ func Test_fmt_pipe(t *testing.T) {
 		expected string
 	}{
 		{unformattedHCL, []string{"fmt", "-"}, nil, formattedHCL},
+		{formattedHCL, []string{"fmt", "-"}, nil, formattedHCL},
 	}
 
 	for _, tc := range tc {

--- a/hcl2template/formatter.go
+++ b/hcl2template/formatter.go
@@ -139,6 +139,10 @@ func (f *HCL2Formatter) processFile(filename string) ([]byte, error) {
 	outSrc := hclwrite.Format(inSrc)
 
 	if bytes.Equal(inSrc, outSrc) {
+		if filename == "-" {
+			_, _ = f.Output.Write(outSrc)
+		}
+
 		return nil, nil
 	}
 


### PR DESCRIPTION
When packer formats the HCL, the result is not printed when stdin is used which causes loss when piping, e.g. in ViM as described in the following issue.

Closes #10698
