### PR TITLE
issue-comment-created: Add guard for labels

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
       issues: write  # for actions-ecosystem/action-remove-labels to remove issue labels
+    if: ${{contains(github.event.issue.labels.*.name, 'waiting-reply') || contains(github.event.issue.labels.*.name, 'stale')}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
The action currently fails when trying to remove the stale or waiting-reply labels from issues
that do not actually contain the labels in question. This update adds a guard clause to only run the
action on issues containing at least one of the labels.
