### PR TITLE
Fix {{packer_version}} interpolation regression

### DIFF
--- a/hcl2template/testdata/build/provisioner_packer_version_interpolation.pkr.hcl
+++ b/hcl2template/testdata/build/provisioner_packer_version_interpolation.pkr.hcl
@@ -1,0 +1,15 @@
+
+// starts resources to provision them.
+build {
+    sources = [
+        "source.virtualbox-iso.ubuntu-1204",
+    ]
+
+    provisioner "shell" {
+        slice_string = ["{{packer_version}}"]
+    }
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}
+

--- a/hcl2template/types.build.post-processor.go
+++ b/hcl2template/types.build.post-processor.go
@@ -68,6 +68,7 @@ func (cfg *PackerConfig) startPostProcessor(source SourceUseBlock, pp *PostProce
 	}
 
 	builderVars := source.builderVariables()
+	builderVars["packer_core_version"] = cfg.CorePackerVersionString
 	builderVars["packer_debug"] = strconv.FormatBool(cfg.debug)
 	builderVars["packer_force"] = strconv.FormatBool(cfg.force)
 	builderVars["packer_on_error"] = cfg.onError

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -156,6 +156,7 @@ func (cfg *PackerConfig) startProvisioner(source SourceUseBlock, pb *Provisioner
 	}
 
 	builderVars := source.builderVariables()
+	builderVars["packer_core_version"] = cfg.CorePackerVersionString
 	builderVars["packer_debug"] = strconv.FormatBool(cfg.debug)
 	builderVars["packer_force"] = strconv.FormatBool(cfg.force)
 	builderVars["packer_on_error"] = cfg.onError

--- a/hcl2template/types.source.go
+++ b/hcl2template/types.source.go
@@ -128,6 +128,7 @@ func (cfg *PackerConfig) startBuilder(source SourceUseBlock, ectx *hcl.EvalConte
 	// prepare at a later step, to make builds from different template types
 	// easier to reason about.
 	builderVars := source.builderVariables()
+	builderVars["packer_core_version"] = cfg.CorePackerVersionString
 	builderVars["packer_debug"] = strconv.FormatBool(cfg.debug)
 	builderVars["packer_force"] = strconv.FormatBool(cfg.force)
 	builderVars["packer_on_error"] = cfg.onError

--- a/packer/core.go
+++ b/packer/core.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	packerregistry "github.com/hashicorp/packer/internal/packer_registry"
 	"github.com/hashicorp/packer/internal/packer_registry/env"
+	packerversion "github.com/hashicorp/packer/version"
 )
 
 // Core is the main executor of Packer. If Packer is being used as a
@@ -453,8 +454,9 @@ func (c *Core) Build(n string) (packersdk.Build, error) {
 // Context returns an interpolation context.
 func (c *Core) Context() *interpolate.Context {
 	return &interpolate.Context{
-		TemplatePath:  c.Template.Path,
-		UserVariables: c.variables,
+		TemplatePath:            c.Template.Path,
+		UserVariables:           c.variables,
+		CorePackerVersionString: packerversion.FormattedVersion(),
 	}
 }
 

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -11,6 +11,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template"
 	configHelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer/version"
 )
 
 func TestCoreBuildNames(t *testing.T) {
@@ -843,5 +844,32 @@ func TestCoreBuild_provRetry(t *testing.T) {
 	// backwards compatibility
 	if !pInt.ProvRetried {
 		t.Fatal("provisioner should retry for max_retries integer value")
+	}
+}
+
+func TestCoreBuild_packerVersion(t *testing.T) {
+	config := TestCoreConfig(t)
+	testCoreTemplate(t, config, fixtureDir("build-var-packer-version.json"))
+	b := TestBuilder(t, config, "test")
+	core := TestCore(t, config)
+
+	expected := version.FormattedVersion()
+	build, err := core.Build("test")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if _, err := build.Prepare(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	// Interpolate the config
+	var result map[string]interface{}
+	err = configHelper.Decode(&result, nil, b.PrepareConfig...)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if result["value"] != expected {
+		t.Fatalf("bad: %#v", result)
 	}
 }

--- a/packer/test-fixtures/build-var-packer-version.json
+++ b/packer/test-fixtures/build-var-packer-version.json
@@ -1,0 +1,9 @@
+{
+  "variables": {
+    "CreatedBy": "{{packer_version}}"
+  },
+    "builders": [{
+        "type": "test",
+        "value": "{{user `CreatedBy`}}"
+    }]
+}


### PR DESCRIPTION
- Add CorePackerVersionString to main context needed for variable interpolation in JSON. 

- Add packer_core_version to interpolation context for HCL configs

Closes #11052 


----

#### Tests for JSON Templates:
Test Results Before Change
```
=== RUN   TestCoreBuild_packerVersion
    testing.go:30: err: template: root:1:2: executing "root" at <packer_version>: error calling packer_version: packer_version not available
--- FAIL: TestCoreBuild_packerVersion (0.00s)
```

Test Results After Change
```
=== RUN   TestCoreBuild_packerVersion
--- PASS: TestCoreBuild_packerVersion (0.00s)
```
----
#### Tests for HCL Templates
Test Results Before Change
```
=== RUN   TestParse_build/provisioner_with_packer_version_interpolation
    common_test.go:109: Parser.getBuilds() unexpected diagnostics. testdata/build/provisioner_packer_version_interpolation.pkr.hcl:8,5-24: Failed preparing provisioner-block
 "shell" ""; render 'slice_string': template: root:1:2: executing "root" at <packer_version>: error calling packer_version: packer_version not available in:

        {{packer_version}}
--- FAIL: TestParse_build (0.01s)
```

Test Results After Change
```
--- PASS: TestParse_build (0.02s)
--- PASS: TestParse_build/provisioner_with_packer_version_interpolation (0.00s)
```

