### PR TITLE
add possibility to use variables everywhere in post-processor blocks

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -38,6 +38,8 @@ mascarpone
 whipped_egg_white
 dress
 `
+	one = "1\n"
+	two = "2\n"
 )
 
 func TestBuild(t *testing.T) {
@@ -404,8 +406,8 @@ func TestBuild(t *testing.T) {
 			},
 			fileCheck: fileCheck{
 				expectedContent: map[string]string{
-					"example1.1.txt": "1\n",
-					"example2.2.txt": "2\n",
+					"example1.1.txt": one,
+					"example2.2.txt": two,
 				},
 				notExpected: []string{
 					"example1.2.txt",

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -396,6 +396,23 @@ func TestBuild(t *testing.T) {
 				expected: []string{"dummy-fooo.txt", "dummy-baar.txt", "postgres/13-fooo.txt", "postgres/13-baar.txt"},
 			},
 		},
+
+		{
+			name: "hcl - variables can be used in shared post-processor fields",
+			args: []string{
+				testFixture("hcl", "var-in-pp-name.pkr.hcl"),
+			},
+			fileCheck: fileCheck{
+				expectedContent: map[string]string{
+					"example1.1.txt": "1\n",
+					"example2.2.txt": "2\n",
+				},
+				notExpected: []string{
+					"example1.2.txt",
+					"example2.1.txt",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/build_windows_test.go
+++ b/command/build_windows_test.go
@@ -6,6 +6,8 @@ func init() {
 	spaghettiCarbonara = fixWindowsLineEndings(spaghettiCarbonara)
 	lasagna = fixWindowsLineEndings(lasagna)
 	tiramisu = fixWindowsLineEndings(tiramisu)
+	one = fixWindowsLineEndings(one)
+	two = fixWindowsLineEndings(two)
 }
 
 func fixWindowsLineEndings(s string) string {

--- a/command/test-fixtures/hcl/var-in-pp-name.pkr.hcl
+++ b/command/test-fixtures/hcl/var-in-pp-name.pkr.hcl
@@ -1,0 +1,30 @@
+source "null" "example1" {
+  communicator = "none"
+}
+
+source "null" "example2" {
+  communicator = "none"
+}
+
+locals {
+  except_example2 = "null.example2"
+  true   = true
+}
+
+variable "only_example2" {
+  default = "null.example2"
+}
+
+build {
+  sources = ["source.null.example1", "source.null.example2"]
+  post-processor "shell-local" {
+    keep_input_artifact = local.true
+    except = [local.except_example2]
+    inline = ["echo 1 > ${source.name}.1.txt"]
+  }
+
+  post-processor "shell-local" {
+    only   = [var.only_example2]
+    inline = ["echo 2 > ${source.name}.2.txt"]
+  }
+}

--- a/command/test-fixtures/hcl/var-in-pp-name.pkr.hcl
+++ b/command/test-fixtures/hcl/var-in-pp-name.pkr.hcl
@@ -15,15 +15,20 @@ variable "only_example2" {
   default = "null.example2"
 }
 
+variable "foo" {
+  default = "bar"
+}
+
 build {
   sources = ["source.null.example1", "source.null.example2"]
   post-processor "shell-local" {
     keep_input_artifact = local.true
-    except = [local.except_example2]
-    inline = ["echo 1 > ${source.name}.1.txt"]
+    except              = [local.except_example2]
+    inline              = ["echo 1 > ${source.name}.1.txt"]
   }
 
   post-processor "shell-local" {
+    name   = var.foo
     only   = [var.only_example2]
     inline = ["echo 2 > ${source.name}.2.txt"]
   }

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -157,7 +157,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 			}
 			build.ErrorCleanupProvisionerBlock = p
 		case buildPostProcessorLabel:
-			pp, moreDiags := p.decodePostProcessor(block)
+			pp, moreDiags := p.decodePostProcessor(block, cfg)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue
@@ -174,7 +174,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 			errored := false
 			postProcessors := []*PostProcessorBlock{}
 			for _, block := range content.Blocks {
-				pp, moreDiags := p.decodePostProcessor(block)
+				pp, moreDiags := p.decodePostProcessor(block, cfg)
 				diags = append(diags, moreDiags...)
 				if moreDiags.HasErrors() {
 					errored = true

--- a/hcl2template/types.build.post-processor.go
+++ b/hcl2template/types.build.post-processor.go
@@ -23,7 +23,7 @@ func (p *PostProcessorBlock) String() string {
 	return fmt.Sprintf(buildPostProcessorLabel+"-block %q %q", p.PType, p.PName)
 }
 
-func (p *Parser) decodePostProcessor(block *hcl.Block) (*PostProcessorBlock, hcl.Diagnostics) {
+func (p *Parser) decodePostProcessor(block *hcl.Block, cfg *PackerConfig) (*PostProcessorBlock, hcl.Diagnostics) {
 	var b struct {
 		Name              string   `hcl:"name,optional"`
 		Only              []string `hcl:"only,optional"`
@@ -31,7 +31,7 @@ func (p *Parser) decodePostProcessor(block *hcl.Block) (*PostProcessorBlock, hcl
 		KeepInputArtifact *bool    `hcl:"keep_input_artifact,optional"`
 		Rest              hcl.Body `hcl:",remain"`
 	}
-	diags := gohcl.DecodeBody(block.Body, nil, &b)
+	diags := gohcl.DecodeBody(block.Body, cfg.EvalContext(BuildContext, nil), &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}


### PR DESCRIPTION
Todo list:
* [x] feature
* [x] tests

Including in:
* name
* only
* except
* keep_input_artifact

Example file:

```hcl
source "null" "example1" {
  communicator = "none"
}

source "null" "example2" {
  communicator = "none"
}

locals {
  except = "null.example1"
}

variable "only" {
  default = "null.example1"
}

build {
  sources = ["source.null.example1", "source.null.example2"]
  post-processor "shell-local" {
    except = [local.except]
    inline = ["echo first post-processor"]
  }

  post-processor "shell-local" {
    only   = [var.only]
    inline = ["echo second post-processor"]
  }
}
```
Ouput:
```shell-session
$ packer build foo.pkr.hcl
null.example1: output will be in this color.
null.example2: output will be in this color.

==> null.example1: Running post-processor:  (type shell-local)
==> null.example2: Running post-processor:  (type shell-local)
==> null.example2 (shell-local): Running local shell script: /var/folders/3k/2gb5ct4s7cncr52_jh2kz6cw0000gq/T/packer-shell201696062
==> null.example1 (shell-local): Running local shell script: /var/folders/3k/2gb5ct4s7cncr52_jh2kz6cw0000gq/T/packer-shell494781572
    null.example1 (shell-local): second post-processor
Build 'null.example1' finished after 61 milliseconds 432 microseconds.
    null.example2 (shell-local): first post-processor
Build 'null.example2' finished after 111 milliseconds 678 microseconds.

==> Wait completed after 111 milliseconds 714 microseconds
```

close #4895