### PR TITLE
[docs] Adjusting links for rewrite project

### DIFF
--- a/website/content/docs/install.mdx
+++ b/website/content/docs/install.mdx
@@ -10,4 +10,4 @@ page_title: Install
 For detailed instructions on how to install Packer, see [this
 Getting Started guide][install].
 
-[install]: https://learn.hashicorp.com/packer/getting-started/install 'Install Packer'
+[install]: /packer/tutorials/docker-get-started/get-started-install-cli 'Install Packer'

--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -18,7 +18,7 @@ This program is intended to be largely a self-service process with links and gui
 Packer is an open source tool for creating identical machine images for multiple platforms from a single source configuration.
 Packer is lightweight, runs on every major operating system, and is highly performant, creating machine images for multiple platforms in parallel. Packer does not replace configuration management like Chef or Puppet. In fact, when building images, Packer is able to use tools like Chef or Puppet to install software onto the image.
 
-A machine image is a single static unit that contains a pre-configured operating system and installed software which is used to quickly create new running machines. Machine image formats change for each platform. Some examples include AMIs for EC2, VMDK/VMX files for VMware, OVF exports for VirtualBox, etc. To know more about use cases of Packer click ([Use Cases - Introduction | Packer by HashiCorp](/#features))
+A machine image is a single static unit that contains a pre-configured operating system and installed software which is used to quickly create new running machines. Machine image formats change for each platform. Some examples include AMIs for EC2, VMDK/VMX files for VMware, OVF exports for VirtualBox, etc. To know more about use cases of Packer click ([Use Cases - Introduction | Packer by HashiCorp](/packer/docs/intro/use-cases))
 
 The diagram below depicts the key Packer integration categories and types.
 


### PR DESCRIPTION
## What

- Updates a Use Cases page link to point to `/packer/docs/intro/use-cases` rather than the old .io home page
- Updates an old learn link to go to the associated devdot tutorial page
