### PR TITLE
Fix URL git repository modern Windows version on the Autounattend Windows Guide

### DIFF
--- a/website/content/guides/automatic-operating-system-installs/autounattend_windows.mdx
+++ b/website/content/guides/automatic-operating-system-installs/autounattend_windows.mdx
@@ -67,7 +67,7 @@ disconnections can fail a build.
 The chef-maintained bento boxes are a great example of a Windows build that
 sets up openssh as part of the unattended installation so that Packer can
 connect using the SSH communicator. The functioning answer files for every
-modern Windows version can be found [here](https://github.com/chef/bento/tree/master/packer_templates/windows/answer_files).
+modern Windows version can be found [here](https://github.com/chef/bento/tree/master/packer_templates/win_answer_files).
 
 Stefan Scherer's [packer-windows repo](https://github.com/StefanScherer/packer-windows)
 is a great example of Windows builds that set up WinRM as part of the unattended


### PR DESCRIPTION
Hi, I fixed an URL that was invalid on the Autounattend Windows Guide
