### PR TITLE
Fix format in plugin-location.mdx

### DIFF
--- a/website/content/partials/plugins/plugin-location.mdx
+++ b/website/content/partials/plugins/plugin-location.mdx
@@ -12,7 +12,7 @@ found version matching `required_plugins` will be taken into consideration.
 
 1. The directory where `packer` is, or the executable directory.
 1. The current working directory. (`"."`)
-1. The `PACKER_HOME_DIR/plugins` directory. PACKER_HOME_DIR refers to *[Packer's home
+1. The `PACKER_HOME_DIR/plugins` directory. `PACKER_HOME_DIR` refers to *[Packer's home
 directory](/docs/configure#packer-s-home-directory)*, if it could be found.
 1. The director(y/ies) under the `PACKER_PLUGIN_PATH` env var, if `PACKER_PLUGIN_PATH`
 is set.


### PR DESCRIPTION
The existing doc looks as below, the `PACKER_HOME_DIR` doesn't show up correctly.
<img width="897" alt="截屏2022-01-30 下午3 54 18" src="https://user-images.githubusercontent.com/4048448/151691553-f2f23615-d71f-4c71-a7a9-80bc84f5b244.png">
