### PR TITLE
[HPR-1038] Remove circular reference between data source doc pages

### DIFF
--- a/website/content/docs/templates/hcl_templates/datasources.mdx
+++ b/website/content/docs/templates/hcl_templates/datasources.mdx
@@ -36,8 +36,8 @@ local name ("example"). The name is used to refer to this data source from elsew
 The data block creates a data instance of the given _type_ (first block label) and _name_ (second block label).
 The combination of the type and name must be unique within a configuration.
 
-Within the block (the `{ }`) is the configuration for the data instance. The configuration is dependent on the type,
-and is documented for each data source in the [data sources](/packer/docs/datasources) section.
+Within the block (the `{ }`) is the configuration for the data instance. The configuration is dependent on the data source type,
+and is documented for each data source. For example the configuration of the `amazon-ami` data source can be found at [plugins/datasources/amazon/ami](/packer/plugins/datasources/amazon/ami#configuration-reference).
 
 A data source can output one or more attributes, which can be used by adding their key name to the data source unique
 identifier, like `data.<TYPE>.<NAME>.<ATTRIBUTE>`.


### PR DESCRIPTION
* Update the data source documentation with a link to the amazon-ami configuration reference guide.

Closes #12336
