### PR TITLE
[WIP] Add `component_type` optional field

### DIFF
--- a/datasource/hcp-packer-image/data.hcl2spec.go
+++ b/datasource/hcp-packer-image/data.hcl2spec.go
@@ -22,6 +22,7 @@ type FlatConfig struct {
 	IterationID         *string           `mapstructure:"iteration_id" required:"true" cty:"iteration_id" hcl:"iteration_id"`
 	CloudProvider       *string           `mapstructure:"cloud_provider" required:"true" cty:"cloud_provider" hcl:"cloud_provider"`
 	Region              *string           `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
+	ComponentType       *string           `mapstructure:"component_type" required:"false" cty:"component_type" hcl:"component_type"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -48,6 +49,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"iteration_id":               &hcldec.AttrSpec{Name: "iteration_id", Type: cty.String, Required: false},
 		"cloud_provider":             &hcldec.AttrSpec{Name: "cloud_provider", Type: cty.String, Required: false},
 		"region":                     &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
+		"component_type":             &hcldec.AttrSpec{Name: "component_type", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/website/content/partials/datasource/hcp-packer-image/Config-not-required.mdx
+++ b/website/content/partials/datasource/hcp-packer-image/Config-not-required.mdx
@@ -1,0 +1,6 @@
+<!-- Code generated from the comments of the Config struct in datasource/hcp-packer-image/data.go; DO NOT EDIT MANUALLY -->
+
+- `component_type` (string) - The specific Packer builder or post-processor used to create the image.
+  For example, "amazon-ebs.example"
+
+<!-- End of code generated from the comments of the Config struct in datasource/hcp-packer-image/data.go; -->


### PR DESCRIPTION
to support specifying the exact build image when multiple images exist in the same provider and region for a given iteration.

Porting over from:
https://github.com/hashicorp/terraform-provider-hcp/pull/347