### PR TITLE
Add support for Env in remote shell provisioners

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -439,6 +439,18 @@ func (p *Provisioner) createFlattenedEnvVars(elevated bool) (flattened string) {
 		envVars[keyValue[0]] = escapedEnvVarValue
 	}
 
+	for k, v := range p.config.Env {
+		envVarName, err := interpolate.Render(k, &p.config.ctx)
+		if err != nil {
+			return
+		}
+		envVarValue, err := interpolate.Render(v, &p.config.ctx)
+		if err != nil {
+			return
+		}
+		envVars[envVarName] = psEscape.Replace(envVarValue)
+	}
+
 	// Create a list of env var keys in sorted order
 	var keys []string
 	for k := range envVars {

--- a/provisioner/powershell/provisioner_test.go
+++ b/provisioner/powershell/provisioner_test.go
@@ -606,16 +606,44 @@ func TestProvisioner_createFlattenedElevatedEnvVars_windows(t *testing.T) {
 		{"FOO=bar`baz"},  // User env var with value containing a backtick
 
 	}
+	userEnvVarmapTests := []map[string]string{
+		{},
+		{
+			"BAR": "foo",
+		},
+		{
+			"BAR": "foo",
+			"YAR": "yaa",
+		},
+		{
+			"BAR": "foo=yaa",
+		},
+		{
+			"BAR": "=foo",
+		},
+		{
+			"BAR": "foo$yaa",
+		},
+		{
+			"BAR": "foo\"yaa",
+		},
+		{
+			"BAR": "foo'yaa",
+		},
+		{
+			"BAR": "foo`yaa",
+		},
+	}
 	expected := []string{
 		`$env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		`$env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		`$env:BAZ="qux"; $env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		`$env:FOO="bar=baz"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		`$env:FOO="=bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		"$env:FOO=\"bar`$baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
-		"$env:FOO=\"bar`\"baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
-		"$env:FOO=\"bar`'baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
-		"$env:FOO=\"bar``baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		`$env:BAR="foo"; $env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
+		`$env:BAR="foo"; $env:BAZ="qux"; $env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; $env:YAR="yaa"; `,
+		`$env:BAR="foo=yaa"; $env:FOO="bar=baz"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
+		`$env:BAR="=foo"; $env:FOO="=bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
+		"$env:BAR=\"foo`$yaa\"; $env:FOO=\"bar`$baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:BAR=\"foo`\"yaa\"; $env:FOO=\"bar`\"baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:BAR=\"foo`'yaa\"; $env:FOO=\"bar`'baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:BAR=\"foo``yaa\"; $env:FOO=\"bar``baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
 	}
 
 	p := new(Provisioner)
@@ -628,6 +656,7 @@ func TestProvisioner_createFlattenedElevatedEnvVars_windows(t *testing.T) {
 
 	for i, expectedValue := range expected {
 		p.config.Vars = userEnvVarTests[i]
+		p.config.Env = userEnvVarmapTests[i]
 		flattenedEnvVars = p.createFlattenedEnvVars(true)
 		if flattenedEnvVars != expectedValue {
 			t.Fatalf("expected flattened env vars to be: %s, got %s.", expectedValue, flattenedEnvVars)
@@ -758,16 +787,44 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 		{"FOO=bar'baz"},  // User env var with value containing a single quote
 		{"FOO=bar`baz"},  // User env var with value containing a backtick
 	}
+	userEnvVarmapTests := []map[string]string{
+		{},
+		{
+			"BAR": "foo",
+		},
+		{
+			"BAR": "foo",
+			"YAR": "yaa",
+		},
+		{
+			"BAR": "foo=yaa",
+		},
+		{
+			"BAR": "=foo",
+		},
+		{
+			"BAR": "foo$yaa",
+		},
+		{
+			"BAR": "foo\"yaa",
+		},
+		{
+			"BAR": "foo'yaa",
+		},
+		{
+			"BAR": "foo`yaa",
+		},
+	}
 	expected := []string{
 		`$env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		`$env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		`$env:BAZ="qux"; $env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		`$env:FOO="bar=baz"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		`$env:FOO="=bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
-		"$env:FOO=\"bar`$baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
-		"$env:FOO=\"bar`\"baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
-		"$env:FOO=\"bar`'baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
-		"$env:FOO=\"bar``baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		`$env:BAR="foo"; $env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
+		`$env:BAR="foo"; $env:BAZ="qux"; $env:FOO="bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; $env:YAR="yaa"; `,
+		`$env:BAR="foo=yaa"; $env:FOO="bar=baz"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
+		`$env:BAR="=foo"; $env:FOO="=bar"; $env:PACKER_BUILDER_TYPE="iso"; $env:PACKER_BUILD_NAME="vmware"; `,
+		"$env:BAR=\"foo`$yaa\"; $env:FOO=\"bar`$baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:BAR=\"foo`\"yaa\"; $env:FOO=\"bar`\"baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:BAR=\"foo`'yaa\"; $env:FOO=\"bar`'baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
+		"$env:BAR=\"foo``yaa\"; $env:FOO=\"bar``baz\"; $env:PACKER_BUILDER_TYPE=\"iso\"; $env:PACKER_BUILD_NAME=\"vmware\"; ",
 	}
 
 	p := new(Provisioner)
@@ -780,6 +837,7 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 
 	for i, expectedValue := range expected {
 		p.config.Vars = userEnvVarTests[i]
+		p.config.Env = userEnvVarmapTests[i]
 		flattenedEnvVars = p.createFlattenedEnvVars(false)
 		if flattenedEnvVars != expectedValue {
 			t.Fatalf("expected flattened env vars to be: %s, got %s.", expectedValue, flattenedEnvVars)

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -438,6 +438,13 @@ func (p *Provisioner) escapeEnvVars() ([]string, map[string]string) {
 		envVars[keyValue[0]] = strings.Replace(keyValue[1], "'", `'"'"'`, -1)
 	}
 
+	// Add the environment variables defined in the HCL specs
+	for k, v := range p.config.Env {
+		// As with p.config.Vars, we escape single-quotes so they're not
+		// misinterpreted by the remote shell.
+		envVars[k] = strings.Replace(v, "'", `'"'"'`, -1)
+	}
+
 	// Create a list of env var keys in sorted order
 	var keys []string
 	for k := range envVars {

--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -262,13 +262,32 @@ func TestProvisioner_createFlattenedEnvVars(t *testing.T) {
 		{"FOO=bar=baz"},        // User env var with value containing equals
 		{"FOO==bar"},           // User env var with value starting with equals
 	}
+	userEnvVarEnvmapTests := []map[string]string{
+		{},
+		{
+			"BAR": "foo",
+		},
+		{
+			"BAR": "foo's",
+		},
+		{
+			"BAR": "foo",
+			"YAR": "yaa",
+		},
+		{
+			"BAR": "foo=yar",
+		},
+		{
+			"BAR": "=foo",
+		},
+	}
 	expected := []string{
 		`PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
-		`FOO='bar' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
-		`FOO='bar'"'"'s' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
-		`BAZ='qux' FOO='bar' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
-		`FOO='bar=baz' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
-		`FOO='=bar' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
+		`BAR='foo' FOO='bar' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
+		`BAR='foo'"'"'s' FOO='bar'"'"'s' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
+		`BAR='foo' BAZ='qux' FOO='bar' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' YAR='yaa' `,
+		`BAR='foo=yar' FOO='bar=baz' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
+		`BAR='=foo' FOO='=bar' PACKER_BUILDER_TYPE='iso' PACKER_BUILD_NAME='vmware' `,
 	}
 
 	p := new(Provisioner)
@@ -281,6 +300,7 @@ func TestProvisioner_createFlattenedEnvVars(t *testing.T) {
 
 	for i, expectedValue := range expected {
 		p.config.Vars = userEnvVarTests[i]
+		p.config.Env = userEnvVarEnvmapTests[i]
 		flattenedEnvVars = p.createFlattenedEnvVars()
 		if flattenedEnvVars != expectedValue {
 			t.Fatalf("expected flattened env vars to be: %s, got %s.", expectedValue, flattenedEnvVars)
@@ -300,13 +320,32 @@ func TestProvisioner_createFlattenedEnvVars_withEnvVarFormat(t *testing.T) {
 		{"FOO=bar=baz"},        // User env var with value containing equals
 		{"FOO==bar"},           // User env var with value starting with equals
 	}
+	userEnvVarEnvmapTests := []map[string]string{
+		{},
+		{
+			"BAR": "foo",
+		},
+		{
+			"BAR": "foo's",
+		},
+		{
+			"BAR": "foo",
+			"YAR": "yaa",
+		},
+		{
+			"BAR": "foo=yar",
+		},
+		{
+			"BAR": "=foo",
+		},
+	}
 	expected := []string{
 		`PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
-		`FOO=bar PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
-		`FOO=bar'"'"'s PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
-		`BAZ=qux FOO=bar PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
-		`FOO=bar=baz PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
-		`FOO==bar PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
+		`BAR=foo FOO=bar PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
+		`BAR=foo'"'"'s FOO=bar'"'"'s PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
+		`BAR=foo BAZ=qux FOO=bar PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware YAR=yaa `,
+		`BAR=foo=yar FOO=bar=baz PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
+		`BAR==foo FOO==bar PACKER_BUILDER_TYPE=iso PACKER_BUILD_NAME=vmware `,
 	}
 
 	p := new(Provisioner)
@@ -320,6 +359,7 @@ func TestProvisioner_createFlattenedEnvVars_withEnvVarFormat(t *testing.T) {
 
 	for i, expectedValue := range expected {
 		p.config.Vars = userEnvVarTests[i]
+		p.config.Env = userEnvVarEnvmapTests[i]
 		flattenedEnvVars = p.createFlattenedEnvVars()
 		if flattenedEnvVars != expectedValue {
 			t.Fatalf("expected flattened env vars to be: %s, got %s.", expectedValue, flattenedEnvVars)
@@ -339,28 +379,53 @@ func TestProvisioner_createEnvVarFileContent(t *testing.T) {
 		{"FOO=bar=baz"},        // User env var with value containing equals
 		{"FOO==bar"},           // User env var with value starting with equals
 	}
+	userEnvVarEnvmapTests := []map[string]string{
+		{},
+		{
+			"BAR": "foo",
+		},
+		{
+			"BAR": "foo's",
+		},
+		{
+			"BAR": "foo",
+			"YAR": "yaa",
+		},
+		{
+			"BAR": "foo=yar",
+		},
+		{
+			"BAR": "=foo",
+		},
+	}
 	expected := []string{
 		`export PACKER_BUILDER_TYPE='iso'
 export PACKER_BUILD_NAME='vmware'
 `,
-		`export FOO='bar'
-export PACKER_BUILDER_TYPE='iso'
-export PACKER_BUILD_NAME='vmware'
-`,
-		`export FOO='bar'"'"'s'
-export PACKER_BUILDER_TYPE='iso'
-export PACKER_BUILD_NAME='vmware'
-`,
-		`export BAZ='qux'
+		`export BAR='foo'
 export FOO='bar'
 export PACKER_BUILDER_TYPE='iso'
 export PACKER_BUILD_NAME='vmware'
 `,
-		`export FOO='bar=baz'
+		`export BAR='foo'"'"'s'
+export FOO='bar'"'"'s'
 export PACKER_BUILDER_TYPE='iso'
 export PACKER_BUILD_NAME='vmware'
 `,
-		`export FOO='=bar'
+		`export BAR='foo'
+export BAZ='qux'
+export FOO='bar'
+export PACKER_BUILDER_TYPE='iso'
+export PACKER_BUILD_NAME='vmware'
+export YAR='yaa'
+`,
+		`export BAR='foo=yar'
+export FOO='bar=baz'
+export PACKER_BUILDER_TYPE='iso'
+export PACKER_BUILD_NAME='vmware'
+`,
+		`export BAR='=foo'
+export FOO='=bar'
 export PACKER_BUILDER_TYPE='iso'
 export PACKER_BUILD_NAME='vmware'
 `,
@@ -377,6 +442,7 @@ export PACKER_BUILD_NAME='vmware'
 
 	for i, expectedValue := range expected {
 		p.config.Vars = userEnvVarTests[i]
+		p.config.Env = userEnvVarEnvmapTests[i]
 		flattenedEnvVars = p.createEnvVarFileContent()
 		if flattenedEnvVars != expectedValue {
 			t.Fatalf("expected flattened env vars to be: %s, got %s.", expectedValue, flattenedEnvVars)
@@ -394,20 +460,37 @@ func TestProvisioner_createEnvVarFileContent_withEnvVarFormat(t *testing.T) {
 		{"FOO=bar=baz"},        // User env var with value containing equals
 		{"FOO==bar"},           // User env var with value starting with equals
 	}
+	userEnvVarEnvmapTests := []map[string]string{
+		{},
+		{
+			"BAR": "foo",
+			"YAR": "yaa",
+		},
+		{
+			"BAR": "foo=yar",
+		},
+		{
+			"BAR": "=foo",
+		},
+	}
 	expected := []string{
 		`PACKER_BUILDER_TYPE=iso
 PACKER_BUILD_NAME=vmware
 `,
-		`BAZ=qux
+		`BAR=foo
+BAZ=qux
 FOO=bar
 PACKER_BUILDER_TYPE=iso
 PACKER_BUILD_NAME=vmware
+YAR=yaa
 `,
-		`FOO=bar=baz
+		`BAR=foo=yar
+FOO=bar=baz
 PACKER_BUILDER_TYPE=iso
 PACKER_BUILD_NAME=vmware
 `,
-		`FOO==bar
+		`BAR==foo
+FOO==bar
 PACKER_BUILDER_TYPE=iso
 PACKER_BUILD_NAME=vmware
 `,
@@ -426,6 +509,7 @@ PACKER_BUILD_NAME=vmware
 
 	for i, expectedValue := range expected {
 		p.config.Vars = userEnvVarTests[i]
+		p.config.Env = userEnvVarEnvmapTests[i]
 		flattenedEnvVars = p.createEnvVarFileContent()
 		if flattenedEnvVars != expectedValue {
 			t.Fatalf("expected flattened env vars to be: %q, got %q.", expectedValue, flattenedEnvVars)

--- a/provisioner/windows-shell/provisioner.go
+++ b/provisioner/windows-shell/provisioner.go
@@ -258,6 +258,11 @@ func (p *Provisioner) createFlattenedEnvVars() (flattened string) {
 		keyValue := strings.SplitN(envVar, "=", 2)
 		envVars[keyValue[0]] = keyValue[1]
 	}
+
+	for k, v := range p.config.Env {
+		envVars[k] = v
+	}
+
 	// Create a list of env var keys in sorted order
 	var keys []string
 	for k := range envVars {

--- a/provisioner/windows-shell/provisioner_test.go
+++ b/provisioner/windows-shell/provisioner_test.go
@@ -402,12 +402,28 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 		{"FOO=bar=baz"},        // User env var with value containing equals
 		{"FOO==bar"},           // User env var with value starting with equals
 	}
+	userEnvVarmapTests := []map[string]string{
+		{},
+		{
+			"BAR": "foo",
+		},
+		{
+			"BAR": "foo",
+			"YAR": "yaa",
+		},
+		{
+			"BAR": "foo=yar",
+		},
+		{
+			"BAR": "=foo",
+		},
+	}
 	expected := []string{
 		`set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && `,
-		`set "FOO=bar" && set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && `,
-		`set "BAZ=qux" && set "FOO=bar" && set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && `,
-		`set "FOO=bar=baz" && set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && `,
-		`set "FOO==bar" && set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && `,
+		`set "BAR=foo" && set "FOO=bar" && set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && `,
+		`set "BAR=foo" && set "BAZ=qux" && set "FOO=bar" && set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && set "YAR=yaa" && `,
+		`set "BAR=foo=yar" && set "FOO=bar=baz" && set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && `,
+		`set "BAR==foo" && set "FOO==bar" && set "PACKER_BUILDER_TYPE=iso" && set "PACKER_BUILD_NAME=vmware" && `,
 	}
 
 	p := new(Provisioner)
@@ -420,6 +436,7 @@ func TestProvisioner_createFlattenedEnvVars_windows(t *testing.T) {
 
 	for i, expectedValue := range expected {
 		p.config.Vars = userEnvVarTests[i]
+		p.config.Env = userEnvVarmapTests[i]
 		flattenedEnvVars = p.createFlattenedEnvVars()
 		if flattenedEnvVars != expectedValue {
 			t.Fatalf("expected flattened env vars to be: %s, got %s.", expectedValue, flattenedEnvVars)


### PR DESCRIPTION
Add the support for defining environment variables through the `Env` map for both: windows-shell, powershell and shell.

Closes #11670