### PR TITLE
website: bump docs-page to fix manual copy issue

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,7 +19,7 @@
         "@hashicorp/react-button": "^6.0.1",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.0.3",
-        "@hashicorp/react-docs-page": "14.14.1-canary-20220128215319",
+        "@hashicorp/react-docs-page": "14.14.3-canary-20220223212614",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -1925,11 +1925,11 @@
       }
     },
     "node_modules/@hashicorp/platform-docs-mdx": {
-      "version": "0.1.4-canary-2022028214714",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4-canary-2022028214714.tgz",
-      "integrity": "sha512-YBCVKboTrCvn7mIyDBtbtUeoX3n9EiJf5xKDtgECLerWWHPuHjatzb1HogAZZ49p6/GF0dqhGXPWvPcKTuy3+A==",
+      "version": "0.1.4-canary-2022123212239",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4-canary-2022123212239.tgz",
+      "integrity": "sha512-EoAHZXDyyhQ63Nz+quJd23lev3M8V5p7quY4KceuQ6iX/Aeoa5KvAO6mzHrrWhoDO8PToS36Gv3KtVs8v2JKbg==",
       "dependencies": {
-        "@hashicorp/react-code-block": "4.4.1-canary-20220128203034",
+        "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -1952,13 +1952,13 @@
       }
     },
     "node_modules/@hashicorp/platform-docs-mdx/node_modules/@hashicorp/react-tabs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-tabs/-/react-tabs-7.1.1.tgz",
-      "integrity": "sha512-5PX4oqyq6suHgHL7zVhg74CwNjEgfamQorbUyI1TMWs1MBatT/5OJ/ls0svbnNfVVVwlMu84pMFhViXWeZw2QA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-tabs/-/react-tabs-7.1.2.tgz",
+      "integrity": "sha512-0ZWPVOvF/FtiXlCVHPsBUfNx4GFNoiakvciE0jdu9it3nJc64GXVKYdlhuBHxF9TSfAMNEqyoeqRsK+HzsCYMA==",
       "dependencies": {
-        "@hashicorp/react-inline-svg": "^6.0.1",
-        "@reach/portal": "^0.16.0",
-        "@reach/tooltip": "^0.16.0",
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@reach/portal": "^0.16.2",
+        "@reach/tooltip": "^0.16.2",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -2254,9 +2254,9 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "4.4.1-canary-20220128203034",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.1-canary-20220128203034.tgz",
-      "integrity": "sha512-k2D+ZLwvwaIii0qN10z7sksL/JdfN/ZWgsI6csH4zRFB7YonqW9fHonHF4GhSZp050hq/oqwR5prV2BrXiX07A==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -2307,9 +2307,9 @@
       }
     },
     "node_modules/@hashicorp/react-content": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.1.0.tgz",
-      "integrity": "sha512-L7z8/GiW2tvoBjLvpwZWWrf/KnGDch0SV29zDdkTtf4oa8Ojd5bVvQYo5Sz6Yva8CpQB2p4EZT6maDepJCnLqA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1.tgz",
+      "integrity": "sha512-qqyK1uejHfsrd+jRlTqQtJpihyUYGdeUottoFmsfPwvcs0Wy+r+AyzetknGiXYbflidjgM9pP6kw2PLtAMwoVQ==",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
@@ -2320,18 +2320,18 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.14.1-canary-20220128215319",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1-canary-20220128215319.tgz",
-      "integrity": "sha512-BdhQ/aaoue7px8yg5h2uxD3eLnDxYsm+AAuk9KDzdaAUaGDoolXrFtvpIK4tV4PKEjQ0GP8Cowo4zvYUFgE98Q==",
+      "version": "14.14.3-canary-20220223212614",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3-canary-20220223212614.tgz",
+      "integrity": "sha512-GYpwg8MlPH7Bn6QSHU66MukPDyxzGN/N+WmqHGJNSYEbMsQQ0cjEhWsJC61tiShvRnq+P+k6PbuK5Xp1OR9/dQ==",
       "dependencies": {
-        "@hashicorp/platform-docs-mdx": "0.1.4-canary-2022028214714",
+        "@hashicorp/platform-docs-mdx": "0.1.4-canary-2022123212239",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.2.1-canary-20220128215319",
+        "@hashicorp/react-content": "^8.2.1",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.4.1-canary-20220128215319",
+        "@hashicorp/react-search": "^6.4.1",
         "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
@@ -2363,56 +2363,6 @@
       },
       "peerDependencies": {
         "react": ">= 16.x"
-      }
-    },
-    "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-content": {
-      "version": "8.2.1-canary-20220128215319",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1-canary-20220128215319.tgz",
-      "integrity": "sha512-/nDVL/P/I8lKQxpyeJRjgVbGh8+MZ4/Nl+jeSTKxR+oWsWDd1cdrLbZos33y50Y3o3ETIPKdHpIwyMSTsFwg6g==",
-      "dependencies": {
-        "@hashicorp/platform-product-meta": "^0.1.0",
-        "classnames": "^2.3.1"
-      },
-      "peerDependencies": {
-        "@hashicorp/mktg-global-styles": ">=3.2.x",
-        "react": ">=16.x"
-      }
-    },
-    "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-search": {
-      "version": "6.4.1-canary-20220128215319",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1-canary-20220128215319.tgz",
-      "integrity": "sha512-GZiDQ74ztI7YPAOcplROP6FTvQ626zzSFM4icM4mxFW34MhoufLRXq7lzdPE8Zz+W/rDPz1qtghFVxQwhbBYcw==",
-      "dependencies": {
-        "@hashicorp/react-inline-svg": "^6.0.3",
-        "@hashicorp/remark-plugins": "^3.3.1",
-        "@reach/visually-hidden": "^0.16.0",
-        "algoliasearch": "^4.12.0",
-        "classnames": "^2.3.1",
-        "dotenv": "^14.3.1",
-        "glob": "^7.2.0",
-        "gray-matter": "^4.0.3",
-        "react-instantsearch-dom": "^6.21.1",
-        "remark": "^13.0.0",
-        "search-insights": "^1.7.1",
-        "unist-util-visit": "^2.0.3"
-      },
-      "peerDependencies": {
-        "@hashicorp/mktg-global-styles": ">=3.x",
-        "react": ">=16.x"
-      }
-    },
-    "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-search/node_modules/remark": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
-      "integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
-      "dependencies": {
-        "remark-parse": "^9.0.0",
-        "remark-stringify": "^9.0.0",
-        "unified": "^9.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/remark-plugins": {
@@ -2455,33 +2405,6 @@
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/@hashicorp/react-docs-page/node_modules/dotenv": {
-      "version": "14.3.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
-      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@hashicorp/react-docs-page/node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@hashicorp/react-docs-page/node_modules/js-yaml": {
@@ -2575,18 +2498,6 @@
       "integrity": "sha512-uqQ/VbaTdxyu/da6npHAso6hA00cMqhA3a59RziQdOLN2KEIkPykAVy52IcmZEVTuauXO0VtpxkyCey4phtHzQ==",
       "dependencies": {
         "mdast-util-to-hast": "^9.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@hashicorp/react-docs-page/node_modules/remark-stringify": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
-      "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
-      "dependencies": {
-        "mdast-util-to-markdown": "^0.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2767,19 +2678,19 @@
       }
     },
     "node_modules/@hashicorp/react-search": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.0.tgz",
-      "integrity": "sha512-ITAvD5QEc+B79VTYC27kdx0P1ynGFPUwed1ttUxlAIhvzasWjKeM6sS1rT8oFF+QcUZqoE7rKq7Y8k53sAB2Lw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1.tgz",
+      "integrity": "sha512-VoFdfjSCyhmbwNT2nB5+midHjZBy+mO5jXAWAzXbQjTvlBA6NEEgPNXnCLCniOKFouiEVSsn9TnqsWfJt41SqQ==",
       "dependencies": {
-        "@hashicorp/react-inline-svg": "^6.0.1",
-        "@hashicorp/remark-plugins": "^3.1.1",
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@hashicorp/remark-plugins": "^3.3.1",
         "@reach/visually-hidden": "^0.16.0",
-        "algoliasearch": "^4.10.3",
+        "algoliasearch": "^4.12.0",
         "classnames": "^2.3.1",
-        "dotenv": "^10.0.0",
-        "glob": "^7.1.7",
+        "dotenv": "^14.3.1",
+        "glob": "^7.2.0",
         "gray-matter": "^4.0.3",
-        "react-instantsearch-dom": "^6.12.1",
+        "react-instantsearch-dom": "^6.21.1",
         "remark": "^13.0.0",
         "search-insights": "^1.7.1",
         "unist-util-visit": "^2.0.3"
@@ -2787,6 +2698,107 @@
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
+      }
+    },
+    "node_modules/@hashicorp/react-search/node_modules/@hashicorp/remark-plugins": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-3.3.1.tgz",
+      "integrity": "sha512-7xThpsBFWasdC/E+E/BAjHxMYqyCcQFiTVspvhBzN51meiQIacVCnyAox/lyvwWiP4N3Yj/ruH4UsR2ifskNeA==",
+      "dependencies": {
+        "@mdx-js/util": "1.6.22",
+        "github-slugger": "^1.3.0",
+        "remark": "12.0.1",
+        "remark-mdx": "1.6.22",
+        "to-vfile": "^6.1.0",
+        "unist-util-flatmap": "^1.0.0",
+        "unist-util-is": "^4.0.2",
+        "unist-util-map": "^2.0.1",
+        "unist-util-visit": "^2.0.3"
+      }
+    },
+    "node_modules/@hashicorp/react-search/node_modules/@hashicorp/remark-plugins/node_modules/remark": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-12.0.1.tgz",
+      "integrity": "sha512-gS7HDonkdIaHmmP/+shCPejCEEW+liMp/t/QwmF0Xt47Rpuhl32lLtDV1uKWvGoq+kxr5jSgg5oAIpGuyULjUw==",
+      "dependencies": {
+        "remark-parse": "^8.0.0",
+        "remark-stringify": "^8.0.0",
+        "unified": "^9.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@hashicorp/react-search/node_modules/@hashicorp/remark-plugins/node_modules/remark-parse": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
+      "integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
+      "dependencies": {
+        "ccount": "^1.0.0",
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^2.0.0",
+        "vfile-location": "^3.0.0",
+        "xtend": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@hashicorp/react-search/node_modules/@hashicorp/remark-plugins/node_modules/remark-stringify": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.1.tgz",
+      "integrity": "sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==",
+      "dependencies": {
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^2.0.0",
+        "mdast-util-compact": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^3.0.0",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@hashicorp/react-search/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@hashicorp/react-search/node_modules/remark": {
@@ -3397,30 +3409,17 @@
       }
     },
     "node_modules/@reach/tooltip": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.0.tgz",
-      "integrity": "sha512-kZr/OqfmmBQVBxJh+OQRCq++T5f6iQaWinpLnwD5FlG5HRKPwNzTnsy+hpyY9pR2mabk+96POp/TsT4Dv3K/qQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.2.tgz",
+      "integrity": "sha512-wtJPnbJ6l4pmudMpQHGU9v1NS4ncDgcwRNi9re9KsIdsM525zccZvHQLteBKYiaW4ib7k09t2dbwhyNU9oa0Iw==",
       "dependencies": {
         "@reach/auto-id": "0.16.0",
-        "@reach/portal": "0.16.0",
+        "@reach/portal": "0.16.2",
         "@reach/rect": "0.16.0",
         "@reach/utils": "0.16.0",
         "@reach/visually-hidden": "0.16.0",
         "prop-types": "^15.7.2",
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/tooltip/node_modules/@reach/portal": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
-      "integrity": "sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -7187,11 +7186,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/download": {
@@ -23675,11 +23674,11 @@
       }
     },
     "@hashicorp/platform-docs-mdx": {
-      "version": "0.1.4-canary-2022028214714",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4-canary-2022028214714.tgz",
-      "integrity": "sha512-YBCVKboTrCvn7mIyDBtbtUeoX3n9EiJf5xKDtgECLerWWHPuHjatzb1HogAZZ49p6/GF0dqhGXPWvPcKTuy3+A==",
+      "version": "0.1.4-canary-2022123212239",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4-canary-2022123212239.tgz",
+      "integrity": "sha512-EoAHZXDyyhQ63Nz+quJd23lev3M8V5p7quY4KceuQ6iX/Aeoa5KvAO6mzHrrWhoDO8PToS36Gv3KtVs8v2JKbg==",
       "requires": {
-        "@hashicorp/react-code-block": "4.4.1-canary-20220128203034",
+        "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -23695,13 +23694,13 @@
           }
         },
         "@hashicorp/react-tabs": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-tabs/-/react-tabs-7.1.1.tgz",
-          "integrity": "sha512-5PX4oqyq6suHgHL7zVhg74CwNjEgfamQorbUyI1TMWs1MBatT/5OJ/ls0svbnNfVVVwlMu84pMFhViXWeZw2QA==",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-tabs/-/react-tabs-7.1.2.tgz",
+          "integrity": "sha512-0ZWPVOvF/FtiXlCVHPsBUfNx4GFNoiakvciE0jdu9it3nJc64GXVKYdlhuBHxF9TSfAMNEqyoeqRsK+HzsCYMA==",
           "requires": {
-            "@hashicorp/react-inline-svg": "^6.0.1",
-            "@reach/portal": "^0.16.0",
-            "@reach/tooltip": "^0.16.0",
+            "@hashicorp/react-inline-svg": "^6.0.3",
+            "@reach/portal": "^0.16.2",
+            "@reach/tooltip": "^0.16.2",
             "classnames": "^2.3.1"
           }
         }
@@ -23931,9 +23930,9 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "4.4.1-canary-20220128203034",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.1-canary-20220128203034.tgz",
-      "integrity": "sha512-k2D+ZLwvwaIii0qN10z7sksL/JdfN/ZWgsI6csH4zRFB7YonqW9fHonHF4GhSZp050hq/oqwR5prV2BrXiX07A==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.2.tgz",
+      "integrity": "sha512-isnojue1SuTaq4jjh6C03jxVLCGmHaSK6D/m3OdEsUeV5PovZ7uNF9MFfhwHErIHKZztxOuIePepqaAB5sMHCw==",
       "requires": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@reach/listbox": "0.16.2",
@@ -23970,27 +23969,27 @@
       }
     },
     "@hashicorp/react-content": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.1.0.tgz",
