### PR TITLE
fix(website): pin packer-plugin-outscale docs to 1.0.2

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -212,7 +212,7 @@
     "title": "Outscale",
     "path": "outscale",
     "repo": "outscale/packer-plugin-outscale",
-    "version": "latest",
+    "version": "v1.0.2",
     "pluginTier": "verified"
   },
   {


### PR DESCRIPTION
This PR pins `packer-plugin-outscale` to `v1.0.2`. The intent is to resolve a website build failure, related to failure to fetch docs assets from the latest release in [packer-plugin-outscale](https://github.com/outscale/packer-plugin-outscale).