### PR TITLE
website: upgrade next version

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,7 @@
         "@hashicorp/platform-cli": "^2.1.0",
         "dart-linkcheck": "2.0.15",
         "husky": "4.3.8",
+        "next": "^12.3.1",
         "prettier": "2.2.1"
       },
       "engines": {
@@ -1107,11 +1108,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.5.tgz",
-      "integrity": "sha512-+34yUJslfJi7Lyx6ELuN8nWcOzi27izfYnZIC1Dqv7kmmfiBVxgzR3BXhlvEMTKC2IRJhXVs2FkMY+buQe3k7Q==",
-      "dev": true,
-      "peer": true
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
+      "integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg==",
+      "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.0.10",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.5.tgz",
-      "integrity": "sha512-SKnGTdYcoN04Y2DvE0/Y7/MjkA+ltsmbuH/y/hR7Ob7tsj+8ZdOYuk+YvW1B8dY20nDPHP58XgDTSm2nA8BzzA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
+      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
       "cpu": [
         "arm"
       ],
@@ -1134,15 +1134,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.5.tgz",
-      "integrity": "sha512-YXiqgQ/9Rxg1dXp6brXbeQM1JDx9SwUY/36JiE+36FXqYEmDYbxld9qkX6GEzkc5rbwJ+RCitargnzEtwGW0mw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
+      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
       "cpu": [
         "arm64"
       ],
@@ -1151,15 +1150,14 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.5.tgz",
-      "integrity": "sha512-y8mhldb/WFZ6lFeowkGfi0cO/lBdiBqDk4T4LZLvCpoQp4Or/NzUN6P5NzBQZ5/b4oUHM/wQICEM+1wKA4qIVw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
+      "integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
       "cpu": [
         "arm64"
       ],
@@ -1168,15 +1166,14 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.5.tgz",
-      "integrity": "sha512-wqJ3X7WQdTwSGi0kIDEmzw34QHISRIQ5uvC+VXmsIlCPFcMA+zM5723uh8NfuKGquDMiEMS31a83QgkuHMYbwQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
+      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
       "cpu": [
         "x64"
       ],
@@ -1185,15 +1182,30 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
+      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.5.tgz",
-      "integrity": "sha512-WnhdM5duONMvt2CncAl+9pim0wBxDS2lHoo7ub/o/i1bRbs11UTzosKzEXVaTDCUkCX2c32lIDi1WcN2ZPkcdw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
+      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
       "cpu": [
         "arm"
       ],
@@ -1202,15 +1214,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.5.tgz",
-      "integrity": "sha512-Jq2H68yQ4bLUhR/XQnbw3LDW0GMQn355qx6rU36BthDLeGue7YV7MqNPa8GKvrpPocEMW77nWx/1yI6w6J07gw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
+      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
       "cpu": [
         "arm64"
       ],
@@ -1219,15 +1230,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.5.tgz",
-      "integrity": "sha512-KgPjwdbhDqXI7ghNN8V/WAiLquc9Ebe8KBrNNEL0NQr+yd9CyKJ6KqjayVkmX+hbHzbyvbui/5wh/p3CZQ9xcQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
+      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
       "cpu": [
         "arm64"
       ],
@@ -1236,15 +1246,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.5.tgz",
-      "integrity": "sha512-O2ErUTvCJ6DkNTSr9pbu1n3tcqykqE/ebty1rwClzIYdOgpB3T2MfEPP+K7GhUR87wmN/hlihO9ch7qpVFDGKw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
+      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
       "cpu": [
         "x64"
       ],
@@ -1253,15 +1262,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.5.tgz",
-      "integrity": "sha512-1eIlZmlO/VRjxxzUBcVosf54AFU3ltAzHi+BJA+9U/lPxCYIsT+R4uO3QksRzRjKWhVQMRjEnlXyyq5SKJm7BA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
+      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
       "cpu": [
         "x64"
       ],
@@ -1270,15 +1278,14 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.5.tgz",
-      "integrity": "sha512-oromsfokbEuVb0CBLLE7R9qX3KGXucZpsojLpzUh1QJjuy1QkrPJncwr8xmWQnwgtQ6ecMWXgXPB+qtvizT9Tw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
+      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
       "cpu": [
         "arm64"
       ],
@@ -1287,15 +1294,14 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.5.tgz",
-      "integrity": "sha512-a/51L5KzBpeZSW9LbekMo3I3Cwul+V+QKwbEIMA+Qwb2qrlcn1L9h3lt8cHqNTFt2y72ce6aTwDTw1lyi5oIRA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
+      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
       "cpu": [
         "ia32"
       ],
@@ -1304,15 +1310,14 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.5.tgz",
-      "integrity": "sha512-/SoXW1Ntpmpw3AXAzfDRaQidnd8kbZ2oSni8u5z0yw6t4RwJvmdZy1eOaAADRThWKV+2oU90++LSnXJIwBRWYQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
+      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
       "cpu": [
         "x64"
       ],
@@ -1321,7 +1326,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1414,6 +1418,21 @@
         "postcss": ">=7.0.0",
         "postcss-syntax": ">=0.36.2"
       }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
