### PR TITLE
Add Packer registry iteration_id to the contextual variables

### DIFF
--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -109,14 +109,22 @@ func (cfg *PackerConfig) EvalContext(ctx BlockContext, variables map[string]cty.
 			}),
 			buildAccessor: cty.UnknownVal(cty.EmptyObject),
 			packerAccessor: cty.ObjectVal(map[string]cty.Value{
-				"version":      cty.StringVal(cfg.CorePackerVersionString),
-				"iteration_id": cty.UnknownVal(cty.String),
+				"version":     cty.StringVal(cfg.CorePackerVersionString),
+				"iterationID": cty.UnknownVal(cty.String),
 			}),
 			pathVariablesAccessor: cty.ObjectVal(map[string]cty.Value{
 				"cwd":  cty.StringVal(strings.ReplaceAll(cfg.Cwd, `\`, `/`)),
 				"root": cty.StringVal(strings.ReplaceAll(cfg.Basedir, `\`, `/`)),
 			}),
 		},
+	}
+
+	// Store the iteration_id, if it exists. Otherwise, it'll be "unknown"
+	if cfg.bucket != nil {
+		ectx.Variables[packerAccessor] = cty.ObjectVal(map[string]cty.Value{
+			"version":     cty.StringVal(cfg.CorePackerVersionString),
+			"iterationID": cty.StringVal(cfg.bucket.Iteration.ID),
+		})
 	}
 
 	// In the future we'd like to load and execute HCL blocks using a graph

--- a/internal/registry/types.bucket_test.go
+++ b/internal/registry/types.bucket_test.go
@@ -42,12 +42,20 @@ func TestInitialize_NewBucketNewIteration(t *testing.T) {
 		t.Errorf("expected a call to CreateIteration but it didn't happen")
 	}
 
-	if !mockService.CreateBuildCalled {
-		t.Errorf("expected a call to CreateBuild but it didn't happen")
+	if mockService.CreateBuildCalled {
+		t.Errorf("Didn't expect a call to CreateBuild")
 	}
 
 	if b.Iteration.ID != "iteration-id" {
 		t.Errorf("expected an iteration to created but it didn't")
+	}
+
+	err = b.PopulateIteration(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+	if !mockService.CreateBuildCalled {
+		t.Errorf("Expected a call to CreateBuild but it didn't happen")
 	}
 
 	if _, ok := b.Iteration.builds.Load("happycloud.image"); !ok {
@@ -91,12 +99,20 @@ func TestInitialize_ExistingBucketNewIteration(t *testing.T) {
 		t.Errorf("expected a call to CreateIteration but it didn't happen")
 	}
 
-	if !mockService.CreateBuildCalled {
-		t.Errorf("expected a call to CreateBuild but it didn't happen")
+	if mockService.CreateBuildCalled {
+		t.Errorf("Didn't expect a call to CreateBuild")
 	}
 
 	if b.Iteration.ID != "iteration-id" {
 		t.Errorf("expected an iteration to created but it didn't")
+	}
+
+	err = b.PopulateIteration(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+	if !mockService.CreateBuildCalled {
+		t.Errorf("Expected a call to CreateBuild but it didn't happen")
 	}
 
 	if _, ok := b.Iteration.builds.Load("happycloud.image"); !ok {
@@ -133,6 +149,10 @@ func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
+	err = b.PopulateIteration(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
 
 	if mockService.CreateBucketCalled {
 		t.Errorf("unexpected call to CreateBucket")
@@ -158,6 +178,10 @@ func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 		t.Errorf("expected an iteration to created but it didn't")
 	}
 
+	err = b.PopulateIteration(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
 	loadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
 	if !ok {
 		t.Errorf("expected a basic build entry to be created but it didn't")
@@ -201,11 +225,11 @@ func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
 
 	err = b.Initialize(context.TODO())
 	if err == nil {
-		t.Errorf("Calling initialize on a completed Iteration should fail hard")
+		t.Errorf("unexpected failure: %v", err)
 	}
 
 	if mockService.CreateIterationCalled {
-		t.Errorf("unexpected a call to CreateIteration")
+		t.Errorf("unexpected call to CreateIteration")
 	}
 
 	if !mockService.GetIterationCalled {
@@ -213,11 +237,11 @@ func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
 	}
 
 	if mockService.CreateBuildCalled {
-		t.Errorf("unexpected a call to CreateBuild")
+		t.Errorf("unexpected call to CreateBuild")
 	}
 
 	if b.Iteration.ID != "iteration-id" {
-		t.Errorf("expected an iteration to returned but it didn't")
+		t.Errorf("expected an iteration to be returned but it wasn't")
 	}
 }
 
@@ -246,6 +270,10 @@ func TestUpdateBuildStatus(t *testing.T) {
 	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+	err = b.PopulateIteration(context.TODO())
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
@@ -309,6 +337,10 @@ func TestUpdateBuildStatus_DONENoImages(t *testing.T) {
 	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
+	if err != nil {
+		t.Errorf("unexpected failure: %v", err)
+	}
+	err = b.PopulateIteration(context.TODO())
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}

--- a/website/content/docs/templates/hcl_templates/contextual-variables.mdx
+++ b/website/content/docs/templates/hcl_templates/contextual-variables.mdx
@@ -129,3 +129,37 @@ null.first-example: output will be in this color.
 Make sure to wrap your variable in single quotes in order to escape the
 string that is returned; if you are running a dev version of packer the
 parenthesis may through off your shell escaping otherwise.
+
+# HCP Packer Iteration ID
+
+If your build is pushing metadata to the HCP Packer reigstry, this variable is
+set to the value of the Iteration ID associated with this run.
+
+```hcl
+source "amazon-ebs" "cannonical-ubuntu-server" {
+  ami_name         = "packer-example"
+  // ...
+  run_volume_tags = {
+    hcp_iteration_id = packer.iterationID
+  }
+}
+```
+
+```shell-session
+==> vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tags to source instance
+    vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tag: "Name": "Packer Builder"
+    vanilla.amazon-ebs.cannonical-ubuntu-server: Adding tag: "hcp_iteration_id": "01FHGF3M2AK4TS6PCZES4VX5E7"
+```
+
+You can also add this value to post-processors, for example to add to a manifest file:
+
+```hcl
+  post-processor "manifest" {
+    output     = "manifest.json"
+    strip_path = true
+    custom_data = {
+      iteration = "${packer.iterationID}"
+    }
+  }
+
+```


### PR DESCRIPTION
Adds the contextual variable packer.iteration_id to HCL templates, as well as documentation for this value. 

The biggest challenge was getting the iteration ID into the eval context for builds, since the initialization was happening _after_ the builds were evaluated, so we could initialize builds into the iteration. 

I did this by splitting the bucket.Initialize into two functions -- initialize(), which I moved before the GetBuilds call, and PopulateIteration, which I kept after the GetBuilds call. We create an empty iteration, then load the builds using an eval context that contains the iteration id, then load the placeholders for the newly-parsed builds into the placeholder iteration. 

This doesn't implement a corollary for JSON templates; if there is demand for it, we can add it later.

Usage is shown in the docs. 