### PR TITLE
hcl2: don't warn on excluded post-processor

### DIFF
--- a/command/build_test.go
+++ b/command/build_test.go
@@ -1321,6 +1321,27 @@ func TestBuildCmd(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "hcl - exclude post-processor, expect no warning",
+			args: []string{
+				"-except", "manifest",
+				testFixture("hcl", "test_except_manifest.pkr.hcl"),
+			},
+			expectedCode: 0,
+			outputCheck: func(out, err string) error {
+				for _, stream := range []string{out, err} {
+					if strings.Contains(stream, "Warning: an 'except' option was passed, but did not match any build") {
+						return fmt.Errorf("Unexpected warning for build no match with except")
+					}
+
+					if strings.Contains(stream, "Running post-processor:") {
+						return fmt.Errorf("Should not run post-processors, but found one")
+					}
+				}
+
+				return nil
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/command/test-fixtures/hcl/test_except_manifest.pkr.hcl
+++ b/command/test-fixtures/hcl/test_except_manifest.pkr.hcl
@@ -1,0 +1,9 @@
+source "null" "test" {
+  communicator = "none"
+}
+
+build {
+  sources = ["null.test"]
+
+  post-processor "manifest" {}
+}

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -514,7 +514,7 @@ func (cfg *PackerConfig) getCoreBuildProvisioner(source SourceUseBlock, pb *Prov
 
 // getCoreBuildProvisioners takes a list of post processor block, starts
 // according provisioners and sends parsed HCL2 over to it.
-func (cfg *PackerConfig) getCoreBuildPostProcessors(source SourceUseBlock, blocksList [][]*PostProcessorBlock, ectx *hcl.EvalContext) ([][]packer.CoreBuildPostProcessor, hcl.Diagnostics) {
+func (cfg *PackerConfig) getCoreBuildPostProcessors(source SourceUseBlock, blocksList [][]*PostProcessorBlock, ectx *hcl.EvalContext, exceptMatches *int) ([][]packer.CoreBuildPostProcessor, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	res := [][]packer.CoreBuildPostProcessor{}
 	for _, blocks := range blocksList {
@@ -533,6 +533,7 @@ func (cfg *PackerConfig) getCoreBuildPostProcessors(source SourceUseBlock, block
 			for _, exceptGlob := range cfg.except {
 				if exceptGlob.Match(name) {
 					exclude = true
+					*exceptMatches = *exceptMatches + 1
 					break
 				}
 			}
@@ -673,7 +674,7 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packersdk.Bu
 			if moreDiags.HasErrors() {
 				continue
 			}
-			pps, moreDiags := cfg.getCoreBuildPostProcessors(srcUsage, build.PostProcessorsLists, cfg.EvalContext(BuildContext, variables))
+			pps, moreDiags := cfg.getCoreBuildPostProcessors(srcUsage, build.PostProcessorsLists, cfg.EvalContext(BuildContext, variables), &opts.ExceptMatches)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
 				continue

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -679,15 +679,14 @@ func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packersdk.Bu
 				continue
 			}
 
-			if build.ErrorCleanupProvisionerBlock != nil {
-				if !build.ErrorCleanupProvisionerBlock.OnlyExcept.Skip(srcUsage.String()) {
-					errorCleanupProv, moreDiags := cfg.getCoreBuildProvisioner(srcUsage, build.ErrorCleanupProvisionerBlock, cfg.EvalContext(BuildContext, variables))
-					diags = append(diags, moreDiags...)
-					if moreDiags.HasErrors() {
-						continue
-					}
-					pcb.CleanupProvisioner = errorCleanupProv
+			if build.ErrorCleanupProvisionerBlock != nil &&
+				!build.ErrorCleanupProvisionerBlock.OnlyExcept.Skip(srcUsage.String()) {
+				errorCleanupProv, moreDiags := cfg.getCoreBuildProvisioner(srcUsage, build.ErrorCleanupProvisionerBlock, cfg.EvalContext(BuildContext, variables))
+				diags = append(diags, moreDiags...)
+				if moreDiags.HasErrors() {
+					continue
 				}
+				pcb.CleanupProvisioner = errorCleanupProv
 			}
 
 			pcb.Builder = builder


### PR DESCRIPTION
When a post-processor is excluded through the -except command-line argument for packer build, we used to print a warning on HCL2 templates if this except statement did not match a build.

However, since we can use the except option to avoid running post-processors, we should account for this as well when printing out a warning that there were no matches.

This commit adds this counter to the except checks for the post-processors as well.

Closes #11871