### PR TITLE
add stdin to docs for fmt

### DIFF
--- a/website/content/docs/commands/fmt.mdx
+++ b/website/content/docs/commands/fmt.mdx
@@ -33,6 +33,15 @@ my-template.pkr.hcl
 
 ```
 
+Format a configuration file, reading from stdin and writing to stdout.
+
+```shell-session
+$ packer fmt -
+
+// You can use pipes to combine this feature with other command line options
+$ cat my-template.pkr.hcl | packer fmt -
+```
+
 ## Options
 
 - `-check` - Checks if the input is formatted. Exit status will be 0 if all
@@ -42,3 +51,5 @@ my-template.pkr.hcl
 
 - `-write=false` - Don't write formatting changes to source files
   (always disabled if using -check)
+
+- `-` - read formatting changes from stdin and write them to stdout.


### PR DESCRIPTION
Document stdin/stdout functionality in `packer fmt`

![Screen Shot 2021-07-06 at 11 23 21 AM](https://user-images.githubusercontent.com/1008838/124648871-9f836000-de4c-11eb-817c-94ccfe4ca66f.png)

Closes #11080