-      "integrity": "sha512-L7z8/GiW2tvoBjLvpwZWWrf/KnGDch0SV29zDdkTtf4oa8Ojd5bVvQYo5Sz6Yva8CpQB2p4EZT6maDepJCnLqA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1.tgz",
+      "integrity": "sha512-qqyK1uejHfsrd+jRlTqQtJpihyUYGdeUottoFmsfPwvcs0Wy+r+AyzetknGiXYbflidjgM9pP6kw2PLtAMwoVQ==",
       "requires": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.14.1-canary-20220128215319",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1-canary-20220128215319.tgz",
-      "integrity": "sha512-BdhQ/aaoue7px8yg5h2uxD3eLnDxYsm+AAuk9KDzdaAUaGDoolXrFtvpIK4tV4PKEjQ0GP8Cowo4zvYUFgE98Q==",
+      "version": "14.14.3-canary-20220223212614",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3-canary-20220223212614.tgz",
+      "integrity": "sha512-GYpwg8MlPH7Bn6QSHU66MukPDyxzGN/N+WmqHGJNSYEbMsQQ0cjEhWsJC61tiShvRnq+P+k6PbuK5Xp1OR9/dQ==",
       "requires": {
-        "@hashicorp/platform-docs-mdx": "0.1.4-canary-2022028214714",
+        "@hashicorp/platform-docs-mdx": "0.1.4-canary-2022123212239",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.2.1-canary-20220128215319",
+        "@hashicorp/react-content": "^8.2.1",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.4.1-canary-20220128215319",
+        "@hashicorp/react-search": "^6.4.1",
         "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
@@ -24014,46 +24013,6 @@
             "rehype-katex": "^5.0.0",
             "remark-math": "^4.0.0",
             "remark-rehype": "^7.0.0"
-          }
-        },
-        "@hashicorp/react-content": {
-          "version": "8.2.1-canary-20220128215319",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1-canary-20220128215319.tgz",
-          "integrity": "sha512-/nDVL/P/I8lKQxpyeJRjgVbGh8+MZ4/Nl+jeSTKxR+oWsWDd1cdrLbZos33y50Y3o3ETIPKdHpIwyMSTsFwg6g==",
-          "requires": {
-            "@hashicorp/platform-product-meta": "^0.1.0",
-            "classnames": "^2.3.1"
-          }
-        },
-        "@hashicorp/react-search": {
-          "version": "6.4.1-canary-20220128215319",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1-canary-20220128215319.tgz",
-          "integrity": "sha512-GZiDQ74ztI7YPAOcplROP6FTvQ626zzSFM4icM4mxFW34MhoufLRXq7lzdPE8Zz+W/rDPz1qtghFVxQwhbBYcw==",
-          "requires": {
-            "@hashicorp/react-inline-svg": "^6.0.3",
-            "@hashicorp/remark-plugins": "^3.3.1",
-            "@reach/visually-hidden": "^0.16.0",
-            "algoliasearch": "^4.12.0",
-            "classnames": "^2.3.1",
-            "dotenv": "^14.3.1",
-            "glob": "^7.2.0",
-            "gray-matter": "^4.0.3",
-            "react-instantsearch-dom": "^6.21.1",
-            "remark": "^13.0.0",
-            "search-insights": "^1.7.1",
-            "unist-util-visit": "^2.0.3"
-          },
-          "dependencies": {
-            "remark": {
-              "version": "13.0.0",
-              "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
-              "integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
-              "requires": {
-                "remark-parse": "^9.0.0",
-                "remark-stringify": "^9.0.0",
-                "unified": "^9.1.0"
-              }
-            }
           }
         },
         "@hashicorp/remark-plugins": {
@@ -24091,24 +24050,6 @@
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
           "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
-        },
-        "dotenv": {
-          "version": "14.3.2",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
-          "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ=="
-        },
-        "glob": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -24176,14 +24117,6 @@
           "integrity": "sha512-uqQ/VbaTdxyu/da6npHAso6hA00cMqhA3a59RziQdOLN2KEIkPykAVy52IcmZEVTuauXO0VtpxkyCey4phtHzQ==",
           "requires": {
             "mdast-util-to-hast": "^9.1.0"
-          }
-        },
-        "remark-stringify": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
-          "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
-          "requires": {
-            "mdast-util-to-markdown": "^0.6.0"
           }
         }
       }
@@ -24316,24 +24249,109 @@
       }
     },
     "@hashicorp/react-search": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.0.tgz",
