### PR TITLE
Update HCP Packer build labels when re-running Packer on an incomplete build

### DIFF
--- a/internal/registry/mock_service.go
+++ b/internal/registry/mock_service.go
@@ -25,7 +25,8 @@ type MockPackerClientService struct {
 	// Mock Gets
 	GetIterationResp *models.HashicorpCloudPackerGetIterationResponse
 
-	ExistingBuilds []string
+	ExistingBuilds      []string
+	ExistingBuildLabels map[string]string
 
 	packerSvc.ClientService
 }
@@ -205,9 +206,14 @@ func (svc *MockPackerClientService) PackerServiceListBuilds(params *packerSvc.Pa
 
 	status := models.HashicorpCloudPackerBuildStatusUNSET
 	images := make([]*models.HashicorpCloudPackerImage, 0)
+	labels := make(map[string]string)
 	if svc.BuildAlreadyDone {
 		status = models.HashicorpCloudPackerBuildStatusDONE
 		images = append(images, &models.HashicorpCloudPackerImage{ImageID: "image-id", Region: "somewhere"})
+	}
+
+	for k, v := range svc.ExistingBuildLabels {
+		labels[k] = v
 	}
 
 	builds := make([]*models.HashicorpCloudPackerBuild, 0, len(svc.ExistingBuilds))
@@ -218,7 +224,7 @@ func (svc *MockPackerClientService) PackerServiceListBuilds(params *packerSvc.Pa
 			CloudProvider: "mockProvider",
 			Status:        status,
 			Images:        images,
-			Labels:        make(map[string]string),
+			Labels:        labels,
 		})
 	}
 

--- a/internal/registry/mock_service.go
+++ b/internal/registry/mock_service.go
@@ -147,6 +147,7 @@ func (svc *MockPackerClientService) PackerServiceGetIteration(params *packerSvc.
 			Images: []*models.HashicorpCloudPackerImage{
 				{ImageID: "image-id", Region: "somewhere"},
 			},
+			Labels: make(map[string]string),
 		})
 	}
 
