### PR TITLE
Upgrade parallels plugin version up to 1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/hashicorp/packer-plugin-openstack v1.0.0
 	github.com/hashicorp/packer-plugin-oracle v1.0.1
 	github.com/hashicorp/packer-plugin-outscale v1.0.2
-	github.com/hashicorp/packer-plugin-parallels v1.0.0
+	github.com/hashicorp/packer-plugin-parallels v1.0.1
 	github.com/hashicorp/packer-plugin-profitbricks v1.0.1
 	github.com/hashicorp/packer-plugin-proxmox v1.0.4
 	github.com/hashicorp/packer-plugin-puppet v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -755,8 +755,8 @@ github.com/hashicorp/packer-plugin-oracle v1.0.1 h1:J2jNLTslCoq9RmMIGA+tsPjqdIZZ
 github.com/hashicorp/packer-plugin-oracle v1.0.1/go.mod h1:9sQcSpS48i4jv3PHWSBuOuO+deAuitZ4ODuZCo/KJfU=
 github.com/hashicorp/packer-plugin-outscale v1.0.2 h1:vO+sMTJNvudtwgJN4C8J4jDMvAhOzYo9YBRLepdVFUo=
 github.com/hashicorp/packer-plugin-outscale v1.0.2/go.mod h1:ZMG1MCuIDqsCr5tNHFNX8PbsQSmAdUNVlGYmdTPx1oM=
-github.com/hashicorp/packer-plugin-parallels v1.0.0 h1:01KR2Br+x8JjjXA4+0RphPU5VKmGlHwQd/baZwncGH0=
-github.com/hashicorp/packer-plugin-parallels v1.0.0/go.mod h1:iRJuNflTXPLxdWEXCNA2JdeQPglric8xidCKaouBazY=
+github.com/hashicorp/packer-plugin-parallels v1.0.1 h1:ejIRJYVeLYhejMz4pVgTogE4zIXI95YpDwzUT6EJ+Cg=
+github.com/hashicorp/packer-plugin-parallels v1.0.1/go.mod h1:e1lODIE9sjtQAR+Y5C5XF7MIqPvEiHGfYLjoIG4oumU=
 github.com/hashicorp/packer-plugin-profitbricks v1.0.1 h1:yFLUoDvm/zwzqj3J4a4pe49JpeDDGx08U9B38FXEyNk=
 github.com/hashicorp/packer-plugin-profitbricks v1.0.1/go.mod h1:qtDQ7sbc0hMXWuxt0gweUwsVyVIazRLyNCHPO19CPU0=
 github.com/hashicorp/packer-plugin-proxmox v1.0.4 h1:z0D7NjGRjHGzlQTk62O33XQiOz4dhOvEnb6e757bniE=


### PR DESCRIPTION
This commit allows to run packer with Parallels Desktop on macOS Monterey >=12.3 w/o necessity to specify plugin version in every template.

Bumps [github/hashicorp/packer-plugin-parallels](https://github.com/hashicorp/packer-plugin-parallels) from 1.0.0 to 1.0.1.
- [Release notes](https://github.com/hashicorp/packer-plugin-parallels/releases)
- [Commits](https://github.com/hashicorp/packer-plugin-parallels/compare/v1.0.0...v1.0.1)