### PR TITLE
Add libvirt plugin

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -160,6 +160,13 @@
     "isHcpPackerReady": true
   },
   {
+    "title": "Libvirt",
+    "path": "libvirt",
+    "repo": "thomasklein94/packer-plugin-libvirt",
+    "pluginTier": "community",
+    "version": "latest"
+  },
+  {
     "title": "LXC",
     "path": "lxc",
     "repo": "hashicorp/packer-plugin-lxc",


### PR DESCRIPTION
This PR adds [my packer plugin](https://github.com/thomasklein94/packer-plugin-libvirt) supporting remote builds on Libvirt hypervisors to the plugin manifest.
The plugin is in a very early stage, so any feedback or help is welcomed.

Thank you!