### PR TITLE
WIP: Add mocks with tests for packer registry client service

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -253,6 +253,12 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	}{m: make(map[string]error)}
 	limitParallel := semaphore.NewWeighted(cla.ParallelBuilds)
 	for i := range builds {
+		/* PAR placeholder
+		Here we need to inform PAR that the build for some builder has begun.
+		What information is needed:
+		 - type, builder_uuid, platform, author, PAR related values.
+
+		*/
 		if err := buildCtx.Err(); err != nil {
 			log.Println("Interrupted, not going to start any more builds.")
 			break

--- a/internal/packer_registry/mock_registry_service.go
+++ b/internal/packer_registry/mock_registry_service.go
@@ -1,0 +1,210 @@
+package packer_registry
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/go-openapi/runtime"
+	packerSvc "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type MockPackerClientService struct {
+	CreateBucketCalled, UpdateBucketCalled, BucketAlreadyExist                           bool
+	CreateIterationCalled, GetIterationCalled, IterationAlreadyExist, IterationCompleted bool
+	CreateBuildCalled, UpdateBuildCalled, ListBuildsCalled, BuildAlreadyDone             bool
+
+	// Mock Creates
+	CreateBucketResp    *models.HashicorpCloudPackerCreateBucketResponse
+	CreateIterationResp *models.HashicorpCloudPackerCreateIterationResponse
+	CreateBuildResp     *models.HashicorpCloudPackerCreateBuildResponse
+
+	// Mock Gets
+	GetIterationResp *models.HashicorpCloudPackerGetIterationResponse
+
+	ExistingBuilds []string
+
+	packerSvc.ClientService
+}
+
+func NewMockPackerClientService() *MockPackerClientService {
+	m := MockPackerClientService{
+		ExistingBuilds: make([]string, 0),
+	}
+
+	m.CreateBucketResp = &models.HashicorpCloudPackerCreateBucketResponse{
+		Bucket: &models.HashicorpCloudPackerBucket{
+			ID: "bucket-id",
+		},
+	}
+
+	m.CreateIterationResp = &models.HashicorpCloudPackerCreateIterationResponse{
+		Iteration: &models.HashicorpCloudPackerIteration{
+			ID: "iteration-id",
+		},
+	}
+
+	m.CreateBuildResp = &models.HashicorpCloudPackerCreateBuildResponse{
+		Build: &models.HashicorpCloudPackerBuild{
+			PackerRunUUID: "test-uuid",
+			Status:        models.HashicorpCloudPackerBuildStatusUNSET,
+		},
+	}
+
+	m.GetIterationResp = &models.HashicorpCloudPackerGetIterationResponse{
+		Iteration: &models.HashicorpCloudPackerIteration{
+			ID:     "iteration-id",
+			Builds: make([]*models.HashicorpCloudPackerBuild, 0),
+		},
+	}
+
+	return &m
+}
+
+func (svc *MockPackerClientService) CreateBucket(params *packerSvc.CreateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.CreateBucketOK, error) {
+	if svc.BucketAlreadyExist {
+		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.AlreadyExists, codes.AlreadyExists.String()))
+	}
+
+	if params.Body.BucketSlug == "" {
+		return nil, errors.New("No bucket slug was passed in")
+	}
+
+	svc.CreateBucketCalled = true
+	svc.CreateBucketResp.Bucket.Slug = params.Body.BucketSlug
+
+	ok := &packerSvc.CreateBucketOK{
+		Payload: svc.CreateBucketResp,
+	}
+
+	return ok, nil
+}
+
+func (svc *MockPackerClientService) UpdateBucket(params *packerSvc.UpdateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.UpdateBucketOK, error) {
+	svc.UpdateBucketCalled = true
+
+	return packerSvc.NewUpdateBucketOK(), nil
+}
+
+func (svc *MockPackerClientService) CreateIteration(params *packerSvc.CreateIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.CreateIterationOK, error) {
+	if svc.IterationAlreadyExist {
+		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.AlreadyExists, codes.AlreadyExists.String()))
+	}
+
+	if params.Body.BucketSlug == "" {
+		return nil, errors.New("No valid BucketSlug was passed in")
+	}
+
+	if params.Body.Fingerprint == "" {
+		return nil, errors.New("No valid Fingerprint was passed in")
+	}
+
+	svc.CreateIterationCalled = true
+	svc.CreateIterationResp.Iteration.BucketSlug = params.Body.BucketSlug
+	svc.CreateIterationResp.Iteration.Fingerprint = params.Body.Fingerprint
+
+	ok := &packerSvc.CreateIterationOK{
+		Payload: svc.CreateIterationResp,
+	}
+
+	return ok, nil
+}
+
+func (svc *MockPackerClientService) GetIteration(params *packerSvc.GetIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.GetIterationOK, error) {
+
+	if params.BucketSlug == "" {
+		return nil, errors.New("No valid BucketSlug was passed in")
+	}
+
+	if params.Fingerprint == nil {
+		return nil, errors.New("No valid Fingerprint was passed in")
+	}
+
+	svc.GetIterationCalled = true
+
+	//
+	ok := &packerSvc.GetIterationOK{
+		Payload: svc.GetIterationResp,
+	}
+
+	if svc.IterationCompleted {
+		ok.Payload.Iteration.Complete = true
+		ok.Payload.Iteration.IncrementalVersion = 1
+	}
+
+	return ok, nil
+}
+
+func (svc *MockPackerClientService) CreateBuild(params *packerSvc.CreateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.CreateBuildOK, error) {
+	if params.Body.BucketSlug == "" {
+		return nil, errors.New("No valid BucketSlug was passed in")
+	}
+
+	if params.Body.Fingerprint == "" {
+		return nil, errors.New("No valid Fingerprint was passed in")
+	}
+
+	if params.Body.Build.ComponentType == "" {
+		return nil, errors.New("No build componentType was passed in")
+	}
+
+	svc.CreateBuildCalled = true
+
+	svc.CreateBuildResp.Build.ComponentType = params.Body.Build.ComponentType
+	svc.CreateBuildResp.Build.IterationID = params.BuildIterationID
+
+	ok := packerSvc.NewCreateBuildOK()
+	ok.Payload = svc.CreateBuildResp
+
+	return ok, nil
+}
+
+func (svc *MockPackerClientService) UpdateBuild(params *packerSvc.UpdateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.UpdateBuildOK, error) {
+	if params.Body.BuildID == "" {
+		return nil, errors.New("No valid BuildID was passed in")
+	}
+
+	if params.Body.Updates == nil {
+		return nil, errors.New("No valid Updates were passed in")
+	}
+
+	if params.Body.Updates.Status == "" {
+		return nil, errors.New("No build status was passed in")
+	}
+
+	svc.UpdateBuildCalled = true
+	ok := packerSvc.NewUpdateBuildOK()
+	ok.Payload = &models.HashicorpCloudPackerUpdateBuildResponse{
+		Build: &models.HashicorpCloudPackerBuild{
+			ID: params.Body.BuildID,
+		},
+	}
+	return ok, nil
+}
+
+func (svc *MockPackerClientService) ListBuilds(params *packerSvc.ListBuildsParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.ListBuildsOK, error) {
+
+	status := models.HashicorpCloudPackerBuildStatusUNSET
+	if svc.BuildAlreadyDone {
+		status = models.HashicorpCloudPackerBuildStatusDONE
+	}
+
+	builds := make([]*models.HashicorpCloudPackerBuild, 0, len(svc.ExistingBuilds))
+	for i, name := range svc.ExistingBuilds {
+		builds = append(builds, &models.HashicorpCloudPackerBuild{
+			ID:            name + "--" + strconv.Itoa(i),
+			ComponentType: name,
+			Status:        status,
+		})
+	}
+
+	ok := packerSvc.NewListBuildsOK()
+	ok.Payload = &models.HashicorpCloudPackerListBuildsResponse{
+		Builds: builds,
+	}
+
+	return ok, nil
+}

