### PR TITLE
Fixes link to tutorial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The images that Packer creates can easily be turned into
 ## Quick Start
 
 **Note:** There is a great
-[introduction and getting started guide](https://www.packer.io/intro)
+[introduction and getting started guide](https://learn.hashicorp.com/tutorials/packer/get-started-install-cli)
 for those with a bit more patience. Otherwise, the quick start below
 will get you up and running quickly, at the sacrifice of not explaining some
 key points.


### PR DESCRIPTION
Hello,

It seems the linked "_getting started_"-guide has some 404s trying to load JSON resources that were moved.
This PR would update the link directly to the tutorial hosted on learn.hashicorp.com instead of packer.io although perhaps the better solution would be to correct the resource locations themselves.

![404](https://user-images.githubusercontent.com/17042203/150950627-d2468f45-d416-49b9-877c-4af349aa9e2d.png)
