### PR TITLE
website: unpin plugin version

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -90,7 +90,7 @@
     "title": "Google Cloud Platform",
     "path": "googlecompute",
     "repo": "hashicorp/packer-plugin-googlecompute",
-    "version": "v1.0.10",
+    "version": "latest",
     "isHcpPackerReady": true
   },
   {


### PR DESCRIPTION
Revert [this PR](https://github.com/hashicorp/packer/pull/11677) as the upstream plugin was fixed.