### PR TITLE
Fix: Correct the spelling of recommended in the Installing Plugins page.

### DIFF
--- a/website/content/partials/plugins/installing-plugins.mdx
+++ b/website/content/partials/plugins/installing-plugins.mdx
@@ -14,7 +14,7 @@ says the component type (e.g. `packer-provisioner-` or `packer-builder`), then
 it is a single-component plugin.
 
 <Tabs>
-<Tab heading="Packer init (recomended from Packer v1.7.0)">
+<Tab heading="Packer init (recommended from Packer v1.7.0)">
 
 ~> **Note**: Only _multi-component plugin binaries_ -- that is plugins named
 packer-plugin-\*, like the `packer-plugin-amazon` -- are expected to work with


### PR DESCRIPTION
This change fixes the spelling of a misspelled word found in the `Installing Plugins` installation documentation.

In `website/content/partials/plugins/installing-plugins.mdx`, a misspelled word `recomended` has been corrected to `recommended`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/recommended).

Attached below is a screenshot of the word's location on the `Installing Plugins` docs page.
<img width="718" alt="Screen Shot 2022-08-24 at 10 12 36 PM" src="https://user-images.githubusercontent.com/20607878/186558460-227021c1-9813-421c-acce-80456f7cc79d.png">
