### PR TITLE
Add Nutanix plugin docs

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -195,6 +195,13 @@
     "version": "latest"
   },
   {
+    "title": "Nutanix",
+    "path": "nutanix",
+    "repo": "nutanix-cloud-native/packer-plugin-nutanix",
+    "version": "latest",
+    "sourceBranch": "main"
+  },
+  {
     "title": "OpenStack",
     "path": "openstack",
     "repo": "hashicorp/packer-plugin-openstack",


### PR DESCRIPTION
Update [website/data/plugins-manifest.json](https://github.com/hashicorp/packer/blob/main/website/data/plugins-manifest.json) to include docs for Nutanix builder plugin

[docs.zip](https://github.com/nutanix-cloud-native/packer-plugin-nutanix/releases/download/v0.3.0/docs.zip) was tested by following this [procedure](https://developer.hashicorp.com/packer/docs/plugins/creation#testing-plugin-documentation) to manually build and launch the website.

Website is OK
