### PR TITLE
hcp: remove duplicated build registration for JSON

### DIFF
--- a/internal/hcp/registry/json.go
+++ b/internal/hcp/registry/json.go
@@ -38,11 +38,6 @@ func NewJSONMetadataRegistry(config *packer.Core) (*JSONMetadataRegistry, hcl.Di
 
 // PopulateIteration creates the metadata on HCP for a build
 func (h *JSONMetadataRegistry) PopulateIteration(ctx context.Context) error {
-	for _, b := range h.configuration.Template.Builders {
-		// Get all builds slated within config ignoring any only or exclude flags.
-		h.bucket.RegisterBuildForComponent(b.Name)
-	}
-
 	err := h.bucket.Validate()
 	if err != nil {
 		return err


### PR DESCRIPTION
In JSON templates, we register the builds to process on HCP at the initialisation of the Registry.

However, during the HCP breakout, this code was duplicated with a slight difference for the JSON templates, and the build names were registered once during initialisation, with the expected full name, and once at the start of PopulateIteration, with the truncated name.

This caused a bug when processing a template that contains a builder with both a name and a type, as both would be registered, but only one would complete, leading to the iteration being unable to complete.
