### PR TITLE
Fix typo in the pipelining-builds docs

### DIFF
--- a/website/content/guides/packer-on-cicd/pipelineing-builds.mdx
+++ b/website/content/guides/packer-on-cicd/pipelineing-builds.mdx
@@ -350,4 +350,6 @@ packer build -only='step1.docker.example' .
 packer build -only='step2.docker.example' .
 ```
 
-To run the pipeline, call pipeline.sh. You can create as many build steps as you want. Each can either inhabit one file
+To run the pipeline, call pipeline.sh. You can create as many build steps as
+you want. Each can either inhabit one file, or you can put multiple steps in
+a single file like shown in the example above.


### PR DESCRIPTION
Somebody forgot to finish their last sentence... I checked and it was never present in the original commit that added this paragraph