### PR TITLE
Fail for revoked iterations

### DIFF
--- a/datasource/hcp-packer-image/data.go
+++ b/datasource/hcp-packer-image/data.go
@@ -120,12 +120,11 @@ func (d *Datasource) Execute() (cty.Value, error) {
 	log.Printf("[INFO] Reading info from HCP Packer registry (%s) [project_id=%s, organization_id=%s, iteration_id=%s]",
 		d.config.Bucket, cli.ProjectID, cli.OrganizationID, d.config.IterationID)
 
-	getIterationResp, err := cli.GetIteration(ctx, d.config.Bucket, packerregistry.GetIteration_byID(d.config.IterationID))
+	iteration, err := cli.GetIteration(ctx, d.config.Bucket, packerregistry.GetIteration_byID(d.config.IterationID))
 	if err != nil {
 		return cty.NullVal(cty.EmptyObject), fmt.Errorf("error retrieving "+
 			"image iteration from HCP Packer registry: %s", err.Error())
 	}
-	iteration := getIterationResp.Payload.Iteration
 
 	output := DatasourceOutput{}
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.11.1
-	github.com/hashicorp/hcp-sdk-go v0.13.1-0.20211004174420-0f36fadb8a34
+	github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4
 	github.com/hashicorp/packer-plugin-amazon v1.0.6
 	github.com/hashicorp/packer-plugin-sdk v0.2.11
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869

--- a/go.sum
+++ b/go.sum
@@ -695,8 +695,8 @@ github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oay
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
-github.com/hashicorp/hcp-sdk-go v0.13.1-0.20211004174420-0f36fadb8a34 h1:Zsp79OtAdC+JTsHnbZtAtNihM/jzbDhT09kMYpVrznk=
-github.com/hashicorp/hcp-sdk-go v0.13.1-0.20211004174420-0f36fadb8a34/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
+github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4 h1:H4V7J/mUKzMpmTqnnDloH0r7mk2Jwn4oKUvealKE9cQ=
+github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -111,7 +111,7 @@ var (
 	}
 )
 
-func (client *Client) GetIteration(ctx context.Context, bucketSlug string, opts ...GetIterationOption, ) (*models.HashicorpCloudPackerIteration, error) {
+func (client *Client) GetIteration(ctx context.Context, bucketSlug string, opts ...GetIterationOption) (*models.HashicorpCloudPackerIteration, error) {
 	getItParams := packer_service.NewPackerServiceGetIterationParams()
 	getItParams.LocationOrganizationID = client.OrganizationID
 	getItParams.LocationProjectID = client.ProjectID

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -279,13 +279,10 @@ func (b *Bucket) createIteration() (*models.HashicorpCloudPackerIteration, error
 
 func (b *Bucket) initializeIteration(ctx context.Context) error {
 	// load existing iteration using fingerprint.
-	createIterationResp, err := b.client.GetIteration(ctx, b.Slug, GetIteration_byFingerprint(b.Iteration.Fingerprint))
-	var iteration *models.HashicorpCloudPackerIteration
+	iteration, err := b.client.GetIteration(ctx, b.Slug, GetIteration_byFingerprint(b.Iteration.Fingerprint))
 	if checkErrorCode(err, codes.Aborted) {
 		// probably means Iteration doesn't exist need a way to check the error
 		iteration, err = b.createIteration()
-	} else {
-		iteration = createIterationResp.Payload.Iteration
 	}
 
 	if err != nil {


### PR DESCRIPTION
This simply adds a check to fail when an iteration is revoked and no longer appropriate to use.

Output is like
```zsh
Error: Datasource.Execute failed: error retrieving iteration from HCP Packer registry: the iteration associated with the channel dev is revoked and can not be used on Packer builds

  on test.pkr.hcl line 10:
  (source code not available)

```