### PR TITLE
cmd/console: Add config-type flag to command help

### DIFF
--- a/command/console.go
+++ b/command/console.go
@@ -85,6 +85,7 @@ Usage: packer console [options] [TEMPLATE]
 Options:
   -var 'key=value'       Variable for templates, can be used multiple times.
   -var-file=path         JSON or HCL2 file containing user variables.
+  -config-type           Set to 'hcl2' to run in HCL2 mode when no file is passed. Defaults to json.
 `
 
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
It is not clear that the console command runs in legacy JSON mode by default and that users can specify the config-type flag to toggle HCL2 mode. This change adds the config-type flag to the command's help text to alert users of the gotcha. 

In the next minor Packer release the console command will be updated to default to HCL2 mode.

Relates to: #12359
Relates to: #10603
