### PR TITLE
Removing duplicate line of text

### DIFF
--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -128,8 +128,6 @@ The expectation from the vendor/partner is to create a mechanism for them to tra
 
 Below is an ordered checklist of steps that should be followed during the integration process. This just reiterates the steps already documented in the sections above.
 
-Below is an ordered checklist of steps that should be followed during the integration process. This just reiterates the steps already documented in the sections above.
-
 <Checklist>
 
 - Fill out the Packer integration [webform](https://docs.google.com/forms/d/e/1FAIpQLSfgq3HJ9Rfsi7LgPLFln28ZrmarATGlD_6A47-Io-bPUftKUw/viewform)


### PR DESCRIPTION
## What

Deletes a duplicate line of text that was in the [/packer/docs/partnerships#checklist](https://developer.hashicorp.com/packer/docs/partnerships#checklist) section

## Testing

- [ ] Go to https://packer-git-ambfix-duplicate-line-hashicorp.vercel.app/packer/docs/partnerships#checklist
- [ ] The following text should only be listed once under the heading: "Below is an ordered checklist of steps that should be followed during the integration process. This just reiterates the steps already documented in the sections above."

## Anything else?

I noticed that the `Checklist` icons are misaligned, so I created a bug ticket for this to be fixed in [dev-portal](https://github.com/hashicorp/dev-portal): https://app.asana.com/0/1202097197789424/1203368245666617/f