@@ -206,7 +207,7 @@ func (svc *MockPackerClientService) PackerServiceListBuilds(params *packerSvc.Pa
 	images := make([]*models.HashicorpCloudPackerImage, 0)
 	if svc.BuildAlreadyDone {
 		status = models.HashicorpCloudPackerBuildStatusDONE
-		images = append(images, &models.HashicorpCloudPackerImage{ID: "image-id", Region: "somewhere"})
+		images = append(images, &models.HashicorpCloudPackerImage{ImageID: "image-id", Region: "somewhere"})
 	}
 
 	builds := make([]*models.HashicorpCloudPackerBuild, 0, len(svc.ExistingBuilds))
@@ -214,8 +215,10 @@ func (svc *MockPackerClientService) PackerServiceListBuilds(params *packerSvc.Pa
 		builds = append(builds, &models.HashicorpCloudPackerBuild{
 			ID:            name + "--" + strconv.Itoa(i),
 			ComponentType: name,
+			CloudProvider: "mockProvider",
 			Status:        status,
 			Images:        images,
+			Labels:        make(map[string]string),
 		})
 	}
 

--- a/internal/registry/mock_service.go
+++ b/internal/registry/mock_service.go
@@ -12,10 +12,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+//MockPackerClientService represents a basic mock of the Cloud Packer Service.
+//Upon calling a service method a boolean is set to true to indicate that a method has been called.
+//To skip the setting of these booleans set TrackCalledServiceMethods to false; defaults to true in NewMockPackerClientService().
 type MockPackerClientService struct {
 	CreateBucketCalled, UpdateBucketCalled, BucketAlreadyExist                           bool
 	CreateIterationCalled, GetIterationCalled, IterationAlreadyExist, IterationCompleted bool
 	CreateBuildCalled, UpdateBuildCalled, ListBuildsCalled, BuildAlreadyDone             bool
+	TrackCalledServiceMethods                                                            bool
 
 	// Mock Creates
 	CreateBucketResp    *models.HashicorpCloudPackerCreateBucketResponse
@@ -31,41 +35,21 @@ type MockPackerClientService struct {
 	packerSvc.ClientService
 }
 
+//NewMockPackerClientService returns a basic mock of the Cloud Packer Service.
+//Upon calling a service method a boolean is set to true to indicate that a method has been called.
+//To skip the setting of these booleans set TrackCalledServiceMethods to false. By default it is true.
 func NewMockPackerClientService() *MockPackerClientService {
 	m := MockPackerClientService{
-		ExistingBuilds: make([]string, 0),
-	}
-
-	m.CreateBucketResp = &models.HashicorpCloudPackerCreateBucketResponse{
-		Bucket: &models.HashicorpCloudPackerBucket{
-			ID: "bucket-id",
-		},
-	}
-
-	m.CreateIterationResp = &models.HashicorpCloudPackerCreateIterationResponse{
-		Iteration: &models.HashicorpCloudPackerIteration{
-			ID: "iteration-id",
-		},
-	}
-
-	m.CreateBuildResp = &models.HashicorpCloudPackerCreateBuildResponse{
-		Build: &models.HashicorpCloudPackerBuild{
-			PackerRunUUID: "test-uuid",
-			Status:        models.HashicorpCloudPackerBuildStatusUNSET,
-		},
-	}
-
-	m.GetIterationResp = &models.HashicorpCloudPackerGetIterationResponse{
-		Iteration: &models.HashicorpCloudPackerIteration{
-			ID:     "iteration-id",
-			Builds: make([]*models.HashicorpCloudPackerBuild, 0),
-		},
+		ExistingBuilds:            make([]string, 0),
+		ExistingBuildLabels:       make(map[string]string),
+		TrackCalledServiceMethods: true,
 	}
 
 	return &m
 }
 
 func (svc *MockPackerClientService) PackerServiceCreateBucket(params *packerSvc.PackerServiceCreateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceCreateBucketOK, error) {
+
 	if svc.BucketAlreadyExist {
 		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("Code:%d %s", codes.AlreadyExists, codes.AlreadyExists.String()))
 	}
@@ -77,19 +61,27 @@ func (svc *MockPackerClientService) PackerServiceCreateBucket(params *packerSvc.
 		return nil, errors.New("No bucket slug was passed in")
 	}
 
-	svc.CreateBucketCalled = true
-	// This is set in NewMockPackerClientService()
-	svc.CreateBucketResp.Bucket.Slug = params.Body.BucketSlug
+	if svc.TrackCalledServiceMethods {
+		svc.CreateBucketCalled = true
+	}
+	payload := &models.HashicorpCloudPackerCreateBucketResponse{
+		Bucket: &models.HashicorpCloudPackerBucket{
+			ID: "bucket-id",
+		},
+	}
+	payload.Bucket.Slug = params.Body.BucketSlug
 
 	ok := &packerSvc.PackerServiceCreateBucketOK{
-		Payload: svc.CreateBucketResp,
+		Payload: payload,
 	}
 
 	return ok, nil
 }
 
 func (svc *MockPackerClientService) PackerServiceUpdateBucket(params *packerSvc.PackerServiceUpdateBucketParams, _ runtime.ClientAuthInfoWriter) (*packerSvc.PackerServiceUpdateBucketOK, error) {
-	svc.UpdateBucketCalled = true
+	if svc.TrackCalledServiceMethods {
+		svc.UpdateBucketCalled = true
+	}
 
 	return packerSvc.NewPackerServiceUpdateBucketOK(), nil
 }
@@ -107,12 +99,20 @@ func (svc *MockPackerClientService) PackerServiceCreateIteration(params *packerS
 		return nil, errors.New("No valid Fingerprint was passed in")
 	}
 
-	svc.CreateIterationCalled = true
-	svc.CreateIterationResp.Iteration.BucketSlug = params.Body.BucketSlug
-	svc.CreateIterationResp.Iteration.Fingerprint = params.Body.Fingerprint
+	if svc.TrackCalledServiceMethods {
+		svc.CreateIterationCalled = true
+	}
+	payload := &models.HashicorpCloudPackerCreateIterationResponse{
+		Iteration: &models.HashicorpCloudPackerIteration{
+			ID: "iteration-id",
+		},
+	}
+
+	payload.Iteration.BucketSlug = params.Body.BucketSlug
+	payload.Iteration.Fingerprint = params.Body.Fingerprint
 
 	ok := &packerSvc.PackerServiceCreateIterationOK{
-		Payload: svc.CreateIterationResp,
+		Payload: payload,
 	}
 
 	return ok, nil
@@ -131,11 +131,21 @@ func (svc *MockPackerClientService) PackerServiceGetIteration(params *packerSvc.
 		return nil, errors.New("No valid Fingerprint was passed in")
 	}
 
-	svc.GetIterationCalled = true
+	if svc.TrackCalledServiceMethods {
+		svc.GetIterationCalled = true
+	}
 
-	//
+	payload := &models.HashicorpCloudPackerGetIterationResponse{
+		Iteration: &models.HashicorpCloudPackerIteration{
+			ID:     "iteration-id",
+			Builds: make([]*models.HashicorpCloudPackerBuild, 0),
+		},
+	}
+
+	payload.Iteration.BucketSlug = params.BucketSlug
+	payload.Iteration.Fingerprint = *params.Fingerprint
 	ok := &packerSvc.PackerServiceGetIterationOK{
-		Payload: svc.GetIterationResp,
+		Payload: payload,
 	}
 
 	if svc.IterationCompleted {
@@ -168,13 +178,22 @@ func (svc *MockPackerClientService) PackerServiceCreateBuild(params *packerSvc.P
 		return nil, errors.New("No build componentType was passed in")
 	}
 
-	svc.CreateBuildCalled = true
+	if svc.TrackCalledServiceMethods {
+		svc.CreateBuildCalled = true
+	}
 
-	svc.CreateBuildResp.Build.ComponentType = params.Body.Build.ComponentType
-	svc.CreateBuildResp.Build.IterationID = params.IterationID
+	payload := &models.HashicorpCloudPackerCreateBuildResponse{
+		Build: &models.HashicorpCloudPackerBuild{
+			PackerRunUUID: "test-uuid",
+			Status:        models.HashicorpCloudPackerBuildStatusUNSET,
+		},
+	}
+
+	payload.Build.ComponentType = params.Body.Build.ComponentType
+	payload.Build.IterationID = params.IterationID
 
 	ok := packerSvc.NewPackerServiceCreateBuildOK()
-	ok.Payload = svc.CreateBuildResp
+	ok.Payload = payload
 
 	return ok, nil
 }
@@ -192,7 +211,10 @@ func (svc *MockPackerClientService) PackerServiceUpdateBuild(params *packerSvc.P
 		return nil, errors.New("No build status was passed in")
 	}
 
-	svc.UpdateBuildCalled = true
+	if svc.TrackCalledServiceMethods {
+		svc.UpdateBuildCalled = true
+	}
+
 	ok := packerSvc.NewPackerServiceUpdateBuildOK()
 	ok.Payload = &models.HashicorpCloudPackerUpdateBuildResponse{
 		Build: &models.HashicorpCloudPackerBuild{

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -352,6 +352,7 @@ func (b *Bucket) PopulateIteration(ctx context.Context) error {
 
 	var errs *multierror.Error
 	var wg sync.WaitGroup
+	var mu sync.Mutex
 	for _, buildName := range toCreate {
 		wg.Add(1)
 		go func(name string) {
@@ -365,10 +366,12 @@ func (b *Bucket) PopulateIteration(ctx context.Context) error {
 				return
 			}
 
+			mu.Lock()
 			errs = multierror.Append(errs, err)
+			mu.Unlock()
 		}(buildName)
-		wg.Wait()
 	}
+	wg.Wait()
 
 	return errs.ErrorOrNil()
 }

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -366,11 +366,11 @@ func (b *Bucket) PopulateIteration(ctx context.Context) error {
 				return
 			}
 
-                        if err != nil {
-                            mu.Lock()
-			   errs = multierror.Append(errs, err)
-			   mu.Unlock()
-                        }
+			if err != nil {
+				mu.Lock()
+				errs = multierror.Append(errs, err)
+				mu.Unlock()
+			}
 		}(buildName)
 	}
 	wg.Wait()

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -354,9 +354,12 @@ func (b *Bucket) PopulateIteration(ctx context.Context) error {
 		}
 	}
 
