### PR TITLE
[HPR-575] HCP all errors at once

### DIFF
--- a/command/registry.go
+++ b/command/registry.go
@@ -63,6 +63,10 @@ func setupRegistryForPackerConfig(pc *hcl2template.PackerConfig) hcl.Diagnostics
 		hasHCP = true
 	}
 
+	if env.IsHCPExplicitelyEnabled() {
+		hasHCP = true
+	}
+
 	if !hasHCP {
 		return nil
 	}
@@ -270,7 +274,7 @@ func setupRegistryForPackerCore(cfg *CoreWrapper) hcl.Diagnostics {
 		return nil
 	}
 
-	if !env.HasPackerRegistryBucket() {
+	if !env.HasPackerRegistryBucket() && !env.IsHCPExplicitelyEnabled() {
 		return nil
 	}
 

--- a/command/registry.go
+++ b/command/registry.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
@@ -17,6 +16,15 @@ import (
 	"github.com/zclconf/go-cty/cty/gocty"
 )
 
+type HCPConfigMode int
+
+const (
+	// HCPConfigMode types
+	HCPConfigUnset HCPConfigMode = iota
+	HCPConfigEnabled
+	HCPEnvEnabled
+)
+
 const (
 	// Known HCP Packer Image Datasource, whose id is the SourceImageId for some build.
 	hcpImageDatasourceType     string = "hcp-packer-image"
@@ -24,8 +32,8 @@ const (
 	buildLabel                 string = "build"
 )
 
-// TrySetupHCP attempts to setup the HCP-related structures if HCP is enabled
-// for the command
+// TrySetupHCP attempts to configure the HCP-related structures if
+// Packer has been configured to publish to a HCP Packer registry.
 func TrySetupHCP(cfg packer.Handler) hcl.Diagnostics {
 	switch cfg := cfg.(type) {
 	case *hcl2template.PackerConfig:
@@ -38,7 +46,7 @@ func TrySetupHCP(cfg packer.Handler) hcl.Diagnostics {
 		&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "unknown Handler type",
-			Detail: "SetupRegistry called with an unknown Handler. " +
+			Detail: "TrySetupHCP called with an unknown Handler. " +
 				"This is a Packer bug and should be brought to the attention " +
 				"of the Packer team, please consider opening an issue for this.",
 		},
@@ -46,33 +54,32 @@ func TrySetupHCP(cfg packer.Handler) hcl.Diagnostics {
 }
 
 func setupRegistryForPackerConfig(pc *hcl2template.PackerConfig) hcl.Diagnostics {
-	var diags hcl.Diagnostics
 
+	// HCP_PACKER_REGISTRY is explicitly turned off
 	if env.IsHCPDisabled() {
 		return nil
 	}
 
-	hasHCP := false
+	mode := HCPConfigUnset
 
+	// TODO move into ConfigCheck
 	for _, build := range pc.Builds {
 		if build.HCPPackerRegistry != nil {
-			hasHCP = true
+			mode = HCPConfigEnabled
 		}
 	}
 
-	if env.HasPackerRegistryBucket() {
-		hasHCP = true
+	// HCP_PACKER_BUCKET_NAME is set or  HCP_PACKER_REGISTRY not toggled off
+	if mode == HCPConfigUnset && (env.HasPackerRegistryBucket() || env.IsHCPExplicitelyEnabled()) {
+		mode = HCPEnvEnabled
 	}
 
-	if env.IsHCPExplicitelyEnabled() {
-		hasHCP = true
-	}
-
-	if !hasHCP {
+	if mode == HCPConfigUnset {
 		return nil
 	}
 
-	if hasHCP && len(pc.Builds) > 1 {
+	var diags hcl.Diagnostics
+	if len(pc.Builds) > 1 {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Multiple " + buildLabel + " blocks",
@@ -81,73 +88,42 @@ func setupRegistryForPackerConfig(pc *hcl2template.PackerConfig) hcl.Diagnostics
 				" block(s). If this " + buildLabel + " is not meant for the Packer registry please " +
 				"clear any HCP_PACKER_* environment variables."),
 		})
+
+		return diags
 	}
 
-	var err error
-	pc.Bucket, err = registry.NewBucketWithIteration(registry.IterationOptions{
-		TemplateBaseDir: pc.Basedir,
-	})
-
-	if err != nil {
-		diags = append(diags, &hcl.Diagnostic{
-			Summary:  "Unable to create a valid bucket object for HCP Packer Registry",
-			Detail:   fmt.Sprintf("%s", err),
-			Severity: hcl.DiagError,
-		})
-	}
-
-	// Configure HCP Packer Registry destination
-	bucketSlug := os.Getenv(env.HCPPackerBucket)
-
-	if pc.Bucket != nil {
-		pc.Bucket.LoadDefaultSettingsFromEnv()
-
-		pc.Bucket.Slug = bucketSlug
-
-		for _, build := range pc.Builds {
-			build.HCPPackerRegistry.WriteToBucketConfig(pc.Bucket)
-			bucketSlug = pc.Bucket.Slug
-
+	WithHCLBucketConfigurtationOpts := func(bb *hcl2template.BuildBlock) func(*registry.Bucket) {
+		return func(bucket *registry.Bucket) {
+			bb.HCPPackerRegistry.WriteToBucketConfig(bucket)
 			// If at this point the bucket.Slug is still empty,
 			// last try is to use the build.Name if present
-			if bucketSlug == "" && build.Name != "" {
-				bucketSlug = build.Name
+			if bucket.Slug == "" && bb.Name != "" {
+				bucket.Slug = bb.Name
 			}
 
 			// If the description is empty, use the one from the build block
-			if pc.Bucket.Description == "" {
-				pc.Bucket.Description = build.Description
-			}
-
-			for _, source := range build.Sources {
-				pc.Bucket.RegisterBuildForComponent(source.String())
+			if bucket.Description == "" && bb.Description != "" {
+				bucket.Description = bb.Description
 			}
 		}
 	}
 
-	if !env.HasHCPCredentials() {
-		diags = append(diags, &hcl.Diagnostic{
-			Summary: "HCP authentication information required",
-			Detail: fmt.Sprintf("The client authentication requires both %s and %s environment "+
-				"variables to be set for authenticating with HCP.",
-				env.HCPClientID,
-				env.HCPClientSecret),
-			Severity: hcl.DiagError,
-		})
+	build := pc.Builds[0]
+	pc.Bucket, diags = createConfiguredBucket(
+		pc.Basedir,
+		WithPackerEnvConfigurationOpts,
+		WithHCLBucketConfigurtationOpts(build),
+	)
+
+	if diags.HasErrors() {
+		return diags
 	}
 
-	if bucketSlug == "" {
-		diags = append(diags, &hcl.Diagnostic{
-			Summary:  "bucket name cannot be empty",
-			Detail:   "empty bucket name, please set it with the HCP_PACKER_BUCKET_NAME environment variable, or in a `hcp_packer_registry` block",
-			Severity: hcl.DiagError,
-		})
+	for _, source := range build.Sources {
+		pc.Bucket.RegisterBuildForComponent(source.String())
 	}
 
-	if pc.Bucket != nil {
-		pc.Bucket.Slug = bucketSlug
-	}
-
+	/// Lets Move this
 	vals, dsDiags := pc.Datasources.Values()
 	if dsDiags != nil {
 		diags = append(diags, dsDiags...)
@@ -163,6 +139,7 @@ func setupRegistryForPackerConfig(pc *hcl2template.PackerConfig) hcl.Diagnostics
 
 	iterations := map[string]iterds.DatasourceOutput{}
 
+	var err error
 	if iterOK {
 		hcpData := map[string]cty.Value{}
 		err = gocty.FromCtyValue(iterDS, &hcpData)
@@ -224,6 +201,90 @@ func setupRegistryForPackerConfig(pc *hcl2template.PackerConfig) hcl.Diagnostics
 
 	return diags
 }
+
+func setupRegistryForPackerCore(cfg *CoreWrapper) hcl.Diagnostics {
+	if env.IsHCPDisabled() {
+		return nil
+	}
+
+	if !env.HasPackerRegistryBucket() && !env.IsHCPExplicitelyEnabled() {
+		return nil
+	}
+
+	core := cfg.Core
+	bucket, diags := createConfiguredBucket(
+		filepath.Dir(core.Template.Path),
+		WithPackerEnvConfigurationOpts,
+	)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	core.Bucket = bucket
+	for _, b := range core.Template.Builders {
+		// Get all builds slated within config ignoring any only or exclude flags.
+		core.Bucket.RegisterBuildForComponent(b.Name)
+	}
+
+	return diags
+}
+
+func createConfiguredBucket(templateDir string, opts ...func(*registry.Bucket)) (*registry.Bucket, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	if !env.HasHCPCredentials() {
+		diags = append(diags, &hcl.Diagnostic{
+			Summary: "HCP authentication information required",
+			Detail: fmt.Sprintf("The client authentication requires both %s and %s environment "+
+				"variables to be set for authenticating with HCP.",
+				env.HCPClientID,
+				env.HCPClientSecret),
+			Severity: hcl.DiagError,
+		})
+	}
+
+	bucket, err := registry.NewBucketWithIteration(registry.IterationOptions{
+		TemplateBaseDir: templateDir,
+	})
+
+	// This error needs to be reworded.
+	if err != nil {
+		diags = append(diags, &hcl.Diagnostic{
+			Summary:  "Unable to create a valid bucket object for HCP Packer Registry",
+			Detail:   fmt.Sprintf("%s", err),
+			Severity: hcl.DiagError,
+		})
+
+		return nil, diags
+	}
+
+	for _, opt := range opts {
+		opt(bucket)
+	}
+
+	if bucket.Slug == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Summary:  "bucket name cannot be empty",
+			Detail:   "empty bucket name, please set it with the HCP_PACKER_BUCKET_NAME environment variable, or in a `hcp_packer_registry` block",
+			Severity: hcl.DiagError,
+		})
+
+		return nil, diags
+	}
+
+	return bucket, diags
+}
+
+func WithPackerEnvConfigurationOpts(pc *registry.Bucket) {
+	// Add default values for Packer settings configured via EnvVars.
+	// TODO look to break this up to be more explicit on what is loaded here.
+	pc.LoadDefaultSettingsFromEnv()
+}
+
+// load handler
+// validate HCP Mode is on
+// Validate we have all the bits to connect
+// Build a connected client
 
 func imageValueToDSOutput(imageVal map[string]cty.Value) imgds.DatasourceOutput {
 	dso := imgds.DatasourceOutput{}
@@ -288,62 +349,4 @@ func iterValueToDSOutput(iterVal map[string]cty.Value) iterds.DatasourceOutput {
 		}
 	}
 	return dso
-}
-
-func setupRegistryForPackerCore(cfg *CoreWrapper) hcl.Diagnostics {
-	if env.IsHCPDisabled() {
-		return nil
-	}
-
-	if !env.HasPackerRegistryBucket() && !env.IsHCPExplicitelyEnabled() {
-		return nil
-	}
-
-	var diags hcl.Diagnostics
-
-	if !env.HasHCPCredentials() {
-		diags = append(diags, &hcl.Diagnostic{
-			Summary:  "missing authentication information",
-			Detail:   fmt.Sprintf("the client authentication requires both %s and %s environment variables to be set", env.HCPClientID, env.HCPClientSecret),
-			Severity: hcl.DiagError,
-		})
-	}
-
-	var err error
-
-	core := cfg.Core
-
-	core.Bucket, err = registry.NewBucketWithIteration(registry.IterationOptions{
-		TemplateBaseDir: filepath.Dir(core.Template.Path),
-	})
-	if err != nil {
-		diags = append(diags, &hcl.Diagnostic{
-			Summary:  "bucket creation failure",
-			Detail:   fmt.Sprintf("failed to create Bucket: %s", err),
-			Severity: hcl.DiagError,
-		})
-	}
-
-	// Configure HCP Packer Registry destination
-	bucketSlug := os.Getenv(env.HCPPackerBucket)
-
-	if bucketSlug == "" {
-		diags = append(diags, &hcl.Diagnostic{
-			Summary:  "bucket name cannot be empty",
-			Detail:   "empty bucket name, please set it with the HCP_PACKER_BUCKET_NAME environment variable",
-			Severity: hcl.DiagError,
-		})
-	}
-
-	if core.Bucket != nil {
-		core.Bucket.Slug = bucketSlug
-		core.Bucket.LoadDefaultSettingsFromEnv()
-
-		for _, b := range core.Template.Builders {
-			// Get all builds slated within config ignoring any only or exclude flags.
-			core.Bucket.RegisterBuildForComponent(b.Name)
-		}
-	}
-
-	return diags
 }

--- a/command/registry.go
+++ b/command/registry.go
@@ -92,7 +92,7 @@ func setupRegistryForPackerConfig(pc *hcl2template.PackerConfig) hcl.Diagnostics
 		return diags
 	}
 
-	withHCLBucketConfigurtation := func(bb *hcl2template.BuildBlock) bucketConfigurationOpts {
+	withHCLBucketConfiguration := func(bb *hcl2template.BuildBlock) bucketConfigurationOpts {
 		return func(bucket *registry.Bucket) hcl.Diagnostics {
 			bb.HCPPackerRegistry.WriteToBucketConfig(bucket)
 			// If at this point the bucket.Slug is still empty,
@@ -119,7 +119,7 @@ func setupRegistryForPackerConfig(pc *hcl2template.PackerConfig) hcl.Diagnostics
 	pc.Bucket, diags = createConfiguredBucket(
 		pc.Basedir,
 		withPackerEnvConfiguration,
-		withHCLBucketConfigurtation(build),
+		withHCLBucketConfiguration(build),
 		withDatasourceConfiguration(vals),
 	)
 

--- a/command/registry.go
+++ b/command/registry.go
@@ -16,13 +16,16 @@ import (
 	"github.com/zclconf/go-cty/cty/gocty"
 )
 
+// HCPConfigMode types specify the mode in which HCP configuration
+// is defined for a given Packer build execution.
 type HCPConfigMode int
 
 const (
-	// HCPConfigMode types specify the mode in which HCP configuration
-	// is defined for a given Packer build execution.
+	// HCPConfigUnset mode is set when no HCP configuration has been found for the Packer execution.
 	HCPConfigUnset HCPConfigMode = iota
+	// HCPConfigEnabled mode is set when the HCP configuration is codified in the template.
 	HCPConfigEnabled
+	// HCPEnvEnabled mode is set when the HCP configuration is read from environment variables.
 	HCPEnvEnabled
 )
 

--- a/command/registry_test.go
+++ b/command/registry_test.go
@@ -400,6 +400,9 @@ func TestRegistrySetup(t *testing.T) {
 		},
 	}
 
+	t.Setenv("HCP_CLIENT_ID", "test")
+	t.Setenv("HCP_CLIENT_SECRET", "test")
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			runRegistryTest(t, tt)

--- a/internal/registry/env/env.go
+++ b/internal/registry/env/env.go
@@ -47,6 +47,6 @@ func IsHCPDisabled() bool {
 
 // IsHCPExplicitelyEnabled returns true if the client enabled HCP_PACKER_REGISTRY explicitely, i.e. it is defined and not 0 or off
 func IsHCPExplicitelyEnabled() bool {
-	hcp, ok := os.LookupEnv(HCPPackerRegistry)
-	return ok && strings.ToLower(hcp) != "off" && hcp != "0"
+	_, ok := os.LookupEnv(HCPPackerRegistry)
+	return ok && !IsHCPDisabled()
 }

--- a/internal/registry/env/env.go
+++ b/internal/registry/env/env.go
@@ -44,3 +44,9 @@ func IsHCPDisabled() bool {
 	hcp, ok := os.LookupEnv(HCPPackerRegistry)
 	return ok && strings.ToLower(hcp) == "off" || hcp == "0"
 }
+
+// IsHCPExplicitelyEnabled returns true if the client enabled HCP_PACKER_REGISTRY explicitely, i.e. it is defined and not 0 or off
+func IsHCPExplicitelyEnabled() bool {
+	hcp, ok := os.LookupEnv(HCPPackerRegistry)
+	return ok && strings.ToLower(hcp) != "off" && hcp != "0"
+}

--- a/internal/registry/env/variables.go
+++ b/internal/registry/env/variables.go
@@ -1,8 +1,9 @@
 package env
 
 const (
-	HCPClientID       = "HCP_CLIENT_ID"
-	HCPClientSecret   = "HCP_CLIENT_SECRET"
-	HCPPackerRegistry = "HCP_PACKER_REGISTRY"
-	HCPPackerBucket   = "HCP_PACKER_BUCKET_NAME"
+	HCPClientID               = "HCP_CLIENT_ID"
+	HCPClientSecret           = "HCP_CLIENT_SECRET"
+	HCPPackerRegistry         = "HCP_PACKER_REGISTRY"
+	HCPPackerBucket           = "HCP_PACKER_BUCKET_NAME"
+	HCPPackerBuildFingerprint = "HCP_PACKER_BUILD_FINGERPRINT"
 )

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -39,20 +39,15 @@ type ParentIteration struct {
 
 // NewBucketWithIteration initializes a simple Bucket that can be used publishing Packer build
 // images to the HCP Packer registry.
-func NewBucketWithIteration(opts IterationOptions) (*Bucket, error) {
+func NewBucketWithIteration() *Bucket {
 	b := Bucket{
 		BucketLabels:                   make(map[string]string),
 		BuildLabels:                    make(map[string]string),
 		SourceImagesToParentIterations: make(map[string]ParentIteration),
 	}
+	b.Iteration = NewIteration()
 
-	i, err := NewIteration(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	b.Iteration = i
-	return &b, nil
+	return &b
 }
 
 func (b *Bucket) Validate() error {

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -264,11 +264,6 @@ func (b *Bucket) UpdateLabelsForBuild(componentType string, data map[string]stri
 
 // Load defaults from environment variables
 func (b *Bucket) LoadDefaultSettingsFromEnv() {
-	// Configure HCP Packer Registry destination
-	if b.Slug == "" {
-		b.Slug = os.Getenv(env.HCPPackerBucket)
-	}
-
 	// Set some iteration values. For Packer RunUUID should always be set.
 	// Creating an iteration differently? Let's not overwrite a UUID that might be set.
 	if b.Iteration.RunUUID == "" {

--- a/internal/registry/types.bucket.go
+++ b/internal/registry/types.bucket.go
@@ -259,6 +259,11 @@ func (b *Bucket) UpdateLabelsForBuild(componentType string, data map[string]stri
 
 // Load defaults from environment variables
 func (b *Bucket) LoadDefaultSettingsFromEnv() {
+	// Configure HCP Packer Registry destination
+	if b.Slug == "" {
+		b.Slug = os.Getenv(env.HCPPackerBucket)
+	}
+
 	// Set some iteration values. For Packer RunUUID should always be set.
 	// Creating an iteration differently? Let's not overwrite a UUID that might be set.
 	if b.Iteration.RunUUID == "" {

--- a/internal/registry/types.bucket_service_test.go
+++ b/internal/registry/types.bucket_service_test.go
@@ -18,8 +18,8 @@ func TestInitialize_NewBucketNewIteration(t *testing.T) {
 		},
 	}
 
-	var err error
-	b.Iteration, err = NewIteration(IterationOptions{})
+	b.Iteration = NewIteration()
+	err := b.Iteration.Initialize(IterationOptions{})
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
@@ -73,12 +73,11 @@ func TestInitialize_ExistingBucketNewIteration(t *testing.T) {
 		},
 	}
 
-	var err error
-	b.Iteration, err = NewIteration(IterationOptions{})
+	b.Iteration = NewIteration()
+	err := b.Iteration.Initialize(IterationOptions{})
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-
 	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, "happycloud.image")
 
 	err = b.Initialize(context.TODO())
@@ -129,8 +128,8 @@ func TestInitialize_ExistingBucketExistingIteration(t *testing.T) {
 		},
 	}
 
-	var err error
-	b.Iteration, err = NewIteration(IterationOptions{})
+	b.Iteration = NewIteration()
+	err := b.Iteration.Initialize(IterationOptions{})
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
@@ -201,8 +200,8 @@ func TestInitialize_ExistingBucketCompleteIteration(t *testing.T) {
 		},
 	}
 
-	var err error
-	b.Iteration, err = NewIteration(IterationOptions{})
+	b.Iteration = NewIteration()
+	err := b.Iteration.Initialize(IterationOptions{})
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
@@ -245,12 +244,11 @@ func TestUpdateBuildStatus(t *testing.T) {
 		},
 	}
 
-	var err error
-	b.Iteration, err = NewIteration(IterationOptions{})
+	b.Iteration = NewIteration()
+	err := b.Iteration.Initialize(IterationOptions{})
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}
-
 	b.Iteration.expectedBuilds = append(b.Iteration.expectedBuilds, "happycloud.image")
 	mockService.ExistingBuilds = append(mockService.ExistingBuilds, "happycloud.image")
 
@@ -300,8 +298,8 @@ func TestUpdateBuildStatus_DONENoImages(t *testing.T) {
 		},
 	}
 
-	var err error
-	b.Iteration, err = NewIteration(IterationOptions{})
+	b.Iteration = NewIteration()
+	err := b.Iteration.Initialize(IterationOptions{})
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
 	}

--- a/internal/registry/types.bucket_test.go
+++ b/internal/registry/types.bucket_test.go
@@ -13,6 +13,11 @@ func createInitialTestBucket(t testing.TB) *Bucket {
 
 	t.Helper()
 	bucket := NewBucketWithIteration()
+	err := bucket.Iteration.Initialize(IterationOptions{})
+	if err != nil {
+		t.Errorf("failed to initialize Bucket: %s", err)
+		return nil
+	}
 
 	mockService := NewMockPackerClientService()
 	mockService.TrackCalledServiceMethods = false

--- a/internal/registry/types.bucket_test.go
+++ b/internal/registry/types.bucket_test.go
@@ -12,10 +12,7 @@ func createInitialTestBucket(t testing.TB) *Bucket {
 	t.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "no-fingerprint-here")
 
 	t.Helper()
-	bucket, err := NewBucketWithIteration(IterationOptions{})
-	if err != nil {
-		t.Fatalf("failed when calling NewBucketWithIteration: %s", err)
-	}
+	bucket := NewBucketWithIteration()
 
 	mockService := NewMockPackerClientService()
 	mockService.TrackCalledServiceMethods = false
@@ -285,7 +282,8 @@ func TestBucket_PopulateIteration(t *testing.T) {
 			mockService.IterationAlreadyExist = true
 			mockService.BuildAlreadyDone = tt.buildCompleted
 
-			bucket, err := NewBucketWithIteration(IterationOptions{})
+			bucket := NewBucketWithIteration()
+			err := bucket.Iteration.Initialize(IterationOptions{})
 			if err != nil {
 				t.Fatalf("failed when calling NewBucketWithIteration: %s", err)
 			}

--- a/internal/registry/types.iterations.go
+++ b/internal/registry/types.iterations.go
@@ -26,7 +26,7 @@ type IterationOptions struct {
 }
 
 // NewIteration returns a pointer to an Iteration that can be used for storing Packer build details needed by PAR.
-func NewIteration(opts IterationOptions) (*Iteration, error) {
+func NewIteration() *Iteration {
 	i := Iteration{
 		expectedBuilds: make([]string, 0),
 	}
@@ -35,17 +35,26 @@ func NewIteration(opts IterationOptions) (*Iteration, error) {
 	// If no variable is defined we should try to load a fingerprint from Git, or other VCS.
 	i.Fingerprint = os.Getenv(env.HCPPackerBuildFingerprint)
 
-	// get a Git SHA
+	return &i
+}
+
+// Initialize prepares the iteration to be used with an active HCP Packer registry bucket.
+func (i *Iteration) Initialize(opts IterationOptions) error {
+	if i == nil {
+		return errors.New("Unexpected call to initialize for a nil Iteration")
+	}
+
 	if i.Fingerprint != "" {
-		return &i, nil
+		return nil
 	}
 
 	fp, err := GetGitFingerprint(opts)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	i.Fingerprint = fp
-	return &i, nil
+
+	return nil
 }
 
 // GetGitFingerprint returns the HEAD commit for some template dir defined in opt.TemplateBaseDir.

--- a/internal/registry/types.iterations.go
+++ b/internal/registry/types.iterations.go
@@ -31,10 +31,6 @@ func NewIteration() *Iteration {
 		expectedBuilds: make([]string, 0),
 	}
 
-	// By default we try to load a Fingerprint from the environment variable.
-	// If no variable is defined we should try to load a fingerprint from Git, or other VCS.
-	i.Fingerprint = os.Getenv(env.HCPPackerBuildFingerprint)
-
 	return &i
 }
 
@@ -43,6 +39,10 @@ func (i *Iteration) Initialize(opts IterationOptions) error {
 	if i == nil {
 		return errors.New("Unexpected call to initialize for a nil Iteration")
 	}
+
+	// By default we try to load a Fingerprint from the environment variable.
+	// If no variable is defined we should try to load a fingerprint from Git, or other VCS.
+	i.Fingerprint = os.Getenv(env.HCPPackerBuildFingerprint)
 
 	if i.Fingerprint != "" {
 		return nil

--- a/internal/registry/types.iterations.go
+++ b/internal/registry/types.iterations.go
@@ -8,6 +8,7 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
+	"github.com/hashicorp/packer/internal/registry/env"
 )
 
 type Iteration struct {
@@ -32,7 +33,7 @@ func NewIteration(opts IterationOptions) (*Iteration, error) {
 
 	// By default we try to load a Fingerprint from the environment variable.
 	// If no variable is defined we should try to load a fingerprint from Git, or other VCS.
-	i.Fingerprint = os.Getenv("HCP_PACKER_BUILD_FINGERPRINT")
+	i.Fingerprint = os.Getenv(env.HCPPackerBuildFingerprint)
 
 	// get a Git SHA
 	if i.Fingerprint != "" {

--- a/internal/registry/types.iterations_test.go
+++ b/internal/registry/types.iterations_test.go
@@ -8,7 +8,7 @@ import (
 	git "github.com/go-git/go-git/v5"
 )
 
-func TestNewIteration(t *testing.T) {
+func TestIteration_Initialize(t *testing.T) {
 	var tc = []struct {
 		name          string
 		fingerprint   string
@@ -74,15 +74,16 @@ func TestNewIteration(t *testing.T) {
 				tt.setupFn(t)
 			}
 
-			i, err := NewIteration(tt.opts)
+			i := NewIteration()
+			err := i.Initialize(tt.opts)
 			if tt.errorExpected {
 				t.Logf("%v", err)
 				if err == nil {
 					t.Errorf("expected %q to result in an error, but it return no error", tt.name)
 				}
 
-				if i != nil {
-					t.Errorf("expected %q to result in an error with no iteration, but got %v", tt.name, i)
+				if i.Fingerprint != "" {
+					t.Errorf("expected %q to result in an error with an empty iteration fingerprint, but got %q", tt.name, i.Fingerprint)
 				}
 				return
 			}


### PR DESCRIPTION
This PR makes some changes in the way errors are reported in an HCP-enabled template, both for JSON and HCL, as the code related to setupping HCP will now return all errors at once rather than just the first one encountered, and adds an extra check for the `HCP_CLIENT_ID` and `HCP_CLIENT_SECRET` at the same time.

The latter check used to be done when initialising the bucket, but now this is done in the setup phase too in order to report the errors at once, so clients what want to enable HCP don't have to do multiple passes on their templates to fix the problems with their environment.