### PR TITLE
Show successful message upon successful packer validate

### DIFF
--- a/command/validate.go
+++ b/command/validate.go
@@ -74,7 +74,12 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 	})
 	diags = append(diags, fixerDiags...)
 
-	return writeDiags(c.Ui, nil, diags)
+	ret = writeDiags(c.Ui, nil, diags)
+	if ret == 0 {
+		c.Ui.Say("Packer Configuration Valid.")
+	}
+
+	return ret
 }
 
 func (*ValidateCommand) Help() string {


### PR DESCRIPTION
Display a successful message when `packer validate` does not find any invalid template(s) and configurations. 

#### Test Results
_(I ran into some issues running existing unit tests, therefore tested `validate` flows manually like below.)_

**Valid HCL template**
<img width="916" alt="Screen Shot 2021-10-16 at 8 42 45 PM" src="https://user-images.githubusercontent.com/5898479/137610368-91118344-14ae-4c30-82a5-a8d1e2ccb8bd.png">


**Invalid HCL template**
<img width="892" alt="Screen Shot 2021-10-16 at 8 43 20 PM" src="https://user-images.githubusercontent.com/5898479/137610384-1f40273a-afe1-438e-8256-047b80911a96.png">


**Valid JSON template**
<img width="894" alt="Screen Shot 2021-10-16 at 8 50 54 PM" src="https://user-images.githubusercontent.com/5898479/137610525-862d8756-ae05-4e27-a839-0da5aade3e40.png">

**Invalid JSON template**
<img width="870" alt="Screen Shot 2021-10-16 at 8 56 55 PM" src="https://user-images.githubusercontent.com/5898479/137610536-88296be9-3879-4c22-9090-7003737eab0f.png">

**All above templates with `--syntax-only`**
<img width="1051" alt="Screen Shot 2021-10-16 at 8 59 26 PM" src="https://user-images.githubusercontent.com/5898479/137610571-9036920b-3fe7-42d4-b57e-7eabc729099c.png">

Closes #11321 
