### PR TITLE
[HPR-1138] Limit recursive plugin scanning to Packer plugin paths set by PACKER_CONFIG_DIR or PACKER_PLUGIN_PATH

### DIFF
--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -6,7 +6,6 @@ package packer
 import (
 	"crypto/sha256"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -81,7 +80,7 @@ func (c *PluginConfig) Discover() error {
 	}
 
 	if len(c.KnownPluginFolders) == 0 {
-		return errors.New("no known plugin folders defined")
+		c.KnownPluginFolders = PluginFolders()
 	}
 
 	// TODO after JSON is deprecated remove support for legacy component plugins.

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -24,6 +24,7 @@ func newPluginConfig() PluginConfig {
 	var conf PluginConfig
 	conf.PluginMinPort = 10000
 	conf.PluginMaxPort = 25000
+	conf.KnownPluginFolders = []string{os.TempDir()}
 	return conf
 }
 

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -24,7 +24,6 @@ func newPluginConfig() PluginConfig {
 	var conf PluginConfig
 	conf.PluginMinPort = 10000
 	conf.PluginMaxPort = 25000
-	conf.KnownPluginFolders = []string{os.TempDir()}
 	return conf
 }
 

--- a/packer/plugin_folders.go
+++ b/packer/plugin_folders.go
@@ -19,7 +19,7 @@ func PluginFolders(dirs ...string) []string {
 	if path, err := os.Executable(); err != nil {
 		log.Printf("[ERR] Error finding executable: %v", err)
 	} else {
-		res = append(res, path)
+		res = append(res, filepath.Dir(path))
 	}
 
 	res = append(res, dirs...)

--- a/packer/plugin_folders.go
+++ b/packer/plugin_folders.go
@@ -16,6 +16,11 @@ import (
 func PluginFolders(dirs ...string) []string {
 	res := []string{}
 
+	if packerPluginPath := os.Getenv("PACKER_PLUGIN_PATH"); packerPluginPath != "" {
+		res = append(res, strings.Split(packerPluginPath, string(os.PathListSeparator))...)
+		return res
+	}
+
 	if path, err := os.Executable(); err != nil {
 		log.Printf("[ERR] Error finding executable: %v", err)
 	} else {
@@ -28,10 +33,6 @@ func PluginFolders(dirs ...string) []string {
 		log.Printf("[ERR] Error loading config directory: %v", err)
 	} else {
 		res = append(res, filepath.Join(cd, "plugins"))
-	}
-
-	if packerPluginPath := os.Getenv("PACKER_PLUGIN_PATH"); packerPluginPath != "" {
-		res = append(res, strings.Split(packerPluginPath, string(os.PathListSeparator))...)
 	}
 
 	return res


### PR DESCRIPTION
Packer will try to discover installed plugins in all of the directories
defined by packer.KnowPluginFolders. In a previous release logic was
added to scan nested directories in order to load plugins installed by
`packer plugins install`. This change resulted in a nested directory
scan for each folder within the KnownPluginFolders slice.

This change reduces the nested directory scan to only the directories
where plugins would have been installed using `packer plugins install`

- Fix executable directory path
- Reduce the number of nest plugin scans

Closes: https://github.com/hashicorp/packer/issues/12405
Closes: https://github.com/hashicorp/packer/issues/12352

This is sort of a breaking change as it changes how plugins are loaded but also not really as I think it works like this now but might be incorrectly documented 😄 

---
### TODO
- [x] Fix broken tests
- [x] Add new test for validating plugin scanning behavior
- [ ] ~Update documentation to reflect how plugins are scanned and loaded. The current docs are a little out of date.~ Opening in a separate PR. 
