### PR TITLE
Associate Packer build to HCP Packer parent iteration

### DIFF
--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -366,6 +366,9 @@ var cmpOpts = []cmp.Option{
 	cmpopts.IgnoreFields(packerregistry.Iteration{},
 		"Fingerprint", // Fingerprint will change everytime
 	),
+	cmpopts.IgnoreFields(packerregistry.Bucket{},
+		"SourceImagesToParentIterations", // Requires execution of datasource at this time
+	),
 	cmpopts.IgnoreFields(VariableAssignment{},
 		"Expr", // its an interface
 	),

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -253,6 +253,21 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		for _, source := range build.Sources {
 			cfg.bucket.RegisterBuildForComponent(source.String())
 		}
+
+		// Known HCP Packer Image Datasource, whose id is the SourceImageId for some build.
+		const hcpDatasourceType string = "hcp-packer-image"
+		values := ectx.Variables[dataAccessor].AsValueMap()
+
+		dsValues, ok := values[hcpDatasourceType]
+		if !ok {
+			return build, diags
+		}
+
+		for _, value := range dsValues.AsValueMap() {
+			values := value.AsValueMap()
+			imgId, itId := values["id"], values["iteration_id"]
+			cfg.bucket.SourceImagesToParentIterations[imgId.AsString()] = itId.AsString()
+		}
 	}
 
 	return build, diags

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -265,8 +265,8 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 
 		for _, value := range dsValues.AsValueMap() {
 			values := value.AsValueMap()
-			imgId, itId := values["id"], values["iteration_id"]
-			cfg.bucket.SourceImagesToParentIterations[imgId.AsString()] = itId.AsString()
+			imgID, itID := values["id"], values["iteration_id"]
+			cfg.bucket.SourceImagesToParentIterations[imgID.AsString()] = itID.AsString()
 		}
 	}
 

--- a/hcl2template/types.build.hcp_packer_registry.go
+++ b/hcl2template/types.build.hcp_packer_registry.go
@@ -48,7 +48,8 @@ func (p *Parser) decodeHCPRegistry(block *hcl.Block, cfg *PackerConfig) (*HCPPac
 		BuildLabels  map[string]string `hcl:"build_labels,optional"`
 		Config       hcl.Body          `hcl:",remain"`
 	}
-	diags := gohcl.DecodeBody(body, cfg.EvalContext(LocalContext, nil), &b)
+	ectx := cfg.EvalContext(DatasourceContext, nil)
+	diags := gohcl.DecodeBody(body, ectx, &b)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/hcl2template/types.build.hcp_packer_registry.go
+++ b/hcl2template/types.build.hcp_packer_registry.go
@@ -48,7 +48,7 @@ func (p *Parser) decodeHCPRegistry(block *hcl.Block, cfg *PackerConfig) (*HCPPac
 		BuildLabels  map[string]string `hcl:"build_labels,optional"`
 		Config       hcl.Body          `hcl:",remain"`
 	}
-	ectx := cfg.EvalContext(DatasourceContext, nil)
+	ectx := cfg.EvalContext(BuildContext, nil)
 	diags := gohcl.DecodeBody(body, ectx, &b)
 	if diags.HasErrors() {
 		return nil, diags

--- a/hcl2template/types.build.hcp_packer_registry_test.go
+++ b/hcl2template/types.build.hcp_packer_registry_test.go
@@ -1,6 +1,7 @@
 package hcl2template
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -11,6 +12,9 @@ import (
 )
 
 func Test_ParseHCPPackerRegistryBlock(t *testing.T) {
+	os.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "hcp-par-test")
+	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
+
 	defaultParser := getBasicParser()
 
 	tests := []parseTest{

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -192,6 +192,7 @@ func (client *Client) UpdateBuild(
 	runUUID,
 	cloudProvider,
 	sourceImageID string,
+	sourceIterationID string,
 	labels map[string]string,
 	status models.HashicorpCloudPackerBuildStatus,
 	images []*models.HashicorpCloudPackerImageCreateBody,
@@ -205,12 +206,13 @@ func (client *Client) UpdateBuild(
 	params.Body = &models.HashicorpCloudPackerUpdateBuildRequest{
 		BuildID: buildID,
 		Updates: &models.HashicorpCloudPackerBuildUpdates{
-			Images:        images,
-			PackerRunUUID: runUUID,
-			Labels:        labels,
-			Status:        status,
-			CloudProvider: cloudProvider,
-			SourceImageID: sourceImageID,
+			Images:            images,
+			PackerRunUUID:     runUUID,
+			Labels:            labels,
+			Status:            status,
+			CloudProvider:     cloudProvider,
+			SourceImageID:     sourceImageID,
+			SourceIterationID: sourceIterationID,
 		},
 	}
 

--- a/internal/registry/types.bucket_service_test.go
+++ b/internal/registry/types.bucket_service_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestInitialize_NewBucketNewIteration(t *testing.T) {
 	//nolint:errcheck
-	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	os.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
 	mockService := NewMockPackerClientService()
 
@@ -66,7 +66,7 @@ func TestInitialize_NewBucketNewIteration(t *testing.T) {
 
 func TestInitialize_ExistingBucketNewIteration(t *testing.T) {
 	//nolint:errcheck
-	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	os.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
 	mockService := NewMockPackerClientService()
 	mockService.BucketAlreadyExist = true
@@ -123,7 +123,7 @@ func TestInitialize_ExistingBucketNewIteration(t *testing.T) {
 
 func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 	//nolint:errcheck
-	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	os.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
 	mockService := NewMockPackerClientService()
 	mockService.BucketAlreadyExist = true
@@ -195,7 +195,7 @@ func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 
 func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
 	//nolint:errcheck
-	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	os.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
 	mockService := NewMockPackerClientService()
 	mockService.BucketAlreadyExist = true
@@ -243,7 +243,7 @@ func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
 
 func TestUpdateBuildStatus(t *testing.T) {
 	//nolint:errcheck
-	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	os.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
 	mockService := NewMockPackerClientService()
 	mockService.BucketAlreadyExist = true
@@ -300,7 +300,7 @@ func TestUpdateBuildStatus(t *testing.T) {
 
 func TestUpdateBuildStatus_DONENoImages(t *testing.T) {
 	//nolint:errcheck
-	os.Setenv("HCP_PACKER_BUILD_FINGEPRINT", "testnumber")
+	os.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "testnumber")
 	defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
 	mockService := NewMockPackerClientService()
 	mockService.BucketAlreadyExist = true

--- a/internal/registry/types.bucket_test.go
+++ b/internal/registry/types.bucket_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -278,9 +279,12 @@ func TestBucket_PopulateIteration(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tc {
+	for i, tt := range tc {
 		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+
+			os.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "test-run-"+strconv.Itoa(i))
+			defer os.Unsetenv("HCP_PACKER_BUILD_FINGERPRINT")
 
 			mockService := NewMockPackerClientService()
 			mockService.BucketAlreadyExist = true


### PR DESCRIPTION
This change allows Packer core to validate that a newly build image is a child of a HCP Packer registry source image. This association is handle by checking the source of a build against the reported source image of a build artifact that is configured to publish to the HCP Packer registry. 