### PR TITLE
feat: print all locals errors when there is a circular error

### DIFF
--- a/command/test-fixtures/validate/circular_error.pkr.hcl
+++ b/command/test-fixtures/validate/circular_error.pkr.hcl
@@ -1,0 +1,5 @@
+
+locals {
+  timestamp = formatdate("YYYY-MM-DDX", timestamp())
+  other_local = "test-${local.timestamp}"
+}

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -33,6 +33,9 @@ func TestValidateCommand(t *testing.T) {
 
 		// wrong packer block
 		{path: filepath.Join(testFixture("validate", "invalid_packer_block.pkr.hcl")), exitCode: 1},
+
+		// Should return multiple errors,
+		{path: filepath.Join(testFixture("validate", "circular_error.pkr.hcl")), exitCode: 1},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
feat: print all locals errors when there is a circular error

Updated with a test in current test suite. However not sure how to validate all output as that is not currently in the test suite, just that an error occurred during validation. If you have any ideas on how I should add that, please let me know

#11397 

