### PR TITLE
feat(website): add version badge to external plugin docs pages

### DIFF
--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -6,6 +6,7 @@ import {
 } from '@hashicorp/react-docs-page/server'
 import renderPageMdx from '@hashicorp/react-docs-page/render-page-mdx'
 import resolveNavData from './utils/resolve-nav-data'
+import fetchLatestReleaseTag from './utils/fetch-latest-release-tag'
 
 async function generateStaticPaths({
   navDataFile,
@@ -49,6 +50,14 @@ async function generateStaticProps({
   const githubFileUrl = remoteFile
     ? remoteFile.sourceUrl
     : `https://github.com/hashicorp/${product.slug}/blob/${mainBranch}/website/${filePath}`
+  // If this is a plugin, and if
+  // the version has been specified as "latest",
+  // determine the tag this corresponds to, so that
+  // we can show this explicit version number in docs
+  const latestReleaseTag =
+    pluginData?.version === 'latest'
+      ? await fetchLatestReleaseTag(pluginData.repo)
+      : pluginData?.version
   // For plugin pages, prefix the MDX content with a
   // label that reflects the plugin tier
   // (current options are "Official" or "Community")
@@ -63,6 +72,10 @@ async function generateStaticProps({
     // Add a badge if the plugin is "HCP Packer Ready"
     if (pluginData?.isHcpPackerReady) {
       badgesMdx.push(`<PluginBadge type="hcp_packer_ready" />`)
+    }
+    // Add badge showing the latest release version number
+    if (latestReleaseTag) {
+      badgesMdx.push(`<Badge label="${latestReleaseTag}" theme="light-gray"/>`)
     }
     // If we have badges to add, inject them into the MDX
     if (badgesMdx.length > 0) {

--- a/website/components/remote-plugin-docs/utils/fetch-latest-release-tag.js
+++ b/website/components/remote-plugin-docs/utils/fetch-latest-release-tag.js
@@ -1,0 +1,24 @@
+async function fetchLatestReleaseTag(repo) {
+  const latestReleaseUrl = `https://github.com/${repo}/releases/latest`
+  const redirectedUrl = await getRedirectedUrl(latestReleaseUrl)
+  if (!redirectedUrl) return false
+  const latestTag = redirectedUrl.match(/tag\/(.*)/)[1]
+  return latestTag
+}
+
+async function getRedirectedUrl(url) {
+  return new Promise((resolve, reject) => {
+    const https = require('https')
+    const req = https.request(url, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400) {
+        resolve(res.headers.location)
+      } else {
+        resolve(false)
+      }
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+module.exports = fetchLatestReleaseTag

--- a/website/components/remote-plugin-docs/utils/resolve-nav-data.js
+++ b/website/components/remote-plugin-docs/utils/resolve-nav-data.js
@@ -184,8 +184,10 @@ async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
       path: urlPath,
       remoteFile: { filePath, fileString, sourceUrl },
       pluginData: {
+        repo,
         tier: parsedPluginTier,
         isHcpPackerReady,
+        version,
       },
     }
   })


### PR DESCRIPTION
👀 [Preview](https://packer-git-fork-zchsh-zsadd-plugin-version-hashicorp.vercel.app)
🎟️ [Asana task](https://app.asana.com/0/1199972659301420/1201484288725531/f)

---

👋 PLEASE NOTE: this branch is largely duplicative of work done in https://github.com/hashicorp/packer/pull/11449

The diff shown in this PR may not be very helpful until #11449 lands. Please see [this PR between the branches](https://github.com/zchsh/packer/pull/1) for a clearly look at how versioned badges are added (with the assumption that refactored badge components are in place). 

---

This PR adds version badges to the top of each external plugin docs page.

The latest version number for a given external plugin `repo` is determined by making a request to `https://github.com/{repo}/releases/latest`. This request is expected to return a redirect to a URL like `https://github.com/{repo}/releases/tag/v1.0.1`. We take the final part of this URL, eg `v1.0.1`, and display it in a badge that we add to the page's MDX at build time. (Thanks to @nywilken for this suggestion! 💯 )

Here's an example of what this looks like on a Community plugin:

<img width="1281" alt="CleanShot 2021-12-16 at 11 56 20@2x" src="https://user-images.githubusercontent.com/4624598/146416088-e7d7ad15-1307-43b0-9873-227229f5d39f.png">

... on an Official plugin:

<img width="1327" alt="CleanShot 2021-12-16 at 11 56 36@2x" src="https://user-images.githubusercontent.com/4624598/146416056-0cf58f2e-657e-4146-bd0e-a4b7ea84710f.png">


... and on an Official plugin that's also marked as HCP Packer Ready:

<img width="1302" alt="CleanShot 2021-12-16 at 12 01 40@2x" src="https://user-images.githubusercontent.com/4624598/146416033-f981f343-779b-4dfd-af05-ad95b70f9b80.png">