### PR TITLE
copywrite: setup configuration for licensing

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,13 @@
+project {
+  license = "MPL-2.0"
+  copyright_year = 2013
+  header_ignore = [
+    "*.hcl2spec.go", # generated code specs, since they'll be wiped out until we support adding the headers at generation-time
+    "hcl2template/testdata/**",
+    "test/**",
+    "**/test-fixtures/**",
+    "examples/**",
+    "hcl2template/fixtures/**",
+    "website/**" # candidates for copyright are coming from external sources, so we should not handle those in Packer
+  ]
+}


### PR DESCRIPTION
Copywrite is a tool developed internally at Hashicorp in order to maintain our source code up-to-date in terms of license headers.

Since this will be monitored soon, we are preparing for this by adding the configuration for files to ignore.

cc @CalebAlbers 