### PR TITLE
Update hcl2_upgrade command to work without vendored plugins

### DIFF
--- a/command/hcl2_upgrade.go
+++ b/command/hcl2_upgrade.go
@@ -159,9 +159,6 @@ func (c *HCL2UpgradeCommand) RunContext(_ context.Context, cla *HCL2UpgradeArgs)
 	}
 
 	core := hdl.(*CoreWrapper).Core
-	if err := core.Initialize(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Ignoring following initialization error: %v", err))
-	}
 	tpl := core.Template
 
 	// Parse blocks
@@ -217,8 +214,9 @@ func (c *HCL2UpgradeCommand) RunContext(_ context.Context, cla *HCL2UpgradeArgs)
 		WithAnnotations: cla.WithAnnotations,
 	}
 	if err := sources.Parse(tpl); err != nil {
-		c.Ui.Error(fmt.Sprintf("Ignoring following sources.Parse error: %v", err))
-		ret = 1
+		c.Ui.Error(fmt.Sprintf("\nIgnoring following sources.Parse error: %v\n"+
+			"Please install any missing builder types before executing a build with the newly upgraded template.\n"+
+			"See: https://www.packer.io/plugins#installing-plugins\n", err))
 	}
 
 	build := &BuildParser{

--- a/command/hcl2_upgrade_test.go
+++ b/command/hcl2_upgrade_test.go
@@ -17,7 +17,7 @@ func Test_hcl2_upgrade(t *testing.T) {
 		exitCode  int
 		exitEarly bool
 	}{
-		{folder: "unknown_builder", flags: []string{}, exitCode: 1},
+		{folder: "unknown_builder", flags: []string{}, exitCode: 0},
 		{folder: "complete", flags: []string{"-with-annotations"}},
 		{folder: "without-annotations", flags: []string{}},
 		{folder: "minimal", flags: []string{"-with-annotations"}},
@@ -28,7 +28,7 @@ func Test_hcl2_upgrade(t *testing.T) {
 		{folder: "variables-with-variables", flags: []string{}},
 		{folder: "complete-variables-with-template-engine", flags: []string{}},
 		{folder: "escaping", flags: []string{}},
-		{folder: "vsphere_linux_options_and_network_interface", exitCode: 1, flags: []string{}},
+		{folder: "vsphere_linux_options_and_network_interface", exitCode: 0, flags: []string{}},
 		{folder: "nonexistent", flags: []string{}, exitCode: 1, exitEarly: true},
 	}
 


### PR DESCRIPTION


Previously the hcl2_upgrade command was Initialization Packer core upon
as part of the upgrade process. But all errors were being ignored, which
implies that the call to Initialize is not really needed. Since Packer
will soon be removing all vendored plugins it is important that the
hcl2_upgrade command works when  a component plugin is not available;
especially since it is not needed for the upgrade command to work.

This change makes it so that the hcl2_upgrade command will execute as
expected and return a successful exit when the source builders are not
available. As an alternative the command will now alert the user to
install any missing builders before executing a build on the new
template.

```
~>  go run . hcl2_upgrade ../packer-templates/googlecompute/googlecompute-centos-shell.json
Successfully created ../packer-templates/googlecompute/googlecompute-centos-shell.json.pkr.hcl. Exit 0

// Running hcl_upgrade with no vendored plugins or pre-installed plugins.
~>  PACKER_LEGACY_MODE=off go run . hcl2_upgrade ../packer-templates/googlecompute/googlecompute-centos-shell.json

Ignoring following sources.Parse error: unknown builder type(s): [googlecompute]

Please install any missing builder types before executing a build with the newly upgraded template.
See: https://www.packer.io/plugins#installing-plugins

Successfully created ../packer-templates/googlecompute/googlecompute-centos-shell.json.pkr.hcl. Exit 0
```

Related to #11560 