### PR TITLE
website: fix intro link

### DIFF
--- a/website/content/guides/index.mdx
+++ b/website/content/guides/index.mdx
@@ -14,4 +14,4 @@ please see the [Packer introduction][intro] instead and then continue on to the
 guides. These guides provide examples for common Packer workflows and actions
 for users of Packer.
 
-[intro]: /intro
+[intro]: /docs/intro


### PR DESCRIPTION
This PR fixes an `/intro` link on the `/guides` page, replacing it with `/docs/intro`.
