### PR TITLE
Add build block variable interpolation

### DIFF
--- a/hcl2template/testdata/build/invalid_build_name_variable.pkr.hcl
+++ b/hcl2template/testdata/build/invalid_build_name_variable.pkr.hcl
@@ -1,0 +1,9 @@
+variable "name" {
+  type    = int
+  default = 123
+}
+
+build {
+  name        = var.name
+}
+

--- a/hcl2template/testdata/build/variables.pkr.hcl
+++ b/hcl2template/testdata/build/variables.pkr.hcl
@@ -1,0 +1,21 @@
+variable "name" {
+  type    = string
+  default = "build-name"
+}
+
+local "description" {
+  expression = "This is the description for ${var.name}."
+}
+
+build {
+  name        = var.name
+  description = local.description
+
+  sources = [
+    "source.virtualbox-iso.ubuntu-1204"
+  ]
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}
+

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -97,7 +97,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		FromSources []string `hcl:"sources,optional"`
 		Config      hcl.Body `hcl:",remain"`
 	}
-	diags := gohcl.DecodeBody(body, nil, &b)
+	diags := gohcl.DecodeBody(body, cfg.EvalContext(LocalContext, nil), &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/hcl2template/types.build_test.go
+++ b/hcl2template/types.build_test.go
@@ -7,6 +7,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	. "github.com/hashicorp/packer/hcl2template/internal"
 	"github.com/hashicorp/packer/packer"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestParse_build(t *testing.T) {
@@ -470,6 +471,67 @@ func TestParse_build(t *testing.T) {
 					PostProcessors: [][]packer.CoreBuildPostProcessor{},
 				},
 			},
+			false,
+		},
+		{"variable interpolation for build name and description",
+			defaultParser,
+			parseTestArgs{"testdata/build/variables.pkr.hcl", nil, nil},
+			&PackerConfig{
+				CorePackerVersionString: lockedVersion,
+				Basedir:                 filepath.Join("testdata", "build"),
+				InputVariables: Variables{
+					"name": &Variable{
+						Name:   "name",
+						Type:   cty.String,
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("build-name")}},
+					},
+				},
+				LocalVariables: Variables{
+					"description": &Variable{
+						Name:   "description",
+						Type:   cty.String,
+						Values: []VariableAssignment{{From: "default", Value: cty.StringVal("This is the description for build-name.")}},
+					},
+				},
+				Sources: map[SourceRef]SourceBlock{
+					refVBIsoUbuntu1204: {Type: "virtualbox-iso", Name: "ubuntu-1204"},
+				},
+				Builds: Builds{
+					&BuildBlock{
+						Name:        "build-name",
+						Description: "This is the description for build-name.",
+						Sources: []SourceUseBlock{
+							{
+								SourceRef: refVBIsoUbuntu1204,
+							},
+						},
+					},
+				},
+			},
+			false, false,
+			[]packersdk.Build{
+				&packer.CoreBuild{
+					BuildName:      "build-name",
+					Type:           "virtualbox-iso.ubuntu-1204",
+					Prepared:       true,
+					Builder:        emptyMockBuilder,
+					Provisioners:   []packer.CoreBuildProvisioner{},
+					PostProcessors: [][]packer.CoreBuildPostProcessor{},
+				},
+			},
+			false,
+		},
+		{"invalid variable for build name",
+			defaultParser,
+			parseTestArgs{"testdata/build/invalid_build_name_variable.pkr.hcl", nil, nil},
+			&PackerConfig{
+				CorePackerVersionString: lockedVersion,
+				Basedir:                 filepath.Join("testdata", "build"),
+				InputVariables:          Variables{},
+				Builds:                  nil,
+			},
+			true, true,
+			[]packersdk.Build{},
 			false,
 		},
 	}


### PR DESCRIPTION
Adds the ability to use variables within a Packer build block for setting name or description. 

```hcl

variable "myname" {
 type = string
 default = "test-build"
}
variable "mydescription" {
 type = string
 default = "test-build"
}
build {
   name = var.myname
   description = var.mydescription
   sources = ["source.null.example"]
}

source "null" "example" {
}
```