### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/auto-close-stale-issues.yml
+++ b/.github/workflows/auto-close-stale-issues.yml
@@ -4,8 +4,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale-bot:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5.1.1

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -2,8 +2,14 @@ name: Milestone Labeler
 on:
   issues:
     types: [milestoned]
+permissions:
+  contents: read
+
 jobs:
   apply_labels:
+    permissions:
+      issues: write  # for andymckay/labeler to label issues
+      pull-requests: write  # for andymckay/labeler to label PRs
     runs-on: ubuntu-latest
     steps:
       - name: Add track-internal


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

GitHub Actions workflows have a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflows:
https://github.com/hashicorp/packer/runs/8239485051?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- auto-close-stale-issues.yml
- issues.yml


The following workflow files already have the least privileged token permission set:

- acceptance-test.yml
- backport.yml
- go-test.yml
- issue-comment-created.yml
- issues-opened.yml
- lock.yml
- nightly-release.yml
- build.yml
- check-plugin-docs.yml
- go-validate.yml
- issue-migrator.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>
