### PR TITLE
Content munge devportal

### DIFF
--- a/website/content/community-tools.mdx
+++ b/website/content/community-tools.mdx
@@ -22,7 +22,7 @@ To learn more about how to use community plugins, or how to build your own,
 check out the docs on [extending Packer](/docs/extending/plugins)
 
 If you have built a plugin and would like to add it to this community list,
-please make a pull request to the website so that we can document your
+please make a pull request so that we can document your
 contribution here!
 
 @include "builders/community_builders.mdx"
@@ -62,8 +62,8 @@ contribution here!
 - [packer-baseboxes](https://github.com/taliesins/packer-baseboxes) - Templates
   for Packer to build base boxes
 
-- [vmware-samples/packer-examples-for-vsphere](https://github.com/vmware-samples/packer-examples-for-vsphere) - Examples 
-  to automate the creation of virtual machine images and their guest operating systems on VMware vSphere using HashiCorp Packer 
+- [vmware-samples/packer-examples-for-vsphere](https://github.com/vmware-samples/packer-examples-for-vsphere) - Examples
+  to automate the creation of virtual machine images and their guest operating systems on VMware vSphere using HashiCorp Packer
   and the Packer Plugin for VMware vSphere (vsphere-iso).
 
 ## Wrappers

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -21,9 +21,7 @@ subcommands and a brief synopsis of what they do. In addition to this, you can
 run any `packer` command with the `-h` flag to output more detailed help for a
 specific subcommand.
 
-In addition to the documentation available on the command-line, each command is
-documented on this website. You can find the documentation for a specific
-subcommand using the navigation to the left.
+The documentation contains information about each subcommand.
 
 ## Machine-Readable Output
 

--- a/website/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -19,7 +19,7 @@ The `HCP Packer Image` Data Source retrieves information about an
 image from the HCP Packer registry. This information can be used to
 provide a source image to various Packer builders.
 
-To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer tutorials](https://learn.hashicorp.com/collections/packer/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
 

--- a/website/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -19,7 +19,7 @@ The `HCP Packer Iteration` Data Source retrieves information about an
 iteration from the HCP Packer registry. This information can be used to query
 HCP for a source image for various Packer builders.
 
-To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer tutorials](https://learn.hashicorp.com/collections/packer/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
 

--- a/website/content/docs/datasources/hcp/packer-image-iteration.mdx
+++ b/website/content/docs/datasources/hcp/packer-image-iteration.mdx
@@ -19,7 +19,7 @@ The `Packer Image Iteration` Data Source retrieves information about an
 iteration from the HCP Packer registry. This information can be parsed to
 provide a source image to various Packer builders.
 
-To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer tutorials](https://learn.hashicorp.com/collections/packer/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
 

--- a/website/content/docs/datasources/index.mdx
+++ b/website/content/docs/datasources/index.mdx
@@ -9,7 +9,7 @@ page_title: Data Sources
 
 Data sources let Packer fetch data to use in a template, including information defined outside of Packer.
 
-Refer to the [`data`](/docs/templates/hcl_templates/datasources) block documentation to learn more about working with data sources. The documentation also contains a page for each type of data source.
+Refer to the [`data`](/docs/templates/hcl_templates/datasources) block documentation to learn more about working with data sources. The documentation also contains details about each type of data source.
 
 -> **Note:** Data sources is a feature exclusively available to HCL2 templates included in Packer `v1.7.0` (and newer).
 

--- a/website/content/docs/datasources/index.mdx
+++ b/website/content/docs/datasources/index.mdx
@@ -7,12 +7,9 @@ page_title: Data Sources
 
 # Data Sources
 
-Data sources allow data to be fetched for use in Packer configuration. Use of data sources
-allows a build to use information defined outside of Packer.
+Data sources let Packer fetch data to use in a template, including information defined outside of Packer.
 
-See the [`data`](/docs/templates/hcl_templates/datasources) block documentation to learn more
-about working with data sources. For information on an individual data source,
-choose it from the sidebar.
+Refer to the [`data`](/docs/templates/hcl_templates/datasources) block documentation to learn more about working with data sources. The documentation also contains a page for each type of data source.
 
 -> **Note:** Data sources is a feature exclusively available to HCL2 templates included in Packer `v1.7.0` (and newer).
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -8,7 +8,7 @@ page_title: Documentation
 
 [Packer](https://www.packer.io/) is an open source tool that enables you to create identical machine images for multiple platforms from a single source template. A common use case is creating "golden images" that teams across an organization can use in cloud infrastructure.
 
-To install Packer and learn the standard Packer workflow, try the [Get Started tutorials](https://learn.hashicorp.com/packer) on HashiCorp Learn.
+To install Packer and learn the standard Packer workflow, try the [Get Started tutorials](https://learn.hashicorp.com/packer).
 
 ## HCP Packer
 
@@ -16,4 +16,4 @@ The HCP Packer registry bridges the gap between image factories and image deploy
 
 The HCP Packer registry stores metadata about your images, including when they were created, where the image exists in the cloud, and what (if any) git commit is associated with your image build. You can use the registry to track information about the golden images your Packer builds produce, clearly designate which images are appropriate for test and production environments, and query for the right golden images to use in both Packer and Terraform configurations.
 
-To get started, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+To get started, visit the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer tutorials](https://learn.hashicorp.com/collections/packer/hcp-get-started).

--- a/website/content/docs/plugins/creation/custom-builders.mdx
+++ b/website/content/docs/plugins/creation/custom-builders.mdx
@@ -175,7 +175,7 @@ about the artifact results and to determine whether they are even able to run
 against a given artifact, so it is important that this ID never changes once
 the builder is published.
 
-The builder ID for each builder is documented on its website docs page.
+The builder ID for each builder is included on the associated documentation page.
 
 ## Provisioning
 

--- a/website/content/docs/plugins/creation/index.mdx
+++ b/website/content/docs/plugins/creation/index.mdx
@@ -156,8 +156,7 @@ Next, build your plugin as you would any other Go application. The resulting
 binary is the plugin that can be installed using
 [standard installation procedures](/docs/plugins#installing-plugins).
 
-The specifics of how to implement each type of interface are covered in the
-relevant subsections available in the navigation to the left.
+This documentation explains how to implement each type of plugin interface: builders, data sources, provisioners, and post-processors.
 
 ~> **Lock your dependencies!** Using `go mod` is highly recommended since
 the Packer codebase will continue to improve, potentially breaking APIs along

--- a/website/content/docs/plugins/creation/index.mdx
+++ b/website/content/docs/plugins/creation/index.mdx
@@ -242,15 +242,15 @@ To register a plugin follow one of the following setups
 
 Documentation for a plugin is maintained within the `docs` directory and served on GitHub.
 
-To include plugin docs on Packer.io a global pre-hook has been added to the main scaffolding [.goreleaser.yml](https://github.com/hashicorp/packer-plugin-scaffolding/blob/42e5b0b1e575879b0477cb6d4291e027f4d92f85/.goreleaser.yml#L10) file, that if uncommented will generate and include a docs.zip file as part of the plugin release.
+To include plugin docs on the website, a global pre-hook has been added to the main scaffolding [.goreleaser.yml](https://github.com/hashicorp/packer-plugin-scaffolding/blob/42e5b0b1e575879b0477cb6d4291e027f4d92f85/.goreleaser.yml#L10) file, that if uncommented will generate and include a docs.zip file as part of the plugin release.
 
-The `docs.zip` file will contain all of the `.mdx` files under the plugins root `docs/` directory that can be consumed remotely by Packer.io.
+The `docs.zip` file contains all of the `.mdx` files under the plugins root `docs/` directory that the website can consume remotely.
 
 </Tab>
 
 <Tab heading="Manually generating docs.zip">
 
-The documentation structure needed for Packer.io can be generated manually, by creating a zip file called `docs.zip` of the docs directory and included in the plugin release.
+You can generate the required documentation structure manually by creating a zip file called `docs.zip` of the docs directory and including that zip file in the plugin release.
 
 ```/bin/bash
 [[ -d docs/ ]] && zip -r docs.zip docs/

--- a/website/content/docs/plugins/hcp-support.mdx
+++ b/website/content/docs/plugins/hcp-support.mdx
@@ -114,5 +114,4 @@ The following plugins currently support HCP Packer and are great references for 
 
 To get to know HCP Packer, visit the
 [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the
-[Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started)
-collection on HashiCorp Learn.
+[Get Started with HCP Packer tutorials](https://learn.hashicorp.com/collections/packer/hcp-get-started).

--- a/website/content/docs/post-processors/index.mdx
+++ b/website/content/docs/post-processors/index.mdx
@@ -7,11 +7,8 @@ page_title: Post-Processors
 
 # Post-Processors
 
-Post-processors run after the image is built by the builder and provisioned by
-the provisioner(s). Post-processors are optional, and they can be used to
-upload artifacts, re-package, or more. For more information about
-post-processors, please choose an option from the sidebar.
+Post-processors run after builders and provisioners. Post-processors are optional, and you can use them to upload artifacts, re-package files, and more. The documentation includes a page for each type of post-processor.
 
-See [`post-processor`](/docs/templates/hcl_templates/blocks/build/post-processor) and
+Refer to the [`post-processor`](/docs/templates/hcl_templates/blocks/build/post-processor) and
 [`post-processors`](/docs/templates/hcl_templates/blocks/build/post-processors)
-blocks documentations to learn more about working with post-processors.
+blocks documentation to learn more about working with post-processors.

--- a/website/content/docs/provisioners/index.mdx
+++ b/website/content/docs/provisioners/index.mdx
@@ -16,4 +16,4 @@ machine image after booting. Provisioners prepare the system, so you may want to
 - downloading application code
 
 Refer to the [`provisioner`](/docs/templates/hcl_templates/blocks/build/provisioner) block documentation to learn more
-about working with provisioners. The documentation includes a page for each type of provisioner.
+about working with provisioners. The documentation includes details about each type of provisioner.

--- a/website/content/docs/provisioners/index.mdx
+++ b/website/content/docs/provisioners/index.mdx
@@ -7,15 +7,13 @@ page_title: Provisioners
 
 # Provisioners
 
-Provisioners use builtin and third-party software to install and configure the
-machine image after booting. Provisioners prepare the system for use, so common
-use cases for provisioners include:
+Provisioners use built-in and third-party software to install and configure the
+machine image after booting. Provisioners prepare the system, so you may want to use them for the following use cases:
 
 - installing packages
 - patching the kernel
 - creating users
 - downloading application code
 
-See the [`provisioner`](/docs/templates/hcl_templates/blocks/build/provisioner) block documentation to learn more
-about working with provisioners. For information on an individual provisioner,
-choose it from the sidebar.
+Refer to the [`provisioner`](/docs/templates/hcl_templates/blocks/build/provisioner) block documentation to learn more
+about working with provisioners. The documentation includes a page for each type of provisioner.

--- a/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -9,7 +9,7 @@ page_title: hcp_packer_registry - build - Blocks
 
 The `hcp_packer_registry` block lets you customize the metadata Packer sends to HCP Packer Registry. It configures the details of an image that is created or updated within the HCP Packer registry.
 
-To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer](https://learn.hashicorp.com/collections/packer/hcp-get-started) collection on HashiCorp Learn.
+To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer tutorials](https://learn.hashicorp.com/collections/packer/hcp-get-started).
 
 ## Usage
 

--- a/website/content/docs/templates/hcl_templates/blocks/index.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/index.mdx
@@ -27,7 +27,7 @@ The most important blocks can be broken into a couple of major types:
   HCL functions or data sources, or composited from variables created in the
   variables blocks.
 
-Use the sidebar to navigate to detailed documentation for each of these blocks.
+The documentation contains a page for each block type.
 
 Other blocks, such as the "packer" block, provide information to the Packer core
 about what version it is allowed to run. The "required_plugins" block helps the
@@ -37,8 +37,7 @@ Blocks can be defined in multiple files and `packer build folder` will build
 using solely the files from a directory named `folder`.
 
 Packer does not support user-defined blocks and so only the blocks built in to
-the language are available for use. The navigation for this section includes a
-list of all of the available built-in HCL2 blocks.
+the language are available for use. The documentation includes all of the available built-in HCL2 blocks.
 
 ## Config example:
 

--- a/website/content/docs/templates/hcl_templates/blocks/index.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/index.mdx
@@ -27,7 +27,7 @@ The most important blocks can be broken into a couple of major types:
   HCL functions or data sources, or composited from variables created in the
   variables blocks.
 
-The documentation contains a page for each block type.
+The documentation contains information for each block type.
 
 Other blocks, such as the "packer" block, provide information to the Packer core
 about what version it is allowed to run. The "required_plugins" block helps the

--- a/website/content/docs/templates/hcl_templates/functions/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/index.mdx
@@ -23,5 +23,4 @@ For more details on syntax, see
 on the Expressions page.
 
 The HCL language does not support user-defined functions, and so only
-the functions built in to the language are available for use. The navigation
-for this section includes a list of all of the available built-in functions.
+the functions built in to the language are available for use. The documentation includes all of the available built-in functions.

--- a/website/content/guides/automatic-operating-system-installs/index.mdx
+++ b/website/content/guides/automatic-operating-system-installs/index.mdx
@@ -20,5 +20,4 @@ installation answer files in order to perfom those installs; we don't mean to
 be a comprehensive guide on each operating system, but we hope to give you
 enough context to be able to more easily find any further information you need.
 
-Please use the left-hand navigation to find instructions for the operating
-system that is relevant to you.
+Refer to the instructions for your operating system.

--- a/website/content/partials/plugins/plugin-tiers-and-namespaces.mdx
+++ b/website/content/partials/plugins/plugin-tiers-and-namespaces.mdx
@@ -1,7 +1,7 @@
 ## Tiers and Namespaces
 
 Packer plugins are published and maintained by a variety of sources, including
-HashiCorp, and the Packer community. This website uses tiers and badges to
+HashiCorp, and the Packer community. We use tiers and badges to
 denote the source of a plugin. Additionally, namespaces are used to help users
 identify the organization or publisher responsible for the integration, as shown
 in the table below.


### PR DESCRIPTION
Updates the content in preparation for the developer portal migration. Specifically:
- Removes mentions of HashiCorp Learn, as this will no longer exist
- Corrects any mentions of packer.io or the platform in a way that will feel awkward
- Removes mentions of the documentation sidebar or navigation (e.g. click the link in the left sidebar navigation)
- Removes mentions of learn "collections" where possible
- Checks for URLs to packer.io or learn that are user-facing (found none)
- Checks for absolute links to docs (found none)