### PR TITLE
docs: Update for packer config file location docs

### DIFF
--- a/website/content/docs/configure.mdx
+++ b/website/content/docs/configure.mdx
@@ -34,12 +34,12 @@ to be set :
 Packer can optionally read a JSON file for the end user to set core settings.
 The config file of Packer will be looked up on the following paths:
 
-| unix                            | windows                          |
-| ------------------------------- | -------------------------------- |
-| `${PACKER_CONFIG}`              | `%PACKER_CONFIG%`                |
-| `PACKER_HOME_DIR/.packerconfig` | `PACKER_HOME_DIR/packer.config/` |
-
-It is not an error if no config file was found.
+| unix                             | windows                          |
+| -------------------------------  | -------------------------------- |
+| `${PACKER_CONFIG}`               | `%PACKER_CONFIG%`                |
+| `PACKER_HOME_DIR/.packerconfig`  | `PACKER_HOME_DIR/packer.config/` |
+| `${XDG_CONFIG_HOME}/packer`      |                                  |
+| `PACKER_HOME_DIR/.config/packer` |                                  |
 
 ## Packer's config directory
 


### PR DESCRIPTION
Updating packer config file locations docs for Unix. Unfortunately I made this change a while ago in packer-plugin-sdk, but forgot to update the docs 😞 

Based on logic [in this file from packer-plugin-sdk](https://github.com/hashicorp/packer-plugin-sdk/blob/main/pathing/config_file_unix.go)

Closes #11781 
