### PR TITLE
Remove Access Token Check, Silence curl request, and Merge Clone & Test steps in HPATS

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -82,8 +82,7 @@ jobs:
           cd hcp-packer-acceptance-tests
       - name: Set HCP Access Token
         run: |
-          export HCP_ACCESS_TOKEN=$(curl --request POST --header "Content-Type: application/json" --data '{"audience": "https://api.hashicorp.cloud","grant_type": "client_credentials","client_id": "'"$AUTH0_CLIENT_ID"'","client_secret": "'"$AUTH0_CLIENT_SECRET"'"}' "${AUTH0_HOST}/oauth/token" | jq '.access_token' --raw-output)
-          if [ -z $HCP_ACCESS_TOKEN ]; then; echo "HCP_ACCESS_TOKEN was not set" && exit 1; else echo "HCP_ACCESS_TOKEN set"; fi;
+          export HCP_ACCESS_TOKEN=$(curl --silent --request POST --header "Content-Type: application/json" --data '{"audience": "https://api.hashicorp.cloud","grant_type": "client_credentials","client_id": "'"$AUTH0_CLIENT_ID"'","client_secret": "'"$AUTH0_CLIENT_SECRET"'"}' "${AUTH0_HOST}/oauth/token" | jq '.access_token' --raw-output)
       - name: Run HPATS
         run: make test
   # Send a slack notification if one of the jobs defined above fails

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -75,16 +75,15 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-      - name: Clone HPATS
+      - name: Set HCP Access Token
+        run: |
+          export HCP_ACCESS_TOKEN=$(curl --silent --request POST --header "Content-Type: application/json" --data '{"audience": "https://api.hashicorp.cloud","grant_type": "client_credentials","client_id": "'"$AUTH0_CLIENT_ID"'","client_secret": "'"$AUTH0_CLIENT_SECRET"'"}' "${AUTH0_HOST}/oauth/token" | jq '.access_token' --raw-output)
+      - name: Clone & Run HPATS
         run: |
           eval `ssh-agent -s` && ssh-add - <<< '${{ secrets.HPATS_ACCESS_TOKEN }}'
           git clone git@github.com:hashicorp/hcp-packer-acceptance-tests
           cd hcp-packer-acceptance-tests
-      - name: Set HCP Access Token
-        run: |
-          export HCP_ACCESS_TOKEN=$(curl --silent --request POST --header "Content-Type: application/json" --data '{"audience": "https://api.hashicorp.cloud","grant_type": "client_credentials","client_id": "'"$AUTH0_CLIENT_ID"'","client_secret": "'"$AUTH0_CLIENT_SECRET"'"}' "${AUTH0_HOST}/oauth/token" | jq '.access_token' --raw-output)
-      - name: Run HPATS
-        run: make test
+          make test
   # Send a slack notification if one of the jobs defined above fails
   slack-notify:
     needs: 


### PR DESCRIPTION
Updates HPATS since we realized the internal tests can validate that environment variable, also forgot to add `--silent` flag to curl to suppress output