### PR TITLE
chore: update source links to new format

### DIFF
--- a/command/hcl2_upgrade.go
+++ b/command/hcl2_upgrade.go
@@ -80,43 +80,43 @@ const (
 # All generated input variables will be of 'string' type as this is how Packer JSON
 # views them; you can change their type later on. Read the variables type
 # constraints documentation
-# https://www.packer.io/docs/templates/hcl_templates/variables#type-constraints for more info.`
+# /packer/docs/templates/hcl_templates/variables#type-constraints for more info.`
 	localsVarHeader = `
 # All locals variables are generated from variables that uses expressions
 # that are not allowed in HCL2 variables.
 # Read the documentation for locals blocks here:
-# https://www.packer.io/docs/templates/hcl_templates/blocks/locals`
+# /packer/docs/templates/hcl_templates/blocks/locals`
 	packerBlockHeader = `
-# See https://www.packer.io/docs/templates/hcl_templates/blocks/packer for more info
+# See /packer/docs/templates/hcl_templates/blocks/packer for more info
 `
 
 	sourcesHeader = `
 # source blocks are generated from your builders; a source can be referenced in
 # build blocks. A build block runs provisioner and post-processors on a
 # source. Read the documentation for source blocks here:
-# https://www.packer.io/docs/templates/hcl_templates/blocks/source`
+# /packer/docs/templates/hcl_templates/blocks/source`
 
 	buildHeader = `
 # a build block invokes sources and runs provisioning steps on them. The
 # documentation for build blocks can be found here:
-# https://www.packer.io/docs/templates/hcl_templates/blocks/build
+# /packer/docs/templates/hcl_templates/blocks/build
 `
 
 	amazonAmiDataHeader = `
 # The amazon-ami data block is generated from your amazon builder source_ami_filter; a data
 # from this block can be referenced in source and locals blocks.
 # Read the documentation for data blocks here:
-# https://www.packer.io/docs/templates/hcl_templates/blocks/data
+# /packer/docs/templates/hcl_templates/blocks/data
 # Read the documentation for the Amazon AMI Data Source here:
-# https://www.packer.io/plugins/datasources/amazon/ami`
+# /packer/plugins/datasources/amazon/ami`
 
 	amazonSecretsManagerDataHeader = `
 # The amazon-secretsmanager data block is generated from your aws_secretsmanager template function; a data
 # from this block can be referenced in source and locals blocks.
 # Read the documentation for data blocks here:
-# https://www.packer.io/docs/templates/hcl_templates/blocks/data
+# /packer/docs/templates/hcl_templates/blocks/data
 # Read the documentation for the Amazon Secrets Manager Data Source here:
-# https://www.packer.io/plugins/datasources/amazon/secretsmanager`
+# /packer/plugins/datasources/amazon/secretsmanager`
 )
 
 var (
@@ -440,7 +440,7 @@ func transposeTemplatingCalls(s []byte) []byte {
 			funcErrors = multierror.Append(funcErrors, UnhandleableArgumentError{
 				"lower",
 				"`lower(var.example)`",
-				"https://www.packer.io/docs/templates/hcl_templates/functions/string/lower",
+				"/packer/docs/templates/hcl_templates/functions/string/lower",
 			})
 			return fmt.Sprintf("{{ lower `%s` }}", a), nil
 		},
@@ -448,7 +448,7 @@ func transposeTemplatingCalls(s []byte) []byte {
 			funcErrors = multierror.Append(funcErrors, UnhandleableArgumentError{
 				"upper",
 				"`upper(var.example)`",
-				"https://www.packer.io/docs/templates/hcl_templates/functions/string/upper",
+				"/packer/docs/templates/hcl_templates/functions/string/upper",
 			})
 			return fmt.Sprintf("{{ upper `%s` }}", a), nil
 		},
@@ -456,7 +456,7 @@ func transposeTemplatingCalls(s []byte) []byte {
 			funcErrors = multierror.Append(funcErrors, UnhandleableArgumentError{
 				"split",
 				"`split(separator, string)`",
-				"https://www.packer.io/docs/templates/hcl_templates/functions/string/split",
+				"/packer/docs/templates/hcl_templates/functions/string/split",
 			})
 			return fmt.Sprintf("{{ split `%s` `%s` %d }}", a, b, n), nil
 		},
@@ -464,7 +464,7 @@ func transposeTemplatingCalls(s []byte) []byte {
 			funcErrors = multierror.Append(funcErrors, UnhandleableArgumentError{
 				"replace",
 				"`replace(string, substring, replacement)` or `regex_replace(string, substring, replacement)`",
-				"https://www.packer.io/docs/templates/hcl_templates/functions/string/replace or https://www.packer.io/docs/templates/hcl_templates/functions/string/regex_replace",
+				"/packer/docs/templates/hcl_templates/functions/string/replace or /packer/docs/templates/hcl_templates/functions/string/regex_replace",
 			})
 			return fmt.Sprintf("{{ replace `%s` `%s` `%s` %d }}", a, b, c, n), nil
 		},
@@ -472,7 +472,7 @@ func transposeTemplatingCalls(s []byte) []byte {
 			funcErrors = multierror.Append(funcErrors, UnhandleableArgumentError{
 				"replace_all",
 				"`replace(string, substring, replacement)` or `regex_replace(string, substring, replacement)`",
-				"https://www.packer.io/docs/templates/hcl_templates/functions/string/replace or https://www.packer.io/docs/templates/hcl_templates/functions/string/regex_replace",
+				"/packer/docs/templates/hcl_templates/functions/string/replace or /packer/docs/templates/hcl_templates/functions/string/regex_replace",
 			})
 			return fmt.Sprintf("{{ replace_all `%s` `%s` `%s` }}", a, b, c), nil
 		},
@@ -481,8 +481,8 @@ func transposeTemplatingCalls(s []byte) []byte {
 				"clean_resource_name",
 				"use custom validation rules, `replace(string, substring, replacement)` or `regex_replace(string, substring, replacement)`",
 				"https://packer.io/docs/templates/hcl_templates/variables#custom-validation-rules" +
-					" , https://www.packer.io/docs/templates/hcl_templates/functions/string/replace" +
-					" or https://www.packer.io/docs/templates/hcl_templates/functions/string/regex_replace",
+					" , /packer/docs/templates/hcl_templates/functions/string/replace" +
+					" or /packer/docs/templates/hcl_templates/functions/string/regex_replace",
 			})
 			return fmt.Sprintf("{{ clean_resource_name `%s` }}", a), nil
 		},
