### PR TITLE
Set PRODUCT_VERSION arg in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 # Use 'docker build --target=<name> .' to build one.
 # e.g. `docker build --target=release-light .`
 #
-# All non-dev targets have a VERSION argument that must be provided 
-# via --build-arg=VERSION=<version> when building. 
-# e.g. --build-arg VERSION=1.11.2
+# All non-dev targets have a PRODUCT_VERSION argument that must be provided 
+# via --build-arg=PRODUCT_VERSION=<version> when building. 
+# e.g. --build-arg PRODUCT_VERSION=1.11.2
 #
 # For local dev and testing purposes, please build and use the `dev` docker image.
 #
@@ -31,13 +31,13 @@ ENTRYPOINT ["/bin/packer"]
 FROM docker.mirror.hashicorp.services/alpine:latest as official
 
 # This is the release of Packer to pull in.
-ARG VERSION
+ARG PRODUCT_VERSION
 
 LABEL name="Packer" \
       maintainer="HashiCorp Packer Team <packer@hashicorp.com>" \
       vendor="HashiCorp" \
-      version=$VERSION \
-      release=$VERSION \
+      version=$PRODUCT_VERSION \
+      release=$PRODUCT_VERSION \
       summary="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration." \
       description="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration. Please submit issues to https://github.com/hashicorp/packer/issues"
 
@@ -55,14 +55,14 @@ RUN set -eux && \
         armhf) packerArch='arm' ;; \
         x86) packerArch='386' ;; \
         x86_64) packerArch='amd64' ;; \
-        *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/packer/${VERSION}/)" && exit 1 ;; \
+        *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/packer/${PRODUCT_VERSION}/)" && exit 1 ;; \
     esac && \
-    wget ${HASHICORP_RELEASES}/packer/${VERSION}/packer_${VERSION}_linux_${packerArch}.zip && \
-    wget ${HASHICORP_RELEASES}/packer/${VERSION}/packer_${VERSION}_SHA256SUMS && \
-    wget ${HASHICORP_RELEASES}/packer/${VERSION}/packer_${VERSION}_SHA256SUMS.sig && \
-    gpg --batch --verify packer_${VERSION}_SHA256SUMS.sig packer_${VERSION}_SHA256SUMS && \
-    grep packer_${VERSION}_linux_${packerArch}.zip packer_${VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip -d /tmp/build packer_${VERSION}_linux_${packerArch}.zip && \
+    wget ${HASHICORP_RELEASES}/packer/${PRODUCT_VERSION}/packer_${PRODUCT_VERSION}_linux_${packerArch}.zip && \
+    wget ${HASHICORP_RELEASES}/packer/${PRODUCT_VERSION}/packer_${PRODUCT_VERSION}_SHA256SUMS && \
+    wget ${HASHICORP_RELEASES}/packer/${PRODUCT_VERSION}/packer_${PRODUCT_VERSION}_SHA256SUMS.sig && \
+    gpg --batch --verify packer_${PRODUCT_VERSION}_SHA256SUMS.sig packer_${PRODUCT_VERSION}_SHA256SUMS && \
+    grep packer_${PRODUCT_VERSION}_linux_${packerArch}.zip packer_${PRODUCT_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /tmp/build packer_${PRODUCT_VERSION}_linux_${packerArch}.zip && \
     cp /tmp/build/packer /bin/packer && \
     cd /tmp && \
     rm -rf /tmp/build && \
@@ -81,7 +81,7 @@ ENTRYPOINT ["/bin/packer"]
 # This image is published to DockerHub under the `light`, `light-$VERSION`, and `latest` tags.
 FROM docker.mirror.hashicorp.services/alpine:latest as release-light
 
-ARG VERSION
+ARG PRODUCT_VERSION
 ARG BIN_NAME
 
 # TARGETARCH and TARGETOS are set automatically when --platform is provided.
@@ -90,8 +90,8 @@ ARG TARGETOS TARGETARCH
 LABEL name="Packer" \
       maintainer="HashiCorp Packer Team <packer@hashicorp.com>" \
       vendor="HashiCorp" \
-      version=$VERSION \
-      release=$VERSION \
+      version=$PRODUCT_VERSION \
+      release=$PRODUCT_VERSION \
       summary="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration." \
       description="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration. Please submit issues to https://github.com/hashicorp/packer/issues"
 


### PR DESCRIPTION
### Description

In `actions-docker-build` we [pass](https://github.com/hashicorp/actions-docker-build/blob/05c370a26e61b06be46c5095d6e914c9f0ea4f3d/scripts/docker_build#L49) `PRODUCT_VERSION` to the docker build command. Since this was not set, the label did not populate properly which is used in a comparison to determine the `minor-latest` and `latest` docker image tags. A change merged in today (https://github.com/hashicorp/actions-docker-build/pull/25) checks for this value being set in the docker build action, and errors out if it does not exist. This will unfortunately cause build failures in this repo on merges to `main`. 

### Testing & Reproduction steps
To test locally:

1. Clone packer, checkout this branch, run `make dev`, copy dev artifact to proper location with `mkdir -p dist/linux/amd64 && cp bin/packer dist/linux/amd64/packer`
2. Build the release-light image: `docker build --tag=packer:1.8.3 --no-cache --target=release-light --build-arg PRODUCT_VERSION=1.8.3 --build-arg BIN_NAME=packer .`
4. Get the image ID from above built images w/ `docker image  ls | grep packer` 
5. Run `docker inspect --format='{{ index .Config.Labels "version" }}' $IMAGE_ID` with the image ID from above

A test run was also triggered in CI. The docker builds should pass before merging: https://github.com/hashicorp/packer/runs/7889752470?check_suite_focus=true

How I expect reviewers to test this PR:
- same as above

### Links

Related [internal-only] post about this: https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2416934922/August+17+2022-+Docker+Build+Failures
