### PR TITLE
registry: add heartbeat call for running builds

### DIFF
--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -144,9 +144,10 @@ func (b *Bucket) CreateInitialBuildForIteration(ctx context.Context, componentTy
 }
 
 // UpdateBuildStatus updates the status of a build entry on the HCP Packer registry with its current local status.
+// For updating a build status to DONE use CompleteBuild.
 func (b *Bucket) UpdateBuildStatus(ctx context.Context, name string, status models.HashicorpCloudPackerBuildStatus) error {
 	if status == models.HashicorpCloudPackerBuildStatusDONE {
-		return b.markBuildComplete(ctx, name)
+		return fmt.Errorf("do not use UpdateBuildStatus for updating to DONE")
 	}
 
 	buildToUpdate, err := b.Iteration.Build(name)
@@ -176,10 +177,10 @@ func (b *Bucket) UpdateBuildStatus(ctx context.Context, name string, status mode
 	return nil
 }
 
-// markBuildComplete should be called to set a build on the HCP Packer registry to DONE.
+// CompleteBuild should be called to set a build on the HCP Packer registry to DONE.
 // Upon a successful call markBuildComplete will publish all images created by the named build,
 // and set the registry build to done. A build with no images can not be set to DONE.
-func (b *Bucket) markBuildComplete(ctx context.Context, name string) error {
+func (b *Bucket) CompleteBuild(ctx context.Context, name string) error {
 	buildToUpdate, err := b.Iteration.Build(name)
 	if err != nil {
 		return err

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -161,10 +161,10 @@ func (b *Bucket) UpdateBuildStatus(ctx context.Context, name string, status mode
 	_, err = b.client.UpdateBuild(ctx,
 		buildToUpdate.ID,
 		buildToUpdate.RunUUID,
-		buildToUpdate.CloudProvider,
 		"",
 		"",
-		buildToUpdate.Labels,
+		"",
+		nil,
 		status,
 		nil,
 	)

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -159,6 +159,10 @@ func (b *Bucket) UpdateBuildStatus(ctx context.Context, name string, status mode
 		return fmt.Errorf("the build for the component %q does not have a valid id", name)
 	}
 
+	if buildToUpdate.Status == models.HashicorpCloudPackerBuildStatusDONE {
+		return fmt.Errorf("cannot modify status of DONE build %s", name)
+	}
+
 	_, err = b.client.UpdateBuild(ctx,
 		buildToUpdate.ID,
 		buildToUpdate.RunUUID,

--- a/packer/registry_builder.go
+++ b/packer/registry_builder.go
@@ -50,6 +50,14 @@ func (b *RegistryBuilder) Run(ctx context.Context, ui packersdk.Ui, hook packers
 		log.Printf("[TRACE] failed to update HCP Packer registry status for %q: %s", b.Name, err)
 	}
 
+	cleanupHeartbeat, err := b.ArtifactMetadataPublisher.HeartbeatBuild(ctx, b.Name)
+	if err != nil {
+		log.Printf("[ERROR] failed to start heartbeat function")
+	}
+	if cleanupHeartbeat != nil {
+		defer cleanupHeartbeat()
+	}
+
 	ui.Say(fmt.Sprintf("Publishing build details for %s to the HCP Packer registry", b.Name))
 	artifact, err := b.Builder.Run(ctx, ui, hook)
 	if err != nil {

--- a/packer/registry_post_processor.go
+++ b/packer/registry_post_processor.go
@@ -39,7 +39,7 @@ func (p *RegistryPostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui
 	// This is a bit of a hack for now to denote that this pp should just update the state of a build in the Packer registry.
 	// TODO create an actual post-processor that we can embed here that will do the updating and printing.
 	if p.PostProcessor == nil {
-		if parErr := p.ArtifactMetadataPublisher.UpdateBuildStatus(ctx, p.BuilderType, models.HashicorpCloudPackerBuildStatusDONE); parErr != nil {
+		if parErr := p.ArtifactMetadataPublisher.CompleteBuild(ctx, p.BuilderType); parErr != nil {
 			err := fmt.Errorf("[TRACE] failed to update Packer registry with image artifacts for %q: %s", p.BuilderType, parErr)
 			return nil, false, true, err
 		}


### PR DESCRIPTION
When a build is running, we send periodic heartbeats to HCP Packer's
API.

This will be used on the service side to detect if a build is stalled on
the core side because of a crash or any other malfunction that caused
Packer not to send an update on the status of a build.