### PR TITLE
Makefile: bump golangci-lint to 1.46.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install-gen-deps: ## Install dependencies for code generation
 
 install-lint-deps: ## Install linter dependencies
 	@echo "==> Updating linter dependencies..."
-	@curl -sSfL -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.42.0
+	@curl -sSfL -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.46.0
 
 dev: ## Build and install a development build
 	@grep 'const VersionPrerelease = ""' version/version.go > /dev/null ; if [ $$? -eq 0 ]; then \


### PR DESCRIPTION
Since we moved to go 1.18, we should bump golangci-lint to a version that supports it.

This change is motivated by the fact that some valid go code was being rejected by the `typecheck` with aliased modules beign unrecognised, namely the `hcl' module, imported from `hcl/v2'.

This should not cause any issues as the typechecker should be aware that the package exported by `hcl/v2' is indeed called `hcl', but for some reason, with version 0.42.0, it does not work.