### PR TITLE
Added mention of HCL in Terminology>Templates

### DIFF
--- a/website/content/docs/terminology.mdx
+++ b/website/content/docs/terminology.mdx
@@ -58,6 +58,7 @@ for quick referencing.
   image. They perform the major work of making the image contain useful
   software. Example provisioners include shell scripts, Chef, Puppet, etc.
 
-- `Templates` are JSON files which define one or more builds by configuring
-  the various components of Packer. Packer is able to read a template and use
-  that information to create multiple machine images in parallel.
+- `Templates` are either [HCL](templates/hcl_templates) or JSON files which
+  define one or more builds by configuring the various components of Packer.
+  Packer is able to read a template and use that information to create
+  multiple machine images in parallel.


### PR DESCRIPTION
This is a simple update to the docs on the [Terminology page](https://www.packer.io/docs/terminology)  in the _"Templates"_ bullet to add a mention of HCL in addition to JSON, with a link to [the HCL page](https://www.packer.io/docs/templates/hcl_templates).
