### PR TITLE
Add JIRA sync action

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,77 @@
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+name: JIRA Sync
+
+jobs:
+  sync:
+    name: Sync to JIRA
+    permissions:
+      issues: write # for actions-ecosytem/action-create-comment
+    runs-on: ubuntu-latest
+    steps:    
+      - name: Login
+        uses: atlassian/gajira-login@v2.0.0
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Set type
+        id: set-ticket-type
+        run: |
+          # Questions are not tracked in JIRA at this time.
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'question') }}" == "true" ]]; then
+            echo "::set-output name=type::Invalid"
+          else
+            # Properly labeled GH issues are assigned the standard "GH Issue" type upon creation.
+            echo "::set-output name=type::GH Issue"
+          fi
+
+      - name: Set labels
+        id: set-ticket-labels 
+        run: |
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'bug') }}" == "true" ]]; then
+            echo "::set-output name=labels::[\"bug\"]"
+          elif [[ "${{ contains(github.event.issue.labels.*.name, 'enhancement') }}" == "true" ]]; then
+            echo "::set-output name=labels::[\"enhancement\"]"
+          else
+            echo "::set-output name=labels::[]"
+          fi
+
+      - name: Validate ticket
+        if: steps.set-ticket-type.outputs.type == 'Invalid'
+        run: |
+          echo "Questions are not being synced to JIRA at this time."
+          echo "If the issue is a bug or an enhancement please remove the question label and reapply the 'sync to jira' label."
+
+      - name: Create ticket
+        id: create-ticket
+        if: github.event.label.name == 'sync to jira' && steps.set-ticket-type.outputs.type != 'Invalid'
+        uses: atlassian/gajira-create@v2.0.1
+        with:
+          project: HPR
+          issuetype: "${{ steps.set-ticket-type.outputs.type }}"
+          summary: "${{ github.event.repository.name }}: ${{ github.event.issue.title }}"
+          description: "${{ github.event.issue.body }}\n\n_Created from GitHub by ${{ github.actor }}._"
+          # The field customfield_10089 refers to the Issue Link field in JIRA. 
+          fields: '{ "customfield_10089": "${{ github.event.issue.html_url }}", 
+                   "components": [{ "name": "OSS" }],
+                   "labels": ${{ steps.set-ticket-labels.outputs.labels }} }'
+
+      - name: Add tracking comment
+        if: steps.create-ticket.outputs.issue != '' && steps.set-ticket-type.outputs.type != 'Invalid'
+        uses: actions-ecosystem/action-create-comment@v1.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            This issue has been synced to JIRA for planning.
+
+            JIRA ID: [${{ steps.create-ticket.outputs.issue }}](https://hashicorp.atlassian.net/browse/${{steps.create-ticket.outputs.issue}})
+
+
+


### PR DESCRIPTION
In order to plan GitHub issues alongside internal JIRA issues
the Packer repository is being updated to support syncing issues from
GitHub to JIRA.

**The action works as follows:** 
----
Issues that are applied the `sync to jira` label will be synced to the Packer JIRA backlog for planning. Upon successfully syncing the issue to JIRA a comment will be added to the GitHub issue with its internal JIRA ID along with a  message indicating that it has been synced. Only bug and enhancement issues can be synced. 

Issues containing the question label will fail validation and not get synced to JIRA. 

### Additional Steps Required
- [x] Create `sync to jira` label
- [x] Configure JIRA Secret Tokens


