### PR TITLE
Fix incorrect `isotime` output

### DIFF
--- a/website/content/docs/templates/legacy_json_templates/engine.mdx
+++ b/website/content/docs/templates/legacy_json_templates/engine.mdx
@@ -276,7 +276,7 @@ You can try and modify the following examples in a packer template or in
 
 | Input                                      | Output                       |
 | ------------------------------------------ | -----------                  |
-| ``"packer-{{isotime `2006-01-02`}}"``          | "packer-2021-05-17 11:40:16" |
+| ``"packer-{{isotime `2006-01-02`}}"``          | "packer-2021-05-17"          |
 | ``"packer-{{isotime `Jan-_2-15:04:05.000`}}"`` | "packer-May-17-23:40:16.786" |
 | ``"packer-{{isotime `3:04PM`}}"``              | "packer-11:40PM"             |
 | ``"{{ isotime }}"``                            | "June 7, 7:22:43pm 2014"     |


### PR DESCRIPTION
```
❯ echo '"packer-{{isotime `2006-01-02`}}"' | packer console
"packer-2021-07-20"
```