+      "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -2545,9 +2564,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001416",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
+      "integrity": "sha512-06wzzdAkCPZO+Qm4e/eNghZBDfVNDsCgw33T27OwBH9unE9S478OYw//Q2L7Npf/zBzs7rjZOszIFQkwQKAEqA==",
       "dev": true,
       "funding": [
         {
@@ -7484,11 +7503,10 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7526,16 +7544,17 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.5.tgz",
-      "integrity": "sha512-YGHDpyfgCfnT5GZObsKepmRnne7Kzp7nGrac07dikhutWQug7hHg85/+sPJ4ZW5Q2pDkb+n0FnmLkmd44htIJQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
+      "integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@next/env": "12.1.5",
-        "caniuse-lite": "^1.0.30001283",
-        "postcss": "8.4.5",
-        "styled-jsx": "5.0.1"
+        "@next/env": "12.3.1",
+        "@swc/helpers": "0.4.11",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.14",
+        "styled-jsx": "5.0.7",
+        "use-sync-external-store": "1.2.0"
       },
       "bin": {
         "next": "dist/bin/next"
@@ -7544,18 +7563,19 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.1.5",
-        "@next/swc-android-arm64": "12.1.5",
-        "@next/swc-darwin-arm64": "12.1.5",
-        "@next/swc-darwin-x64": "12.1.5",
-        "@next/swc-linux-arm-gnueabihf": "12.1.5",
-        "@next/swc-linux-arm64-gnu": "12.1.5",
-        "@next/swc-linux-arm64-musl": "12.1.5",
-        "@next/swc-linux-x64-gnu": "12.1.5",
-        "@next/swc-linux-x64-musl": "12.1.5",
-        "@next/swc-win32-arm64-msvc": "12.1.5",
-        "@next/swc-win32-ia32-msvc": "12.1.5",
-        "@next/swc-win32-x64-msvc": "12.1.5"
+        "@next/swc-android-arm-eabi": "12.3.1",
+        "@next/swc-android-arm64": "12.3.1",
+        "@next/swc-darwin-arm64": "12.3.1",
+        "@next/swc-darwin-x64": "12.3.1",
+        "@next/swc-freebsd-x64": "12.3.1",
+        "@next/swc-linux-arm-gnueabihf": "12.3.1",
+        "@next/swc-linux-arm64-gnu": "12.3.1",
+        "@next/swc-linux-arm64-musl": "12.3.1",
+        "@next/swc-linux-x64-gnu": "12.3.1",
+        "@next/swc-linux-x64-musl": "12.3.1",
+        "@next/swc-win32-arm64-msvc": "12.3.1",
+        "@next/swc-win32-ia32-msvc": "12.3.1",
+        "@next/swc-win32-x64-msvc": "12.3.1"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -8371,22 +8391,27 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "dev": true,
-      "peer": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
       "dependencies": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-html": {
@@ -10147,7 +10172,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10584,11 +10608,10 @@
       "dev": true
     },
     "node_modules/styled-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.1.tgz",
-      "integrity": "sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
+      "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -11511,6 +11534,15 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -12821,11 +12853,10 @@
       }
     },
     "@next/env": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.5.tgz",
