### PR TITLE
[CI] Remove nightly release draft

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -67,6 +67,7 @@ jobs:
           prerelease: true
           allowUpdates: true
           removeArtifacts: true
+          draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
   # Send a slack notification if either job defined above fails
   slack-notify:


### PR DESCRIPTION
This will stop nightly releases from being published as drafts on github releases. Nightlies will show up as prereleases instead.

Current 👇 

<img width="1176" alt="Screen Shot 2022-02-28 at 6 26 17 PM" src="https://user-images.githubusercontent.com/12939567/156092952-e38340aa-2eb8-47f9-afd4-1f7e7478d28f.png">

In this PR 👇 

<img width="930" alt="Screen Shot 2022-02-28 at 6 27 14 PM" src="https://user-images.githubusercontent.com/12939567/156093034-42517ca9-31e1-4238-b551-f3b27084f894.png">
 
[Feel free to merge at your convenience!] 