### PR TITLE
Update issue-labeler action

### DIFF
--- a/.github/workflows/issues-opened.yml
+++ b/.github/workflows/issues-opened.yml
@@ -13,4 +13,5 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml
+        enable-versioned-regex: 0
 


### PR DESCRIPTION
The latest release of the action requires the field
enable_versioned_regex to be set. We currently don't use
versioned_regex. So this change sets the field to false.