-      "integrity": "sha512-+34yUJslfJi7Lyx6ELuN8nWcOzi27izfYnZIC1Dqv7kmmfiBVxgzR3BXhlvEMTKC2IRJhXVs2FkMY+buQe3k7Q==",
-      "dev": true,
-      "peer": true
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
+      "integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg==",
+      "dev": true
     },
     "@next/eslint-plugin-next": {
       "version": "12.0.10",
@@ -12837,100 +12868,95 @@
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.5.tgz",
-      "integrity": "sha512-SKnGTdYcoN04Y2DvE0/Y7/MjkA+ltsmbuH/y/hR7Ob7tsj+8ZdOYuk+YvW1B8dY20nDPHP58XgDTSm2nA8BzzA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
+      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.5.tgz",
-      "integrity": "sha512-YXiqgQ/9Rxg1dXp6brXbeQM1JDx9SwUY/36JiE+36FXqYEmDYbxld9qkX6GEzkc5rbwJ+RCitargnzEtwGW0mw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
+      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.5.tgz",
-      "integrity": "sha512-y8mhldb/WFZ6lFeowkGfi0cO/lBdiBqDk4T4LZLvCpoQp4Or/NzUN6P5NzBQZ5/b4oUHM/wQICEM+1wKA4qIVw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
+      "integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.5.tgz",
-      "integrity": "sha512-wqJ3X7WQdTwSGi0kIDEmzw34QHISRIQ5uvC+VXmsIlCPFcMA+zM5723uh8NfuKGquDMiEMS31a83QgkuHMYbwQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
+      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
+      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.5.tgz",
-      "integrity": "sha512-WnhdM5duONMvt2CncAl+9pim0wBxDS2lHoo7ub/o/i1bRbs11UTzosKzEXVaTDCUkCX2c32lIDi1WcN2ZPkcdw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
+      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.5.tgz",
-      "integrity": "sha512-Jq2H68yQ4bLUhR/XQnbw3LDW0GMQn355qx6rU36BthDLeGue7YV7MqNPa8GKvrpPocEMW77nWx/1yI6w6J07gw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
+      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.5.tgz",
-      "integrity": "sha512-KgPjwdbhDqXI7ghNN8V/WAiLquc9Ebe8KBrNNEL0NQr+yd9CyKJ6KqjayVkmX+hbHzbyvbui/5wh/p3CZQ9xcQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
+      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.5.tgz",
-      "integrity": "sha512-O2ErUTvCJ6DkNTSr9pbu1n3tcqykqE/ebty1rwClzIYdOgpB3T2MfEPP+K7GhUR87wmN/hlihO9ch7qpVFDGKw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
+      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.5.tgz",
-      "integrity": "sha512-1eIlZmlO/VRjxxzUBcVosf54AFU3ltAzHi+BJA+9U/lPxCYIsT+R4uO3QksRzRjKWhVQMRjEnlXyyq5SKJm7BA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
+      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.5.tgz",
-      "integrity": "sha512-oromsfokbEuVb0CBLLE7R9qX3KGXucZpsojLpzUh1QJjuy1QkrPJncwr8xmWQnwgtQ6ecMWXgXPB+qtvizT9Tw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
+      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.5.tgz",
-      "integrity": "sha512-a/51L5KzBpeZSW9LbekMo3I3Cwul+V+QKwbEIMA+Qwb2qrlcn1L9h3lt8cHqNTFt2y72ce6aTwDTw1lyi5oIRA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
+      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.5.tgz",
-      "integrity": "sha512-/SoXW1Ntpmpw3AXAzfDRaQidnd8kbZ2oSni8u5z0yw6t4RwJvmdZy1eOaAADRThWKV+2oU90++LSnXJIwBRWYQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
+      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -13001,6 +13027,23 @@
       "requires": {
         "remark": "^13.0.0",
         "unist-util-find-all-after": "^3.0.2"
+      }
+    },
+    "@swc/helpers": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
+      "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
       }
     },
     "@tootallnate/once": {
@@ -13845,9 +13888,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001416",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
+      "integrity": "sha512-06wzzdAkCPZO+Qm4e/eNghZBDfVNDsCgw33T27OwBH9unE9S478OYw//Q2L7Npf/zBzs7rjZOszIFQkwQKAEqA==",
       "dev": true
     },
     "capture-exit": {
@@ -17609,11 +17652,10 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-      "dev": true,
-      "peer": true
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -17642,28 +17684,30 @@
       "dev": true
     },
     "next": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.5.tgz",
