### PR TITLE
add changelog update for vendor label for linux packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
      it difficult to identify the broken build block. Packer has been updated to
      display the proper filename and line number where the unknown reference
      resides. [GH-12167](https://github.com/hashicorp/packer/pull/12167)
+* core: Linux packages now have vendor label and set the default label to HashiCorp.
+        This fix is implemented for any future releases, but will not be 
+        updated for historical releases.
 
 ### NOTES:
 * core: Users will see some changes in how names are displayed during a Packer


### PR DESCRIPTION
This PR is just an update to the changelog to reflect a bug that was fixed in our [actions-packaging-linux](https://github.com/hashicorp/actions-packaging-linux) action. We received a report from a user stating that vendor labels were missing when downloading linux packages (for products that were released via CRT) We fixed this in [this PR](https://github.com/hashicorp/actions-packaging-linux/pull/14) and we added a vendor label and set the default to `HashiCorp` This will only affect future releases that go through our linux promotion pipeline -- historical releases will not have this vendor label. 
