### PR TITLE
Correct document issue in provisioner block doc

### DIFF
--- a/website/content/docs/templates/hcl_templates/blocks/build/provisioner.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/provisioner.mdx
@@ -135,7 +135,7 @@ build {
 ```
 
 As you can see, the `override` key is used. The value of this key is another
-HCL attribute map where the key is the name of a [builder
+HCL attribute map where the key is the name of a [source
 definition](/docs/templates/hcl_templates/blocks/source). The value of this is in turn
 another HCL attribute map. This HCL attribute map simply contains the provisioner
 configuration as normal. This configuration is merged into the default


### PR DESCRIPTION
It looks like the key name is a `source`'s name actually .