### PR TITLE
Add workflow to link to discuss on new question

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Packer Community Support
+    url: https://discuss.hashicorp.com/c/packer/23
+    about: If you have a question, or are looking for advice, please post on our Discuss forum! The community loves to chime in to help. Happy Coding!

--- a/.github/workflows/auto-close-stale-issues.yml
+++ b/.github/workflows/auto-close-stale-issues.yml
@@ -1,0 +1,23 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 23
+          days-before-pr-stale: -1 # deactivate the action for PRs
+          days-before-close: 7
+          stale-issue-message: |
+            Hi,
+
+            This issue has not received any update in the last 3 weeks, and will automatically be closed in 7 days if it does not receive any activity by then.
+
+            If you find the [community forum](https://discuss.hashicorp.com/c/packer) to be more helpful or if you've found the answer to your question elsewhere please feel free to post a response and close the issue.
+          only-labels: needs-reply

--- a/.github/workflows/issues-opened.yml
+++ b/.github/workflows/issues-opened.yml
@@ -36,7 +36,7 @@ jobs:
 
             For general questions we recommend reaching out to the [community forum](https://discuss.hashicorp.com/c/packer) for greater visibility.
             As the GitHub issue tracker is only watched by a small subset of maintainers and is really reserved for bugs and enhancements, you'll have a better chance of finding someone who can help you in the forum.
-            We'll mark this issue as needs-reply to help inform folks, including maintainers, that this question is awaiting a response.
+            We'll mark this issue as needs-reply to help inform maintainers that this question is awaiting a response.
             If no activity is taken on this question within 30 days it will be automatically closed.
 
             If you find the forum to be more helpful or if you've found the answer to your question elsewhere please feel free to post a response and close the issue.

--- a/.github/workflows/issues-opened.yml
+++ b/.github/workflows/issues-opened.yml
@@ -23,4 +23,25 @@ jobs:
           github-token: ${{ secrets.PACKER_PROJ_BOARD_TOKEN }}
           labeled: bug, enhancement
           label-operator: OR
+  label-question:
+    name: Redirect to discuss
+    if: contains(github.event.issue.labels.*.name, 'question')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-create-comment@v1.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Hi 👋 thanks for reaching out.
+
+            For general questions we recommend reaching out to the [community forum](https://discuss.hashicorp.com/c/packer) for greater visibility.
+            As the GitHub issue tracker is only watched by a small subset of maintainers and is really reserved for bugs and enhancements, you'll have a better chance of finding someone who can help you in the forum.
+            We'll mark this issue as needs-reply to help inform folks, including maintainers, that this question is awaiting a response.
+            If no activity is taken on this question within 30 days it will be automatically closed.
+
+            If you find the forum to be more helpful or if you've found the answer to your question elsewhere please feel free to post a response and close the issue.
+      - uses: actions-ecosystem/action-add-labels@v1.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: needs-reply
 


### PR DESCRIPTION
While some of the community lives here, this is not the best place to ask general usage-related questions, as that would be the forums (https://discuss.hashicorp.com/c/packer).

However, users may not yet know this exists, and to make it clearer this is the best place for asking such questions, as well as make issue-tracking smoother for maintainers of the project, we add an action to automatically signal the intent of such forum, and state that such issues are best opened there.