### PR TITLE
Update allowed dependencies to track

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,4 @@ updates:
     interval: daily
   allow:
     - dependency-name: "github.com/hashicorp/packer-plugin-sdk"
-    - dependency-name: "github.com/hashicorp/hcl/v2"
-    - dependency-name: "github.com/zclconf/go-cty"
     - dependency-name: "github.com/hashicorp/hcp-sdk-go"
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: daily


### PR DESCRIPTION
* Packer plugins rely on the Packer SDK for the majority of its HCL
dependency. To prevent issues with the version of go-cty or hcl/v2 pkg
getting out of sync this changes sets the allowed dependency to
packer-plugin-sdk only.

* HashiCorp is standardizing on pinning versions of allowed GitHub actions to prevent
the introduction of potential security issues. This change removes GitHub actions
from dependabot.
