### PR TITLE
Cancellation handling with hcp

### DIFF
--- a/internal/hcp/registry/types.bucket.go
+++ b/internal/hcp/registry/types.bucket.go
@@ -569,7 +569,11 @@ func (b *Bucket) completeBuild(
 	}
 
 	if buildErr != nil {
-		err := b.UpdateBuildStatus(ctx, buildName, models.HashicorpCloudPackerBuildStatusFAILED)
+		status := models.HashicorpCloudPackerBuildStatusFAILED
+		if ctx.Err() != nil {
+			status = models.HashicorpCloudPackerBuildStatusCANCELLED
+		}
+		err := b.UpdateBuildStatus(context.Background(), buildName, status)
 		if err != nil {
 			log.Printf("[ERROR] failed to update build %q status to FAILED: %s", buildName, err)
 		}

--- a/packer/build.go
+++ b/packer/build.go
@@ -238,7 +238,7 @@ func (b *CoreBuild) Run(ctx context.Context, originalUi packersdk.Ui) ([]packers
 	select {
 	case <-ctx.Done():
 		log.Println("Build was cancelled. Skipping post-processors.")
-		return nil, nil
+		return nil, ctx.Err()
 	default:
 	}
 


### PR DESCRIPTION
When a build is cancelled by a user, the current implementation of CoreBuild.Run does not return an error signifying that there was a problem with the build.
    
This in turn causes the HCP code to attempt to update the status of the build to DONE, but fails because there are no artifacts to push.
    
This commit changes this behaviour by returning the error provoked by the cancellation to the caller, so it can be taken into account when setting the status of the build.