### PR TITLE
Remove a skip for darwin arm64 (m1/m2 macs) for exec tests.

### DIFF
--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -27,10 +27,6 @@ func HasExec() bool {
 	switch runtime.GOOS {
 	case "js":
 		return false
-	case "darwin":
-		if runtime.GOARCH == "arm64" {
-			return false
-		}
 	}
 	return true
 }


### PR DESCRIPTION
This PR removes a no longer needed skip for the exec command test, previously this was setup to skip on ARM macs but now these tests are passing on our development apple silicon macs
