### PR TITLE
Plugin latest unavailable checksum fail fix

### DIFF
--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -520,7 +520,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 					err := fmt.Errorf("could not get %s checksum file for %s version %s. Is the file present on the release and correctly named ? %w", checksummer.Type, pr.Identifier, version, err)
 					errs = multierror.Append(errs, err)
 					log.Printf("[TRACE] %s", err)
-					return nil, errs
+					continue
 				}
 				entries, err := ParseChecksumFileEntries(checksumFile)
 				_ = checksumFile.Close()
@@ -737,6 +737,8 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 		err := fmt.Errorf("could not find a local nor a remote checksum for plugin %q %q", pr.Identifier, pr.VersionConstraints)
 		errs = multierror.Append(errs, err)
 	}
+
+	errs = multierror.Append(errs, fmt.Errorf("could not install any compatible version of plugin %q", pr.Identifier))
 
 	return nil, errs
 }

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -541,6 +541,56 @@ func TestRequirement_InstallLatest(t *testing.T) {
 				Version:    "v2.10.1",
 			}, false},
 
+		{"upgrade-with-one-missing-checksum-file",
+			// here we have something locally and test that a newer version will
+			// be installed.
+			fields{"amazon", ">= v2"},
+			args{InstallOptions{
+				[]Getter{
+					&mockPluginGetter{
+						Releases: []Release{
+							{Version: "v1.2.3"},
+							{Version: "v1.2.4"},
+							{Version: "v1.2.5"},
+							{Version: "v2.0.0"},
+							{Version: "v2.1.0"},
+							{Version: "v2.10.0"},
+							{Version: "v2.10.1"},
+						},
+						ChecksumFileEntries: map[string][]ChecksumFileEntry{
+							"2.10.0": {{
+								Filename: "packer-plugin-amazon_v2.10.0_x6.1_linux_amd64.zip",
+								Checksum: "825fc931ae0cb151df0c56be41a17a9136c4d1f1ee73ddb8ed6baa17cef31afa",
+							}},
+						},
+						Zips: map[string]io.ReadCloser{
+							"github.com/hashicorp/packer-plugin-amazon/packer-plugin-amazon_v2.10.0_x6.1_linux_amd64.zip": zipFile(map[string]string{
+								"packer-plugin-amazon_v2.10.0_x6.1_linux_amd64": "v2.10.0_x6.1_linux_amd64",
+							}),
+						},
+					},
+				},
+				[]string{
+					pluginFolderWrongChecksums,
+					pluginFolderOne,
+					pluginFolderTwo,
+				},
+				BinaryInstallationOptions{
+					APIVersionMajor: "6", APIVersionMinor: "1",
+					OS: "linux", ARCH: "amd64",
+					Checksummers: []Checksummer{
+						{
+							Type: "sha256",
+							Hash: sha256.New(),
+						},
+					},
+				},
+			}},
+			&Installation{
+				BinaryPath: "testdata/plugins_2/github.com/hashicorp/amazon/packer-plugin-amazon_v2.10.0_x6.1_linux_amd64",
+				Version:    "v2.10.0",
+			}, false},
+
 		{"wrong-zip-checksum",
 			// here we have something locally and test that a newer version with
 			// a wrong checksum will not be installed and error.

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -676,7 +676,11 @@ func (g *mockPluginGetter) Get(what string, options GetOptions) (io.ReadCloser, 
 	case "releases":
 		toEncode = g.Releases
 	case "sha256":
-		toEncode = g.ChecksumFileEntries[options.version.String()]
+		enc, ok := g.ChecksumFileEntries[options.version.String()]
+		if !ok {
+			return nil, fmt.Errorf("No checksum available for version %q", options.version.String())
+		}
+		toEncode = enc
 	case "zip":
 		acc := options.PluginRequirement.Identifier.Hostname + "/" +
 			options.PluginRequirement.Identifier.RealRelativePath() + "/" +


### PR DESCRIPTION
When Packer tries to get the latest version of a plugin, it will attempt to get the latest version from a list that is picked from the list of releases, fetched directly from Github.

What may happen is that a release is triggered, the assets are not yet available, including the checksum file, which is uploaded last, at the end of the release process.

This causes any client that tries to get the latest version of a plugin to fail during that window, as the code will fail immediately whenever a checksum file is unavailable.

To circumvent this issue, and fallback to a previous version, we acknowledge that a checksum was unavailable then trying to get the latest version, and fallback to a previous one.

Closes #11897