### PR TITLE
Enable Iron Bank integration

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -266,3 +266,16 @@ event "post-publish-website" {
     on = "always"
   }
 }
+
+event "update-ironbank" {
+  depends = ["post-publish-website"]
+  action "update-ironbank" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "update-ironbank"
+  }
+
+  notification {
+    on = "fail"
+  }
+}


### PR DESCRIPTION
This patch enables CRT's Iron Bank integration.

Matching backport labels to https://repo1.dso.mil/dsop/hashicorp/packer except ``1.9.x`` which does not appear in the list of labels.