+	if len(toCreate) == 0 {
+		return nil
+	}
+
 	var errs *multierror.Error
 	var wg sync.WaitGroup
-
 	for _, buildName := range toCreate {
 		wg.Add(1)
 		go func(name string) {
@@ -374,8 +377,8 @@ func (b *Bucket) PopulateIteration(ctx context.Context) error {
 
 			errs = multierror.Append(errs, err)
 		}(buildName)
+		wg.Wait()
 	}
-	wg.Wait()
 
 	return errs.ErrorOrNil()
 }

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -366,9 +366,11 @@ func (b *Bucket) PopulateIteration(ctx context.Context) error {
 				return
 			}
 
-			mu.Lock()
-			errs = multierror.Append(errs, err)
-			mu.Unlock()
+                        if err != nil {
+                            mu.Lock()
+			   errs = multierror.Append(errs, err)
+			   mu.Unlock()
+                        }
 		}(buildName)
 	}
 	wg.Wait()

--- a/internal/registry/types.bucket_service_test.go
+++ b/internal/registry/types.bucket_service_test.go
@@ -58,7 +58,7 @@ func TestInitialize_NewBucketNewIteration(t *testing.T) {
 		t.Errorf("Expected a call to CreateBuild but it didn't happen")
 	}
 
-	if _, ok := b.Iteration.builds.Load("happycloud.image"); !ok {
+	if ok := b.Iteration.HasBuild("happycloud.image"); !ok {
 		t.Errorf("expected a basic build entry to be created but it didn't")
 	}
 
@@ -115,7 +115,7 @@ func TestInitialize_ExistingBucketNewIteration(t *testing.T) {
 		t.Errorf("Expected a call to CreateBuild but it didn't happen")
 	}
 
-	if _, ok := b.Iteration.builds.Load("happycloud.image"); !ok {
+	if ok := b.Iteration.HasBuild("happycloud.image"); !ok {
 		t.Errorf("expected a basic build entry to be created but it didn't")
 	}
 
@@ -182,14 +182,10 @@ func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-	loadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
-	if !ok {
-		t.Errorf("expected a basic build entry to be created but it didn't")
-	}
 
-	existingBuild, ok := loadedBuild.(*Build)
-	if !ok {
-		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	existingBuild, err := b.Iteration.Build("happycloud.image")
+	if err != nil {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid: %v", err)
 	}
 
 	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusUNSET {
@@ -278,14 +274,9 @@ func TestUpdateBuildStatus(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	loadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
-	if !ok {
-		t.Errorf("expected a basic build entry to be created but it didn't")
-	}
-
-	existingBuild, ok := loadedBuild.(*Build)
-	if !ok {
-		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	existingBuild, err := b.Iteration.Build("happycloud.image")
+	if err != nil {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid: %v", err)
 	}
 
 	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusUNSET {
@@ -297,14 +288,9 @@ func TestUpdateBuildStatus(t *testing.T) {
 		t.Errorf("unexpected failure for PublishBuildStatus: %v", err)
 	}
 
-	reloadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
-	if !ok {
-		t.Errorf("expected a basic build entry to be created but it didn't")
-	}
-
-	existingBuild, ok = reloadedBuild.(*Build)
-	if !ok {
-		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	existingBuild, err = b.Iteration.Build("happycloud.image")
+	if err != nil {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid: %v", err)
 	}
 
 	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusRUNNING {
@@ -345,14 +331,9 @@ func TestUpdateBuildStatus_DONENoImages(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
-	loadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
-	if !ok {
-		t.Errorf("expected a basic build entry to be created but it didn't")
-	}
-
-	existingBuild, ok := loadedBuild.(*Build)
-	if !ok {
-		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	existingBuild, err := b.Iteration.Build("happycloud.image")
+	if err != nil {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid: %v", err)
 	}
 
 	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusUNSET {
@@ -367,14 +348,9 @@ func TestUpdateBuildStatus_DONENoImages(t *testing.T) {
 		t.Errorf("expected failure for PublishBuildStatus when setting status to DONE with no images")
 	}
 
-	reloadedBuild, ok := b.Iteration.builds.Load("happycloud.image")
-	if !ok {
-		t.Errorf("expected a basic build entry to be created but it didn't")
-	}
-
-	existingBuild, ok = reloadedBuild.(*Build)
-	if !ok {
-		t.Errorf("expected the existing build loaded from an existing bucket to be valid")
+	existingBuild, err = b.Iteration.Build("happycloud.image")
+	if err != nil {
+		t.Errorf("expected the existing build loaded from an existing bucket to be valid: %v", err)
 	}
 
 	if existingBuild.Status != models.HashicorpCloudPackerBuildStatusRUNNING {

--- a/internal/registry/types.bucket_test.go
+++ b/internal/registry/types.bucket_test.go
@@ -132,7 +132,7 @@ func TestBucket_UpdateLabelsForBuild(t *testing.T) {
 				bucket.BuildLabels[k] = v
 			}
 
-			err := bucket.PopulateIteration(context.TODO())
+			err := bucket.CreateInitialBuildForIteration(context.TODO(), componentName)
 			checkError(t, err)
 
 			err = bucket.UpdateLabelsForBuild(componentName, tt.buildLabels)
@@ -171,11 +171,12 @@ func TestBucket_UpdateLabelsForBuild_withMultipleBuilds(t *testing.T) {
 
 	firstComponent := "happycloud.image"
 	bucket.RegisterBuildForComponent(firstComponent)
+	err := bucket.CreateInitialBuildForIteration(context.TODO(), firstComponent)
+	checkError(t, err)
 
 	secondComponent := "happycloud.image2"
 	bucket.RegisterBuildForComponent(secondComponent)
-
-	err := bucket.PopulateIteration(context.TODO())
+	err = bucket.CreateInitialBuildForIteration(context.TODO(), secondComponent)
 	checkError(t, err)
 
 	err = bucket.UpdateLabelsForBuild(firstComponent, map[string]string{

--- a/internal/registry/types.bucket_test.go
+++ b/internal/registry/types.bucket_test.go
@@ -219,7 +219,14 @@ func TestBucket_PopulateIteration(t *testing.T) {
 		noDiffExpected    bool
 	}{
 		{
-			desc:      "existing incomplete build",
+			desc:           "populating iteration with existing incomplete build and no bucket build labels does nothing",
+			buildName:      "happcloud.image",
+			labelsCount:    0,
+			buildCompleted: false,
+			noDiffExpected: true,
+		},
+		{
+			desc:      "populating iteration with existing incomplete build should add bucket build labels",
 			buildName: "happcloud.image",
 			bucketBuildLabels: map[string]string{
 				"version":   "1.7.0",
@@ -230,7 +237,7 @@ func TestBucket_PopulateIteration(t *testing.T) {
 			noDiffExpected: true,
 		},
 		{
-			desc:      "existing incomplete build with improperly set build labels",
+			desc:      "populating iteration with existing incomplete build should update bucket build labels",
 			buildName: "happcloud.image",
 			bucketBuildLabels: map[string]string{
 				"version":   "1.7.3",
@@ -245,7 +252,7 @@ func TestBucket_PopulateIteration(t *testing.T) {
 			noDiffExpected: true,
 		},
 		{
-			desc:      "completed build with no labels",
+			desc:      "populating iteration with completed build should not modify any labels",
 			buildName: "happcloud.image",
 			bucketBuildLabels: map[string]string{
 				"version":   "1.7.0",
@@ -256,7 +263,7 @@ func TestBucket_PopulateIteration(t *testing.T) {
 			noDiffExpected: false,
 		},
 		{
-			desc:      "existing incomplete build with extra previously set build label",
+			desc:      "populating iteration with existing build should only modify bucket build labels",
 			buildName: "happcloud.image",
 			bucketBuildLabels: map[string]string{
 				"version":   "1.7.3",

--- a/internal/registry/types.bucket_test.go
+++ b/internal/registry/types.bucket_test.go
@@ -223,7 +223,7 @@ func TestBucket_UpdateLabelsForBuild_withMultipleBuilds(t *testing.T) {
 	}
 }
 
-func TestBucket_UpdateLabelsForBuild_withExistingBuilds(t *testing.T) {
+func TestBucket_PopulateIteration(t *testing.T) {
 	tc := []struct {
 		desc              string
 		buildName         string
@@ -245,15 +245,15 @@ func TestBucket_UpdateLabelsForBuild_withExistingBuilds(t *testing.T) {
 			noDiffExpected: true,
 		},
 		{
-			desc:      "existing incomplete build with previous build labels",
+			desc:      "existing incomplete build with improperly set build labels",
 			buildName: "happcloud.image",
 			bucketBuildLabels: map[string]string{
 				"version":   "1.7.3",
 				"based_off": "alpine-3.14",
 			},
 			buildLabels: map[string]string{
-				"version":   "1.7.0",
-				"based_off": "alpine",
+				"version":   "packer.version",
+				"based_off": "var.distro",
 			},
 			labelsCount:    2,
 			buildCompleted: false,
@@ -271,7 +271,7 @@ func TestBucket_UpdateLabelsForBuild_withExistingBuilds(t *testing.T) {
 			noDiffExpected: false,
 		},
 		{
-			desc:      "existing incomplete build with extra previously set build labels",
+			desc:      "existing incomplete build with extra previously set build label",
 			buildName: "happcloud.image",
 			bucketBuildLabels: map[string]string{
 				"version":   "1.7.3",

--- a/internal/registry/types.bucket_test.go
+++ b/internal/registry/types.bucket_test.go
@@ -132,7 +132,7 @@ func TestBucket_UpdateLabelsForBuild(t *testing.T) {
 				bucket.BuildLabels[k] = v
 			}
 
-			err := bucket.CreateInitialBuildForIteration(context.TODO(), componentName)
+			err := bucket.PopulateIteration(context.TODO())
 			checkError(t, err)
 
 			err = bucket.UpdateLabelsForBuild(componentName, tt.buildLabels)
@@ -176,7 +176,7 @@ func TestBucket_UpdateLabelsForBuild_withMultipleBuilds(t *testing.T) {
 
 	secondComponent := "happycloud.image2"
 	bucket.RegisterBuildForComponent(secondComponent)
-	err = bucket.CreateInitialBuildForIteration(context.TODO(), secondComponent)
+	err = bucket.PopulateIteration(context.TODO())
 	checkError(t, err)
 
 	err = bucket.UpdateLabelsForBuild(firstComponent, map[string]string{

--- a/internal/registry/types.builds.go
+++ b/internal/registry/types.builds.go
@@ -94,6 +94,8 @@ func (b *Build) AddImages(images ...registryimage.Image) error {
 	return nil
 }
 
+// IsNotDone returns true if build does not satisfy all requirements of a completed build.
+// A completed build must have a valid ID, one or more Images, and its Status is HashicorpCloudPackerBuildStatusDONE.
 func (b *Build) IsNotDone() bool {
 	hasBuildID := b.ID != ""
 	hasImages := len(b.Images) == 0

--- a/internal/registry/types.builds.go
+++ b/internal/registry/types.builds.go
@@ -34,15 +34,15 @@ func NewBuildFromCloudPackerBuild(src *models.HashicorpCloudPackerBuild) (*Build
 	var err error
 	for _, image := range src.Images {
 		image := image
-		build.AddImages(registryimage.Image{
+		err = build.AddImages(registryimage.Image{
 			ImageID:        image.ImageID,
 			ProviderName:   build.CloudProvider,
 			ProviderRegion: image.Region,
 		})
-	}
 
-	if err != nil {
-		return nil, fmt.Errorf("NewBuildFromCloudPackerBuild: %w", err)
+		if err != nil {
+			return nil, fmt.Errorf("NewBuildFromCloudPackerBuild: %w", err)
+		}
 	}
 
 	return &build, nil

--- a/internal/registry/types.builds.go
+++ b/internal/registry/types.builds.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
 	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
 )
@@ -14,4 +16,88 @@ type Build struct {
 	Labels        map[string]string
 	Images        map[string]registryimage.Image
 	Status        models.HashicorpCloudPackerBuildStatus
+}
+
+// NewBuildFromCloudPackerBuild converts a HashicorpCloudePackerBuild to a local build that can be tracked and published to the HCP Packer Registry.
+// Any existing labels or images associated to src will be copied to the returned Build.
+func NewBuildFromCloudPackerBuild(src *models.HashicorpCloudPackerBuild) (*Build, error) {
+
+	build := Build{
+		ID:            src.ID,
+		ComponentType: src.ComponentType,
+		CloudProvider: src.CloudProvider,
+		RunUUID:       src.PackerRunUUID,
+		Status:        src.Status,
+		Labels:        src.Labels,
+	}
+
+	var err error
+	for _, image := range src.Images {
+		image := image
+		build.AddImages(registryimage.Image{
+			ImageID:        image.ImageID,
+			ProviderName:   build.CloudProvider,
+			ProviderRegion: image.Region,
+		})
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("NewBuildFromCloudPackerBuild: %w", err)
+	}
+
+	return &build, nil
+}
+
+// AddLabelsToBuild merges the contents of data to the labels associated with the build.
+// Duplicate keys will be updated to reflect the new value.
+func (b *Build) MergeLabels(data map[string]string) {
+	if data == nil {
+		return
+	}
+
+	if b.Labels == nil {
+		b.Labels = make(map[string]string)
+	}
+
+	for k, v := range data {
+		// TODO: (nywilken) Determine why we skip labels already set
+		//if _, ok := build.Labels[k]; ok {
+		//continue
+		//}
+		b.Labels[k] = v
+	}
+
+}
+
+// AddImages appends one or more images artifacts to the build.
+func (b *Build) AddImages(images ...registryimage.Image) error {
+
+	if b.Images == nil {
+		b.Images = make(map[string]registryimage.Image)
+	}
+
+	for _, image := range images {
+		image := image
+
+		if err := image.Validate(); err != nil {
+			return fmt.Errorf("AddImages: failed to add image to build %q: %w", b.ComponentType, err)
+		}
+
+		if b.CloudProvider == "" {
+			b.CloudProvider = image.ProviderName
+		}
+
+		b.MergeLabels(image.Labels)
+		b.Images[image.String()] = image
+	}
+
+	return nil
+}
+
+func (b *Build) IsNotDone() bool {
+	hasBuildID := b.ID != ""
+	hasImages := len(b.Images) == 0
+	isNotDone := b.Status != models.HashicorpCloudPackerBuildStatusDONE
+
+	return hasBuildID && hasImages && isNotDone
 }


### PR DESCRIPTION
Previously when running a partial build on multi-cloud build template it was found that build labels were only being applied at the creation for the partially executed build. Leaving all other completed builds with no HCP Packer build labels. This updates how incomplete builds are loaded from the registry and ensures that any defined hcp_packer_registry.build_labels are assigned to the build before starting an actual Packer build.

Related to: #11573