### PR TITLE
[HPR-817] command/validate: add option to eval datasources

### DIFF
--- a/command/cli.go
+++ b/command/cli.go
@@ -136,6 +136,7 @@ type FixArgs struct {
 func (va *ValidateArgs) AddFlagSets(flags *flag.FlagSet) {
 	flags.BoolVar(&va.SyntaxOnly, "syntax-only", false, "check syntax only")
 	flags.BoolVar(&va.NoWarnUndeclaredVar, "no-warn-undeclared-var", false, "Ignore warnings for variable files containing undeclared variables.")
+	flags.BoolVar(&va.EvaluateDatasources, "evaluate-datasources", false, "evaluate datasources for validation (HCL2 only, may incur costs)")
 
 	va.MetaArgs.AddFlagSets(flags)
 }
@@ -144,6 +145,7 @@ func (va *ValidateArgs) AddFlagSets(flags *flag.FlagSet) {
 type ValidateArgs struct {
 	MetaArgs
 	SyntaxOnly, NoWarnUndeclaredVar bool
+	EvaluateDatasources             bool
 }
 
 func (va *InspectArgs) AddFlagSets(flags *flag.FlagSet) {

--- a/command/test-fixtures/hcl/local-ds-validate.pkr.hcl
+++ b/command/test-fixtures/hcl/local-ds-validate.pkr.hcl
@@ -1,0 +1,17 @@
+data "null" "dep" {
+	input = "upload"
+}
+
+source "null" "test" {
+	communicator = "none"
+}
+
+build {
+	sources = ["sources.null.test"]
+
+	provisioner "file" {
+		source = "test-fixtures/hcl/force.pkr.hcl"
+		destination = "dest"
+		direction = "${data.null.dep.output}"
+	}
+}

--- a/command/validate.go
+++ b/command/validate.go
@@ -63,7 +63,7 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 	}
 
 	diags := packerStarter.Initialize(packer.InitializeOptions{
-		SkipDatasourcesExecution: true,
+		SkipDatasourcesExecution: !cla.EvaluateDatasources,
 	})
 	ret = writeDiags(c.Ui, nil, diags)
 	if ret != 0 {

--- a/website/content/docs/commands/build.mdx
+++ b/website/content/docs/commands/build.mdx
@@ -58,3 +58,11 @@ artifacts that are created will be outputted at the end of the build.
   multiple times. This is useful for setting version numbers for your build.
 
 - `-var-file` - Set template variables from a file.
+
+- `-warn-on-undeclared-var` - Setting this flag will yield a warning for each assignment within
+  a variable definitions file (*.pkrvars.hcl | *.pkrvars.json) that does not have an accompanying
+  variable block. This can occur when using a var-file that contains a large amount of unused variables
+  for a given HCL2 template. For HCL2 template builds defining a value for a variable in a var-file is
+  not enough on its own for Packer to function, as there also needs to be a variable block definition in
+  the template files `pkr.hcl` for the variable. By default `packer build` will not warn when a var-file
+  contains one or more undeclared variables.

--- a/website/content/docs/commands/validate.mdx
+++ b/website/content/docs/commands/validate.mdx
@@ -31,6 +31,14 @@ Errors validating build 'vmware'. 1 error(s) occurred:
 - `-syntax-only` - Only the syntax of the template is checked. The
   configuration is not validated.
 
+- `-evaluate-datasources` - Evaluate all data sources when validating a template.
+  This is only valid on HCL2 templates, since JSON templates do not feature
+  datasources, this option will be ignored.
+
+  ~> **Warning:** Data sources may rely on external services for fetching data,
+  which can incur some costs at validation if the services being contacted are
+  billing per operation.
+
 - `-except=foo,bar,baz` - Validates all the builds except those with the
   comma-separated names. In legacy JSON templates, build names default to the
   types of their builders (e.g. `docker` or

--- a/website/content/docs/commands/validate.mdx
+++ b/website/content/docs/commands/validate.mdx
@@ -47,6 +47,15 @@ Errors validating build 'vmware'. 1 error(s) occurred:
   source block's "name" label, unless an in-build source definition adds the
   "name" configuration option.
 
+- `-no-warn-on-undeclared-var` - Silence warnings when the a variable definition
+  file contains variable assignments for undeclared variables. This can occur
+  when using a var-file that contains a large amount of unused variables for a
+  given HCL2 template. For HCL2 template defining a value for a variable in a
+  var-file is not enough on its own for Packer to function, as there also needs
+  to be a variable block definition in the template files `pkr.hcl` for the
+  variable. By default `packer validate` will warn when a var-file contains one
+  or more undeclared variables.
+
 - `-only=foo,bar,baz` - Only validate the builds with the given comma-separated
   names. In legacy JSON templates, build names default to the
   types of their builders (e.g. `docker` or


### PR DESCRIPTION
When packer validate is invoked, it does not try to evaluate the datasources before attempting to decide if the template is valid.

In many cases, this works, but sometimes it will fail as the value is unknown by the validation code.

Since the validation code for all the elements of a Packer template is left to be implemented by plugins, we cannot rely on checking for unknown values everywhere, especially since the unknown references are replaced automatically by a value of the right type for the configuration expected.

So, in order for such configurations to be validable, we add an extra option to packer validate, that will let users evaluate the datasources from a template.

Closes #11294
