### PR TITLE
Update test client to use Org/Project ID from client; not environment variables

### DIFF
--- a/internal/registry/acctest/par.go
+++ b/internal/registry/acctest/par.go
@@ -46,8 +46,8 @@ func NewTestConfig(t *testing.T) (*Config, error) {
 	return &Config{
 		Client: cli,
 		Loc: &sharedmodels.HashicorpCloudLocationLocation{
-			OrganizationID: cfg.OrgId,
-			ProjectID:      cfg.ProjectId,
+			OrganizationID: cli.OrganizationID,
+			ProjectID:      cli.ProjectID,
 		},
 		T: t,
 	}, nil


### PR DESCRIPTION
On a local developer machine there is a good chance the HCP_ORG_ID and HCP_PROJECT_ID are not set since the HCP Packer client can derive this information using the token/secret. This change initializes the location
structure with the information obtained from the client and not the envs.

Results of tests before change with no HCP_ORG_ID or HCP_PROJECT_ID set
```
    par_test.go:185: (*packer_service.PackerServiceGetIterationOK)(nil)
    par_test.go:185: &{0 []  } (*models.GrpcGatewayRuntimeError) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
--- FAIL: TestAcc_PAR_pkr_build (3.94s)
FAIL
FAIL    github.com/hashicorp/packer/internal/registry/acctest   6.446s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/packer/internal/registry/env       0.318s [no tests to run]
FAIL

```

Results of tests after change with no HCP_ORG_ID or HCP_PROJECT_ID set
```
2022/01/18 12:23:48 ui: --> null.example: Published metadata to HCP Packer registry packer/pkr-acctest-temp-2/iterations/01FSQ3EPPY69PMXJSTTFYDPQ5R
--- PASS: TestAcc_PAR_pkr_build (3.20s)
PASS
ok      github.com/hashicorp/packer/internal/registry/acctest   5.121s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/packer/internal/registry/env       0.155s [no tests to run]

```
