### PR TITLE
fix: work around deleted plugin release

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -111,7 +111,7 @@
     "title": "HuaweiCloud",
     "path": "huaweicloud",
     "repo": "huaweicloud/packer-plugin-huaweicloud",
-    "version": "latest",
+    "version": "v0.4.0",
     "pluginTier": "community",
     "sourceBranch": "master"
   },

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -255,7 +255,7 @@
     "path": "sshkey",
     "repo": "ivoronin/packer-plugin-sshkey",
     "pluginTier": "community",
-    "version": "latest"
+    "version": "v1.0.1"
   },
   {
     "title": "Tencent Cloud",


### PR DESCRIPTION
This PR pins the versions of [huaweicloud/packer-plugin-huaweicloud](https://github.com/huaweicloud/packer-plugin-huaweicloud) and [ivoronin/packer-plugin-sshkey](https://github.com/ivoronin/packer-plugin-sshkey). Without these plugin packages pinned, we run into build errors, which affect our deployments of hashicorp/dev-portal.

Note: we're working on a more robust fix for this issue in https://github.com/hashicorp/web-platform-packages/pull/47. That fix will allow use to provide more robust resolution of docs `.mdx` files when `versions` is set to `latest`. This may mitigate the need to pin plugins to specific versions when they fail.