### PR TITLE
[HPR-1189] Migrate external Parallels plugin to Parallels/packer-plugin-parallels

### DIFF
--- a/command/vendored_plugins.go
+++ b/command/vendored_plugins.go
@@ -32,8 +32,6 @@ import (
 	googlecomputebuilder "github.com/hashicorp/packer-plugin-googlecompute/builder/googlecompute"
 	googlecomputeexportpostprocessor "github.com/hashicorp/packer-plugin-googlecompute/post-processor/googlecompute-export"
 	googlecomputeimportpostprocessor "github.com/hashicorp/packer-plugin-googlecompute/post-processor/googlecompute-import"
-	parallelsisobuilder "github.com/hashicorp/packer-plugin-parallels/builder/parallels/iso"
-	parallelspvmbuilder "github.com/hashicorp/packer-plugin-parallels/builder/parallels/pvm"
 	qemubuilder "github.com/hashicorp/packer-plugin-qemu/builder/qemu"
 	vagrantbuilder "github.com/hashicorp/packer-plugin-vagrant/builder/vagrant"
 	vagrantpostprocessor "github.com/hashicorp/packer-plugin-vagrant/post-processor/vagrant"
@@ -69,8 +67,6 @@ var VendoredBuilders = map[string]packersdk.Builder{
 	"azure-dtl":           new(azuredtlbuilder.Builder),
 	"docker":              new(dockerbuilder.Builder),
 	"googlecompute":       new(googlecomputebuilder.Builder),
-	"parallels-iso":       new(parallelsisobuilder.Builder),
-	"parallels-pvm":       new(parallelspvmbuilder.Builder),
 	"qemu":                new(qemubuilder.Builder),
 	"vagrant":             new(vagrantbuilder.Builder),
 	"vsphere-clone":       new(vsphereclonebuilder.Builder),

--- a/go.mod
+++ b/go.mod
@@ -59,11 +59,11 @@ require (
 )
 
 require (
+	github.com/go-openapi/strfmt v0.21.3
 	github.com/hashicorp/packer-plugin-ansible v1.0.3
 	github.com/hashicorp/packer-plugin-azure v1.4.0
 	github.com/hashicorp/packer-plugin-docker v1.0.8
 	github.com/hashicorp/packer-plugin-googlecompute v1.1.0
-	github.com/hashicorp/packer-plugin-parallels v1.0.3
 	github.com/hashicorp/packer-plugin-qemu v1.0.9
 	github.com/hashicorp/packer-plugin-vagrant v1.0.3
 	github.com/hashicorp/packer-plugin-virtualbox v1.0.4
@@ -127,7 +127,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/loads v0.21.2 // indirect
 	github.com/go-openapi/spec v0.20.8 // indirect
-	github.com/go-openapi/strfmt v0.21.3 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-openapi/validate v0.22.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,6 @@ github.com/hashicorp/packer-plugin-docker v1.0.8 h1:UWPG/pl+1RFsaNQVhEuowCeOZuES
 github.com/hashicorp/packer-plugin-docker v1.0.8/go.mod h1:4U3gHULbUw3okSqqZgQZD5ptyJKs0S7LfOOt2U3V4Jk=
 github.com/hashicorp/packer-plugin-googlecompute v1.1.0 h1:/cSZCJuRV6osaSa1uOy8cpN+c/uiCbrSsZ8vyNC0slk=
 github.com/hashicorp/packer-plugin-googlecompute v1.1.0/go.mod h1:k7MhKwEDw9ASP3a1y1syKJFZiZ8pO4oH40HvVgGHzUE=
-github.com/hashicorp/packer-plugin-parallels v1.0.3 h1:smypphUCEj3arCdlvbNtZvGC1ujsUSRtN1MBvZHt/w8=
-github.com/hashicorp/packer-plugin-parallels v1.0.3/go.mod h1:Q842nvosVmP5FnYozk8ZZj93HGIan19jHTxGeteBCb0=
 github.com/hashicorp/packer-plugin-qemu v1.0.9 h1:1YKBBzBULYUBWtpAZJTbaLjjZPAdQ63okkpTqMBTnzM=
 github.com/hashicorp/packer-plugin-qemu v1.0.9/go.mod h1:BpWIpVpOoPFV9Ppmzq4DP/S0QNoh1R+7DUCqxHdXc+Y=
 github.com/hashicorp/packer-plugin-sdk v0.4.0 h1:UyLYe0y02D9wkOQ3FeeZWyFg2+mx2vLuWRGUL5xt50I=

--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -235,8 +235,9 @@
   {
     "title": "Parallels",
     "path": "parallels",
-    "repo": "hashicorp/packer-plugin-parallels",
-    "version": "latest"
+    "repo": "parallels/packer-plugin-parallels",
+    "version": "latest",
+    "pluginTier": "verified"
   },
   {
     "title": "Profitbricks",


### PR DESCRIPTION
* Update external plugin documentation source

The Parallels plugin for Packer is now maintained by the Parallels team, under
their respective GitHub org. This changes updates the source address for
the external plugin that should be used for pulling new plugin
documentation.

* Removed packer-plugin-parallels for list of vendored plugins
