### PR TITLE
Create parent directories for packer log path if they don't exist

### DIFF
--- a/log.go
+++ b/log.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -22,6 +23,11 @@ func logOutput() (logOutput io.Writer, err error) {
 
 		if logPath := os.Getenv(EnvLogFile); logPath != "" {
 			var err error
+			err = os.MkdirAll(filepath.Dir(logPath), 0o755)
+			if err != nil {
+				return nil, err
+			}
+
 			logOutput, err = os.Create(logPath)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This PR allows Packer to handle the creation of the parent directories in the absolute path provided by the user in `PACKER_LOG_PATH`. I submitted this PR with the intention of making the packer build logging process more flexible/forgiving. 