### PR TITLE
Add external plugin docs

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -80,6 +80,13 @@
     "isHcpPackerReady": true
   },
   {
+    "title": "External",
+    "path": "external",
+    "repo": "joomcode/packer-plugin-external",
+    "version": "latest",
+    "sourceBranch": "main"
+  },
+  {
     "title": "Git",
     "path": "git",
     "repo": "ethanmdavidson/packer-plugin-git",


### PR DESCRIPTION
Hello,

I have implemented a Terraform-like `external` data source [plugin](http://github.com/joomcode/packer-plugin-external), which allows to run arbitrary commands. Interface is similar to Terraform provider, but provides additional raw source with plaintext protocol for cases where json is not desired.
Documentation is mostly taken from Terraform plugin docs with minor adjustments.

Any feedback on the plugin itself would be greatly appreciated!

Tested documentation locally using [this guide](https://developer.hashicorp.com/packer/docs/plugins/creation#testing-plugin-documentation), from local zip and from GitHub release, looks fine.