### PR TITLE
hcl2template: only iterate on known HCP datasource

### DIFF
--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -264,6 +264,19 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 		}
 
 		for _, value := range dsValues.AsValueMap() {
+			// Only try to check ancestry if we have fetched the
+			// data from HCP for the data source.
+			//
+			// NOTE: this will happen especially during validate as
+			// when we reach this point, we haven't fetched the
+			// data from HCP.
+			//
+			// TODO: maybe move this HCP-related logic outside that
+			// decode block so it's only executed during build?
+			if !value.IsKnown() {
+				continue
+			}
+
 			values := value.AsValueMap()
 			imgID, itID := values["id"], values["iteration_id"]
 			cfg.bucket.SourceImagesToParentIterations[imgID.AsString()] = itID.AsString()


### PR DESCRIPTION
When we try to validate a build that contains references to
hcp_packer_image, the data is not fetched, and the value is therefore
unknown.

However, during the decoding phase for the build blocks, we attempt to
fetch the ancestry information for the current build, from the
information previously fetched from HCP.

Since we're validating, there's no way this is set, and attempting to
cast without checking causes Packer to crash on the conversion.

To avoid this, we only attempt this conversion if the value is known.

Closes #11870
