### PR TITLE
hcp-packer-image: add support for channel

### DIFF
--- a/datasource/hcp-packer-image/data.go
+++ b/datasource/hcp-packer-image/data.go
@@ -39,7 +39,7 @@ type Config struct {
 	// `hcp_packer_image`s use a shared `hcp_packer_iteration` that will
 	// only generate one potentially billable request.
 	Channel string `mapstructure:"channel" required:"true"`
-	// The name of the iteration Id to use when retrieving your image
+	// The ID of the iteration to use when retrieving your image
 	// Either this or `channel` MUST be set.
 	// Mutually exclusive with `channel`
 	IterationID string `mapstructure:"iteration_id" required:"true"`

--- a/datasource/hcp-packer-image/data.hcl2spec.go
+++ b/datasource/hcp-packer-image/data.hcl2spec.go
@@ -19,6 +19,7 @@ type FlatConfig struct {
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
 	Bucket              *string           `mapstructure:"bucket_name" required:"true" cty:"bucket_name" hcl:"bucket_name"`
+	Channel             *string           `mapstructure:"channel" required:"true" cty:"channel" hcl:"channel"`
 	IterationID         *string           `mapstructure:"iteration_id" required:"true" cty:"iteration_id" hcl:"iteration_id"`
 	CloudProvider       *string           `mapstructure:"cloud_provider" required:"true" cty:"cloud_provider" hcl:"cloud_provider"`
 	Region              *string           `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
@@ -45,6 +46,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"bucket_name":                &hcldec.AttrSpec{Name: "bucket_name", Type: cty.String, Required: false},
+		"channel":                    &hcldec.AttrSpec{Name: "channel", Type: cty.String, Required: false},
 		"iteration_id":               &hcldec.AttrSpec{Name: "iteration_id", Type: cty.String, Required: false},
 		"cloud_provider":             &hcldec.AttrSpec{Name: "cloud_provider", Type: cty.String, Required: false},
 		"region":                     &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},

--- a/website/content/partials/datasource/hcp-packer-image/Config-required.mdx
+++ b/website/content/partials/datasource/hcp-packer-image/Config-required.mdx
@@ -12,7 +12,7 @@
   `hcp_packer_image`s use a shared `hcp_packer_iteration` that will
   only generate one potentially billable request.
 
-- `iteration_id` (string) - The name of the iteration Id to use when retrieving your image
+- `iteration_id` (string) - The ID of the iteration to use when retrieving your image
   Either this or `channel` MUST be set.
   Mutually exclusive with `channel`
 

--- a/website/content/partials/datasource/hcp-packer-image/Config-required.mdx
+++ b/website/content/partials/datasource/hcp-packer-image/Config-required.mdx
@@ -2,7 +2,19 @@
 
 - `bucket_name` (string) - The name of the bucket your image is in.
 
+- `channel` (string) - The name of the channel to use when retrieving your image.
+  Either this or `iteration_id` MUST be set.
+  Mutually exclusive with `iteration_id`.
+  If using several images from a single iteration, you may prefer
+  sourcing an iteration first, and referencing it for subsequent uses,
+  as every `hcp_packer_image` with the channel set will generate a
+  potentially billable HCP Packer request, but if several
+  `hcp_packer_image`s use a shared `hcp_packer_iteration` that will
+  only generate one potentially billable request.
+
 - `iteration_id` (string) - The name of the iteration Id to use when retrieving your image
+  Either this or `channel` MUST be set.
+  Mutually exclusive with `channel`
 
 - `cloud_provider` (string) - The name of the cloud provider that your image is for. For example,
   "aws" or "gce".


### PR DESCRIPTION
In addition to the current way of specifying an image based on an
iteration on HCP Packer, which requires first declaring an iteration,
and then referencing it from the image to build, we add the capacity of
specifying a channel.

This alternative will get the iteration linked to the channel, and is
essentially a more convenient way to get an image's metadata from HCP
Packer.

This commit is essentially a backport from the Terraform HCP provider,
for consistency between the two tools.