### PR TITLE
[WIP] Include password datasource plugin in Packer site docs.

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -332,5 +332,12 @@
     "repo": "hashicorp/packer-plugin-yandex",
     "version": "latest",
     "pluginTier": "community"
-  }
+  },
+  {
+    "title": "Password",
+    "path": "password",
+    "repo": " alexp-computematrix/packer-plugin-password",
+    "pluginTier": "community",    
+    "version": "latest",
+  }  
 ]

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -215,6 +215,13 @@
     "version": "latest"
   },
   {
+    "title": "Password",
+    "path": "password",
+    "repo": " alexp-computematrix/packer-plugin-password",
+    "pluginTier": "community",    
+    "version": "latest",
+  },  
+  {
     "title": "Profitbricks",
     "path": "profitbricks",
     "repo": "hashicorp/packer-plugin-profitbricks",
@@ -332,12 +339,5 @@
     "repo": "hashicorp/packer-plugin-yandex",
     "version": "latest",
     "pluginTier": "community"
-  },
-  {
-    "title": "Password",
-    "path": "password",
-    "repo": " alexp-computematrix/packer-plugin-password",
-    "pluginTier": "community",    
-    "version": "latest",
-  }  
+  } 
 ]

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -217,7 +217,7 @@
   {
     "title": "Password",
     "path": "password",
-    "repo": " alexp-computematrix/packer-plugin-password",
+    "repo": "alexp-computematrix/packer-plugin-password",
     "pluginTier": "community",    
     "version": "latest",
   },  


### PR DESCRIPTION
Hello everyone,

Dropping in to propose my first contribution to the Packer project, after having been using it in production for over a year now.

Decided to append the "WIP" label to this request to in order to encourage discussion from the community and receive feedback before officially requesting the addition to the Packer plugin site docs.

In short, this datasource plugin is used to generate cryptographically secure pseudo-random passwords for use within a build environment. Users can also optionally specify a desired password when needed.

The main goal is to reduce the complications surrounding GNU/Linux (/etc/shadow) and BSD (/etc/master.passwd) compatible password creation, by preventing the need for external scripts or additional steps. There is also the added convenience of redacting plaintext passwords in build configuration files, reducing fallout in the event of CI/CD / repository compromise. 

Outputs for other use cases are also provided, such as MD5 hex checksum, for databases which still use unsalted hashing for storing credentials.

There is Datasource ACCT tests for the plugin, as well as module tests:
- https://github.com/alexp-computematrix/packer-plugin-password/blob/main/password/datasource_acct_test.go
- https://github.com/alexp-computematrix/packer-plugin-password/blob/main/password/password_test.go
- https://github.com/alexp-computematrix/packer-plugin-password/blob/main/password/test-fixtures/outputs.pkr.hcl

I encourage you all to visit the repository and review the README.md for additional insight if interested.
[packer-plugin-password](https://github.com/alexp-computematrix/packer-plugin-password)

Appreciate your time and consideration.