### PR TITLE
Update handling of image metadata before pushing to registry

### DIFF
--- a/packer/registry_builder.go
+++ b/packer/registry_builder.go
@@ -73,7 +73,7 @@ func (b *RegistryBuilder) Run(ctx context.Context, ui packersdk.Ui, hook packers
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Result:           &images,
 		WeaklyTypedInput: true,
-		ErrorUnused:      true,
+		ErrorUnused:      false,
 	})
 	if err != nil {
 		return artifact, fmt.Errorf("failed to create decoder for HCP Packer registry image: %w", err)

--- a/packer/registry_post_processor.go
+++ b/packer/registry_post_processor.go
@@ -65,7 +65,7 @@ func (p *RegistryPostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Result:           &images,
 		WeaklyTypedInput: true,
-		ErrorUnused:      true,
+		ErrorUnused:      false,
 	})
 	if err != nil {
 		return source, false, false, fmt.Errorf("failed to create decoder for HCP Packer registry image: %w", err)


### PR DESCRIPTION
When obtaining image metadata for a HCP Packer build, Packer core will
use mapstructure to decode the image metadata and validate that is has
all of the required data set. Before this change Packer core would fail
if there is extra metadata fields in the image metadata that Packer is
  not aware.

This change removes the restriction of erroring on unused metadata
fields. Packer should only care about the fields it knows and ignore the
rest. In the future, we will add new fields to the SDK but plugins may
begin sending that data sooner.
