### PR TITLE
update debugging info for cloud-init

### DIFF
--- a/website/content/docs/debugging.mdx
+++ b/website/content/docs/debugging.mdx
@@ -116,7 +116,7 @@ AMI.
 {
   "type": "shell",
   "inline": [
-    "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done"
+    "cloud-init status --wait"
   ]
 }
 ```


### PR DESCRIPTION
Modify example showing how to wait for cloud-init to finish, using `cloud-init status --wait`.
Should be compatible with all moderately recent cloud-init versions. Though sadly the *cloud-init* changelog does not tell when it was introduced.
