### PR TITLE
Add `packer plugins` command and subcommands to interact with plugins

### DIFF
--- a/command/cli.go
+++ b/command/cli.go
@@ -99,10 +99,15 @@ func (ia *InitArgs) AddFlagSets(flags *flag.FlagSet) {
 	ia.MetaArgs.AddFlagSets(flags)
 }
 
-// InitArgs represents a parsed cli line for a `packer build`
+// InitArgs represents a parsed cli line for a `packer init <path>`
 type InitArgs struct {
 	MetaArgs
 	Upgrade bool
+}
+
+// PluginsRequiredArgs represents a parsed cli line for a `packer plugins required <path>`
+type PluginsRequiredArgs struct {
+	MetaArgs
 }
 
 // ConsoleArgs represents a parsed cli line for a `packer console`

--- a/command/core_wrapper.go
+++ b/command/core_wrapper.go
@@ -29,8 +29,8 @@ func (c *CoreWrapper) Initialize(_ packer.InitializeOptions) hcl.Diagnostics {
 func (c *CoreWrapper) PluginRequirements() (plugingetter.Requirements, hcl.Diagnostics) {
 	return nil, hcl.Diagnostics{
 		&hcl.Diagnostic{
-			Summary:  "Packer init is supported for HCL2 configuration templates only",
-			Detail:   "Please manually install plugins or use a HCL2 configuration that will do that for you.",
+			Summary:  "Packer plugins currently only works with HCL2 configuration templates",
+			Detail:   "Please manually install plugins with the plugins command or use a HCL2 configuration that will do that for you.",
 			Severity: hcl.DiagError,
 		},
 	}

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -1,0 +1,38 @@
+package command
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+)
+
+type PluginsCommand struct {
+	Meta
+}
+
+func (c *PluginsCommand) Synopsis() string {
+	return "Interact with Packer plugins and catalog"
+}
+
+func (c *PluginsCommand) Help() string {
+	helpText := `
+Usage: packer plugins <subcommand> [options] [args]
+  This command groups subcommands for interacting with Packer plugins.
+
+- "installed" lists all installed plugins and their version. Ex: "packer plugins installed".
+- "install" a plugin version with "packer plugins install <plugin> <version>".
+- "required" lists required plugins. Ex: "packer plugins required <path>".
+- "remove" a plugin version with "packer plugins remove <plugin> <version>".
+  Omit the version parameter to remove all versions.
+
+Related but not under the "plugins" command :
+
+- "packer init <path>" will install all plugins required by a config.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PluginsCommand) Run(args []string) int {
+	return cli.RunResultHelp
+}

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -19,12 +19,6 @@ func (c *PluginsCommand) Help() string {
 Usage: packer plugins <subcommand> [options] [args]
   This command groups subcommands for interacting with Packer plugins.
 
-- "installed" lists all installed plugins and their version. Ex: "packer plugins installed".
-- "install" a plugin version with "packer plugins install <plugin> <version>".
-- "required" lists required plugins. Ex: "packer plugins required <path>".
-- "remove" a plugin version with "packer plugins remove <plugin> <version>".
-  Omit the version parameter to remove all versions.
-
 Related but not under the "plugins" command :
 
 - "packer init <path>" will install all plugins required by a config.

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -28,6 +28,7 @@ func (c *PluginsInstallCommand) Synopsis() string {
 func (c *PluginsInstallCommand) Help() string {
 	helpText := `
 Usage: packer plugins install <plugin-path> [<version>]
+
   This command will install a Packer plugins at a specific version constrain.
   When the version is omitted the most recent version will be installed.
 

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -1,0 +1,118 @@
+package command
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
+	"github.com/hashicorp/packer/hcl2template/addrs"
+	"github.com/hashicorp/packer/packer"
+	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
+	"github.com/hashicorp/packer/packer/plugin-getter/github"
+	pkrversion "github.com/hashicorp/packer/version"
+	"github.com/mitchellh/cli"
+)
+
+type PluginsInstallCommand struct {
+	Meta
+}
+
+func (c *PluginsInstallCommand) Synopsis() string {
+	return "Install a Packer plugin at a version"
+}
+
+func (c *PluginsInstallCommand) Help() string {
+	helpText := `
+Usage: packer plugins install github.com/hashicorp/happycloud v1.2.3
+  This command will install a Packer plugins at a specific version constrain.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PluginsInstallCommand) Run(args []string) int {
+	ctx, cleanup := handleTermInterrupt(c.Ui)
+	defer cleanup()
+
+	return c.RunContext(ctx, args)
+}
+
+func (c *PluginsInstallCommand) RunContext(buildCtx context.Context, args []string) int {
+	if len(args) < 1 || len(args) > 2 {
+		return cli.RunResultHelp
+	}
+
+	opts := plugingetter.ListInstallationsOptions{
+		FromFolders: c.Meta.CoreConfig.Components.PluginConfig.KnownPluginFolders,
+		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{
+			OS:              runtime.GOOS,
+			ARCH:            runtime.GOARCH,
+			APIVersionMajor: pluginsdk.APIVersionMajor,
+			APIVersionMinor: pluginsdk.APIVersionMinor,
+			Checksummers: []plugingetter.Checksummer{
+				{Type: "sha256", Hash: sha256.New()},
+			},
+		},
+	}
+
+	plugin, diags := addrs.ParsePluginSourceString(args[0])
+	if diags.HasErrors() {
+		c.Ui.Error(diags.Error())
+		return 1
+	}
+
+	// a plugin requirement that matches them all
+	pluginRequirement := plugingetter.Requirement{
+		Identifier: plugin,
+		Implicit:   false,
+	}
+
+	if len(args) > 1 {
+		constraints, err := version.NewConstraint(args[1])
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		pluginRequirement.VersionConstraints = constraints
+	}
+
+	getters := []plugingetter.Getter{
+		&github.Getter{
+			// In the past some terraform plugins downloads were blocked from a
+			// specific aws region by s3. Changing the user agent unblocked the
+			// downloads so having one user agent per version will help mitigate
+			// that a little more. Especially in the case someone forks this
+			// code to make it more aggressive or something.
+			// TODO: allow to set this from the config file or an environment
+			// variable.
+			UserAgent: "packer-getter-github-" + pkrversion.String(),
+		},
+	}
+
+	newInstall, err := pluginRequirement.InstallLatest(plugingetter.InstallOptions{
+		InFolders:                 opts.FromFolders,
+		BinaryInstallationOptions: opts.BinaryInstallationOptions,
+		Getters:                   getters,
+	})
+
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	if newInstall != nil {
+		msg := fmt.Sprintf("Installed plugin %s %s in %q", pluginRequirement.Identifier, newInstall.Version, newInstall.BinaryPath)
+		ui := &packer.ColoredUi{
+			Color: packer.UiColorCyan,
+			Ui:    c.Ui,
+		}
+		ui.Say(msg)
+		return 0
+	}
+
+	return 0
+}

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -29,7 +29,7 @@ func (c *PluginsInstallCommand) Help() string {
 	helpText := `
 Usage: packer plugins install <plugin-path> [<version>]
   This command will install a Packer plugins at a specific version constrain.
-  When the version is omitted the most recent plugin will be installed.
+  When the version is omitted the most recent version will be installed.
 
   Ex: packer plugins install github.com/hashicorp/happycloud v1.2.3
 `

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -22,15 +22,16 @@ type PluginsInstallCommand struct {
 }
 
 func (c *PluginsInstallCommand) Synopsis() string {
-	return "Install a Packer plugin [at a version]"
+	return "Install latest Packer plugin [matching version constraint]"
 }
 
 func (c *PluginsInstallCommand) Help() string {
 	helpText := `
-Usage: packer plugins install <plugin-path> [<version>]
+Usage: packer plugins install <plugin> [<version constraint>]
 
-  This command will install a Packer plugins at a specific version constrain.
-  When the version is omitted the most recent version will be installed.
+  This command will install the most recent compatible Packer plugins matching
+  version constraint. When the version constraint is omitted, the most recent
+  version will be installed.
 
   Ex: packer plugins install github.com/hashicorp/happycloud v1.2.3
 `

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -22,13 +22,16 @@ type PluginsInstallCommand struct {
 }
 
 func (c *PluginsInstallCommand) Synopsis() string {
-	return "Install a Packer plugin at a version"
+	return "Install a Packer plugin [at a version]"
 }
 
 func (c *PluginsInstallCommand) Help() string {
 	helpText := `
-Usage: packer plugins install github.com/hashicorp/happycloud v1.2.3
+Usage: packer plugins install <plugin-path> [<version>]
   This command will install a Packer plugins at a specific version constrain.
+  When the version is omitted the most recent plugin will be installed.
+
+  Ex: packer plugins install github.com/hashicorp/happycloud v1.2.3
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -29,9 +29,10 @@ func (c *PluginsInstallCommand) Help() string {
 	helpText := `
 Usage: packer plugins install <plugin> [<version constraint>]
 
-  This command will install the most recent compatible Packer plugins matching
-  version constraint. When the version constraint is omitted, the most recent
-  version will be installed.
+  This command will install the most recent compatible Packer plugin matching 
+  version constraint.
+  When the version constraint is omitted, the most recent version will be
+  installed.
 
   Ex: packer plugins install github.com/hashicorp/happycloud v1.2.3
 `

--- a/command/plugins_installed.go
+++ b/command/plugins_installed.go
@@ -21,6 +21,7 @@ func (c *PluginsInstalledCommand) Synopsis() string {
 func (c *PluginsInstalledCommand) Help() string {
 	helpText := `
 Usage: packer plugins installed
+
   This command lists all installed plugins and their version.
 `
 

--- a/command/plugins_installed.go
+++ b/command/plugins_installed.go
@@ -15,7 +15,7 @@ type PluginsInstalledCommand struct {
 }
 
 func (c *PluginsInstalledCommand) Synopsis() string {
-	return "List all installed Packer plugins binaries"
+	return "List all installed Packer plugin binaries"
 }
 
 func (c *PluginsInstalledCommand) Help() string {

--- a/command/plugins_installed.go
+++ b/command/plugins_installed.go
@@ -15,14 +15,16 @@ type PluginsInstalledCommand struct {
 }
 
 func (c *PluginsInstalledCommand) Synopsis() string {
-	return "List all installed Packer plugins and their version"
+	return "List all installed Packer plugins binaries"
 }
 
 func (c *PluginsInstalledCommand) Help() string {
 	helpText := `
 Usage: packer plugins installed
 
-  This command lists all installed plugins and their version.
+  This command lists all installed plugins binaries that match with the current
+  OS and architecture. Packer's API version will be ignored.
+
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/plugins_installed.go
+++ b/command/plugins_installed.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"crypto/sha256"
-	"fmt"
 	"log"
 	"runtime"
 	"strings"
@@ -69,7 +68,7 @@ func (c *PluginsInstalledCommand) RunContext(buildCtx context.Context) int {
 	}
 
 	for _, installation := range installations {
-		fmt.Printf("%v\n", installation)
+		c.Ui.Message(installation.BinaryPath)
 	}
 
 	return 0

--- a/command/plugins_installed.go
+++ b/command/plugins_installed.go
@@ -22,7 +22,7 @@ func (c *PluginsInstalledCommand) Help() string {
 	helpText := `
 Usage: packer plugins installed
 
-  This command lists all installed plugins binaries that match with the current
+  This command lists all installed plugin binaries that match with the current
   OS and architecture. Packer's API version will be ignored.
 
 `

--- a/command/plugins_installed.go
+++ b/command/plugins_installed.go
@@ -1,0 +1,76 @@
+package command
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log"
+	"runtime"
+	"strings"
+
+	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
+)
+
+type PluginsInstalledCommand struct {
+	Meta
+}
+
+func (c *PluginsInstalledCommand) Synopsis() string {
+	return "List all installed Packer plugins and their version"
+}
+
+func (c *PluginsInstalledCommand) Help() string {
+	helpText := `
+Usage: packer plugins installed
+  This command lists all installed plugins and their version.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PluginsInstalledCommand) Run(args []string) int {
+	ctx, cleanup := handleTermInterrupt(c.Ui)
+	defer cleanup()
+
+	return c.RunContext(ctx)
+}
+
+func (c *PluginsInstalledCommand) RunContext(buildCtx context.Context) int {
+
+	opts := plugingetter.ListInstallationsOptions{
+		FromFolders: c.Meta.CoreConfig.Components.PluginConfig.KnownPluginFolders,
+		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{
+			OS:   runtime.GOOS,
+			ARCH: runtime.GOARCH,
+			Checksummers: []plugingetter.Checksummer{
+				{Type: "sha256", Hash: sha256.New()},
+			},
+		},
+	}
+
+	if runtime.GOOS == "windows" && opts.Ext == "" {
+		opts.BinaryInstallationOptions.Ext = ".exe"
+	}
+
+	log.Printf("[TRACE] init: %#v", opts)
+
+	// a plugin requirement that matches them all
+	allPlugins := plugingetter.Requirement{
+		Accessor:           "",
+		VersionConstraints: nil,
+		Identifier:         nil,
+		Implicit:           false,
+	}
+
+	installations, err := allPlugins.ListInstallations(opts)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	for _, installation := range installations {
+		fmt.Printf("%v\n", installation)
+	}
+
+	return 0
+}

--- a/command/plugins_remove.go
+++ b/command/plugins_remove.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
-	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
 	"github.com/hashicorp/packer/hcl2template/addrs"
 	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
 	"github.com/mitchellh/cli"
@@ -19,15 +18,18 @@ type PluginsRemoveCommand struct {
 }
 
 func (c *PluginsRemoveCommand) Synopsis() string {
-	return "Remove a Packer plugin [at a version]"
+	return "Remove Packer plugins [matching a version]"
 }
 
 func (c *PluginsRemoveCommand) Help() string {
 	helpText := `
-Usage: packer plugins remove <plugin-path> [<version>]
+Usage: packer plugins remove <plugin> [<version constraint>]
 
-  This command will remove a Packer plugin for a specific version constrain.
+  This command will remove all Packer plugins matching version constraint and
+  the current OS and architecture.
   When the version is omitted all installed versions will be removed.
+
+  Ex: packer plugins remove github.com/hashicorp/happycloud v1.2.3
 `
 
 	return strings.TrimSpace(helpText)
@@ -48,10 +50,8 @@ func (c *PluginsRemoveCommand) RunContext(buildCtx context.Context, args []strin
 	opts := plugingetter.ListInstallationsOptions{
 		FromFolders: c.Meta.CoreConfig.Components.PluginConfig.KnownPluginFolders,
 		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{
-			OS:              runtime.GOOS,
-			ARCH:            runtime.GOARCH,
-			APIVersionMajor: pluginsdk.APIVersionMajor,
-			APIVersionMinor: pluginsdk.APIVersionMinor,
+			OS:   runtime.GOOS,
+			ARCH: runtime.GOARCH,
 			Checksummers: []plugingetter.Checksummer{
 				{Type: "sha256", Hash: sha256.New()},
 			},

--- a/command/plugins_remove.go
+++ b/command/plugins_remove.go
@@ -1,0 +1,95 @@
+package command
+
+import (
+	"context"
+	"crypto/sha256"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
+	"github.com/hashicorp/packer/hcl2template/addrs"
+	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
+	"github.com/mitchellh/cli"
+)
+
+type PluginsRemoveCommand struct {
+	Meta
+}
+
+func (c *PluginsRemoveCommand) Synopsis() string {
+	return "Remove a Packer plugin [at a version]"
+}
+
+func (c *PluginsRemoveCommand) Help() string {
+	helpText := `
+Usage: packer plugins remove github.com/hashicorp/happycloud v1.2.3
+  This command will remove a Packer plugin for a specific version constrain.
+  When the version is omitted all versions will be removed.
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PluginsRemoveCommand) Run(args []string) int {
+	ctx, cleanup := handleTermInterrupt(c.Ui)
+	defer cleanup()
+
+	return c.RunContext(ctx, args)
+}
+
+func (c *PluginsRemoveCommand) RunContext(buildCtx context.Context, args []string) int {
+	if len(args) < 1 || len(args) > 2 {
+		return cli.RunResultHelp
+	}
+
+	opts := plugingetter.ListInstallationsOptions{
+		FromFolders: c.Meta.CoreConfig.Components.PluginConfig.KnownPluginFolders,
+		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{
+			OS:              runtime.GOOS,
+			ARCH:            runtime.GOARCH,
+			APIVersionMajor: pluginsdk.APIVersionMajor,
+			APIVersionMinor: pluginsdk.APIVersionMinor,
+			Checksummers: []plugingetter.Checksummer{
+				{Type: "sha256", Hash: sha256.New()},
+			},
+		},
+	}
+
+	plugin, diags := addrs.ParsePluginSourceString(args[0])
+	if diags.HasErrors() {
+		c.Ui.Error(diags.Error())
+		return 1
+	}
+
+	// a plugin requirement that matches them all
+	pluginRequirement := plugingetter.Requirement{
+		Identifier: plugin,
+		Implicit:   false,
+	}
+
+	if len(args) > 1 {
+		constraints, err := version.NewConstraint(args[1])
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		pluginRequirement.VersionConstraints = constraints
+	}
+
+	installations, err := pluginRequirement.ListInstallations(opts)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	for _, installation := range installations {
+		if err := os.Remove(installation.BinaryPath); err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		c.Ui.Message(installation.BinaryPath)
+	}
+
+	return 0
+}

--- a/command/plugins_remove.go
+++ b/command/plugins_remove.go
@@ -24,10 +24,10 @@ func (c *PluginsRemoveCommand) Synopsis() string {
 
 func (c *PluginsRemoveCommand) Help() string {
 	helpText := `
-Usage: packer plugins remove github.com/hashicorp/happycloud v1.2.3
+Usage: packer plugins remove <plugin-path> [<version>]
 
   This command will remove a Packer plugin for a specific version constrain.
-  When the version is omitted all versions will be removed.
+  When the version is omitted all installed versions will be removed.
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/plugins_remove.go
+++ b/command/plugins_remove.go
@@ -25,6 +25,7 @@ func (c *PluginsRemoveCommand) Synopsis() string {
 func (c *PluginsRemoveCommand) Help() string {
 	helpText := `
 Usage: packer plugins remove github.com/hashicorp/happycloud v1.2.3
+
   This command will remove a Packer plugin for a specific version constrain.
   When the version is omitted all versions will be removed.
 `

--- a/command/plugins_remove.go
+++ b/command/plugins_remove.go
@@ -25,8 +25,8 @@ func (c *PluginsRemoveCommand) Help() string {
 	helpText := `
 Usage: packer plugins remove <plugin> [<version constraint>]
 
-  This command will remove all Packer plugins matching version constraint and
-  the current OS and architecture.
+  This command will remove all Packer plugins matching the version constraint
+  for the current OS and architecture.
   When the version is omitted all installed versions will be removed.
 
   Ex: packer plugins remove github.com/hashicorp/happycloud v1.2.3

--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -24,7 +24,10 @@ func (c *PluginsRequiredCommand) Help() string {
 	helpText := `
 Usage: packer plugins required <path>
 
-  This command will list all Packer plugin required by a Packer config.
+  This command will list every Packer plugins required by a Packer config.
+  All binaries matching the required version constrain and the current OS and 
+  Architecture will be listed.
+
 
   Ex: packer plugins required require.pkr.hcl
   Ex: packer plugins required path/to/folder/

--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -106,5 +106,13 @@ func (c *PluginsRequiredCommand) RunContext(buildCtx context.Context, cla *Plugi
 		c.Ui.Message(s)
 	}
 
+	if len(reqs) == 0 {
+		c.Ui.Message(`
+No plugins requirement found, make sure you reference a Packer config
+containing a packer.required_plugins block. See
+https://www.packer.io/docs/templates/hcl_templates/blocks/packer
+for more info.`)
+	}
+
 	return 0
 }

--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -1,0 +1,105 @@
+package command
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"runtime"
+	"strings"
+
+	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
+	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
+	"github.com/mitchellh/cli"
+)
+
+type PluginsRequiredCommand struct {
+	Meta
+}
+
+func (c *PluginsRequiredCommand) Synopsis() string {
+	return "List plugins required by a config"
+}
+
+func (c *PluginsRequiredCommand) Help() string {
+	helpText := `
+Usage: packer plugins required <path>
+  This command will list all Packer plugin required by a Packer config.
+
+  Ex: packer plugins required require.pkr.hcl
+  Ex: packer plugins required path/to/folder/
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *PluginsRequiredCommand) Run(args []string) int {
+	ctx, cleanup := handleTermInterrupt(c.Ui)
+	defer cleanup()
+
+	cfg, ret := c.ParseArgs(args)
+	if ret != 0 {
+		return ret
+	}
+
+	return c.RunContext(ctx, cfg)
+}
+
+func (c *PluginsRequiredCommand) ParseArgs(args []string) (*PluginsRequiredArgs, int) {
+	var cfg PluginsRequiredArgs
+	flags := c.Meta.FlagSet("plugins required", 0)
+	flags.Usage = func() { c.Ui.Say(c.Help()) }
+	cfg.AddFlagSets(flags)
+	if err := flags.Parse(args); err != nil {
+		return &cfg, 1
+	}
+
+	args = flags.Args()
+	if len(args) != 1 {
+		return &cfg, cli.RunResultHelp
+	}
+	cfg.Path = args[0]
+	return &cfg, 0
+}
+
+func (c *PluginsRequiredCommand) RunContext(buildCtx context.Context, cla *PluginsRequiredArgs) int {
+
+	packerStarter, ret := c.GetConfig(&cla.MetaArgs)
+	if ret != 0 {
+		return ret
+	}
+
+	// Get plugins requirements
+	reqs, diags := packerStarter.PluginRequirements()
+	ret = writeDiags(c.Ui, nil, diags)
+	if ret != 0 {
+		return ret
+	}
+
+	opts := plugingetter.ListInstallationsOptions{
+		FromFolders: c.Meta.CoreConfig.Components.PluginConfig.KnownPluginFolders,
+		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{
+			OS:              runtime.GOOS,
+			ARCH:            runtime.GOARCH,
+			APIVersionMajor: pluginsdk.APIVersionMajor,
+			APIVersionMinor: pluginsdk.APIVersionMinor,
+			Checksummers: []plugingetter.Checksummer{
+				{Type: "sha256", Hash: sha256.New()},
+			},
+		},
+	}
+
+	for _, pluginRequirement := range reqs {
+		s := fmt.Sprintf("%s %s %q", pluginRequirement.Accessor, pluginRequirement.Identifier.String(), pluginRequirement.VersionConstraints.String())
+		installs, err := pluginRequirement.ListInstallations(opts)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		for _, install := range installs {
+			s += fmt.Sprintf(" %s", install.BinaryPath)
+		}
+		c.Ui.Message(s)
+	}
+
+	return 0
+}

--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -24,10 +24,11 @@ func (c *PluginsRequiredCommand) Help() string {
 	helpText := `
 Usage: packer plugins required <path>
 
-  This command will list every Packer plugin required by a Packer config.
-  All binaries matching the required version constrain and the current OS and 
-  Architecture will be listed.
-
+  This command will list every Packer plugin required by a Packer config, in
+  packer.required_plugins blocks. All binaries matching the required version
+  constrain and the current OS and Architecture will be listed. The most recent
+  version (and the first of the list) will be the one picked by Packer during a
+  build.
 
   Ex: packer plugins required require.pkr.hcl
   Ex: packer plugins required path/to/folder/

--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -24,7 +24,7 @@ func (c *PluginsRequiredCommand) Help() string {
 	helpText := `
 Usage: packer plugins required <path>
 
-  This command will list every Packer plugins required by a Packer config.
+  This command will list every Packer plugin required by a Packer config.
   All binaries matching the required version constrain and the current OS and 
   Architecture will be listed.
 

--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -23,6 +23,7 @@ func (c *PluginsRequiredCommand) Synopsis() string {
 func (c *PluginsRequiredCommand) Help() string {
 	helpText := `
 Usage: packer plugins required <path>
+
   This command will list all Packer plugin required by a Packer config.
 
   Ex: packer plugins required require.pkr.hcl

--- a/commands.go
+++ b/commands.go
@@ -69,7 +69,7 @@ func init() {
 		},
 
 		"plugins installed": func() (cli.Command, error) {
-			return &command.PluginsCommand{
+			return &command.PluginsInstalledCommand{
 				Meta: *CommandMeta,
 			}, nil
 		},

--- a/commands.go
+++ b/commands.go
@@ -68,6 +68,30 @@ func init() {
 			}, nil
 		},
 
+		"plugins installed": func() (cli.Command, error) {
+			return &command.PluginsCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+
+		"plugins install": func() (cli.Command, error) {
+			return &command.PluginsCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+
+		"plugins remove": func() (cli.Command, error) {
+			return &command.PluginsCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+
+		"plugins required": func() (cli.Command, error) {
+			return &command.PluginsCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+
 		"validate": func() (cli.Command, error) {
 			return &command.ValidateCommand{
 				Meta: *CommandMeta,

--- a/commands.go
+++ b/commands.go
@@ -87,7 +87,7 @@ func init() {
 		},
 
 		"plugins required": func() (cli.Command, error) {
-			return &command.PluginsCommand{
+			return &command.PluginsRequiredCommand{
 				Meta: *CommandMeta,
 			}, nil
 		},

--- a/commands.go
+++ b/commands.go
@@ -62,6 +62,12 @@ func init() {
 			}, nil
 		},
 
+		"plugins": func() (cli.Command, error) {
+			return &command.PluginsCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+
 		"validate": func() (cli.Command, error) {
 			return &command.ValidateCommand{
 				Meta: *CommandMeta,

--- a/commands.go
+++ b/commands.go
@@ -81,7 +81,7 @@ func init() {
 		},
 
 		"plugins remove": func() (cli.Command, error) {
-			return &command.PluginsCommand{
+			return &command.PluginsRemoveCommand{
 				Meta: *CommandMeta,
 			}, nil
 		},

--- a/commands.go
+++ b/commands.go
@@ -75,7 +75,7 @@ func init() {
 		},
 
 		"plugins install": func() (cli.Command, error) {
-			return &command.PluginsCommand{
+			return &command.PluginsInstallCommand{
 				Meta: *CommandMeta,
 			}, nil
 		},

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/packer/hcl2template/addrs"
 )
 
@@ -66,6 +67,61 @@ func TestPlugin_ListInstallations(t *testing.T) {
 		wantErr bool
 		want    InstallList
 	}{
+
+		{
+			"windows_all_plugins",
+			fields{
+				// empty
+			},
+			ListInstallationsOptions{
+				[]string{
+					pluginFolderOne,
+					pluginFolderTwo,
+				},
+				BinaryInstallationOptions{
+					OS: "windows", ARCH: "amd64",
+					Ext: ".exe",
+					Checksummers: []Checksummer{
+						{
+							Type: "sha256",
+							Hash: sha256.New(),
+						},
+					},
+				},
+			},
+			false,
+			[]*Installation{
+				{
+					Version:    "v1.2.3",
+					BinaryPath: "testdata/plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.2.3_x5.0_windows_amd64.exe",
+				},
+				{
+					Version:    "v1.2.4",
+					BinaryPath: "testdata/plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.2.4_x5.0_windows_amd64.exe",
+				},
+				{
+					Version:    "v1.2.5",
+					BinaryPath: "testdata/plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.2.5_x5.0_windows_amd64.exe",
+				},
+				{
+					BinaryPath: filepath.Join(pluginFolderOne, "github.com", "hashicorp", "google", "packer-plugin-google_v4.5.6_x5.0_windows_amd64.exe"),
+					Version:    "v4.5.6",
+				},
+				{
+					Version:    "v4.5.7",
+					BinaryPath: filepath.Join(pluginFolderOne, "github.com", "hashicorp", "google", "packer-plugin-google_v4.5.7_x5.0_windows_amd64.exe"),
+				},
+				{
+					Version:    "v4.5.8",
+					BinaryPath: filepath.Join(pluginFolderOne, "github.com", "hashicorp", "google", "packer-plugin-google_v4.5.8_x5.0_windows_amd64.exe"),
+				},
+				{
+					Version:    "v4.5.9",
+					BinaryPath: filepath.Join(pluginFolderTwo, "github.com", "hashicorp", "google", "packer-plugin-google_v4.5.9_x5.0_windows_amd64.exe"),
+				},
+			},
+		},
+
 		{
 			"darwin_amazon_prot_5.0",
 			fields{
@@ -227,9 +283,13 @@ func TestPlugin_ListInstallations(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			identifier, diags := addrs.ParsePluginSourceString(tt.fields.Identifier)
-			if diags.HasErrors() {
-				t.Fatalf("%v", diags)
+			var identifier *addrs.Plugin
+			if tt.fields.Identifier != "" {
+				var diags hcl.Diagnostics
+				identifier, diags = addrs.ParsePluginSourceString(tt.fields.Identifier)
+				if diags.HasErrors() {
+					t.Fatalf("%v", diags)
+				}
 			}
 			p := Requirement{
 				Identifier:         identifier,

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -93,15 +93,15 @@ func TestPlugin_ListInstallations(t *testing.T) {
 			[]*Installation{
 				{
 					Version:    "v1.2.3",
-					BinaryPath: "testdata/plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.2.3_x5.0_windows_amd64.exe",
+					BinaryPath: filepath.Join(pluginFolderOne, "github.com", "hashicorp", "amazon", "packer-plugin-amazon_v1.2.3_x5.0_windows_amd64.exe"),
 				},
 				{
 					Version:    "v1.2.4",
-					BinaryPath: "testdata/plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.2.4_x5.0_windows_amd64.exe",
+					BinaryPath: filepath.Join(pluginFolderOne, "github.com", "hashicorp", "amazon", "packer-plugin-amazon_v1.2.4_x5.0_windows_amd64.exe"),
 				},
 				{
 					Version:    "v1.2.5",
-					BinaryPath: "testdata/plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.2.5_x5.0_windows_amd64.exe",
+					BinaryPath: filepath.Join(pluginFolderOne, "github.com", "hashicorp", "amazon", "packer-plugin-amazon_v1.2.5_x5.0_windows_amd64.exe"),
 				},
 				{
 					BinaryPath: filepath.Join(pluginFolderOne, "github.com", "hashicorp", "google", "packer-plugin-google_v4.5.6_x5.0_windows_amd64.exe"),

--- a/website/content/docs/commands/plugins/index.mdx
+++ b/website/content/docs/commands/plugins/index.mdx
@@ -9,12 +9,22 @@ page_title: plugins Command
 
 The `plugins` command groups subcommands for interacting with Packers' plugins.
 
-- `installed` lists all installed plugins and their version. Ex: `packer plugins installed`.
-- `install` a plugin version with `packer plugins install <plugin> <version>`.
-- `required` lists required plugins. Ex: `packer plugins required <path>`.
-- `remove` a plugin version with `packer plugins remove <plugin> <version>`.
-  Ommit the version parameter to remove all versions.
+```shell-session
+$ packer plugins -h
+Usage: packer plugins <subcommand> [options] [args]
+  This command groups subcommands for interacting with Packer plugins.
 
-Related but not under the `plugins` command :
+Related but not under the "plugins" command :
 
-- `packer init <path>` will install all plugins required by a config.
+- "packer init <path>" will install all plugins required by a config.
+
+Subcommands:
+    install      Install latest Packer plugin [matching version constraint]
+    installed    List all installed Packer plugins binaries
+    remove       Remove Packer plugins [matching a version]
+    required     List plugins required by a config
+```
+
+## Related
+
+- [`packer init`](/docs/commands/init) will install all required plugins.

--- a/website/content/docs/commands/plugins/index.mdx
+++ b/website/content/docs/commands/plugins/index.mdx
@@ -20,7 +20,7 @@ Related but not under the "plugins" command :
 
 Subcommands:
     install      Install latest Packer plugin [matching version constraint]
-    installed    List all installed Packer plugins binaries
+    installed    List all installed Packer plugin binaries
     remove       Remove Packer plugins [matching a version]
     required     List plugins required by a config
 ```

--- a/website/content/docs/commands/plugins/index.mdx
+++ b/website/content/docs/commands/plugins/index.mdx
@@ -11,9 +11,9 @@ The `plugins` command groups subcommands for interacting with Packers' plugins.
 
 - `installed` lists all installed plugins and their version. Ex: `packer plugins installed`.
 - `install` a plugin version with `packer plugins install <plugin> <version>`.
-- `remove` a plugin version with `packer plugins remove <plugin> <version>`.
-- `remove` all plugin versions with `packer plugins remove <plugin>`.
 - `required` lists required plugins. Ex: `packer plugins required <path>`.
+- `remove` a plugin version with `packer plugins remove <plugin> <version>`.
+  Ommit the version parameter to remove all versions.
 
 Related but not under the `plugins` command :
 

--- a/website/content/docs/commands/plugins/index.mdx
+++ b/website/content/docs/commands/plugins/index.mdx
@@ -1,0 +1,20 @@
+---
+description: |
+  The "plugin" command groups subcommands for interacting with
+  Packer's plugin and the plugin catalog.
+page_title: plugins Command
+---
+
+# `plugins`
+
+The `plugins` command groups subcommands for interacting with Packers' plugins.
+
+- `installed` lists all installed plugins and their version. Ex: `packer plugins installed`.
+- `install` a plugin version with `packer plugins install <plugin> <version>`.
+- `remove` a plugin version with `packer plugins remove <plugin> <version>`.
+- `remove` all plugin versions with `packer plugins remove <plugin>`.
+- `required` lists required plugins. Ex: `packer plugins required <path>`.
+
+Related but not under the `plugins` command :
+
+- `packer init <path>` will install all plugins required by a config.

--- a/website/content/docs/commands/plugins/install.mdx
+++ b/website/content/docs/commands/plugins/install.mdx
@@ -12,7 +12,7 @@ The `plugins install` subcommand installs a Packer plugin at a version constrain
 $ packer plugins install -h
 Usage: packer plugins install <plugin> [<version constraint>]
 
-  This command will install the most recent compatible Packer plugins matching
+  This command will install the most recent compatible Packer plugin matching
   version constraint. When the version constraint is omitted, the most recent
   version will be installed.
 

--- a/website/content/docs/commands/plugins/install.mdx
+++ b/website/content/docs/commands/plugins/install.mdx
@@ -1,0 +1,24 @@
+---
+description: |
+  The "plugins install" command can install a plugin at a version constraint.
+page_title: plugins Command
+---
+
+# `plugins install`
+
+The `plugins install` subcommand installs a Packer plugin at a version constraint
+
+```shell-session
+$ packer plugins install -h
+Usage: packer plugins install <plugin> [<version constraint>]
+
+  This command will install the most recent compatible Packer plugins matching
+  version constraint. When the version constraint is omitted, the most recent
+  version will be installed.
+
+  Ex: packer plugins install github.com/hashicorp/happycloud v1.2.3
+```
+
+## Related
+
+- [`packer init`](/docs/commands/init) will install all required plugins.

--- a/website/content/docs/commands/plugins/installed.mdx
+++ b/website/content/docs/commands/plugins/installed.mdx
@@ -1,0 +1,21 @@
+---
+description: |
+  The "plugins installed" command will list installed plugins.
+page_title: plugins Command
+---
+
+# `plugins installed`
+
+The `plugins installed` subcommand lists installed Packer plugins
+
+```shell-session
+$ packer plugins installed -h
+Usage: packer plugins installed
+
+  This command lists all installed plugins binaries that match with the current
+  OS and architecture. Packer's API version will be ignored.
+```
+
+## Related
+
+- [`packer init`](/docs/commands/init) will install all required plugins.

--- a/website/content/docs/commands/plugins/installed.mdx
+++ b/website/content/docs/commands/plugins/installed.mdx
@@ -12,7 +12,7 @@ The `plugins installed` subcommand lists installed Packer plugins
 $ packer plugins installed -h
 Usage: packer plugins installed
 
-  This command lists all installed plugins binaries that match with the current
+  This command lists all installed plugin binaries that match with the current
   OS and architecture. Packer's API version will be ignored.
 ```
 

--- a/website/content/docs/commands/plugins/remove.mdx
+++ b/website/content/docs/commands/plugins/remove.mdx
@@ -12,8 +12,8 @@ The `plugins remove` subcommand removes a Packer plugin at a version constraint
 $ packer  plugins remove -h
 Usage: packer plugins remove <plugin> [<version constraint>]
 
-  This command will remove all Packer plugins matching version constraint and
-  the current OS and architecture.
+  This command will remove all Packer plugins matching the version constraint
+  for the current OS and architecture.
   When the version is omitted all installed versions will be removed.
 
   Ex: packer plugins remove github.com/hashicorp/happycloud v1.2.3

--- a/website/content/docs/commands/plugins/remove.mdx
+++ b/website/content/docs/commands/plugins/remove.mdx
@@ -1,6 +1,6 @@
 ---
 description: |
-  The "plugins remove" command can install a plugin at a version constraint.
+  The "plugins remove" command can remove a plugin at a version constraint.
 page_title: plugins Command
 ---
 

--- a/website/content/docs/commands/plugins/remove.mdx
+++ b/website/content/docs/commands/plugins/remove.mdx
@@ -1,0 +1,24 @@
+---
+description: |
+  The "plugins remove" command can install a plugin at a version constraint.
+page_title: plugins Command
+---
+
+# `plugins remove`
+
+The `plugins remove` subcommand removes a Packer plugin at a version constraint
+
+```shell-session
+$ packer  plugins remove -h
+Usage: packer plugins remove <plugin> [<version constraint>]
+
+  This command will remove all Packer plugins matching version constraint and
+  the current OS and architecture.
+  When the version is omitted all installed versions will be removed.
+
+  Ex: packer plugins remove github.com/hashicorp/happycloud v1.2.3
+```
+
+## Related
+
+- [`packer init`](/docs/commands/init) will install all required plugins.

--- a/website/content/docs/commands/plugins/required.mdx
+++ b/website/content/docs/commands/plugins/required.mdx
@@ -14,9 +14,11 @@ all the installed binaries that match the constraint. The first binary
 $ packer plugins required -h
 Usage: packer plugins required <path>
 
-  This command will list every Packer plugin required by a Packer config.
-  All binaries matching the required version constrain and the current OS and
-  Architecture will be listed.
+  This command will list every Packer plugin required by a Packer config, in
+  packer.required_plugins blocks. All binaries matching the required version
+  constrain and the current OS and Architecture will be listed. The most recent
+  version (and the first of the list) will be the one picked by Packer during a
+  build.
 
 
   Ex: packer plugins required require.pkr.hcl

--- a/website/content/docs/commands/plugins/required.mdx
+++ b/website/content/docs/commands/plugins/required.mdx
@@ -1,0 +1,27 @@
+---
+description: |
+  The "plugins required" command can install a plugin at a version constraint.
+page_title: plugins Command
+---
+
+# `plugins required`
+
+The `plugins required` command lists all plugins required by a Packer config and
+binaries.
+
+```shell-session
+$ packer plugins required -h
+Usage: packer plugins required <path>
+
+  This command will list every Packer plugins required by a Packer config.
+  All binaries matching the required version constrain and the current OS and
+  Architecture will be listed.
+
+
+  Ex: packer plugins required require.pkr.hcl
+  Ex: packer plugins required path/to/folder/
+```
+
+## Related
+
+- [`packer init`](/docs/commands/init) will install all required plugins.

--- a/website/content/docs/commands/plugins/required.mdx
+++ b/website/content/docs/commands/plugins/required.mdx
@@ -7,7 +7,8 @@ page_title: plugins Command
 # `plugins required`
 
 The `plugins required` command lists all plugins required by a Packer config and
-binaries.
+all the installed binaries that match the constraint. The first binary 
+— also the most recent version — will be  the one picked by Packer in a build.
 
 ```shell-session
 $ packer plugins required -h

--- a/website/content/docs/commands/plugins/required.mdx
+++ b/website/content/docs/commands/plugins/required.mdx
@@ -13,7 +13,7 @@ binaries.
 $ packer plugins required -h
 Usage: packer plugins required <path>
 
-  This command will list every Packer plugins required by a Packer config.
+  This command will list every Packer plugin required by a Packer config.
   All binaries matching the required version constrain and the current OS and
   Architecture will be listed.
 

--- a/website/content/docs/commands/plugins/required.mdx
+++ b/website/content/docs/commands/plugins/required.mdx
@@ -8,7 +8,7 @@ page_title: plugins Command
 
 The `plugins required` command lists all plugins required by a Packer config and
 all the installed binaries that match the constraint. The first binary 
-— also the most recent version — will be  the one picked by Packer in a build.
+is the most up-to-date installed version and will be  the one picked by Packer in a build.
 
 ```shell-session
 $ packer plugins required -h

--- a/website/content/docs/commands/plugins/required.mdx
+++ b/website/content/docs/commands/plugins/required.mdx
@@ -1,6 +1,6 @@
 ---
 description: |
-  The "plugins required" command can install a plugin at a version constraint.
+  The "plugins required" command lists all plugins required in a Packer configuration.
 page_title: plugins Command
 ---
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -18,6 +18,15 @@
         "path": "commands/init"
       },
       {
+        "title": "<code>plugins</code>",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "commands/plugins"
+          }
+        ]
+      },
+      {
         "title": "<code>build</code>",
         "path": "commands/build"
       },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -23,6 +23,22 @@
           {
             "title": "Overview",
             "path": "commands/plugins"
+          },
+          {
+            "title": "<code>install</code>",
+            "path": "commands/plugins/install"
+          },
+          {
+            "title": "<code>installed</code>",
+            "path": "commands/plugins/installed"
+          },
+          {
+            "title": "<code>remove</code>",
+            "path": "commands/plugins/remove"
+          },
+          {
+            "title": "<code>required</code>",
+            "path": "commands/plugins/required"
           }
         ]
       },


### PR DESCRIPTION

```shell-session
❯ packer plugins -h
Usage: packer plugins <subcommand> [options] [args]
  This command groups subcommands for interacting with Packer plugins.

Related but not under the "plugins" command :

- "packer init <path>" will install all plugins required by a config.

Subcommands:
    install      Install latest Packer plugin [matching version constraint]
    installed    List all installed Packer plugins binaries
    remove       Remove Packer plugins [matching a version]
    required     List plugins required by a config
```

* [x] feature
* [x] docs
* [x] tests