### PR TITLE
website: support Verified pluginTier, support Archived badge

### DIFF
--- a/website/components/badge/index.tsx
+++ b/website/components/badge/index.tsx
@@ -3,7 +3,7 @@ import InlineSvg from '@hashicorp/react-inline-svg'
 import classnames from 'classnames'
 import s from './style.module.css'
 
-type BadgeTheme = 'gray' | 'blue' | 'gold'
+type BadgeTheme = 'gray' | 'blue' | 'gold' | 'purple' | 'light-gray'
 
 interface BadgeProps {
   label: string

--- a/website/components/badge/style.module.css
+++ b/website/components/badge/style.module.css
@@ -1,5 +1,5 @@
 .root {
-  /* theming. Note that gold and gray
+  /* theming. Note that gold, gray, and purple
   have been set to hex values in order
   to match Terraform Registry tier labels. */
   &.theme-gray {
@@ -17,6 +17,10 @@
   &.theme-blue {
     --background-color: var(--packer);
     --text-color: var(--packer-text-on-primary);
+  }
+  &.theme-purple {
+    --background-color: #5c4ee5;
+    --text-color: var(--white);
   }
 
   align-items: center;

--- a/website/components/plugin-badge/index.tsx
+++ b/website/components/plugin-badge/index.tsx
@@ -14,12 +14,20 @@ const badgeTypes = {
   community: {
     label: 'Community',
     theme: 'gray',
-    iconSvg: false,
   },
   hcp_packer_ready: {
     label: 'HCP Packer Ready',
     theme: 'blue',
     iconSvg: svgCheckIcon,
+  },
+  verified: {
+    label: 'Verified',
+    theme: 'purple',
+    iconSvg: svgRibbonIcon,
+  },
+  archived: {
+    label: 'Archived',
+    theme: 'light-gray',
   },
 }
 

--- a/website/components/plugin-badge/index.tsx
+++ b/website/components/plugin-badge/index.tsx
@@ -3,7 +3,12 @@ import Badge, { BadgeTheme } from '../badge'
 import svgRibbonIcon from './ribbon-icon.svg?include'
 import svgCheckIcon from './check-icon.svg?include'
 
-type PluginLabelType = 'official' | 'community' | 'hcp_packer_ready'
+type PluginLabelType =
+  | 'official'
+  | 'community'
+  | 'hcp_packer_ready'
+  | 'verified'
+  | 'archived'
 
 const badgeTypes = {
   official: {
@@ -14,6 +19,7 @@ const badgeTypes = {
   community: {
     label: 'Community',
     theme: 'gray',
+    iconSvg: false,
   },
   hcp_packer_ready: {
     label: 'HCP Packer Ready',
@@ -28,6 +34,7 @@ const badgeTypes = {
   archived: {
     label: 'Archived',
     theme: 'light-gray',
+    iconSvg: false,
   },
 }
 

--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -61,10 +61,6 @@ async function generateStaticProps({
   // Also add a badge to show the latest version
   function mdxContentHook(mdxContent) {
     const badgesMdx = []
-    // If the plugin is archived, add an "Archived" badge
-    if (pluginData?.archived == true) {
-      badgesMdx.push(`<PluginBadge type="archived" />`)
-    }
     // Add a badge for the plugin tier
     if (pluginData?.tier) {
       badgesMdx.push(`<PluginBadge type="${pluginData.tier}" />`)
@@ -72,6 +68,10 @@ async function generateStaticProps({
     // Add a badge if the plugin is "HCP Packer Ready"
     if (pluginData?.isHcpPackerReady) {
       badgesMdx.push(`<PluginBadge type="hcp_packer_ready" />`)
+    }
+    // If the plugin is archived, add an "Archived" badge
+    if (pluginData?.archived == true) {
+      badgesMdx.push(`<PluginBadge type="archived" />`)
     }
     // Add badge showing the latest release version number,
     // and link this badge to the latest release

--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -77,6 +77,10 @@ async function generateStaticProps({
         `<Badge href="${href}" label="${latestReleaseTag}" theme="light-gray"/>`
       )
     }
+    // If the plugin is archived, add an "Archived" badge
+    if (pluginData?.archived == true) {
+      badgesMdx.push(`<PluginBadge type="archived" />`)
+    }
     // If we have badges to add, inject them into the MDX
     if (badgesMdx.length > 0) {
       const badgeChildrenMdx = badgesMdx.join('')

--- a/website/components/remote-plugin-docs/server.js
+++ b/website/components/remote-plugin-docs/server.js
@@ -61,6 +61,10 @@ async function generateStaticProps({
   // Also add a badge to show the latest version
   function mdxContentHook(mdxContent) {
     const badgesMdx = []
+    // If the plugin is archived, add an "Archived" badge
+    if (pluginData?.archived == true) {
+      badgesMdx.push(`<PluginBadge type="archived" />`)
+    }
     // Add a badge for the plugin tier
     if (pluginData?.tier) {
       badgesMdx.push(`<PluginBadge type="${pluginData.tier}" />`)
@@ -76,10 +80,6 @@ async function generateStaticProps({
       badgesMdx.push(
         `<Badge href="${href}" label="${latestReleaseTag}" theme="light-gray"/>`
       )
-    }
-    // If the plugin is archived, add an "Archived" badge
-    if (pluginData?.archived == true) {
-      badgesMdx.push(`<PluginBadge type="archived" />`)
     }
     // If we have badges to add, inject them into the MDX
     if (badgesMdx.length > 0) {

--- a/website/components/remote-plugin-docs/utils/resolve-nav-data.js
+++ b/website/components/remote-plugin-docs/utils/resolve-nav-data.js
@@ -92,6 +92,7 @@ async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
     repo,
     version,
     pluginTier,
+    archived = false,
     isHcpPackerReady = false,
     sourceBranch = 'main',
     zipFile = '',
@@ -141,6 +142,7 @@ async function resolvePluginEntryDocs(pluginConfigEntry, currentPath) {
         tier: parsedPluginTier,
         isHcpPackerReady,
         version,
+        archived,
       },
     }
   })

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -11,7 +11,8 @@
     "path": "alicloud",
     "repo": "hashicorp/packer-plugin-alicloud",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "latest",
+    "archived": true
   },
   {
     "title": "Anka",
@@ -24,20 +25,24 @@
     "title": "Ansible",
     "path": "ansible",
     "repo": "hashicorp/packer-plugin-ansible",
-    "version": "latest"
+    "version": "latest",
+    "archived": true
   },
   {
     "title": "Amazon EC2",
     "path": "amazon",
     "repo": "hashicorp/packer-plugin-amazon",
     "version": "latest",
-    "isHcpPackerReady": true
+    "pluginTier": "verified",
+    "isHcpPackerReady": true,
+    "archived": true
   },
   {
     "title": "Azure",
     "path": "azure",
     "repo": "hashicorp/packer-plugin-azure",
     "version": "latest",
+    "pluginTier": "verified",
     "isHcpPackerReady": true
   },
   {
@@ -94,6 +99,7 @@
     "path": "hashicups",
     "repo": "hashicorp/packer-plugin-hashicups",
     "version": "latest",
+    "pluginTier": "verified",
     "isHcpPackerReady": false
   },
   {

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -45,7 +45,8 @@
     "path": "chef",
     "repo": "hashicorp/packer-plugin-chef",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "latest",
+    "archived": true
   },
   {
     "title": "Cloudstack",
@@ -59,7 +60,8 @@
     "path": "converge",
     "repo": "hashicorp/packer-plugin-converge",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "latest",
+    "archived": true
   },
   {
     "title": "DigitalOcean",
@@ -130,7 +132,8 @@
     "path": "inspec",
     "repo": "hashicorp/packer-plugin-inspec",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "latest",
+    "archived": true
   },
   {
     "title": "JD Cloud",
@@ -193,7 +196,7 @@
     "path": "outscale",
     "repo": "outscale/packer-plugin-outscale",
     "version": "latest",
-    "pluginTier": "community"
+    "pluginTier": "verified"
   },
   {
     "title": "Parallels",
@@ -220,7 +223,8 @@
     "path": "puppet",
     "repo": "hashicorp/packer-plugin-puppet",
     "version": "latest",
-    "pluginTier": "community"
+    "pluginTier": "community",
+    "archived": true
   },
   {
     "title": "QEMU",
@@ -233,13 +237,14 @@
     "path": "salt",
     "repo": "hashicorp/packer-plugin-salt",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "latest",
+    "archived": true
   },
   {
     "title": "Scaleway",
     "path": "scaleway",
     "repo": "scaleway/packer-plugin-scaleway",
-    "pluginTier": "community",
+    "pluginTier": "verified",
     "version": "latest"
   },
   {
@@ -275,7 +280,7 @@
     "path": "upcloud",
     "repo": "UpCloudLtd/packer-plugin-upcloud",
     "version": "latest",
-    "pluginTier": "community",
+    "pluginTier": "verified",
     "sourceBranch": "master"
   },
   {

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -11,8 +11,7 @@
     "path": "alicloud",
     "repo": "hashicorp/packer-plugin-alicloud",
     "pluginTier": "community",
-    "version": "latest",
-    "archived": true
+    "version": "latest"
   },
   {
     "title": "Anka",
@@ -25,24 +24,20 @@
     "title": "Ansible",
     "path": "ansible",
     "repo": "hashicorp/packer-plugin-ansible",
-    "version": "latest",
-    "archived": true
+    "version": "latest"
   },
   {
     "title": "Amazon EC2",
     "path": "amazon",
     "repo": "hashicorp/packer-plugin-amazon",
     "version": "latest",
-    "pluginTier": "verified",
-    "isHcpPackerReady": true,
-    "archived": true
+    "isHcpPackerReady": true
   },
   {
     "title": "Azure",
     "path": "azure",
     "repo": "hashicorp/packer-plugin-azure",
     "version": "latest",
-    "pluginTier": "verified",
     "isHcpPackerReady": true
   },
   {
@@ -99,7 +94,6 @@
     "path": "hashicups",
     "repo": "hashicorp/packer-plugin-hashicups",
     "version": "latest",
-    "pluginTier": "verified",
     "isHcpPackerReady": false
   },
   {


### PR DESCRIPTION
🎟️ [Task](https://app.asana.com/0/1100423001970639/1201908607457939/f)
👀 [Preview](https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app)

This PR adds support for additional plugin entry options in `website/data/plugins-manifest.json`. Specifically:

1. Adds support for a new `"verified"` option for the `pluginTier` property. Using this option will display a purple `Verified` badge, similar to the Verified badges on <https://registry.terraform.io>.

2. Adds support for a new, optional `archived` boolean property. Setting this property to `true` will display an `Archived` badge at the top of the plugin's pages, alongside the other badges that apply to the plugin.

This PR also updates `website/data/plugins-manifest.json` to use these new properties:

### Archived plugins

- [Chef][chef]
- [Converge][converge]
- [Inspec][inspec]
- [Puppet][puppet]
- [Salt][salt]

### Verified plugins

- [UpCloud][upcloud]
- [Outscale][outscale]
- [Scaleway][scaleway]

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201908607457939

[chef]: https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app/plugins/provisioners/chef/chef-client
[converge]: https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app/plugins/provisioners/converge
[inspec]: https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app/plugins/provisioners/inspec
[puppet]: https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app/plugins/provisioners/puppet/puppet-masterless
[salt]: https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app/plugins/provisioners/salt
[upcloud]: https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app/plugins/builders/upcloud
[scaleway]: https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app/plugins/builders/scaleway
[outscale]: https://packer-git-zsadd-verified-and-archived-badges-hashicorp.vercel.app/plugins/builders/outscale