### PR TITLE
website: pin plugin version

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -90,7 +90,7 @@
     "title": "Google Cloud Platform",
     "path": "googlecompute",
     "repo": "hashicorp/packer-plugin-googlecompute",
-    "version": "latest",
+    "version": "v1.0.11",
     "isHcpPackerReady": true
   },
   {


### PR DESCRIPTION
Pinning the plugin version for `packer-plugin-googlecompute` so that site builds can succeed. The latest version is missing the `docs.zip` artifact due to the recent GH outage.