### PR TITLE
hcp: use HCP_PACKER_REGISTRY to disable HCP

### DIFF
--- a/internal/registry/env/env.go
+++ b/internal/registry/env/env.go
@@ -6,18 +6,23 @@ import (
 )
 
 func HasClientID() bool {
-	_, ok := os.LookupEnv(HCPClientID)
-	return ok
+	return hasEnvVar(HCPClientID)
 }
 
 func HasClientSecret() bool {
-	_, ok := os.LookupEnv(HCPClientSecret)
-	return ok
+	return hasEnvVar(HCPClientSecret)
 }
 
 func HasPackerRegistryBucket() bool {
-	_, ok := os.LookupEnv(HCPPackerBucket)
-	return ok
+	return hasEnvVar(HCPPackerBucket)
+}
+
+func hasEnvVar(varName string) bool {
+	val, ok := os.LookupEnv(varName)
+	if !ok {
+		return false
+	}
+	return val != ""
 }
 
 func HasHCPCredentials() bool {
@@ -35,7 +40,7 @@ func HasHCPCredentials() bool {
 	return true
 }
 
-func IsPAREnabled() bool {
-	val, ok := os.LookupEnv(HCPPackerRegistry)
-	return ok && strings.ToLower(val) != "off" && val != "0"
+func IsHCPDisabled() bool {
+	hcp, ok := os.LookupEnv(HCPPackerRegistry)
+	return ok && strings.ToLower(hcp) == "off" || hcp == "0"
 }

--- a/internal/registry/env/env_test.go
+++ b/internal/registry/env/env_test.go
@@ -1,50 +1,46 @@
 package env
 
 import (
-	"os"
 	"testing"
 )
 
-func Test_IsPAREnabled(t *testing.T) {
+func Test_IsHCPDisabled(t *testing.T) {
 	tcs := []struct {
-		name   string
-		value  string
-		output bool
+		name           string
+		registry_value string
+		output         bool
 	}{
 		{
-			name:   "set with 1",
-			value:  "1",
-			output: true,
+			name:           "nothing set",
+			registry_value: "",
+			output:         false,
 		},
 		{
-			name:   "set with ON",
-			value:  "ON",
-			output: true,
+			name:           "registry set with 1",
+			registry_value: "1",
+			output:         false,
 		},
 		{
-			name:   "set with 0",
-			value:  "0",
-			output: false,
+			name:           "registry set with 0",
+			registry_value: "0",
+			output:         true,
 		},
 		{
-			name:   "set with OFF",
-			value:  "OFF",
-			output: false,
+			name:           "registry set with OFF",
+			registry_value: "OFF",
+			output:         true,
 		},
 		{
-			name:   "unset",
-			value:  "",
-			output: false,
+			name:           "registry set with off",
+			registry_value: "off",
+			output:         true,
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.value != "" {
-				_ = os.Setenv(HCPPackerRegistry, tc.value)
-				defer os.Unsetenv(HCPPackerRegistry)
-			}
-			out := IsPAREnabled()
+			t.Setenv(HCPPackerRegistry, tc.registry_value)
+			out := IsHCPDisabled()
 			if out != tc.output {
 				t.Fatalf("unexpected output: %t", out)
 			}


### PR DESCRIPTION
The current behaviour for HCP integration is based on the presence of the HCP_PACKER_REGISTRY environment variable, where if it is either not "0" or "off", the HCP integration is 

This commit changes the behaviour to only use this variable explicitely disable HCP, and the HCP_PACKER_BUCKET_NAME variable will condition if the HCP integration is enabled for a build or not in JSON templates.

For HCL templates, the integration can also be disabled if the HCP_PACKER_REGISTRY variable is set to "0" or "off", and will be considered enabled if the HCP_PACKER_BUCKET_NAME is set, or there is a "hcp_packer_registry" block in a build.

This should be reviewed, but only merged when we have acceptance tests.
