### PR TITLE
copywrite: add command/plugin.go to ignore list

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -8,6 +8,7 @@ project {
     "**/test-fixtures/**",
     "examples/**",
     "hcl2template/fixtures/**",
+    "command/plugin.go",
     "website/**" # candidates for copyright are coming from external sources, so we should not handle those in Packer
   ]
 }


### PR DESCRIPTION
The command/plugin.go file is auto-generated and should not be processed as part of copywrite headers.

Follow-up to #12254 