-      "integrity": "sha512-ITAvD5QEc+B79VTYC27kdx0P1ynGFPUwed1ttUxlAIhvzasWjKeM6sS1rT8oFF+QcUZqoE7rKq7Y8k53sAB2Lw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1.tgz",
+      "integrity": "sha512-VoFdfjSCyhmbwNT2nB5+midHjZBy+mO5jXAWAzXbQjTvlBA6NEEgPNXnCLCniOKFouiEVSsn9TnqsWfJt41SqQ==",
       "requires": {
-        "@hashicorp/react-inline-svg": "^6.0.1",
-        "@hashicorp/remark-plugins": "^3.1.1",
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@hashicorp/remark-plugins": "^3.3.1",
         "@reach/visually-hidden": "^0.16.0",
-        "algoliasearch": "^4.10.3",
+        "algoliasearch": "^4.12.0",
         "classnames": "^2.3.1",
-        "dotenv": "^10.0.0",
-        "glob": "^7.1.7",
+        "dotenv": "^14.3.1",
+        "glob": "^7.2.0",
         "gray-matter": "^4.0.3",
-        "react-instantsearch-dom": "^6.12.1",
+        "react-instantsearch-dom": "^6.21.1",
         "remark": "^13.0.0",
         "search-insights": "^1.7.1",
         "unist-util-visit": "^2.0.3"
       },
       "dependencies": {
+        "@hashicorp/remark-plugins": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-3.3.1.tgz",
+          "integrity": "sha512-7xThpsBFWasdC/E+E/BAjHxMYqyCcQFiTVspvhBzN51meiQIacVCnyAox/lyvwWiP4N3Yj/ruH4UsR2ifskNeA==",
+          "requires": {
+            "@mdx-js/util": "1.6.22",
+            "github-slugger": "^1.3.0",
+            "remark": "12.0.1",
+            "remark-mdx": "1.6.22",
+            "to-vfile": "^6.1.0",
+            "unist-util-flatmap": "^1.0.0",
+            "unist-util-is": "^4.0.2",
+            "unist-util-map": "^2.0.1",
+            "unist-util-visit": "^2.0.3"
+          },
+          "dependencies": {
+            "remark": {
+              "version": "12.0.1",
+              "resolved": "https://registry.npmjs.org/remark/-/remark-12.0.1.tgz",
+              "integrity": "sha512-gS7HDonkdIaHmmP/+shCPejCEEW+liMp/t/QwmF0Xt47Rpuhl32lLtDV1uKWvGoq+kxr5jSgg5oAIpGuyULjUw==",
+              "requires": {
+                "remark-parse": "^8.0.0",
+                "remark-stringify": "^8.0.0",
+                "unified": "^9.0.0"
+              }
+            },
+            "remark-parse": {
+              "version": "8.0.3",
+              "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
+              "integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
+              "requires": {
+                "ccount": "^1.0.0",
+                "collapse-white-space": "^1.0.2",
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "is-word-character": "^1.0.0",
+                "markdown-escapes": "^1.0.0",
+                "parse-entities": "^2.0.0",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
+                "trim": "0.0.1",
+                "trim-trailing-lines": "^1.0.0",
+                "unherit": "^1.0.4",
+                "unist-util-remove-position": "^2.0.0",
+                "vfile-location": "^3.0.0",
+                "xtend": "^4.0.1"
+              }
+            },
+            "remark-stringify": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.1.tgz",
+              "integrity": "sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==",
+              "requires": {
+                "ccount": "^1.0.0",
+                "is-alphanumeric": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "longest-streak": "^2.0.1",
+                "markdown-escapes": "^1.0.0",
+                "markdown-table": "^2.0.0",
+                "mdast-util-compact": "^2.0.0",
+                "parse-entities": "^2.0.0",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
+                "stringify-entities": "^3.0.0",
+                "unherit": "^1.0.4",
+                "xtend": "^4.0.1"
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "remark": {
           "version": "13.0.0",
           "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
@@ -24801,29 +24819,18 @@
       }
     },
     "@reach/tooltip": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.0.tgz",
-      "integrity": "sha512-kZr/OqfmmBQVBxJh+OQRCq++T5f6iQaWinpLnwD5FlG5HRKPwNzTnsy+hpyY9pR2mabk+96POp/TsT4Dv3K/qQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.16.2.tgz",
+      "integrity": "sha512-wtJPnbJ6l4pmudMpQHGU9v1NS4ncDgcwRNi9re9KsIdsM525zccZvHQLteBKYiaW4ib7k09t2dbwhyNU9oa0Iw==",
       "requires": {
         "@reach/auto-id": "0.16.0",
-        "@reach/portal": "0.16.0",
+        "@reach/portal": "0.16.2",
         "@reach/rect": "0.16.0",
         "@reach/utils": "0.16.0",
         "@reach/visually-hidden": "0.16.0",
         "prop-types": "^15.7.2",
         "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "@reach/portal": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
-          "integrity": "sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
-        }
       }
     },
     "@reach/utils": {
@@ -27707,9 +27714,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ=="
     },
     "download": {
       "version": "6.2.5",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,7 +19,7 @@
         "@hashicorp/react-button": "^6.0.1",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.0.3",
-        "@hashicorp/react-docs-page": "^14.13.0",
+        "@hashicorp/react-docs-page": "^14.14.1-canary-20220128203034",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -57,118 +57,123 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.5.tgz",
-      "integrity": "sha512-cfX2rEKOtuuljcGI5DMDHClwZHdDqd2nT2Ohsc8aHtBiz6bUxKVyIqxr2gaC6tU8AgPtrTVBzcxCA+UavXpKww==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.12.1.tgz",
+      "integrity": "sha512-ERFFOnC9740xAkuO0iZTQqm2AzU7Dpz/s+g7o48GlZgx5p9GgNcsuK5eS0GoW/tAK+fnKlizCtlFHNuIWuvfsg==",
       "dependencies": {
-        "@algolia/cache-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.5.tgz",
-      "integrity": "sha512-1mClwdmTHll+OnHkG+yeRoFM17kSxDs4qXkjf6rNZhoZGXDvfYLy3YcZ1FX4Kyz0DJv8aroq5RYGBDsWkHj6Tw=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.12.1.tgz",
+      "integrity": "sha512-UugTER3V40jT+e19Dmph5PKMeliYKxycNPwrPNADin0RcWNfT2QksK9Ff2N2W7UKraqMOzoeDb4LAJtxcK1a8Q=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.5.tgz",
-      "integrity": "sha512-+ciQnfIGi5wjMk02XhEY8fmy2pzy+oY1nIIfu8LBOglaSipCRAtjk6WhHc7/KIbXPiYzIwuDbM2K1+YOwSGjwA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.12.1.tgz",
+      "integrity": "sha512-U6iaunaxK1lHsAf02UWF58foKFEcrVLsHwN56UkCtwn32nlP9rz52WOcHsgk6TJrL8NDcO5swMjtOQ5XHESFLw==",
       "dependencies": {
-        "@algolia/cache-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.5.tgz",
-      "integrity": "sha512-I9UkSS2glXm7RBZYZIALjBMmXSQbw/fI/djPcBHxiwXIheNIlqIFl2SNPkvihpPF979BSkzjqdJNRPhE1vku3Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.12.1.tgz",
+      "integrity": "sha512-jGo4ConJNoMdTCR2zouO0jO/JcJmzOK6crFxMMLvdnB1JhmMbuIKluOTJVlBWeivnmcsqb7r0v7qTCPW5PAyxQ==",
       "dependencies": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.5.tgz",
-      "integrity": "sha512-h2owwJSkovPxzc+xIsjY1pMl0gj+jdVwP9rcnGjlaTY2fqHbSLrR9yvGyyr6305LvTppxsQnfAbRdE/5Z3eFxw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.12.1.tgz",
+      "integrity": "sha512-h1It7KXzIthlhuhfBk7LteYq72tym9maQDUsyRW0Gft8b6ZQahnRak9gcCvKwhcJ1vJoP7T7JrNYGiYSicTD9g==",
       "dependencies": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.5.tgz",
-      "integrity": "sha512-21FAvIai5qm8DVmZHm2Gp4LssQ/a0nWwMchAx+1hIRj1TX7OcdW6oZDPyZ8asQdvTtK7rStQrRnD8a95SCUnzA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.12.1.tgz",
+      "integrity": "sha512-obnJ8eSbv+h94Grk83DTGQ3bqhViSWureV6oK1s21/KMGWbb3DkduHm+lcwFrMFkjSUSzosLBHV9EQUIBvueTw==",
       "dependencies": {
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.5.tgz",
-      "integrity": "sha512-nH+IyFKBi8tCyzGOanJTbXC5t4dspSovX3+ABfmwKWUYllYzmiQNFUadpb3qo+MLA3jFx5IwBesjneN6dD5o3w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.12.1.tgz",
+      "integrity": "sha512-sMSnjjPjRgByGHYygV+5L/E8a6RgU7l2GbpJukSzJ9GRY37tHmBHuvahv8JjdCGJ2p7QDYLnQy5bN5Z02qjc7Q==",
       "dependencies": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.5.tgz",
-      "integrity": "sha512-1eQFMz9uodrc5OM+9HeT+hHcfR1E1AsgFWXwyJ9Q3xejA2c1c4eObGgOgC9ZoshuHHdptaTN1m3rexqAxXRDBg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.12.1.tgz",
+      "integrity": "sha512-MwwKKprfY6X2nJ5Ki/ccXM2GDEePvVjZnnoOB2io3dLKW4fTqeSRlC5DRXeFD7UM0vOPPHr4ItV2aj19APKNVQ==",
       "dependencies": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
+    "node_modules/@algolia/events": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
+      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
+    },
     "node_modules/@algolia/logger-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.5.tgz",
-      "integrity": "sha512-gRJo9zt1UYP4k3woEmZm4iuEBIQd/FrArIsjzsL/b+ihNoOqIxZKTSuGFU4UUZOEhvmxDReiA4gzvQXG+TMTmA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.12.1.tgz",
+      "integrity": "sha512-fCgrzlXGATNqdFTxwx0GsyPXK+Uqrx1SZ3iuY2VGPPqdt1a20clAG2n2OcLHJpvaa6vMFPlJyWvbqAgzxdxBlQ=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.5.tgz",
-      "integrity": "sha512-4WfIbn4253EDU12u9UiYvz+QTvAXDv39mKNg9xSoMCjKE5szcQxfcSczw2byc6pYhahOJ9PmxPBfs1doqsdTKQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.12.1.tgz",
+      "integrity": "sha512-0owaEnq/davngQMYqxLA4KrhWHiXujQ1CU3FFnyUcMyBR7rGHI48zSOUpqnsAXrMBdSH6rH5BDkSUUFwsh8RkQ==",
       "dependencies": {
-        "@algolia/logger-common": "4.10.5"
+        "@algolia/logger-common": "4.12.1"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.5.tgz",
-      "integrity": "sha512-53/MURQEqtK+bGdfq4ITSPwTh5hnADU99qzvpAINGQveUFNSFGERipJxHjTJjIrjFz3vxj5kKwjtxDnU6ygO9g==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.12.1.tgz",
+      "integrity": "sha512-OaMxDyG0TZG0oqz1lQh9e3woantAG1bLnuwq3fmypsrQxra4IQZiyn1x+kEb69D2TcXApI5gOgrD4oWhtEVMtw==",
       "dependencies": {
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.5.tgz",
-      "integrity": "sha512-UkVa1Oyuj6NPiAEt5ZvrbVopEv1m/mKqjs40KLB+dvfZnNcj+9Fry4Oxnt15HMy/HLORXsx4UwcthAvBuOXE9Q=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.12.1.tgz",
+      "integrity": "sha512-XWIrWQNJ1vIrSuL/bUk3ZwNMNxl+aWz6dNboRW6+lGTcMIwc3NBFE90ogbZKhNrFRff8zI4qCF15tjW+Fyhpow=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.5.tgz",
-      "integrity": "sha512-aNEKVKXL4fiiC+bS7yJwAHdxln81ieBwY3tsMCtM4zF9f5KwCzY2OtN4WKEZa5AAADVcghSAUdyjs4AcGUlO5w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.12.1.tgz",
+      "integrity": "sha512-awBtwaD+s0hxkA1aehYn8F0t9wqGoBVWgY4JPHBmp1ChO3pK7RKnnvnv7QQa9vTlllX29oPt/BBVgMo1Z3n1Qg==",
       "dependencies": {
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.5.tgz",
-      "integrity": "sha512-F8DLkmIlvCoMwSCZA3FKHtmdjH3o5clbt0pi2ktFStVNpC6ZDmY307HcK619bKP5xW6h8sVJhcvrLB775D2cyA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.12.1.tgz",
+      "integrity": "sha512-BGeNgdEHc6dXIk2g8kdlOoQ6fQ6OIaKQcplEj7HPoi+XZUeAvRi3Pff3QWd7YmybWkjzd9AnTzieTASDWhL+sQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.10.5",
-        "@algolia/logger-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2213,25 +2218,25 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.13.0.tgz",
-      "integrity": "sha512-uaV1AztfwH6liSdUVGgu+BDQblV4tedqeAZFMKOCveZOZAdg6eFq46CJppTQGLaa4P6swcifmVyF9TK4r5cFJg==",
+      "version": "14.14.1-canary-20220128203034",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1-canary-20220128203034.tgz",
+      "integrity": "sha512-8Q2pI7n89iSV1KccB/OLg1EwjW3FEG9jeNPXrOdCYnHi83/+wreDugb9Pi3x1PZyyw9lmPLHl7Mrs373ibBArA==",
       "dependencies": {
         "@hashicorp/platform-docs-mdx": "^0.1.3",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.1.0",
-        "@hashicorp/react-docs-sidenav": "^8.4.0",
+        "@hashicorp/react-content": "^8.2.1-canary-20220128203034",
+        "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.3.1",
+        "@hashicorp/react-search": "^6.4.1-canary-20220128203034",
         "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "line-reader": "^0.4.0",
-        "moize": "^6.0.3",
+        "moize": "^6.1.0",
         "readdirp": "^3.6.0",
         "semver": "^7.3.5"
       },
@@ -2256,6 +2261,56 @@
       },
       "peerDependencies": {
         "react": ">= 16.x"
+      }
+    },
+    "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-content": {
+      "version": "8.2.1-canary-20220128211122",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1-canary-20220128211122.tgz",
+      "integrity": "sha512-D9oYclElHD8VIwnoIu7o5RkbuP+fMCIXPFGiBsnciP1oq+bOJ3+tuVuM67Gcbzr5X8KB22gSgWByHZsFl+sByA==",
+      "dependencies": {
+        "@hashicorp/platform-product-meta": "^0.1.0",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@hashicorp/mktg-global-styles": ">=3.2.x",
+        "react": ">=16.x"
+      }
+    },
+    "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-search": {
+      "version": "6.4.1-canary-20220128211122",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1-canary-20220128211122.tgz",
+      "integrity": "sha512-LU05EZzYu3KJUVo1C9b+ar7v+dgCFe5R82oDIhg+1DV4VJQ1NiX0WmVowwwLgbPTpFNqDrv0M9oU6ogY69XHdA==",
+      "dependencies": {
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@hashicorp/remark-plugins": "^3.3.1",
+        "@reach/visually-hidden": "^0.16.0",
+        "algoliasearch": "^4.12.0",
+        "classnames": "^2.3.1",
+        "dotenv": "^14.3.1",
+        "glob": "^7.2.0",
+        "gray-matter": "^4.0.3",
+        "react-instantsearch-dom": "^6.21.1",
+        "remark": "^13.0.0",
+        "search-insights": "^1.7.1",
+        "unist-util-visit": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@hashicorp/mktg-global-styles": ">=3.x",
+        "react": ">=16.x"
+      }
+    },
+    "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-search/node_modules/remark": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
+      "integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
+      "dependencies": {
+        "remark-parse": "^9.0.0",
+        "remark-stringify": "^9.0.0",
+        "unified": "^9.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/remark-plugins": {
@@ -2298,6 +2353,33 @@
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/@hashicorp/react-docs-page/node_modules/dotenv": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@hashicorp/react-docs-page/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@hashicorp/react-docs-page/node_modules/js-yaml": {
@@ -2391,6 +2473,18 @@
       "integrity": "sha512-uqQ/VbaTdxyu/da6npHAso6hA00cMqhA3a59RziQdOLN2KEIkPykAVy52IcmZEVTuauXO0VtpxkyCey4phtHzQ==",
       "dependencies": {
         "mdast-util-to-hast": "^9.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@hashicorp/react-docs-page/node_modules/remark-stringify": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
+      "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
+      "dependencies": {
+        "mdast-util-to-markdown": "^0.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3038,13 +3132,9 @@
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.3.tgz",
       "integrity": "sha512-TwP4krjhs+uU9pesDYCShEXZrLSbJr78p12e7XnLBBaNf20SgWLlVmQUT9gX9KbWan5V0sUbJfmcS8MRNHgYuA==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": ">= 10"
       }
@@ -3053,13 +3143,9 @@
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.3.tgz",
       "integrity": "sha512-ZSWmkg/PxccHFNUSeBdrfaH8KwSkoeUtewXKvuYYt7Ph0yRsbqSyNIvhUezDua96lApiXXq6EL2d1THfeWomvw==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": ">= 10"
       }
@@ -3068,13 +3154,9 @@
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.3.tgz",
       "integrity": "sha512-PrTBN0iZudAuj4jSbtXcdBdmfpaDCPIneG4Oms4zcs93KwMgLhivYW082Mvlgx9QVEiRm7+RkFpIVtG/i7JitA==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">= 10"
       }
@@ -3083,13 +3165,9 @@
       "version": "11.1.3",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.3.tgz",
       "integrity": "sha512-mRwbscVjRoHk+tDY7XbkT5d9FCwujFIQJpGp0XNb1i5OHCSDO8WW/C9cLEWS4LxKRbIZlTLYg1MTXqLQkvva8w==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">= 10"
       }
@@ -3840,43 +3918,35 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.5.tgz",
-      "integrity": "sha512-KmH2XkiN+8FxhND4nWFbQDkIoU6g2OjfeU9kIv4Lb+EiOOs3Gpp7jvd+JnatsCisAZsnWQdjd7zVlW7I/85QvQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.12.1.tgz",
+      "integrity": "sha512-c0dM1g3zZBJrkzE5GA/Nu1y3fFxx3LCzxKzcmp2dgGS8P4CjszB/l3lsSh2MSrrK1Hn/KV4BlbBMXtYgG1Bfrw==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.10.5",
-        "@algolia/cache-common": "4.10.5",
-        "@algolia/cache-in-memory": "4.10.5",
-        "@algolia/client-account": "4.10.5",
-        "@algolia/client-analytics": "4.10.5",
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-personalization": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/logger-common": "4.10.5",
-        "@algolia/logger-console": "4.10.5",
-        "@algolia/requester-browser-xhr": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/requester-node-http": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/cache-browser-local-storage": "4.12.1",
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/cache-in-memory": "4.12.1",
+        "@algolia/client-account": "4.12.1",
+        "@algolia/client-analytics": "4.12.1",
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-personalization": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/logger-console": "4.12.1",
+        "@algolia/requester-browser-xhr": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/requester-node-http": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.6.0.tgz",
-      "integrity": "sha512-F4Smiq+Vyv/JJytuKNFuzXndPSb4pjtiHZSkEztQCcB+SORu71A8grgt2NSJhbB5VhqHW19QDtlPKbdYdcNrLg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.7.0.tgz",
+      "integrity": "sha512-XJ3QfERBLfeVCyTVx80gon7r3/rgm/CE8Ha1H7cbablRe/X7SfYQ14g/eO+MhjVKIQp+gy9oC6G5ilmLwS1k6w==",
       "dependencies": {
-        "events": "^1.1.1"
+        "@algolia/events": "^4.0.1"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 5"
-      }
-    },
-    "node_modules/algoliasearch-helper/node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/anser": {
@@ -8630,9 +8700,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -17814,12 +17882,12 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-instantsearch-core": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.12.1.tgz",
-      "integrity": "sha512-X4OqakDI3DOcFiS1S46z+cciKEQcKBmH8HGQLztzW14hoHRqFfZzuqWydlSxfJZN5WksMMm78EmL2jvoqIHd/A==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.21.1.tgz",
+      "integrity": "sha512-be4+J9sOA2cR+uYi4vGvZGC4u19Rs379UtOzv0JBNSUD8hDSxewhxqovqhJRhMH6y5RKw7EFYQUYp9bHxj01rw==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.5.3",
+        "algoliasearch-helper": "^3.7.0",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0"
       },
@@ -17829,16 +17897,16 @@
       }
     },
     "node_modules/react-instantsearch-dom": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.12.1.tgz",
-      "integrity": "sha512-KXk2UDmJ3OP9B57owPC0+7fdcVtmYAA6/UWimR9CXhvFGCMi11xlR/wscYMYxdPuxs9IkmnnLDIJSjSGADYnow==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.21.1.tgz",
+      "integrity": "sha512-3f7VrKW4L1jnah51UbRitDMcfFIl6FoLSc2JmCF9qND2nbDh/NlZvcT45BPxbCYnK4qNc2HJFx0ipe+zoGbNtA==",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.5.3",
+        "algoliasearch-helper": "^3.7.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "^6.12.1"
+        "react-instantsearch-core": "6.21.1"
       },
       "peerDependencies": {
         "react": ">= 16.3.0 < 18",
@@ -22070,118 +22138,123 @@
   },
   "dependencies": {
     "@algolia/cache-browser-local-storage": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.5.tgz",
-      "integrity": "sha512-cfX2rEKOtuuljcGI5DMDHClwZHdDqd2nT2Ohsc8aHtBiz6bUxKVyIqxr2gaC6tU8AgPtrTVBzcxCA+UavXpKww==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.12.1.tgz",
+      "integrity": "sha512-ERFFOnC9740xAkuO0iZTQqm2AzU7Dpz/s+g7o48GlZgx5p9GgNcsuK5eS0GoW/tAK+fnKlizCtlFHNuIWuvfsg==",
       "requires": {
-        "@algolia/cache-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.5.tgz",
-      "integrity": "sha512-1mClwdmTHll+OnHkG+yeRoFM17kSxDs4qXkjf6rNZhoZGXDvfYLy3YcZ1FX4Kyz0DJv8aroq5RYGBDsWkHj6Tw=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.12.1.tgz",
+      "integrity": "sha512-UugTER3V40jT+e19Dmph5PKMeliYKxycNPwrPNADin0RcWNfT2QksK9Ff2N2W7UKraqMOzoeDb4LAJtxcK1a8Q=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.5.tgz",
-      "integrity": "sha512-+ciQnfIGi5wjMk02XhEY8fmy2pzy+oY1nIIfu8LBOglaSipCRAtjk6WhHc7/KIbXPiYzIwuDbM2K1+YOwSGjwA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.12.1.tgz",
+      "integrity": "sha512-U6iaunaxK1lHsAf02UWF58foKFEcrVLsHwN56UkCtwn32nlP9rz52WOcHsgk6TJrL8NDcO5swMjtOQ5XHESFLw==",
       "requires": {
-        "@algolia/cache-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1"
       }
     },
     "@algolia/client-account": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.5.tgz",
-      "integrity": "sha512-I9UkSS2glXm7RBZYZIALjBMmXSQbw/fI/djPcBHxiwXIheNIlqIFl2SNPkvihpPF979BSkzjqdJNRPhE1vku3Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.12.1.tgz",
+      "integrity": "sha512-jGo4ConJNoMdTCR2zouO0jO/JcJmzOK6crFxMMLvdnB1JhmMbuIKluOTJVlBWeivnmcsqb7r0v7qTCPW5PAyxQ==",
       "requires": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.5.tgz",
-      "integrity": "sha512-h2owwJSkovPxzc+xIsjY1pMl0gj+jdVwP9rcnGjlaTY2fqHbSLrR9yvGyyr6305LvTppxsQnfAbRdE/5Z3eFxw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.12.1.tgz",
+      "integrity": "sha512-h1It7KXzIthlhuhfBk7LteYq72tym9maQDUsyRW0Gft8b6ZQahnRak9gcCvKwhcJ1vJoP7T7JrNYGiYSicTD9g==",
       "requires": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.5.tgz",
-      "integrity": "sha512-21FAvIai5qm8DVmZHm2Gp4LssQ/a0nWwMchAx+1hIRj1TX7OcdW6oZDPyZ8asQdvTtK7rStQrRnD8a95SCUnzA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.12.1.tgz",
+      "integrity": "sha512-obnJ8eSbv+h94Grk83DTGQ3bqhViSWureV6oK1s21/KMGWbb3DkduHm+lcwFrMFkjSUSzosLBHV9EQUIBvueTw==",
       "requires": {
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.5.tgz",
-      "integrity": "sha512-nH+IyFKBi8tCyzGOanJTbXC5t4dspSovX3+ABfmwKWUYllYzmiQNFUadpb3qo+MLA3jFx5IwBesjneN6dD5o3w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.12.1.tgz",
+      "integrity": "sha512-sMSnjjPjRgByGHYygV+5L/E8a6RgU7l2GbpJukSzJ9GRY37tHmBHuvahv8JjdCGJ2p7QDYLnQy5bN5Z02qjc7Q==",
       "requires": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "@algolia/client-search": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.5.tgz",
-      "integrity": "sha512-1eQFMz9uodrc5OM+9HeT+hHcfR1E1AsgFWXwyJ9Q3xejA2c1c4eObGgOgC9ZoshuHHdptaTN1m3rexqAxXRDBg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.12.1.tgz",
+      "integrity": "sha512-MwwKKprfY6X2nJ5Ki/ccXM2GDEePvVjZnnoOB2io3dLKW4fTqeSRlC5DRXeFD7UM0vOPPHr4ItV2aj19APKNVQ==",
       "requires": {
-        "@algolia/client-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/client-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
+    "@algolia/events": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
+      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
+    },
     "@algolia/logger-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.5.tgz",
-      "integrity": "sha512-gRJo9zt1UYP4k3woEmZm4iuEBIQd/FrArIsjzsL/b+ihNoOqIxZKTSuGFU4UUZOEhvmxDReiA4gzvQXG+TMTmA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.12.1.tgz",
+      "integrity": "sha512-fCgrzlXGATNqdFTxwx0GsyPXK+Uqrx1SZ3iuY2VGPPqdt1a20clAG2n2OcLHJpvaa6vMFPlJyWvbqAgzxdxBlQ=="
     },
     "@algolia/logger-console": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.5.tgz",
-      "integrity": "sha512-4WfIbn4253EDU12u9UiYvz+QTvAXDv39mKNg9xSoMCjKE5szcQxfcSczw2byc6pYhahOJ9PmxPBfs1doqsdTKQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.12.1.tgz",
+      "integrity": "sha512-0owaEnq/davngQMYqxLA4KrhWHiXujQ1CU3FFnyUcMyBR7rGHI48zSOUpqnsAXrMBdSH6rH5BDkSUUFwsh8RkQ==",
       "requires": {
-        "@algolia/logger-common": "4.10.5"
+        "@algolia/logger-common": "4.12.1"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.5.tgz",
-      "integrity": "sha512-53/MURQEqtK+bGdfq4ITSPwTh5hnADU99qzvpAINGQveUFNSFGERipJxHjTJjIrjFz3vxj5kKwjtxDnU6ygO9g==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.12.1.tgz",
+      "integrity": "sha512-OaMxDyG0TZG0oqz1lQh9e3woantAG1bLnuwq3fmypsrQxra4IQZiyn1x+kEb69D2TcXApI5gOgrD4oWhtEVMtw==",
       "requires": {
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.5.tgz",
-      "integrity": "sha512-UkVa1Oyuj6NPiAEt5ZvrbVopEv1m/mKqjs40KLB+dvfZnNcj+9Fry4Oxnt15HMy/HLORXsx4UwcthAvBuOXE9Q=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.12.1.tgz",
+      "integrity": "sha512-XWIrWQNJ1vIrSuL/bUk3ZwNMNxl+aWz6dNboRW6+lGTcMIwc3NBFE90ogbZKhNrFRff8zI4qCF15tjW+Fyhpow=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.5.tgz",
-      "integrity": "sha512-aNEKVKXL4fiiC+bS7yJwAHdxln81ieBwY3tsMCtM4zF9f5KwCzY2OtN4WKEZa5AAADVcghSAUdyjs4AcGUlO5w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.12.1.tgz",
+      "integrity": "sha512-awBtwaD+s0hxkA1aehYn8F0t9wqGoBVWgY4JPHBmp1ChO3pK7RKnnvnv7QQa9vTlllX29oPt/BBVgMo1Z3n1Qg==",
       "requires": {
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@algolia/transporter": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.5.tgz",
-      "integrity": "sha512-F8DLkmIlvCoMwSCZA3FKHtmdjH3o5clbt0pi2ktFStVNpC6ZDmY307HcK619bKP5xW6h8sVJhcvrLB775D2cyA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.12.1.tgz",
+      "integrity": "sha512-BGeNgdEHc6dXIk2g8kdlOoQ6fQ6OIaKQcplEj7HPoi+XZUeAvRi3Pff3QWd7YmybWkjzd9AnTzieTASDWhL+sQ==",
       "requires": {
-        "@algolia/cache-common": "4.10.5",
-        "@algolia/logger-common": "4.10.5",
-        "@algolia/requester-common": "4.10.5"
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/requester-common": "4.12.1"
       }
     },
     "@babel/code-frame": {
@@ -23793,25 +23866,25 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.13.0.tgz",
-      "integrity": "sha512-uaV1AztfwH6liSdUVGgu+BDQblV4tedqeAZFMKOCveZOZAdg6eFq46CJppTQGLaa4P6swcifmVyF9TK4r5cFJg==",
+      "version": "14.14.1-canary-20220128203034",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1-canary-20220128203034.tgz",
+      "integrity": "sha512-8Q2pI7n89iSV1KccB/OLg1EwjW3FEG9jeNPXrOdCYnHi83/+wreDugb9Pi3x1PZyyw9lmPLHl7Mrs373ibBArA==",
       "requires": {
         "@hashicorp/platform-docs-mdx": "^0.1.3",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.1.0",
-        "@hashicorp/react-docs-sidenav": "^8.4.0",
+        "@hashicorp/react-content": "^8.2.1-canary-20220128203034",
+        "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.3.1",
+        "@hashicorp/react-search": "^6.4.1-canary-20220128203034",
         "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "line-reader": "^0.4.0",
-        "moize": "^6.0.3",
+        "moize": "^6.1.0",
         "readdirp": "^3.6.0",
         "semver": "^7.3.5"
       },
@@ -23828,6 +23901,46 @@
             "rehype-katex": "^5.0.0",
             "remark-math": "^4.0.0",
             "remark-rehype": "^7.0.0"
+          }
+        },
+        "@hashicorp/react-content": {
+          "version": "8.2.1-canary-20220128211122",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1-canary-20220128211122.tgz",
+          "integrity": "sha512-D9oYclElHD8VIwnoIu7o5RkbuP+fMCIXPFGiBsnciP1oq+bOJ3+tuVuM67Gcbzr5X8KB22gSgWByHZsFl+sByA==",
+          "requires": {
+            "@hashicorp/platform-product-meta": "^0.1.0",
+            "classnames": "^2.3.1"
+          }
+        },
+        "@hashicorp/react-search": {
+          "version": "6.4.1-canary-20220128211122",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1-canary-20220128211122.tgz",
+          "integrity": "sha512-LU05EZzYu3KJUVo1C9b+ar7v+dgCFe5R82oDIhg+1DV4VJQ1NiX0WmVowwwLgbPTpFNqDrv0M9oU6ogY69XHdA==",
+          "requires": {
+            "@hashicorp/react-inline-svg": "^6.0.3",
+            "@hashicorp/remark-plugins": "^3.3.1",
+            "@reach/visually-hidden": "^0.16.0",
+            "algoliasearch": "^4.12.0",
+            "classnames": "^2.3.1",
+            "dotenv": "^14.3.1",
+            "glob": "^7.2.0",
+            "gray-matter": "^4.0.3",
+            "react-instantsearch-dom": "^6.21.1",
+            "remark": "^13.0.0",
+            "search-insights": "^1.7.1",
+            "unist-util-visit": "^2.0.3"
+          },
+          "dependencies": {
+            "remark": {
+              "version": "13.0.0",
+              "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
+              "integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
+              "requires": {
+                "remark-parse": "^9.0.0",
+                "remark-stringify": "^9.0.0",
+                "unified": "^9.1.0"
+              }
+            }
           }
         },
         "@hashicorp/remark-plugins": {
@@ -23865,6 +23978,24 @@
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
           "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        },
+        "dotenv": {
+          "version": "14.3.2",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+          "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ=="
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -23932,6 +24063,14 @@
           "integrity": "sha512-uqQ/VbaTdxyu/da6npHAso6hA00cMqhA3a59RziQdOLN2KEIkPykAVy52IcmZEVTuauXO0VtpxkyCey4phtHzQ==",
           "requires": {
             "mdast-util-to-hast": "^9.1.0"
+          }
+        },
+        "remark-stringify": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
+          "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
+          "requires": {
+            "mdast-util-to-markdown": "^0.6.0"
           }
         }
       }
@@ -25013,39 +25152,32 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.10.5",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.5.tgz",
-      "integrity": "sha512-KmH2XkiN+8FxhND4nWFbQDkIoU6g2OjfeU9kIv4Lb+EiOOs3Gpp7jvd+JnatsCisAZsnWQdjd7zVlW7I/85QvQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.12.1.tgz",
+      "integrity": "sha512-c0dM1g3zZBJrkzE5GA/Nu1y3fFxx3LCzxKzcmp2dgGS8P4CjszB/l3lsSh2MSrrK1Hn/KV4BlbBMXtYgG1Bfrw==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.10.5",
-        "@algolia/cache-common": "4.10.5",
-        "@algolia/cache-in-memory": "4.10.5",
-        "@algolia/client-account": "4.10.5",
-        "@algolia/client-analytics": "4.10.5",
-        "@algolia/client-common": "4.10.5",
-        "@algolia/client-personalization": "4.10.5",
-        "@algolia/client-search": "4.10.5",
-        "@algolia/logger-common": "4.10.5",
-        "@algolia/logger-console": "4.10.5",
-        "@algolia/requester-browser-xhr": "4.10.5",
-        "@algolia/requester-common": "4.10.5",
-        "@algolia/requester-node-http": "4.10.5",
-        "@algolia/transporter": "4.10.5"
+        "@algolia/cache-browser-local-storage": "4.12.1",
+        "@algolia/cache-common": "4.12.1",
+        "@algolia/cache-in-memory": "4.12.1",
+        "@algolia/client-account": "4.12.1",
+        "@algolia/client-analytics": "4.12.1",
+        "@algolia/client-common": "4.12.1",
+        "@algolia/client-personalization": "4.12.1",
+        "@algolia/client-search": "4.12.1",
+        "@algolia/logger-common": "4.12.1",
+        "@algolia/logger-console": "4.12.1",
+        "@algolia/requester-browser-xhr": "4.12.1",
+        "@algolia/requester-common": "4.12.1",
+        "@algolia/requester-node-http": "4.12.1",
+        "@algolia/transporter": "4.12.1"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.6.0.tgz",
-      "integrity": "sha512-F4Smiq+Vyv/JJytuKNFuzXndPSb4pjtiHZSkEztQCcB+SORu71A8grgt2NSJhbB5VhqHW19QDtlPKbdYdcNrLg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.7.0.tgz",
+      "integrity": "sha512-XJ3QfERBLfeVCyTVx80gon7r3/rgm/CE8Ha1H7cbablRe/X7SfYQ14g/eO+MhjVKIQp+gy9oC6G5ilmLwS1k6w==",
       "requires": {
-        "events": "^1.1.1"
-      },
-      "dependencies": {
-        "events": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-        }
+        "@algolia/events": "^4.0.1"
       }
     },
     "anser": {
@@ -35689,27 +35821,27 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-instantsearch-core": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.12.1.tgz",
-      "integrity": "sha512-X4OqakDI3DOcFiS1S46z+cciKEQcKBmH8HGQLztzW14hoHRqFfZzuqWydlSxfJZN5WksMMm78EmL2jvoqIHd/A==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.21.1.tgz",
+      "integrity": "sha512-be4+J9sOA2cR+uYi4vGvZGC4u19Rs379UtOzv0JBNSUD8hDSxewhxqovqhJRhMH6y5RKw7EFYQUYp9bHxj01rw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.5.3",
+        "algoliasearch-helper": "^3.7.0",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0"
       }
     },
     "react-instantsearch-dom": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.12.1.tgz",
