### PR TITLE
Remove sidebar entries that no longer exist

### DIFF
--- a/website/data/intro-nav-data.json
+++ b/website/data/intro-nav-data.json
@@ -6,30 +6,5 @@
   {
     "title": "Use Cases",
     "path": "use-cases"
-  },
-  {
-    "title": "Getting Started",
-    "routes": [
-      {
-        "title": "Install",
-        "href": "/intro/getting-started/install"
-      },
-      {
-        "title": "Build An Image",
-        "href": "/intro/getting-started/build-image"
-      },
-      {
-        "title": "Provision",
-        "href": "/intro/getting-started/provision"
-      },
-      {
-        "title": "Parallel Builds",
-        "href": "/intro/getting-started/parallel-builds"
-      },
-      {
-        "title": "Vagrant Boxes",
-        "href": "/intro/getting-started/vagrant"
-      }
-    ]
   }
 ]


### PR DESCRIPTION
The new [hashicorp developer portal ](https://developer.hashicorp.com/packer/intro)is showing links to previously removed getting started pages. These pages are now learn tutorials! This PR removes those mentions from the sidebar to hopefully fix this problem :) 

Please note: This is a hot fix to get these broken links out of here. I generally think we need to revise the structure of the packer docs so that everything flows better moving forward :) 

<img width="289" alt="Screen Shot 2022-10-13 at 6 45 46 PM" src="https://user-images.githubusercontent.com/83350965/195724255-7ae27214-49e8-4a4f-8bfc-9827ce82312e.png">
