### PR TITLE
website: bump nextjs-scripts for latest code-block

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1048,11 +1048,11 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.6.tgz",
-      "integrity": "sha512-Xl8SPYtdjcMoCsIM4teyVRg7jIcgl8F2kRtoCcXuHzXswt9UxZCS6BzRo8fcnCuP6u2XtPgvyonmEPF57Kxo9Q==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.7.tgz",
+      "integrity": "sha512-Wvzcw4mBYbTagyBVZpAJWI06auSIj033T/yNE0Zn1xcup83MieCddZA7ls3kme17L4NOGBrQ09Q+nKB41RLWBA==",
       "requires": {
-        "core-js-pure": "^3.14.0",
+        "core-js-pure": "^3.15.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -1227,13 +1227,13 @@
       "integrity": "sha512-mZyJ3xG1YTufyDLC2vWFDfj6ppXJ8uK1z5+U/9fgcuJynet5STtEpeVsyZz3oTNcXJiCjAQzvK63T0V8npnKYQ=="
     },
     "@hashicorp/nextjs-scripts": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/nextjs-scripts/-/nextjs-scripts-19.0.1.tgz",
-      "integrity": "sha512-qsbcfXqkDWlI482RyHuZTsCj9w5io83wdcbkIyyvllZrZHYtds6nZoqjGUFNBD2aOQEGGkOoJDMXmJHTtwPqyA==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/nextjs-scripts/-/nextjs-scripts-19.0.2.tgz",
+      "integrity": "sha512-hGUuLX9ee5mNAeopBjCS28BUlR8WyE8K1eAhQNn0m2o3nPmkAKM8qFkA9jBhYpc6I5eCAi0Us1/SXkyoNXpvGA==",
       "requires": {
         "@bugsnag/js": "7.5.4",
         "@bugsnag/plugin-react": "7.5.4",
-        "@hashicorp/react-code-block": "4.1.1",
+        "@hashicorp/react-code-block": "4.1.2",
         "@hashicorp/react-consent-manager": "5.1.0",
         "@hashicorp/react-enterprise-alert": "5.0.0",
         "@hashicorp/react-tabs": "6.0.0",
@@ -1355,9 +1355,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.1.tgz",
-      "integrity": "sha512-Wn8U5gsdK5RcEDhrq/WnYu2F5DZ5O4/wm7HUgmeQ3v0EewZYBykv1WFbPbGPdNY1SF5os8x0BUWwb7M7CVAWjA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.2.tgz",
+      "integrity": "sha512-kHlk0lid8kp1MmrGGtmPvRP2BNSz8rQBYWH0txqipBJv5ZPsXnyflypcBlivIppxA1+gciwAwg3B/Zcx8L6m1A==",
       "requires": {
         "@hashicorp/react-inline-svg": "6.0.1",
         "@reach/listbox": "0.15.0",
@@ -2789,9 +2789,9 @@
       }
     },
     "axe-core": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.2.tgz",
-      "integrity": "sha512-OKRkKM4ojMEZRJ5UNJHmq9tht7cEnRnqKG6KyB/trYws00Xtkv12mHtlJ0SK7cmuNbrU8dPUova3ELTuilfBbw=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.3.tgz",
+      "integrity": "sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ=="
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -4129,9 +4129,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js-pure": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.14.0.tgz",
-      "integrity": "sha512-YVh+LN2FgNU0odThzm61BsdkwrbrchumFq3oztnE9vTKC4KS2fvnPmcx8t6jnqAyOTCTF4ZSiuK8Qhh7SNcL4g=="
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.0.tgz",
+      "integrity": "sha512-RO+LFAso8DB6OeBX9BAcEGvyth36QtxYon1OyVsITNVtSKr/Hos0BXZwnsOJ7o+O6KHtK+O+cJIEj9NGg6VwFA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6414,9 +6414,9 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+      "version": "15.5.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
+      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw=="
     },
     "graphql-request": {
       "version": "3.4.0",
@@ -16258,9 +16258,9 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs-parser": {
-      "version": "20.2.7",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@hashicorp/mktg-global-styles": "3.0.1",
     "@hashicorp/mktg-logos": "1.0.2",
-    "@hashicorp/nextjs-scripts": "19.0.1",
+    "@hashicorp/nextjs-scripts": "19.0.2",
     "@hashicorp/react-alert-banner": "^6.1.1",
     "@hashicorp/react-button": "5.0.0",
     "@hashicorp/react-command-line-terminal": "^2.0.2",


### PR DESCRIPTION
:tickets: [Asana ticket](https://app.asana.com/0/1100423001970639/1200499258820834/f)
:mag: [Deploy preview](https://packer-git-fork-zchsh-zsbump-code-block-hashicorp.vercel.app/docs/templates/hcl_templates/variables)

This PR pulls in the most recent version of code-block. This patch switches the custom MDX primitive to the `<pre>` element. See https://github.com/hashicorp/react-components/pull/258 for details.