### PR TITLE
website: Added Tart builder

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -279,6 +279,13 @@
     "version": "v1.0.1"
   },
   {
+    "title": "Tart",
+    "path": "tart",
+    "repo": "cirruslabs/packer-plugin-tart",
+    "pluginTier": "community",
+    "version": "latest"
+  },
+  {
     "title": "Tencent Cloud",
     "path": "tencentcloud",
     "repo": "hashicorp/packer-plugin-tencentcloud",


### PR DESCRIPTION
This PR add [`tart` builder](https://github.com/cirruslabs/packer-plugin-tart) to the list of all the builders.

Tart is a open-source toolset for building, running and managing Linux and macOS virtual machines on Apple Silicon. Part of the toolset is this packer plugin.
