### PR TITLE
Turn nvd security scanning off temporarily

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -9,5 +9,5 @@ binary {
 	go_modules   = true
 	osv          = true
 	oss_index    = true
-	nvd          = true
+	nvd          = false
 }


### PR DESCRIPTION
Related slack thread: https://hashicorp.slack.com/archives/C010VJT0FRP/p1646938611596409?thread_ts=1646936500.488179&cid=C010VJT0FRP.

This change needs to be backported to all active release branches.
