### PR TITLE
Add support for variable interpolation to hcp_packer_registry and build blocks. 

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -434,6 +434,17 @@ func TestBuild(t *testing.T) {
 			},
 			expectedCode: 1,
 		},
+		{
+			name: "hcl - using variables in build block",
+			args: []string{
+				testFixture("hcl", "vars-in-build-block.pkr.hcl"),
+			},
+			fileCheck: fileCheck{
+				expectedContent: map[string]string{
+					"example.2.txt": two,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/test-fixtures/hcl/vars-in-build-block.pkr.hcl
+++ b/command/test-fixtures/hcl/vars-in-build-block.pkr.hcl
@@ -1,0 +1,24 @@
+variable "name" {
+  type    = string
+  default = "example"
+}
+
+variable "description" {
+  type    = string
+  default = "blah blah blah"
+}
+
+source "null" "example" {
+  communicator = "none"
+}
+
+build {
+  name        = var.name
+  description = var.description
+
+  sources     = ["source.null.example"]
+
+  post-processor "shell-local" {
+    inline = ["echo 2 > ${build.name}.2.txt"]
+  }
+}

--- a/hcl2template/testdata/build/invalid_build_name_variable.pkr.hcl
+++ b/hcl2template/testdata/build/invalid_build_name_variable.pkr.hcl
@@ -1,0 +1,9 @@
+variable "name" {
+  type    = int
+  default = 123
+}
+
+build {
+  name        = var.name
+}
+

--- a/hcl2template/testdata/build/variables.pkr.hcl
+++ b/hcl2template/testdata/build/variables.pkr.hcl
@@ -1,0 +1,21 @@
+variable "name" {
+  type    = string
+  default = "build-name"
+}
+
+local "description" {
+  expression = "This is the description for ${var.name}."
+}
+
+build {
+  name        = var.name
+  description = local.description
+
+  sources = [
+    "source.virtualbox-iso.ubuntu-1204"
+  ]
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}
+

--- a/hcl2template/testdata/hcp_par/variable-for-bucket_name.pkr.hcl
+++ b/hcl2template/testdata/hcp_par/variable-for-bucket_name.pkr.hcl
@@ -1,0 +1,15 @@
+variable "bucket" {
+  type = string
+  default = "variable-bucket-slug"
+}
+build {
+  hcp_packer_registry {
+    bucket_name   = var.bucket
+  }
+  sources = [
+    "source.virtualbox-iso.ubuntu-1204",
+  ]
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}

--- a/hcl2template/testdata/hcp_par/variables-for-labels.pkr.hcl
+++ b/hcl2template/testdata/hcp_par/variables-for-labels.pkr.hcl
@@ -1,0 +1,30 @@
+
+variable "bucket_labels" {
+  type = map(string)
+  default = {
+    "team": "development",
+  }
+}
+
+variable "build_labels" {
+  type = map(string)
+  default = {
+    "packageA": "v3.17.5",
+    "packageZ": "v0.6",
+  }
+}
+
+build {
+  hcp_packer_registry {
+    bucket_name   = "bucket-slug"
+    bucket_labels = var.bucket_labels
+    build_labels  = var.build_labels
+  }
+  sources = [
+    "source.virtualbox-iso.ubuntu-1204",
+  ]
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}
+

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -97,7 +97,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		FromSources []string `hcl:"sources,optional"`
 		Config      hcl.Body `hcl:",remain"`
 	}
-	diags := gohcl.DecodeBody(body, nil, &b)
+	diags := gohcl.DecodeBody(body, cfg.EvalContext(LocalContext, nil), &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -144,7 +144,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 				})
 				continue
 			}
-			hcpPackerRegistry, moreDiags := p.decodeHCPRegistry(block)
+			hcpPackerRegistry, moreDiags := p.decodeHCPRegistry(block, cfg)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue

