### PR TITLE
[HPR-763] Update HCL variable documentation

### DIFF
--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -79,33 +79,29 @@ name for the variable, which must be unique among all variables in the same
 build. This name is used to assign a value to the variable from outside and to
 reference the variable's value from within the build.
 
-The `variable` block can optionally include a `type` argument to specify what
-value types are accepted for the variable, as described in the following
-section.
 
-The `variable` declaration can also include a `default` argument. If present,
+## Arguments
+
+Terraform CLI defines the following optional arguments for variable declarations:
+
+* [`default`][inpage-default] - A default value which then makes the variable optional.
+* [`type`][inpage-type] - This argument specifies what value types are accepted for the variable.
+* [`description`][inpage-description] - This specifies the input variable's documentation.
+* [`validation`][inpage-validation] - A block to define validation rules, usually in addition to type constraints.
+
+### Default values
+
+[inpage-default]: #default-values
+
+The variable declaration can also include a `default` argument. If present,
 the variable is considered to be _optional_ and the default value will be used
-if no value is set when calling the build or running Packer. The `default`
+if no value is set when calling the module or running Terraform. The `default`
 argument requires a literal value and cannot reference other objects in the
 configuration.
 
-## Using Input Variable Values
-
-Within the build that declared a variable, its value can be accessed from
-within [expressions](/docs/templates/hcl_templates/expressions) as `var.<NAME>`, where `<NAME>`
-matches the label given in the declaration block:
-
-```hcl
-source "googlecompute" "debian"  {
-    zone = var.gcp_zone
-    tags = var.gcp_debian_tags
-}
-```
-
-The value assigned to a variable can be accessed only from expressions within
-the folder where it was declared.
 
 ## Type Constraints
