### PR TITLE
Add sensitive=true to AWS secret key in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ variable "access_key" {
 }
 
 variable "secret_key" {
-  type    = string
-  default = "${env("AWS_SECRET_ACCESS_KEY")}"
+  type      = string
+  default   = "${env("AWS_SECRET_ACCESS_KEY")}"
+  sensitive = true
 }
 
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }


### PR DESCRIPTION
As per [the documentation](https://www.packer.io/docs/templates/hcl_templates/variables#a-variable-can-be-sensitive), sensitive variables can be marked as such to be masked out from the command output. Would it make sense to include this feature in the `README.md` examples?