### PR TITLE
[CI-only] Build and publish dev dockerhub images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,5 +257,5 @@ jobs:
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:light-${{ env.version }}
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:${{ env.version }}
           dev_tags: |
-            hashicorppreview/${{ env.REPO_NAME }}:${{ env.version }}-dev
+            docker.io/hashicorppreview/${{ env.REPO_NAME }}:${{ env.version }}
             docker.io/hashicorppreview/${{ env.REPO_NAME }}:${{ env.version }}-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,4 +258,4 @@ jobs:
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:${{ env.version }}
           dev_tags: |
             hashicorppreview/${{ env.REPO_NAME }}:${{ env.version }}-dev
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-${{ github.sha }}
+            docker.io/hashicorppreview/${{ env.REPO_NAME }}:${{ env.version }}-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,3 +256,6 @@ jobs:
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:light
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:light-${{ env.version }}
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:${{ env.version }}
+          dev_tags: |
+            hashicorppreview/${{ env.REPO_NAME }}:${{ env.version }}-dev
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-${{ github.sha }}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,7 +9,8 @@ project "packer" {
     organization = "hashicorp"
     repository = "packer"
     release_branches = [
-        "main"
+        "main",
+        "support-dev-image-publishing",
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,8 +9,7 @@ project "packer" {
     organization = "hashicorp"
     repository = "packer"
     release_branches = [
-        "main",
-        "support-dev-image-publishing",
+        "main"
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -161,6 +161,20 @@ event "verify" {
   }
 }
 
+event "promote-dev-docker" {
+  depends = ["verify"]
+  action "promote-dev-docker" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-dev-docker"
+    depends = ["verify"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
 ## These are promotion and post-publish events
 ## they should be added to the end of the file after the verify event stanza.
 


### PR DESCRIPTION
### Description

This introduces build/publishing of dev dockerhub images to the `hashicorppreview` dockerhub org. This will be kicked off when a PR is merged to any of the release branches (or main) listed in the `release_branches` array in `.release/ci.hcl`. 

The two tags that will be published are `vX.Y.Z-dev` and `vX.Y.Z-dev-$COMMITSHA`. `vX.Y.Z-dev` will be updated to the latest image built from the code in the tip of the branch, and `vX.Y.Z-dev-$COMMITSHA` will point to the image built from the commit itself- the latter will be most useful for debugging individual commits.

### Testing & Reproduction steps
I tested out a publish from this test branch in commit: https://github.com/hashicorp/packer/commit/572f67739b992587dc6f3f7c482ad5dac3830dcb. You can see the images available here: https://hub.docker.com/r/hashicorppreview/packer/tags (which I will delete after this PR is merged). 

### Links
Link to full documentation describing how dev images are created and published, their naming conventions, etc: https://go.hashi.co/dev-docker-images

