### PR TITLE
fix 404 to plugins docs

### DIFF
--- a/website/content/docs/builders/index.mdx
+++ b/website/content/docs/builders/index.mdx
@@ -11,7 +11,7 @@ Builders create machines and generate images from those machines for various pla
 
 Packer has the following types of builders:
 
-- [Plugin](/plugin): Each plugin has its own associated set of builders. For example, there are separate builders for EC2, VMware, VirtualBox, etc.
+- [Plugin](/plugins): Each plugin has its own associated set of builders. For example, there are separate builders for EC2, VMware, VirtualBox, etc.
 - [File](/docs/builders/file): The `file` builder creates an artifact from a file.
 - [Null](/docs/builders/null): The `null` builder sets up an SSH connection and runs the provisioners.
 - [Custom](/docs/plugins/creation/custom-builders): You can write new builders for new or existing platforms.


### PR DESCRIPTION

The link on https://www.packer.io/docs/builders to the plugins documentation is a 404. I believe it should link to https://www.packer.io/plugins instead.