### PR TITLE
hcp packer registry doc changes

### DIFF
--- a/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -22,7 +22,7 @@ source "file" "basic-example" {
 
 build {
    hcp_packer_registry {
-    slug = "sample-artifact"
+    bucket_name = "sample-artifact"
 
     description = <<EOT
 Some nice description about the image which artifact is being published to HCP Packer Registry. =D
@@ -38,7 +38,7 @@ Some nice description about the image which artifact is being published to HCP P
 }
 ```
 
-- `slug` (string) - The image name when published to the HCP Packer registry. Should always be the same, otherwise a new image will be created.
+- `bucket_name` (string) - The image name when published to the HCP Packer registry. Should always be the same, otherwise a new image will be created.
   Defaults to `build.name` if not set. Will be overwritten if `HCP_PACKER_BUCKET_NAME` is set.
 
 - `description` (string) - The image description. Useful to provide a summary about the image. The description will appear

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -76,10 +76,6 @@
                     "path": "templates/hcl_templates/blocks/build"
                   },
                   {
-                    "title": "<code>hcp_packer_registry</code>",
-                    "path": "templates/hcl_templates/blocks/build/hcp_packer_registry"
-                  },
-                  {
                     "title": "<code>source</code>",
                     "path": "templates/hcl_templates/blocks/build/source"
                   },


### PR DESCRIPTION
- Rename slug to bucket_name
- Temporarily remove hcp_packer_registry docs until out of internal beta
