### PR TITLE
Fix panic when running a Packer registry build in a clean directory

### DIFF
--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -218,13 +218,17 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		cfg.bucket, err = packerregistry.NewBucketWithIteration(packerregistry.IterationOptions{
 			TemplateBaseDir: cfg.Basedir,
 		})
+
 		if err != nil {
 			diags = append(diags, &hcl.Diagnostic{
 				Summary:  "Unable to create a valid bucket object for HCP Packer Registry",
 				Detail:   fmt.Sprintf("%s", err),
 				Severity: hcl.DiagError,
 			})
+
+			return build, diags
 		}
+
 		cfg.bucket.LoadDefaultSettingsFromEnv()
 		build.HCPPackerRegistry.WriteToBucketConfig(cfg.bucket)
 


### PR DESCRIPTION
Give the case where a new build was executed using a template in a clean non-Git controlled directory without specifying the HCP_PACKER_BUILD_FINGERPRINT env. variable would result in a panic.

This was do to the call the NewIteration throwing an error that was not being captured upstream when creating the bucket.

Results of tests before change
```
=== RUN   TestNewIteration/using_empty_git_directory
    types.iterations_test.go:94: expected "using empty git directory" to return with no error, but it Packer encountered an issue reading the git info for the path "/var/folders/_9/_q1cqjtd3358p1ldhy7j399m0000gn/T/empty-init".
        If your Packer template is not in a git repo, please add a unique template fingerprint using the env var HCP_PACKER_BUILD_FINGERPRINT. Error: reference not found
--- FAIL: TestNewIteration (0.65s)
```

Results of tests after change
```
--- PASS: TestNewIteration (0.71s)
    --- PASS: TestNewIteration/using_fingerprint_env_variable (0.00s)
    --- PASS: TestNewIteration/using_git_fingerprint (0.70s)
    --- PASS: TestNewIteration/using_empty_git_directory (0.00s)
    --- PASS: TestNewIteration/using_no_fingerprint_in_clean_directory (0.00s)
PASS
```


Reproduction steps using #11154 
- Create a new directory locally
- Run `git init` in the new directory.
- Save the template file below into the created directory
- Configuration HCP Packer Registry settings.
- Using a build of packer from #11154 run `packer build source.pkr.hcl`

```
packer {
  required_plugins {
    amazon = {
      version = ">= 1.0.1-dev"
      source  = "github.com/hashicorp/amazon"
    }
  }
}

source "amazon-ebs" "basic-example" {
  region = "us-east-1"
  source_ami_filter {
    filters = {
      virtualization-type = "hvm"
      name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
      root-device-type    = "ebs"
    }
    owners      = ["099720109477"]
    most_recent = true
  }
  instance_type  = "t2.small"
  ssh_username   = "ubuntu"
  ssh_agent_auth = false
  ami_name       = "packer_AWS_{{timestamp}}"
  ami_regions    = ["us-west-2"]
}

build {
  name = "ubuntu-xenial"

  hcp_packer_registry {
    slug        = "ubuntu-xenial"
    description = <<EOT
Some nice description about the image which artifact is being published to HCP Packer Registry. =D
    EOT

    labels = {
      "foo-version" = "3.4.0",
      "foo"         = "bar",
    }
  }

  sources = [
    "source.amazon-ebs.basic-example"
  ]
  provisioner "shell-local" {
    inline = ["echo '${build.SSHPrivateKey}'", "echo '${build.SSHPrivateKey}' > /tmp/packer-aws.pem"]
  }
  provisioner "breakpoint" {}
}```