### PR TITLE
website: upgrade react-head

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1513,9 +1513,9 @@
       }
     },
     "@hashicorp/react-head": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.0.1.tgz",
-      "integrity": "sha512-kWNPvYZHLVOcCj4SDQxWTG/xSTHne39Yunga0CPtmEtOjYYeiFCjH9TjfedrQkrb2ioNtFsltuxC7LjNb1lNXg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.1.0.tgz",
+      "integrity": "sha512-tXfxi9Aqhx83p6wt753WfiYUhOEMzrsWKON200zsNFdwN2WkHPwArWbR6+ludVXleEmsBufL8GRYq7iqnnKKlQ=="
     },
     "@hashicorp/react-image": {
       "version": "2.0.4",

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "@hashicorp/react-command-line-terminal": "^2.0.2",
     "@hashicorp/react-docs-page": "13.2.0",
     "@hashicorp/react-hashi-stack-menu": "2.0.3",
-    "@hashicorp/react-head": "3.0.1",
+    "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-inline-svg": "6.0.0",
     "@hashicorp/react-markdown-page": "1.2.0",
     "@hashicorp/react-product-downloads-page": "2.0.2",


### PR DESCRIPTION
[Preview](https://packer-pkjskd8d6-hashicorp.vercel.app/)

Upgrading `react-head` and dependencies to set the new Safari theme-color feature.

[_Created by Sourcegraph campaign `kstraut/upgrade-react-head`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/upgrade-react-head)

**After**
<img width="1257" alt="Screen Shot 2021-06-25 at 8 21 02 AM" src="https://user-images.githubusercontent.com/36613477/123447063-53076d00-d58e-11eb-84f7-d56b9d53f47c.png">

**Before**
<img width="1262" alt="Screen Shot 2021-06-25 at 8 21 09 AM" src="https://user-images.githubusercontent.com/36613477/123447077-54d13080-d58e-11eb-91f3-bd4dca5b7fca.png">
