### PR TITLE
Update fix command autocomplete to work for JSON template files only

### DIFF
--- a/contrib/zsh-completion/_packer
+++ b/contrib/zsh-completion/_packer
@@ -38,7 +38,7 @@ _packer () {
   )
 
   local -a fix_arguments && fix_arguments=(
-    '(-)*:files:_files -g "*pkr.{hcl,json}"'
+    '(-)*:files:_files -g "*.json"'
   )
 
   local -a fmt_arguments && fmt_arguments=(


### PR DESCRIPTION
This change updates the Zsh autocomplete for the fix command to only complete for *.json files, 
as the fix command is not implemented for HCL2 templates. 

This is a fast follow to #12356
