### PR TITLE
docs: add link to builder list

### DIFF
--- a/website/content/docs/builders/index.mdx
+++ b/website/content/docs/builders/index.mdx
@@ -10,7 +10,7 @@ page_title: Builders
 Builders are responsible for creating machines and generating images from them
 for various platforms. For example, there are separate builders for EC2,
 VMware, VirtualBox, etc. Packer comes with many builders by default, and can
-also be extended to add new builders.
+also be extended to add new builders. See [`plugins`](/plugins) for a list of plugins and their builders.
 
 See the [`source`](/docs/templates/hcl_templates/blocks/source) block documentation to learn more
 about configuring builders in the Packer language.


### PR DESCRIPTION
browsing through the documentation I was searching for the list of builders available. The obvious choice (builders page) didn't link to the list of builders and it took me a few minutes to find that. Adding a link to the plugins might speed up that bit and would avoid having to rescue to the search engine.