### PR TITLE
Linode is HCP Packer ready

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -156,7 +156,8 @@
     "path": "linode",
     "repo": "hashicorp/packer-plugin-linode",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "latest",
+    "isHcpPackerReady": true
   },
   {
     "title": "LXC",


### PR DESCRIPTION
Trivial PR to mark Linode plugin as HCP Packer Ready after its newest release https://github.com/hashicorp/packer-plugin-linode/releases/tag/v1.0.2