### PR TITLE
add content field to shell provisioner which can support templatefile

### DIFF
--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -173,6 +173,18 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		}
 	}
 
+	if p.config.Content != "" {
+		file, err := tmp.File("pkr-file-content")
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		if _, err := file.WriteString(p.config.Content); err != nil {
+			return err
+		}
+		p.config.Scripts = []string{file.Name()}
+	}
+
 	// Do a check for bad environment variables, such as '=foo', 'foobar'
 	for _, kv := range p.config.Vars {
 		vs := strings.SplitN(kv, "=", 2)

--- a/provisioner/shell/provisioner.hcl2spec.go
+++ b/provisioner/shell/provisioner.hcl2spec.go
@@ -27,6 +27,7 @@ type FlatConfig struct {
 	Binary              *bool             `cty:"binary" hcl:"binary"`
 	RemotePath          *string           `mapstructure:"remote_path" cty:"remote_path" hcl:"remote_path"`
 	ExecuteCommand      *string           `mapstructure:"execute_command" cty:"execute_command" hcl:"execute_command"`
+	Content             *string           `mapstructure:"content" cty:"content" hcl:"content"`
 	InlineShebang       *string           `mapstructure:"inline_shebang" cty:"inline_shebang" hcl:"inline_shebang"`
 	PauseAfter          *string           `mapstructure:"pause_after" cty:"pause_after" hcl:"pause_after"`
 	UseEnvVarFile       *bool             `mapstructure:"use_env_var_file" cty:"use_env_var_file" hcl:"use_env_var_file"`
@@ -66,6 +67,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"binary":                     &hcldec.AttrSpec{Name: "binary", Type: cty.Bool, Required: false},
 		"remote_path":                &hcldec.AttrSpec{Name: "remote_path", Type: cty.String, Required: false},
 		"execute_command":            &hcldec.AttrSpec{Name: "execute_command", Type: cty.String, Required: false},
+		"content":                    &hcldec.AttrSpec{Name: "content", Type: cty.String, Required: false},
 		"inline_shebang":             &hcldec.AttrSpec{Name: "inline_shebang", Type: cty.String, Required: false},
 		"pause_after":                &hcldec.AttrSpec{Name: "pause_after", Type: cty.String, Required: false},
 		"use_env_var_file":           &hcldec.AttrSpec{Name: "use_env_var_file", Type: cty.Bool, Required: false},

--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -259,6 +259,41 @@ func TestProvisionerPrepare_Scripts(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_Content(t *testing.T) {
+	config := testConfig()
+	delete(config, "inline")
+
+	content := `
+  #! /usr/bin/env bash
+  echo "hello"
+  exit 0
+  `
+
+	config["content"] = content
+
+	p := new(Provisioner)
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if len(p.config.Scripts) != 1 {
+		t.Fatal("a packer-generated tempfile should now be the element in p.config.Scripts")
+	}
+
+	tempfile := p.config.Scripts[0]
+	defer os.Remove(tempfile)
+
+	result, err := ioutil.ReadFile(tempfile)
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if string(result) != content {
+		t.Fatalf("content of file %s was not as expected", tempfile)
+	}
+}
+
 func TestProvisionerPrepare_EnvironmentVars(t *testing.T) {
 	config := testConfig()
 

--- a/website/content/partials/provisioners/shell-config.mdx
+++ b/website/content/partials/provisioners/shell-config.mdx
@@ -20,6 +20,11 @@ Exactly _one_ of the following is required:
   executed in isolation, so state such as variables from one script won't
   carry on to the next.
 
+- `content` (string) - This is the content to write to the machine and execute.
+  It will be chmodded to 0755 and executed as-is. Any dependencies necessary on
+  the target machine for this content to execute successfully must already be
+  satisfied.
+
 Optional parameters:
 
 - `binary` (boolean) - If true, specifies that the script(s) are binary


### PR DESCRIPTION
closes #11437

This PR adds a `content` field to the shell provisioner that is a peer of the existing must-choose-one fields of `inline`, `script`, and `scripts`. `content` takes a string (which may be the result of Packer's `templatefile` function) to be written as-is to target machine and executed.

In order to simplify the must-choose-one behavior of `inline`, `script`, `scripts`, and `content`, the existing code that checks these fields is refactored and error messages are condensed to: `Exactly one of inline, script, scripts, or content must be specified.`

---

`test.pkr.hcl`:
```hcl
variable "foo" {
  type    = string
  default = "bar"
}

source "docker" "example" {
  image       = "ubuntu"
  export_path = "image.tar"
}

build {
  provisioner "shell" {
    content = templatefile("${path.root}/foo.sh.tmpl", { FOO = var.foo })
  }
  sources = ["source.docker.example"]
}
```

`foo.sh.tmpl`:
```sh
#! /usr/bin/env bash

echo "${FOO}"

exit 0
```

```
./bin/packer build test.pkr.hcl

docker.example: output will be in this color.

==> docker.example: Creating a temporary directory for sharing data...
==> docker.example: Pulling Docker image: ubuntu
    docker.example: Trying to pull docker.io/library/ubuntu:latest...
    docker.example: Getting image source signatures
    docker.example: Copying blob sha256:7b1a6ab2e44dbac178598dabe7cff59bd67233dba0b27e4fbd1f9d4b3c877a54
    docker.example: Copying config sha256:ba6acccedd2923aee4c2acc6a23780b14ed4b8a5fa4e14e252a23b846df9b6c1
    docker.example: Writing manifest to image destination
    docker.example: Storing signatures
    docker.example: ba6acccedd2923aee4c2acc6a23780b14ed4b8a5fa4e14e252a23b846df9b6c1
==> docker.example: Starting docker container...
    docker.example: Run command: docker run -v /home/<redacted>/.config/packer/tmp787614249:/packer-files -d -i -t --entrypoint=/bin/sh -- ubuntu
    docker.example: Container ID: e0df8a157dd5d24af25f85ebcb5abefaf497f561e7f691f88d9a0a0981cb3363
==> docker.example: Using docker communicator to connect:
==> docker.example: Provisioning with shell script: /tmp/pkr-file-content280631096
    docker.example: bar
==> docker.example: Exporting the container
==> docker.example: Killing the container: e0df8a157dd5d24af25f85ebcb5abefaf497f561e7f691f88d9a0a0981cb3363
Build 'docker.example' finished after 4 seconds 494 milliseconds.
```