### PR TITLE
command/validate: Add `-evaluate-datasources` flag to command help text

### DIFF
--- a/command/validate.go
+++ b/command/validate.go
@@ -108,6 +108,7 @@ Options:
   -var 'key=value'              Variable for templates, can be used multiple times.
   -var-file=path                JSON or HCL2 file containing user variables, can be used multiple times.
   -no-warn-undeclared-var       Disable warnings for user variable files containing undeclared variables.
+  -evaluate-datasources         Evaluate data sources during validation (HCL2 only, may incur costs); Defaults to false. 
 `
 
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
```
Usage: packer validate [options] TEMPLATE

  Checks the template is valid by parsing the template and also
  checking the configuration with the various builders, provisioners, etc.

  If it is not valid, the errors will be shown and the command will exit
  with a non-zero exit status. If it is valid, it will exit with a zero
  exit status.

Options:

  -syntax-only                  Only check syntax. Do not verify config of the template.
  -except=foo,bar,baz           Validate all builds other than these.
  -only=foo,bar,baz             Validate only these builds.
  -machine-readable             Produce machine-readable output.
  -var 'key=value'              Variable for templates, can be used multiple times.
  -var-file=path                JSON or HCL2 file containing user variables, can be used multiple times.
  -no-warn-undeclared-var       Disable warnings for user variable files containing undeclared variables.
  -evaluate-datasources         Evaluate data sources during validation (HCL2 only, may incur costs); Defaults to false.

```

Related to #12151 
