### PR TITLE
[CI cleanup] Remove setup-go from get-product-version CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,11 @@ jobs:
           echo "::set-output name=go-version::$(cat .go-version)"
 
   get-product-version:
-    needs: get-go-version
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
       - uses: actions/checkout@v2
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: "${{ needs.get-go-version.outputs.go-version }}"
       - name: get product version
         id: get-product-version
         run: |


### PR DESCRIPTION
Thanks to @claire-labry for catching this. This will be ready to merge once the github checks are green. 
