### PR TITLE
core/hcl2: Fix issue preventing builds from pausing between provisioners when the `--debug` argument has been passed

### DIFF
--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -609,6 +609,7 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packersdk.Bu
 				BuildName: build.Name,
 				Type:      srcUsage.String(),
 			}
+			pcb.SetDebug(cfg.debug)
 
 			// Apply the -only and -except command-line options to exclude matching builds.
 			buildName := pcb.Name()

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -609,7 +609,10 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packersdk.Bu
 				BuildName: build.Name,
 				Type:      srcUsage.String(),
 			}
+
 			pcb.SetDebug(cfg.debug)
+			pcb.SetForce(cfg.force)
+			pcb.SetOnError(cfg.onError)
 
 			// Apply the -only and -except command-line options to exclude matching builds.
 			buildName := pcb.Name()


### PR DESCRIPTION
This change fixes the debug mode settings for HCL2 builds by calling SetDebug mode for CoreBuild when the `--debug` flag is passed at build time.  When in debug mode provisioners will get wrapped by a DebuggedProvisioner and properly pause between provisioning steps. 

```
~>  packer build --debug /tmp/source.pkr.hcl
Debug mode enabled. Builds will not be parallelized.
null.example: output will be in this color.

==> null.example: Pausing after run of step 'StepConnect'. Press enter to continue.
==> null.example: Pausing before the next provisioner . Press enter to continue.
==> null.example: Running local shell script: /var/folders/vz/rv7bk6v15211jxg8q801f7kw0000gq/T/packer-shell4149319610
    null.example: hi
==> null.example: Pausing before the next provisioner . Press enter to continue.
==> null.example: Running local shell script: /var/folders/vz/rv7bk6v15211jxg8q801f7kw0000gq/T/packer-shell3210691290
    null.example: hi 2
==> null.example: Pausing after run of step 'StepProvision'. Press enter to continue.
==> null.example: Pausing before cleanup of step 'StepProvision'. Press enter to continue.
==> null.example: Pausing before cleanup of step 'StepConnect'. Press enter to continue.
Build 'null.example' finished after 8 seconds 284 milliseconds.

==> Wait completed after 8 seconds 284 milliseconds

==> Builds finished. The artifacts of successful builds are:
--> null.example: Did not export anything. This is the null builder
```

Closes #11457 
