### PR TITLE
Update JSON template does not return substitute values in 1.8.6 version

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -421,7 +421,7 @@ func (c *Core) Build(n string) (packersdk.Build, error) {
 	// Return a structure that contains the plugins, their types, variables, and
 	// the raw builder config loaded from the json template
 	cb := &CoreBuild{
-		Type:               configBuilder.Name,
+		Type:               n,
 		Builder:            builder,
 		BuilderConfig:      configBuilder.Config,
 		BuilderType:        configBuilder.Type,
@@ -432,6 +432,8 @@ func (c *Core) Build(n string) (packersdk.Build, error) {
 		Variables:          c.variables,
 	}
 
+	//configBuilder.Name is left uninterpolated so we must check against
+	// the interpolated name.
 	if configBuilder.Type != configBuilder.Name {
 		cb.BuildName = configBuilder.Type
 	}

--- a/packer/core_test.go
+++ b/packer/core_test.go
@@ -68,6 +68,10 @@ func TestCoreBuild_basic(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	if build.Name() != "test" {
+		t.Fatalf("bad: build name does not match expected: %q, got: %q", "test", build.Name())
+	}
+
 	if _, err := build.Prepare(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -96,6 +100,10 @@ func TestCoreBuild_basicInterpolated(t *testing.T) {
 	build, err := core.Build("NAME")
 	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+
+	if build.Name() != "test.NAME" {
+		t.Fatalf("bad: build name does not match expected: %q, got: %q", "NAME", build.Name())
 	}
 
 	if _, err := build.Prepare(); err != nil {
@@ -863,5 +871,66 @@ func TestCoreBuild_packerVersion(t *testing.T) {
 
 	if result["value"] != expected {
 		t.Fatalf("bad: %#v", result)
+	}
+}
+
+func TestCoreBuild_buildNameIntepolation(t *testing.T) {
+	config := TestCoreConfig(t)
+	cases := []struct {
+		File                       string
+		InterpolatedName, Expected string
+		Vars                       map[string]string
+	}{
+		{
+			File:             "build-interpolated-name.json",
+			InterpolatedName: "mybuild-RandomToken",
+			Expected:         "test.mybuild-RandomToken",
+			Vars: map[string]string{
+				"build_name": "mybuild-RandomToken",
+			},
+		},
+		{
+			File:             "build-interpolated-name.json",
+			InterpolatedName: "build-vardata",
+			Expected:         "test.build-vardata",
+			Vars: map[string]string{
+				"build_name": "build-vardata",
+			},
+		},
+		{
+			File:             "build-interpolated-name.json",
+			InterpolatedName: "build-12345",
+			Expected:         "test.build-12345",
+			Vars: map[string]string{
+				"something":  "build-12345",
+				"build_name": "{{user `something`}}",
+			},
+		},
+		{
+			// When no name attribute is provided in the config the builder type is the default name.
+			File:             "build-basic.json",
+			InterpolatedName: "test",
+			Expected:         "test",
+		},
+	}
+
+	for _, tc := range cases {
+		config.Variables = tc.Vars
+		testCoreTemplate(t, config, fixtureDir(tc.File))
+		core := TestCore(t, config)
+		diags := core.Initialize(InitializeOptions{})
+		if diags.HasErrors() {
+			t.Fatalf("err: %s\n\n%s", tc.File, diags)
+		}
+
+		build, err := core.Build(tc.InterpolatedName)
+		if err != nil {
+			t.Fatalf("err for InterpolatedName(%q): %s", tc.InterpolatedName, err)
+		}
+
+		if build.Name() != tc.Expected {
+			t.Errorf("build type interpolation failed; expected %q, got %q", tc.Expected, build.Name())
+		}
+
 	}
 }

--- a/packer/test-fixtures/build-interpolated-name.json
+++ b/packer/test-fixtures/build-interpolated-name.json
@@ -1,0 +1,7 @@
+
+{
+    "builders": [{
+        "type": "test",
+        "name": "{{user `build_name`}}"
+    }]
+}


### PR DESCRIPTION
This change fixes a regression introduced in Packer 1.8.6, where configurations custom builder names
, via the name attribute, would internally interpolate the proper build names, but would display the
name to STDOUT as uninterpolated values. The change updates the creation of a CoreBuild for legacy JSON templates
to use use the interpolated name as the final build type, which gets rendered to the screen.

Test Results Before Fix
```
~>  go test ./... -run='TestCoreBuild_buildNameIntepolation' -v
--- FAIL: TestCoreBuild_buildTypeIntepolation (0.01s)
    core_test.go:930: build type interpolation failed; expected "test.mybuild-RandomToken", got "test.{{user `build_name`}}"
    core_test.go:930: build type interpolation failed; expected "test.build-vardata", got "test.{{user `build_name`}}"
    core_test.go:930: build type interpolation failed; expected "test.build-12345", got "test.{{user `build_name`}}"
FAIL
```

Test Results After Fix
```
~>  go test ./... -run='TestCoreBuild_buildNameIntepolation' -v
=== RUN   TestCoreBuild_buildTypeIntepolation
--- PASS: TestCoreBuild_buildTypeIntepolation (0.01s)
PASS
```

Closes #12281
