### PR TITLE
chore: add empty page redirects

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -36,18 +36,56 @@ module.exports = [
    * should be a 404. Asana task for this "don't return content for empty" work:
    * https://app.asana.com/0/1100423001970639/1202110665886351/f
    */
-  /*
-  packer/docs/templates/hcl_templates/functions/collection
-  packer/docs/templates/hcl_templates/functions/contextual
-  packer/docs/templates/hcl_templates/functions/conversion
-  packer/docs/templates/hcl_templates/functions/crypto
-  packer/docs/templates/hcl_templates/functions/encoding
-  packer/docs/templates/hcl_templates/functions/file
-  packer/docs/templates/hcl_templates/functions/ipnet
-  packer/docs/templates/hcl_templates/functions/numeric
-  packer/docs/templates/hcl_templates/functions/string
-  packer/docs/templates/hcl templates/functions/uuid
-  */
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/collection',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/contextual',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/conversion',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/crypto',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/encoding',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/file',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/ipnet',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/numeric',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/string',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
+  {
+    source: '/packer/docs/templates/hcl_templates/functions/uuid',
+    destination: '/packer/docs/templates/hcl_templates/functions',
+    permanent: true,
+  },
   /**
    * END EMPTY PAGE REDIRECTS
    */

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -24,4 +24,31 @@ module.exports = [
     permanent: true,
   },
   */
+  /**
+   * BEGIN EMPTY PAGE REDIRECTS
+   * These redirects ensure some empty placeholder pages, dating back to when
+   * "Overview" pages were a requirement, cannot be visited.
+   *
+   * These redirects can likely be removed once we have content API "pruning"
+   * in place. That is, assuming the page at https://developer.hashicorp.com/packer/docs/templates/hcl_templates/functions/conversion
+   * is still empty, the content API response from the content URL for that page
+   * (https://content.hashicorp.com/api/content/packer/doc/latest/docs/templates/hcl_templates/functions/conversion)
+   * should be a 404. Asana task for this "don't return content for empty" work:
+   * https://app.asana.com/0/1100423001970639/1202110665886351/f
+   */
+  /*
+  packer/docs/templates/hcl_templates/functions/collection
+  packer/docs/templates/hcl_templates/functions/contextual
+  packer/docs/templates/hcl_templates/functions/conversion
+  packer/docs/templates/hcl_templates/functions/crypto
+  packer/docs/templates/hcl_templates/functions/encoding
+  packer/docs/templates/hcl_templates/functions/file
+  packer/docs/templates/hcl_templates/functions/ipnet
+  packer/docs/templates/hcl_templates/functions/numeric
+  packer/docs/templates/hcl_templates/functions/string
+  packer/docs/templates/hcl templates/functions/uuid
+  */
+  /**
+   * END EMPTY PAGE REDIRECTS
+   */
 ]


### PR DESCRIPTION
Adds redirects for the empty pages removed in #11702.

> **Note**: these pages were likely not linked to extensively, if at all, as they've always been more or less empty. The redirects introduced can likely be removed once we update our content API to return `404` for previously-existing pages that no longer exist. I've added a comment to reflect this.