### PR TITLE
Update instance runner for workflow

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,8 +1,8 @@
-name: create a release branch
+name: Create a release branch
 on: [workflow_dispatch]
 jobs:
   create-branch:
-    runs-on: [linux, small]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/actions-create-release-branch@v1


### PR DESCRIPTION
Small Linux runners are only supported within on-prem actions. This
change updates the workflow to use a public Linux runner.
