### PR TITLE
Update validation options for undeclared variables

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -400,7 +400,8 @@ Options:
   -parallel-builds=1            Number of builds to run in parallel. 1 disables parallelization. 0 means no limit (Default: 0)
   -timestamp-ui                 Enable prefixing of each ui output with an RFC3339 timestamp.
   -var 'key=value'              Variable for templates, can be used multiple times.
-  -var-file=path                JSON or HCL2 file containing user variables.
+  -var-file=path                JSON or HCL2 file containing user variables, can be used multiple times.
+  -warn-on-undeclared-var       Display warnings for user variable files containing undeclared variables.
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/build_test.go
+++ b/command/build_test.go
@@ -1149,19 +1149,11 @@ func TestBuildCmd(t *testing.T) {
 			},
 			expectedCode: 0,
 			outputCheck: func(out, err string) error {
-				if !strings.Contains(out, "Warning: Undefined variable") {
-					return fmt.Errorf("expected 'Warning: Undefined variable' in output, did not find it")
-				}
-
 				nbWarns := strings.Count(out, "Warning: ")
-				if nbWarns != 1 {
+				if nbWarns != 0 {
 					return fmt.Errorf(
-						"error: too many warnings in build output, expected 1, got %d",
+						"error: too many warnings in build output, expected 0, got %d",
 						nbWarns)
-				}
-
-				if !strings.Contains(out, "variable \"testvar\" {") {
-					return fmt.Errorf("missing definition example for undefined variable")
 				}
 
 				nbErrs := strings.Count(err, "Error: ")

--- a/command/cli.go
+++ b/command/cli.go
@@ -86,6 +86,7 @@ func (ba *BuildArgs) AddFlagSets(flags *flag.FlagSet) {
 	flagOnError := enumflag.New(&ba.OnError, "cleanup", "abort", "ask", "run-cleanup-provisioner")
 	flags.Var(flagOnError, "on-error", "")
 
+	flags.BoolVar(&ba.MetaArgs.WarnOnUndeclaredVar, "warn-on-undeclared-var", false, "Show warnings for variable files containing undeclared variables.")
 	ba.MetaArgs.AddFlagSets(flags)
 }
 

--- a/command/cli.go
+++ b/command/cli.go
@@ -58,7 +58,7 @@ func (ma *MetaArgs) AddFlagSets(fs *flag.FlagSet) {
 	fs.Var(&ma.ConfigType, "config-type", "set to 'hcl2' to run in hcl2 mode when no file is passed.")
 }
 
-// MetaArgs defines commonalities between all comands
+// MetaArgs defines commonalities between all commands
 type MetaArgs struct {
 	// TODO(azr): in the future, I want to allow passing multiple path to
 	// merge HCL confs together; but this will probably need an RFC first.
@@ -67,7 +67,8 @@ type MetaArgs struct {
 	Vars         map[string]string
 	VarFiles     []string
 	// set to "hcl2" to force hcl2 mode
-	ConfigType configType
+	ConfigType       configType
+	StrictValidation bool
 }
 
 func (ba *BuildArgs) AddFlagSets(flags *flag.FlagSet) {
@@ -88,9 +89,10 @@ func (ba *BuildArgs) AddFlagSets(flags *flag.FlagSet) {
 // BuildArgs represents a parsed cli line for a `packer build`
 type BuildArgs struct {
 	MetaArgs
-	Color, Debug, Force, TimestampUi, MachineReadable bool
-	ParallelBuilds                                    int64
-	OnError                                           string
+	Debug, Force                        bool
+	Color, TimestampUi, MachineReadable bool
+	ParallelBuilds                      int64
+	OnError                             string
 }
 
 func (ia *InitArgs) AddFlagSets(flags *flag.FlagSet) {
@@ -129,6 +131,7 @@ type FixArgs struct {
 
 func (va *ValidateArgs) AddFlagSets(flags *flag.FlagSet) {
 	flags.BoolVar(&va.SyntaxOnly, "syntax-only", false, "check syntax only")
+	flags.BoolVar(&va.WarnOnUndeclared, "warn-on-undeclared", true, "show warnings for pkrvars definition files containing undeclared variables")
 
 	va.MetaArgs.AddFlagSets(flags)
 }
@@ -136,7 +139,7 @@ func (va *ValidateArgs) AddFlagSets(flags *flag.FlagSet) {
 // ValidateArgs represents a parsed cli line for a `packer validate`
 type ValidateArgs struct {
 	MetaArgs
-	SyntaxOnly bool
+	SyntaxOnly, WarnOnUndeclared bool
 }
 
 func (va *InspectArgs) AddFlagSets(flags *flag.FlagSet) {

--- a/command/cli.go
+++ b/command/cli.go
@@ -67,8 +67,11 @@ type MetaArgs struct {
 	Vars         map[string]string
 	VarFiles     []string
 	// set to "hcl2" to force hcl2 mode
-	ConfigType       configType
-	StrictValidation bool
+	ConfigType configType
+
+	// WarnOnUndeclared does not have a common default, as the default varies per sub-command usage.
+	// Refer to individual command FlagSets for usage.
+	WarnOnUndeclaredVar bool
 }
 
 func (ba *BuildArgs) AddFlagSets(flags *flag.FlagSet) {
@@ -131,7 +134,7 @@ type FixArgs struct {
 
 func (va *ValidateArgs) AddFlagSets(flags *flag.FlagSet) {
 	flags.BoolVar(&va.SyntaxOnly, "syntax-only", false, "check syntax only")
-	flags.BoolVar(&va.WarnOnUndeclared, "warn-on-undeclared", true, "show warnings for pkrvars definition files containing undeclared variables")
+	flags.BoolVar(&va.NoWarnUndeclaredVar, "no-warn-undeclared-var", false, "Ignore warnings for variable files containing undeclared variables.")
 
 	va.MetaArgs.AddFlagSets(flags)
 }
@@ -139,7 +142,7 @@ func (va *ValidateArgs) AddFlagSets(flags *flag.FlagSet) {
 // ValidateArgs represents a parsed cli line for a `packer validate`
 type ValidateArgs struct {
 	MetaArgs
-	SyntaxOnly, WarnOnUndeclared bool
+	SyntaxOnly, NoWarnUndeclaredVar bool
 }
 
 func (va *InspectArgs) AddFlagSets(flags *flag.FlagSet) {

--- a/command/meta.go
+++ b/command/meta.go
@@ -137,7 +137,7 @@ func (m *Meta) GetConfigFromHCL(cla *MetaArgs) (*hcl2template.PackerConfig, int)
 		Parser:                  hclparse.NewParser(),
 		PluginConfig:            m.CoreConfig.Components.PluginConfig,
 		ValidationOptions: hcl2template.ValidationOptions{
-			Strict: cla.StrictValidation,
+			WarnOnUndeclaredVar: cla.WarnOnUndeclaredVar,
 		},
 	}
 	cfg, diags := parser.Parse(cla.Path, cla.VarFiles, cla.Vars)

--- a/command/meta.go
+++ b/command/meta.go
@@ -136,6 +136,9 @@ func (m *Meta) GetConfigFromHCL(cla *MetaArgs) (*hcl2template.PackerConfig, int)
 		CorePackerVersionString: version.FormattedVersion(),
 		Parser:                  hclparse.NewParser(),
 		PluginConfig:            m.CoreConfig.Components.PluginConfig,
+		ValidationOptions: hcl2template.ValidationOptions{
+			Strict: cla.StrictValidation,
+		},
 	}
 	cfg, diags := parser.Parse(cla.Path, cla.VarFiles, cla.Vars)
 	return cfg, writeDiags(m.Ui, parser.Files(), diags)

--- a/command/test-fixtures/validate/var-file-tests/basic.pkr.hcl
+++ b/command/test-fixtures/validate/var-file-tests/basic.pkr.hcl
@@ -1,0 +1,17 @@
+packer {
+  required_version = ">= v1.0.0"
+}
+
+variable "test" {
+ type = string
+ default = null
+}
+
+source "file" "chocolate" {
+  target = "chocolate.txt"
+  content = "chocolate"
+}
+
+build {
+  sources = ["source.file.chocolate"]
+}

--- a/command/test-fixtures/validate/var-file-tests/basic.pkrvars.hcl
+++ b/command/test-fixtures/validate/var-file-tests/basic.pkrvars.hcl
@@ -1,0 +1,1 @@
+test = "myvalue"

--- a/command/test-fixtures/validate/var-file-tests/undeclared.json
+++ b/command/test-fixtures/validate/var-file-tests/undeclared.json
@@ -1,0 +1,3 @@
+{
+    "unused": ["one", "cookie", "two", "cookie"]
+}

--- a/command/test-fixtures/validate/var-file-tests/undeclared.pkrvars.hcl
+++ b/command/test-fixtures/validate/var-file-tests/undeclared.pkrvars.hcl
@@ -1,0 +1,1 @@
+unused = "unused variables should warn"

--- a/command/validate.go
+++ b/command/validate.go
@@ -45,7 +45,11 @@ func (c *ValidateCommand) ParseArgs(args []string) (*ValidateArgs, int) {
 }
 
 func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int {
-	cla.StrictValidation = cla.WarnOnUndeclared
+	// By default we want to inform users of undeclared variables when validating but not during build time.
+	cla.MetaArgs.WarnOnUndeclaredVar = true
+	if cla.NoWarnUndeclaredVar {
+		cla.MetaArgs.WarnOnUndeclaredVar = false
+	}
 
 	packerStarter, ret := c.GetConfig(&cla.MetaArgs)
 	if ret != 0 {
@@ -61,7 +65,6 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 	diags := packerStarter.Initialize(packer.InitializeOptions{
 		SkipDatasourcesExecution: true,
 	})
-
 	ret = writeDiags(c.Ui, nil, diags)
 	if ret != 0 {
 		return ret
@@ -100,11 +103,11 @@ Options:
 
   -syntax-only                  Only check syntax. Do not verify config of the template.
   -except=foo,bar,baz           Validate all builds other than these.
-  -machine-readable             Produce machine-readable output.
   -only=foo,bar,baz             Validate only these builds.
+  -machine-readable             Produce machine-readable output.
   -var 'key=value'              Variable for templates, can be used multiple times.
-  -var-file=path                JSON or HCL2 file containing user variables.
-  -warn-on-undeclared=false     Disable warnings for JSON or HCL2  files containing undeclared variables. (Default true)
+  -var-file=path                JSON or HCL2 file containing user variables, can be used multiple times.
+  -no-warn-undeclared-var       Disable warnings for user variable files containing undeclared variables.
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/validate.go
+++ b/command/validate.go
@@ -45,6 +45,8 @@ func (c *ValidateCommand) ParseArgs(args []string) (*ValidateArgs, int) {
 }
 
 func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int {
+	cla.StrictValidation = cla.WarnOnUndeclared
+
 	packerStarter, ret := c.GetConfig(&cla.MetaArgs)
 	if ret != 0 {
 		return 1
@@ -59,6 +61,7 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 	diags := packerStarter.Initialize(packer.InitializeOptions{
 		SkipDatasourcesExecution: true,
 	})
+
 	ret = writeDiags(c.Ui, nil, diags)
 	if ret != 0 {
 		return ret
@@ -95,12 +98,13 @@ Usage: packer validate [options] TEMPLATE
 
 Options:
 
-  -syntax-only           Only check syntax. Do not verify config of the template.
-  -except=foo,bar,baz    Validate all builds other than these.
-  -machine-readable      Produce machine-readable output.
-  -only=foo,bar,baz      Validate only these builds.
-  -var 'key=value'       Variable for templates, can be used multiple times.
-  -var-file=path         JSON or HCL2 file containing user variables.
+  -syntax-only                  Only check syntax. Do not verify config of the template.
+  -except=foo,bar,baz           Validate all builds other than these.
+  -machine-readable             Produce machine-readable output.
+  -only=foo,bar,baz             Validate only these builds.
+  -var 'key=value'              Variable for templates, can be used multiple times.
+  -var-file=path                JSON or HCL2 file containing user variables.
+  -warn-on-undeclared=false     Disable warnings for JSON or HCL2  files containing undeclared variables. (Default true)
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -250,12 +250,12 @@ func TestValidateCommand_VarFilesWarnOnUndeclared(t *testing.T) {
 		varfile  string
 		exitCode int
 	}{
-		{name: "warn-on-undeclared=true with unused variable in var-file definition",
+		{name: "default warning with unused variable in HCL var-file definition",
 			path:     filepath.Join(testFixture(filepath.Join("validate", "var-file-tests")), "basic.pkr.hcl"),
 			varfile:  filepath.Join(testFixture(filepath.Join("validate", "var-file-tests")), "undeclared.pkrvars.hcl"),
 			exitCode: 0,
 		},
-		{name: "warn-on-undeclared=true with unused variable in var-file definition",
+		{name: "default warning with unused variable in JSON var-file definition",
 			path:     filepath.Join(testFixture(filepath.Join("validate", "var-file-tests")), "basic.pkr.hcl"),
 			varfile:  filepath.Join(testFixture(filepath.Join("validate", "var-file-tests")), "undeclared.json"),
 			exitCode: 0,
@@ -302,12 +302,12 @@ func TestValidateCommand_VarFilesDisableWarnOnUndeclared(t *testing.T) {
 		varfile  string
 		exitCode int
 	}{
-		{name: "warn-on-undeclared=false with unused variable in var-file definition",
+		{name: "no-warn-undeclared-var with unused variable in HCL var-file definition",
 			path:     filepath.Join(testFixture(filepath.Join("validate", "var-file-tests")), "basic.pkr.hcl"),
 			varfile:  filepath.Join(testFixture(filepath.Join("validate", "var-file-tests")), "undeclared.pkrvars.hcl"),
 			exitCode: 0,
 		},
-		{name: "warn-on-undeclared=false with unused variable in JSON var-file definition",
+		{name: "no-warn-undeclared-var with unused variable in JSON var-file definition",
 			path:     filepath.Join(testFixture(filepath.Join("validate", "var-file-tests")), "basic.pkr.hcl"),
 			varfile:  filepath.Join(testFixture(filepath.Join("validate", "var-file-tests")), "undeclared.json"),
 			exitCode: 0,
@@ -319,7 +319,7 @@ func TestValidateCommand_VarFilesDisableWarnOnUndeclared(t *testing.T) {
 				Meta: TestMetaFile(t),
 			}
 			tc := tc
-			args := []string{"-warn-on-undeclared=false", "-var-file", tc.varfile, tc.path}
+			args := []string{"-no-warn-undeclared-var", "-var-file", tc.varfile, tc.path}
 			if code := c.Run(args); code != tc.exitCode {
 				fatalCommand(t, c.Meta)
 			}

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -60,9 +60,11 @@ type Parser struct {
 
 	CorePackerVersionString string
 
-	*hclparse.Parser
-
 	PluginConfig *packer.PluginConfig
+
+	ValidationOptions
+
+	*hclparse.Parser
 }
 
 const (
@@ -138,6 +140,7 @@ func (p *Parser) Parse(filename string, varFiles []string, argVars map[string]st
 		Cwd:                     wd,
 		CorePackerVersionString: p.CorePackerVersionString,
 		HCPVars:                 map[string]cty.Value{},
+		ValidationOptions:       p.ValidationOptions,
 		parser:                  p,
 		files:                   files,
 	}

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -68,7 +68,7 @@ type PackerConfig struct {
 }
 
 type ValidationOptions struct {
-	Strict bool
+	WarnOnUndeclaredVar bool
 }
 
 const (

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -659,7 +659,7 @@ func (cfg *PackerConfig) collectInputVariableValues(env []string, files []*hcl.F
 		for name, attr := range attrs {
 			variable, found := variables[name]
 			if !found {
-				if cfg.ValidationOptions.Strict == false {
+				if !cfg.ValidationOptions.WarnOnUndeclaredVar {
 					continue
 				}
 

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -659,19 +659,19 @@ func (cfg *PackerConfig) collectInputVariableValues(env []string, files []*hcl.F
 		for name, attr := range attrs {
 			variable, found := variables[name]
 			if !found {
-				sev := hcl.DiagWarning
-				if cfg.ValidationOptions.Strict {
-					sev = hcl.DiagError
+				if cfg.ValidationOptions.Strict == false {
+					continue
 				}
+
 				diags = append(diags, &hcl.Diagnostic{
-					Severity: sev,
+					Severity: hcl.DiagWarning,
 					Summary:  "Undefined variable",
-					Detail: fmt.Sprintf("A %[1]q variable was set but was "+
-						"not declared as an input variable. To declare "+
-						"variable %[1]q, place this block in one of your "+
-						".pkr.hcl files, such as variables.pkr.hcl\n\n"+
+					Detail: fmt.Sprintf("The variable %[1]q was set but was not declared as an input variable."+
+						"\nTo declare variable %[1]q place this block in one of your .pkr.hcl files, "+
+						"such as variables.pkr.hcl\n\n"+
 						"variable %[1]q {\n"+
-						"  type = string\n"+
+						"  type    = string\n"+
+						"  default = null\n"+
 						"}",
 						name),
 					Context: attr.Range.Ptr(),

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -859,7 +859,7 @@ func TestVariables_collectVariableValues(t *testing.T) {
 		{name: "undefined but set value - pkrvar file - strict mode",
 			variables: Variables{},
 			validationOptions: ValidationOptions{
-				Strict: true,
+				WarnOnUndeclaredVar: true,
 			},
 			args: args{
 				hclFiles: []string{`undefined_string="value"`},

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -476,7 +476,7 @@ func TestParse_variables(t *testing.T) {
 				},
 				Basedir: filepath.Join("testdata", "variables"),
 			},
-			true, false,
+			false, false,
 			[]packersdk.Build{
 				&packer.CoreBuild{
 					Type:           "null.test",
@@ -850,7 +850,7 @@ func TestVariables_collectVariableValues(t *testing.T) {
 			},
 
 			// output
-			wantDiags:         true,
+			wantDiags:         false,
 			wantDiagsHasError: false,
 			wantVariables:     Variables{},
 			wantValues:        map[string]cty.Value{},
@@ -867,7 +867,7 @@ func TestVariables_collectVariableValues(t *testing.T) {
 
 			// output
 			wantDiags:         true,
-			wantDiagsHasError: true,
+			wantDiagsHasError: false,
 			wantVariables:     Variables{},
 			wantValues:        map[string]cty.Value{},
 		},


### PR DESCRIPTION
In an effort to help users move from JSON to HCL2 templates the support for variable definitions files are being updated to ignore undeclared variable warnings on build execution. For legacy JSON template builds no warnings are displayed when var-files contain undeclared variables. So the behavior is sort of the same. 

Since the preferred mode for HCL2 templates is to be explicit with variable declarations - they must be declared to be used - validation for undeclared variables still warns when running `packer validate`. A new flag has been added to the validate command that can be used to disable undeclared variable warnings.

Closes: https://github.com/hashicorp/packer/issues/12109
Related to: https://github.com/hashicorp/packer/issues/9822

Example `packer validate` run
```
~>  go run . validate -no-warn-undeclared-var -var-file command/test-fixtures/validate/var-file-tests/undeclared.pkrvars.hcl \
command/test-fixtures/validate/var-file-tests/basic.pkr.hcl
The configuration is valid.

~>  go run . validate -var-file command/test-fixtures/validate/var-file-tests/undeclared.pkrvars.hcl \
command/test-fixtures/validate/var-file-tests/basic.pkr.hcl
Warning: Undefined variable

The variable "unused" was set but was not declared as an input variable.
To declare variable "unused" place this block in one of your .pkr.hcl
files,
such as variables.pkr.hcl

variable "unused" {
  type    = string
  default = null

}

The configuration is valid.
```

Example `packer build` runs
```
~>  go run . build -var-file command/test-fixtures/validate/var-file-tests/undeclared.pkrvars.hcl \
command/test-fixtures/validate/var-file-tests/basic.pkr.hcl
file.chocolate: output will be in this color.

Build 'file.chocolate' finished after 744 microseconds.

==> Wait completed after 798 microseconds

==> Builds finished. The artifacts of successful builds are:
--> file.chocolate: Stored file: chocolate.txt

~>  go run . build -warn-on-undeclared-var -var-file command/test-fixtures/validate/var-file-tests/undeclared.pkrvars.hcl command/test-fixtures/validate/var-file-tests/basic.pkr.hcl
Warning: Undefined variable

The variable "unused" was set but was not declared as an input variable.
To declare variable "unused" place this block in one of your .pkr.hcl files,
such as variables.pkr.hcl

variable "unused" {
  type    = string
  default = null
}


file.chocolate: output will be in this color.

Build 'file.chocolate' finished after 762 microseconds.

==> Wait completed after 799 microseconds

==> Builds finished. The artifacts of successful builds are:
--> file.chocolate: Stored file: chocolate.txt
```
