### PR TITLE
Update changelog scripts to work with Python3

### DIFF
--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -11,7 +11,7 @@ is_doc_or_tech_debt_pr(){
         echo "jq not found"
         return 1
     fi
-    out=$(cat pull.json | python -m json.tool \
+    out=$(cat pull.json | python3 -m json.tool \
     | jq '[.labels[].name == "docs" or .labels[].name == "tech-debt" or .labels[].name == "website"] | any')
     grep -q true <<< $out
     return $?
@@ -49,7 +49,7 @@ get_prs(){
             echo "Skipping PR ${PR_NUM}: labeled as tech debt, docs or website. (waiting a second so we don't get rate-limited...)"
             continue
         fi
-        echo "$(cat pull.json | python -m json.tool | jq -r '.title') - [GH-${PR_NUM}](https://github.com/hashicorp/packer/pull/${PR_NUM})"
+        echo "$(cat pull.json | python3 -m json.tool | jq -r '.title') - [GH-${PR_NUM}](https://github.com/hashicorp/packer/pull/${PR_NUM})"
     done
 }
 

--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -11,7 +11,7 @@ is_doc_or_tech_debt_pr(){
         echo "jq not found"
         return 1
     fi
-    out=$(cat pull.json | python3 -m json.tool \
+    out=$(python3 -m json.tool < pull.json  \
     | jq '[.labels[].name == "docs" or .labels[].name == "tech-debt" or .labels[].name == "website"] | any')
     grep -q true <<< $out
     return $?
@@ -49,7 +49,7 @@ get_prs(){
             echo "Skipping PR ${PR_NUM}: labeled as tech debt, docs or website. (waiting a second so we don't get rate-limited...)"
             continue
         fi
-        echo "$(cat pull.json | python3 -m json.tool | jq -r '.title') - [GH-${PR_NUM}](https://github.com/hashicorp/packer/pull/${PR_NUM})"
+        echo "$(python3 -m json.tool < pull.json | jq -r '.title') - [GH-${PR_NUM}](https://github.com/hashicorp/packer/pull/${PR_NUM})"
     done
 }
 

--- a/scripts/sort-md-list.py
+++ b/scripts/sort-md-list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 sort-md-list.py sorts markdown lists
 
@@ -55,19 +55,19 @@ if __name__ == '__main__':
     # take care of blank line at start of selection
     sys.stdin.seek(0)
     if sys.stdin.readlines()[0].strip() == "":
-        print ""
+        print()
 
     for line in sorted(lines, key=lambda s: s.lower()):
         if line.strip() == "":
             continue
         # print "-"*79
         wrapped = textwrap.wrap(line, 79)
-        print wrapped[0]
+        print( wrapped[0] )
         indented = " ".join([s.strip() for s in wrapped[1:]])
         for iline in textwrap.wrap(indented, 79-4):
-            print "    " + iline
+            print("     " + iline)
 
     # take care of blank line at end of selection
     sys.stdin.seek(0)
     if sys.stdin.readlines()[-1].strip() == "":
-        print ""
+        print()


### PR DESCRIPTION
Now that Python 2 has been removed from Macos 12.x and replaced with
Python3 I'm updating the simple tools to work with the Python3
interrupter.
