### PR TITLE
Migrate external Linode plugin to linode/packer-plugin-linode

### DIFF
--- a/command/vendored_plugins.go
+++ b/command/vendored_plugins.go
@@ -46,7 +46,6 @@ import (
 	hypervvmcxbuilder "github.com/hashicorp/packer-plugin-hyperv/builder/hyperv/vmcx"
 	inspecprovisioner "github.com/hashicorp/packer-plugin-inspec/provisioner/inspec"
 	jdcloudbuilder "github.com/hashicorp/packer-plugin-jdcloud/builder/jdcloud"
-	linodebuilder "github.com/hashicorp/packer-plugin-linode/builder/linode"
 	lxcbuilder "github.com/hashicorp/packer-plugin-lxc/builder/lxc"
 	lxdbuilder "github.com/hashicorp/packer-plugin-lxd/builder/lxd"
 	ncloudbuilder "github.com/hashicorp/packer-plugin-ncloud/builder/ncloud"
@@ -110,7 +109,6 @@ var VendoredBuilders = map[string]packersdk.Builder{
 	"hyperv-vmcx":         new(hypervvmcxbuilder.Builder),
 	"hyperone":            new(hyperonebuilder.Builder),
 	"jdcloud":             new(jdcloudbuilder.Builder),
-	"linode":              new(linodebuilder.Builder),
 	"lxc":                 new(lxcbuilder.Builder),
 	"lxd":                 new(lxdbuilder.Builder),
 	"ncloud":              new(ncloudbuilder.Builder),

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,6 @@ require (
 	github.com/hashicorp/packer-plugin-hyperv v1.0.4
 	github.com/hashicorp/packer-plugin-inspec v1.0.0
 	github.com/hashicorp/packer-plugin-jdcloud v1.0.1
-	github.com/hashicorp/packer-plugin-linode v1.0.3
 	github.com/hashicorp/packer-plugin-lxc v1.0.2
 	github.com/hashicorp/packer-plugin-lxd v1.0.1
 	github.com/hashicorp/packer-plugin-ncloud v1.0.3
@@ -164,7 +163,6 @@ require (
 	github.com/go-openapi/strfmt v0.21.3 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-openapi/validate v0.22.1 // indirect
-	github.com/go-resty/resty/v2 v2.6.0 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
@@ -212,7 +210,6 @@ require (
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/fs v0.1.0 // indirect
-	github.com/linode/linodego v0.30.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect
 	github.com/matryer/is v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -305,9 +305,7 @@ github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/validate v0.22.1 h1:G+c2ub6q47kfX1sOBLwIQwzBVt8qmOAARyo/9Fqs9NU=
 github.com/go-openapi/validate v0.22.1/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUriMu5/zuPSQ1hg=
-github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-resty/resty/v2 v2.6.0 h1:joIR5PNLM2EFqqESUjCMGXrWmXNHEU9CEiK813oKYS4=
-github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -543,8 +541,6 @@ github.com/hashicorp/packer-plugin-inspec v1.0.0 h1:6qRgH90Q+L3HSzo5UvuSozzS4VzU
 github.com/hashicorp/packer-plugin-inspec v1.0.0/go.mod h1:SsVyBs8b/g1wMC+4HgZQWT01kqxrwprA7dKxHAIRFKw=
 github.com/hashicorp/packer-plugin-jdcloud v1.0.1 h1:qgecywtT8EqGiHdvopC36eBz1lSZs336w7X2q+y+UY0=
 github.com/hashicorp/packer-plugin-jdcloud v1.0.1/go.mod h1:1i/cCievlQE+grHJWUxhwi5nzwSXt9n0WmcHpFVMt5I=
-github.com/hashicorp/packer-plugin-linode v1.0.3 h1:CHE4G5GsgT8CEiMn7FBsckBFsfwUF+0i0b/t+a0PyEs=
-github.com/hashicorp/packer-plugin-linode v1.0.3/go.mod h1:zxEZrwpN8X1L1P3QlRvaT5asH33xdx62/qPIVnqycbA=
 github.com/hashicorp/packer-plugin-lxc v1.0.2 h1:JvIkbSynft+9JAi1uPEVHesIe02OX2yL9rPj1Ud0kM8=
 github.com/hashicorp/packer-plugin-lxc v1.0.2/go.mod h1:kirXCLekY6h0YPbWaue2YRqKqiumyDnbwwww/TGjGjE=
 github.com/hashicorp/packer-plugin-lxd v1.0.1 h1:sqdaEdip0y/wC7x99CQHIbakJSmZY2kI3LfFT0FvYVo=
@@ -668,8 +664,6 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/linode/linodego v0.30.0 h1:r9Sujfeo4FfEn/KdOjYegMP5sNCXL5rZUc4zNcDa+2E=
-github.com/linode/linodego v0.30.0/go.mod h1:BR0gVkCJffEdIGJSl6bHR80Ty+Uvg/2jkjmrWaFectM=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1033,7 +1027,6 @@ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -161,8 +161,8 @@
   {
     "title": "Linode",
     "path": "linode",
-    "repo": "hashicorp/packer-plugin-linode",
-    "pluginTier": "community",
+    "repo": "linode/packer-plugin-linode",
+    "pluginTier": "verified",
     "version": "latest",
     "isHcpPackerReady": true
   },


### PR DESCRIPTION

The Linode plugin for Packer is now maintained by the Linode team, under their respective GitHub org. This changes updates the source address for the external plugin that should be used for pulling new plugin documentation, and removes Linode as a vendored plugin to ensure user download the latest version from the new release repository. 

#### TODO
- [x] Update external plugin documentation source
- [x] Removed packer-plugin-linode for list of vendored plugins

Depends on https://github.com/linode/packer-plugin-linode/pull/73 being merged and released. 
