### PR TITLE
Register documentation for Volcengine plugin

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -329,6 +329,13 @@
     "version": "latest"
   },
   {
+    "title": "Volcengine",
+    "path": "volcengine",
+    "repo": "volcengine/packer-plugin-volcengine",
+    "pluginTier": "community",
+    "version": "latest"
+  },
+  {
     "title": "VMware vSphere",
     "path": "vsphere",
     "repo": "hashicorp/packer-plugin-vsphere",


### PR DESCRIPTION
This PR implements a new official [Volcengine ](https://www.volcengine.com/)Packer builder volcengine-ecs which adds support for building custom images for Volcengine Ecs instance. Additionally it includes documentation for the volcengine-ecs builder.