### PR TITLE
Digital Ocean is HCP Packer Ready

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -69,7 +69,8 @@
     "path": "digitalocean",
     "repo": "hashicorp/packer-plugin-digitalocean",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "latest",
+    "isHcpPackerReady": true
   },
   {
     "title": "Docker",


### PR DESCRIPTION
Marks Digital Ocean as HCP Packer Ready after https://github.com/hashicorp/packer-plugin-digitalocean/pull/46, will merge post release