### PR TITLE
Add release branches to CRT build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,13 @@
 
 name: build
 
-on: [ workflow_dispatch, push, workflow_call ]
+on: 
+  workflow_dispatch: 
+  workflow_call:
+  push:
+    branches:
+      - main
+      - release/**
 
 env:
   REPO_NAME: "packer"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,6 +10,7 @@ project "packer" {
     repository = "packer"
     release_branches = [
         "main", 
+        "release/**"
     ]
   }
 }


### PR DESCRIPTION
This change will allow for release branches `release/<MAJOR>.<MINOR>.x`
to be built add uploaded to the CRT build tool chain, which can then be
promoted and released publicly if needed.
