### PR TITLE
Update output directory used in TestArchive

### DIFF
--- a/post-processor/compress/post-processor_test.go
+++ b/post-processor/compress/post-processor_test.go
@@ -235,6 +235,7 @@ func TestArchive(t *testing.T) {
 		},
 	}
 
+	tmpArchiveFile := "temp-archive-package"
 	for format, unzip := range tc {
 		t.Run(format, func(t *testing.T) {
 			config := fmt.Sprintf(`
@@ -242,11 +243,11 @@ func TestArchive(t *testing.T) {
 			"post-processors": [
 				{
 					"type": "compress",
-					"output": "package.%s"
+					"output": "%s.%s"
 				}
 			]
 		}
-		`, format)
+		`, tmpArchiveFile, format)
 
 			artifact := testArchive(t, config)
 			defer func() {
@@ -256,7 +257,7 @@ func TestArchive(t *testing.T) {
 				}
 			}()
 
-			filename := fmt.Sprintf("package.%s", format)
+			filename := fmt.Sprintf("%s.%s", tmpArchiveFile, format)
 			// Verify things look good
 			_, err := os.Stat(filename)
 			if err != nil {


### PR DESCRIPTION
This change uses a different  as part of the TestArchive output path to fix an intermittently failing test case on Windows caused by using the same output name across test cases.

Originally tired to use t.TempDir() to get a temp path but ran into errors with parsing the config on Windows.

```
Unable to parse test config: invalid character 'U' in string escape code
```
