### PR TITLE
[document] `variables.mdx` - Correct content seems like copied from Terraform document

### DIFF
--- a/website/content/docs/templates/hcl_templates/variables.mdx
+++ b/website/content/docs/templates/hcl_templates/variables.mdx
@@ -98,7 +98,7 @@ Packer defines the following arguments for variable declarations:
 
 The variable declaration can also include a `default` argument. If present,
 the variable is considered to be _optional_ and the default value will be used
-if no value is set when calling the module or running Terraform. The `default`
+if no value is set when running Packer. The `default`
 argument requires a literal value and cannot reference other objects in the
 configuration.
 


### PR DESCRIPTION
Hi folks,

This segment looks like be copied from Terraform document without properly modification.