### PR TITLE
bump hcp-sdk-go and fix import path

### DIFF
--- a/datasource/packer-image-iteration/data.go
+++ b/datasource/packer-image-iteration/data.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/hcl2helper"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hcl/v2 v2.12.0
-	github.com/hashicorp/hcp-sdk-go v0.18.1-0.20220506085537-4a8c08ea0676
+	github.com/hashicorp/hcp-sdk-go v0.19.0
 	github.com/hashicorp/packer-plugin-amazon v1.0.8
 	github.com/hashicorp/packer-plugin-sdk v0.2.12
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hcl/v2 v2.12.0
-	github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4
+	github.com/hashicorp/hcp-sdk-go v0.18.1-0.20220506085537-4a8c08ea0676
 	github.com/hashicorp/packer-plugin-amazon v1.0.8
 	github.com/hashicorp/packer-plugin-sdk v0.2.12
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869

--- a/go.sum
+++ b/go.sum
@@ -701,6 +701,8 @@ github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4 h1:H4V7J/m
 github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/hcp-sdk-go v0.18.1-0.20220506085537-4a8c08ea0676 h1:P9D5qXaLWl9GBT0AXqnMYEn5zWwE+3vUTZsbdhu5Z5Y=
 github.com/hashicorp/hcp-sdk-go v0.18.1-0.20220506085537-4a8c08ea0676/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
+github.com/hashicorp/hcp-sdk-go v0.19.0 h1:uaM2YlL84yLz2m9WyeK9HOUmcVkgw1u32aUJx7L64zw=
+github.com/hashicorp/hcp-sdk-go v0.19.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=

--- a/go.sum
+++ b/go.sum
@@ -699,6 +699,8 @@ github.com/hashicorp/hcl/v2 v2.12.0 h1:PsYxySWpMD4KPaoJLnsHwtK5Qptvj/4Q6s0t4sUxZ
 github.com/hashicorp/hcl/v2 v2.12.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4 h1:H4V7J/mUKzMpmTqnnDloH0r7mk2Jwn4oKUvealKE9cQ=
 github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
+github.com/hashicorp/hcp-sdk-go v0.18.1-0.20220506085537-4a8c08ea0676 h1:P9D5qXaLWl9GBT0AXqnMYEn5zWwE+3vUTZsbdhu5Z5Y=
+github.com/hashicorp/hcp-sdk-go v0.18.1-0.20220506085537-4a8c08ea0676/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=

--- a/internal/registry/acctest/par.go
+++ b/internal/registry/acctest/par.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	structenv "github.com/caarlos0/env/v6"
-	packer_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	packer_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/client/packer_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/packer/acctest"
 	"github.com/hashicorp/packer/internal/registry"

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"fmt"
 
-	packerSvc "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
+	packerSvc "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/client/packer_service"
 	organizationSvc "github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/preview/2019-12-10/client/organization_service"
 	projectSvc "github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/preview/2019-12-10/client/project_service"
 	rmmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/preview/2019-12-10/models"

--- a/internal/registry/mock_service.go
+++ b/internal/registry/mock_service.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 
 	"github.com/go-openapi/runtime"
-	packerSvc "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	packerSvc "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/client/packer_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/client/packer_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	"google.golang.org/grpc/codes"
 )
 

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
 	"github.com/hashicorp/packer/internal/registry/env"
 	"google.golang.org/grpc/codes"

--- a/internal/registry/types.bucket_service_test.go
+++ b/internal/registry/types.bucket_service_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 )
 
 func TestInitialize_NewBucketNewIteration(t *testing.T) {

--- a/internal/registry/types.builds.go
+++ b/internal/registry/types.builds.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
 )
 

--- a/packer/registry_builder.go
+++ b/packer/registry_builder.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
 	packerregistry "github.com/hashicorp/packer/internal/registry"

--- a/packer/registry_post_processor.go
+++ b/packer/registry_post_processor.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
 	packerregistry "github.com/hashicorp/packer/internal/registry"


### PR DESCRIPTION
Test output:
```ssh
==> Wait completed after 4 minutes 21 seconds

==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs.basic-example: AMIs were created:
us-west-2: ami-0fba6906c79ade3e7

--> amazon-ebs.basic-example: Published metadata to HCP Packer registry packer/amazon-example/iterations/01G2C9WTDYQ38HDHAE7GBM6AS2

```