### PR TITLE
Add HCP Packer Ready badge to support plugins

### DIFF
--- a/website/data/docs-remote-plugins.json
+++ b/website/data/docs-remote-plugins.json
@@ -30,13 +30,15 @@
     "title": "Amazon EC2",
     "path": "amazon",
     "repo": "hashicorp/packer-plugin-amazon",
-    "version": "latest"
+    "version": "latest",
+    "isHcpPackerReady": true
   },
   {
     "title": "Azure",
     "path": "azure",
     "repo": "hashicorp/packer-plugin-azure",
-    "version": "latest"
+    "version": "latest",
+    "isHcpPackerReady": true
   },
   {
     "title": "Chef",
@@ -70,7 +72,8 @@
     "title": "Docker",
     "path": "docker",
     "repo": "hashicorp/packer-plugin-docker",
-    "version": "latest"
+    "version": "latest",
+    "isHcpPackerReady": true
   },
   {
     "title": "Git",
@@ -83,7 +86,8 @@
     "title": "Google Cloud Platform",
     "path": "googlecompute",
     "repo": "hashicorp/packer-plugin-googlecompute",
-    "version": "latest"
+    "version": "latest",
+    "isHcpPackerReady": true
   },
   {
     "title": "HashiCups",
@@ -283,7 +287,8 @@
     "title": "VMware vSphere",
     "path": "vsphere",
     "repo": "hashicorp/packer-plugin-vsphere",
-    "version": "latest"
+    "version": "latest",
+    "isHcpPackerReady": true
   },
   {
     "title": "VMware",


### PR DESCRIPTION
This changes marks the five currently supported plugins as HCP Packer Ready. We will continue to update this list as more plugins get added to HCP Packer.
