### PR TITLE
docs: move legacy JSON warning under title

### DIFF
--- a/website/content/docs/templates/legacy_json_templates/engine.mdx
+++ b/website/content/docs/templates/legacy_json_templates/engine.mdx
@@ -6,13 +6,13 @@ description: |
 page_title: Template Engine - Templates
 ---
 
-`@include 'from-1.5/legacy-json-warning.mdx'`
-
 # Template Engine
 
 All strings within templates are processed by a common Packer templating
 engine, where variables and functions can be used to modify the value of a
 configuration parameter at runtime.
+
+`@include 'from-1.5/legacy-json-warning.mdx'`
 
 The syntax of templates uses the following conventions:
 


### PR DESCRIPTION
With the move to Hashidocs, the version picker is within the text area for the documentation being displayed. This negatively interacts with the Note on top, as it obstructs part of the text.

To circumvent this problem, we move the Note after the title/intro.