### PR TITLE
Remove external archived provisioner plugins

### DIFF
--- a/command/vendored_plugins.go
+++ b/command/vendored_plugins.go
@@ -28,10 +28,7 @@ import (
 	azurechrootbuilder "github.com/hashicorp/packer-plugin-azure/builder/azure/chroot"
 	azuredtlbuilder "github.com/hashicorp/packer-plugin-azure/builder/azure/dtl"
 	azuredtlartifactprovisioner "github.com/hashicorp/packer-plugin-azure/provisioner/azure-dtlartifact"
-	chefclientprovisioner "github.com/hashicorp/packer-plugin-chef/provisioner/chef-client"
-	chefsoloprovisioner "github.com/hashicorp/packer-plugin-chef/provisioner/chef-solo"
 	cloudstackbuilder "github.com/hashicorp/packer-plugin-cloudstack/builder/cloudstack"
-	convergeprovisioner "github.com/hashicorp/packer-plugin-converge/provisioner/converge"
 	dockerbuilder "github.com/hashicorp/packer-plugin-docker/builder/docker"
 	dockerimportpostprocessor "github.com/hashicorp/packer-plugin-docker/post-processor/docker-import"
 	dockerpushpostprocessor "github.com/hashicorp/packer-plugin-docker/post-processor/docker-push"
@@ -44,7 +41,6 @@ import (
 	hyperonebuilder "github.com/hashicorp/packer-plugin-hyperone/builder/hyperone"
 	hypervisobuilder "github.com/hashicorp/packer-plugin-hyperv/builder/hyperv/iso"
 	hypervvmcxbuilder "github.com/hashicorp/packer-plugin-hyperv/builder/hyperv/vmcx"
-	inspecprovisioner "github.com/hashicorp/packer-plugin-inspec/provisioner/inspec"
 	jdcloudbuilder "github.com/hashicorp/packer-plugin-jdcloud/builder/jdcloud"
 	lxcbuilder "github.com/hashicorp/packer-plugin-lxc/builder/lxc"
 	lxdbuilder "github.com/hashicorp/packer-plugin-lxd/builder/lxd"
@@ -56,10 +52,7 @@ import (
 	profitbricksbuilder "github.com/hashicorp/packer-plugin-profitbricks/builder/profitbricks"
 	proxmoxclone "github.com/hashicorp/packer-plugin-proxmox/builder/proxmox/clone"
 	proxmoxiso "github.com/hashicorp/packer-plugin-proxmox/builder/proxmox/iso"
-	puppetmasterlessprovisioner "github.com/hashicorp/packer-plugin-puppet/provisioner/puppet-masterless"
-	puppetserverprovisioner "github.com/hashicorp/packer-plugin-puppet/provisioner/puppet-server"
 	qemubuilder "github.com/hashicorp/packer-plugin-qemu/builder/qemu"
-	saltmasterlessprovisioner "github.com/hashicorp/packer-plugin-salt/provisioner/salt-masterless"
 	tencentcloudcvmbuilder "github.com/hashicorp/packer-plugin-tencentcloud/builder/tencentcloud/cvm"
 	tritonbuilder "github.com/hashicorp/packer-plugin-triton/builder/triton"
 	vagrantbuilder "github.com/hashicorp/packer-plugin-vagrant/builder/vagrant"
@@ -138,13 +131,6 @@ var VendoredProvisioners = map[string]packersdk.Provisioner{
 	"azure-dtlartifact": new(azuredtlartifactprovisioner.Provisioner),
 	"ansible":           new(ansibleprovisioner.Provisioner),
 	"ansible-local":     new(ansiblelocalprovisioner.Provisioner),
-	"chef-client":       new(chefclientprovisioner.Provisioner),
-	"chef-solo":         new(chefsoloprovisioner.Provisioner),
-	"converge":          new(convergeprovisioner.Provisioner),
-	"inspec":            new(inspecprovisioner.Provisioner),
-	"puppet-masterless": new(puppetmasterlessprovisioner.Provisioner),
-	"puppet-server":     new(puppetserverprovisioner.Provisioner),
-	"salt-masterless":   new(saltmasterlessprovisioner.Provisioner),
 }
 
 // VendoredPostProcessors are post-processor components that were once bundled with the

--- a/go.mod
+++ b/go.mod
@@ -64,15 +64,12 @@ require (
 	github.com/hashicorp/packer-plugin-alicloud v1.0.7
 	github.com/hashicorp/packer-plugin-ansible v1.0.3
 	github.com/hashicorp/packer-plugin-azure v1.4.0
-	github.com/hashicorp/packer-plugin-chef v1.0.2
 	github.com/hashicorp/packer-plugin-cloudstack v1.0.2
-	github.com/hashicorp/packer-plugin-converge v1.0.1
 	github.com/hashicorp/packer-plugin-docker v1.0.8
 	github.com/hashicorp/packer-plugin-googlecompute v1.1.0
 	github.com/hashicorp/packer-plugin-hcloud v1.0.5
 	github.com/hashicorp/packer-plugin-hyperone v1.0.1
 	github.com/hashicorp/packer-plugin-hyperv v1.0.4
-	github.com/hashicorp/packer-plugin-inspec v1.0.0
 	github.com/hashicorp/packer-plugin-jdcloud v1.0.1
 	github.com/hashicorp/packer-plugin-lxc v1.0.2
 	github.com/hashicorp/packer-plugin-lxd v1.0.1
@@ -82,9 +79,7 @@ require (
 	github.com/hashicorp/packer-plugin-parallels v1.0.3
 	github.com/hashicorp/packer-plugin-profitbricks v1.0.2
 	github.com/hashicorp/packer-plugin-proxmox v1.1.1
-	github.com/hashicorp/packer-plugin-puppet v1.0.1
 	github.com/hashicorp/packer-plugin-qemu v1.0.9
-	github.com/hashicorp/packer-plugin-salt v1.0.0
 	github.com/hashicorp/packer-plugin-tencentcloud v1.0.6
 	github.com/hashicorp/packer-plugin-triton v1.0.2
 	github.com/hashicorp/packer-plugin-vagrant v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -521,12 +521,8 @@ github.com/hashicorp/packer-plugin-ansible v1.0.3 h1:XjltQVPYnnZdNyBjwHr1QthR413
 github.com/hashicorp/packer-plugin-ansible v1.0.3/go.mod h1:N4OZtNDq2FSRBknuNU/GSoKtllfxQnHCYYaJUD1p1MA=
 github.com/hashicorp/packer-plugin-azure v1.4.0 h1:rxkcGe5pjjnzddfR5/sBJmg8kb+ko+r2M+Ce7OC8sQ4=
 github.com/hashicorp/packer-plugin-azure v1.4.0/go.mod h1:7j1q0SNPeZr7xRID0c/Hu9QojE41pSlSJwsNB9/rOTI=
-github.com/hashicorp/packer-plugin-chef v1.0.2 h1:hkVhBuglBc5wY4cNfFObW7hzJuT+VdWMAu/gQ9nDNOI=
-github.com/hashicorp/packer-plugin-chef v1.0.2/go.mod h1:RWNaO+NprfeW4mdZDAGaLPJE3hUR8f/poSw1MNTt+NA=
 github.com/hashicorp/packer-plugin-cloudstack v1.0.2 h1:JsT2AuCcZGajbFL0w/sQ5yzoWLwOPyETboDR+Ws0xbo=
 github.com/hashicorp/packer-plugin-cloudstack v1.0.2/go.mod h1:WCX3zX0P6ubg3QoErIFu/b7UwzxVli2WVa82wfbPqa0=
-github.com/hashicorp/packer-plugin-converge v1.0.1 h1:LNjhWQCaPNHSgeKGj/vXwqlEuqz3lA4P7gD7YQ1XsNA=
-github.com/hashicorp/packer-plugin-converge v1.0.1/go.mod h1:iXfr0QvDEOmSIK2ry53KCfztK3QaeQuTo8eHqzWMlVI=
 github.com/hashicorp/packer-plugin-docker v1.0.8 h1:UWPG/pl+1RFsaNQVhEuowCeOZuES6/mqy5R6FTyMeQo=
 github.com/hashicorp/packer-plugin-docker v1.0.8/go.mod h1:4U3gHULbUw3okSqqZgQZD5ptyJKs0S7LfOOt2U3V4Jk=
 github.com/hashicorp/packer-plugin-googlecompute v1.1.0 h1:/cSZCJuRV6osaSa1uOy8cpN+c/uiCbrSsZ8vyNC0slk=
@@ -537,8 +533,6 @@ github.com/hashicorp/packer-plugin-hyperone v1.0.1 h1:rTxnbFE8UDnzWG3prHQZpWmCpF
 github.com/hashicorp/packer-plugin-hyperone v1.0.1/go.mod h1:tT5g5xjFRuFX28w0NhpiwMum/JQDjboJwfa3Zt3ND+Q=
 github.com/hashicorp/packer-plugin-hyperv v1.0.4 h1:SHdo60jfrmeSz+T25Aa2BuSWBioFOWe4hKmp7W6lIUs=
 github.com/hashicorp/packer-plugin-hyperv v1.0.4/go.mod h1:8kHew9yWRaKYojmOMj1FYVlhOrdtiIZX2Z8RM+sHxJE=
-github.com/hashicorp/packer-plugin-inspec v1.0.0 h1:6qRgH90Q+L3HSzo5UvuSozzS4VzU+ckkwJi9pMHYW1M=
-github.com/hashicorp/packer-plugin-inspec v1.0.0/go.mod h1:SsVyBs8b/g1wMC+4HgZQWT01kqxrwprA7dKxHAIRFKw=
 github.com/hashicorp/packer-plugin-jdcloud v1.0.1 h1:qgecywtT8EqGiHdvopC36eBz1lSZs336w7X2q+y+UY0=
 github.com/hashicorp/packer-plugin-jdcloud v1.0.1/go.mod h1:1i/cCievlQE+grHJWUxhwi5nzwSXt9n0WmcHpFVMt5I=
 github.com/hashicorp/packer-plugin-lxc v1.0.2 h1:JvIkbSynft+9JAi1uPEVHesIe02OX2yL9rPj1Ud0kM8=
@@ -557,12 +551,8 @@ github.com/hashicorp/packer-plugin-profitbricks v1.0.2 h1:wAlTRm1A39T9hferxFtKaL
 github.com/hashicorp/packer-plugin-profitbricks v1.0.2/go.mod h1:Gpg/h6A0UcTYzLwDw2GrUJjlPUmL5QaxGBJWH0NMx0g=
 github.com/hashicorp/packer-plugin-proxmox v1.1.1 h1:uBwW7MQN1p3vUha1BVIG3wqWrxa349qWekYyScSvDls=
 github.com/hashicorp/packer-plugin-proxmox v1.1.1/go.mod h1:S83+dabgqpNuKvm7sdNh2ivqx5rpgO6mbJn/iVrrXjk=
-github.com/hashicorp/packer-plugin-puppet v1.0.1 h1:/obGvsyiKiO2hX9TxRTJ7Y+/44K4WqKJlzg4xHAyIoY=
-github.com/hashicorp/packer-plugin-puppet v1.0.1/go.mod h1:avMyKLTT/6SVR/hEgJk92SMziK3nwlNJ00kOYgwIDMk=
 github.com/hashicorp/packer-plugin-qemu v1.0.9 h1:1YKBBzBULYUBWtpAZJTbaLjjZPAdQ63okkpTqMBTnzM=
 github.com/hashicorp/packer-plugin-qemu v1.0.9/go.mod h1:BpWIpVpOoPFV9Ppmzq4DP/S0QNoh1R+7DUCqxHdXc+Y=
-github.com/hashicorp/packer-plugin-salt v1.0.0 h1:bLGdlDG2nLyOzjp/5d2rmZ9XVxDeDUGejOK3wayqEL4=
-github.com/hashicorp/packer-plugin-salt v1.0.0/go.mod h1:onggPITzeB6LPSW8XlSobu8eI6yj3IMUi5cS6vWnL7s=
 github.com/hashicorp/packer-plugin-sdk v0.4.0 h1:UyLYe0y02D9wkOQ3FeeZWyFg2+mx2vLuWRGUL5xt50I=
 github.com/hashicorp/packer-plugin-sdk v0.4.0/go.mod h1:uNhU3pmjM2ejgHYce/g4J+sa5rh81iYQztpGvGa5FOs=
 github.com/hashicorp/packer-plugin-tencentcloud v1.0.6 h1:h7thXtVaXZhrF5L+bMcdMktrcV4RufQvJI41y10dHtE=


### PR DESCRIPTION
This change removes a set of plugins that have not been updated in a while. These
plugins have been archived for some time now. Users wishing to continue using these plugins
should use the `packer plugins install` or `packer init` commands to install the external plugin.