-      "integrity": "sha512-KXk2UDmJ3OP9B57owPC0+7fdcVtmYAA6/UWimR9CXhvFGCMi11xlR/wscYMYxdPuxs9IkmnnLDIJSjSGADYnow==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.21.1.tgz",
+      "integrity": "sha512-3f7VrKW4L1jnah51UbRitDMcfFIl6FoLSc2JmCF9qND2nbDh/NlZvcT45BPxbCYnK4qNc2HJFx0ipe+zoGbNtA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "algoliasearch-helper": "^3.5.3",
+        "algoliasearch-helper": "^3.7.0",
         "classnames": "^2.2.5",
         "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "^6.12.1"
+        "react-instantsearch-core": "6.21.1"
       }
     },
     "react-is": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,7 +19,7 @@
         "@hashicorp/react-button": "^6.0.1",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.0.3",
-        "@hashicorp/react-docs-page": "^14.14.1-canary-20220128203034",
+        "@hashicorp/react-docs-page": "14.14.1-canary-20220128215319",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -881,6 +881,146 @@
       "integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ==",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.2.tgz",
+      "integrity": "sha512-kHlk0lid8kp1MmrGGtmPvRP2BNSz8rQBYWH0txqipBJv5ZPsXnyflypcBlivIppxA1+gciwAwg3B/Zcx8L6m1A==",
+      "dependencies": {
+        "@hashicorp/react-inline-svg": "6.0.1",
+        "@reach/listbox": "0.15.0",
+        "shellwords": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@hashicorp/mktg-global-styles": ">=3.x",
+        "@hashicorp/nextjs-scripts": ">=17.x",
+        "react": ">=16.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@hashicorp/react-inline-svg": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-6.0.1.tgz",
+      "integrity": "sha512-EpvJd0AkE5tvlentS/Oez5W7SFJ32UjvU0RVFPYQlwR6tOTMOR9wK7Ose69WjkmtdjPMHWRE6MxWeSn0c1N5Bw==",
+      "peerDependencies": {
+        "@hashicorp/mktg-global-styles": ">=3.x",
+        "@hashicorp/nextjs-scripts": ">=17.x",
+        "react": ">=16.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.15.0.tgz",
+      "integrity": "sha512-3Vvpte0HQkfo3sT4Cz6gG9h+E/La2IwbtLQDTesEmDzToQ8bk9rOfuFDVp7IXUyOdDggfDCOEz/ZphsuniADWA==",
+      "dependencies": {
+        "@reach/auto-id": "0.15.0",
+        "@reach/descendants": "0.15.0",
+        "@reach/machine": "0.15.0",
+        "@reach/popover": "0.15.0",
+        "@reach/utils": "0.15.0",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox/node_modules/@reach/auto-id": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
+      "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
+      "dependencies": {
+        "@reach/utils": "0.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox/node_modules/@reach/descendants": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.15.0.tgz",
+      "integrity": "sha512-MGs+7sGjx07sm29Wc2d/Ya72qwatNVHofnYwwHMT6LImv99kE5TQMCgkMSDeRwqQxHURmcjb4I7Tab+ahvCGiw==",
+      "dependencies": {
+        "@reach/utils": "0.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox/node_modules/@reach/machine": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.15.0.tgz",
+      "integrity": "sha512-o3vvqsTQyj7apxpbSuIn4xKYlqNagcjhlMnroJ2uqgJfFwy1tLrsQo4Sr8GnZu4hitPbNAfqGExYjV8ZV8SHpA==",
+      "dependencies": {
+        "@reach/utils": "0.15.0",
+        "@xstate/fsm": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox/node_modules/@reach/popover": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.15.0.tgz",
+      "integrity": "sha512-nBR6ZlULF7ZZIqkN47QEWmdqUX2Zd6FSeYJku1il9OkiMnWzI3aTOyu1B+IJfYeIqg28D/aeF4ff0oVu1VUrqQ==",
+      "dependencies": {
+        "@reach/portal": "0.15.0",
+        "@reach/rect": "0.15.0",
+        "@reach/utils": "0.15.0",
+        "tabbable": "^4.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox/node_modules/@reach/popover/node_modules/@reach/portal": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.0.tgz",
+      "integrity": "sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==",
+      "dependencies": {
+        "@reach/utils": "0.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox/node_modules/@reach/popover/node_modules/@reach/rect": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.15.0.tgz",
+      "integrity": "sha512-Nu0zG4Xq8Z0C3Yr3wbjtj7fvII1q2KopHDStNtmL26oWPzlaZJ9A1K6rZSPIqxKkx1hvl6AUTeom7eHTIKhHjA==",
+      "dependencies": {
+        "@reach/observe-rect": "1.2.0",
+        "@reach/utils": "0.15.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-code-block/node_modules/@reach/listbox/node_modules/@reach/utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
+      "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@hashicorp/nextjs-scripts/node_modules/@hashicorp/react-consent-manager": {
@@ -1785,11 +1925,11 @@
       }
     },
     "node_modules/@hashicorp/platform-docs-mdx": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.3.tgz",
-      "integrity": "sha512-NPVvn3s/JuFfebvymJ9JkOd6CHKfCVISz/QenmPgPim1nzJfe3uXKFeqolYdfMb8k1++XpX7KM70nJMVDyQLpw==",
+      "version": "0.1.4-canary-2022028214714",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4-canary-2022028214714.tgz",
+      "integrity": "sha512-YBCVKboTrCvn7mIyDBtbtUeoX3n9EiJf5xKDtgECLerWWHPuHjatzb1HogAZZ49p6/GF0dqhGXPWvPcKTuy3+A==",
       "dependencies": {
-        "@hashicorp/react-code-block": "^4.1.0",
+        "@hashicorp/react-code-block": "4.4.1-canary-20220128203034",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -1824,33 +1964,6 @@
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
-      }
-    },
-    "node_modules/@hashicorp/platform-docs-mdx/node_modules/@reach/portal": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
-      "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@hashicorp/platform-docs-mdx/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@hashicorp/platform-markdown-utils": {
@@ -2141,27 +2254,16 @@
       }
     },
     "node_modules/@hashicorp/react-code-block": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.2.tgz",
-      "integrity": "sha512-kHlk0lid8kp1MmrGGtmPvRP2BNSz8rQBYWH0txqipBJv5ZPsXnyflypcBlivIppxA1+gciwAwg3B/Zcx8L6m1A==",
+      "version": "4.4.1-canary-20220128203034",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.1-canary-20220128203034.tgz",
+      "integrity": "sha512-k2D+ZLwvwaIii0qN10z7sksL/JdfN/ZWgsI6csH4zRFB7YonqW9fHonHF4GhSZp050hq/oqwR5prV2BrXiX07A==",
       "dependencies": {
-        "@hashicorp/react-inline-svg": "6.0.1",
-        "@reach/listbox": "0.15.0",
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@reach/listbox": "0.16.2",
         "shellwords": "^0.1.1"
       },
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
-        "@hashicorp/nextjs-scripts": ">=17.x",
-        "react": ">=16.x"
-      }
-    },
-    "node_modules/@hashicorp/react-code-block/node_modules/@hashicorp/react-inline-svg": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-6.0.1.tgz",
-      "integrity": "sha512-EpvJd0AkE5tvlentS/Oez5W7SFJ32UjvU0RVFPYQlwR6tOTMOR9wK7Ose69WjkmtdjPMHWRE6MxWeSn0c1N5Bw==",
-      "peerDependencies": {
-        "@hashicorp/mktg-global-styles": ">=3.x",
-        "@hashicorp/nextjs-scripts": ">=17.x",
         "react": ">=16.x"
       }
     },
@@ -2218,18 +2320,18 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.14.1-canary-20220128203034",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1-canary-20220128203034.tgz",
-      "integrity": "sha512-8Q2pI7n89iSV1KccB/OLg1EwjW3FEG9jeNPXrOdCYnHi83/+wreDugb9Pi3x1PZyyw9lmPLHl7Mrs373ibBArA==",
+      "version": "14.14.1-canary-20220128215319",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1-canary-20220128215319.tgz",
+      "integrity": "sha512-BdhQ/aaoue7px8yg5h2uxD3eLnDxYsm+AAuk9KDzdaAUaGDoolXrFtvpIK4tV4PKEjQ0GP8Cowo4zvYUFgE98Q==",
       "dependencies": {
-        "@hashicorp/platform-docs-mdx": "^0.1.3",
+        "@hashicorp/platform-docs-mdx": "0.1.4-canary-2022028214714",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.2.1-canary-20220128203034",
+        "@hashicorp/react-content": "^8.2.1-canary-20220128215319",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.4.1-canary-20220128203034",
+        "@hashicorp/react-search": "^6.4.1-canary-20220128215319",
         "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
@@ -2264,9 +2366,9 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-content": {
-      "version": "8.2.1-canary-20220128211122",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1-canary-20220128211122.tgz",
-      "integrity": "sha512-D9oYclElHD8VIwnoIu7o5RkbuP+fMCIXPFGiBsnciP1oq+bOJ3+tuVuM67Gcbzr5X8KB22gSgWByHZsFl+sByA==",
+      "version": "8.2.1-canary-20220128215319",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1-canary-20220128215319.tgz",
+      "integrity": "sha512-/nDVL/P/I8lKQxpyeJRjgVbGh8+MZ4/Nl+jeSTKxR+oWsWDd1cdrLbZos33y50Y3o3ETIPKdHpIwyMSTsFwg6g==",
       "dependencies": {
         "@hashicorp/platform-product-meta": "^0.1.0",
         "classnames": "^2.3.1"
@@ -2277,9 +2379,9 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page/node_modules/@hashicorp/react-search": {
-      "version": "6.4.1-canary-20220128211122",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1-canary-20220128211122.tgz",
-      "integrity": "sha512-LU05EZzYu3KJUVo1C9b+ar7v+dgCFe5R82oDIhg+1DV4VJQ1NiX0WmVowwwLgbPTpFNqDrv0M9oU6ogY69XHdA==",
+      "version": "6.4.1-canary-20220128215319",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1-canary-20220128215319.tgz",
+      "integrity": "sha512-GZiDQ74ztI7YPAOcplROP6FTvQ626zzSFM4icM4mxFW34MhoufLRXq7lzdPE8Zz+W/rDPz1qtghFVxQwhbBYcw==",
       "dependencies": {
         "@hashicorp/react-inline-svg": "^6.0.3",
         "@hashicorp/remark-plugins": "^3.3.1",
@@ -2648,32 +2750,6 @@
       "peerDependencies": {
         "@hashicorp/mktg-global-styles": ">=3.x",
         "react": ">=16.x"
-      }
-    },
-    "node_modules/@hashicorp/react-product-downloads-page/node_modules/@reach/portal": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
-      "integrity": "sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@hashicorp/react-product-downloads-page/node_modules/@reach/utils": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@hashicorp/react-product-features-list": {
@@ -3213,12 +3289,12 @@
       }
     },
     "node_modules/@reach/auto-id": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
-      "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3226,12 +3302,12 @@
       }
     },
     "node_modules/@reach/descendants": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.15.0.tgz",
-      "integrity": "sha512-MGs+7sGjx07sm29Wc2d/Ya72qwatNVHofnYwwHMT6LImv99kE5TQMCgkMSDeRwqQxHURmcjb4I7Tab+ahvCGiw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3239,15 +3315,15 @@
       }
     },
     "node_modules/@reach/listbox": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.15.0.tgz",
