### PR TITLE
website: update consent manager

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1653,13 +1653,12 @@
       }
     },
     "@hashicorp/react-consent-manager": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-5.3.2.tgz",
-      "integrity": "sha512-+diaaneosC7xMjODrPusvc5g1+0THX9gePHCfkMON7EsFC0fG5R7Cjn6sssBgOQbxYe0Bbx3amDmkhMcFjdDWQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-6.0.0.tgz",
+      "integrity": "sha512-ew15fmxR+Js9W1F160r324QNxhlKjj8txmueW2Ud/qlztzKpPoOOWALDEI4nUhEUqhdVC6/M6DHlXX+J9iv6wA==",
       "requires": {
         "@hashicorp/react-button": "^5.2.1",
         "@hashicorp/react-toggle": "^3.0.2",
-        "@segment/in-eu": "^0.2.1",
         "js-cookie": "^2.2.0"
       }
     },

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
     "@hashicorp/react-alert-banner": "^6.1.2",
     "@hashicorp/react-button": "^5.2.1",
     "@hashicorp/react-command-line-terminal": "^2.0.3",
-    "@hashicorp/react-consent-manager": "^5.3.2",
+    "@hashicorp/react-consent-manager": "^6.0.0",
     "@hashicorp/react-docs-page": "^13.5.1",
     "@hashicorp/react-hashi-stack-menu": "^2.0.6",
     "@hashicorp/react-head": "^3.1.1",


### PR DESCRIPTION
Updates `react-consent-manager` to latest. HashiCorp staff: see [RFC MKTG-036](https://docs.google.com/document/d/12UIDBgpR6lilkFrxQFr7i1zTxCm04szAZkGKSSlgRkI/edit) for context.