### PR TITLE
website: pin previous version of plugin

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -247,7 +247,7 @@
     "path": "sshkey",
     "repo": "ivoronin/packer-plugin-sshkey",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "v0.1.0"
   },
   {
     "title": "Tencent Cloud",


### PR DESCRIPTION
packer-plugin-sshkey's latest release is missing the docs artifacts. Pinning to the old version here so that website builds can succeed.
