### PR TITLE
Support `packer plugins installed` plugins in JSON (and HCL without required block) 

### DIFF
--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -89,7 +89,7 @@ func (pr Requirement) FilenamePrefix() string {
 	return "packer-plugin-" + pr.Identifier.Type + "_"
 }
 
-func (opts BinaryInstallationOptions) filenameSuffix() string {
+func (opts BinaryInstallationOptions) FilenameSuffix() string {
 	return "_" + opts.OS + "_" + opts.ARCH + opts.Ext
 }
 
@@ -104,7 +104,7 @@ func (opts BinaryInstallationOptions) filenameSuffix() string {
 func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallList, error) {
 	res := InstallList{}
 	FilenamePrefix := pr.FilenamePrefix()
-	filenameSuffix := opts.filenameSuffix()
+	filenameSuffix := opts.FilenameSuffix()
 	log.Printf("[TRACE] listing potential installations for %q that match %q. %#v", pr.Identifier, pr.VersionConstraints, opts)
 	for _, knownFolder := range opts.FromFolders {
 		glob := ""

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -300,8 +300,8 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 
 		// Look for foo-bar-baz. The plugin name is "baz"
 		pluginName := file[len(prefix):]
-		// For multi-component plugins installed via the plugins we expect the name to look like baz_vx.y.z_x5.0_os_arch.
-		// The plugin name is "baz"
+		// multi-component plugins installed via the plugins subcommand will have a name that looks like baz_vx.y.z_x5.0_darwin_arm64.
+		// After the split the plugin name is "baz".
 		pluginName = strings.SplitN(pluginName, "_", 2)[0]
 
 		log.Printf("[DEBUG] Discovered plugin: %s = %s", pluginName, match)

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -265,7 +265,6 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 		// Look for foo-bar-baz. The plugin name is "baz"
 		pluginName := file[len(prefix):]
 
-		// if Plugin name has OS_ARCH in it, split at _v(0-9) with regex
 		if strings.HasSuffix(pluginName, OS_ARCH) {
 			pluginName = strings.SplitN(pluginName, "_", 2)[0]
 

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -268,8 +268,7 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 		}
 
 		// Look for foo-bar-baz. The plugin name is "baz"
-		pluginName := ""
-		pluginName = file[len(prefix):]
+		pluginName := file[len(prefix):]
 
 		// if Plugin name has OS_ARCH in it, split at _v(0-9) with regex
 		if strings.Contains(pluginName, OS_ARCH) {

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -240,12 +240,8 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 	// Sort the matches so we add the newer version of a plugin last
 	sort.Strings(matches)
 	//If we see OS_ARCH (i.e. darwin_arm64 for an m1 mac user) ignore it in the binary name
-	if strings.Contains(glob, OS_ARCH) {
-		prefix = "packer-plugin-"
-	} else {
-		prefix = filepath.Base(glob)
-		prefix = prefix[:strings.Index(prefix, "*")]
-	}
+        prefix := filepath.Base(glob)
+        prefix = prefix[:strings.Index(prefix, "*")]
 	for _, match := range matches {
 		file := filepath.Base(match)
 		// skip folders like packer-plugin-sdk

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -238,7 +238,6 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 	res := make(map[string]string)
 	// Sort the matches so we add the newer version of a plugin last
 	sort.Strings(matches)
-	//If we see OS_ARCH (i.e. darwin_arm64 for an m1 mac user) ignore it in the binary name
 	prefix = filepath.Base(glob)
 	prefix = prefix[:strings.Index(prefix, "*")]
 	for _, match := range matches {

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -271,7 +271,7 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 		pluginName := file[len(prefix):]
 
 		// if Plugin name has OS_ARCH in it, split at _v(0-9) with regex
-		if strings.Contains(pluginName, OS_ARCH) {
+		if strings.HasSuffix(pluginName, OS_ARCH) {
 			regex := regexp.MustCompile(`_v[0-9]`)
 			pluginName = regex.Split(pluginName, -1)[0]
 

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -235,7 +235,7 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	prefix := ""
+	var prefix string
 	res := make(map[string]string)
 	// Sort the matches so we add the newer version of a plugin last
 	sort.Strings(matches)

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -240,8 +239,8 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 	// Sort the matches so we add the newer version of a plugin last
 	sort.Strings(matches)
 	//If we see OS_ARCH (i.e. darwin_arm64 for an m1 mac user) ignore it in the binary name
-        prefix := filepath.Base(glob)
-        prefix = prefix[:strings.Index(prefix, "*")]
+	prefix = filepath.Base(glob)
+	prefix = prefix[:strings.Index(prefix, "*")]
 	for _, match := range matches {
 		file := filepath.Base(match)
 		// skip folders like packer-plugin-sdk
@@ -268,8 +267,7 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 
 		// if Plugin name has OS_ARCH in it, split at _v(0-9) with regex
 		if strings.HasSuffix(pluginName, OS_ARCH) {
-			regex := regexp.MustCompile(`_v[0-9]`)
-			pluginName = regex.Split(pluginName, -1)[0]
+			pluginName = strings.SplitN(pluginName, "_", 2)[0]
 
 		}
 		log.Printf("[DEBUG] Discovered plugin: %s = %s", pluginName, match)

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -48,7 +48,7 @@ type PluginConfig struct {
 // without being confused with spaces in the path to the command itself.
 const PACKERSPACE = "-PACKERSPACE-"
 
-const OS_ARCH = runtime.GOOS + "_" + runtime.GOARCH
+const osArch = runtime.GOOS + "_" + runtime.GOARCH
 
 // Discover discovers plugins.
 //
@@ -204,7 +204,7 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 	}
 
 	//Check for installed plugins using the `packer plugins install` command
-	pluginPaths, err = c.discoverSingle(filepath.Join(path, "*", "*", "*", fmt.Sprintf("packer-plugin-*%s", OS_ARCH)))
+	pluginPaths, err = c.discoverSingle(filepath.Join(path, "*", "*", "*", fmt.Sprintf("packer-plugin-*%s", osArch)))
 	if err != nil {
 		return err
 	}
@@ -264,7 +264,7 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 		// Look for foo-bar-baz. The plugin name is "baz"
 		pluginName := file[len(prefix):]
 
-		if strings.HasSuffix(pluginName, OS_ARCH) {
+		if strings.HasSuffix(pluginName, osArch) {
 			pluginName = strings.SplitN(pluginName, "_", 2)[0]
 
 		}

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -154,52 +154,6 @@ func TestDiscoverDatasource(t *testing.T) {
 	}
 }
 
-func TestDiscoverPluginsInstalledWithPackerPluginsCommand(t *testing.T) {
-	dir, _, cleanUpFunc, err := generateInstalledFakePlugins("custom_plugin_dir",
-		[]string{"packer-datasource-partyparrot"})
-	if err != nil {
-		t.Fatalf("Error creating fake custom plugins: %s", err)
-	}
-
-	defer cleanUpFunc()
-
-	pathsep := ":"
-	if runtime.GOOS == "windows" {
-		pathsep = ";"
-	}
-
-	// Create a second dir to look in that will be empty
-	decoyDir, err := ioutil.TempDir("", "decoy")
-	if err != nil {
-		t.Fatalf("Failed to create a temporary test dir.")
-	}
-	defer os.Remove(decoyDir)
-
-	pluginPath := dir + pathsep + decoyDir
-
-	// Add temp dir to path.
-	os.Setenv("PACKER_PLUGIN_PATH", pluginPath)
-	defer os.Unsetenv("PACKER_PLUGIN_PATH")
-
-	config := newPluginConfig()
-
-	err = config.Discover()
-	if err != nil {
-		t.Fatalf("Should not have errored: %s", err)
-	}
-
-	if len(config.DataSources.List()) == 0 {
-		t.Fatalf("Should have found partyparrot datasource")
-	}
-	if !config.DataSources.Has("partyparrot") {
-		t.Fatalf("Should have found partyparrot datasource.")
-	}
-}
-
-func TestDiscoverInvalidPluginBinariesIgnored(t *testing.T) {
-	t.Fatalf("To be implemented maybe")
-}
-
 func generateFakePlugins(dirname string, pluginNames []string) (string, []string, func(), error) {
 	dir, err := ioutil.TempDir("", dirname)
 	if err != nil {
@@ -208,46 +162,6 @@ func generateFakePlugins(dirname string, pluginNames []string) (string, []string
 
 	cleanUpFunc := func() {
 		os.RemoveAll(dir)
-	}
-
-	var suffix string
-	if runtime.GOOS == "windows" {
-		suffix = ".exe"
-	}
-
-	plugins := make([]string, len(pluginNames))
-	for i, plugin := range pluginNames {
-		plug := filepath.Join(dir, plugin+suffix)
-		plugins[i] = plug
-		_, err := os.Create(plug)
-		if err != nil {
-			cleanUpFunc()
-			return "", nil, nil, fmt.Errorf("failed to create temporary plugin file (%s): %v", plug, err)
-		}
-	}
-
-	return dir, plugins, cleanUpFunc, nil
-}
-
-func generateInstalledFakePlugins(dirname string, pluginNames []string) (string, []string, func(), error) {
-	topLevelDir, err := ioutil.TempDir("", dirname)
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
-	}
-	dir, err := ioutil.TempDir(topLevelDir, "github.com")
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
-	}
-	dir, err = ioutil.TempDir(dir, "hashicorp")
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
-	}
-	dir, err = ioutil.TempDir(dir, "plugin")
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
-	}
-	cleanUpFunc := func() {
-		os.RemoveAll(topLevelDir)
 	}
 
 	var suffix string
@@ -476,6 +390,14 @@ func Test_multiplugin_describe(t *testing.T) {
 			}
 		}
 	}
+}
+
+func Test_multiplugin_describe_installed(t *testing.T) {
+	t.Fatalf("unimplemented")
+}
+
+func Test_multiplugin_describe_installed_ignores_unformatted(t *testing.T) {
+	t.Fatalf("unimplemented")
 }
 
 func Test_multiplugin_defaultName(t *testing.T) {

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -1,8 +1,8 @@
 package packer
 
 import (
+	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -14,6 +14,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
 	"github.com/hashicorp/packer-plugin-sdk/tmp"
+	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
 )
 
 func newPluginConfig() PluginConfig {
@@ -84,7 +85,7 @@ func TestEnvVarPackerPluginPath_MultiplePaths(t *testing.T) {
 	}
 
 	// Create a second dir to look in that will be empty
-	decoyDir, err := ioutil.TempDir("", "decoy")
+	decoyDir, err := os.MkdirTemp("", "decoy")
 	if err != nil {
 		t.Fatalf("Failed to create a temporary test dir.")
 	}
@@ -127,7 +128,7 @@ func TestDiscoverDatasource(t *testing.T) {
 	}
 
 	// Create a second dir to look in that will be empty
-	decoyDir, err := ioutil.TempDir("", "decoy")
+	decoyDir, err := os.MkdirTemp("", "decoy")
 	if err != nil {
 		t.Fatalf("Failed to create a temporary test dir.")
 	}
@@ -155,7 +156,7 @@ func TestDiscoverDatasource(t *testing.T) {
 }
 
 func generateFakePlugins(dirname string, pluginNames []string) (string, []string, func(), error) {
-	dir, err := ioutil.TempDir("", dirname)
+	dir, err := os.MkdirTemp("", dirname)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
 	}
@@ -287,7 +288,7 @@ func createMockPlugins(t *testing.T, plugins map[string]pluginsdk.Set) {
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, name, "$@")...),
 				" ")
-			if err := ioutil.WriteFile(plugin, []byte(fileContent), os.ModePerm); err != nil {
+			if err := os.WriteFile(plugin, []byte(fileContent), os.ModePerm); err != nil {
 				t.Fatalf("failed to create fake plugin binary: %v", err)
 			}
 		}
@@ -295,7 +296,30 @@ func createMockPlugins(t *testing.T, plugins map[string]pluginsdk.Set) {
 	os.Setenv("PACKER_PLUGIN_PATH", pluginDir)
 }
 
-func createMockInstalledPlugins(t *testing.T, plugins map[string]pluginsdk.Set) {
+func createMockChecksumFile(t testing.TB, filePath string) {
+	cs := plugingetter.Checksummer{
+		Type: "sha256",
+		Hash: sha256.New(),
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("failed to open fake plugin binary: %v", err)
+	}
+	defer f.Close()
+
+	sum, err := cs.Sum(f)
+	if err != nil {
+		t.Fatalf("failed to checksum fake plugin binary: %v", err)
+	}
+
+	t.Logf("creating fake plugin checksum file %s with contents %x", filePath+cs.FileExt(), string(sum))
+	if err := os.WriteFile(filePath+cs.FileExt(), []byte(fmt.Sprintf("%x", sum)), os.ModePerm); err != nil {
+		t.Fatalf("failed to write checksum fake plugin binary: %v", err)
+	}
+}
+
+func createMockInstalledPlugins(t *testing.T, plugins map[string]pluginsdk.Set, opts ...func(tb testing.TB, filePath string)) {
 	pluginDir, err := tmp.Dir("pkr-multi-component-plugin-test-*")
 	{
 		// create an exectutable file with a `sh` sheebang
@@ -310,15 +334,15 @@ func createMockInstalledPlugins(t *testing.T, plugins map[string]pluginsdk.Set) 
 		if err != nil {
 			t.Fatal(err)
 		}
-		dir, err := ioutil.TempDir(pluginDir, "github.com")
+		dir, err := os.MkdirTemp(pluginDir, "github.com")
 		if err != nil {
 			t.Fatalf("failed to create temporary test directory: %v", err)
 		}
-		dir, err = ioutil.TempDir(dir, "hashicorp")
+		dir, err = os.MkdirTemp(dir, "hashicorp")
 		if err != nil {
 			t.Fatalf("failed to create temporary test directory: %v", err)
 		}
-		dir, err = ioutil.TempDir(dir, "plugin")
+		dir, err = os.MkdirTemp(dir, "plugin")
 		if err != nil {
 			t.Fatalf("failed to create temporary test directory: %v", err)
 		}
@@ -333,8 +357,12 @@ func createMockInstalledPlugins(t *testing.T, plugins map[string]pluginsdk.Set) 
 			fileContent += strings.Join(
 				append([]string{"PKR_WANT_TEST_PLUGINS=1"}, helperCommand(t, strings.Split(name, "_")[0], "$@")...),
 				" ")
-			if err := ioutil.WriteFile(plugin, []byte(fileContent), os.ModePerm); err != nil {
+			if err := os.WriteFile(plugin, []byte(fileContent), os.ModePerm); err != nil {
 				t.Fatalf("failed to create fake plugin binary: %v", err)
+			}
+
+			for _, opt := range opts {
+				opt(t, plugin)
 			}
 		}
 	}
@@ -347,36 +375,36 @@ func getFormattedInstalledPluginSuffix() string {
 
 var (
 	mockPlugins = map[string]pluginsdk.Set{
-		"bird": pluginsdk.Set{
+		"bird": {
 			Builders: map[string]packersdk.Builder{
 				"feather":   nil,
 				"guacamole": nil,
 			},
 		},
-		"chimney": pluginsdk.Set{
+		"chimney": {
 			PostProcessors: map[string]packersdk.PostProcessor{
 				"smoke": nil,
 			},
 		},
-		"data": pluginsdk.Set{
+		"data": {
 			Datasources: map[string]packersdk.Datasource{
 				"source": nil,
 			},
 		},
 	}
 	mockInstalledPlugins = map[string]pluginsdk.Set{
-		fmt.Sprintf("bird_%s", getFormattedInstalledPluginSuffix()): pluginsdk.Set{
+		fmt.Sprintf("bird_%s", getFormattedInstalledPluginSuffix()): {
 			Builders: map[string]packersdk.Builder{
 				"feather":   nil,
 				"guacamole": nil,
 			},
 		},
-		fmt.Sprintf("chimney_%s", getFormattedInstalledPluginSuffix()): pluginsdk.Set{
+		fmt.Sprintf("chimney_%s", getFormattedInstalledPluginSuffix()): {
 			PostProcessors: map[string]packersdk.PostProcessor{
 				"smoke": nil,
 			},
 		},
-		fmt.Sprintf("data_%s", getFormattedInstalledPluginSuffix()): pluginsdk.Set{
+		fmt.Sprintf("data_%s", getFormattedInstalledPluginSuffix()): {
 			Datasources: map[string]packersdk.Datasource{
 				"source": nil,
 			},
@@ -384,25 +412,25 @@ var (
 	}
 
 	invalidInstalledPluginsMock = map[string]pluginsdk.Set{
-		"bird_v0.1.1_x5.0_wrong_architecture": pluginsdk.Set{
+		"bird_v0.1.1_x5.0_wrong_architecture": {
 			Builders: map[string]packersdk.Builder{
 				"feather":   nil,
 				"guacamole": nil,
 			},
 		},
-		"chimney_cool_ranch": pluginsdk.Set{
+		"chimney_cool_ranch": {
 			PostProcessors: map[string]packersdk.PostProcessor{
 				"smoke": nil,
 			},
 		},
-		"data": pluginsdk.Set{
+		"data": {
 			Datasources: map[string]packersdk.Datasource{
 				"source": nil,
 			},
 		},
 	}
 	defaultNameMock = map[string]pluginsdk.Set{
-		"foo": pluginsdk.Set{
+		"foo": {
 			Builders: map[string]packersdk.Builder{
 				"bar":                  nil,
 				"baz":                  nil,
@@ -412,7 +440,7 @@ var (
 	}
 
 	doubleDefaultMock = map[string]pluginsdk.Set{
-		"yolo": pluginsdk.Set{
+		"yolo": {
 			Builders: map[string]packersdk.Builder{
 				"bar":                  nil,
 				"baz":                  nil,
@@ -425,7 +453,7 @@ var (
 	}
 
 	badDefaultNameMock = map[string]pluginsdk.Set{
-		"foo": pluginsdk.Set{
+		"foo": {
 			Builders: map[string]packersdk.Builder{
 				"bar":                  nil,
 				"baz":                  nil,
@@ -475,7 +503,7 @@ func Test_multiplugin_describe(t *testing.T) {
 }
 
 func Test_multiplugin_describe_installed(t *testing.T) {
-	createMockInstalledPlugins(t, mockInstalledPlugins)
+	createMockInstalledPlugins(t, mockInstalledPlugins, createMockChecksumFile)
 	pluginDir := os.Getenv("PACKER_PLUGIN_PATH")
 	defer os.RemoveAll(pluginDir)
 
@@ -515,44 +543,69 @@ func Test_multiplugin_describe_installed(t *testing.T) {
 }
 
 func Test_multiplugin_describe_installed_for_invalid(t *testing.T) {
-	createMockInstalledPlugins(t, invalidInstalledPluginsMock)
-	pluginDir := os.Getenv("PACKER_PLUGIN_PATH")
-	defer os.RemoveAll(pluginDir)
+	tc := []struct {
+		desc                 string
+		installedPluginsMock map[string]pluginsdk.Set
+		createMockFn         func(*testing.T, map[string]pluginsdk.Set)
+	}{
+		{
+			desc:                 "Incorrectly named plugins",
+			installedPluginsMock: invalidInstalledPluginsMock,
+			createMockFn: func(t *testing.T, mocks map[string]pluginsdk.Set) {
+				createMockInstalledPlugins(t, mocks, createMockChecksumFile)
+			},
+		},
+		{
+			desc:                 "Plugins missing checksums",
+			installedPluginsMock: mockInstalledPlugins,
+			createMockFn: func(t *testing.T, mocks map[string]pluginsdk.Set) {
+				createMockInstalledPlugins(t, mocks)
+			},
+		},
+	}
 
-	c := PluginConfig{}
-	err := c.Discover()
-	if err != nil {
-		t.Fatalf("error discovering plugins; %s", err.Error())
-	}
-	if c.Builders.Has("feather") {
-		t.Fatalf("expected to not find builder %q", "feather")
-	}
-	for mockPluginName, plugin := range invalidInstalledPluginsMock {
-		mockPluginName = strings.Split(mockPluginName, "_")[0]
-		for mockBuilderName := range plugin.Builders {
-			expectedBuilderName := mockPluginName + "-" + mockBuilderName
-			if c.Builders.Has(expectedBuilderName) {
-				t.Fatalf("expected to not find builder %q", expectedBuilderName)
+	for _, tt := range tc {
+		t.Run(tt.desc, func(t *testing.T) {
+			tt.createMockFn(t, tt.installedPluginsMock)
+			pluginDir := os.Getenv("PACKER_PLUGIN_PATH")
+			defer os.RemoveAll(pluginDir)
+
+			c := PluginConfig{}
+			err := c.Discover()
+			if err != nil {
+				t.Fatalf("error discovering plugins; %s", err.Error())
 			}
-		}
-		for mockProvisionerName := range plugin.Provisioners {
-			expectedProvisionerName := mockPluginName + "-" + mockProvisionerName
-			if c.Provisioners.Has(expectedProvisionerName) {
-				t.Fatalf("expected to not find builder %q", expectedProvisionerName)
+			if c.Builders.Has("feather") {
+				t.Fatalf("expected to not find builder %q", "feather")
 			}
-		}
-		for mockPostProcessorName := range plugin.PostProcessors {
-			expectedPostProcessorName := mockPluginName + "-" + mockPostProcessorName
-			if c.PostProcessors.Has(expectedPostProcessorName) {
-				t.Fatalf("expected to not find post-processor %q", expectedPostProcessorName)
+			for mockPluginName, plugin := range tt.installedPluginsMock {
+				mockPluginName = strings.Split(mockPluginName, "_")[0]
+				for mockBuilderName := range plugin.Builders {
+					expectedBuilderName := mockPluginName + "-" + mockBuilderName
+					if c.Builders.Has(expectedBuilderName) {
+						t.Fatalf("expected to not find builder %q", expectedBuilderName)
+					}
+				}
+				for mockProvisionerName := range plugin.Provisioners {
+					expectedProvisionerName := mockPluginName + "-" + mockProvisionerName
+					if c.Provisioners.Has(expectedProvisionerName) {
+						t.Fatalf("expected to not find builder %q", expectedProvisionerName)
+					}
+				}
+				for mockPostProcessorName := range plugin.PostProcessors {
+					expectedPostProcessorName := mockPluginName + "-" + mockPostProcessorName
+					if c.PostProcessors.Has(expectedPostProcessorName) {
+						t.Fatalf("expected to not find post-processor %q", expectedPostProcessorName)
+					}
+				}
+				for mockDatasourceName := range plugin.Datasources {
+					expectedDatasourceName := mockPluginName + "-" + mockDatasourceName
+					if c.DataSources.Has(expectedDatasourceName) {
+						t.Fatalf("expected to not find datasource %q", expectedDatasourceName)
+					}
+				}
 			}
-		}
-		for mockDatasourceName := range plugin.Datasources {
-			expectedDatasourceName := mockPluginName + "-" + mockDatasourceName
-			if c.DataSources.Has(expectedDatasourceName) {
-				t.Fatalf("expected to not find datasource %q", expectedDatasourceName)
-			}
-		}
+		})
 	}
 }
 

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -532,7 +532,7 @@ func Test_multiplugin_describe_installed_for_invalid(t *testing.T) {
 		for mockBuilderName := range plugin.Builders {
 			expectedBuilderName := mockPluginName + "-" + mockBuilderName
 			if c.Builders.Has(expectedBuilderName) {
-				t.Fatalf("expected to find builder %q", expectedBuilderName)
+				t.Fatalf("expected to not find builder %q", expectedBuilderName)
 			}
 		}
 		for mockProvisionerName := range plugin.Provisioners {

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -514,7 +514,7 @@ func Test_multiplugin_describe_installed(t *testing.T) {
 	}
 }
 
-func Test_multiplugin_describe_installed_ignores_unformatted(t *testing.T) {
+func Test_multiplugin_describe_installed_for_invalid(t *testing.T) {
 	createMockInstalledPlugins(t, invalidInstalledPluginsMock)
 	pluginDir := os.Getenv("PACKER_PLUGIN_PATH")
 	defer os.RemoveAll(pluginDir)

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -527,7 +527,7 @@ func Test_multiplugin_describe_installed_ignores_unformatted(t *testing.T) {
 	if c.Builders.Has("feather") {
 		t.Fatalf("expected to not find builder %q", "feather")
 	}
-	for mockPluginName, plugin := range mockInstalledPlugins {
+	for mockPluginName, plugin := range invalidInstalledPluginsMock {
 		mockPluginName = strings.Split(mockPluginName, "_")[0]
 		for mockBuilderName := range plugin.Builders {
 			expectedBuilderName := mockPluginName + "-" + mockBuilderName

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -538,19 +538,19 @@ func Test_multiplugin_describe_installed_for_invalid(t *testing.T) {
 		for mockProvisionerName := range plugin.Provisioners {
 			expectedProvisionerName := mockPluginName + "-" + mockProvisionerName
 			if c.Provisioners.Has(expectedProvisionerName) {
-				t.Fatalf("expected to find builder %q", expectedProvisionerName)
+				t.Fatalf("expected to not find builder %q", expectedProvisionerName)
 			}
 		}
 		for mockPostProcessorName := range plugin.PostProcessors {
 			expectedPostProcessorName := mockPluginName + "-" + mockPostProcessorName
 			if c.PostProcessors.Has(expectedPostProcessorName) {
-				t.Fatalf("expected to find post-processor %q", expectedPostProcessorName)
+				t.Fatalf("expected to not find post-processor %q", expectedPostProcessorName)
 			}
 		}
 		for mockDatasourceName := range plugin.Datasources {
 			expectedDatasourceName := mockPluginName + "-" + mockDatasourceName
 			if c.DataSources.Has(expectedDatasourceName) {
-				t.Fatalf("expected to find datasource %q", expectedDatasourceName)
+				t.Fatalf("expected to not find datasource %q", expectedDatasourceName)
 			}
 		}
 	}

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -154,6 +154,52 @@ func TestDiscoverDatasource(t *testing.T) {
 	}
 }
 
+func TestDiscoverPluginsInstalledWithPackerPluginsCommand(t *testing.T) {
+	dir, _, cleanUpFunc, err := generateInstalledFakePlugins("custom_plugin_dir",
+		[]string{"packer-datasource-partyparrot"})
+	if err != nil {
+		t.Fatalf("Error creating fake custom plugins: %s", err)
+	}
+
+	defer cleanUpFunc()
+
+	pathsep := ":"
+	if runtime.GOOS == "windows" {
+		pathsep = ";"
+	}
+
+	// Create a second dir to look in that will be empty
+	decoyDir, err := ioutil.TempDir("", "decoy")
+	if err != nil {
+		t.Fatalf("Failed to create a temporary test dir.")
+	}
+	defer os.Remove(decoyDir)
+
+	pluginPath := dir + pathsep + decoyDir
+
+	// Add temp dir to path.
+	os.Setenv("PACKER_PLUGIN_PATH", pluginPath)
+	defer os.Unsetenv("PACKER_PLUGIN_PATH")
+
+	config := newPluginConfig()
+
+	err = config.Discover()
+	if err != nil {
+		t.Fatalf("Should not have errored: %s", err)
+	}
+
+	if len(config.DataSources.List()) == 0 {
+		t.Fatalf("Should have found partyparrot datasource")
+	}
+	if !config.DataSources.Has("partyparrot") {
+		t.Fatalf("Should have found partyparrot datasource.")
+	}
+}
+
+func TestDiscoverInvalidPluginBinariesIgnored(t *testing.T) {
+	t.Fatalf("To be implemented maybe")
+}
+
 func generateFakePlugins(dirname string, pluginNames []string) (string, []string, func(), error) {
 	dir, err := ioutil.TempDir("", dirname)
 	if err != nil {
@@ -162,6 +208,46 @@ func generateFakePlugins(dirname string, pluginNames []string) (string, []string
 
 	cleanUpFunc := func() {
 		os.RemoveAll(dir)
+	}
+
+	var suffix string
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+
+	plugins := make([]string, len(pluginNames))
+	for i, plugin := range pluginNames {
+		plug := filepath.Join(dir, plugin+suffix)
+		plugins[i] = plug
+		_, err := os.Create(plug)
+		if err != nil {
+			cleanUpFunc()
+			return "", nil, nil, fmt.Errorf("failed to create temporary plugin file (%s): %v", plug, err)
+		}
+	}
+
+	return dir, plugins, cleanUpFunc, nil
+}
+
+func generateInstalledFakePlugins(dirname string, pluginNames []string) (string, []string, func(), error) {
+	topLevelDir, err := ioutil.TempDir("", dirname)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
+	}
+	dir, err := ioutil.TempDir(topLevelDir, "github.com")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
+	}
+	dir, err = ioutil.TempDir(dir, "hashicorp")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
+	}
+	dir, err = ioutil.TempDir(dir, "plugin")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
+	}
+	cleanUpFunc := func() {
+		os.RemoveAll(topLevelDir)
 	}
 
 	var suffix string


### PR DESCRIPTION
This makes it so plugins installed via the `packer plugins installed` command will be detected in both JSON builds, and HCL builds not using the required block field.  This duplicates some logic used by the required block plugin scanner.

Previously many plugin unit tests were disabled on Darwin arm64, My development machine is an Apple Silicon mac so I was able to verify these tests pass locally.

Closes #11697
Closes #11696