--- a/hcl2template/types.build.hcp_packer_registry.go
+++ b/hcl2template/types.build.hcp_packer_registry.go
@@ -35,7 +35,7 @@ func (b *HCPPackerRegistryBlock) WriteToBucketConfig(bucket *packerregistry.Buck
 	}
 }
 
-func (p *Parser) decodeHCPRegistry(block *hcl.Block) (*HCPPackerRegistryBlock, hcl.Diagnostics) {
+func (p *Parser) decodeHCPRegistry(block *hcl.Block, cfg *PackerConfig) (*HCPPackerRegistryBlock, hcl.Diagnostics) {
 	par := &HCPPackerRegistryBlock{}
 	body := block.Body
 
@@ -48,7 +48,7 @@ func (p *Parser) decodeHCPRegistry(block *hcl.Block) (*HCPPackerRegistryBlock, h
 		BuildLabels  map[string]string `hcl:"build_labels,optional"`
 		Config       hcl.Body          `hcl:",remain"`
 	}
-	diags := gohcl.DecodeBody(body, nil, &b)
+	diags := gohcl.DecodeBody(body, cfg.EvalContext(LocalContext, nil), &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/hcl2template/types.build_test.go
+++ b/hcl2template/types.build_test.go
@@ -7,6 +7,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	. "github.com/hashicorp/packer/hcl2template/internal"
 	"github.com/hashicorp/packer/packer"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestParse_build(t *testing.T) {
@@ -470,6 +471,67 @@ func TestParse_build(t *testing.T) {
 					PostProcessors: [][]packer.CoreBuildPostProcessor{},
 				},
 			},
+			false,
+		},
+		{"variable interpolation for build name and description",
+			defaultParser,
+			parseTestArgs{"testdata/build/variables.pkr.hcl", nil, nil},
+			&PackerConfig{
+				CorePackerVersionString: lockedVersion,
+				Basedir:                 filepath.Join("testdata", "build"),
+				InputVariables: Variables{
+					"name": &Variable{
+						Name:   "name",
+						Type:   cty.String,
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("build-name")}},
+					},
+				},
+				LocalVariables: Variables{
+					"description": &Variable{
+						Name:   "description",
+						Type:   cty.String,
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("This is the description for build-name.")}},
+					},
+				},
+				Sources: map[SourceRef]SourceBlock{
+					refVBIsoUbuntu1204: {Type: "virtualbox-iso", Name: "ubuntu-1204"},
+				},
+				Builds: Builds{
+					&BuildBlock{
+						Name:        "build-name",
+						Description: "This is the description for build-name.",
+						Sources: []SourceUseBlock{
+							{
+								SourceRef: refVBIsoUbuntu1204,
+							},
+						},
+					},
+				},
+			},
+			false, false,
+			[]packersdk.Build{
+				&packer.CoreBuild{
+					BuildName:      "build-name",
+					Type:           "virtualbox-iso.ubuntu-1204",
+					Prepared:       true,
+					Builder:        emptyMockBuilder,
+					Provisioners:   []packer.CoreBuildProvisioner{},
+					PostProcessors: [][]packer.CoreBuildPostProcessor{},
+				},
+			},
+			false,
+		},
+		{"invalid variable for build name",
+			defaultParser,
+			parseTestArgs{"testdata/build/invalid_build_name_variable.pkr.hcl", nil, nil},
+			&PackerConfig{
+				CorePackerVersionString: lockedVersion,
+				Basedir:                 filepath.Join("testdata", "build"),
+				InputVariables:          Variables{},
+				Builds:                  nil,
+			},
+			true, true,
+			[]packersdk.Build{},
 			false,
 		},
 	}


### PR DESCRIPTION
* This change allows for the use of variables for setting HCP Packer metadata. 
Users should be able to set variables either statically or dynamically via environment variables to set bucket_name, bucket_labels, and build_labels. 

* This change adds support for using variables within the base Packer build block - merged in from #11425 

Closes #9794
Closes https://github.com/hashicorp/packer-internal-issues/issues/20