### PR TITLE
[HPR-1184] hcp: support HCP_PROJECT_ID environment variable

### DIFF
--- a/internal/hcp/api/client_test.go
+++ b/internal/hcp/api/client_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/preview/2019-12-10/models"
+)
+
+func TestFindProjectID(t *testing.T) {
+	testcases := []struct {
+		Name            string
+		ProjectID       string
+		ProjectList     []*models.HashicorpCloudResourcemanagerProject
+		ExpectProjectID string
+		ExpectErr       bool
+	}{
+		{
+			"Only one project, project exists, success",
+			"test-project-exists",
+			[]*models.HashicorpCloudResourcemanagerProject{
+				{
+					ID: "test-project-exists",
+				},
+			},
+			"test-project-exists",
+			false,
+		},
+		{
+			"Multiple projects, project exists, success",
+			"test-project-exists",
+			[]*models.HashicorpCloudResourcemanagerProject{
+				{
+					ID: "other-project-exists",
+				},
+				{
+					ID: "test-project-exists",
+				},
+			},
+			"test-project-exists",
+			false,
+		},
+		{
+			"One project, no id match, fail",
+			"test-project-exists",
+			[]*models.HashicorpCloudResourcemanagerProject{
+				{
+					ID: "other-project-exists",
+				},
+			},
+			"",
+			true,
+		},
+		{
+			"Multiple projects, no id match, fail",
+			"test-project-exists",
+			[]*models.HashicorpCloudResourcemanagerProject{
+				{
+					ID: "other-project-exists",
+				},
+				{
+					ID: "yet-another-project-exists",
+				},
+			},
+			"",
+			true,
+		},
+		{
+			"No projects, no id match, fail",
+			"test-project-exists",
+			[]*models.HashicorpCloudResourcemanagerProject{},
+			"",
+			true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.Name, func(t *testing.T) {
+			proj, err := findProjectByID(tt.ProjectID, tt.ProjectList)
+			if (err != nil) != tt.ExpectErr {
+				t.Errorf("test findProjectByID, expected %t, got %t",
+					tt.ExpectErr,
+					err != nil)
+			}
+
+			if proj != nil && proj.ID != tt.ExpectProjectID {
+				t.Errorf("expected to select project %q, got %q", tt.ExpectProjectID, proj.ID)
+			}
+		})
+	}
+}
+
+func TestFindOldestProject(t *testing.T) {
+	testcases := []struct {
+		Name            string
+		ProjectList     []*models.HashicorpCloudResourcemanagerProject
+		ExpectProjectID string
+		ExpectErr       bool
+	}{
+		{
+			"Only one project, project exists, success",
+			[]*models.HashicorpCloudResourcemanagerProject{
+				{
+					ID: "test-project-exists",
+				},
+			},
+			"test-project-exists",
+			false,
+		},
+		{
+			"Multiple projects, pick the oldest",
+			[]*models.HashicorpCloudResourcemanagerProject{
+				{
+					ID:        "test-project-exists",
+					CreatedAt: strfmt.DateTime(time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC)),
+				},
+				{
+					ID:        "test-oldest-project",
+					CreatedAt: strfmt.DateTime(time.Date(2022, 1, 1, 1, 0, 0, 0, time.UTC)),
+				},
+			},
+			"test-oldest-project",
+			false,
+		},
+		{
+			"Multiple projects, different order, pick the oldest",
+			[]*models.HashicorpCloudResourcemanagerProject{
+				{
+					ID:        "test-oldest-project",
+					CreatedAt: strfmt.DateTime(time.Date(2022, 1, 1, 1, 0, 0, 0, time.UTC)),
+				},
+				{
+					ID:        "test-project-exists",
+					CreatedAt: strfmt.DateTime(time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC)),
+				},
+			},
+			"test-oldest-project",
+			false,
+		},
+		{
+			"No projects, should error",
+			[]*models.HashicorpCloudResourcemanagerProject{},
+			"",
+			true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.Name, func(t *testing.T) {
+			proj, err := findOldestProject(tt.ProjectList)
+			if (err != nil) != tt.ExpectErr {
+				t.Errorf("test findProjectByID, expected %t, got %t",
+					tt.ExpectErr,
+					err != nil)
+			}
+
+			if proj != nil && proj.ID != tt.ExpectProjectID {
+				t.Errorf("expected to select project %q, got %q", tt.ExpectProjectID, proj.ID)
+			}
+		})
+	}
+}

--- a/internal/hcp/env/env.go
+++ b/internal/hcp/env/env.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 )
 
+func HasProjectID() bool {
+	return hasEnvVar(HCPProjectID)
+}
+
 func HasClientID() bool {
 	return hasEnvVar(HCPClientID)
 }

--- a/internal/hcp/env/variables.go
+++ b/internal/hcp/env/variables.go
@@ -6,6 +6,7 @@ package env
 const (
 	HCPClientID               = "HCP_CLIENT_ID"
 	HCPClientSecret           = "HCP_CLIENT_SECRET"
+	HCPProjectID              = "HCP_PROJECT_ID"
 	HCPPackerRegistry         = "HCP_PACKER_REGISTRY"
 	HCPPackerBucket           = "HCP_PACKER_BUCKET_NAME"
 	HCPPackerBuildFingerprint = "HCP_PACKER_BUILD_FINGERPRINT"

--- a/website/content/docs/hcp/index.mdx
+++ b/website/content/docs/hcp/index.mdx
@@ -4,6 +4,8 @@ description: |
 page_title: HCP Packer
 ---
 
+-> **Note:** On May 16th 2023, HCP introduced multi-project support to the platform. In order to use multiple projects in your organization, you will need to update Packer to version 1.9.1 or above. Starting with 1.9.1, you may specify a project ID to push builds to with the `HCP_PROJECT_ID` environment variable. If no project ID is specified, Packer will pick the project with the oldest creation date. Older versions of Packer are incompatible with multi-project support on HCP, and builds will fail for HCP organizations with multiple projects on versions before 1.9.1.
+
 # HCP Packer
 
 The HCP Packer registry bridges the gap between image factories and image deployments, allowing development and security teams to work together to create, manage, and consume images in a centralized way.


### PR DESCRIPTION
With HCP supporting multi-projects now, Packer needs to take it into account when picking a project from an organisation.

This commit adds two cases:

1. multiple projects are defined, none is supplied through HCP_PROJECT_ID: in this case we will default to the oldest project defined for the organisation.

2. we supply HCP_PROJECT_ID: in this case, we pick the project with the corresponding ID, and use it for publishing metadata.