### PR TITLE
Add checksum validation for multi-component plugins installed by the packer plugins subcommand

### DIFF
--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -89,7 +89,7 @@ func (pr Requirement) FilenamePrefix() string {
 	return "packer-plugin-" + pr.Identifier.Type + "_"
 }
 
-func (opts BinaryInstallationOptions) filenameSuffix() string {
+func (opts BinaryInstallationOptions) FilenameSuffix() string {
 	return "_" + opts.OS + "_" + opts.ARCH + opts.Ext
 }
 
@@ -104,7 +104,7 @@ func (opts BinaryInstallationOptions) filenameSuffix() string {
 func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallList, error) {
 	res := InstallList{}
 	FilenamePrefix := pr.FilenamePrefix()
-	filenameSuffix := opts.filenameSuffix()
+	filenameSuffix := opts.FilenameSuffix()
 	log.Printf("[TRACE] listing potential installations for %q that match %q. %#v", pr.Identifier, pr.VersionConstraints, opts)
 	for _, knownFolder := range opts.FromFolders {
 		glob := ""

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -1,6 +1,7 @@
 package packer
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -14,6 +15,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/pathing"
 	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
+	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
 )
 
 // PluginConfig helps load and use packer plugins
@@ -47,8 +49,6 @@ type PluginConfig struct {
 // PACKERSPACE is used to represent the spaces that separate args for a command
 // without being confused with spaces in the path to the command itself.
 const PACKERSPACE = "-PACKERSPACE-"
-
-const osArch = runtime.GOOS + "_" + runtime.GOARCH
 
 // Discover discovers plugins.
 //
@@ -204,12 +204,47 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 	}
 
 	//Check for installed plugins using the `packer plugins install` command
-	pluginPaths, err = c.discoverSingle(filepath.Join(path, "*", "*", "*", fmt.Sprintf("packer-plugin-*%s", osArch)))
+	binInstallOpts := plugingetter.BinaryInstallationOptions{
+		OS:              runtime.GOOS,
+		ARCH:            runtime.GOARCH,
+		APIVersionMajor: pluginsdk.APIVersionMajor,
+		APIVersionMinor: pluginsdk.APIVersionMinor,
+		Checksummers: []plugingetter.Checksummer{
+			{Type: "sha256", Hash: sha256.New()},
+		},
+	}
+
+	if runtime.GOOS == "windows" {
+		binInstallOpts.Ext = ".exe"
+	}
+
+	pluginPaths, err = c.discoverSingle(filepath.Join(path, "*", "*", "*", fmt.Sprintf("packer-plugin-*%s", binInstallOpts.FilenameSuffix())))
 	if err != nil {
 		return err
 	}
 
 	for pluginName, pluginPath := range pluginPaths {
+		var checksumOk bool
+		for _, checksummer := range binInstallOpts.Checksummers {
+			cs, err := checksummer.GetCacheChecksumOfFile(pluginPath)
+			if err != nil {
+				log.Printf("[TRACE] GetChecksumOfFile(%q) failed: %v", pluginPath, err)
+				continue
+			}
+
+			if err := checksummer.ChecksumFile(cs, pluginPath); err != nil {
+				log.Printf("[TRACE] ChecksumFile(%q) failed: %v", pluginPath, err)
+				continue
+			}
+			checksumOk = true
+			break
+		}
+
+		if !checksumOk {
+			log.Printf("[TRACE] No checksum found for %q ignoring possibly unsafe binary", path)
+			continue
+		}
+
 		if err := c.DiscoverMultiPlugin(pluginName, pluginPath); err != nil {
 			return err
 		}
@@ -263,11 +298,9 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 
 		// Look for foo-bar-baz. The plugin name is "baz"
 		pluginName := file[len(prefix):]
+		// For multi-plugins installed via the plugins slit name  baz_vx.y.z_x5.0_os_arch. The plugin name is "baz"
+		pluginName = strings.SplitN(pluginName, "_", 2)[0]
 
-		if strings.HasSuffix(pluginName, osArch) {
-			pluginName = strings.SplitN(pluginName, "_", 2)[0]
-
-		}
 		log.Printf("[DEBUG] Discovered plugin: %s = %s", pluginName, match)
 		res[pluginName] = match
 	}

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -300,7 +300,7 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 
 		// Look for foo-bar-baz. The plugin name is "baz"
 		pluginName := file[len(prefix):]
-		// For multi-compent plugins installed via the plugins split name  baz_vx.y.z_x5.0_os_arch.
+		// For multi-component plugins installed via the plugins we expect the name to look like baz_vx.y.z_x5.0_os_arch.
 		// The plugin name is "baz"
 		pluginName = strings.SplitN(pluginName, "_", 2)[0]
 

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -250,6 +250,8 @@ func (c *PluginConfig) discoverExternalComponents(path string) error {
 		}
 	}
 
+	// Manually installed plugins take precedence over all. Duplicate plugins installed
+	// prior to the packer plugins install command should be removed by user to avoid overrides.
 	pluginPaths, err = c.discoverSingle(filepath.Join(path, "packer-plugin-*"))
 	if err != nil {
 		return err
@@ -298,7 +300,8 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 
 		// Look for foo-bar-baz. The plugin name is "baz"
 		pluginName := file[len(prefix):]
-		// For multi-plugins installed via the plugins slit name  baz_vx.y.z_x5.0_os_arch. The plugin name is "baz"
+		// For multi-compent plugins installed via the plugins split name  baz_vx.y.z_x5.0_os_arch.
+		// The plugin name is "baz"
 		pluginName = strings.SplitN(pluginName, "_", 2)[0]
 
 		log.Printf("[DEBUG] Discovered plugin: %s = %s", pluginName, match)

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -3,7 +3,6 @@ package packer
 import (
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -86,7 +85,7 @@ func TestEnvVarPackerPluginPath_MultiplePaths(t *testing.T) {
 	}
 
 	// Create a second dir to look in that will be empty
-	decoyDir, err := ioutil.TempDir("", "decoy")
+	decoyDir, err := os.MkdirTemp("", "decoy")
 	if err != nil {
 		t.Fatalf("Failed to create a temporary test dir.")
 	}
@@ -129,7 +128,7 @@ func TestDiscoverDatasource(t *testing.T) {
 	}
 
 	// Create a second dir to look in that will be empty
-	decoyDir, err := ioutil.TempDir("", "decoy")
+	decoyDir, err := os.MkdirTemp("", "decoy")
 	if err != nil {
 		t.Fatalf("Failed to create a temporary test dir.")
 	}
@@ -157,7 +156,7 @@ func TestDiscoverDatasource(t *testing.T) {
 }
 
 func generateFakePlugins(dirname string, pluginNames []string) (string, []string, func(), error) {
-	dir, err := ioutil.TempDir("", dirname)
+	dir, err := os.MkdirTemp("", dirname)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to create temporary test directory: %v", err)
 	}
@@ -297,7 +296,7 @@ func createMockPlugins(t *testing.T, plugins map[string]pluginsdk.Set) {
 	os.Setenv("PACKER_PLUGIN_PATH", pluginDir)
 }
 
-func withMockChecksumFile(t testing.TB, filePath string) {
+func createMockChecksumFile(t testing.TB, filePath string) {
 	cs := plugingetter.Checksummer{
 		Type: "sha256",
 		Hash: sha256.New(),
@@ -335,15 +334,15 @@ func createMockInstalledPlugins(t *testing.T, plugins map[string]pluginsdk.Set, 
 		if err != nil {
 			t.Fatal(err)
 		}
-		dir, err := ioutil.TempDir(pluginDir, "github.com")
+		dir, err := os.MkdirTemp(pluginDir, "github.com")
 		if err != nil {
 			t.Fatalf("failed to create temporary test directory: %v", err)
 		}
-		dir, err = ioutil.TempDir(dir, "hashicorp")
+		dir, err = os.MkdirTemp(dir, "hashicorp")
 		if err != nil {
 			t.Fatalf("failed to create temporary test directory: %v", err)
 		}
-		dir, err = ioutil.TempDir(dir, "plugin")
+		dir, err = os.MkdirTemp(dir, "plugin")
 		if err != nil {
 			t.Fatalf("failed to create temporary test directory: %v", err)
 		}
@@ -504,7 +503,7 @@ func Test_multiplugin_describe(t *testing.T) {
 }
 
 func Test_multiplugin_describe_installed(t *testing.T) {
-	createMockInstalledPlugins(t, mockInstalledPlugins, withMockChecksumFile)
+	createMockInstalledPlugins(t, mockInstalledPlugins, createMockChecksumFile)
 	pluginDir := os.Getenv("PACKER_PLUGIN_PATH")
 	defer os.RemoveAll(pluginDir)
 
@@ -553,7 +552,7 @@ func Test_multiplugin_describe_installed_for_invalid(t *testing.T) {
 			desc:                 "Incorrectly named plugins",
 			installedPluginsMock: invalidInstalledPluginsMock,
 			createMockFn: func(t *testing.T, mocks map[string]pluginsdk.Set) {
-				createMockInstalledPlugins(t, mocks, withMockChecksumFile)
+				createMockInstalledPlugins(t, mocks, createMockChecksumFile)
 			},
 		},
 		{

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -315,7 +315,9 @@ func withMockChecksumFile(t testing.TB, filePath string) {
 	}
 
 	t.Logf("creating fake plugin checksum file %s with contents %x", filePath+cs.FileExt(), string(sum))
-	os.WriteFile(filePath+cs.FileExt(), []byte(fmt.Sprintf("%x", sum)), os.ModePerm)
+	if err := os.WriteFile(filePath+cs.FileExt(), []byte(fmt.Sprintf("%x", sum)), os.ModePerm); err != nil {
+		t.Fatalf("failed to write checksum fake plugin binary: %v", err)
+	}
 }
 
 func createMockInstalledPlugins(t *testing.T, plugins map[string]pluginsdk.Set, opts ...func(tb testing.TB, filePath string)) {


### PR DESCRIPTION
- Updates glob to use BinaryInstallationOptions.FilenameSuffix() to fix mismatch on Windows Os. 
- Add checksummer logic to validate discovered binaries; mimics the logic used for required_plugins. 
- Updates mock tests to create a SHASUM file for mocked binaries. 
- Removes osArch constant in favor of BinaryInstallationOptions.

#### Manually Tested On
- [x] Windows
- [x] MacOs
- [ ] Linux