### PR TITLE
Partifact source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -265,3 +265,7 @@ require (
 )
 
 go 1.17
+
+replace github.com/hashicorp/packer-plugin-sdk => /Users/mmarsh/Projects/packer-plugin-sdk
+
+replace github.com/hashicorp/hcp-sdk-go => /Users/mmarsh/go/src/github.com/hashicorp/hcp-sdk-go

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.10.1
-	github.com/hashicorp/hcp-sdk-go v0.10.1-0.20210727200019-239ce8d80646
+	github.com/hashicorp/hcp-sdk-go v0.13.1-0.20211004174420-0f36fadb8a34
 	github.com/hashicorp/packer-plugin-alicloud v1.0.0
 	github.com/hashicorp/packer-plugin-amazon v1.0.1
 	github.com/hashicorp/packer-plugin-ansible v1.0.0
@@ -64,7 +64,7 @@ require (
 	github.com/hashicorp/packer-plugin-puppet v1.0.0
 	github.com/hashicorp/packer-plugin-qemu v1.0.0
 	github.com/hashicorp/packer-plugin-salt v0.0.8
-	github.com/hashicorp/packer-plugin-sdk v0.2.5
+	github.com/hashicorp/packer-plugin-sdk v0.2.6
 	github.com/hashicorp/packer-plugin-tencentcloud v1.0.1
 	github.com/hashicorp/packer-plugin-triton v1.0.0
 	github.com/hashicorp/packer-plugin-ucloud v1.0.0
@@ -265,7 +265,3 @@ require (
 )
 
 go 1.17
-
-replace github.com/hashicorp/packer-plugin-sdk => /Users/mmarsh/Projects/packer-plugin-sdk
-
-replace github.com/hashicorp/hcp-sdk-go => /Users/mmarsh/go/src/github.com/hashicorp/hcp-sdk-go

--- a/go.sum
+++ b/go.sum
@@ -588,7 +588,6 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/shlex v0.0.0-20150127133951-6f45313302b9/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v0.0.0-20170306145142-6a5e28554805/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -709,8 +708,6 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
-github.com/hashicorp/hcp-sdk-go v0.10.1-0.20210727200019-239ce8d80646 h1:4WbtYgGIxeRrGC0hGBtOi6XuJ23024H7r724rCL+eXI=
-github.com/hashicorp/hcp-sdk-go v0.10.1-0.20210727200019-239ce8d80646/go.mod h1:Tm9BAlTkp6jknZ0YNxF/556JBC/meCN1LUmWFN38HsU=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=
@@ -775,11 +772,6 @@ github.com/hashicorp/packer-plugin-qemu v1.0.0 h1:EiWFadbgahXzY15a6G1BJ49wsmqVYQ
 github.com/hashicorp/packer-plugin-qemu v1.0.0/go.mod h1:U+IMWD5NjkCBNQIzttMPOQp+9Xzi4q/atkUJs2Nfv4s=
 github.com/hashicorp/packer-plugin-salt v0.0.8 h1:npF2bukm0qFdUcZ11K4aZPu0zlUXdi24cbmZrHTSvdY=
 github.com/hashicorp/packer-plugin-salt v0.0.8/go.mod h1:KEMBCXLWT4U7CQ0TggCfLww/ci6QyjvZlUSPpadKT6M=
-github.com/hashicorp/packer-plugin-sdk v0.2.2/go.mod h1:MAOhxLneNh27t6N6SMyRcIR5qSE86e6yYCcEfRScwIE=
-github.com/hashicorp/packer-plugin-sdk v0.2.3/go.mod h1:MAOhxLneNh27t6N6SMyRcIR5qSE86e6yYCcEfRScwIE=
-github.com/hashicorp/packer-plugin-sdk v0.2.4/go.mod h1:g24hx1lY+/ancDs4vGNo+o0V4YCzZW4o2jzZ7LEXyII=
-github.com/hashicorp/packer-plugin-sdk v0.2.5 h1:qydxm7rbyUuUvvh2rxTZjur8kG5JQNGtpOifS4Xv1BY=
-github.com/hashicorp/packer-plugin-sdk v0.2.5/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.1 h1:gqFHT79OjQT/xAtEL/BEBDPulFlSqoy6Zj74WZbymr0=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.1/go.mod h1:X3O5Sq7/6TQXaeJXxqqJyTEgrfwQM+gUFU/Sd7J9p9o=
 github.com/hashicorp/packer-plugin-triton v1.0.0 h1:Uvh8fjEKqlii61BzIt1VEgSyJXL+UYfuMHCj44aVpU8=
@@ -820,6 +812,7 @@ github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hyperonecom/h1-client-go v0.0.0-20191203060043-b46280e4c4a4 h1:mSmyzhwBeQt2TlHbsXYLona9pwjWAvYGwQJ2Cq/k3VE=
 github.com/hyperonecom/h1-client-go v0.0.0-20191203060043-b46280e4c4a4/go.mod h1:yNUVHSleURKSaYUKq4Wx0i/vjCen2aq7CvPyHd/Vj2Q=
+github.com/iancoleman/strcase v0.1.3/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/go.sum
+++ b/go.sum
@@ -588,6 +588,7 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20150127133951-6f45313302b9/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v0.0.0-20170306145142-6a5e28554805/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -708,6 +709,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
+github.com/hashicorp/hcp-sdk-go v0.13.1-0.20211004174420-0f36fadb8a34 h1:Zsp79OtAdC+JTsHnbZtAtNihM/jzbDhT09kMYpVrznk=
+github.com/hashicorp/hcp-sdk-go v0.13.1-0.20211004174420-0f36fadb8a34/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=
@@ -772,6 +775,12 @@ github.com/hashicorp/packer-plugin-qemu v1.0.0 h1:EiWFadbgahXzY15a6G1BJ49wsmqVYQ
 github.com/hashicorp/packer-plugin-qemu v1.0.0/go.mod h1:U+IMWD5NjkCBNQIzttMPOQp+9Xzi4q/atkUJs2Nfv4s=
 github.com/hashicorp/packer-plugin-salt v0.0.8 h1:npF2bukm0qFdUcZ11K4aZPu0zlUXdi24cbmZrHTSvdY=
 github.com/hashicorp/packer-plugin-salt v0.0.8/go.mod h1:KEMBCXLWT4U7CQ0TggCfLww/ci6QyjvZlUSPpadKT6M=
+github.com/hashicorp/packer-plugin-sdk v0.2.2/go.mod h1:MAOhxLneNh27t6N6SMyRcIR5qSE86e6yYCcEfRScwIE=
+github.com/hashicorp/packer-plugin-sdk v0.2.3/go.mod h1:MAOhxLneNh27t6N6SMyRcIR5qSE86e6yYCcEfRScwIE=
+github.com/hashicorp/packer-plugin-sdk v0.2.4/go.mod h1:g24hx1lY+/ancDs4vGNo+o0V4YCzZW4o2jzZ7LEXyII=
+github.com/hashicorp/packer-plugin-sdk v0.2.5/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
+github.com/hashicorp/packer-plugin-sdk v0.2.6 h1:/v6NODvwDC5XKbF/A6/WQrRmUoPLy70Uu+IGSSklfOc=
+github.com/hashicorp/packer-plugin-sdk v0.2.6/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.1 h1:gqFHT79OjQT/xAtEL/BEBDPulFlSqoy6Zj74WZbymr0=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.1/go.mod h1:X3O5Sq7/6TQXaeJXxqqJyTEgrfwQM+gUFU/Sd7J9p9o=
 github.com/hashicorp/packer-plugin-triton v1.0.0 h1:Uvh8fjEKqlii61BzIt1VEgSyJXL+UYfuMHCj44aVpU8=

--- a/internal/registry/mock_service.go
+++ b/internal/registry/mock_service.go
@@ -75,6 +75,7 @@ func (svc *MockPackerClientService) CreateBucket(params *packerSvc.PackerService
 
 	svc.CreateBucketCalled = true
 	svc.CreateBucketResp.Bucket.Slug = params.Body.BucketSlug
+	svc.CreateBucketResp.Bucket.ID = "01FGYZEH6VV1HFS14YRNBW78G8"
 
 	ok := &packerSvc.PackerServiceCreateBucketOK{
 		Payload: svc.CreateBucketResp,

--- a/internal/registry/mock_service.go
+++ b/internal/registry/mock_service.go
@@ -64,18 +64,21 @@ func NewMockPackerClientService() *MockPackerClientService {
 	return &m
 }
 
-func (svc *MockPackerClientService) CreateBucket(params *packerSvc.PackerServiceCreateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateBucketOK, error) {
+func (svc *MockPackerClientService) PackerServiceCreateBucket(params *packerSvc.PackerServiceCreateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateBucketOK, error) {
 	if svc.BucketAlreadyExist {
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.AlreadyExists, codes.AlreadyExists.String()))
 	}
 
+	if params.Body == nil {
+		return nil, errors.New("No body provided.")
+	}
 	if params.Body.BucketSlug == "" {
 		return nil, errors.New("No bucket slug was passed in")
 	}
 
 	svc.CreateBucketCalled = true
+	// This is set in NewMockPackerClientService()
 	svc.CreateBucketResp.Bucket.Slug = params.Body.BucketSlug
-	svc.CreateBucketResp.Bucket.ID = "01FGYZEH6VV1HFS14YRNBW78G8"
 
 	ok := &packerSvc.PackerServiceCreateBucketOK{
 		Payload: svc.CreateBucketResp,
@@ -84,13 +87,13 @@ func (svc *MockPackerClientService) CreateBucket(params *packerSvc.PackerService
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) UpdateBucket(params *packerSvc.PackerServiceUpdateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceUpdateBucketOK, error) {
+func (svc *MockPackerClientService) PackerServiceUpdateBucket(params *packerSvc.PackerServiceUpdateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceUpdateBucketOK, error) {
 	svc.UpdateBucketCalled = true
 
 	return packerSvc.NewPackerServiceUpdateBucketOK(), nil
 }
 
-func (svc *MockPackerClientService) CreateIteration(params *packerSvc.PackerServiceCreateIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateIterationOK, error) {
+func (svc *MockPackerClientService) PackerServiceCreateIteration(params *packerSvc.PackerServiceCreateIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateIterationOK, error) {
 	if svc.IterationAlreadyExist {
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.AlreadyExists, codes.AlreadyExists.String()))
 	}
@@ -114,7 +117,7 @@ func (svc *MockPackerClientService) CreateIteration(params *packerSvc.PackerServ
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) GetIteration(params *packerSvc.PackerServiceGetIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceGetIterationOK, error) {
+func (svc *MockPackerClientService) PackerServiceGetIteration(params *packerSvc.PackerServiceGetIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceGetIterationOK, error) {
 	if !svc.IterationAlreadyExist {
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.Aborted, codes.Aborted.String()))
 	}
@@ -150,7 +153,7 @@ func (svc *MockPackerClientService) GetIteration(params *packerSvc.PackerService
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) CreateBuild(params *packerSvc.PackerServiceCreateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateBuildOK, error) {
+func (svc *MockPackerClientService) PackerServiceCreateBuild(params *packerSvc.PackerServiceCreateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateBuildOK, error) {
 	if params.Body.BucketSlug == "" {
 		return nil, errors.New("No valid BucketSlug was passed in")
 	}
@@ -174,7 +177,7 @@ func (svc *MockPackerClientService) CreateBuild(params *packerSvc.PackerServiceC
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) UpdateBuild(params *packerSvc.PackerServiceUpdateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceUpdateBuildOK, error) {
+func (svc *MockPackerClientService) PackerServiceUpdateBuild(params *packerSvc.PackerServiceUpdateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceUpdateBuildOK, error) {
 	if params.Body.BuildID == "" {
 		return nil, errors.New("No valid BuildID was passed in")
 	}
@@ -197,7 +200,7 @@ func (svc *MockPackerClientService) UpdateBuild(params *packerSvc.PackerServiceU
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) ListBuilds(params *packerSvc.PackerServiceListBuildsParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceListBuildsOK, error) {
+func (svc *MockPackerClientService) PackerServiceListBuilds(params *packerSvc.PackerServiceListBuildsParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceListBuildsOK, error) {
 
 	status := models.HashicorpCloudPackerBuildStatusUNSET
 	images := make([]*models.HashicorpCloudPackerImage, 0)

--- a/internal/registry/mock_service.go
+++ b/internal/registry/mock_service.go
@@ -64,7 +64,7 @@ func NewMockPackerClientService() *MockPackerClientService {
 	return &m
 }
 
-func (svc *MockPackerClientService) CreateBucket(params *packerSvc.CreateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.CreateBucketOK, error) {
+func (svc *MockPackerClientService) CreateBucket(params *packerSvc.PackerServiceCreateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateBucketOK, error) {
 	if svc.BucketAlreadyExist {
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.AlreadyExists, codes.AlreadyExists.String()))
 	}
@@ -76,20 +76,20 @@ func (svc *MockPackerClientService) CreateBucket(params *packerSvc.CreateBucketP
 	svc.CreateBucketCalled = true
 	svc.CreateBucketResp.Bucket.Slug = params.Body.BucketSlug
 
-	ok := &packerSvc.CreateBucketOK{
+	ok := &packerSvc.PackerServiceCreateBucketOK{
 		Payload: svc.CreateBucketResp,
 	}
 
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) UpdateBucket(params *packerSvc.UpdateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.UpdateBucketOK, error) {
+func (svc *MockPackerClientService) UpdateBucket(params *packerSvc.PackerServiceUpdateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceUpdateBucketOK, error) {
 	svc.UpdateBucketCalled = true
 
-	return packerSvc.NewUpdateBucketOK(), nil
+	return packerSvc.NewPackerServiceUpdateBucketOK(), nil
 }
 
-func (svc *MockPackerClientService) CreateIteration(params *packerSvc.CreateIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.CreateIterationOK, error) {
+func (svc *MockPackerClientService) CreateIteration(params *packerSvc.PackerServiceCreateIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateIterationOK, error) {
 	if svc.IterationAlreadyExist {
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.AlreadyExists, codes.AlreadyExists.String()))
 	}
@@ -106,14 +106,14 @@ func (svc *MockPackerClientService) CreateIteration(params *packerSvc.CreateIter
 	svc.CreateIterationResp.Iteration.BucketSlug = params.Body.BucketSlug
 	svc.CreateIterationResp.Iteration.Fingerprint = params.Body.Fingerprint
 
-	ok := &packerSvc.CreateIterationOK{
+	ok := &packerSvc.PackerServiceCreateIterationOK{
 		Payload: svc.CreateIterationResp,
 	}
 
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) GetIteration(params *packerSvc.GetIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.GetIterationOK, error) {
+func (svc *MockPackerClientService) GetIteration(params *packerSvc.PackerServiceGetIterationParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceGetIterationOK, error) {
 	if !svc.IterationAlreadyExist {
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.Aborted, codes.Aborted.String()))
 	}
@@ -129,7 +129,7 @@ func (svc *MockPackerClientService) GetIteration(params *packerSvc.GetIterationP
 	svc.GetIterationCalled = true
 
 	//
-	ok := &packerSvc.GetIterationOK{
+	ok := &packerSvc.PackerServiceGetIterationOK{
 		Payload: svc.GetIterationResp,
 	}
 
@@ -149,7 +149,7 @@ func (svc *MockPackerClientService) GetIteration(params *packerSvc.GetIterationP
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) CreateBuild(params *packerSvc.CreateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.CreateBuildOK, error) {
+func (svc *MockPackerClientService) CreateBuild(params *packerSvc.PackerServiceCreateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateBuildOK, error) {
 	if params.Body.BucketSlug == "" {
 		return nil, errors.New("No valid BucketSlug was passed in")
 	}
@@ -165,15 +165,15 @@ func (svc *MockPackerClientService) CreateBuild(params *packerSvc.CreateBuildPar
 	svc.CreateBuildCalled = true
 
 	svc.CreateBuildResp.Build.ComponentType = params.Body.Build.ComponentType
-	svc.CreateBuildResp.Build.IterationID = params.BuildIterationID
+	svc.CreateBuildResp.Build.IterationID = params.IterationID
 
-	ok := packerSvc.NewCreateBuildOK()
+	ok := packerSvc.NewPackerServiceCreateBuildOK()
 	ok.Payload = svc.CreateBuildResp
 
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) UpdateBuild(params *packerSvc.UpdateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.UpdateBuildOK, error) {
+func (svc *MockPackerClientService) UpdateBuild(params *packerSvc.PackerServiceUpdateBuildParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceUpdateBuildOK, error) {
 	if params.Body.BuildID == "" {
 		return nil, errors.New("No valid BuildID was passed in")
 	}
@@ -187,7 +187,7 @@ func (svc *MockPackerClientService) UpdateBuild(params *packerSvc.UpdateBuildPar
 	}
 
 	svc.UpdateBuildCalled = true
-	ok := packerSvc.NewUpdateBuildOK()
+	ok := packerSvc.NewPackerServiceUpdateBuildOK()
 	ok.Payload = &models.HashicorpCloudPackerUpdateBuildResponse{
 		Build: &models.HashicorpCloudPackerBuild{
 			ID: params.Body.BuildID,
@@ -196,7 +196,7 @@ func (svc *MockPackerClientService) UpdateBuild(params *packerSvc.UpdateBuildPar
 	return ok, nil
 }
 
-func (svc *MockPackerClientService) ListBuilds(params *packerSvc.ListBuildsParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.ListBuildsOK, error) {
+func (svc *MockPackerClientService) ListBuilds(params *packerSvc.PackerServiceListBuildsParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceListBuildsOK, error) {
 
 	status := models.HashicorpCloudPackerBuildStatusUNSET
 	images := make([]*models.HashicorpCloudPackerImage, 0)
@@ -215,7 +215,7 @@ func (svc *MockPackerClientService) ListBuilds(params *packerSvc.ListBuildsParam
 		})
 	}
 
-	ok := packerSvc.NewListBuildsOK()
+	ok := packerSvc.NewPackerServiceListBuildsOK()
 	ok.Payload = &models.HashicorpCloudPackerListBuildsResponse{
 		Builds: builds,
 	}

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -13,12 +13,12 @@ import (
 // CreateBucket creates a bucket on a HCP Packer Registry.
 func CreateBucket(ctx context.Context, client *Client, input *models.HashicorpCloudPackerCreateBucketRequest) (string, error) {
 
-	params := packerSvc.NewCreateBucketParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceCreateBucketParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
 	params.Body = input
 
-	resp, err := client.Packer.CreateBucket(params, nil)
+	resp, err := client.Packer.PackerServiceCreateBucket(params, nil)
 	if err != nil {
 		return "", err
 	}
@@ -40,7 +40,7 @@ func UpsertBucket(ctx context.Context, client *Client, input *models.HashicorpCl
 		return nil
 	}
 
-	params := packerSvc.NewUpdateBucketParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceUpdateBucketParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
 	params.BucketSlug = input.BucketSlug
@@ -48,20 +48,20 @@ func UpsertBucket(ctx context.Context, client *Client, input *models.HashicorpCl
 		Description: input.Description,
 		Labels:      input.Labels,
 	}
-	_, err = client.Packer.UpdateBucket(params, nil)
+	_, err = client.Packer.PackerServiceUpdateBucket(params, nil)
 
 	return err
 }
 
 // CreateIteration creates an Iteration for some Bucket on a HCP Packer Registry.
 func CreateIteration(ctx context.Context, client *Client, input *models.HashicorpCloudPackerCreateIterationRequest) (*models.HashicorpCloudPackerIteration, error) {
-	params := packerSvc.NewCreateIterationParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceCreateIterationParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
 	params.BucketSlug = input.BucketSlug
 	params.Body = input
 
-	it, err := client.Packer.CreateIteration(params, nil)
+	it, err := client.Packer.PackerServiceCreateIteration(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func CreateIteration(ctx context.Context, client *Client, input *models.Hashicor
 
 // GetIteration queries the HCP Packer registry for an existing bucket iteration.
 func GetIteration(ctx context.Context, client *Client, bucketslug string, fingerprint string) (*models.HashicorpCloudPackerIteration, error) {
-	params := packerSvc.NewGetIterationParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceGetIterationParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
 	params.BucketSlug = bucketslug
@@ -80,7 +80,7 @@ func GetIteration(ctx context.Context, client *Client, bucketslug string, finger
 	// for now, we only care about fingerprint so we're hardcoding it.
 	params.Fingerprint = &fingerprint
 
-	it, err := client.Packer.GetIteration(params, nil)
+	it, err := client.Packer.PackerServiceGetIteration(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -90,14 +90,14 @@ func GetIteration(ctx context.Context, client *Client, bucketslug string, finger
 
 // CreateBuild create a build entry to track for the IterationID and BucketSlug defined within input.
 func CreateBuild(ctx context.Context, client *Client, input *models.HashicorpCloudPackerCreateBuildRequest) (string, error) {
-	params := packerSvc.NewCreateBuildParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceCreateBuildParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
+	params.IterationID = input.IterationID
 	params.BucketSlug = input.BucketSlug
-	params.BuildIterationID = input.Build.IterationID
 	params.Body = input
 
-	resp, err := client.Packer.CreateBuild(params, nil)
+	resp, err := client.Packer.PackerServiceCreateBuild(params, nil)
 	if err != nil {
 		return "", err
 	}
@@ -108,13 +108,13 @@ func CreateBuild(ctx context.Context, client *Client, input *models.HashicorpClo
 // ListBuilds queries an Iteration on HCP Packer registry for all of it's associated builds.
 // Currently all builds are returned regardless of status.
 func ListBuilds(ctx context.Context, client *Client, bucketSlug string, iterationID string) ([]*models.HashicorpCloudPackerBuild, error) {
-	params := packerSvc.NewListBuildsParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceListBuildsParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
 	params.BucketSlug = bucketSlug
 	params.IterationID = iterationID
 
-	resp, err := client.Packer.ListBuilds(params, nil)
+	resp, err := client.Packer.PackerServiceListBuilds(params, nil)
 	if err != nil {
 		return []*models.HashicorpCloudPackerBuild{}, err
 	}
@@ -124,13 +124,13 @@ func ListBuilds(ctx context.Context, client *Client, bucketSlug string, iteratio
 
 // UpdateBuild updates a single iteration build entry with the incoming input data.
 func UpdateBuild(ctx context.Context, client *Client, input *models.HashicorpCloudPackerUpdateBuildRequest) (string, error) {
-	params := packerSvc.NewUpdateBuildParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceUpdateBuildParamsWithContext(ctx)
 	params.BuildID = input.BuildID
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
 	params.Body = input
 
-	resp, err := client.Packer.UpdateBuild(params, nil)
+	resp, err := client.Packer.PackerServiceUpdateBuild(params, nil)
 	if err != nil {
 		return "", err
 	}
@@ -145,13 +145,13 @@ func UpdateBuild(ctx context.Context, client *Client, input *models.HashicorpClo
 // GetChannel loads the iterationId associated with a current channel. If
 // the channel does not exist in HCP Packer, GetChannel returns an error.
 func GetIterationFromChannel(ctx context.Context, client *Client, bucketSlug string, channelName string) (*models.HashicorpCloudPackerIteration, error) {
-	params := packerSvc.NewGetChannelParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceGetChannelParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
 	params.BucketSlug = bucketSlug
 	params.Slug = channelName
 
-	resp, err := client.Packer.GetChannel(params, nil)
+	resp, err := client.Packer.PackerServiceGetChannel(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func GetIterationFromChannel(ctx context.Context, client *Client, bucketSlug str
 
 // GetIteration queries the HCP Packer registry for an existing bucket iteration.
 func GetIterationFromId(ctx context.Context, client *Client, bucketslug string, iterationId string) (*models.HashicorpCloudPackerIteration, error) {
-	params := packerSvc.NewGetIterationParamsWithContext(ctx)
+	params := packerSvc.NewPackerServiceGetIterationParamsWithContext(ctx)
 	params.LocationOrganizationID = client.OrganizationID
 	params.LocationProjectID = client.ProjectID
 	params.BucketSlug = bucketslug
@@ -181,7 +181,7 @@ func GetIterationFromId(ctx context.Context, client *Client, bucketslug string, 
 	// for now, we only care about fingerprint so we're hardcoding it.
 	params.IterationID = &iterationId
 
-	it, err := client.Packer.GetIteration(params, nil)
+	it, err := client.Packer.PackerServiceGetIteration(params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -109,9 +109,9 @@ func (b *Bucket) CreateInitialBuildForIteration(ctx context.Context, componentTy
 	buildInput := &models.HashicorpCloudPackerCreateBuildRequest{
 		BucketSlug:  b.Slug,
 		Fingerprint: b.Iteration.Fingerprint,
-		Build: &models.HashicorpCloudPackerBuild{
+		IterationID: b.Iteration.ID,
+		Build: &models.HashicorpCloudPackerBuildCreateBody{
 			ComponentType: componentType,
-			IterationID:   b.Iteration.ID,
 			PackerRunUUID: b.Iteration.RunUUID,
 			Status:        status,
 		},
@@ -215,12 +215,12 @@ func (b *Bucket) markBuildComplete(ctx context.Context, name string) error {
 	}
 
 	var providerName string
-	images := make([]*models.HashicorpCloudPackerImage, 0, len(buildToUpdate.Images))
+	images := make([]*models.HashicorpCloudPackerImageCreateBody, 0, len(buildToUpdate.Images))
 	for _, image := range buildToUpdate.Images {
 		if providerName == "" {
 			providerName = image.ProviderName
 		}
-		images = append(images, &models.HashicorpCloudPackerImage{ImageID: image.ImageID, Region: image.ProviderRegion})
+		images = append(images, &models.HashicorpCloudPackerImageCreateBody{ImageID: image.ImageID, Region: image.ProviderRegion})
 	}
 
 	buildInput.Updates.CloudProvider = providerName

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -104,7 +104,6 @@ func (b *Bucket) RegisterBuildForComponent(sourceName string) {
 // CreateInitialBuildForIteration will create a build entry on the HCP Packer Registry for the named componentType.
 // This initial creation is needed so that Packer can properly track when an iteration is complete.
 func (b *Bucket) CreateInitialBuildForIteration(ctx context.Context, componentType string) error {
-
 	status := models.HashicorpCloudPackerBuildStatusUNSET
 	buildInput := &models.HashicorpCloudPackerCreateBuildRequest{
 		BucketSlug:  b.Slug,
@@ -214,16 +213,23 @@ func (b *Bucket) markBuildComplete(ctx context.Context, name string) error {
 		return fmt.Errorf("setting a build to DONE with no published images is not currently supported.")
 	}
 
-	var providerName string
+	var providerName, sourceID string
 	images := make([]*models.HashicorpCloudPackerImageCreateBody, 0, len(buildToUpdate.Images))
 	for _, image := range buildToUpdate.Images {
+		// These values will always be the same for all images in a single build,
+		// so we can just set it inside the loop without consequence
 		if providerName == "" {
 			providerName = image.ProviderName
 		}
+		if image.SourceImageID != "" {
+			sourceID = image.SourceImageID
+		}
+
 		images = append(images, &models.HashicorpCloudPackerImageCreateBody{ImageID: image.ImageID, Region: image.ProviderRegion})
 	}
 
 	buildInput.Updates.CloudProvider = providerName
+	buildInput.Updates.SourceImageID = sourceID
 	buildInput.Updates.Images = images
 
 	_, err := UpdateBuild(ctx, b.client, buildInput)


### PR DESCRIPTION
**DELETE THIS TEMPLATE BEFORE SUBMITTING**

This PR updates the HCP sdk to use the regenerated sdk name. It looks like a bigger change than it is. 

It also updates the packer plugin sdk, allowing us to set the "source" field on the PARtifact. This will enable the HCP Packer registry to track image ancestry. 
