### PR TITLE
fix(website): sourceBranch for anka in plugins-manifest

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -18,7 +18,7 @@
     "path": "anka",
     "repo": "veertuinc/packer-plugin-veertu-anka",
     "pluginTier": "community",
-    "source_branch": "master",
+    "sourceBranch": "master",
     "version": "latest"
   },
   {


### PR DESCRIPTION
Fixes `sourceBranch` config option for `anka` plugin in `plugins-manifest.json`.

The `source_branch` option isn't picked up. While the plugin docs still build (since we fetch from a release), the `Edit on GitHub` links end up 404'ing. See for example https://www.packer.io/plugins/post-processors/anka.