### PR TITLE
website: Upgrade platform analytics package

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
         "@hashicorp/mktg-global-styles": "^4.0.0",
         "@hashicorp/mktg-logos": "^1.2.0",
         "@hashicorp/nextjs-scripts": "^19.0.3",
-        "@hashicorp/platform-analytics": "^0.1.0",
+        "@hashicorp/platform-analytics": "^0.2.0",
         "@hashicorp/platform-code-highlighting": "^0.1.2",
         "@hashicorp/platform-runtime-error-monitoring": "^0.1.0",
         "@hashicorp/platform-util": "^0.1.0",
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/@hashicorp/platform-analytics": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.1.0.tgz",
-      "integrity": "sha512-kR/E0KWemjazSrSFN9l22v8JqlQvkgjgkZHPJEhGiBt05LMtt2ugxIakv+gnzW5lU9434nnr7oDooUyj4eufPA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.2.0.tgz",
+      "integrity": "sha512-4Pmb4Fy/2eDCZPFu/O4wKK2L5VIqwsXfDPDGX3eA4Dk67ytZ//SXuW9oFtG97ACyW/p1i72EmwoqcrR6usDwtg==",
       "dependencies": {
         "fathom-client": "^3.2.0"
       },
@@ -22439,9 +22439,9 @@
       }
     },
     "@hashicorp/platform-analytics": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.1.0.tgz",
-      "integrity": "sha512-kR/E0KWemjazSrSFN9l22v8JqlQvkgjgkZHPJEhGiBt05LMtt2ugxIakv+gnzW5lU9434nnr7oDooUyj4eufPA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-analytics/-/platform-analytics-0.2.0.tgz",
+      "integrity": "sha512-4Pmb4Fy/2eDCZPFu/O4wKK2L5VIqwsXfDPDGX3eA4Dk67ytZ//SXuW9oFtG97ACyW/p1i72EmwoqcrR6usDwtg==",
       "requires": {
         "fathom-client": "^3.2.0"
       }

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "@hashicorp/mktg-global-styles": "^4.0.0",
     "@hashicorp/mktg-logos": "^1.2.0",
     "@hashicorp/nextjs-scripts": "^19.0.3",
-    "@hashicorp/platform-analytics": "^0.1.0",
+    "@hashicorp/platform-analytics": "^0.2.0",
     "@hashicorp/platform-code-highlighting": "^0.1.2",
     "@hashicorp/platform-runtime-error-monitoring": "^0.1.0",
     "@hashicorp/platform-util": "^0.1.0",


### PR DESCRIPTION
This PR updates the Packer website's `@hashicorp/platform-analytics` package.