### PR TITLE
Update index.mdx

### DIFF
--- a/website/content/docs/templates/hcl_templates/blocks/build/index.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/index.mdx
@@ -75,7 +75,7 @@ matching **builders** (source) or all referenced builders 'except' the matching
 ones, for example with the same config file:
 
 ```shell-session
-> packer build -only "*.second" ./folder
+> packer build -only "*.second-example" ./folder
 Build 'null.second-example' finished.
 Build 'a.null.second-example' finished.
 


### PR DESCRIPTION
This is not a huge thing... In trying the example, I found that you have to type "*.second-example" for the expected results.   I took the command line on line #78 literal and it didn't work as typed. When I used my proposed change... it worked for me.
Alternatively, "*.second*" works but that could grab builders that were not intended and is probably not a good practice.
