### PR TITLE
packer: include builder type in HCP name for JSON

### DIFF
--- a/command/registry.go
+++ b/command/registry.go
@@ -158,7 +158,7 @@ func setupRegistryForPackerCore(cfg *CoreWrapper) hcl.Diagnostics {
 	cfg.Core.Bucket = bucket
 	for _, b := range cfg.Core.Template.Builders {
 		// Get all builds slated within config ignoring any only or exclude flags.
-		cfg.Core.Bucket.RegisterBuildForComponent(b.Name)
+		cfg.Core.Bucket.RegisterBuildForComponent(packer.HCPName(b))
 	}
 
 	return diags


### PR DESCRIPTION
JSON templates used only to report the builder's type in HCP builds, even if the name was specified.

This commit changes this behaviour to include both if they're available, in a similar fashion as what is done on the HCL2 templates.