### PR TITLE
build: exit immediately if no builds and diags

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -192,8 +192,10 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	if len(builds) == 0 {
 		return writeDiags(c.Ui, nil, hcl.Diagnostics{
 			&hcl.Diagnostic{
-				Summary:  "No builds to run",
-				Detail:   "a build command cannot run without at least one build to process",
+				Summary: "No builds to run",
+				Detail: "A build command cannot run without at least one build to process. " +
+					"If the only or except flags have been specified at run time check that" +
+					" at least one build is selected for execution.",
 				Severity: hcl.DiagError,
 			},
 		})

--- a/command/build.go
+++ b/command/build.go
@@ -128,6 +128,9 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	// here, something could have gone wrong but we still want to run valid
 	// builds.
 	ret = writeDiags(c.Ui, nil, diags)
+	if len(builds) == 0 && ret != 0 {
+		return ret
+	}
 
 	if cla.Debug {
 		c.Ui.Say("Debug mode enabled. Builds will not be parallelized.")

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -22,13 +22,6 @@ func fatalCommand(t *testing.T, m Meta) {
 		err.String())
 }
 
-func outputCommand(t *testing.T, m Meta) (string, string) {
-	ui := m.Ui.(*packersdk.BasicUi)
-	out := ui.Writer.(*bytes.Buffer)
-	err := ui.ErrorWriter.(*bytes.Buffer)
-	return out.String(), err.String()
-}
-
 func testFixtureContent(n ...string) string {
 	path := filepath.Join(append([]string{fixturesDir}, n...)...)
 	b, err := ioutil.ReadFile(path)

--- a/command/test-fixtures/hcl/no_build.pkr.hcl
+++ b/command/test-fixtures/hcl/no_build.pkr.hcl
@@ -1,0 +1,3 @@
+source "null" "papaya" {
+  communicator = "none"
+}

--- a/command/test_utils.go
+++ b/command/test_utils.go
@@ -32,6 +32,14 @@ func TestMetaFile(t *testing.T) Meta {
 	}
 }
 
+// GetStdoutAndErrFromTestMeta extracts stdout/stderr from a Meta created by TestMetaFile
+func GetStdoutAndErrFromTestMeta(t *testing.T, m Meta) (string, string) {
+	ui := m.Ui.(*packersdk.BasicUi)
+	out := ui.Writer.(*bytes.Buffer)
+	err := ui.ErrorWriter.(*bytes.Buffer)
+	return out.String(), err.String()
+}
+
 // testCoreConfigBuilder creates a packer CoreConfig that has a file builder
 // available. This allows us to test a builder that writes files to disk.
 func testCoreConfigBuilder(t *testing.T) *packer.CoreConfig {

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -137,7 +137,7 @@ func TestValidateCommandBadVersion(t *testing.T) {
 		t.Errorf("Expected exit code 1")
 	}
 
-	stdout, stderr := outputCommand(t, c.Meta)
+	stdout, stderr := GetStdoutAndErrFromTestMeta(t, c.Meta)
 	expected := `Error: 
 
 This template requires Packer version 101.0.0 or higher; using 100.0.0


### PR DESCRIPTION
When a template with some builds to run ends its GetBuilds with an error, and no builds produced, we can exit immediately without printing more errors.

Closes: #12010 