### PR TITLE
don't set iteration id unless it exists?

### DIFF
--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -109,8 +109,7 @@ func (cfg *PackerConfig) EvalContext(ctx BlockContext, variables map[string]cty.
 			}),
 			buildAccessor: cty.UnknownVal(cty.EmptyObject),
 			packerAccessor: cty.ObjectVal(map[string]cty.Value{
-				"version":     cty.StringVal(cfg.CorePackerVersionString),
-				"iterationID": cty.UnknownVal(cty.String),
+				"version": cty.StringVal(cfg.CorePackerVersionString),
 			}),
 			pathVariablesAccessor: cty.ObjectVal(map[string]cty.Value{
 				"cwd":  cty.StringVal(strings.ReplaceAll(cfg.Cwd, `\`, `/`)),


### PR DESCRIPTION
This PR doesn't set iteration_id unless it exists. The value here is that it will cause a validation failure rather than setting the value of the id to "unknown" if it's being evaluated in a context where the Id is known. 

I opened this to show that it _could_ be done, but I think we need to discuss whether it _should_ be. On the one hand, only creating the accessor when the variable actually exists makes sense, and will prevent issues. On the other, I can see a situation where a user would want to always set iteration id (if it exists) in their template, rather than having specialized logic for their HCP and non-HCP builds.