### PR TITLE
HCL2: fix a crash when an HCL2 component is nil after a misconfiguration

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -426,6 +426,14 @@ func TestBuild(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			name: "hcl - test crash #11381",
+			args: []string{
+				testFixture("hcl", "nil-component-crash.pkr.hcl"),
+			},
+			expectedCode: 1,
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/test-fixtures/hcl/nil-component-crash.pkr.hcl
+++ b/command/test-fixtures/hcl/nil-component-crash.pkr.hcl
@@ -1,0 +1,10 @@
+source "null" "basic-example" {
+}
+
+build {
+    sources = ["sources.null.basic-example"]
+
+    provisioner "foo" {
+        timeout = "10"
+    }
+}

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -146,7 +146,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 			}
 			hcpPackerRegistry, moreDiags := p.decodeHCPRegistry(block)
 			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() {
+			if moreDiags.HasErrors() || hcpPackerRegistry == nil {
 				continue
 			}
 			build.HCPPackerRegistry = hcpPackerRegistry
@@ -160,7 +160,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		case buildProvisionerLabel:
 			p, moreDiags := p.decodeProvisioner(block, cfg)
 			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() {
+			if moreDiags.HasErrors() || p == nil {
 				continue
 			}
 			build.ProvisionerBlocks = append(build.ProvisionerBlocks, p)
@@ -175,14 +175,14 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 			}
 			p, moreDiags := p.decodeProvisioner(block, cfg)
 			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() {
+			if moreDiags.HasErrors() || p == nil {
 				continue
 			}
 			build.ErrorCleanupProvisionerBlock = p
 		case buildPostProcessorLabel:
 			pp, moreDiags := p.decodePostProcessor(block, cfg)
 			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() {
+			if moreDiags.HasErrors() || pp == nil {
 				continue
 			}
 			build.PostProcessorsLists = append(build.PostProcessorsLists, []*PostProcessorBlock{pp})

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -146,7 +146,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 			}
 			hcpPackerRegistry, moreDiags := p.decodeHCPRegistry(block)
 			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() || hcpPackerRegistry == nil {
+			if moreDiags.HasErrors() {
 				continue
 			}
 			build.HCPPackerRegistry = hcpPackerRegistry
@@ -160,7 +160,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		case buildProvisionerLabel:
 			p, moreDiags := p.decodeProvisioner(block, cfg)
 			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() || p == nil {
+			if moreDiags.HasErrors() {
 				continue
 			}
 			build.ProvisionerBlocks = append(build.ProvisionerBlocks, p)
@@ -175,14 +175,14 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 			}
 			p, moreDiags := p.decodeProvisioner(block, cfg)
 			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() || p == nil {
+			if moreDiags.HasErrors() {
 				continue
 			}
 			build.ErrorCleanupProvisionerBlock = p
 		case buildPostProcessorLabel:
 			pp, moreDiags := p.decodePostProcessor(block, cfg)
 			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() || pp == nil {
+			if moreDiags.HasErrors() {
 				continue
 			}
 			build.PostProcessorsLists = append(build.PostProcessorsLists, []*PostProcessorBlock{pp})

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -122,6 +122,7 @@ func (p *Parser) decodeProvisioner(block *hcl.Block, cfg *PackerConfig) (*Provis
 				Summary:  "Failed to parse pause_before duration",
 				Severity: hcl.DiagError,
 				Detail:   err.Error(),
+				Subject:  &block.DefRange,
 			})
 		}
 		provisioner.PauseBefore = pauseBefore
@@ -133,6 +134,7 @@ func (p *Parser) decodeProvisioner(block *hcl.Block, cfg *PackerConfig) (*Provis
 			return nil, append(diags, &hcl.Diagnostic{
 				Summary: "Failed to parse timeout duration",
 				Detail:  err.Error(),
+				Subject: &block.DefRange,
 			})
 		}
 		provisioner.Timeout = timeout

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -132,9 +132,10 @@ func (p *Parser) decodeProvisioner(block *hcl.Block, cfg *PackerConfig) (*Provis
 		timeout, err := time.ParseDuration(b.Timeout)
 		if err != nil {
 			return nil, append(diags, &hcl.Diagnostic{
-				Summary: "Failed to parse timeout duration",
-				Detail:  err.Error(),
-				Subject: &block.DefRange,
+				Summary:  "Failed to parse timeout duration",
+				Severity: hcl.DiagError,
+				Detail:   err.Error(),
+				Subject:  &block.DefRange,
 			})
 		}
 		provisioner.Timeout = timeout


### PR DESCRIPTION
fix #11381