### PR TITLE
Add environment variable precheck for datasource acceptance tests

### DIFF
--- a/datasource/hcp-packer-iteration/data_acc_test.go
+++ b/datasource/hcp-packer-iteration/data_acc_test.go
@@ -3,10 +3,16 @@ package hcp_packer_iteration
 import (
 	_ "embed"
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 
 	"github.com/hashicorp/packer-plugin-sdk/acctest"
+)
+
+const (
+	HCPClientID     string = "HCP_CLIENT_ID"
+	HCPClientSecret string = "HCP_CLIENT_SECRET"
 )
 
 //go:embed test-fixtures/template.pkr.hcl
@@ -25,6 +31,11 @@ var testDatasourceBasic string
 // as defined above.
 
 func TestAccDatasource_HCPPackerIteration(t *testing.T) {
+	if os.Getenv(HCPClientID) == "" && os.Getenv(HCPClientSecret) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless envs %q and %q are set", HCPClientID, HCPClientSecret))
+		return
+	}
+
 	testCase := &acctest.PluginTestCase{
 		Name:     "hcp_packer_iteration_datasource_basic_test",
 		Template: testDatasourceBasic,


### PR DESCRIPTION
Before change
```
=== Failed
=== FAIL: datasource/hcp-packer-iteration TestAccDatasource_HCPPackerIteration (1.97s)
    pluginacc.go:143: Error running plugin acceptance tests: Bad exit code. Logfile: packer_log_hcp_packer_iteration_datasource_basic_test.txt
        Logs can be found at /Users/wilkenrivera/Development/packer/datasource/hcp-packer-iteration/packer_log_hcp_packer_iteration_datasource_basic_test.txt
        and the acceptance test template can be found at /Users/wilkenrivera/Development/packer/datasource/hcp-packer-iteration/hcp_packer_iteration_datasource_basic_test.pkr.hcl

DONE 690 tests, 5 skipped, 1 failure in 387.912s
```

After change
```
=== SKIP: datasource/hcp-packer-iteration TestAccDatasource_HCPPackerIteration (0.00s)
    data_acc_test.go:35: Acceptance tests skipped unless envs "HCP_CLIENT_ID" and "HCP_CLIENT_SECRET" are set
```
