### PR TITLE
[website] Update Outscale plugin HCP Ready tag

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -230,6 +230,7 @@
     "repo": "outscale/packer-plugin-outscale",
     "version": "latest",
     "pluginTier": "verified"
+    "isHcpPackerReady": true
   },
   {
     "title": "Parallels",


### PR DESCRIPTION
Adding the HCP Ready tag to the Outscale plugin. The HCP compatibility was added in this PR: https://github.com/outscale/packer-plugin-outscale/pull/70