-      "integrity": "sha512-YGHDpyfgCfnT5GZObsKepmRnne7Kzp7nGrac07dikhutWQug7hHg85/+sPJ4ZW5Q2pDkb+n0FnmLkmd44htIJQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
+      "integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "@next/env": "12.1.5",
-        "@next/swc-android-arm-eabi": "12.1.5",
-        "@next/swc-android-arm64": "12.1.5",
-        "@next/swc-darwin-arm64": "12.1.5",
-        "@next/swc-darwin-x64": "12.1.5",
-        "@next/swc-linux-arm-gnueabihf": "12.1.5",
-        "@next/swc-linux-arm64-gnu": "12.1.5",
-        "@next/swc-linux-arm64-musl": "12.1.5",
-        "@next/swc-linux-x64-gnu": "12.1.5",
-        "@next/swc-linux-x64-musl": "12.1.5",
-        "@next/swc-win32-arm64-msvc": "12.1.5",
-        "@next/swc-win32-ia32-msvc": "12.1.5",
-        "@next/swc-win32-x64-msvc": "12.1.5",
-        "caniuse-lite": "^1.0.30001283",
-        "postcss": "8.4.5",
-        "styled-jsx": "5.0.1"
+        "@next/env": "12.3.1",
+        "@next/swc-android-arm-eabi": "12.3.1",
+        "@next/swc-android-arm64": "12.3.1",
+        "@next/swc-darwin-arm64": "12.3.1",
+        "@next/swc-darwin-x64": "12.3.1",
+        "@next/swc-freebsd-x64": "12.3.1",
+        "@next/swc-linux-arm-gnueabihf": "12.3.1",
+        "@next/swc-linux-arm64-gnu": "12.3.1",
+        "@next/swc-linux-arm64-musl": "12.3.1",
+        "@next/swc-linux-x64-gnu": "12.3.1",
+        "@next/swc-linux-x64-musl": "12.3.1",
+        "@next/swc-win32-arm64-msvc": "12.3.1",
+        "@next/swc-win32-ia32-msvc": "12.3.1",
+        "@next/swc-win32-x64-msvc": "12.3.1",
+        "@swc/helpers": "0.4.11",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.14",
+        "styled-jsx": "5.0.7",
+        "use-sync-external-store": "1.2.0"
       }
     },
     "nice-try": {
@@ -18272,15 +18316,14 @@
       "peer": true
     },
     "postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
+        "source-map-js": "^1.0.2"
       }
     },
     "postcss-html": {
@@ -19664,8 +19707,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -20017,11 +20059,10 @@
       "dev": true
     },
     "styled-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.1.tgz",
-      "integrity": "sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
+      "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "stylelint": {
@@ -20722,6 +20763,13 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true,
       "peer": true
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "dev": true,
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -7,6 +7,7 @@
     "@hashicorp/platform-cli": "^2.1.0",
     "dart-linkcheck": "2.0.15",
     "husky": "4.3.8",
+    "next": "^12.3.1",
     "prettier": "2.2.1"
   },
   "husky": {


### PR DESCRIPTION
Upgrade the version of next.js used by the website to the latest (12.3.1)

[_Created by Sourcegraph batch change `bkalow/upgrade-next-12.3`._](https://hashicorp-mktg.sourcegraph.com/users/bkalow/batch-changes/upgrade-next-12.3)