--- a/internal/packer_registry/mock_registry_service.go
+++ b/internal/packer_registry/mock_registry_service.go
@@ -114,6 +114,9 @@ func (svc *MockPackerClientService) CreateIteration(params *packerSvc.CreateIter
 }
 
 func (svc *MockPackerClientService) GetIteration(params *packerSvc.GetIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.GetIterationOK, error) {
+	if !svc.IterationAlreadyExist {
+		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.Aborted, codes.Aborted.String()))
+	}
 
 	if params.BucketSlug == "" {
 		return nil, errors.New("No valid BucketSlug was passed in")

--- a/internal/packer_registry/mock_registry_service.go
+++ b/internal/packer_registry/mock_registry_service.go
@@ -136,6 +136,14 @@ func (svc *MockPackerClientService) GetIteration(params *packerSvc.GetIterationP
 	if svc.IterationCompleted {
 		ok.Payload.Iteration.Complete = true
 		ok.Payload.Iteration.IncrementalVersion = 1
+		ok.Payload.Iteration.Builds = append(ok.Payload.Iteration.Builds, &models.HashicorpCloudPackerBuild{
+			ID:            "build-id",
+			ComponentType: svc.ExistingBuilds[0],
+			Status:        models.HashicorpCloudPackerBuildStatusDONE,
+			Images: []*models.HashicorpCloudPackerImage{
+				{ImageID: "image-id", Region: "somewhere"},
+			},
+		})
 	}
 
 	return ok, nil
@@ -191,8 +199,10 @@ func (svc *MockPackerClientService) UpdateBuild(params *packerSvc.UpdateBuildPar
 func (svc *MockPackerClientService) ListBuilds(params *packerSvc.ListBuildsParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.ListBuildsOK, error) {
 
 	status := models.HashicorpCloudPackerBuildStatusUNSET
+	images := make([]*models.HashicorpCloudPackerImage, 0)
 	if svc.BuildAlreadyDone {
 		status = models.HashicorpCloudPackerBuildStatusDONE
+		images = append(images, &models.HashicorpCloudPackerImage{ID: "image-id", Region: "somewhere"})
 	}
 
 	builds := make([]*models.HashicorpCloudPackerBuild, 0, len(svc.ExistingBuilds))
@@ -201,6 +211,7 @@ func (svc *MockPackerClientService) ListBuilds(params *packerSvc.ListBuildsParam
 			ID:            name + "--" + strconv.Itoa(i),
 			ComponentType: name,
 			Status:        status,
+			Images:        images,
 		})
 	}
 

--- a/internal/packer_registry/registry_service.go
+++ b/internal/packer_registry/registry_service.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"errors"
 
+	"github.com/go-openapi/runtime"
 	packerSvc "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
 	"google.golang.org/grpc/codes"
 )
+
+type CloudPackerClientService interface {
+	CreateBucket(*packerSvc.CreateBucketParams, runtime.ClientAuthInfoWriter) (*packerSvc.CreateBucketOK, error)
+	UpdateBucket(*packerSvc.UpdateBucketParams, runtime.ClientAuthInfoWriter) (*packerSvc.UpdateBucketOK, error)
+	CreateBuild(*packerSvc.CreateBuildParams, runtime.ClientAuthInfoWriter) (*packerSvc.CreateBuildOK, error)
+}
 
 // CreateBucket creates a bucket on a HCP Packer Registry.
 func CreateBucket(ctx context.Context, client *Client, input *models.HashicorpCloudPackerCreateBucketRequest) (string, error) {

--- a/internal/packer_registry/registry_service.go
+++ b/internal/packer_registry/registry_service.go
@@ -65,7 +65,7 @@ and returns the ID associated with the persisted Bucket iteration.
 
 input: *models.HashicorpCloudPackerCreateIterationRequest{BucketSlug: "bucket name"
 */
-func CreateIteration(ctx context.Context, client *Client, input *models.HashicorpCloudPackerCreateIterationRequest) (string, error) {
+func CreateIteration(ctx context.Context, client *Client, input *models.HashicorpCloudPackerCreateIterationRequest) (*models.HashicorpCloudPackerIteration, error) {
 	// Create/find iteration
 	params := packerSvc.NewCreateIterationParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
@@ -75,13 +75,13 @@ func CreateIteration(ctx context.Context, client *Client, input *models.Hashicor
 
 	it, err := client.Packer.CreateIteration(params, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return it.Payload.Iteration.ID, nil
+	return it.Payload.Iteration, nil
 }
 
-func GetIteration(ctx context.Context, client *Client, bucketslug string, fingerprint string) (string, error) {
+func GetIteration(ctx context.Context, client *Client, bucketslug string, fingerprint string) (*models.HashicorpCloudPackerIteration, error) {
 	// Create/find iteration
 	params := packerSvc.NewGetIterationParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
@@ -93,10 +93,10 @@ func GetIteration(ctx context.Context, client *Client, bucketslug string, finger
 
 	it, err := client.Packer.GetIteration(params, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return it.Payload.Iteration.ID, nil
+	return it.Payload.Iteration, nil
 }
 
 func CreateBuild(ctx context.Context, client *Client, input *models.HashicorpCloudPackerCreateBuildRequest) (string, error) {

--- a/internal/packer_registry/types.bucket.go
+++ b/internal/packer_registry/types.bucket.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+// Bucket represents a single Image bucket on the HCP Packer registry.
 type Bucket struct {
 	Slug        string
 	Description string
@@ -23,8 +24,8 @@ type Bucket struct {
 	client      *Client
 }
 
-// NewBucketWithIteration initializes a simple Bucket that can be used for tracking Packer
-// related build bits.
+// NewBucketWithIteration initializes a simple Bucket that can be used publishing Packer build
+// images to the HCP Packer registry.
 func NewBucketWithIteration(opts IterationOptions) (*Bucket, error) {
 	b := Bucket{}
 
@@ -32,8 +33,8 @@ func NewBucketWithIteration(opts IterationOptions) (*Bucket, error) {
 	if err != nil {
 		return nil, err
 	}
-	b.Iteration = i
 
+	b.Iteration = i
 	return &b, nil
 }
 
@@ -44,9 +45,24 @@ func (b *Bucket) Validate() error {
 	return nil
 }
 
+// connect initializes a client connection to a remote HCP Packer Registry service on HCP.
+// Upon a successful connection the initialized client is persisted on the Bucket b for later usage.
+func (b *Bucket) connect() error {
+	if b.client != nil {
+		return nil
+	}
+
+	registryClient, err := NewClient()
+	if err != nil {
+		return errors.New("Failed to create client connection to artifact registry: " + err.Error())
+	}
+	b.client = registryClient
+	return nil
+}
+
 // Initialize registers the Bucket b with the configured HCP Packer Registry.
-// Upon initialization a Bucket will be upserted to, a new iteration will be created for the build if the configured
-// fingerprint has not associated builds. Lastly, the initialization process with registered the builds that need to be
+// Upon initialization a Bucket will be upserted to, and new iteration will be created for the build if the configured
+// fingerprint has no associated iterations. Lastly, the initialization process with register the builds that need to be
 // completed before an iteration can be marked as DONE.
 //
 // b.Initialize() must be called before any data can be published to the configured HCP Packer Registry.
@@ -70,22 +86,7 @@ func (b *Bucket) Initialize(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize bucket %q: %w", b.Slug, err)
 	}
 
-	return b.InitializeIteration(ctx)
-}
-
-// connect initializes a client connection to a remote HCP Packer Registry service on HCP.
-// Upon a successful connection the initialized client is persisted on the Bucket b for later usage.
-func (b *Bucket) connect() error {
-	if b.client != nil {
-		return nil
-	}
-
-	registryClient, err := NewClient()
-	if err != nil {
-		return errors.New("Failed to create client connection to artifact registry: " + err.Error())
-	}
-	b.client = registryClient
-	return nil
+	return b.initializeIteration(ctx)
 }
 
 func (b *Bucket) RegisterBuildForComponent(sourceName string) {
@@ -96,61 +97,10 @@ func (b *Bucket) RegisterBuildForComponent(sourceName string) {
 	if _, ok := b.Iteration.builds.Load(sourceName); ok {
 		return
 	}
-	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, sourceName)
+	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, sourceName)
 }
 
-func (b *Bucket) PublishBuildStatus(ctx context.Context, name string, status models.HashicorpCloudPackerBuildStatus) error {
-	// Lets check if we have something already for this build
-	build, ok := b.Iteration.builds.Load(name)
-	if !ok {
-		return fmt.Errorf("no build for the component %q associated to the iteration %q", name, b.Iteration.ID)
-	}
-
-	buildToUpdate, ok := build.(*Build)
-	if !ok {
-		return fmt.Errorf("the build for the component %q does not appear to be a valid registry Build", name)
-	}
-
-	if buildToUpdate.ID == "" {
-		return fmt.Errorf("the build for the component %q does not have a valid id", name)
-	}
-
-	buildInput := &models.HashicorpCloudPackerUpdateBuildRequest{
-		BuildID: buildToUpdate.ID,
-		Updates: &models.HashicorpCloudPackerBuildUpdates{
-			PackerRunUUID: buildToUpdate.RunUUID,
-			Labels:        buildToUpdate.Labels,
-			Status:        status,
-		},
-	}
-
-	if status == models.HashicorpCloudPackerBuildStatusDONE {
-		images := make([]*models.HashicorpCloudPackerImage, 0, len(buildToUpdate.Images))
-		var providerName string
-		for _, partifact := range buildToUpdate.Images {
-			if providerName == "" {
-				providerName = partifact.ProviderName
-			}
-			images = append(images, &models.HashicorpCloudPackerImage{ImageID: partifact.ID, Region: partifact.ProviderRegion})
-		}
-		buildInput.Updates.CloudProvider = providerName
-		buildInput.Updates.Images = images
-
-		if len(images) == 0 {
-			return fmt.Errorf("setting a build to DONE with no published artifacts is not currently support. exiting")
-		}
-	}
-
-	_, err := UpdateBuild(ctx, b.client, buildInput)
-	if err != nil {
-		return err
-	}
-	buildToUpdate.Status = status
-	b.Iteration.builds.Store(name, buildToUpdate)
-	return nil
-}
-
-// CreateInitialBuildForIteration will create a build record on the HCP Packer Registry for named componentType.
+// CreateInitialBuildForIteration will create a build entry on the HCP Packer Registry for the named componentType.
 // This initial creation is needed so that Packer can properly track when an iteration is complete.
 func (b *Bucket) CreateInitialBuildForIteration(ctx context.Context, componentType string) error {
 
@@ -186,6 +136,105 @@ func (b *Bucket) CreateInitialBuildForIteration(ctx context.Context, componentTy
 	return nil
 }
 
+// UpdateBuildStatus updates the status of a build entry on the HCP Packer registry with its current local status.
+func (b *Bucket) UpdateBuildStatus(ctx context.Context, name string, status models.HashicorpCloudPackerBuildStatus) error {
+	if status == models.HashicorpCloudPackerBuildStatusDONE {
+		return b.markBuildComplete(ctx, name)
+	}
+
+	// Lets check if we have something already for this build
+	build, ok := b.Iteration.builds.Load(name)
+	if !ok {
+		return fmt.Errorf("no build for the component %q associated to the iteration %q", name, b.Iteration.ID)
+	}
+
+	buildToUpdate, ok := build.(*Build)
+	if !ok {
+		return fmt.Errorf("the build for the component %q does not appear to be a valid registry Build", name)
+	}
+
+	if buildToUpdate.ID == "" {
+		return fmt.Errorf("the build for the component %q does not have a valid id", name)
+	}
+
+	buildInput := &models.HashicorpCloudPackerUpdateBuildRequest{
+		BuildID: buildToUpdate.ID,
+		Updates: &models.HashicorpCloudPackerBuildUpdates{
+			PackerRunUUID: buildToUpdate.RunUUID,
+			Labels:        buildToUpdate.Labels,
+			Status:        status,
+		},
+	}
+
+	_, err := UpdateBuild(ctx, b.client, buildInput)
+	if err != nil {
+		return err
+	}
+	buildToUpdate.Status = status
+	b.Iteration.builds.Store(name, buildToUpdate)
+	return nil
+}
+
+// markBuildComplete should be called to set a build on the HCP Packer registry to DONE.
+// Upon a successful call markBuildComplete will publish all images created by the named build,
+// and set the registry build to done. A build with no images can not be set to DONE.
+func (b *Bucket) markBuildComplete(ctx context.Context, name string) error {
+	build, ok := b.Iteration.builds.Load(name)
+	if !ok {
+		return fmt.Errorf("no build for the component %q associated to the iteration %q", name, b.Iteration.ID)
+	}
+
+	buildToUpdate, ok := build.(*Build)
+	if !ok {
+		return fmt.Errorf("the build for the component %q does not appear to be a valid registry Build", name)
+	}
+
+	if buildToUpdate.ID == "" {
+		return fmt.Errorf("the build for the component %q does not have a valid id", name)
+	}
+
+	status := models.HashicorpCloudPackerBuildStatusDONE
+
+	if buildToUpdate.Status == status {
+		// let's no mess with anything that is already done
+		return nil
+	}
+
+	buildInput := &models.HashicorpCloudPackerUpdateBuildRequest{
+		BuildID: buildToUpdate.ID,
+		Updates: &models.HashicorpCloudPackerBuildUpdates{
+			PackerRunUUID: buildToUpdate.RunUUID,
+			Labels:        buildToUpdate.Labels,
+			Status:        status,
+		},
+	}
+
+	if len(buildToUpdate.Images) == 0 {
+		return fmt.Errorf("setting a build to DONE with no published images is not currently support. exiting")
+	}
+
+	var providerName string
+	images := make([]*models.HashicorpCloudPackerImage, 0, len(buildToUpdate.Images))
+	for _, image := range buildToUpdate.Images {
+		if providerName == "" {
+			providerName = image.ProviderName
+		}
+		images = append(images, &models.HashicorpCloudPackerImage{ImageID: image.ID, Region: image.ProviderRegion})
+	}
+
+	buildInput.Updates.CloudProvider = providerName
+	buildInput.Updates.Images = images
+
+	_, err := UpdateBuild(ctx, b.client, buildInput)
+	if err != nil {
+		return err
+	}
+
+	buildToUpdate.Status = status
+	b.Iteration.builds.Store(name, buildToUpdate)
+	return nil
+}
+
 // UpdateImageForBuild appends one or more images artifacts to the build referred to by componentType.
 func (b *Bucket) UpdateImageForBuild(componentType string, images ...Image) error {
 	return b.Iteration.AddImageToBuild(componentType, images...)
@@ -211,6 +260,9 @@ func (b *Bucket) LoadDefaultSettingsFromEnv() {
 
 }
 
+// createIteration creates an empty iteration for a give bucket on the HCP Packer registry.
+// The iteration can then be stored locally and used for tracking build status and images for a running
+// Packer build.
 func (b *Bucket) createIteration() (*models.HashicorpCloudPackerIteration, error) {
 	iterationInput := &models.HashicorpCloudPackerCreateIterationRequest{
 		BucketSlug:  b.Slug,
@@ -230,23 +282,38 @@ func (b *Bucket) createIteration() (*models.HashicorpCloudPackerIteration, error
 	return iterationResp, nil
 }
 
-func (b *Bucket) InitializeIteration(ctx context.Context) error {
+// initializeIteration populates the bucket iteration with the details needed for tracking builds for a Packer run.
+// If an existing Packer registry iteration exists for the said iteration fingerprint, calling initialize on iteration
+// that doesn't yet exist will call createIteration to create the entry on the HCP packer registry for the given bucket.
+// All build details will be created (if they don't exists) and added to b.Iteration.builds for tracking during runtime.
+func (b *Bucket) initializeIteration(ctx context.Context) error {
 
 	// load existing iteration using fingerprint.
 	iterationResp, err := GetIteration(ctx, b.client, b.Slug, b.Iteration.Fingerprint)
-	if checkErrorCode(err, codes.Aborted) { //probably means Iteration doesn't exist need a way to check the error
+	if checkErrorCode(err, codes.Aborted) {
+		//probably means Iteration doesn't exist need a way to check the error
 		iterationResp, err = b.createIteration()
 	}
 
 	if err != nil {
 		return fmt.Errorf("failed to initialize iteration for fingerprint %s: %s", b.Iteration.Fingerprint, err)
 	}
+
 	if iterationResp == nil {
 		return fmt.Errorf("failed to initialize iteration details for Bucket %s with error: %w", b.Slug, err)
 	}
 
 	log.Println("[TRACE] a valid iteration was retrieved with the id", iterationResp.ID)
 	b.Iteration.ID = iterationResp.ID
+
+	// If the iteration is completed and there are no new builds to add, Packer
+	// should exit and inform the user that artifacts already exists for the
+	// fingerprint associated with the iteration.
+	if iterationResp.Complete {
+		return fmt.Errorf("This iteration associated to the fingerprint %s is complete. "+
+			"If you wish to add a new build to this image a new iteration must be created by changing the build fingerprint."+
+			"Exiting.", b.Iteration.Fingerprint)
+	}
 
 	// list all this iteration's builds so we can figure out which ones
 	// we want to run against. TODO: pagination?
@@ -256,7 +323,7 @@ func (b *Bucket) InitializeIteration(ctx context.Context) error {
 	}
 
 	var toCreate []string
-	for _, expected := range b.Iteration.registeredBuilds {
+	for _, expected := range b.Iteration.expectedBuilds {
 		var found bool
 		for _, existing := range existingBuilds {
 			if existing.ComponentType == expected {
@@ -270,12 +337,20 @@ func (b *Bucket) InitializeIteration(ctx context.Context) error {
 				}
 				b.Iteration.builds.Store(existing.ComponentType, build)
 
+				// TODO validate that this is safe. For builds that are DONE do we want to keep track of completed things
+				// potential issue on updating the status of a build that is already DONE. Is this possible?
 				for _, image := range existing.Images {
-					b.UpdateImageForBuild(existing.ComponentType, Image{
+
+					err := b.UpdateImageForBuild(existing.ComponentType, Image{
 						ID:             image.ImageID,
 						ProviderRegion: image.Region,
 					})
+
+					if err != nil {
+						log.Printf("[TRACE] unable to load existing images for %q: %v", existing.ComponentType, err)
+					}
 				}
+
 				log.Printf("[TRACE] a build of component type %s already exists; skipping the create call", expected)
 				break
 			}
@@ -285,13 +360,6 @@ func (b *Bucket) InitializeIteration(ctx context.Context) error {
 			missingbuild := expected
 			toCreate = append(toCreate, missingbuild)
 		}
-	}
-	// If the iteration is completed and there are no new builds to add, Packer
-	// should exit and inform the user that artifacts already exists for the
-	// fingerprint associated with the iteration.
-	if iterationResp.Complete && len(toCreate) == 0 {
-		return fmt.Errorf("This iteration associated to the fingerprint %s is complete "+
-			"and this Packer build adds no new components. Exiting.", b.Iteration.Fingerprint)
 	}
 
 	var errs *multierror.Error
@@ -318,4 +386,21 @@ func (b *Bucket) InitializeIteration(ctx context.Context) error {
 	wg.Wait()
 
 	return errs.ErrorOrNil()
+}
+
+// IsExpectingBuildForComponent returns true if the component referenced by buildName is part of the iteration
+// and is not marked as DONE on the HCP Packer registry.
+func (b *Bucket) IsExpectingBuildForComponent(buildName string) bool {
+
+	v, ok := b.Iteration.builds.Load(buildName)
+	if !ok {
+		return false
+	}
+
+	build := v.(*Build)
+	hasBuildID := build.ID != ""
+	hasImages := len(build.Images) == 0
+	isNotDone := build.Status != models.HashicorpCloudPackerBuildStatusDONE
+
+	return hasBuildID && hasImages && isNotDone
 }

--- a/internal/packer_registry/types.bucket_test.go
+++ b/internal/packer_registry/types.bucket_test.go
@@ -83,10 +83,6 @@ func TestInitialize_ExistingBucketNewIteration(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	if mockService.CreateBucketCalled {
-		t.Errorf("unexpected call to CreateBucket")
-	}
-
 	if !mockService.UpdateBucketCalled {
 		t.Errorf("expected call to UpdateBucket but it didn't happen")
 	}
@@ -179,7 +175,6 @@ func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 }
 
 func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
-	t.Skip("Currently being addressed in 11174")
 	//nolint:errcheck
 	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")

--- a/internal/packer_registry/types.bucket_test.go
+++ b/internal/packer_registry/types.bucket_test.go
@@ -27,7 +27,7 @@ func TestInitialize_NewBucketNewIteration(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
 	if err != nil {
@@ -76,7 +76,7 @@ func TestInitialize_ExistingBucketNewIteration(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
 	if err != nil {
@@ -126,7 +126,7 @@ func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, "happycloud.image")
 	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
@@ -171,7 +171,6 @@ func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusUNSET {
 		t.Errorf("expected the existing build to be in the default state")
 	}
-
 }
 
 func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
@@ -197,7 +196,7 @@ func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, "happycloud.image")
 	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
@@ -220,14 +219,9 @@ func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
 	if b.Iteration.ID != "iteration-id" {
 		t.Errorf("expected an iteration to returned but it didn't")
 	}
-
-	if _, ok := b.Iteration.builds.Load("happycloud.image"); ok {
-		t.Errorf("there should be no builds as the iteration is complete")
-	}
-
 }
 
-func TestPublishBuildStatus(t *testing.T) {
+func TestUpdateBuildStatus(t *testing.T) {
 	//nolint:errcheck
 	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
@@ -248,7 +242,7 @@ func TestPublishBuildStatus(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, "happycloud.image")
 	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
@@ -270,7 +264,7 @@ func TestPublishBuildStatus(t *testing.T) {
 		t.Errorf("expected the existing build to be in the default state")
 	}
 
-	err = b.PublishBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusRUNNING)
+	err = b.UpdateBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusRUNNING)
 	if err != nil {
 		t.Errorf("unexpected failure for PublishBuildStatus: %v", err)
 	}
@@ -290,7 +284,7 @@ func TestPublishBuildStatus(t *testing.T) {
 	}
 }
 
-func TestPublishBuildStatus_DONENoImages(t *testing.T) {
+func TestUpdateBuildStatus_DONENoImages(t *testing.T) {
 	//nolint:errcheck
 	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
@@ -311,7 +305,7 @@ func TestPublishBuildStatus_DONENoImages(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, "happycloud.image")
 	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
@@ -334,9 +328,9 @@ func TestPublishBuildStatus_DONENoImages(t *testing.T) {
 	}
 
 	//nolint:errcheck
-	b.PublishBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusRUNNING)
+	b.UpdateBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusRUNNING)
 
-	err = b.PublishBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusDONE)
+	err = b.UpdateBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusDONE)
 	if err == nil {
 		t.Errorf("expected failure for PublishBuildStatus when setting status to DONE with no images")
 	}

--- a/internal/packer_registry/types.bucket_test.go
+++ b/internal/packer_registry/types.bucket_test.go
@@ -1,0 +1,364 @@
+package packer_registry
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+)
+
+func TestInitialize_NewBucketNewIteration(t *testing.T) {
+	//nolint:errcheck
+	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
+	mockService := NewMockPackerClientService()
+
+	b := &Bucket{
+		Slug: "TestBucket",
+		client: &Client{
+			Packer: mockService,
+		},
+	}
+
+	var err error
+	b.Iteration, err = NewIteration(IterationOptions{})
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+
+	err = b.Initialize(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	if !mockService.CreateBucketCalled {
+		t.Errorf("expected a call to CreateBucket but it didn't happen")
+	}
+
+	if !mockService.CreateIterationCalled {
+		t.Errorf("expected a call to CreateIteration but it didn't happen")
+	}
+
+	if !mockService.CreateBuildCalled {
+		t.Errorf("expected a call to CreateBuild but it didn't happen")
+	}
+
+	if b.Iteration.ID != "iteration-id" {
+		t.Errorf("expected an iteration to created but it didn't")
+	}
+
+	if _, ok := b.Iteration.builds.Load("happycloud.image"); !ok {
+		t.Errorf("expected a basic build entry to be created but it didn't")
+	}
+
+}
+
+func TestInitialize_ExistingBucketNewIteration(t *testing.T) {
+	//nolint:errcheck
+	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
+	mockService := NewMockPackerClientService()
+	mockService.BucketAlreadyExist = true
+
+	b := &Bucket{
+		Slug: "TestBucket",
+		client: &Client{
+			Packer: mockService,
+		},
+	}
+
+	var err error
+	b.Iteration, err = NewIteration(IterationOptions{})
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+
+	err = b.Initialize(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	if mockService.CreateBucketCalled {
+		t.Errorf("unexpected call to CreateBucket")
+	}
+
+	if !mockService.UpdateBucketCalled {
+		t.Errorf("expected call to UpdateBucket but it didn't happen")
+	}
+
+	if !mockService.CreateIterationCalled {
+		t.Errorf("expected a call to CreateIteration but it didn't happen")
+	}
+
+	if !mockService.CreateBuildCalled {
+		t.Errorf("expected a call to CreateBuild but it didn't happen")
+	}
+
+	if b.Iteration.ID != "iteration-id" {
+		t.Errorf("expected an iteration to created but it didn't")
+	}
+
+	if _, ok := b.Iteration.builds.Load("happycloud.image"); !ok {
+		t.Errorf("expected a basic build entry to be created but it didn't")
+	}
+
+}
+
+func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
+	//nolint:errcheck
+	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
+	mockService := NewMockPackerClientService()
+	mockService.BucketAlreadyExist = true
+	mockService.IterationAlreadyExist = true
+
+	b := &Bucket{
+		Slug: "TestBucket",
+		client: &Client{
+			Packer: mockService,
+		},
+	}
+
+	var err error
+	b.Iteration, err = NewIteration(IterationOptions{})
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
+
+	err = b.Initialize(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	if mockService.CreateBucketCalled {
+		t.Errorf("unexpected call to CreateBucket")
+	}
+
+	if !mockService.UpdateBucketCalled {
+		t.Errorf("expected call to UpdateBucket but it didn't happen")
+	}
+
+	if mockService.CreateIterationCalled {
+		t.Errorf("unexpected a call to CreateIteration")
+	}
+
+	if !mockService.GetIterationCalled {
+		t.Errorf("expected a call to GetIteration but it didn't happen")
+	}
+
+	if mockService.CreateBuildCalled {
+		t.Errorf("unexpected a call to CreateBuild")
+	}
+
+	if b.Iteration.ID != "iteration-id" {
+		t.Errorf("expected an iteration to created but it didn't")
+	}
+
+	loadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
+	if !ok {
+		t.Errorf("expected a basic build entry to be created but it didn't")
+	}
+
+	existingBuild, ok := loadedBuild.(*Build)
+	if !ok {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	}
+
+	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusUNSET {
+		t.Errorf("expected the existing build to be in the default state")
+	}
+
+}
+
+func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
+	t.Skip("Currently being addressed in 11174")
+	//nolint:errcheck
+	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
+	mockService := NewMockPackerClientService()
+	mockService.BucketAlreadyExist = true
+	mockService.IterationAlreadyExist = true
+	mockService.IterationCompleted = true
+	mockService.BuildAlreadyDone = true
+
+	b := &Bucket{
+		Slug: "TestBucket",
+		client: &Client{
+			Packer: mockService,
+		},
+	}
+
+	var err error
+	b.Iteration, err = NewIteration(IterationOptions{})
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
+
+	err = b.Initialize(context.TODO())
+	if err == nil {
+		t.Errorf("Calling initialize on a completed Iteration should fail hard")
+	}
+
+	if mockService.CreateIterationCalled {
+		t.Errorf("unexpected a call to CreateIteration")
+	}
+
+	if !mockService.GetIterationCalled {
+		t.Errorf("expected a call to GetIteration but it didn't happen")
+	}
+
+	if mockService.CreateBuildCalled {
+		t.Errorf("unexpected a call to CreateBuild")
+	}
+
+	if b.Iteration.ID != "iteration-id" {
+		t.Errorf("expected an iteration to returned but it didn't")
+	}
+
+	if _, ok := b.Iteration.builds.Load("happycloud.image"); ok {
+		t.Errorf("there should be no builds as the iteration is complete")
+	}
+
+}
+
+func TestPublishBuildStatus(t *testing.T) {
+	//nolint:errcheck
+	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
+	mockService := NewMockPackerClientService()
+	mockService.BucketAlreadyExist = true
+	mockService.IterationAlreadyExist = true
+
+	b := &Bucket{
+		Slug: "TestBucket",
+		client: &Client{
+			Packer: mockService,
+		},
+	}
+
+	var err error
+	b.Iteration, err = NewIteration(IterationOptions{})
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
+
+	err = b.Initialize(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	loadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
+	if !ok {
+		t.Errorf("expected a basic build entry to be created but it didn't")
+	}
+
+	existingBuild, ok := loadedBuild.(*Build)
+	if !ok {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	}
+
+	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusUNSET {
+		t.Errorf("expected the existing build to be in the default state")
+	}
+
+	err = b.PublishBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusRUNNING)
+	if err != nil {
+		t.Errorf("unexpected failure for PublishBuildStatus: %v", err)
+	}
+
+	reloadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
+	if !ok {
+		t.Errorf("expected a basic build entry to be created but it didn't")
+	}
+
+	existingBuild, ok = reloadedBuild.(*Build)
+	if !ok {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	}
+
+	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusRUNNING {
+		t.Errorf("expected the existing build to be in the running state")
+	}
+}
+
+func TestPublishBuildStatus_DONENoImages(t *testing.T) {
+	//nolint:errcheck
+	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
+	mockService := NewMockPackerClientService()
+	mockService.BucketAlreadyExist = true
+	mockService.IterationAlreadyExist = true
+
+	b := &Bucket{
+		Slug: "TestBucket",
+		client: &Client{
+			Packer: mockService,
+		},
+	}
+
+	var err error
+	b.Iteration, err = NewIteration(IterationOptions{})
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	b.Iteration.registeredBuilds = append(b.Iteration.registeredBuilds, "happycloud.image")
+	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
+
+	err = b.Initialize(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+
+	loadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
+	if !ok {
+		t.Errorf("expected a basic build entry to be created but it didn't")
+	}
+
+	existingBuild, ok := loadedBuild.(*Build)
+	if !ok {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	}
+
+	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusUNSET {
+		t.Errorf("expected the existing build to be in the default state")
+	}
+
+	//nolint:errcheck
+	b.PublishBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusRUNNING)
+
+	err = b.PublishBuildStatus(context.TODO(), "happycloud.image", models.HashicorpCloudPackerBuildStatusDONE)
+	if err == nil {
+		t.Errorf("expected failure for PublishBuildStatus when setting status to DONE with no images")
+	}
+
+	reloadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
+	if !ok {
+		t.Errorf("expected a basic build entry to be created but it didn't")
+	}
+
+	existingBuild, ok = reloadedBuild.(*Build)
+	if !ok {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	}
+
+	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusRUNNING {
+		t.Errorf("expected the existing build to be in the running state")
+	}
+}
+
+//func (b *Bucket) PublishBuildStatus(ctx context.Context, name string, status models.HashicorpCloudPackerBuildStatus) error {}

--- a/internal/packer_registry/types.builds.go
+++ b/internal/packer_registry/types.builds.go
@@ -10,8 +10,8 @@ type Build struct {
 	CloudProvider string
 	ComponentType string
 	RunUUID       string
-	Metadata      map[string]string
-	Images        []Image
+	Labels        map[string]string
+	Images        map[string]Image
 	Status        models.HashicorpCloudPackerBuildStatus
 }
 

--- a/internal/packer_registry/types.iterations.go
+++ b/internal/packer_registry/types.iterations.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Iteration struct {
-	ID               string
-	AncestorSlug     string
-	Fingerprint      string
-	RunUUID          string
-	Labels           map[string]string
-	builds           sync.Map
-	registeredBuilds []string
+	ID             string
+	AncestorSlug   string
+	Fingerprint    string
+	RunUUID        string
+	Labels         map[string]string
+	builds         sync.Map
+	expectedBuilds []string
 }
 
 type IterationOptions struct {
@@ -26,7 +26,7 @@ type IterationOptions struct {
 // NewIteration returns a pointer to an Iteration that can be used for storing Packer build details needed by PAR.
 func NewIteration(opts IterationOptions) (*Iteration, error) {
 	i := Iteration{
-		registeredBuilds: make([]string, 0),
+		expectedBuilds: make([]string, 0),
 	}
 
 	// By default we try to load a Fingerprint from the environment variable.

--- a/internal/packer_registry/types.iterations.go
+++ b/internal/packer_registry/types.iterations.go
@@ -1,6 +1,7 @@
 package packer_registry
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -78,4 +79,57 @@ func GetGitFingerprint(opts IterationOptions) (string, error) {
 	// log.Printf("Author: %v, Commit: %v\n", c.User.Email, ref.Hash())
 
 	return ref.Hash().String(), nil
+}
+
+// AddImageToBuild appends one or more images artifacts to the build referred to by buildName.
+func (i *Iteration) AddImageToBuild(buildName string, images ...Image) error {
+	existingBuild, ok := i.builds.Load(buildName)
+	if !ok {
+		return errors.New("no build found for the name " + buildName)
+	}
+
+	build, ok := existingBuild.(*Build)
+	if !ok {
+		return fmt.Errorf("the build for the component %q does not appear to be a valid registry Build", buildName)
+	}
+
+	if build.Images == nil {
+		build.Images = make(map[string]Image)
+	}
+
+	for _, image := range images {
+		if build.CloudProvider == "" {
+			build.CloudProvider = image.ProviderName
+		}
+
+		k := fmt.Sprintf("%s.region:%s", buildName, image.ProviderRegion)
+		build.Images[k] = image
+	}
+
+	i.builds.Store(buildName, build)
+	return nil
+}
+
+// AddLabelsToBuild merges the contents of data to the labels associated with the build referred to by buildName.
+func (i *Iteration) AddLabelsToBuild(buildName string, data map[string]string) error {
+	existingBuild, ok := i.builds.Load(buildName)
+	if !ok {
+		return errors.New("no associated build found for the name " + buildName)
+	}
+
+	build, ok := existingBuild.(*Build)
+	if !ok {
+		return fmt.Errorf("the build for the component %q does not appear to be a valid registry Build", buildName)
+	}
+
+	for k, v := range data {
+		if _, ok := build.Labels[k]; ok {
+			continue
+		}
+		build.Labels[k] = v
+	}
+
+	i.builds.Store(buildName, build)
+
+	return nil
 }

--- a/packer/registry_builder.go
+++ b/packer/registry_builder.go
@@ -14,7 +14,6 @@ import (
 type RegistryBuilder struct {
 	Name                      string
 	ArtifactMetadataPublisher *packerregistry.Bucket
-
 	packersdk.Builder
 }
 
@@ -60,7 +59,7 @@ func (b *RegistryBuilder) Run(ctx context.Context, ui packersdk.Ui, hook packers
 		metadata := make(map[string]string)
 		metadata[artifact.BuilderId()] = artifact.String()
 		metadata[artifact.BuilderId()+".files"] = strings.Join(artifact.Files(), ", ")
-		err := b.ArtifactMetadataPublisher.AddBuildMetadata(b.Name, metadata)
+		err := b.ArtifactMetadataPublisher.UpdateLabelsForBuild(b.Name, metadata)
 		if err != nil {
 			log.Printf("[TRACE] failed to add build labels for %q: %s", b.Name, err)
 		}
@@ -72,7 +71,7 @@ func (b *RegistryBuilder) Run(ctx context.Context, ui packersdk.Ui, hook packers
 				m[k.(string)] = v.(string)
 			}
 			// TODO handle these error better
-			err := b.ArtifactMetadataPublisher.AddImageToBuild(b.Name, packerregistry.Image{
+			err := b.ArtifactMetadataPublisher.UpdateImageForBuild(b.Name, packerregistry.Image{
 				ProviderName:   m["ProviderName"],
 				ProviderRegion: m["ProviderRegion"],
 				ID:             m["ImageID"],
@@ -83,7 +82,7 @@ func (b *RegistryBuilder) Run(ctx context.Context, ui packersdk.Ui, hook packers
 		case []interface{}:
 			for _, d := range state {
 				d := d.(map[interface{}]interface{})
-				err := b.ArtifactMetadataPublisher.AddImageToBuild(b.Name, packerregistry.Image{
+				err := b.ArtifactMetadataPublisher.UpdateImageForBuild(b.Name, packerregistry.Image{
 					ProviderName:   d["ProviderName"].(string),
 					ProviderRegion: d["ProviderRegion"].(string),
 					ID:             d["ImageID"].(string),

--- a/packer/registry_builder.go
+++ b/packer/registry_builder.go
@@ -2,6 +2,7 @@ package packer
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -28,9 +29,9 @@ func (b *RegistryBuilder) Run(ctx context.Context, ui packersdk.Ui, hook packers
 		for {
 			select {
 			case <-ctx.Done():
-				log.Printf("[TRACE] marking build %q as cancelled in Packer registry", b.Name)
+				log.Printf("[TRACE] marking build %q as cancelled in HCP Packer registry", b.Name)
 				if err := b.ArtifactMetadataPublisher.PublishBuildStatus(context.TODO(), b.Name, models.HashicorpCloudPackerBuildStatusCANCELLED); err != nil {
-					log.Printf("[TRACE] failed to update Packer registry status for %q: %s", b.Name, err)
+					log.Printf("[TRACE] failed to update HCP Packer registry status for %q: %s", b.Name, err)
 				}
 				return
 			case <-runCompleted:
@@ -40,59 +41,55 @@ func (b *RegistryBuilder) Run(ctx context.Context, ui packersdk.Ui, hook packers
 	}()
 
 	if err := b.ArtifactMetadataPublisher.PublishBuildStatus(ctx, b.Name, models.HashicorpCloudPackerBuildStatusRUNNING); err != nil {
-		log.Printf("[TRACE] failed to update Packer registry status for %q: %s", b.Name, err)
+		log.Printf("[TRACE] failed to update HCP Packer registry status for %q: %s", b.Name, err)
 	}
 
+	ui.Say(fmt.Sprintf("Publishing build details for %s to the HCP Packer registry", b.Name))
 	artifact, err := b.Builder.Run(ctx, ui, hook)
 	if err != nil {
 		if parErr := b.ArtifactMetadataPublisher.PublishBuildStatus(ctx, b.Name, models.HashicorpCloudPackerBuildStatusFAILED); parErr != nil {
-			log.Printf("[TRACE] failed to update Packer registry status for %q: %s", b.Name, parErr)
+			log.Printf("[TRACE] failed to update HCP Packer registry status for %q: %s", b.Name, parErr)
 		}
 	}
 
 	// close chan to mark completion
 	close(runCompleted)
 
-	var artifacts []packersdk.Artifact
-	artifacts = append(artifacts, artifact)
+	// Lets post state
+	if artifact != nil {
+		metadata := make(map[string]string)
+		metadata[artifact.BuilderId()] = artifact.String()
+		metadata[artifact.BuilderId()+".files"] = strings.Join(artifact.Files(), ", ")
+		err := b.ArtifactMetadataPublisher.AddBuildMetadata(b.Name, metadata)
+		if err != nil {
+			log.Printf("[TRACE] failed to add build labels for %q: %s", b.Name, err)
+		}
 
-	for _, artifact := range artifacts {
-		// Lets post state
-		if artifact != nil {
-			metadata := make(map[string]string)
-			metadata[artifact.BuilderId()] = artifact.String()
-			metadata[artifact.BuilderId()+".files"] = strings.Join(artifact.Files(), ", ")
-			err := b.ArtifactMetadataPublisher.AddBuildMetadata(b.Name, metadata)
-			if err != nil {
-				log.Printf("[TRACE] failed to add build labels for %q: %s", b.Name, err)
+		switch state := artifact.State("par.artifact.metadata").(type) {
+		case map[interface{}]interface{}:
+			m := make(map[string]string)
+			for k, v := range state {
+				m[k.(string)] = v.(string)
 			}
-
-			switch state := artifact.State("par.artifact.metadata").(type) {
-			case map[interface{}]interface{}:
-				m := make(map[string]string)
-				for k, v := range state {
-					m[k.(string)] = v.(string)
-				}
-				// TODO handle these error better
+			// TODO handle these error better
+			err := b.ArtifactMetadataPublisher.AddImageToBuild(b.Name, packerregistry.Image{
+				ProviderName:   m["ProviderName"],
+				ProviderRegion: m["ProviderRegion"],
+				ID:             m["ImageID"],
+			})
+			if err != nil {
+				log.Printf("[TRACE] failed to add image artifact for %q: %s", b.Name, err)
+			}
+		case []interface{}:
+			for _, d := range state {
+				d := d.(map[interface{}]interface{})
 				err := b.ArtifactMetadataPublisher.AddImageToBuild(b.Name, packerregistry.Image{
-					ProviderName:   m["ProviderName"],
-					ProviderRegion: m["ProviderRegion"],
-					ID:             m["ImageID"],
+					ProviderName:   d["ProviderName"].(string),
+					ProviderRegion: d["ProviderRegion"].(string),
+					ID:             d["ImageID"].(string),
 				})
 				if err != nil {
 					log.Printf("[TRACE] failed to add image artifact for %q: %s", b.Name, err)
-				}
-			case []interface{}:
-				for _, d := range state {
-					d := d.(map[interface{}]interface{})
-					err := b.ArtifactMetadataPublisher.AddImageToBuild(b.Name, packerregistry.Image{
-						ProviderName:   d["ProviderName"].(string),
-						ProviderRegion: d["ProviderRegion"].(string),
-						ID:             d["ImageID"].(string),
-					})
-					if err != nil {
-						log.Printf("[TRACE] failed to add image artifact for %q: %s", b.Name, err)
-					}
 				}
 			}
 		}

--- a/packer/registry_builder.go
+++ b/packer/registry_builder.go
@@ -98,9 +98,5 @@ func (b *RegistryBuilder) Run(ctx context.Context, ui packersdk.Ui, hook packers
 		}
 	}
 
-	//if parErr := b.ArtifactMetadataPublisher.PublishBuildStatus(ctx, b.Name, models.HashicorpCloudPackerBuildStatusDONE); parErr != nil {
-	//log.Printf("[TRACE] failed to update Packer registry with image artifacts for %q: %s", b.Name, parErr)
-	//}
-
 	return artifact, err
 }

--- a/packer/registry_post_processor.go
+++ b/packer/registry_post_processor.go
@@ -39,7 +39,7 @@ func (p *RegistryPostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui
 	// TODO create an actual post-processor that we can embed here that will do the updating and printing.
 	if p.PostProcessor == nil {
 		if parErr := p.ArtifactMetadataPublisher.PublishBuildStatus(ctx, p.BuilderType, models.HashicorpCloudPackerBuildStatusDONE); parErr != nil {
-			return nil, true, false, fmt.Errorf("[TRACE] failed to update Packer registry with image artifacts for %q: %s", p.BuilderType, parErr)
+			return nil, false, true, fmt.Errorf("[TRACE] failed to update Packer registry with image artifacts for %q: %s", p.BuilderType, parErr)
 		}
 
 		r := &RegistryArtifact{

--- a/packer/registry_post_processor.go
+++ b/packer/registry_post_processor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
@@ -27,8 +26,6 @@ func (p *RegistryPostProcessor) ConfigSpec() hcldec.ObjectSpec {
 }
 
 func (p *RegistryPostProcessor) Configure(raws ...interface{}) error {
-	// If we have all of the Packer registry information here we can safely validate and exit
-	// if the final build is complete or has potential conflicts.
 	if p.PostProcessor == nil {
 		return nil
 	}
@@ -37,11 +34,12 @@ func (p *RegistryPostProcessor) Configure(raws ...interface{}) error {
 }
 
 func (p *RegistryPostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, source packersdk.Artifact) (packersdk.Artifact, bool, bool, error) {
-	// This is a bit of a hack for now to denote that this pp should just update the state of a build in PAR.
+	// This is a bit of a hack for now to denote that this pp should just update the state of a build in the Packer registry.
 	// TODO create an actual post-processor that we can embed here that will do the updating and printing.
 	if p.PostProcessor == nil {
-		if parErr := p.ArtifactMetadataPublisher.PublishBuildStatus(ctx, p.BuilderType, models.HashicorpCloudPackerBuildStatusDONE); parErr != nil {
-			return nil, false, true, fmt.Errorf("[TRACE] failed to update Packer registry with image artifacts for %q: %s", p.BuilderType, parErr)
+		if parErr := p.ArtifactMetadataPublisher.UpdateBuildStatus(ctx, p.BuilderType, models.HashicorpCloudPackerBuildStatusDONE); parErr != nil {
+			err := fmt.Errorf("[TRACE] failed to update Packer registry with image artifacts for %q: %s", p.BuilderType, parErr)
+			return nil, false, true, err
 		}
 
 		r := &RegistryArtifact{
@@ -55,7 +53,7 @@ func (p *RegistryPostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui
 
 	source, keep, override, err := p.PostProcessor.PostProcess(ctx, ui, source)
 	if err != nil {
-		if parErr := p.ArtifactMetadataPublisher.PublishBuildStatus(ctx, p.BuilderType, models.HashicorpCloudPackerBuildStatusFAILED); parErr != nil {
+		if parErr := p.ArtifactMetadataPublisher.UpdateBuildStatus(ctx, p.BuilderType, models.HashicorpCloudPackerBuildStatusFAILED); parErr != nil {
 			log.Printf("[TRACE] failed to update Packer registry with image artifacts for %q: %s", p.BuilderType, parErr)
 		}
 		return source, false, false, err
@@ -63,16 +61,6 @@ func (p *RegistryPostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui
 
 	// Lets post state
 	if source != nil {
-		metadata := make(map[string]string)
-		metadata[source.BuilderId()] = source.String()
-		if len(source.Files()) > 0 {
-			metadata[source.BuilderId()+".files"] = strings.Join(source.Files(), ", ")
-		}
-		err := p.ArtifactMetadataPublisher.UpdateLabelsForBuild(p.BuilderType, metadata)
-		if err != nil {
-			log.Printf("[TRACE] failed to add build labels for %q: %s", p.BuilderType, err)
-		}
-
 		switch state := source.State("par.artifact.metadata").(type) {
 		case map[interface{}]interface{}:
 			m := make(map[string]string)


### PR DESCRIPTION
This change also fixes an issue where setting DONE on a build was being allowed when the final build on the Packer Registry had no images. For now an image is required in order to set a build to DONE.

* Update RegistryPostProcessor to delete artifacts if setting DONE status fails