### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -10,6 +10,9 @@ on:
   # Runs against the default branch every day at midnight
   - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   get-go-version:
     runs-on: ubuntu-latest
@@ -61,6 +64,8 @@ jobs:
           PACKER_ACC=1 gotestsum --format=short-verbose --junitfile /tmp/test-results/gotestsum-report.xml -- -timeout=120m -p 2 $(go list ./... | grep -v inspec | grep -v profitbricks | grep -v oneandone)
   # Send a slack notification if either job defined above fails
   slack-notify:
+    permissions:
+      contents: none
     needs: 
       - get-go-version
       - acceptance-test

--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -10,6 +10,9 @@ on:
       # Runs on push events to the stable-website branch
       - 'stable-website'
 
+permissions:
+  contents: read
+
 jobs:
   algolia-index:
     runs-on: ubuntu-latest

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,8 +7,13 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   backport:
+    permissions:
+      contents: none
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     container: hashicorpdev/backport-assistant:0.2.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ env:
   REPO_NAME: "packer"
   GO_TAGS: ""
 
+permissions:
+  contents: read
+
 jobs:
   get-go-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-plugin-docs.yml
+++ b/.github/workflows/check-plugin-docs.yml
@@ -15,6 +15,9 @@ on:
   schedule:
     - cron: "45 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   check-plugin-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -10,6 +10,9 @@ on: [ workflow_dispatch, push ]
 env:
   PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   linux-go-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -6,6 +6,9 @@ name: "Go Validate"
 
 on: [ workflow_dispatch, push ]
 
+permissions:
+  contents: read
+
 jobs:
   check-mod-tidy:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -4,8 +4,14 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   issue_comment_triage:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for actions-ecosystem/action-remove-labels to remove issue labels
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/issues-opened.yml
+++ b/.github/workflows/issues-opened.yml
@@ -4,8 +4,14 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   issue_triage:
+    permissions:
+      contents: read  # for github/issue-labeler to get repo contents
+      issues: write  # for github/issue-labeler to create or remove labels
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,8 +5,14 @@ on:
     - cron: '50 1 * * *'
 
 # Only 50 issues will be handled during a given run.
+permissions:
+  contents: read
+
 jobs:
   lock:
+    permissions:
+      issues: write  # for dessant/lock-threads to lock issues
+      pull-requests: write  # for dessant/lock-threads to lock PRs
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   # Build a fresh set of artifacts
   build-artifacts:
+    permissions:
+      contents: none
     uses: hashicorp/packer/.github/workflows/build.yml@main
   github-release:
     needs: build-artifacts
@@ -78,6 +80,8 @@ jobs:
           release_id: ${{ steps.create_prerelease.outputs.id }}
   # Send a slack notification if either job defined above fails
   slack-notify:
+    permissions:
+      contents: none
     needs:
       - build-artifacts
       - github-release

--- a/.github/workflows/website-docker-publish.yml
+++ b/.github/workflows/website-docker-publish.yml
@@ -13,6 +13,9 @@ on:
       # Push events on main branch
       - 'main'
 
+permissions:
+  contents: read
+
 jobs:
   website-docker-publish:
     runs-on: ubuntu-latest  
@@ -39,6 +42,8 @@ jobs:
           fi
   # Send a slack notification if the job defined above fails
   slack-notify:
+    permissions:
+      contents: none
     needs: 
       - website-docker-publish
     if: always() && (needs.website-docker-publish.result == 'failure')


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
