### PR TITLE
Allow the use of `build.name` for naming provisioners and post-processors

### DIFF
--- a/hcl2template/testdata/build/post-processor_build_name_interpolation.pkr.hcl
+++ b/hcl2template/testdata/build/post-processor_build_name_interpolation.pkr.hcl
@@ -1,0 +1,13 @@
+build {
+    name = "test-build"
+    sources = [ "source.virtualbox-iso.ubuntu-1204" ]
+
+    post-processor "manifest" {
+        name         = build.name
+        slice_string = ["${packer.version}", "${build.name}"]
+    }
+
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}

--- a/hcl2template/testdata/build/provisioner_build_name_interpolation.pkr.hcl
+++ b/hcl2template/testdata/build/provisioner_build_name_interpolation.pkr.hcl
@@ -1,0 +1,17 @@
+
+// starts resources to provision them.
+build {
+    name = "build-name-test"
+    sources = [
+        "source.virtualbox-iso.ubuntu-1204",
+    ]
+
+    provisioner "shell" {
+        name = build.name
+        slice_string = ["${build.name}"]
+    }
+}
+
+source "virtualbox-iso" "ubuntu-1204" {
+}
+

--- a/hcl2template/types.build.post-processor.go
+++ b/hcl2template/types.build.post-processor.go
@@ -23,7 +23,7 @@ func (p *PostProcessorBlock) String() string {
 	return fmt.Sprintf(buildPostProcessorLabel+"-block %q %q", p.PType, p.PName)
 }
 
-func (p *Parser) decodePostProcessor(block *hcl.Block, cfg *PackerConfig) (*PostProcessorBlock, hcl.Diagnostics) {
+func (p *Parser) decodePostProcessor(block *hcl.Block, ectx *hcl.EvalContext) (*PostProcessorBlock, hcl.Diagnostics) {
 	var b struct {
 		Name              string   `hcl:"name,optional"`
 		Only              []string `hcl:"only,optional"`
@@ -31,7 +31,8 @@ func (p *Parser) decodePostProcessor(block *hcl.Block, cfg *PackerConfig) (*Post
 		KeepInputArtifact *bool    `hcl:"keep_input_artifact,optional"`
 		Rest              hcl.Body `hcl:",remain"`
 	}
-	diags := gohcl.DecodeBody(block.Body, cfg.EvalContext(BuildContext, nil), &b)
+
+	diags := gohcl.DecodeBody(block.Body, ectx, &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -74,7 +74,7 @@ func (p *ProvisionerBlock) String() string {
 	return fmt.Sprintf(buildProvisionerLabel+"-block %q %q", p.PType, p.PName)
 }
 
-func (p *Parser) decodeProvisioner(block *hcl.Block, cfg *PackerConfig) (*ProvisionerBlock, hcl.Diagnostics) {
+func (p *Parser) decodeProvisioner(block *hcl.Block, ectx *hcl.EvalContext) (*ProvisionerBlock, hcl.Diagnostics) {
 	var b struct {
 		Name        string    `hcl:"name,optional"`
 		PauseBefore string    `hcl:"pause_before,optional"`
@@ -85,7 +85,7 @@ func (p *Parser) decodeProvisioner(block *hcl.Block, cfg *PackerConfig) (*Provis
 		Override    cty.Value `hcl:"override,optional"`
 		Rest        hcl.Body  `hcl:",remain"`
 	}
-	diags := gohcl.DecodeBody(block.Body, cfg.EvalContext(BuildContext, nil), &b)
+	diags := gohcl.DecodeBody(block.Body, ectx, &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}


### PR DESCRIPTION
This changes makes the builder variable `build.name` avialable at parsing so that it can be used to name provisioners and post-processors. 

```hcl
source "null" "pizza" {
    communicator = "none"
}

build {
    name = "pineapple"
    sources = [
        "sources.null.pizza",
    ]

    provisioner "shell-local" {
        name = "${build.name}"
        inline = [
            "echo '' > ${build.name}.txt"
        ]
    }
    post-processor "shell-local" {
        name = "${build.name}"
        inline = [
            "echo '' > ${build.name}-pps.txt"
        ]
    }
}

```

Closes #11411
