### PR TITLE
Revert "Update test client to use Org/Project ID from client; not environment variables"

### DIFF
--- a/internal/registry/acctest/par.go
+++ b/internal/registry/acctest/par.go
@@ -46,8 +46,8 @@ func NewTestConfig(t *testing.T) (*Config, error) {
 	return &Config{
 		Client: cli,
 		Loc: &sharedmodels.HashicorpCloudLocationLocation{
-			OrganizationID: cli.OrganizationID,
-			ProjectID:      cli.ProjectID,
+			OrganizationID: cfg.OrgId,
+			ProjectID:      cfg.ProjectId,
 		},
 		T: t,
 	}, nil


### PR DESCRIPTION
Reverts hashicorp/packer#11502