### PR TITLE
Remove deprecated use of set-output within GHA

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -26,7 +26,7 @@ jobs:
         # version, because "goenv" can react to it automatically.
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "::set-output name=go-version::$(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
   acceptance-test:
     runs-on: ubuntu-latest
     name: Acceptance Test

--- a/.github/workflows/auto-close-stale-issues.yml
+++ b/.github/workflows/auto-close-stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5.2.0 # TSCCR: no entry for repository "actions/stale"
+      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v8.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         # version, because "goenv" can react to it automatically.
         run: |
           echo "Building with Go $(cat .go-version)"
-          echo "::set-output name=go-version::$(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
   set-product-version:
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
         id: set-ld-flags
         run: |
           T="github.com/hashicorp/packer/version"
-          echo "::set-output name=set-ld-flags::-s -w -X ${T}.GitCommit=${GITHUB_SHA::8} -X ${T}.GitDescribe=${{ steps.set-product-version.outputs.product-version }} -X ${T}.Version=${{ steps.set-product-version.outputs.base-product-version }} -X ${T}.VersionPrerelease=${{ steps.set-product-version.outputs.prerelease-product-version }} -X ${T}.VersionMetadata="
+          echo "set-ld-flags='-s -w -X ${T}.GitCommit=${GITHUB_SHA::8} -X ${T}.GitDescribe=${{ steps.set-product-version.outputs.product-version }} -X ${T}.Version=${{ steps.set-product-version.outputs.base-product-version }} -X ${T}.VersionPrerelease=${{ steps.set-product-version.outputs.prerelease-product-version }} -X ${T}.VersionMetadata='" >> $GITHUB_OUTPUT
       - name: validate outputs
         run: |
           echo "Product Version: ${{ steps.set-product-version.outputs.product-version }}"

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -35,21 +35,21 @@ jobs:
         run: |
           # Questions are not tracked in JIRA at this time.
           if [[ "${{ contains(github.event.issue.labels.*.name, 'question') }}" == "true" ]]; then
-            echo "::set-output name=type::Invalid"
+            echo "type=Invalid" >> $GITHUB_OUTPUT
           else
             # Properly labeled GH issues are assigned the standard "GH Issue" type upon creation.
-            echo "::set-output name=type::GH Issue"
+            echo "type=GH Issue" >> $GITHUB_OUTPUT
           fi
 
       - name: Set labels
         id: set-ticket-labels 
         run: |
           if [[ "${{ contains(github.event.issue.labels.*.name, 'bug') }}" == "true" ]]; then
-            echo "::set-output name=labels::[\"bug\"]"
+            echo "labels=[\"bug\"]" >> $GITHUB_OUTPUT
           elif [[ "${{ contains(github.event.issue.labels.*.name, 'enhancement') }}" == "true" ]]; then
-            echo "::set-output name=labels::[\"enhancement\"]"
+            echo "labels=[\"enhancement\"]" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=labels::[]"
+            echo "labels=[]" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate ticket


### PR DESCRIPTION
- jira GHA: Address set-output deprecation warnings
- acceptance-test GHA: Address set-output deprecation warnings
- auto-close-stale-issues: Bump action/stale to latest available release
- build GHA: Address set-output deprecation warnings

Addresses: #12426 
Closes: #12425 #12424 #12423  #12422 
