### PR TITLE
Fix: Correct spelling mistakes within the README.md of the website project directory.

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -126,7 +126,7 @@ The `Tabs` component creates tabbed content of any type, but is often used for c
 
 ![Tabs Component](https://p176.p0.n0.cdn.getcloudapp.com/items/WnubALZ4/Screen%20Recording%202020-06-11%20at%2006.03%20PM.gif?v=1de81ea720a8cc8ade83ca64fb0b9edd)
 
-> Please refer to the [Swingset](https://react-components.vercel.app/?component=Tabs) documention for the latest examples and API reference.
+> Please refer to the [Swingset](https://react-components.vercel.app/?component=Tabs) documentation for the latest examples and API reference.
 
 It can be used as such within a markdown file:
 
@@ -150,7 +150,7 @@ $ curl ...
 </Tab>
 </Tabs>
 
-Contined normal markdown content
+Continued normal markdown content
 ````
 
 The intentionally skipped line is a limitation of the mdx parser which is being actively worked on. All tabs must have a heading, and there is no limit to the number of tabs, though it is recommended to go for a maximum of three or four.
@@ -451,7 +451,7 @@ This configuration would display something like the following text on the websit
 A {{ release candidate }} for <Product> {{ v1.0.0 }} is available! The release can be <a href='https://releases.hashicorp.com/<product>/{{ 1.0.0-rc1 }}'>downloaded here</a>.
 ```
 
-You may customize the parameters in any way you'd like. To remove a prerelease from the website, simply delete the `prerelease` paremeter from the above component.
+You may customize the parameters in any way you'd like. To remove a prerelease from the website, simply delete the `prerelease` parameter from the above component.
 
 <!-- END: releases -->
 


### PR DESCRIPTION
These changes fix various spelling errors found in the `README.md` kept within the `website` project directory.

In `website/README.md`, three spelling mistakes were resolved:
* a misspelled word `documention` has been corrected to `documentation`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/documentation).
* a misspelled word `Contined` has been corrected to `Continued`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/continued).
  *  (I made a guess here based on the context that it meant to say continued, but lemme know if I'm wrong here!)
* a misspelled word `paremeter` has been corrected to `parameter`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/parameter).
