### PR TITLE
Set default file extension for binary removal on Windows

### DIFF
--- a/command/plugins_remove.go
+++ b/command/plugins_remove.go
@@ -58,6 +58,10 @@ func (c *PluginsRemoveCommand) RunContext(buildCtx context.Context, args []strin
 		},
 	}
 
+	if runtime.GOOS == "windows" && opts.Ext == "" {
+		opts.BinaryInstallationOptions.Ext = ".exe"
+	}
+
 	plugin, diags := addrs.ParsePluginSourceString(args[0])
 	if diags.HasErrors() {
 		c.Ui.Error(diags.Error())


### PR DESCRIPTION
Related to #11625

Testing output. Next step after release is full testing for this command.

```shell
$ go run . plugins install github.com/outscale/outscale
Installed plugin github.com/outscale/outscale v1.0.2 in "C:/Users/Packer/AppData/Roaming/packer.d/plugins/github.com/outscale/outscale/packer-plugin-outscale_v1.0.2_x5.0_windows_amd64.exe"   

$ go run . plugins installed
C:\Users\Packer\AppData\Roaming\packer.d\plugins\github.com\outscale\outscale\packer-plugin-outscale_v1.0.2_x5.0_windows_amd64.exe
C:\Users\Packer\AppData\Roaming\packer.d\plugins\github.com\hashicorp\amazon\packer-plugin-amazon_v1.0.8_x5.0_windows_amd64.exe

$ go run . plugins remove github.com/hashicorp/amazon

$ go run . plugins installed
C:\Users\Packer\AppData\Roaming\packer.d\plugins\github.com\outscale\outscale\packer-plugin-outscale_v1.0.2_x5.0_windows_amd64.exe
C:\Users\Packer\AppData\Roaming\packer.d\plugins\github.com\hashicorp\amazon\packer-plugin-amazon_v1.0.8_x5.0_windows_amd64.exe

$ go run . plugins remove github.com/hashicorp/amazon
C:\Users\Packer\AppData\Roaming\packer.d\plugins\github.com\hashicorp\amazon\packer-plugin-amazon_v1.0.8_x5.0_windows_amd64.exe

$ go run . plugins installed
C:\Users\Packer\AppData\Roaming\packer.d\plugins\github.com\outscale\outscale\packer-plugin-outscale_v1.0.2_x5.0_windows_amd64.exe
```