### PR TITLE
Unregister packer-image-iteration datasource

### DIFF
--- a/command/plugin.go
+++ b/command/plugin.go
@@ -18,7 +18,6 @@ import (
 	hcppackerimagedatasource "github.com/hashicorp/packer/datasource/hcp-packer-image"
 	hcppackeriterationdatasource "github.com/hashicorp/packer/datasource/hcp-packer-iteration"
 	nulldatasource "github.com/hashicorp/packer/datasource/null"
-	packerimageiterationdatasource "github.com/hashicorp/packer/datasource/packer-image-iteration"
 	artificepostprocessor "github.com/hashicorp/packer/post-processor/artifice"
 	checksumpostprocessor "github.com/hashicorp/packer/post-processor/checksum"
 	compresspostprocessor "github.com/hashicorp/packer/post-processor/compress"
@@ -63,10 +62,9 @@ var PostProcessors = map[string]packersdk.PostProcessor{
 }
 
 var Datasources = map[string]packersdk.Datasource{
-	"hcp-packer-image":       new(hcppackerimagedatasource.Datasource),
-	"hcp-packer-iteration":   new(hcppackeriterationdatasource.Datasource),
-	"null":                   new(nulldatasource.Datasource),
-	"packer-image-iteration": new(packerimageiterationdatasource.Datasource),
+	"hcp-packer-image":     new(hcppackerimagedatasource.Datasource),
+	"hcp-packer-iteration": new(hcppackeriterationdatasource.Datasource),
+	"null":                 new(nulldatasource.Datasource),
 }
 
 var pluginRegexp = regexp.MustCompile("packer-(builder|post-processor|provisioner|datasource)-(.+)")

--- a/datasource/packer-image-iteration/data.go
+++ b/datasource/packer-image-iteration/data.go
@@ -18,7 +18,10 @@ import (
 	packerregistry "github.com/hashicorp/packer/internal/registry"
 )
 
-type Datasource struct {
+// Type for Packer datasource has been renamed temporarily to prevent it from being
+// automatically registered as a viable datasource plugin in command/plugin.go.
+// In the future this type will be renamed to allow for the use of the datasource.
+type DeactivatedDatasource struct {
 	config Config
 }
 
@@ -32,11 +35,11 @@ type Config struct {
 	// TODO: Label          string `mapstructure:"label"`
 }
 
-func (d *Datasource) ConfigSpec() hcldec.ObjectSpec {
+func (d *DeactivatedDatasource) ConfigSpec() hcldec.ObjectSpec {
 	return d.config.FlatMapstructure().HCL2Spec()
 }
 
-func (d *Datasource) Configure(raws ...interface{}) error {
+func (d *DeactivatedDatasource) Configure(raws ...interface{}) error {
 	err := config.Decode(&d.config, nil, raws...)
 	if err != nil {
 		return err
@@ -125,11 +128,11 @@ type DatasourceOutput struct {
 	Builds []ParBuild `mapstructure:"builds"`
 }
 
-func (d *Datasource) OutputSpec() hcldec.ObjectSpec {
+func (d *DeactivatedDatasource) OutputSpec() hcldec.ObjectSpec {
 	return (&DatasourceOutput{}).FlatMapstructure().HCL2Spec()
 }
 
-func (d *Datasource) Execute() (cty.Value, error) {
+func (d *DeactivatedDatasource) Execute() (cty.Value, error) {
 	cli, err := packerregistry.NewClient()
 	if err != nil {
 		return cty.NullVal(cty.EmptyObject), err


### PR DESCRIPTION
This change temporarily renames the type of the packer-image-iteration
datasource to prevent it from being automatically registered by the
Packer plugin tooling. The datasource is fully functional, but not quite
ready for full usage. It will be updated in a future release.
