### PR TITLE
fix typo in configure docs

### DIFF
--- a/website/content/docs/configure.mdx
+++ b/website/content/docs/configure.mdx
@@ -111,7 +111,7 @@ each can be found below:
   [Packer's home directory](#packer-s-home-directory) for more.
 
 - `PACKER_GITHUB_API_TOKEN` - When using Packer init on HCL2 templates, Packer
-  queries the public API from Github which limits the ammount of queries on can
+  queries the public API from Github which limits the amount of queries on can
   set the `PACKER_GITHUB_API_TOKEN` with a Github Token to make it higher.
 
 - `PACKER_LOG` - Setting this to any value other than "" (empty string) or


### PR DESCRIPTION
I found a typo while reading the docs. This PR fixes it.