### PR TITLE
Add legacy mode to Packer

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -113,7 +113,7 @@ func (m *Meta) GetConfig(cla *MetaArgs) (packer.Handler, int) {
 // This is an internal-only method that should be called by commands that don't have
 // a different mode when handling legacy JSON templates; mainly build, validate.
 func DisplayLegacyConfigWarning(ui packersdk.Ui) {
-	if v := os.Getenv("PACKER_LEGACY_MODE"); strings.ToLower(v) == "on" {
+	if v := os.Getenv(PackerLegacyModeEnv); strings.ToUpper(v) == packerLegacyModeOn {
 		return
 	}
 
@@ -130,11 +130,11 @@ templates will continue to work but users are encouraged to move to HCL style te
 See: https://learn.hashicorp.com/tutorials/packer/hcl2-upgrade
 `)
 
-	coloredUi.Say(`In JSON mode automatic loading of vendored plugins is enabled by default.  In future
-this feature will be removed and Packer will rely only on system installed plugins.
-To disable automatic loading of vendored plugins set PACKER_LEGACY_MODE=off
+	coloredUi.Say(fmt.Sprintf(`In JSON mode automatic loading of vendored plugins is enabled by default. In the
+future this feature will be removed and Packer will rely only on system installed plugins.
+To disable automatic loading of vendored plugins set %s=%s
 See: https://packer.io/docs/templates/legacy-mode
-`)
+`, PackerLegacyModeEnv, packerLegacyModeOff))
 
 }
 

--- a/command/build.go
+++ b/command/build.go
@@ -113,7 +113,7 @@ func (m *Meta) GetConfig(cla *MetaArgs) (packer.Handler, int) {
 // This is an internal-only method that should be called by commands that don't have
 // a different mode when handling legacy JSON templates; mainly build, validate.
 func DisplayLegacyConfigWarning(ui packersdk.Ui) {
-	if v, ok := os.LookupEnv("PACKER_LEGACY_MODE"); ok && strings.ToLower(v) == "on" {
+	if v := os.Getenv("PACKER_LEGACY_MODE"); strings.ToLower(v) == "on" {
 		return
 	}
 

--- a/command/build.go
+++ b/command/build.go
@@ -128,8 +128,12 @@ The template will be parsed in the legacy configuration style. Legacy style
 templates will continue to work but users are encouraged to move HCL style templates.
 templates will continue to work but users are encouraged to move to HCL style templates.
 See: https://learn.hashicorp.com/tutorials/packer/hcl2-upgrade
+`)
 
-To disable legacy warnings including this one set the environment variable PACKER_LEGACY_MODE=on
+	coloredUi.Say(`In JSON mode automatic loading of vendored plugins is enabled by default.  In future
+this feature will be removed and Packer will rely only on system installed plugins.
+To disable automatic loading of vendored plugins set PACKER_LEGACY_MODE=off
+See: https://packer.io/docs/templates/legacy-mode
 `)
 
 }

--- a/command/build.go
+++ b/command/build.go
@@ -126,13 +126,12 @@ func DisplayLegacyConfigWarning(ui packersdk.Ui) {
 Legacy JSON Configuration Mode enabled.
 The template will be parsed in the legacy configuration style. Legacy style
 templates will continue to work but users are encouraged to move HCL style templates.
-templates will continue to work but users are encouraged to move to HCL style templates.
 See: https://learn.hashicorp.com/tutorials/packer/hcl2-upgrade
 `)
 
-	coloredUi.Say(fmt.Sprintf(`In JSON mode automatic loading of vendored plugins is enabled by default. In the
-future this feature will be removed and Packer will rely only on system installed plugins.
-To disable automatic loading of vendored plugins set %s=%s
+	coloredUi.Say(fmt.Sprintf(`In JSON mode automatic loading of bundled plugins is enabled by default.
+In the future this feature will be removed and Packer will rely only on system installed plugins.
+To disable automatic loading of bundled plugins set %s=%s
 See: https://packer.io/docs/templates/legacy-mode
 `, PackerLegacyModeEnv, packerLegacyModeOff))
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -23,6 +23,19 @@ const (
 	FlagSetVars
 )
 
+const (
+	/*
+		PACKER_LEGACY_MODE is an environment variable used by Packer to control features consider legacy as of 1.8.0.
+		By default when the variable is unset Packer will display warnings to the user.
+
+		Setting PACKER_LEGACY_MODE=OFF will display warnings to the user when running, and may disable other features.
+		Setting PACKER_LEGACY_MODE=ON  will not display warnings, and will Packer with all legacy features enabled.
+	*/
+	PackerLegacyModeEnv string = "PACKER_LEGACY_MODE"
+	packerLegacyModeOn  string = "ON"
+	packerLegacyModeOff string = "OFF"
+)
+
 // Meta contains the meta-options and functionality that nearly every
 // Packer command inherits.
 type Meta struct {

--- a/command/validate.go
+++ b/command/validate.go
@@ -50,6 +50,10 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 		return 1
 	}
 
+	if cla.ConfigType == ConfigTypeJSON {
+		DisplayLegacyConfigWarning(c.Ui)
+	}
+
 	// If we're only checking syntax, then we're done already
 	if cla.SyntaxOnly {
 		c.Ui.Say("Syntax-only check passed. Everything looks okay.")

--- a/command/vendored_plugins.go
+++ b/command/vendored_plugins.go
@@ -1,6 +1,9 @@
 package command
 
 import (
+	"os"
+	"strings"
+
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 
 	// Previously core-bundled components, split into their own plugins but
@@ -187,6 +190,14 @@ var VendoredPostProcessors = map[string]packersdk.PostProcessor{
 // Upon init lets load up any plugins that were vendored manually into the default
 // set of plugins.
 func init() {
+
+	// By default PACKER_LEGACY_MODE=auto to enable automatic loading of vendored plugins.
+	// In preparation for removing vendored plugins entirely we are providing users a flag to
+	//  to control if vendored plugins should be loaded or not.
+	if v, ok := os.LookupEnv("PACKER_LEGACY_MODE"); ok && strings.ToLower(v) == "off" {
+		return
+	}
+
 	for k, v := range VendoredDatasources {
 		if _, ok := Datasources[k]; ok {
 			continue

--- a/command/vendored_plugins.go
+++ b/command/vendored_plugins.go
@@ -194,7 +194,7 @@ func init() {
 	// By default PACKER_LEGACY_MODE=auto to enable automatic loading of vendored plugins.
 	// In preparation for removing vendored plugins entirely we are providing users a flag to
 	//  to control if vendored plugins should be loaded or not.
-	if v, ok := os.LookupEnv("PACKER_LEGACY_MODE"); ok && strings.ToLower(v) == "off" {
+	if v := os.Getenv("PACKER_LEGACY_MODE"); strings.ToLower(v) == "off" {
 		return
 	}
 

--- a/command/vendored_plugins.go
+++ b/command/vendored_plugins.go
@@ -191,10 +191,10 @@ var VendoredPostProcessors = map[string]packersdk.PostProcessor{
 // set of plugins.
 func init() {
 
-	// By default PACKER_LEGACY_MODE=auto to enable automatic loading of vendored plugins.
+	// By default PACKER_LEGACY_MODE is unset to enable automatic loading of vendored plugins.
 	// In preparation for removing vendored plugins entirely we are providing users a flag to
 	//  to control if vendored plugins should be loaded or not.
-	if v := os.Getenv("PACKER_LEGACY_MODE"); strings.ToLower(v) == "off" {
+	if v := os.Getenv(PackerLegacyModeEnv); strings.ToUpper(v) == packerLegacyModeOff {
 		return
 	}
 


### PR DESCRIPTION
<details>
<summary> Add concept of Legacy mode to Packer</summary>


In the legacy mode users running build or validate with JSON templates will get a warning indicating that Packer is in Legacy Configuration Mode.

Legacy mode can be controlled by an environment variable.

PACKER_LEGACY_MODE=      // default if not set will display warnings to the user.
PACKER_LEGACY_MODE=off // will display warnings to the user when running, and may disable other features.
PACKER_LEGACY_MODE=on // will not display warnings with all legacy features enabled.

    ~>  go run . validate ../packer-templates/amazon-chroot/amazon-chroot_shell.json

    Legacy JSON Configuration Mode enabled.
    The template will be parsed in the legacy configuration style. Legacy style
    templates will continue to work but users are encouraged to move HCL style templates.
    templates will continue to work but users are encouraged to move to HCL style templates.
    See: https://learn.hashicorp.com/tutorials/packer/hcl2-upgrade

    The configuration is valid.

    ~>  PACKER_LEGACY_MODE=on go run . validate ../packer-templates/amazon-chroot/amazon-chroot_shell.json
    The configuration is valid.

</details>

<details>
<summary>Disable vendored plugins when PACKER_LEGACY_MODE is off</summary>

This change allows users to disable the loading of vendored plugins by setting legacy mode off. In this mode Packer will rely only on plugins that have been installed via packer init or the packer plugins command.


    // Running validate on JSON with Packer legacy mode unset; all plugins loaded by default
    ~>  go run . validate ../packer-templates/amazon-ebs/amazon-ebs_ubuntu_shell_manifest.json

    Legacy JSON Configuration Mode enabled.
    The template will be parsed in the legacy configuration style. Legacy style
    templates will continue to work but users are encouraged to move HCL style templates.
    templates will continue to work but users are encouraged to move to HCL style templates.
    See: https://learn.hashicorp.com/tutorials/packer/hcl2-upgrade

    In JSON mode automatic loading of vendored plugins is enabled by default.  In future
    this feature will be removed and Packer will rely only on system installed plugins.
    To disable automatic loading of vendored plugins set PACKER_LEGACY_MODE=off
    See: https://packer.io/docs/templates/legacy-mode

    The configuration is valid.

    // Running validate on JSON with Packer legacy mode explicitly set to on; all plugins loded
    ~>  PACKER_LEGACY_MODE=on go run . validate ../packer-templates/amazon-ebs/amazon-ebs_ubuntu_shell_manifest.json
    The configuration is valid.

    // Running validate on JSON with Packer legacy mode explicitly set to off
    ~>  PACKER_LEGACY_MODE=off go run . validate ../packer-templates/amazon-ebs/amazon-ebs_ubuntu_shell_manifest.json

    Legacy JSON Configuration Mode enabled.
    The template will be parsed in the legacy configuration style. Legacy style
    templates will continue to work but users are encouraged to move HCL style templates.
    templates will continue to work but users are encouraged to move to HCL style templates.
    See: https://learn.hashicorp.com/tutorials/packer/hcl2-upgrade

    In JSON mode automatic loading of vendored plugins is enabled by default.  In future
    this feature will be removed and Packer will rely only on system installed plugins.
    To disable automatic loading of vendored plugins set PACKER_LEGACY_MODE=off
    See: https://packer.io/docs/templates/legacy-mode

    Error: Failed to initialize build "amazon-ebs"

    error initializing builder 'amazon-ebs': Unknown builder amazon-ebs

    exit status 1
    
</details>

See related PRs:
- #11562 
- #11563 

## TODO

- [ ] Tests
- [ ] Docs

Closes https://github.com/hashicorp/packer-internal-issues/issues/16 (HashiCorp-only link)