### PR TITLE
website: link plugin version badges

### DIFF
--- a/website/components/badge/index.tsx
+++ b/website/components/badge/index.tsx
@@ -9,18 +9,21 @@ interface BadgeProps {
   label: string
   iconSvg?: string
   theme?: BadgeTheme
+  href?: string
 }
 
 function Badge({
   theme = 'gray',
   label,
   iconSvg,
+  href,
 }: BadgeProps): React.ReactElement {
+  const Elem = href ? 'a' : 'div'
   return (
-    <div className={classnames(s.root, s[`theme-${theme}`])}>
+    <Elem href={href} className={classnames(s.root, s[`theme-${theme}`])}>
       {iconSvg ? <InlineSvg className={s.icon} src={iconSvg} /> : null}
       <span className={s.text}>{label}</span>
-    </div>
+    </Elem>
   )
 }
 

--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -69,9 +69,13 @@ async function generateStaticProps({
     if (pluginData?.isHcpPackerReady) {
       badgesMdx.push(`<PluginBadge type="hcp_packer_ready" />`)
     }
-    // Add badge showing the latest release version number
+    // Add badge showing the latest release version number,
+    // and link this badge to the latest release
     if (latestReleaseTag) {
-      badgesMdx.push(`<Badge label="${latestReleaseTag}" theme="light-gray"/>`)
+      const href = `https://github.com/${pluginData.repo}/releases/tag/${latestReleaseTag}`
+      badgesMdx.push(
+        `<Badge href="${href}" label="${latestReleaseTag}" theme="light-gray"/>`
+      )
     }
     // If we have badges to add, inject them into the MDX
     if (badgesMdx.length > 0) {


### PR DESCRIPTION
👀 [Preview](https://packer-git-zslink-plugin-version-tags-hashicorp.vercel.app/plugins/builders/outscale)
🎟️ [Asana task](https://app.asana.com/0/1100423001970639/1201602850457682/f)

This PR adds links to each plugin's version tag badge, such that the badge links to the latest release.

For example, the `v1.0.2` tag on the [Outscale plugin page](https://packer-git-zslink-plugin-version-tags-hashicorp.vercel.app/plugins/builders/outscale) now links to https://github.com/outscale/packer-plugin-outscale/releases/tag/v1.0.2. 

![example](https://user-images.githubusercontent.com/4624598/150690231-b306b9e8-c362-401c-a51e-121cf6ba3dea.png)
