### PR TITLE
fix source accessor to allow use in source block

### DIFF
--- a/hcl2template/testdata/complete/sources.pkr.hcl
+++ b/hcl2template/testdata/complete/sources.pkr.hcl
@@ -13,7 +13,7 @@ source "amazon-ebs" "ubuntu-1604" {
 }
 
 source "virtualbox-iso" "ubuntu-1204" {
-    string   = "string"
+    string   = "${source.name}-${source.type}"
     int      = 42
     int64    = 43
     bool     = true

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -3,9 +3,11 @@ package hcl2template
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-version"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer/hcl2template/addrs"
 	. "github.com/hashicorp/packer/hcl2template/internal"
 	hcl2template "github.com/hashicorp/packer/hcl2template/internal"
@@ -204,7 +206,39 @@ func TestParser_complete(t *testing.T) {
 				&packer.CoreBuild{
 					Type:     "virtualbox-iso.ubuntu-1204",
 					Prepared: true,
-					Builder:  basicMockBuilder,
+					Builder: &MockBuilder{
+						Config: MockConfig{
+							NestedMockConfig: NestedMockConfig{
+								// interpolates source and type in builder
+								String:   "ubuntu-1204-virtualbox-iso",
+								Int:      42,
+								Int64:    43,
+								Bool:     true,
+								Trilean:  config.TriTrue,
+								Duration: 10 * time.Second,
+								MapStringString: map[string]string{
+									"a": "b",
+									"c": "d",
+								},
+								SliceString: []string{
+									"a",
+									"b",
+									"c",
+								},
+								SliceSliceString: [][]string{
+									{"a", "b"},
+									{"c", "d"},
+								},
+								Tags:       []MockTag{},
+								Datasource: "string",
+							},
+							Nested: builderBasicNestedMockConfig,
+							NestedSlice: []NestedMockConfig{
+								builderBasicNestedMockConfig,
+								builderBasicNestedMockConfig,
+							},
+						},
+					},
 					Provisioners: []packer.CoreBuildProvisioner{
 						{
 							PType: "shell",

--- a/hcl2template/types.source.go
+++ b/hcl2template/types.source.go
@@ -111,10 +111,7 @@ func (cfg *PackerConfig) startBuilder(source SourceUseBlock, ectx *hcl.EvalConte
 
 	body := source.Body
 	// Add known values to source accessor in eval context.
-	ectx.Variables[sourcesAccessor] = cty.ObjectVal(map[string]cty.Value{
-		"type": cty.StringVal(source.Type),
-		"name": cty.StringVal(source.Name),
-	})
+	ectx.Variables[sourcesAccessor] = cty.ObjectVal(source.ctyValues())
 
 	decoded, moreDiags := decodeHCL2Spec(body, ectx, builder)
 	diags = append(diags, moreDiags...)


### PR DESCRIPTION
Makes sure that the source name and type are part of the eval context for builds; this allows you to use source.type and source.

Test func: 

```
source "amazon-ebs" "cannonical-ubuntu-server" {
// ...
  run_volume_tags = {
    builder-type-hcl = source.type
    builder-name-hcl = source.name
  }
}
```

Before: 

```
==> vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tags to source instance
    vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tag: "Name": "Packer Builder"
    vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tag: "builder-name-hcl": "<unknown>"
    vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tag: "builder-type-hcl": "<unknown>"
```

After: 

```
==> vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tags to source instance
    vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tag: "Name": "Packer Builder"
    vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tag: "builder-name-hcl": "cannonical-ubuntu-server"
    vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tag: "builder-type-hcl": "amazon-ebs"
```
