### PR TITLE
fix(website): remove empty index pages

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/collection/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: Collection - Functions - Configuration Language
-description: Overview of available collection functions
----

--- a/website/content/docs/templates/hcl_templates/functions/contextual/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: Contextual - Functions - Configuration Language
-description: Overview of available Contextual functions
----

--- a/website/content/docs/templates/hcl_templates/functions/conversion/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: conversion - Functions - Configuration Language
-description: Overview of available conversion functions
----

--- a/website/content/docs/templates/hcl_templates/functions/crypto/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/crypto/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: crypto - Functions - Configuration Language
-description: Overview of available crypto functions
----

--- a/website/content/docs/templates/hcl_templates/functions/encoding/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/encoding/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: encoding - Functions - Configuration Language
-description: Overview of available encoding functions
----

--- a/website/content/docs/templates/hcl_templates/functions/file/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/file/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: filesystem - Functions - Configuration Language
-description: Overview of available filesystem functions
----

--- a/website/content/docs/templates/hcl_templates/functions/ipnet/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/ipnet/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: ipnet - Functions - Configuration Language
-description: Overview of available ipnet functions
----

--- a/website/content/docs/templates/hcl_templates/functions/numeric/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/numeric/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: Numeric - Functions - Configuration Language
-description: Overview of available numeric functions
----

--- a/website/content/docs/templates/hcl_templates/functions/string/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/string/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: string - Functions - Configuration Language
-description: Overview of available string functions
----

--- a/website/content/docs/templates/hcl_templates/functions/uuid/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/uuid/index.mdx
@@ -1,4 +1,0 @@
----
-page_title: uuid - Functions - Configuration Language
-description: Overview of available uuid functions
----

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -155,10 +155,6 @@
                 "title": "Contextual Functions",
                 "routes": [
                   {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/contextual"
-                  },
-                  {
                     "title": "aws_secretsmanager",
                     "path": "templates/hcl_templates/functions/contextual/aws_secretsmanager"
                   },
@@ -179,10 +175,6 @@
               {
                 "title": "Numeric Functions",
                 "routes": [
-                  {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/numeric"
-                  },
                   {
                     "title": "abs",
                     "path": "templates/hcl_templates/functions/numeric/abs"
@@ -224,10 +216,6 @@
               {
                 "title": "String Functions",
                 "routes": [
-                  {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/string"
-                  },
                   {
                     "title": "chomp",
                     "path": "templates/hcl_templates/functions/string/chomp"
@@ -309,10 +297,6 @@
               {
                 "title": "Collection Functions",
                 "routes": [
-                  {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/collection"
-                  },
                   {
                     "title": "chunklist",
                     "path": "templates/hcl_templates/functions/collection/chunklist"
@@ -411,10 +395,6 @@
                 "title": "Encoding Functions",
                 "routes": [
                   {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/encoding"
-                  },
-                  {
                     "title": "base64decode",
                     "path": "templates/hcl_templates/functions/encoding/base64decode"
                   },
@@ -451,10 +431,6 @@
               {
                 "title": "Filesystem Functions",
                 "routes": [
-                  {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/file"
-                  },
                   {
                     "title": "abspath",
                     "path": "templates/hcl_templates/functions/file/abspath"
@@ -518,10 +494,6 @@
                 "title": "Hash and Crypto Functions",
                 "routes": [
                   {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/crypto"
-                  },
-                  {
                     "title": "bcrypt",
                     "path": "templates/hcl_templates/functions/crypto/bcrypt"
                   },
@@ -551,10 +523,6 @@
                 "title": "UUID Functions",
                 "routes": [
                   {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/uuid"
-                  },
-                  {
                     "title": "uuidv4",
                     "path": "templates/hcl_templates/functions/uuid/uuidv4"
                   },
@@ -567,10 +535,6 @@
               {
                 "title": "IP Network Functions",
                 "routes": [
-                  {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/ipnet"
-                  },
                   {
                     "title": "cidrhost",
                     "path": "templates/hcl_templates/functions/ipnet/cidrhost"
@@ -592,10 +556,6 @@
               {
                 "title": "Type Conversion Functions",
                 "routes": [
-                  {
-                    "title": "Overview",
-                    "path": "templates/hcl_templates/functions/conversion"
-                  },
                   {
                     "title": "can",
                     "path": "templates/hcl_templates/functions/conversion/can"


### PR DESCRIPTION
👀 [Preview](https://packer-git-zsrm-empty-pages-hashicorp.vercel.app)
🎟️ [Asana task](https://app.asana.com/0/1100423001970639/1202059456316732/f)

This PR removes empty overview pages from the website. The intent behind this removal is to improve user experience - it can be a strange experience to click on page only to find it empty.

It's likely these pages are a holdover from past iterations of the website where Overview pages were required.