### PR TITLE
remove hashibot

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -1,0 +1,5 @@
+bug:
+  - 'panic:'
+crash:
+  - 'panic:'
+

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -1,0 +1,16 @@
+name: Issue Comment Created Triage
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue_comment_triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            stale
+            waiting-reply

--- a/.github/workflows/issues-opened.yml
+++ b/.github/workflows/issues-opened.yml
@@ -1,0 +1,16 @@
+name: Issue Opened Triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  issue_triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: github/issue-labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler-issue-triage.yml
+

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,29 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '50 1 * * *'
+
+# Only 50 issues will be handled during a given run.
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-comment: >
+            I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+            If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          issue-lock-inactive-days: '30'
+          # Issues older than 180 days ago should be ignored
+          issue-exclude-created-before: '2020-01-11'
+          pr-lock-comment: >
+            I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+            If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+          pr-lock-inactive-days: '30'
+          # Issues older than 180 days ago should be ignored
+          pr-exclude-created-before: '2020-01-11'
+

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -9,20 +9,6 @@ behavior "remove_labels_on_reply" "remove_stale" {
     only_non_maintainers = true
 }
 
-poll "closed_issue_locker" "locker" {
-  schedule             = "0 50 1 * * *"
-  closed_for           = "720h" # 30 days
-  max_issues           = 500
-  sleep_between_issues = "5s"
-  no_comment_if_no_activity_for = "4320h" # 180 days
-
-  message = <<-EOF
-    I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
-
-    If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-  EOF
-}
-
 poll "label_issue_migrater" "remote_plugin_migrater" {
   schedule                = "0 20 * * * *"
   new_owner               = "hashicorp"

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -4,11 +4,6 @@ behavior "regexp_issue_labeler" "panic_label" {
     labels = ["crash", "bug"]
 }
 
-behavior "remove_labels_on_reply" "remove_stale" {
-    labels = ["waiting-reply", "stale"]
-    only_non_maintainers = true
-}
-
 poll "label_issue_migrater" "remote_plugin_migrater" {
   schedule                = "0 20 * * * *"
   new_owner               = "hashicorp"

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,9 +1,3 @@
-
-behavior "regexp_issue_labeler" "panic_label" {
-    regexp = "panic:"
-    labels = ["crash", "bug"]
-}
-
 poll "label_issue_migrater" "remote_plugin_migrater" {
   schedule                = "0 20 * * * *"
   new_owner               = "hashicorp"


### PR DESCRIPTION
- Replace `closed_issue_locker` HashiBot action with GitHub action
- Replace  `remove_labels_on_reply` with GitHub action
- Replace  `regexp_issue_labeler` with GitHub action

The remaining issue transfer action I am going to let ride for a bit to figure out if we want to update another action to do the same thing. Or maybe just delete it outright and use the GitHub issue transfer option. 

Partially resolves #11053 