### PR TITLE
Add source_image_id to null builder to teste ancestry

### DIFF
--- a/builder/null/artifact_export.go
+++ b/builder/null/artifact_export.go
@@ -8,6 +8,7 @@ import (
 
 // dummy Artifact implementation - does nothing
 type NullArtifact struct {
+	SourceImageId string
 }
 
 func (*NullArtifact) BuilderId() string {
@@ -33,7 +34,7 @@ func (a *NullArtifact) State(name string) interface{} {
 			registryimage.WithID(a.Id()),
 			registryimage.WithProvider("null"),
 			registryimage.WithRegion("null"),
-			registryimage.WithSourceID("null"),
+			registryimage.WithSourceID(a.SourceImageId),
 		)
 		return img
 	case "generated_data":

--- a/builder/null/builder.go
+++ b/builder/null/builder.go
@@ -59,6 +59,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	}
 
 	// No errors, must've worked
-	artifact := &NullArtifact{}
+	artifact := &NullArtifact{
+		SourceImageId: b.config.SourceImageID,
+	}
 	return artifact, nil
 }

--- a/builder/null/config.go
+++ b/builder/null/config.go
@@ -16,6 +16,10 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
 	CommConfig communicator.Config `mapstructure:",squash"`
+
+	// Is used by the packer team to test HCP Packer ancestry. This value will be pushed to HCP Packer as the source
+	// image of this build.
+	SourceImageID string `mapstructure:"source_image_id"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {

--- a/builder/null/config.hcl2spec.go
+++ b/builder/null/config.hcl2spec.go
@@ -67,6 +67,7 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
+	SourceImageID             *string           `mapstructure:"source_image_id" cty:"source_image_id" hcl:"source_image_id"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -138,6 +139,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"source_image_id":              &hcldec.AttrSpec{Name: "source_image_id", Type: cty.String, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
Just want to be able to give a `source_image_id` value to the null builder so we know ancestry is being properly set with Packer. 