### PR TITLE
Remove IONOS plugins from vendored plugins

### DIFF
--- a/command/vendored_plugins.go
+++ b/command/vendored_plugins.go
@@ -8,7 +8,7 @@ import (
 
 	// Previously core-bundled components, split into their own plugins but
 	// still vendored with Packer for now. Importing as library instead of
-	// forcing use of packer init, until packer v1.8.0
+	// forcing use of packer init.
 
 	alicloudecsbuilder "github.com/hashicorp/packer-plugin-alicloud/builder/ecs"
 	alicloudimportpostprocessor "github.com/hashicorp/packer-plugin-alicloud/post-processor/alicloud-import"
@@ -47,11 +47,9 @@ import (
 	lxcbuilder "github.com/hashicorp/packer-plugin-lxc/builder/lxc"
 	lxdbuilder "github.com/hashicorp/packer-plugin-lxd/builder/lxd"
 	ncloudbuilder "github.com/hashicorp/packer-plugin-ncloud/builder/ncloud"
-	oneandonebuilder "github.com/hashicorp/packer-plugin-oneandone/builder/oneandone"
 	openstackbuilder "github.com/hashicorp/packer-plugin-openstack/builder/openstack"
 	parallelsisobuilder "github.com/hashicorp/packer-plugin-parallels/builder/parallels/iso"
 	parallelspvmbuilder "github.com/hashicorp/packer-plugin-parallels/builder/parallels/pvm"
-	profitbricksbuilder "github.com/hashicorp/packer-plugin-profitbricks/builder/profitbricks"
 	proxmoxclone "github.com/hashicorp/packer-plugin-proxmox/builder/proxmox/clone"
 	proxmoxiso "github.com/hashicorp/packer-plugin-proxmox/builder/proxmox/iso"
 	puppetmasterlessprovisioner "github.com/hashicorp/packer-plugin-puppet/provisioner/puppet-masterless"
@@ -107,9 +105,7 @@ var VendoredBuilders = map[string]packersdk.Builder{
 	"lxc":                 new(lxcbuilder.Builder),
 	"lxd":                 new(lxdbuilder.Builder),
 	"ncloud":              new(ncloudbuilder.Builder),
-	"oneandone":           new(oneandonebuilder.Builder),
 	"openstack":           new(openstackbuilder.Builder),
-	"profitbricks":        new(profitbricksbuilder.Builder),
 	"proxmox":             new(proxmoxiso.Builder),
 	"proxmox-iso":         new(proxmoxiso.Builder),
 	"proxmox-clone":       new(proxmoxclone.Builder),

--- a/go.mod
+++ b/go.mod
@@ -76,10 +76,8 @@ require (
 	github.com/hashicorp/packer-plugin-lxc v1.0.2
 	github.com/hashicorp/packer-plugin-lxd v1.0.1
 	github.com/hashicorp/packer-plugin-ncloud v1.0.3
-	github.com/hashicorp/packer-plugin-oneandone v1.0.1
 	github.com/hashicorp/packer-plugin-openstack v1.0.1
 	github.com/hashicorp/packer-plugin-parallels v1.0.3
-	github.com/hashicorp/packer-plugin-profitbricks v1.0.2
 	github.com/hashicorp/packer-plugin-proxmox v1.1.1
 	github.com/hashicorp/packer-plugin-puppet v1.0.1
 	github.com/hashicorp/packer-plugin-qemu v1.0.9
@@ -99,7 +97,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.1.1 // indirect
 	cloud.google.com/go/iam v0.6.0 // indirect
 	cloud.google.com/go/storage v1.27.0 // indirect
-	github.com/1and1/oneandone-cloudserver-sdk-go v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go v64.0.0+incompatible // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.19 // indirect
@@ -225,7 +222,6 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/profitbricks/profitbricks-sdk-go v4.0.2+incompatible // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ cloud.google.com/go/longrunning v0.1.1 h1:y50CXG4j0+qvEukslYFBCrzaXX0qpFbBzc3Pch
 cloud.google.com/go/storage v1.27.0 h1:YOO045NZI9RKfCj1c5A/ZtuuENUc8OAW+gHdGnDgyMQ=
 cloud.google.com/go/storage v1.27.0/go.mod h1:x9DOL8TK/ygDUMieqwfhdpQryTeEkhGKMi80i/iqR2s=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/1and1/oneandone-cloudserver-sdk-go v1.0.1 h1:RMTyvS5bjvSWiUcfqfr/E2pxHEMrALvU+E12n6biymg=
-github.com/1and1/oneandone-cloudserver-sdk-go v1.0.1/go.mod h1:61apmbkVJH4kg+38ftT+/l0XxdUCVnHggqcOTqZRSEE=
 github.com/Azure/azure-sdk-for-go v51.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v64.0.0+incompatible h1:WAA77WBDWYtNfCC95V70VvkdzHe+wM/r2MQ9mG7fnQs=
 github.com/Azure/azure-sdk-for-go v64.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -543,14 +541,10 @@ github.com/hashicorp/packer-plugin-lxd v1.0.1 h1:sqdaEdip0y/wC7x99CQHIbakJSmZY2k
 github.com/hashicorp/packer-plugin-lxd v1.0.1/go.mod h1:IZJTYWyGxlNZm0GKUgVejCPrXAU/cTlIpRiFgeQCCn4=
 github.com/hashicorp/packer-plugin-ncloud v1.0.3 h1:+LCQ404nhWM871dy8oLuspFgTAt6qpx1fXZj9e4GcZY=
 github.com/hashicorp/packer-plugin-ncloud v1.0.3/go.mod h1:5KQwE5s6GG8rAjwmzmWbjwQH7/nrn/hmJ/aZJIn4i+Q=
-github.com/hashicorp/packer-plugin-oneandone v1.0.1 h1:6rnqSWSve4XB+im1MYfgdGnyDCFJuEKCORw3aLsYkfk=
-github.com/hashicorp/packer-plugin-oneandone v1.0.1/go.mod h1:9alSvlih9aE4Pebnnw7CmfmOyKKjnAxbxXZN9yFCCsE=
 github.com/hashicorp/packer-plugin-openstack v1.0.1 h1:R4Iw0Vx/o14e2GRbKypwsR1B21z6CkaISX+KqwtLuTo=
 github.com/hashicorp/packer-plugin-openstack v1.0.1/go.mod h1:i5qn9aUabJM9mjhpXS81hFSuDjJYA2kOi0vLlo3VGsE=
 github.com/hashicorp/packer-plugin-parallels v1.0.3 h1:smypphUCEj3arCdlvbNtZvGC1ujsUSRtN1MBvZHt/w8=
 github.com/hashicorp/packer-plugin-parallels v1.0.3/go.mod h1:Q842nvosVmP5FnYozk8ZZj93HGIan19jHTxGeteBCb0=
-github.com/hashicorp/packer-plugin-profitbricks v1.0.2 h1:wAlTRm1A39T9hferxFtKaLCDmlsqA9cU7dTQtMLcvKQ=
-github.com/hashicorp/packer-plugin-profitbricks v1.0.2/go.mod h1:Gpg/h6A0UcTYzLwDw2GrUJjlPUmL5QaxGBJWH0NMx0g=
 github.com/hashicorp/packer-plugin-proxmox v1.1.1 h1:uBwW7MQN1p3vUha1BVIG3wqWrxa349qWekYyScSvDls=
 github.com/hashicorp/packer-plugin-proxmox v1.1.1/go.mod h1:S83+dabgqpNuKvm7sdNh2ivqx5rpgO6mbJn/iVrrXjk=
 github.com/hashicorp/packer-plugin-puppet v1.0.1 h1:/obGvsyiKiO2hX9TxRTJ7Y+/44K4WqKJlzg4xHAyIoY=
@@ -788,8 +782,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/profitbricks/profitbricks-sdk-go v4.0.2+incompatible h1:ZoVHH6voxW9Onzo6z2yLtocVoN6mBocyDoqoyAMHokE=
-github.com/profitbricks/profitbricks-sdk-go v4.0.2+incompatible/go.mod h1:T3/WrziK7fYH3C8ilAFAHe99R452/IzIG3YYkqaOFeQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=


### PR DESCRIPTION
* Remove profitbricks plugin
* Remove oneandone plugin

The following plugins have been unmaintained for some time now, and their upstream cloud provider has consolidate the services. These plugins will continue to be available to Packer via direct installation using packer init or the packer plugins install command. But they will no longer be bundled with Packer.
