### PR TITLE
Update DigitalOcean Plugin paths

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -67,8 +67,8 @@
   {
     "title": "DigitalOcean",
     "path": "digitalocean",
-    "repo": "hashicorp/packer-plugin-digitalocean",
-    "pluginTier": "community",
+    "repo": "digitalocean/packer-plugin-digitalocean",
+    "pluginTier": "verified",
     "version": "latest",
     "isHcpPackerReady": true
   },


### PR DESCRIPTION
Updates the plugin paths for both documentation and go.mod file to with the new DigitalOcean plugin repo.

Opening as a draft as we should not merge until a new release has been made from 
https://github.com/digitalocean/packer-plugin-digitalocean

[Doc Preview](https://packer-58fbodbff-hashicorp.vercel.app/plugins/builders/digitalocean)


Closes https://github.com/hashicorp/packer-internal-issues/issues/41 (HashiCorp only)
