### PR TITLE
Fix linux packaging step for workflow_call events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Linux Packaging
         uses: hashicorp/actions-packaging-linux@v1
         with:
-          name: ${{ github.event.repository.name }}
+          name: "${{ env.PKG_NAME }}"
           description: "HashiCorp Packer - A tool for creating identical machine images for multiple platforms from a single source configuration"
           arch: ${{ matrix.goarch }}
           version: ${{ needs.get-product-version.outputs.product-version }}


### PR DESCRIPTION
This PR should fix the linux packaging build failure happening within the nightly-release github actions workflow. A recent failure is available here: https://github.com/hashicorp/packer/runs/5341017655?check_suite_focus=true.  

When the `build` workflow is called from the `nightly-release` workflow, `${{ github.event.repository.name }}` evaluates to nothing because this value isn't available on the `workflow_call` event. This value should evaluate to `packer`, so we're just reusing the env var `PKG_NAME` to set that. 

---

More detail:

If we look at a recent run from the `build` job triggered on a merge to `master`, https://github.com/hashicorp/packer/runs/5341305084?check_suite_focus=true, this shows the inputs to the linux packaging action:

```
Run hashicorp/actions-packaging-linux@v1
  with:
    name: packer
    description: HashiCorp Packer - A tool for creating identical machine images for multiple platforms from a single source configuration
    arch: arm
    version: 1.7.11-dev
    maintainer: HashiCorp
    homepage: https://www.packer.io/docs
    license: MPL-[2](https://github.com/hashicorp/packer/runs/5341305084?check_suite_focus=true#step:7:2).0
    binary: dist/packer
    deb_depends: openssl
    rpm_depends: openssl
    config_dir: .release/linux/package/
    preinstall: .release/linux/preinst
    postremove: .release/linux/postrm
```

On the failing job, the inputs look like this: 

```
Run hashicorp/actions-packaging-linux@v1
  with:
    description: HashiCorp Packer - A tool for creating identical machine images for multiple platforms from a single source configuration
    arch: 386
    version: 1.7.11-dev
    maintainer: HashiCorp
    homepage: https://www.packer.io/docs
    license: MPL-[2](https://github.com/hashicorp/packer/runs/5341017655?check_suite_focus=true#step:7:2).0
    binary: dist/packer
    deb_depends: openssl
    rpm_depends: openssl
    config_dir: .release/linux/package/
    preinstall: .release/linux/preinst
    postremove: .release/linux/postrm
```

Notice the missing (required) `name` field. 