### PR TITLE
Set default file extension for binary installations on Windows

### DIFF
--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -86,6 +86,10 @@ func (c *PluginsInstallCommand) RunContext(buildCtx context.Context, args []stri
 		pluginRequirement.VersionConstraints = constraints
 	}
 
+	if runtime.GOOS == "windows" && opts.Ext == "" {
+		opts.BinaryInstallationOptions.Ext = ".exe"
+	}
+
 	getters := []plugingetter.Getter{
 		&github.Getter{
 			// In the past some terraform plugins downloads were blocked from a


### PR DESCRIPTION
This change sets the default file extension for binary installations on
Windows.

Results before change
```
$ packer plugins install github.com/hashicorp/amazon
9 errors occurred:
        * ignoring invalid remote binary packer-plugin-amazon_v1.0.8_x5.0_freebsd_arm64.zip: wrong system, expected windows_amd64
        * ignoring invalid remote binary packer-plugin-amazon_v1.0.8_x5.0_darwin_amd64.zip: wrong system, expected windows_amd64
        * ignoring invalid remote binary packer-plugin-amazon_v1.0.8_x5.0_freebsd_amd64.zip: wrong system, expected windows_amd64
        * ignoring invalid remote binary packer-plugin-amazon_v1.0.8_x5.0_linux_amd64.zip: wrong system, expected windows_amd64
        * ignoring invalid remote binary packer-plugin-amazon_v1.0.8_x5.0_darwin_arm64.zip: wrong system, expected windows_amd64
        * ignoring invalid remote binary packer-plugin-amazon_v1.0.8_x5.0_windows_arm64.zip: wrong system, expected windows_amd64
        * ignoring invalid remote binary packer-plugin-amazon_v1.0.8_x5.0_windows_386.zip: wrong system, expected windows_amd64
        * ignoring invalid remote binary packer-plugin-amazon_v1.0.8_x5.0_linux_arm.zip: wrong system, expected windows_amd64
        * could not find a packer-plugin-amazon_v1.0.8_x5.0_windows_amd64.zip file in zipfile

exit status 1
```

Results after change
```
$ packer plugins install github.com/hashicorp/amazon
Installed plugin github.com/hashicorp/amazon v1.0.8 in "C:/Users/Packer/AppData/Roaming/packer.d/plugins/github.com/hashicorp/amazon/packer-plugin-amazon_v1.0.8_x5.0_windows_amd64.exe"
```
