### PR TITLE
Fix basic datasource acceptance test flakiness

### DIFF
--- a/acctest/plugin/test-fixtures/basic-amazon-ami-datasource.pkr.hcl
+++ b/acctest/plugin/test-fixtures/basic-amazon-ami-datasource.pkr.hcl
@@ -13,6 +13,7 @@ data "amazon-ami" "test" {
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
+  region = "us-west-2"
   most_recent = true
   owners      = ["099720109477"]
 }


### PR DESCRIPTION
This change sets a region on the test datasource config to fix intermittent InvalidAMIID.NotFound errors.

Closes https://github.com/hashicorp/packer-internal-issues/issues/14

Failing results before change

```
> AWS_DEFAULT_REGION=us-west-1 make testacc
=== RUN   TestAccInitAndBuildBasicAmazonAmiDatasource
2021/12/07 20:40:05 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2021/12/07 20:40:05 Found region us-west-1
2021/12/07 20:40:05 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
    pluginacc.go:143: Error running plugin acceptance tests: Bad exit code. Logfile: packer_log_amazon-ami_basic_datasource_test.txt
        Logs can be found at /Users/wilkenrivera/Development/packer/acctest/plugin/packer_log_amazon-ami_basic_datasource_test.txt
        and the acceptance test template can be found at /Users/wilkenrivera/Development/packer/acctest/plugin/amazon-ami_basic_datasource_test.pkr.hcl
--- FAIL: TestAccInitAndBuildBasicAmazonAmiDatasource (9.87s)
FAIL
FAIL    github.com/hashicorp/packer/acctest/plugin      10.326s
```

Passing results after change
```
> AWS_DEFAULT_REGION=us-west-1 make testacc
=== RUN   TestAccInitAndBuildBasicAmazonAmiDatasource
2021/12/07 20:47:28 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2021/12/07 20:47:28 Found region us-west-1
2021/12/07 20:47:28 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
--- PASS: TestAccInitAndBuildBasicAmazonAmiDatasource (223.32s)
PASS

```
