### PR TITLE
Removing Huawei from plugin docs

### DIFF
--- a/website/content/partials/builders/community_builders.mdx
+++ b/website/content/partials/builders/community_builders.mdx
@@ -7,8 +7,6 @@
 
 - [Exoscale builder](https://github.com/exoscale/packer-plugin-exoscale) - A builder to create Exoscale custom templates based on a Compute instance snapshot.
 
-- [Huawei Cloud ECS builder](https://github.com/huaweicloud/packer-builder-huaweicloud-ecs) - Plugin for creating [Huawei Cloud ECS](https://www.huaweicloud.com/intl/en-us/) images.
-
 - [Citrix XenServer/Citrix Hypervisor](https://github.com/xenserver/packer-builder-xenserver) - Plugin for creating [Citrix XenServer/Citrix Hypervisor](https://xenserver.org/) images from an iso image or from an existing template.
 
 - [XCP-NG/Citrix XenServer/Citrix Hypervisor/Updated Fork](https://github.com/ddelnano/packer-plugin-xenserver) - Plugin for creating [XCP-NG/Citrix XenServer/Citrix Hypervisor](https://xcp-ng.org/) images from an iso image or from an existing template. This is a fork of the orginal, and reccomended by the developers of XCP-NG.

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -116,14 +116,6 @@
     "pluginTier": "community"
   },
   {
-    "title": "HuaweiCloud",
-    "path": "huaweicloud",
-    "repo": "huaweicloud/packer-plugin-huaweicloud",
-    "version": "v0.4.0",
-    "pluginTier": "community",
-    "sourceBranch": "master"
-  },
-  {
     "title": "HyperOne",
     "path": "hyperone",
     "repo": "hashicorp/packer-plugin-hyperone",


### PR DESCRIPTION
Hey All,

As requested by our legal team is stay in compliance with federal regulations. This PR removes the Huawei builder plugin documentation from the packer.io website. 

