### PR TITLE
Update ldflags used to build release binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         id: set-ld-flags
         run: |
           T="github.com/hashicorp/packer/version"
-          echo "::set-output name=set-ld-flags::-X ${T}.GitCommit=${GITHUB_SHA::8} -X ${T}.GitDescribe=${{ steps.set-product-version.outputs.product-version }} -X ${T}.Version=${{ steps.set-product-version.outputs.base-product-version }} -X ${T}.VersionPrerelease=${{ steps.set-product-version.outputs.prerelease-product-version }} -X ${T}.VersionMetadata="
+          echo "::set-output name=set-ld-flags::-s -w -X ${T}.GitCommit=${GITHUB_SHA::8} -X ${T}.GitDescribe=${{ steps.set-product-version.outputs.product-version }} -X ${T}.Version=${{ steps.set-product-version.outputs.base-product-version }} -X ${T}.VersionPrerelease=${{ steps.set-product-version.outputs.prerelease-product-version }} -X ${T}.VersionMetadata="
       - name: validate outputs
         run: |
           echo "Product Version: ${{ steps.set-product-version.outputs.product-version }}"


### PR DESCRIPTION
Prior to v1.8.6 a change to the release pipeline was introduced to automatically set and bump product version information. In that change the ldflags for striping debug symbols was removed resulting in binaries with full debug symbols. Thus resulting in larger binary deliverables. This change adds the missing ldflags back into the build pipeline.

Results for Packer 1.8.5
```
~>  unzip ~/packer_1.8.5_linux_amd64.zip
~>  go tool nm -size packer| c++filt
reading packer: no symbol section
reading packer: no symbols

```

Results for Packer 1.8.6
```
~>  unzip ~/packer_1.8.6_linux_amd64.zip
~>  go tool nm -size packer| c++filt | tail -n 10
 8d97ac0       2816 D vendor/golang.org/x/text/unicode/norm.nfcSparseValues
 8df2f60       6144 D vendor/golang.org/x/text/unicode/norm.nfcValues
 8f96fc8          8 D vendor/golang.org/x/text/unicode/norm.nfkcData
 8d985c0       2816 D vendor/golang.org/x/text/unicode/norm.nfkcIndex
 8fa40a0         48 D vendor/golang.org/x/text/unicode/norm.nfkcSparse
 8f4a3c0         24 D vendor/golang.org/x/text/unicode/norm.nfkcSparseOffset
 8db5c00       3580 D vendor/golang.org/x/text/unicode/norm.nfkcSparseValues
 8e48d60      12032 D vendor/golang.org/x/text/unicode/norm.nfkcValues
 8f96fd0          8 D vendor/golang.org/x/text/unicode/norm.recompMap
 8fe5bd0         12 D vendor/golang.org/x/text/unicode/norm.recompMapOnce
```

Closes #12392

---
Pull Request where the changed occurred
https://github.com/hashicorp/packer/pull/12135/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R49
