### PR TITLE
added newest packer-plugin-xenserver and xcp-ng

### DIFF
--- a/website/content/partials/builders/community_builders.mdx
+++ b/website/content/partials/builders/community_builders.mdx
@@ -14,3 +14,5 @@
 - [Vultr builder](https://github.com/vultr/packer-builder-vultr) - A builder for creating [Vultr](https://www.vultr.com/) snapshots.
 
 - [Citrix XenServer/Citrix Hypervisor](https://github.com/xenserver/packer-builder-xenserver) - Plugin for creating [Citrix XenServer/Citrix Hypervisor](https://xenserver.org/) images from an iso image or from an existing template.
+
+- [XCP-NG/Citrix XenServer/Citrix Hypervisor/Updated Fork](https://github.com/ddelnano/packer-plugin-xenserver) - Plugin for creating [XCP-NG/Citrix XenServer/Citrix Hypervisor](https://xcp-ng.org/) images from an iso image or from an existing template.  This is a fork of the orginal, and reccomended by the developers of XCP-NG.


### PR DESCRIPTION
the old citrix plugin has not been updated recently, so the sponsored fork is added, and references to xcp-ng added

I am just updating docs

