### PR TITLE
Update Go checks to run on pull_requests

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -5,7 +5,11 @@
 
 name: "Go Test"
 
-on: [ workflow_dispatch, push ]
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
 
 env:
   PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -4,7 +4,11 @@
 
 name: "Go Validate"
 
-on: [ workflow_dispatch, push ]
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently go-test and go-validate only run for users who have push
access to the Packer repo. We want to ensure tests and validation run
for all opened pull requests including public forks.