-      "integrity": "sha512-3Vvpte0HQkfo3sT4Cz6gG9h+E/La2IwbtLQDTesEmDzToQ8bk9rOfuFDVp7IXUyOdDggfDCOEz/ZphsuniADWA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.16.2.tgz",
+      "integrity": "sha512-UBotBw7X8e2ajHn6tg1M9ArinisvSvwtu/aP3edEQKCvobd95nAa+dqnfAdihPAQFH2AQ2NFfa/73yawWV3LOQ==",
       "dependencies": {
-        "@reach/auto-id": "0.15.0",
-        "@reach/descendants": "0.15.0",
-        "@reach/machine": "0.15.0",
-        "@reach/popover": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/machine": "0.16.0",
+        "@reach/popover": "0.16.2",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -3256,13 +3332,13 @@
       }
     },
     "node_modules/@reach/machine": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.15.0.tgz",
-      "integrity": "sha512-o3vvqsTQyj7apxpbSuIn4xKYlqNagcjhlMnroJ2uqgJfFwy1tLrsQo4Sr8GnZu4hitPbNAfqGExYjV8ZV8SHpA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.16.0.tgz",
+      "integrity": "sha512-c8SRQz2xGtg5M9aXuuM5pFgaV1ZW5/nyMIYpZzBwHUlNFKGO+VBhwedbnqUxO0yLcbgl3wPvjPh740O3YjqiHg==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "@xstate/fsm": "1.4.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3275,15 +3351,15 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
     "node_modules/@reach/popover": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.15.0.tgz",
