### PR TITLE
Correct syntax of sources in only/except docs

### DIFF
--- a/website/content/docs/templates/hcl_templates/onlyexcept.mdx
+++ b/website/content/docs/templates/hcl_templates/onlyexcept.mdx
@@ -21,7 +21,7 @@ post-processors for a specific source:
 ```hcl
 build {
   name = "my_build"
-  sources [
+  sources = [
     "source.amazon-ebs.first-example",
   ]
   source "source.amazon-ebs.second-example"
@@ -43,7 +43,7 @@ build {
 }
 
 build {
-  sources [
+  sources = [
     "source.amazon-ebs.third-example",
   ]
 }


### PR DESCRIPTION
Trying to use `sources` without an equals sign produces this error:

```
   2:     sources [

An argument or block definition is required here. To set an argument, use the
equals sign "=" to introduce the argument value.
```

Adding an equals sign in the obvious place fixes the syntax error.

I've checked across the rest of the repository, and no other files contain
the string `sources [`.