### PR TITLE
Update community note on GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,16 @@ about: You're experiencing an issue with Packer that is different from the docum
 labels: bug
 ---
 
+<!--- Please keep this note for the community --->
+
+#### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!--- Thank you for keeping this note for the community --->
+
 When filing a bug, please include the following headings if possible. Any
 example text in this template can be deleted.
 

--- a/.github/ISSUE_TEMPLATE/feature_requests.md
+++ b/.github/ISSUE_TEMPLATE/feature_requests.md
@@ -4,16 +4,20 @@ about: If you have something you think Packer could improve or add support for.
 labels: enhancement
 ---
 
+<!--- Please keep this note for the community --->
+
+#### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!--- Thank you for keeping this note for the community --->
+
 Please search the existing issues for relevant feature requests, and use the
 reaction feature
 (https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
 to add upvotes to pre-existing requests.
-
-#### Community Note
-
-Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
-Please do not leave "+1" or "me too" comments, they generate extra noise for issue followers and do not help prioritize the request.
-If you are interested in working on this issue or have submitted a pull request, please leave a comment.
 
 #### Description
 


### PR DESCRIPTION
In an effort to help prioritize issues (i.e bugs and feature requests) that are important to the community
the community note pertaining to issue voting has been moved to the top of each template with a comment informing users not to delete it. The goal is to rely more on votes for feature requests and issues that are not critical.

Critical issues being crashes, regressions, security vulnerabilities, and broken features.