-      "integrity": "sha512-nBR6ZlULF7ZZIqkN47QEWmdqUX2Zd6FSeYJku1il9OkiMnWzI3aTOyu1B+IJfYeIqg28D/aeF4ff0oVu1VUrqQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.16.2.tgz",
+      "integrity": "sha512-IwkRrHM7Vt33BEkSXneovymJv7oIToOfTDwRKpuYEB/BWYMAuNfbsRL7KVe6MjkgchDeQzAk24cYY1ztQj5HQQ==",
       "dependencies": {
-        "@reach/portal": "0.15.0",
-        "@reach/rect": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/portal": "0.16.2",
+        "@reach/rect": "0.16.0",
+        "@reach/utils": "0.16.0",
         "tabbable": "^4.0.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3291,12 +3367,13 @@
       }
     },
     "node_modules/@reach/portal": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.0.tgz",
-      "integrity": "sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
+      "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
       "dependencies": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3304,15 +3381,15 @@
       }
     },
     "node_modules/@reach/rect": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.15.0.tgz",
-      "integrity": "sha512-Nu0zG4Xq8Z0C3Yr3wbjtj7fvII1q2KopHDStNtmL26oWPzlaZJ9A1K6rZSPIqxKkx1hvl6AUTeom7eHTIKhHjA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
+      "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
       "dependencies": {
         "@reach/observe-rect": "1.2.0",
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2",
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -3338,19 +3415,6 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/tooltip/node_modules/@reach/auto-id": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-      "dependencies": {
-        "@reach/utils": "0.16.0",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
     "node_modules/@reach/tooltip/node_modules/@reach/portal": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
@@ -3364,42 +3428,13 @@
         "react-dom": "^16.8.0 || 17.x"
       }
     },
