### PR TITLE
all shells: Pass env vars through a key value store

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -475,7 +475,7 @@ func TestBuild(t *testing.T) {
 					"foo.txt": "foo",
 				},
 				expected: []string{
-					"s3cr3t.txt",
+					"s3cr3t",
 				},
 			},
 		},

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -465,6 +465,20 @@ func TestBuild(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "hcl - unknown ",
+			args: []string{
+				testFixture("hcl", "data-source-validation.pkr.hcl"),
+			},
+			fileCheck: fileCheck{
+				expectedContent: map[string]string{
+					"foo.txt": "foo",
+				},
+				expected: []string{
+					"s3cr3t.txt",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tc {

--- a/command/test-fixtures/hcl/data-source-validation.pkr.hcl
+++ b/command/test-fixtures/hcl/data-source-validation.pkr.hcl
@@ -23,7 +23,7 @@ build {
     }
     inline           = [
       "echo yo, my secret is $MY_SECRET",
-      "echo '' > $MY_SECRET.txt",
+      "echo '' > $MY_SECRET",
     ]
   }
   provisioner "shell-local" {
@@ -33,7 +33,7 @@ build {
     }
     inline           = [
       "echo yo, my secret is %MY_SECRET%",
-      "echo '' > %MY_SECRET%.txt",
+      "echo '' > %MY_SECRET%",
     ]
   }
 }

--- a/command/test-fixtures/hcl/data-source-validation.pkr.hcl
+++ b/command/test-fixtures/hcl/data-source-validation.pkr.hcl
@@ -1,0 +1,25 @@
+
+data "null" "secret" {
+  input = "s3cr3t"
+}
+
+locals {
+  secret = data.null.secret.output
+}
+
+source "file" "foo" {
+  content = "foo"
+  target = "foo.txt"
+}
+
+build {
+  sources = ["file.foo"]
+  provisioner "shell-local" {
+    # original bug in :
+    # environment_vars = ["MY_SECRET=${local.secret}"]
+    env = {
+      "MY_SECRET":"${local.secret}",
+    }
+    inline           = ["echo yo, my secret is $MY_SECRET"]
+  }
+}

--- a/command/test-fixtures/hcl/data-source-validation.pkr.hcl
+++ b/command/test-fixtures/hcl/data-source-validation.pkr.hcl
@@ -20,6 +20,9 @@ build {
     env = {
       "MY_SECRET":"${local.secret}",
     }
-    inline           = ["echo yo, my secret is $MY_SECRET"]
+    inline           = [
+      "echo yo, my secret is $MY_SECRET",
+      "echo '' > $MY_SECRET.txt",
+    ]
   }
 }

--- a/command/test-fixtures/hcl/data-source-validation.pkr.hcl
+++ b/command/test-fixtures/hcl/data-source-validation.pkr.hcl
@@ -15,6 +15,7 @@ source "file" "foo" {
 build {
   sources = ["file.foo"]
   provisioner "shell-local" {
+    only_on = ["darwin", "freebsd", "linux", "openbsd", "solaris"]
     # original bug in :
     # environment_vars = ["MY_SECRET=${local.secret}"]
     env = {
@@ -23,6 +24,16 @@ build {
     inline           = [
       "echo yo, my secret is $MY_SECRET",
       "echo '' > $MY_SECRET.txt",
+    ]
+  }
+  provisioner "shell-local" {
+    only_on = ["windows"]
+    env = {
+      "MY_SECRET":"${local.secret}",
+    }
+    inline           = [
+      "echo yo, my secret is %MY_SECRET%",
+      "echo '' > %MY_SECRET%.txt",
     ]
   }
 }

--- a/command/test_utils.go
+++ b/command/test_utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/packer/builder/null"
 	hcppackerimagedatasource "github.com/hashicorp/packer/datasource/hcp-packer-image"
 	hcppackeriterationdatasource "github.com/hashicorp/packer/datasource/hcp-packer-iteration"
+	nulldatasource "github.com/hashicorp/packer/datasource/null"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/post-processor/manifest"
 	shell_local_pp "github.com/hashicorp/packer/post-processor/shell-local"
@@ -51,6 +52,7 @@ func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {
 			},
 			DataSources: packer.MapOfDatasource{
 				"mock":                 func() (packersdk.Datasource, error) { return &packersdk.MockDatasource{}, nil },
+				"null":                 func() (packersdk.Datasource, error) { return &nulldatasource.Datasource{}, nil },
 				"hcp-packer-image":     func() (packersdk.Datasource, error) { return &hcppackerimagedatasource.Datasource{}, nil },
 				"hcp-packer-iteration": func() (packersdk.Datasource, error) { return &hcppackeriterationdatasource.Datasource{}, nil },
 			},

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -36,6 +36,9 @@ func TestValidateCommand(t *testing.T) {
 
 		// Should return multiple errors,
 		{path: filepath.Join(testFixture("validate", "circular_error.pkr.hcl")), exitCode: 1},
+
+		// datasource could be unknown at that moment
+		{path: filepath.Join(testFixture("hcl", "data-source-validation.pkr.hcl")), exitCode: 0},
 	}
 
 	for _, tc := range tt {

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4
 	github.com/hashicorp/packer-plugin-amazon v1.0.6
-	github.com/hashicorp/packer-plugin-sdk v0.2.11
+	github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220215104433-24404dc7a52e
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869
 	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/klauspost/pgzip v1.2.5

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4
 	github.com/hashicorp/packer-plugin-amazon v1.0.6
-	github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220215104433-24404dc7a52e
+	github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220216103740-f7d4bf877a45
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869
 	github.com/klauspost/compress v1.13.5 // indirect
 	github.com/klauspost/pgzip v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -768,6 +768,8 @@ github.com/hashicorp/packer-plugin-sdk v0.2.7/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7
 github.com/hashicorp/packer-plugin-sdk v0.2.9/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/packer-plugin-sdk v0.2.11 h1:FsL2oOfLJmXC9F6W9eMFe0eUi3+ggFuqkLGX41fyPE0=
 github.com/hashicorp/packer-plugin-sdk v0.2.11/go.mod h1:DI8REf9TEIcVkYPErI/nedo6zS2h81ze7sKuc/mIlTE=
+github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220215104433-24404dc7a52e h1:bWsX98L1C0rFA1q3YVYNqUltygRxy7y7QKZ6upg2bO4=
+github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220215104433-24404dc7a52e/go.mod h1:DI8REf9TEIcVkYPErI/nedo6zS2h81ze7sKuc/mIlTE=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.3 h1:8U2vMFyIE+pizoMDsSLyMBsbNdB1HzRAIaTJNIELyi4=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.3/go.mod h1:TCSlq9lCFU8H8eMMWNtwdnCeyHmaQ1A13PR11EJoJh0=
 github.com/hashicorp/packer-plugin-triton v1.0.0 h1:Uvh8fjEKqlii61BzIt1VEgSyJXL+UYfuMHCj44aVpU8=

--- a/go.sum
+++ b/go.sum
@@ -766,10 +766,9 @@ github.com/hashicorp/packer-plugin-sdk v0.2.3/go.mod h1:MAOhxLneNh27t6N6SMyRcIR5
 github.com/hashicorp/packer-plugin-sdk v0.2.5/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/packer-plugin-sdk v0.2.7/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/packer-plugin-sdk v0.2.9/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
-github.com/hashicorp/packer-plugin-sdk v0.2.11 h1:FsL2oOfLJmXC9F6W9eMFe0eUi3+ggFuqkLGX41fyPE0=
 github.com/hashicorp/packer-plugin-sdk v0.2.11/go.mod h1:DI8REf9TEIcVkYPErI/nedo6zS2h81ze7sKuc/mIlTE=
-github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220215104433-24404dc7a52e h1:bWsX98L1C0rFA1q3YVYNqUltygRxy7y7QKZ6upg2bO4=
-github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220215104433-24404dc7a52e/go.mod h1:DI8REf9TEIcVkYPErI/nedo6zS2h81ze7sKuc/mIlTE=
+github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220216103740-f7d4bf877a45 h1:NOEkBi0iohcGGVFjM8QBlZS69AbrXCuv5Vx+41CG34A=
+github.com/hashicorp/packer-plugin-sdk v0.2.12-0.20220216103740-f7d4bf877a45/go.mod h1:DI8REf9TEIcVkYPErI/nedo6zS2h81ze7sKuc/mIlTE=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.3 h1:8U2vMFyIE+pizoMDsSLyMBsbNdB1HzRAIaTJNIELyi4=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.3/go.mod h1:TCSlq9lCFU8H8eMMWNtwdnCeyHmaQ1A13PR11EJoJh0=
 github.com/hashicorp/packer-plugin-triton v1.0.0 h1:Uvh8fjEKqlii61BzIt1VEgSyJXL+UYfuMHCj44aVpU8=

--- a/provisioner/powershell/provisioner.hcl2spec.go
+++ b/provisioner/powershell/provisioner.hcl2spec.go
@@ -23,6 +23,7 @@ type FlatConfig struct {
 	Scripts                []string          `cty:"scripts" hcl:"scripts"`
 	ValidExitCodes         []int             `mapstructure:"valid_exit_codes" cty:"valid_exit_codes" hcl:"valid_exit_codes"`
 	Vars                   []string          `mapstructure:"environment_vars" cty:"environment_vars" hcl:"environment_vars"`
+	Env                    map[string]string `mapstructure:"env" cty:"env" hcl:"env"`
 	EnvVarFormat           *string           `mapstructure:"env_var_format" cty:"env_var_format" hcl:"env_var_format"`
 	Binary                 *bool             `cty:"binary" hcl:"binary"`
 	RemotePath             *string           `mapstructure:"remote_path" cty:"remote_path" hcl:"remote_path"`
@@ -63,6 +64,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"scripts":                    &hcldec.AttrSpec{Name: "scripts", Type: cty.List(cty.String), Required: false},
 		"valid_exit_codes":           &hcldec.AttrSpec{Name: "valid_exit_codes", Type: cty.List(cty.Number), Required: false},
 		"environment_vars":           &hcldec.AttrSpec{Name: "environment_vars", Type: cty.List(cty.String), Required: false},
+		"env":                        &hcldec.AttrSpec{Name: "env", Type: cty.Map(cty.String), Required: false},
 		"env_var_format":             &hcldec.AttrSpec{Name: "env_var_format", Type: cty.String, Required: false},
 		"binary":                     &hcldec.AttrSpec{Name: "binary", Type: cty.Bool, Required: false},
 		"remote_path":                &hcldec.AttrSpec{Name: "remote_path", Type: cty.String, Required: false},

--- a/provisioner/shell/provisioner.hcl2spec.go
+++ b/provisioner/shell/provisioner.hcl2spec.go
@@ -23,6 +23,7 @@ type FlatConfig struct {
 	Scripts             []string          `cty:"scripts" hcl:"scripts"`
 	ValidExitCodes      []int             `mapstructure:"valid_exit_codes" cty:"valid_exit_codes" hcl:"valid_exit_codes"`
 	Vars                []string          `mapstructure:"environment_vars" cty:"environment_vars" hcl:"environment_vars"`
+	Env                 map[string]string `mapstructure:"env" cty:"env" hcl:"env"`
 	EnvVarFormat        *string           `mapstructure:"env_var_format" cty:"env_var_format" hcl:"env_var_format"`
 	Binary              *bool             `cty:"binary" hcl:"binary"`
 	RemotePath          *string           `mapstructure:"remote_path" cty:"remote_path" hcl:"remote_path"`
@@ -62,6 +63,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"scripts":                    &hcldec.AttrSpec{Name: "scripts", Type: cty.List(cty.String), Required: false},
 		"valid_exit_codes":           &hcldec.AttrSpec{Name: "valid_exit_codes", Type: cty.List(cty.Number), Required: false},
 		"environment_vars":           &hcldec.AttrSpec{Name: "environment_vars", Type: cty.List(cty.String), Required: false},
+		"env":                        &hcldec.AttrSpec{Name: "env", Type: cty.Map(cty.String), Required: false},
 		"env_var_format":             &hcldec.AttrSpec{Name: "env_var_format", Type: cty.String, Required: false},
 		"binary":                     &hcldec.AttrSpec{Name: "binary", Type: cty.Bool, Required: false},
 		"remote_path":                &hcldec.AttrSpec{Name: "remote_path", Type: cty.String, Required: false},

--- a/provisioner/windows-shell/provisioner.hcl2spec.go
+++ b/provisioner/windows-shell/provisioner.hcl2spec.go
@@ -23,6 +23,7 @@ type FlatConfig struct {
 	Scripts             []string          `cty:"scripts" hcl:"scripts"`
 	ValidExitCodes      []int             `mapstructure:"valid_exit_codes" cty:"valid_exit_codes" hcl:"valid_exit_codes"`
 	Vars                []string          `mapstructure:"environment_vars" cty:"environment_vars" hcl:"environment_vars"`
+	Env                 map[string]string `mapstructure:"env" cty:"env" hcl:"env"`
 	EnvVarFormat        *string           `mapstructure:"env_var_format" cty:"env_var_format" hcl:"env_var_format"`
 	Binary              *bool             `cty:"binary" hcl:"binary"`
 	RemotePath          *string           `mapstructure:"remote_path" cty:"remote_path" hcl:"remote_path"`
@@ -55,6 +56,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"scripts":                    &hcldec.AttrSpec{Name: "scripts", Type: cty.List(cty.String), Required: false},
 		"valid_exit_codes":           &hcldec.AttrSpec{Name: "valid_exit_codes", Type: cty.List(cty.Number), Required: false},
 		"environment_vars":           &hcldec.AttrSpec{Name: "environment_vars", Type: cty.List(cty.String), Required: false},
+		"env":                        &hcldec.AttrSpec{Name: "env", Type: cty.Map(cty.String), Required: false},
 		"env_var_format":             &hcldec.AttrSpec{Name: "env_var_format", Type: cty.String, Required: false},
 		"binary":                     &hcldec.AttrSpec{Name: "binary", Type: cty.Bool, Required: false},
 		"remote_path":                &hcldec.AttrSpec{Name: "remote_path", Type: cty.String, Required: false},

--- a/website/content/docs/post-processors/shell-local.mdx
+++ b/website/content/docs/post-processors/shell-local.mdx
@@ -94,6 +94,11 @@ Exactly _one_ of the following is required:
 
 Optional parameters:
 
+- `env` (map of strings) - A map of key/value pairs to inject prior to the
+  execute_command. Packer injects some environmental variables by default into
+  the environment, as well, which are covered in the section below. Duplciate
+  `env` settings override `environment_vars` settings.
+
 - `environment_vars` (array of strings) - An array of key/value pairs to
   inject prior to the `execute_command`. The format should be `key=value`.
   Packer injects some environmental variables by default into the

--- a/website/content/docs/provisioners/powershell.mdx
+++ b/website/content/docs/provisioners/powershell.mdx
@@ -75,6 +75,12 @@ provisioner "powershell" {
   - `Vars`: The location of a temp file containing the list of
     `environment_vars`, if configured.
 
+- `env` (map of strings) - A map of key/value pairs to inject prior to the
+  execute_command. Packer injects some environmental variables by default into
+  the environment, as well, which are covered in the section below. Duplciate
+  `env` settings override `environment_vars` settings. This is not a JSON
+  template engine enabled function. HCL interpolation works as usual.
+
 - `environment_vars` (array of strings) - An array of key/value pairs to
   inject prior to the execute_command. The format should be `key=value`.
   Packer injects some environmental variables by default into the

--- a/website/content/docs/provisioners/powershell.mdx
+++ b/website/content/docs/provisioners/powershell.mdx
@@ -17,8 +17,8 @@ The PowerShell Packer provisioner runs PowerShell scripts on Windows machines.
 It assumes that the communicator in use is WinRM. However, the provisioner can
 work equally well (with a few caveats) when combined with the SSH communicator.
 See the [section
-below](/docs/provisioners/powershell#combining-the-powershell-provisioner-with-the-ssh-communicator)
-for details.
+below](#combining-the-powershell-provisioner-with-the-ssh-communicator) for
+details.
 
 `@include 'path/separator-note.mdx'`
 

--- a/website/content/docs/provisioners/shell-local.mdx
+++ b/website/content/docs/provisioners/shell-local.mdx
@@ -103,6 +103,11 @@ Exactly _one_ of the following is required:
 
 Optional parameters:
 
+- `env` (map of strings) - A map of key/value pairs to inject prior to the
+  execute_command. Packer injects some environmental variables by default into
+  the environment, as well, which are covered in the section below. Duplciate
+  `env` settings override `environment_vars` settings.
+
 - `environment_vars` (array of strings) - An array of key/value pairs to
   inject prior to the `execute_command`. The format should be `key=value`.
   Packer injects some environmental variables by default into the

--- a/website/content/docs/provisioners/shell.mdx
+++ b/website/content/docs/provisioners/shell.mdx
@@ -52,6 +52,11 @@ provisioner "shell" {
 
 @include 'provisioners/shell-config.mdx'
 
+- `env` (map of strings) - A map of key/value pairs to inject prior to the
+  execute_command. Packer injects some environmental variables by default into
+  the environment, as well, which are covered in the section below. Duplciate
+  `env` settings override `environment_vars` settings.
+
 - `environment_vars` (array of strings) - An array of key/value pairs to
   inject prior to the execute_command. The format should be `key=value`.
   Packer injects some environmental variables by default into the

--- a/website/content/docs/provisioners/windows-shell.mdx
+++ b/website/content/docs/provisioners/windows-shell.mdx
@@ -46,6 +46,11 @@ provisioner "windows-shell" {
 
 @include 'provisioners/shell-config.mdx'
 
+- `env` (map of strings) - A map of key/value pairs to inject prior to the
+  execute_command. Packer injects some environmental variables by default into
+  the environment, as well, which are covered in the section below. Duplciate
+  `env` settings override `environment_vars` settings.
+
 - `environment_vars` (array of strings) - An array of key/value pairs to
   inject prior to the execute_command. The format should be `key=value`.
   Packer injects some environmental variables by default into the


### PR DESCRIPTION
This potentially fixes #11197, by allowing to set shell env vars from a key/value map.

Merge https://github.com/hashicorp/packer-plugin-sdk/pull/98 first.

* [x] shell: add env `key`/`value` store possibility
* [x] docs shell
* [x] docs shell-local
* [x] docs PowerShell
* [x] docs windows shell
* [x] docs shell-local-post-processor
* [x] validation test
* [x] build test
* [x] build test on windows