### PR TITLE
hcl2template: don't use it's var type when the default value for a variable is empty

### DIFF
--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -386,7 +386,12 @@ func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.Eval
 
 		// It's possible no type attribute was assigned so lets make sure we
 		// have a valid type otherwise there could be issues parsing the value.
-		if v.Type == cty.NilType {
+		if v.Type == cty.NilType &&
+			// converting a value to one of these empty type works but makes the
+			// converted value empty.
+			!defaultValue.Type().Equals(cty.EmptyObject) &&
+			!defaultValue.Type().Equals(cty.EmptyTuple) {
+
 			v.Type = defaultValue.Type()
 		}
 	}


### PR DESCRIPTION
In HCL, when no type is given for a var, the type of the default value will be used. But the type of `default = {}` is the `EmptyObject`.

Converting something in HCL to the EmptyObject or EmptyTuple types will return a new empty object. Meaning that if we try to set these later on, the result will remain something empty.

This potentially fixes #11551

* [x] fix
* [ ] tests