### PR TITLE
Update plugin directory check for ci

### DIFF
--- a/acctest/plugin/plugin_acc_test.go
+++ b/acctest/plugin/plugin_acc_test.go
@@ -85,6 +85,17 @@ func cleanupPluginInstallation(plugin addrs.Plugin) error {
 		plugin.Hostname,
 		plugin.Namespace,
 		plugin.Type)
+
+	if _, ok := os.LookupEnv("CIRCLECI"); ok {
+		pluginPath = filepath.Join(home,
+			".config",
+			"packer",
+			"plugins",
+			plugin.Hostname,
+			plugin.Namespace,
+			plugin.Type)
+	}
+
 	testutils.CleanupFiles(pluginPath)
 	return nil
 }

--- a/acctest/plugin/plugin_acc_test.go
+++ b/acctest/plugin/plugin_acc_test.go
@@ -99,12 +99,24 @@ func checkPluginInstallation(initOutput string, plugin addrs.Plugin) error {
 	if err != nil {
 		return err
 	}
+
 	pluginPath := filepath.Join(home,
 		".packer.d",
 		"plugins",
 		plugin.Hostname,
 		plugin.Namespace,
 		plugin.Type)
+
+	if _, ok := os.LookupEnv("CIRCLECI"); ok {
+		pluginPath = filepath.Join(home,
+			".config",
+			"packer",
+			"plugins",
+			plugin.Hostname,
+			plugin.Namespace,
+			plugin.Type)
+	}
+
 	if !testutils.FileExists(pluginPath) {
 		return fmt.Errorf("%s plugin installation not found", plugin.String())
 	}


### PR DESCRIPTION
On CIRCLECI the default plugin direction is under `$HOME/.config/packer`
this changes updates the acctest just a bit to check if we are running
in a CIRCLECI env.
