### PR TITLE
docs: Update community-tools.mdx

### DIFF
--- a/website/content/community-tools.mdx
+++ b/website/content/community-tools.mdx
@@ -19,7 +19,7 @@ vendors. These plugins are not officially tested nor officially maintained by
 HashiCorp, and are listed here in order to help users find them easily.
 
 To learn more about how to use community plugins, or how to build your own,
-check out the docs on [extending Packer](/packer/docs/plugins/install-plugins)
+check out the docs on [extending Packer](https://developer.hashicorp.com/packer/docs/plugins/install-plugins)
 
 If you have built a plugin and would like to add it to this community list,
 please make a pull request so that we can document your


### PR DESCRIPTION
This is a [fast follow](https://github.com/hashicorp/packer/pull/12192#discussion_r1089243999) from the link migration work, to fix a link that remains on packerproject.io community tools page. 