-    "node_modules/@reach/tooltip/node_modules/@reach/rect": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
-      "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
-      "dependencies": {
-        "@reach/observe-rect": "1.2.0",
-        "@reach/utils": "0.16.0",
-        "prop-types": "^15.7.2",
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/tooltip/node_modules/@reach/utils": {
+    "node_modules/@reach/utils": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
       "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
       "dependencies": {
         "tiny-warning": "^1.0.3",
         "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -22864,6 +22899,111 @@
             }
           }
         },
+        "@hashicorp/react-code-block": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.2.tgz",
+          "integrity": "sha512-kHlk0lid8kp1MmrGGtmPvRP2BNSz8rQBYWH0txqipBJv5ZPsXnyflypcBlivIppxA1+gciwAwg3B/Zcx8L6m1A==",
+          "requires": {
+            "@hashicorp/react-inline-svg": "6.0.1",
+            "@reach/listbox": "0.15.0",
+            "shellwords": "^0.1.1"
+          },
+          "dependencies": {
+            "@hashicorp/react-inline-svg": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-6.0.1.tgz",
+              "integrity": "sha512-EpvJd0AkE5tvlentS/Oez5W7SFJ32UjvU0RVFPYQlwR6tOTMOR9wK7Ose69WjkmtdjPMHWRE6MxWeSn0c1N5Bw==",
+              "requires": {}
+            },
+            "@reach/listbox": {
+              "version": "0.15.0",
+              "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.15.0.tgz",
+              "integrity": "sha512-3Vvpte0HQkfo3sT4Cz6gG9h+E/La2IwbtLQDTesEmDzToQ8bk9rOfuFDVp7IXUyOdDggfDCOEz/ZphsuniADWA==",
+              "requires": {
+                "@reach/auto-id": "0.15.0",
+                "@reach/descendants": "0.15.0",
+                "@reach/machine": "0.15.0",
+                "@reach/popover": "0.15.0",
+                "@reach/utils": "0.15.0",
+                "prop-types": "^15.7.2"
+              },
+              "dependencies": {
+                "@reach/auto-id": {
+                  "version": "0.15.0",
+                  "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
+                  "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
+                  "requires": {
+                    "@reach/utils": "0.15.0",
+                    "tslib": "^2.1.0"
+                  }
+                },
+                "@reach/descendants": {
+                  "version": "0.15.0",
+                  "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.15.0.tgz",
+                  "integrity": "sha512-MGs+7sGjx07sm29Wc2d/Ya72qwatNVHofnYwwHMT6LImv99kE5TQMCgkMSDeRwqQxHURmcjb4I7Tab+ahvCGiw==",
+                  "requires": {
+                    "@reach/utils": "0.15.0",
+                    "tslib": "^2.1.0"
+                  }
+                },
+                "@reach/machine": {
+                  "version": "0.15.0",
+                  "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.15.0.tgz",
+                  "integrity": "sha512-o3vvqsTQyj7apxpbSuIn4xKYlqNagcjhlMnroJ2uqgJfFwy1tLrsQo4Sr8GnZu4hitPbNAfqGExYjV8ZV8SHpA==",
+                  "requires": {
+                    "@reach/utils": "0.15.0",
+                    "@xstate/fsm": "1.4.0",
+                    "tslib": "^2.1.0"
+                  }
+                },
+                "@reach/popover": {
+                  "version": "0.15.0",
+                  "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.15.0.tgz",
+                  "integrity": "sha512-nBR6ZlULF7ZZIqkN47QEWmdqUX2Zd6FSeYJku1il9OkiMnWzI3aTOyu1B+IJfYeIqg28D/aeF4ff0oVu1VUrqQ==",
+                  "requires": {
+                    "@reach/portal": "0.15.0",
+                    "@reach/rect": "0.15.0",
+                    "@reach/utils": "0.15.0",
+                    "tabbable": "^4.0.0",
+                    "tslib": "^2.1.0"
+                  },
+                  "dependencies": {
+                    "@reach/portal": {
+                      "version": "0.15.0",
+                      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.0.tgz",
+                      "integrity": "sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==",
+                      "requires": {
+                        "@reach/utils": "0.15.0",
+                        "tslib": "^2.1.0"
+                      }
+                    },
+                    "@reach/rect": {
+                      "version": "0.15.0",
+                      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.15.0.tgz",
+                      "integrity": "sha512-Nu0zG4Xq8Z0C3Yr3wbjtj7fvII1q2KopHDStNtmL26oWPzlaZJ9A1K6rZSPIqxKkx1hvl6AUTeom7eHTIKhHjA==",
+                      "requires": {
+                        "@reach/observe-rect": "1.2.0",
+                        "@reach/utils": "0.15.0",
+                        "prop-types": "^15.7.2",
+                        "tiny-warning": "^1.0.3",
+                        "tslib": "^2.1.0"
+                      }
+                    }
+                  }
+                },
+                "@reach/utils": {
+                  "version": "0.15.0",
+                  "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
+                  "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
+                  "requires": {
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.1.0"
+                  }
+                }
+              }
+            }
+          }
+        },
         "@hashicorp/react-consent-manager": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/@hashicorp/react-consent-manager/-/react-consent-manager-5.1.0.tgz",
@@ -23535,11 +23675,11 @@
       }
     },
     "@hashicorp/platform-docs-mdx": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.3.tgz",
-      "integrity": "sha512-NPVvn3s/JuFfebvymJ9JkOd6CHKfCVISz/QenmPgPim1nzJfe3uXKFeqolYdfMb8k1++XpX7KM70nJMVDyQLpw==",
+      "version": "0.1.4-canary-2022028214714",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4-canary-2022028214714.tgz",
+      "integrity": "sha512-YBCVKboTrCvn7mIyDBtbtUeoX3n9EiJf5xKDtgECLerWWHPuHjatzb1HogAZZ49p6/GF0dqhGXPWvPcKTuy3+A==",
       "requires": {
-        "@hashicorp/react-code-block": "^4.1.0",
+        "@hashicorp/react-code-block": "4.4.1-canary-20220128203034",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
         "@hashicorp/react-tabs": "^7.0.1",
         "@mdx-js/react": "1.6.22"
@@ -23563,25 +23703,6 @@
             "@reach/portal": "^0.16.0",
             "@reach/tooltip": "^0.16.0",
             "classnames": "^2.3.1"
-          }
-        },
-        "@reach/portal": {
-          "version": "0.16.2",
-          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
-          "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
           }
         }
       }
@@ -23810,21 +23931,13 @@
       }
     },
     "@hashicorp/react-code-block": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.1.2.tgz",
-      "integrity": "sha512-kHlk0lid8kp1MmrGGtmPvRP2BNSz8rQBYWH0txqipBJv5ZPsXnyflypcBlivIppxA1+gciwAwg3B/Zcx8L6m1A==",
+      "version": "4.4.1-canary-20220128203034",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-code-block/-/react-code-block-4.4.1-canary-20220128203034.tgz",
+      "integrity": "sha512-k2D+ZLwvwaIii0qN10z7sksL/JdfN/ZWgsI6csH4zRFB7YonqW9fHonHF4GhSZp050hq/oqwR5prV2BrXiX07A==",
       "requires": {
-        "@hashicorp/react-inline-svg": "6.0.1",
-        "@reach/listbox": "0.15.0",
+        "@hashicorp/react-inline-svg": "^6.0.3",
+        "@reach/listbox": "0.16.2",
         "shellwords": "^0.1.1"
-      },
-      "dependencies": {
-        "@hashicorp/react-inline-svg": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-6.0.1.tgz",
-          "integrity": "sha512-EpvJd0AkE5tvlentS/Oez5W7SFJ32UjvU0RVFPYQlwR6tOTMOR9wK7Ose69WjkmtdjPMHWRE6MxWeSn0c1N5Bw==",
-          "requires": {}
-        }
       }
     },
     "@hashicorp/react-command-line-terminal": {
@@ -23866,18 +23979,18 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.14.1-canary-20220128203034",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1-canary-20220128203034.tgz",
-      "integrity": "sha512-8Q2pI7n89iSV1KccB/OLg1EwjW3FEG9jeNPXrOdCYnHi83/+wreDugb9Pi3x1PZyyw9lmPLHl7Mrs373ibBArA==",
+      "version": "14.14.1-canary-20220128215319",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.1-canary-20220128215319.tgz",
+      "integrity": "sha512-BdhQ/aaoue7px8yg5h2uxD3eLnDxYsm+AAuk9KDzdaAUaGDoolXrFtvpIK4tV4PKEjQ0GP8Cowo4zvYUFgE98Q==",
       "requires": {
-        "@hashicorp/platform-docs-mdx": "^0.1.3",
+        "@hashicorp/platform-docs-mdx": "0.1.4-canary-2022028214714",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
-        "@hashicorp/react-content": "^8.2.1-canary-20220128203034",
+        "@hashicorp/react-content": "^8.2.1-canary-20220128215319",
         "@hashicorp/react-docs-sidenav": "^8.4.1",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-placeholder": "^0.1.0",
-        "@hashicorp/react-search": "^6.4.1-canary-20220128203034",
+        "@hashicorp/react-search": "^6.4.1-canary-20220128215319",
         "@hashicorp/react-version-select": "^0.3.0",
         "classnames": "^2.3.1",
         "fs-exists-sync": "^0.1.0",
@@ -23904,18 +24017,18 @@
           }
         },
         "@hashicorp/react-content": {
-          "version": "8.2.1-canary-20220128211122",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1-canary-20220128211122.tgz",
-          "integrity": "sha512-D9oYclElHD8VIwnoIu7o5RkbuP+fMCIXPFGiBsnciP1oq+bOJ3+tuVuM67Gcbzr5X8KB22gSgWByHZsFl+sByA==",
+          "version": "8.2.1-canary-20220128215319",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-content/-/react-content-8.2.1-canary-20220128215319.tgz",
+          "integrity": "sha512-/nDVL/P/I8lKQxpyeJRjgVbGh8+MZ4/Nl+jeSTKxR+oWsWDd1cdrLbZos33y50Y3o3ETIPKdHpIwyMSTsFwg6g==",
           "requires": {
             "@hashicorp/platform-product-meta": "^0.1.0",
             "classnames": "^2.3.1"
           }
         },
         "@hashicorp/react-search": {
-          "version": "6.4.1-canary-20220128211122",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1-canary-20220128211122.tgz",
-          "integrity": "sha512-LU05EZzYu3KJUVo1C9b+ar7v+dgCFe5R82oDIhg+1DV4VJQ1NiX0WmVowwwLgbPTpFNqDrv0M9oU6ogY69XHdA==",
+          "version": "6.4.1-canary-20220128215319",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-search/-/react-search-6.4.1-canary-20220128215319.tgz",
+          "integrity": "sha512-GZiDQ74ztI7YPAOcplROP6FTvQ626zzSFM4icM4mxFW34MhoufLRXq7lzdPE8Zz+W/rDPz1qtghFVxQwhbBYcw==",
           "requires": {
             "@hashicorp/react-inline-svg": "^6.0.3",
             "@hashicorp/remark-plugins": "^3.3.1",
@@ -24188,24 +24301,6 @@
             "@reach/portal": "^0.16.0",
             "@reach/tooltip": "^0.16.0",
             "classnames": "^2.3.1"
-          }
-        },
-        "@reach/portal": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
-          "integrity": "sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
           }
         }
       }
@@ -24626,44 +24721,44 @@
       }
     },
     "@reach/auto-id": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
-      "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
+      "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
       "requires": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       }
     },
     "@reach/descendants": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.15.0.tgz",
