### PR TITLE
Read labels into the data source, and regenerate code.

### DIFF
--- a/datasource/hcp-packer-image/data.go
+++ b/datasource/hcp-packer-image/data.go
@@ -100,6 +100,8 @@ type DatasourceOutput struct {
 	// For locally managed clouds, this may map instead to a cluster, server
 	// or datastore.
 	Region string `mapstructure:"region"`
+	// The key:value metadata labels associated with this build.
+	Labels map[string]string `mapstructure:"labels"`
 }
 
 func (d *Datasource) OutputSpec() hcldec.ObjectSpec {
@@ -142,6 +144,7 @@ func (d *Datasource) Execute() (cty.Value, error) {
 					PackerRunUUID: build.PackerRunUUID,
 					ID:            image.ImageID,
 					Region:        image.Region,
+					Labels:        build.Labels,
 				}
 				return hcl2helper.HCL2ValueFromConfig(output, d.OutputSpec()), nil
 			}

--- a/datasource/hcp-packer-image/data.hcl2spec.go
+++ b/datasource/hcp-packer-image/data.hcl2spec.go
@@ -55,14 +55,15 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatDatasourceOutput is an auto-generated flat version of DatasourceOutput.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatDatasourceOutput struct {
-	CloudProvider *string `mapstructure:"cloud_provider" cty:"cloud_provider" hcl:"cloud_provider"`
-	ComponentType *string `mapstructure:"component_type" cty:"component_type" hcl:"component_type"`
-	CreatedAt     *string `mapstructure:"created_at" cty:"created_at" hcl:"created_at"`
-	BuildID       *string `mapstructure:"build_id" cty:"build_id" hcl:"build_id"`
-	IterationID   *string `mapstructure:"iteration_id" cty:"iteration_id" hcl:"iteration_id"`
-	PackerRunUUID *string `mapstructure:"packer_run_uuid" cty:"packer_run_uuid" hcl:"packer_run_uuid"`
-	ID            *string `mapstructure:"id" cty:"id" hcl:"id"`
-	Region        *string `mapstructure:"region" cty:"region" hcl:"region"`
+	CloudProvider *string           `mapstructure:"cloud_provider" cty:"cloud_provider" hcl:"cloud_provider"`
+	ComponentType *string           `mapstructure:"component_type" cty:"component_type" hcl:"component_type"`
+	CreatedAt     *string           `mapstructure:"created_at" cty:"created_at" hcl:"created_at"`
+	BuildID       *string           `mapstructure:"build_id" cty:"build_id" hcl:"build_id"`
+	IterationID   *string           `mapstructure:"iteration_id" cty:"iteration_id" hcl:"iteration_id"`
+	PackerRunUUID *string           `mapstructure:"packer_run_uuid" cty:"packer_run_uuid" hcl:"packer_run_uuid"`
+	ID            *string           `mapstructure:"id" cty:"id" hcl:"id"`
+	Region        *string           `mapstructure:"region" cty:"region" hcl:"region"`
+	Labels        map[string]string `mapstructure:"labels" cty:"labels" hcl:"labels"`
 }
 
 // FlatMapstructure returns a new FlatDatasourceOutput.
@@ -85,6 +86,7 @@ func (*FlatDatasourceOutput) HCL2Spec() map[string]hcldec.Spec {
 		"packer_run_uuid": &hcldec.AttrSpec{Name: "packer_run_uuid", Type: cty.String, Required: false},
 		"id":              &hcldec.AttrSpec{Name: "id", Type: cty.String, Required: false},
 		"region":          &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
+		"labels":          &hcldec.AttrSpec{Name: "labels", Type: cty.Map(cty.String), Required: false},
 	}
 	return s
 }

--- a/website/content/partials/datasource/hcp-packer-image/DatasourceOutput.mdx
+++ b/website/content/partials/datasource/hcp-packer-image/DatasourceOutput.mdx
@@ -23,4 +23,6 @@
   For locally managed clouds, this may map instead to a cluster, server
   or datastore.
 
+- `labels` (map[string]string) - The key:value metadata labels associated with this build.
+
 <!-- End of code generated from the comments of the DatasourceOutput struct in datasource/hcp-packer-image/data.go; -->

--- a/website/content/partials/datasource/packer-image-iteration/DeactivatedDatasource.mdx
+++ b/website/content/partials/datasource/packer-image-iteration/DeactivatedDatasource.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the DeactivatedDatasource struct in datasource/packer-image-iteration/data.go; DO NOT EDIT MANUALLY -->
+
+Type for Packer datasource has been renamed temporarily to prevent it from being
+automatically registered as a viable datasource plugin in command/plugin.go.
+In the future this type will be renamed to allow for the use of the datasource.
+
+<!-- End of code generated from the comments of the DeactivatedDatasource struct in datasource/packer-image-iteration/data.go; -->


### PR DESCRIPTION
This allows users to read labels off the data source. This could be important when labels confer important contextual information about the build, like vsphere datastores. 

Example usage: 

```hcl
data "hcp-packer-iteration" "vanilla-prod" {
  bucket_name = "vsphere-ubuntu-18"
  channel     = "test-megan"
}

data "hcp-packer-image" "vanilla-aws" {
  bucket_name    = "vsphere-ubuntu-18"
  iteration_id   = data.hcp-packer-iteration.vanilla-prod.id
  cloud_provider = "vsphere"
  region         = "Black Mesa"
}

source "null" "printvals" {
  communicator = "none"
}

build {
  sources = ["source.null.printvals"]

  provisioner "shell-local" {
    inline = ["echo ${data.hcp-packer-image.vanilla-aws.labels["annotation"]}"]
  }
}

```