@@ -553,7 +553,7 @@ func variableTransposeTemplatingCalls(s []byte) (isLocal bool, body []byte) {
 
 	// Make locals from variables using valid template engine,
 	// expect the ones using only 'env'
-	// ref: https://www.packer.io/docs/templates/legacy_json_templates/engine#template-engine
+	// ref: /packer/docs/templates/legacy_json_templates/engine#template-engine
 	funcMap := texttemplate.FuncMap{
 		"aws_secretsmanager": setIsLocal,
 		"timestamp":          setIsLocal,

--- a/command/meta.go
+++ b/command/meta.go
@@ -160,7 +160,7 @@ func (m *Meta) GetConfigFromJSON(cla *MetaArgs) (packer.Handler, int) {
 		m.Ui.Error(fmt.Sprintf("Failed to parse file as legacy JSON template: "+
 			"if you are using an HCL template, check your file extensions; they "+
 			"should be either *.pkr.hcl or *.pkr.json; see the docs for more "+
-			"details: https://www.packer.io/docs/templates/hcl_templates. \n"+
+			"details: /packer/docs/templates/hcl_templates. \n"+
 			"Original error: %s", err))
 		return nil, 1
 	}

--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -110,7 +110,7 @@ func (c *PluginsRequiredCommand) RunContext(buildCtx context.Context, cla *Plugi
 		c.Ui.Message(`
 No plugins requirement found, make sure you reference a Packer config
 containing a packer.required_plugins block. See
-https://www.packer.io/docs/templates/hcl_templates/blocks/packer
+/packer/docs/templates/hcl_templates/blocks/packer
 for more info.`)
 	}
 

--- a/hcl2template/function/datetime.go
+++ b/hcl2template/function/datetime.go
@@ -79,7 +79,7 @@ var LegacyStrftimeFunc = function.New(&function.Spec{
 // LegacyIsotimeFunc returns a string representation of the current date and
 // time using the given format string. The format string follows golang's
 // datetime formatting. See
-// https://www.packer.io/docs/templates/legacy_json_templates/engine#isotime-function-format-reference
+// /packer/docs/templates/legacy_json_templates/engine#isotime-function-format-reference
 // for more details.
 //
 // This function has been provided to create backwards compatability with

--- a/hcl2template/types.required_plugins.go
+++ b/hcl2template/types.required_plugins.go
@@ -242,7 +242,7 @@ func decodeRequiredPluginsBlock(block *hcl.Block) (*RequiredPlugins, hcl.Diagnos
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "No version constraint was set",
-					Detail:   "The version field must be specified as a string. Ex: `version = \">= 1.2.0, < 2.0.0\". See https://www.packer.io/docs/templates/hcl_templates/blocks/packer#version-constraints for docs",
+					Detail:   "The version field must be specified as a string. Ex: `version = \">= 1.2.0, < 2.0.0\". See /packer/docs/templates/hcl_templates/blocks/packer#version-constraints for docs",
 					Subject:  attr.Expr.Range().Ptr(),
 				})
 				continue
@@ -256,7 +256,7 @@ func decodeRequiredPluginsBlock(block *hcl.Block) (*RequiredPlugins, hcl.Diagnos
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid version constraint",
-					Detail:   "Version must be specified as a string. See https://www.packer.io/docs/templates/hcl_templates/blocks/packer#version-constraint-syntax for docs.",
+					Detail:   "Version must be specified as a string. See /packer/docs/templates/hcl_templates/blocks/packer#version-constraint-syntax for docs.",
 					Subject:  attr.Expr.Range().Ptr(),
 				})
 				continue
@@ -270,7 +270,7 @@ func decodeRequiredPluginsBlock(block *hcl.Block) (*RequiredPlugins, hcl.Diagnos
 					Severity: hcl.DiagError,
 					Summary:  "Invalid version constraint",
 					Detail: "This string does not use correct version constraint syntax. " +
-						"See https://www.packer.io/docs/templates/hcl_templates/blocks/packer#version-constraint-syntax for docs.\n" +
+						"See /packer/docs/templates/hcl_templates/blocks/packer#version-constraint-syntax for docs.\n" +
 						err.Error(),
 					Subject: attr.Expr.Range().Ptr(),
 				})
@@ -283,7 +283,7 @@ func decodeRequiredPluginsBlock(block *hcl.Block) (*RequiredPlugins, hcl.Diagnos
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "No source was set",
-					Detail:   "The source field must be specified as a string. Ex: `source = \"coolcloud\". See https://www.packer.io/docs/templates/hcl_templates/blocks/packer#specifying-plugin-requirements for docs",
+					Detail:   "The source field must be specified as a string. Ex: `source = \"coolcloud\". See /packer/docs/templates/hcl_templates/blocks/packer#specifying-plugin-requirements for docs",
 					Subject:  attr.Expr.Range().Ptr(),
 				})
 				continue

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -343,7 +343,7 @@ type Getter interface {
 	//    See
 	//    https://github.com/hashicorp/packer-plugin-scaffolding/blob/main/.goreleaser.yml
 	//    and
-	//    https://www.packer.io/docs/plugins/creation#plugin-development-basics
+	//    /packer/docs/plugins/creation#plugin-development-basics
 	//    to learn how to create and automate your releases and for docs on
 	//    plugin development basics.
 	//


### PR DESCRIPTION
This PR updates references to legacy link from packer.io, to the new format where links are relative to developer.hashicorp.com root. This PR is a precursor to finishing up the[ link migration work here.](https://github.com/hashicorp/packer/pull/12192) 
