### PR TITLE
Remove Beta language from HCP packer docs

### DIFF
--- a/website/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -19,8 +19,7 @@ The `HCP Packer Image` Data Source retrieves information about an
 image from the HCP Packer registry. This information can be used to
 provide a source image to various Packer builders.
 
-~> **Note:** HCP Packer is under active development, and we are currently offering a [public beta version](https://portal.cloud.hashicorp.com) to collect feedback and continue improving the product.
-To get started, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+~> **Note:** To get started with HCP Packer, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
 
 ## Basic Example
 

--- a/website/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -19,7 +19,9 @@ The `HCP Packer Image` Data Source retrieves information about an
 image from the HCP Packer registry. This information can be used to
 provide a source image to various Packer builders.
 
-~> **Note:** To get started with HCP Packer, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
 
 ## Basic Example
 

--- a/website/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -19,8 +19,7 @@ The `HCP Packer Iteration` Data Source retrieves information about an
 iteration from the HCP Packer registry. This information can be used to query
 HCP for a source image for various Packer builders.
 
-~> **Note:** HCP Packer is under active development, and we are currently offering a [public beta version](https://portal.cloud.hashicorp.com) to collect feedback and continue improving the product.
-To get started, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+~> **Note:** To get started with HCP Packer, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
 
 ## Basic Example
 

--- a/website/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -19,7 +19,9 @@ The `HCP Packer Iteration` Data Source retrieves information about an
 iteration from the HCP Packer registry. This information can be used to query
 HCP for a source image for various Packer builders.
 
-~> **Note:** To get started with HCP Packer, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
 
 ## Basic Example
 

--- a/website/content/docs/datasources/hcp/index.mdx
+++ b/website/content/docs/datasources/hcp/index.mdx
@@ -13,7 +13,7 @@ sidebar_title: Overview
 
 The HCP Packer registry bridges the gap between image factories and image
 deployments, allowing development and security teams to work together to create,
-manage, and consume golden images in a centralized way.
+manage, and consume images in a centralized way.
 
 The HCP Packer registry stores metadata about your images, including when they
 were created, where the image exists in the cloud, and what (if any) git commit
@@ -22,10 +22,6 @@ information about the golden images your Packer builds produce, clearly
 designate which images are appropriate for test and production environments,
 and query for the right golden images to use in both Packer and Terraform
 configurations.
-
-HCP Packer is under active development, and we are currently offering a public
-beta version to collect feedback and continue improving the product. We
-encourage you to try HCP Packer and submit your feedback.
 
 Packer has two data sources that work together to retrieve information from the
 HCP Packer registry:

--- a/website/content/docs/datasources/hcp/packer-image-iteration.mdx
+++ b/website/content/docs/datasources/hcp/packer-image-iteration.mdx
@@ -19,7 +19,9 @@ The `Packer Image Iteration` Data Source retrieves information about an
 iteration from the HCP Packer registry. This information can be parsed to
 provide a source image to various Packer builders.
 
-~> **Note:** To get started with HCP Packer, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
 
 ## Basic Example
 

--- a/website/content/docs/datasources/hcp/packer-image-iteration.mdx
+++ b/website/content/docs/datasources/hcp/packer-image-iteration.mdx
@@ -19,8 +19,7 @@ The `Packer Image Iteration` Data Source retrieves information about an
 iteration from the HCP Packer registry. This information can be parsed to
 provide a source image to various Packer builders.
 
-~> **Note:** HCP Packer is under active development, and we are currently offering a [public beta version](https://portal.cloud.hashicorp.com) to collect feedback and continue improving the product.
-To get started, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+~> **Note:** To get started with HCP Packer, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
 
 ## Basic Example
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -12,10 +12,8 @@ To install Packer and learn the standard Packer workflow, try the [Get Started t
 
 ## HCP Packer
 
-The HCP Packer registry bridges the gap between image factories and image deployments, allowing development and security teams to work together to create, manage, and consume golden images in a centralized way.
+The HCP Packer registry bridges the gap between image factories and image deployments, allowing development and security teams to work together to create, manage, and consume images in a centralized way.
 
 The HCP Packer registry stores metadata about your images, including when they were created, where the image exists in the cloud, and what (if any) git commit is associated with your image build. You can use the registry to track information about the golden images your Packer builds produce, clearly designate which images are appropriate for test and production environments, and query for the right golden images to use in both Packer and Terraform configurations.
-
-HCP Packer is under active development, and we are currently offering a [public beta version](https://portal.cloud.hashicorp.com) to collect feedback and continue improving the product. We encourage you to try HCP Packer and submit your feedback.
 
 To get started, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.

--- a/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -7,13 +7,7 @@ page_title: hcp_packer_registry - build - Blocks
 
 # The `hcp_packer_registry` block
 
-~> **Note:** HCP Packer is under active development, and we are currently
-offering a [public beta version](https://portal.cloud.hashicorp.com) to collect
-feedback and continue improving the product.
-To get started, visit the
-[HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the
-[Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started)
-collection on HashiCorp Learn.
+~> **Note:** To get started with HCP Packer, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
 
 
 The `hcp_packer_registry` block allows operators the ability to customize the

--- a/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -7,12 +7,11 @@ page_title: hcp_packer_registry - build - Blocks
 
 # The `hcp_packer_registry` block
 
-~> **Note:** To get started with HCP Packer, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+The `hcp_packer_registry` block lets you customize the metadata Packer sends to HCP Packer Registry. It configures the details of an image that is created or updated within the HCP Packer registry.
 
+To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
 
-The `hcp_packer_registry` block allows operators the ability to customize the
-metadata sent to HCP Packer Registry. It configures the details of an image
-that is created or updated within the HCP Packer registry.
+## Usage
 
 This block is available from version 1.7.7 of Packer.
 
@@ -22,6 +21,8 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 `HCP_CLIENT_SECRET`). If no HCP credentials are set, Packer will fail the build
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
+
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
 
 ```hcl
 # file: builds.pkr.hcl


### PR DESCRIPTION
This PR removes the language about HCP Packer being in beta, in preparation for the GA launch.