### PR TITLE
hcl2_upgrade: Improve regex to fix escaping on split function

### DIFF
--- a/command/hcl2_upgrade.go
+++ b/command/hcl2_upgrade.go
@@ -1289,7 +1289,8 @@ var PASSTHROUGHS = map[string]string{"NVME_Present": "{{ .NVME_Present }}",
 func fixQuoting(old string) string {
 	// This regex captures golang template functions that use escaped quotes:
 	// {{ env \"myvar\" }}
-	re := regexp.MustCompile(`{{\s*\w*\s*(\\".*\\")\s*}}`)
+	// {{ split `some-string` \"-\" 0 }}
+	re := regexp.MustCompile(`{{\s*\w*(\s*(\\".*\\")\s*)+\w*\s*}}`)
 
 	body := re.ReplaceAllFunc([]byte(old), func(s []byte) []byte {
 		// Get the capture group

--- a/command/test-fixtures/hcl2_upgrade/escaping/expected.pkr.hcl
+++ b/command/test-fixtures/hcl2_upgrade/escaping/expected.pkr.hcl
@@ -28,4 +28,14 @@ build {
     inline = ["echo ${var.conf}-${local.timestamp}-${legacy_isotime("01-02-2006")}"]
   }
 
+
+  # 1 error occurred upgrading the following block:
+  # unhandled "split" call:
+  # there is no way to automatically upgrade the "split" call.
+  # Please manually upgrade to `split(separator, string)`
+  # Visit https://www.packer.io/docs/templates/hcl_templates/functions/string/split for more infos.
+  provisioner "shell-local" {
+    inline = ["echo {{ split `some-string` `-` 0 }}"]
+  }
+
 }

--- a/command/test-fixtures/hcl2_upgrade/escaping/input.json
+++ b/command/test-fixtures/hcl2_upgrade/escaping/input.json
@@ -16,6 +16,12 @@
 			"inline": [
 				"echo {{user \"conf\"}}-{{timestamp}}-{{isotime \"01-02-2006\"}}"
 			]
+		},
+		{
+			"type": "shell-local",
+			"inline": [
+				"echo {{ split \"some-string\" \"-\" 0 }}"
+			]
 		}
 	]
 }


### PR DESCRIPTION
Closes https://github.com/hashicorp/packer/issues/10911