### PR TITLE
Update variables.mdx

### DIFF
--- a/website/content/guides/hcl/variables.mdx
+++ b/website/content/guides/hcl/variables.mdx
@@ -190,9 +190,9 @@ $ packer build -var-file="variables.pkrvars.hcl" .
 ```
 
 Packer will automatically load any var file that matches the name
-`*.auto.pkrvars.hcl`, without the need to pass the file via the command line.
-If we rename the above variable definitions file from `variables.pkrvars.hcl` to
-`variables.auto.pkrvars.hcl`, then we can run our build simply by calling
+`*.auto.pkr.hcl`, without the need to pass the file via the command line.
+If we rename the above variable definitions file from `variables.pkr.hcl` to
+`variables.auto.pkr.hcl`, then we can run our build simply by calling
 
 ```shell-session
 $ packer build .


### PR DESCRIPTION
Changed references to `*.auto.pkrvars.hcl` to `*.auto.pkr.hcl` as the former does not work (on Windows).

I had two files in my working directory:

* `sources.pkr.hcl`
* `variables.auto.pkrvars.hcl`

`packer build .` failed with:
```
Error: Variable declaration in a .pkrvar file

  on variables.auto.pkrvars.hcl line 1, in variable "creation_date":
   1: variable "creation_date" {

A .pkrvar file is used to assign values to variables that have already been
declared in .pkr files, not to declare new variables. To declare variable
"creation_date", place this block in one of your .pkr files, such as
variables.pkr.hcl

To set a value for this variable in variables.auto.pkrvars.hcl, use the
definition syntax instead:
    creation_date = <value>
```

Changing the contents of `variables..auto.pkrvars.hcl` to `creation_date = "{{isotime \"2006-01-02 15:04\"}}"` failed with:
```
Warning: Undefined variable

A "creation_date" variable was set but was not found in known variables. To
declare variable "creation_date", place this block in one of your .pkr files,
such as variables.pkr.hcl


Error: Unsupported attribute

  on sources.pkr.hcl line 29:
  (source code not available)

This object does not have an attribute named "creation_date".
```
What worked was renaming the file to `variables.auto.pkr.hcl` with the contents:
```
variable "creation_date" {
  type = string
  default = "{{isotime \"2006-01-02 15:04\"}}"
}

```

I am not entirely sure that I am not doing something wrong, but if my PR is wrong, perhaps the section needs making clearer.

Thanks