### PR TITLE
Remove dead code / superfluous fmt.Sprintf statements

### DIFF
--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -28,8 +28,6 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/uuid"
 )
 
-var retryableSleep = 2 * time.Second
-
 var psEscape = strings.NewReplacer(
 	"$", "`$",
 	"\"", "`\"",

--- a/provisioner/powershell/provisioner.go
+++ b/provisioner/powershell/provisioner.go
@@ -257,7 +257,7 @@ func extractScript(p *Provisioner) (string, error) {
 }
 
 func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packersdk.Communicator, generatedData map[string]interface{}) error {
-	ui.Say(fmt.Sprintf("Provisioning with Powershell..."))
+	ui.Say("Provisioning with Powershell...")
 	p.communicator = comm
 	p.generatedData = generatedData
 


### PR DESCRIPTION
Just a few fixes in the providers/powershell package that the linter would rightfully suggest