-      "integrity": "sha512-MGs+7sGjx07sm29Wc2d/Ya72qwatNVHofnYwwHMT6LImv99kE5TQMCgkMSDeRwqQxHURmcjb4I7Tab+ahvCGiw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.16.1.tgz",
+      "integrity": "sha512-3WZgRnD9O4EORKE31rrduJDiPFNMOjUkATx0zl192ZxMq3qITe4tUj70pS5IbJl/+v9zk78JwyQLvA1pL7XAPA==",
       "requires": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tslib": "^2.3.0"
       }
     },
     "@reach/listbox": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.15.0.tgz",
-      "integrity": "sha512-3Vvpte0HQkfo3sT4Cz6gG9h+E/La2IwbtLQDTesEmDzToQ8bk9rOfuFDVp7IXUyOdDggfDCOEz/ZphsuniADWA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.16.2.tgz",
+      "integrity": "sha512-UBotBw7X8e2ajHn6tg1M9ArinisvSvwtu/aP3edEQKCvobd95nAa+dqnfAdihPAQFH2AQ2NFfa/73yawWV3LOQ==",
       "requires": {
-        "@reach/auto-id": "0.15.0",
-        "@reach/descendants": "0.15.0",
-        "@reach/machine": "0.15.0",
-        "@reach/popover": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/auto-id": "0.16.0",
+        "@reach/descendants": "0.16.1",
+        "@reach/machine": "0.16.0",
+        "@reach/popover": "0.16.2",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2"
       }
     },
     "@reach/machine": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.15.0.tgz",
-      "integrity": "sha512-o3vvqsTQyj7apxpbSuIn4xKYlqNagcjhlMnroJ2uqgJfFwy1tLrsQo4Sr8GnZu4hitPbNAfqGExYjV8ZV8SHpA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.16.0.tgz",
+      "integrity": "sha512-c8SRQz2xGtg5M9aXuuM5pFgaV1ZW5/nyMIYpZzBwHUlNFKGO+VBhwedbnqUxO0yLcbgl3wPvjPh740O3YjqiHg==",
       "requires": {
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "@xstate/fsm": "1.4.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@reach/observe-rect": {
@@ -24672,36 +24767,37 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
     "@reach/popover": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.15.0.tgz",
-      "integrity": "sha512-nBR6ZlULF7ZZIqkN47QEWmdqUX2Zd6FSeYJku1il9OkiMnWzI3aTOyu1B+IJfYeIqg28D/aeF4ff0oVu1VUrqQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.16.2.tgz",
+      "integrity": "sha512-IwkRrHM7Vt33BEkSXneovymJv7oIToOfTDwRKpuYEB/BWYMAuNfbsRL7KVe6MjkgchDeQzAk24cYY1ztQj5HQQ==",
       "requires": {
-        "@reach/portal": "0.15.0",
-        "@reach/rect": "0.15.0",
-        "@reach/utils": "0.15.0",
+        "@reach/portal": "0.16.2",
+        "@reach/rect": "0.16.0",
+        "@reach/utils": "0.16.0",
         "tabbable": "^4.0.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@reach/portal": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.0.tgz",
-      "integrity": "sha512-Aulqjk/PIRu+R7yhINYAAYfYh++ZdC30qwHDWDtGk2cmTEJT7m9AlvBX+W7T+Q3Ux6Wy5f37eV+TTGid1CcjFw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
+      "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
       "requires": {
-        "@reach/utils": "0.15.0",
-        "tslib": "^2.1.0"
+        "@reach/utils": "0.16.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
       }
     },
     "@reach/rect": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.15.0.tgz",
-      "integrity": "sha512-Nu0zG4Xq8Z0C3Yr3wbjtj7fvII1q2KopHDStNtmL26oWPzlaZJ9A1K6rZSPIqxKkx1hvl6AUTeom7eHTIKhHjA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
+      "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
       "requires": {
         "@reach/observe-rect": "1.2.0",
-        "@reach/utils": "0.15.0",
+        "@reach/utils": "0.16.0",
         "prop-types": "^15.7.2",
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@reach/tooltip": {
@@ -24719,15 +24815,6 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
-        "@reach/auto-id": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.16.0.tgz",
-          "integrity": "sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==",
-          "requires": {
-            "@reach/utils": "0.16.0",
-            "tslib": "^2.3.0"
-          }
-        },
         "@reach/portal": {
           "version": "0.16.0",
           "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.0.tgz",
@@ -24736,37 +24823,16 @@
             "@reach/utils": "0.16.0",
             "tslib": "^2.3.0"
           }
-        },
-        "@reach/rect": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.16.0.tgz",
-          "integrity": "sha512-/qO9jQDzpOCdrSxVPR6l674mRHNTqfEjkaxZHluwJ/2qGUtYsA0GSZiF/+wX/yOWeBif1ycxJDa6HusAMJZC5Q==",
-          "requires": {
-            "@reach/observe-rect": "1.2.0",
-            "@reach/utils": "0.16.0",
-            "prop-types": "^15.7.2",
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@reach/utils": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
-          "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
-          "requires": {
-            "tiny-warning": "^1.0.3",
-            "tslib": "^2.3.0"
-          }
         }
       }
     },
     "@reach/utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
-      "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
       "requires": {
         "tiny-warning": "^1.0.3",
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.0"
       }
     },
     "@reach/visually-hidden": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,7 +19,7 @@
         "@hashicorp/react-button": "^6.0.1",
         "@hashicorp/react-command-line-terminal": "^2.0.4",
         "@hashicorp/react-consent-manager": "^7.0.3",
-        "@hashicorp/react-docs-page": "14.14.3-canary-20220223212614",
+        "@hashicorp/react-docs-page": "^14.14.3",
         "@hashicorp/react-hashi-stack-menu": "^2.1.2",
         "@hashicorp/react-head": "^3.1.2",
         "@hashicorp/react-inline-svg": "^6.0.3",
@@ -1925,9 +1925,9 @@
       }
     },
     "node_modules/@hashicorp/platform-docs-mdx": {
-      "version": "0.1.4-canary-2022123212239",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4-canary-2022123212239.tgz",
-      "integrity": "sha512-EoAHZXDyyhQ63Nz+quJd23lev3M8V5p7quY4KceuQ6iX/Aeoa5KvAO6mzHrrWhoDO8PToS36Gv3KtVs8v2JKbg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4.tgz",
+      "integrity": "sha512-/yAZDWR7pgrTkNzoNxZXyWZ1dvSO+KVw5/ZFsUR8d+kZhSKqiLAHVEAH6i7Jd4GlW074OytUzWmA3Je2jAVetA==",
       "dependencies": {
         "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
@@ -2320,11 +2320,11 @@
       }
     },
     "node_modules/@hashicorp/react-docs-page": {
-      "version": "14.14.3-canary-20220223212614",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3-canary-20220223212614.tgz",
-      "integrity": "sha512-GYpwg8MlPH7Bn6QSHU66MukPDyxzGN/N+WmqHGJNSYEbMsQQ0cjEhWsJC61tiShvRnq+P+k6PbuK5Xp1OR9/dQ==",
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3.tgz",
+      "integrity": "sha512-prRWKE/Ykr+LGouJgdYfxTOMrpjRQf72IJYFUrZx+wL+LV+bT5hFNyWiHgJWNKg7DCUMQreX7RNAidzNOoxc6g==",
       "dependencies": {
-        "@hashicorp/platform-docs-mdx": "0.1.4-canary-2022123212239",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
         "@hashicorp/react-content": "^8.2.1",
@@ -23674,9 +23674,9 @@
       }
     },
     "@hashicorp/platform-docs-mdx": {
-      "version": "0.1.4-canary-2022123212239",
-      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4-canary-2022123212239.tgz",
-      "integrity": "sha512-EoAHZXDyyhQ63Nz+quJd23lev3M8V5p7quY4KceuQ6iX/Aeoa5KvAO6mzHrrWhoDO8PToS36Gv3KtVs8v2JKbg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-docs-mdx/-/platform-docs-mdx-0.1.4.tgz",
+      "integrity": "sha512-/yAZDWR7pgrTkNzoNxZXyWZ1dvSO+KVw5/ZFsUR8d+kZhSKqiLAHVEAH6i7Jd4GlW074OytUzWmA3Je2jAVetA==",
       "requires": {
         "@hashicorp/react-code-block": "^4.4.2",
         "@hashicorp/react-enterprise-alert": "^6.0.1",
@@ -23978,11 +23978,11 @@
       }
     },
     "@hashicorp/react-docs-page": {
-      "version": "14.14.3-canary-20220223212614",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3-canary-20220223212614.tgz",
-      "integrity": "sha512-GYpwg8MlPH7Bn6QSHU66MukPDyxzGN/N+WmqHGJNSYEbMsQQ0cjEhWsJC61tiShvRnq+P+k6PbuK5Xp1OR9/dQ==",
+      "version": "14.14.3",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-docs-page/-/react-docs-page-14.14.3.tgz",
+      "integrity": "sha512-prRWKE/Ykr+LGouJgdYfxTOMrpjRQf72IJYFUrZx+wL+LV+bT5hFNyWiHgJWNKg7DCUMQreX7RNAidzNOoxc6g==",
       "requires": {
-        "@hashicorp/platform-docs-mdx": "0.1.4-canary-2022123212239",
+        "@hashicorp/platform-docs-mdx": "^0.1.4",
         "@hashicorp/platform-markdown-utils": "^0.2.0",
         "@hashicorp/react-alert": "^6.0.2",
         "@hashicorp/react-content": "^8.2.1",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@hashicorp/react-button": "^6.0.1",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.0.3",
-    "@hashicorp/react-docs-page": "^14.14.1-canary-20220128203034",
+    "@hashicorp/react-docs-page": "14.14.1-canary-20220128215319",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-inline-svg": "^6.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@hashicorp/react-button": "^6.0.1",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.0.3",
-    "@hashicorp/react-docs-page": "^14.13.0",
+    "@hashicorp/react-docs-page": "^14.14.1-canary-20220128203034",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-inline-svg": "^6.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@hashicorp/react-button": "^6.0.1",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.0.3",
-    "@hashicorp/react-docs-page": "14.14.1-canary-20220128215319",
+    "@hashicorp/react-docs-page": "14.14.3-canary-20220223212614",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-inline-svg": "^6.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@hashicorp/react-button": "^6.0.1",
     "@hashicorp/react-command-line-terminal": "^2.0.4",
     "@hashicorp/react-consent-manager": "^7.0.3",
-    "@hashicorp/react-docs-page": "14.14.3-canary-20220223212614",
+    "@hashicorp/react-docs-page": "^14.14.3",
     "@hashicorp/react-hashi-stack-menu": "^2.1.2",
     "@hashicorp/react-head": "^3.1.2",
     "@hashicorp/react-inline-svg": "^6.0.3",


### PR DESCRIPTION
👀 [Preview][preview]

This PR bumps to the latest `@hashicorp/react-docs-page` release, in order to fix an underlying issue in `@hashicorp/react-code-block` (via `@hashicorp/platform-docs-mdx`).

This fix is specific to Firefox browsers, and with this fix, newlines are now included when manually selecting and copying `code-block` contents.

See https://github.com/hashicorp/react-components/pull/503 for further details.

## Review notes

When using [Firefox](https://www.mozilla.org/en-US/firefox/new/):

- On [the live site][live], manually selecting code block contents, copying, and pasting into a plain text editor should result in missing newlines.
- On [the preview][preview], manually selecting code block contents, copying, and pasting into a plain text editor should result in the expected content, with newlines intact.

[preview]: https://packer-hnob0lmju-hashicorp.vercel.app/docs/commands/init
[live]: https://packer.io/docs/commands/init

