### PR TITLE
Remove iteration revocation check

### DIFF
--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
@@ -127,13 +126,6 @@ func (client *Client) GetIteration(ctx context.Context, bucketSlug string, opts 
 	}
 
 	if resp.Payload.Iteration != nil {
-		revokeAt := time.Time(resp.Payload.Iteration.RevokeAt)
-		if !revokeAt.IsZero() && revokeAt.Before(time.Now().UTC()) {
-			// If RevokeAt is not a zero date and is before NOW, it means this iteration is revoked and should not be used
-			// to build new images.
-			return nil, fmt.Errorf("the iteration %s is revoked and can not be used on Packer builds",
-				resp.Payload.Iteration.ID)
-		}
 		return resp.Payload.Iteration, nil
 	}
 
@@ -255,13 +247,6 @@ func (client *Client) GetIterationFromChannel(
 
 	if resp.Payload.Channel != nil {
 		if resp.Payload.Channel.Iteration != nil {
-			revokeAt := time.Time(resp.Payload.Channel.Iteration.RevokeAt)
-			if !revokeAt.IsZero() && revokeAt.Before(time.Now().UTC()) {
-				// If RevokeAt is not a zero date and is before NOW, it means this iteration is revoked and should not be used
-				// to build new images.
-				return nil, fmt.Errorf("the iteration associated with the channel %s is revoked and can not be used on Packer builds",
-					channelName)
-			}
 			return resp.Payload.Channel.Iteration, nil
 		}
 		return nil, fmt.Errorf("there is no iteration associated with the channel %s",


### PR DESCRIPTION
Keeping Packer datasources consistent with TF ones. 