+[inpage-type]: #type-constraints
 
 The `type` argument in a `variable` block allows you to restrict the [type of
 value](/docs/templates/hcl_templates/expressions#types-and-values) that will be accepted as the value
@@ -148,6 +144,8 @@ as a string.
 
 ## Input Variable Documentation
 
+[inpage-description]: #input-variable-documentation
+
 Because the input variables of a build are part of its user interface, you can
 briefly describe the purpose of each variable using the optional `description`
 argument:
@@ -165,11 +163,28 @@ documentation about the build, and so it should be written from the perspective
 of the user of the build rather than its maintainer. For commentary for build
 maintainers, use comments.
 
+`@include 'from-1.5/variables/custom-validation.mdx'`
+
+## Using Input Variable Values
+
+Within the build that declared a variable, its value can be accessed from
+within [expressions](/docs/templates/hcl_templates/expressions) as `var.<NAME>`, where `<NAME>`
+matches the label given in the declaration block:
+
+```hcl
+source "googlecompute" "debian"  {
+    zone = var.gcp_zone
+    tags = var.gcp_debian_tags
+}
+```
+
+The value assigned to a variable can be accessed only from expressions within
+the folder where it was declared.
+
+
 `@include 'from-1.5/variables/assignment.mdx'`
 
 The following sections describe these options in more detail.
-
-`@include 'from-1.5/variables/custom-validation.mdx'`
 
 ### Variables on the Command Line
 

--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -92,7 +92,7 @@ Packer defines the following arguments for variable declarations:
 
 
 
-## Default values
+### Default values
 
 [inpage-default]: #default-values
 
@@ -103,7 +103,7 @@ argument requires a literal value and cannot reference other objects in the
 configuration.
 
 
-## Type Constraints
+### Type Constraints
 [inpage-type]: #type-constraints
 
 The `type` argument in a `variable` block allows you to restrict the [type of
@@ -145,7 +145,7 @@ variable [from env vars](#environment-variables) or [from the command
 line](#variables-on-the-command-line), the variable will always be interpreted
 as a string.
 
-## Input Variable Documentation
+### Input Variable Documentation
 
 [inpage-description]: #input-variable-documentation
 

--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -88,7 +88,7 @@ Packer defines the following arguments for variable declarations:
 * [`type`][inpage-type] - This argument specifies what value types are accepted for the variable.
 * [`description`][inpage-description] - This specifies the input variable's documentation.
 * [`validation`][inpage-validation] - A block to define validation rules, usually in addition to type constraints.
-* [`sensitive`][inpage-sensitive] -  This causes string-values from that variable will be obfuscated from Packer's output.
+* [`sensitive`][inpage-sensitive] -  This causes string-values from that variable to be obfuscated from Packer's output.
 
 
 

--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -88,6 +88,9 @@ Terraform CLI defines the following optional arguments for variable declarations
 * [`type`][inpage-type] - This argument specifies what value types are accepted for the variable.
 * [`description`][inpage-description] - This specifies the input variable's documentation.
 * [`validation`][inpage-validation] - A block to define validation rules, usually in addition to type constraints.
+* [`sensitive`][inpage-sensitive] -  This causes string-values from that variable will be obfuscated from Packer's output.
+
+
 
 ## Default values
 
@@ -164,6 +167,9 @@ of the user of the build rather than its maintainer. For commentary for build
 maintainers, use comments.
 
 `@include 'from-1.5/variables/custom-validation.mdx'`
+
+`@include 'from-1.5/variables/sensitive.mdx'`
+
 
 ## Using Input Variable Values
 
@@ -333,4 +339,3 @@ other variables: the last value found overrides the previous values.
 |     `-var bar=yz` argument     | error, "bar undeclared" |  error, "bar undeclared"  |
 |    `export PKR_VAR_bar=yz`     |            -            |             -             |
 
-`@include 'from-1.5/variables/sensitive.mdx'`

--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -232,7 +232,7 @@ availability_zone_names = [
 ]
 ```
 
-~> **Warning**: Unlike legacy JSON templates the input variables within a variable definitions file must be declared 
+~> **Important**: Unlike legacy JSON templates the input variables within a variable definitions file must be declared 
 via a variables block within a standard HCL2 template file `*.pkr.hcl` before it can be assigned a value. 
 Failure to do so will result in an unknown variable error during Packer's runtime.
 
@@ -253,7 +253,7 @@ with the root object properties corresponding to variable names:
 }
 ```
 
-~> **Warning**: Unlike legacy JSON templates the input variables within a variable definitions file must be declared 
+~> **Important**: Unlike legacy JSON templates the input variables within a variable definitions file must be declared 
 via a variables block within a standard HCL2 template file `*.pkr.hcl` before it can be assigned a value. 
 Failure to do so will result in an unknown variable error during Packer's runtime.
 

--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -82,7 +82,7 @@ reference the variable's value from within the build.
 
 ## Arguments
 
-Terraform CLI defines the following optional arguments for variable declarations:
+Packer defines the following arguments for variable declarations:
 
 * [`default`][inpage-default] - A default value which then makes the variable optional.
 * [`type`][inpage-type] - This argument specifies what value types are accepted for the variable.

--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -89,7 +89,7 @@ Terraform CLI defines the following optional arguments for variable declarations
 * [`description`][inpage-description] - This specifies the input variable's documentation.
 * [`validation`][inpage-validation] - A block to define validation rules, usually in addition to type constraints.
 
-### Default values
+## Default values
 
 [inpage-default]: #default-values
 
@@ -204,11 +204,11 @@ you at least set a default type instead of using empty blocks; this helps the
 HCL parser understand what is being set. Otherwise, the interpreter will assume
 that any variable set on the command line is a string.
 
-### Variable Definitions (`.pkrvars.hcl` and `.auto.pkrvars.hcl`) Files
+### Standard Variable Definitions Files
 
 To set lots of variables, it is more convenient to specify their values in a
-_variable definitions file_ (with a filename ending in either `.pkrvars.hcl` or
-`.pkrvars.json`) and then specify that file on the command line with
+_variable definitions file_ with a filename ending in either `.pkrvars.hcl` or
+`.pkrvars.json` and then specify that file on the command line with
 `-var-file`:
 
 ```shell-session
@@ -216,7 +216,7 @@ $ packer build -var-file="testing.pkrvars.hcl"
 ```
 
 A variable definitions file uses the same basic syntax as Packer language
-files, but consists only of variable name assignments:
+files, but consists only of variable name and its assigned values:
 
 ```hcl
 image_id = "ami-abc123"
@@ -226,7 +226,13 @@ availability_zone_names = [
 ]
 ```
 
-Packer also automatically loads a number of variable definitions files if they
+~> **Warning**: Unlike legacy JSON templates the input variables within a variable definitions file must be declared 
+via a variables block within a standard HCL2 template file `*.pkr.hcl` before it can be assigned a value. 
+Failure to do so will result in an unknown variable error during Packer's runtime.
+
+### Auto-loaded Variable Definitions Files
+
+Packer also has the ability automatically load one or more variable definitions files if they
 are present:
 
 - Any files with names ending in `.auto.pkrvars.hcl` or `.auto.pkrvars.json`.
@@ -240,6 +246,11 @@ with the root object properties corresponding to variable names:
   "availability_zone_names": ["us-west-1a", "us-west-1c"]
 }
 ```
+
+~> **Warning**: Unlike legacy JSON templates the input variables within a variable definitions file must be declared 
+via a variables block within a standard HCL2 template file `*.pkr.hcl` before it can be assigned a value. 
+Failure to do so will result in an unknown variable error during Packer's runtime.
+
 
 ### Environment Variables
 

--- a/website/content/partials/from-1.5/variables/assignment.mdx
+++ b/website/content/partials/from-1.5/variables/assignment.mdx
@@ -1,8 +1,7 @@
-## Assigning Values to build Variables
+## Assigning Values to input Variables
 
 Once a variable is declared in your configuration, you can set it:
 
 - Individually, with the `-var foo=bar` command line option.
-- In variable definitions (`.pkrvars.hcl` and `.auto.pkrvars.hcl`) files,
-  either specified on the command line or automatically loaded.
+- In variable definitions files, either specified on the command line with the `-var-files values.pkrvars.hcl` or automatically loaded (`*.auto.pkrvars.hcl`).
 - As environment variables, for example: `PKR_VAR_foo=bar`

--- a/website/content/partials/from-1.5/variables/custom-validation.mdx
+++ b/website/content/partials/from-1.5/variables/custom-validation.mdx
@@ -1,5 +1,7 @@
 ## Custom Validation Rules
 
+[inpage-validation]: #custom-validation-rules
+
 In addition to Type Constraints, you can specify arbitrary custom validation
 rules for a particular variable using one or more `validation` block nested
 within the corresponding `variable` block:

--- a/website/content/partials/from-1.5/variables/custom-validation.mdx
+++ b/website/content/partials/from-1.5/variables/custom-validation.mdx
@@ -1,4 +1,4 @@
-## Custom Validation Rules
+### Custom Validation Rules
 
 [inpage-validation]: #custom-validation-rules
 

--- a/website/content/partials/from-1.5/variables/sensitive.mdx
+++ b/website/content/partials/from-1.5/variables/sensitive.mdx
@@ -1,4 +1,8 @@
-## A variable can be sensitive
+## Suppressing Sensitive Variables
+
+[inpage-sensitive]: #suppressing-sensitive-variables
+
+
 
 When a variable is sensitive all string-values from that variable will be
 obfuscated from Packer's output :

--- a/website/content/partials/from-1.5/variables/sensitive.mdx
+++ b/website/content/partials/from-1.5/variables/sensitive.mdx
@@ -1,4 +1,4 @@
-## Suppressing Sensitive Variables
+### Suppressing Sensitive Variables
 
 [inpage-sensitive]: #suppressing-sensitive-variables
 

--- a/website/content/partials/from-1.5/variables/sensitive.mdx
+++ b/website/content/partials/from-1.5/variables/sensitive.mdx
@@ -3,7 +3,6 @@
 [inpage-sensitive]: #suppressing-sensitive-variables
 
 
-
 When a variable is sensitive all string-values from that variable will be
 obfuscated from Packer's output :
 


### PR DESCRIPTION
As it stand the organization of the variables documentation is confusing to user as the sections are not too cohesive. This change is an attempt to cluster related sections together; especially those related to assigning variables. The goal here is to make it easier for a user to understand how input variables work, to help them understand the various options for assigning values to a declared variable, and, lastly, to highlight the supported arguments for a variable block. 

[Preview Link](https://packer-qeasz01rx-hashicorp.vercel.app/docs/templates/hcl_templates/variables)

Related to: https://github.com/hashicorp/packer/issues/11659
