### PR TITLE
clean up docs and comments to use marketing-approved name

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -158,8 +158,8 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 
 	/*
 		Ideal world we want to send all builds for a new iterations.
-		-only flag doesn't work with PAR to start; future only will be allowed to filter only builds not
-		complete in PAR.
+		-only flag doesn't work with the HCP Packer registry to start; future only will be allowed to filter only builds not
+		complete in the HCP Packer registry.
 	*/
 
 	builds, diags := packerStarter.GetBuilds(packer.GetBuildsOptions{

--- a/command/core_wrapper.go
+++ b/command/core_wrapper.go
@@ -41,7 +41,7 @@ func (c *CoreWrapper) PluginRequirements() (plugingetter.Requirements, hcl.Diagn
 func (c *CoreWrapper) ConfiguredArtifactMetadataPublisher() (*packerregistry.Bucket, hcl.Diagnostics) {
 	bucket := c.Core.GetRegistryBucket()
 
-	// If at this point the bucket is nil, it means PAR is not enabled
+	// If at this point the bucket is nil, it means the HCP Packer registry is not enabled
 	if bucket == nil {
 		return nil, hcl.Diagnostics{
 			&hcl.Diagnostic{

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -375,7 +375,7 @@ func (p *Parser) parseConfig(f *hcl.File, cfg *PackerConfig) hcl.Diagnostics {
 				continue
 			}
 
-			// If we are in PAR mode check that only one build block has been parsed.
+			// If we are in PAR (HCP Packer registry) mode check that only one build block has been parsed.
 			// If we've already parsed one fail because PAR does not support more than one build block.
 			// bucket is created upon the call to decodeBuildConfig.
 			if cfg.bucket != nil && len(cfg.Builds) > 0 {

--- a/hcl2template/registry.go
+++ b/hcl2template/registry.go
@@ -8,7 +8,7 @@ import (
 // ConfiguredArtifactMetadataPublisher returns a configured image bucket that can be used for publishing
 // build image artifacts to a configured Packer Registry destination.
 func (cfg *PackerConfig) ConfiguredArtifactMetadataPublisher() (*packerregistry.Bucket, hcl.Diagnostics) {
-	// If this was a PAR build either env.InPARMode() is true, or if the is an hcp_packer_registry block
+	// If this was a PAR (HCP Packer registry) build either env.InPARMode() is true, or if the is an hcp_packer_registry block
 	// defined we would have a non-nil bucket. So if nil assume we are not in a some sort of PAR mode.
 	if cfg.bucket == nil {
 		return nil, hcl.Diagnostics{

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -211,8 +211,8 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		}
 	}
 
-	// Creates a bucket if either a hcp_packer_registry block is set or PAR is enabled via
-	// environment variable
+	// Creates a bucket if either a hcp_packer_registry block is set or the HCP
+	// Packer registry is enabled via environment variable
 	if build.HCPPackerRegistry != nil || env.IsPAREnabled() {
 		var err error
 		cfg.bucket, err = packerregistry.NewBucketWithIteration(packerregistry.IterationOptions{

--- a/internal/packer_registry/types.iterations.go
+++ b/internal/packer_registry/types.iterations.go
@@ -45,7 +45,7 @@ func GetGitFingerprint(opts IterationOptions) (string, error) {
 	return ref.Hash().String(), nil
 }
 
-// NewIteration returns a pointer to an Iteration that can be used for storing Packer build details needed by PAR.
+// NewIteration returns a pointer to an Iteration that can be used for storing Packer build details needed by the HCP Packer registry.
 func NewIteration(opts IterationOptions) (*Iteration, error) {
 	i := Iteration{
 		expectedBuilds: make([]string, 0),

--- a/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -1,17 +1,17 @@
 ---
 description: >
   The hcp_packer_registry allows operators the ability to customize the metadata sent to HCP Packer Registry.
-  It configures the base details of an image that is created or updated within HCP PAR.
+  It configures the base details of an image that is created or updated within the HCP Packer registry.
 page_title: hcp_packer_registry - build - Blocks
 ---
 
 # The `hcp_packer_registry` block
 
 The `hcp_packer_registry` block allows operators the ability to customize the metadata sent to
-HCP Packer Registry. It configures the details of an image that is created or updated within HCP PAR.
+HCP Packer Registry. It configures the details of an image that is created or updated within the HCP Packer registry.
 
-The presence of a `hcp_packer_registry` block will enable HCP PAR mode and all the builds within that build block
-will be pushed to the remote registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and `HCP_CLIENT_SECRET`). If no HCP credentials are set Packer will fail the build and exit immediately to avoid any potential artifact drift between the build providers and the Packer registry.
+The presence of a `hcp_packer_registry` block will enable the HCP Packer registry mode and all the builds within that build block
+will be pushed to the remote registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and `HCP_CLIENT_SECRET`). If no HCP credentials are set Packer will fail the build and exit immediately to avoid any potential artifact drift between the build providers and the HCP Packer registry.
 
 ```hcl
 # file: builds.pkr.hcl
@@ -38,13 +38,13 @@ Some nice description about the image which artifact is being published to HCP P
 }
 ```
 
-- `slug` (string) - The image name when published to PAR. Should always be the same, otherwise a new image will be created.
+- `slug` (string) - The image name when published to the HCP Packer registry. Should always be the same, otherwise a new image will be created.
   Defaults to `build.name` if not set. Will be overwritten if `HCP_PACKER_BUCKET_NAME` is set.
 
 - `description` (string) - The image description. Useful to provide a summary about the image. The description will appear
-  at the image's main page and will be updated whenever it is changed and a new build is pushed to HCP PAR. Should contain
+  at the image's main page and will be updated whenever it is changed and a new build is pushed to the HCP Packer registry. Should contain
   a maximum of 255 characters. Defaults to `build.description` if not set.
 
 - `labels` (map[string]string) - Map of labels. Can provide any information, such as tools versions
   (e.g. go 1.16, python 3.5, etc...). The labels will appear at the image's main page and will be updated
-  whenever it is changed and a new build is pushed to HCP PAR.
+  whenever it is changed and a new build is pushed to the HCP Packer registry.


### PR DESCRIPTION
PAR is a holdover from before we had an official name for the service. We need to get out of the habit of using it in anything customer-facing. 