### PR TITLE
website: fix typo in documentation of validate command

### DIFF
--- a/website/content/docs/commands/validate.mdx
+++ b/website/content/docs/commands/validate.mdx
@@ -47,7 +47,7 @@ Errors validating build 'vmware'. 1 error(s) occurred:
   source block's "name" label, unless an in-build source definition adds the
   "name" configuration option.
 
-- `-no-warn-on-undeclared-var` - Silence warnings when the a variable definition
+- `-no-warn-undeclared-var` - Silence warnings when the variable definition
   file contains variable assignments for undeclared variables. This can occur
   when using a var-file that contains a large amount of unused variables for a
   given HCL2 template. For HCL2 template defining a value for a variable in a


### PR DESCRIPTION
This fixes a misspelled option in the documentation of `packer validate` command