### PR TITLE
hcl2template: only warn once for missing plugins

### DIFF
--- a/hcl2template/plugin.go
+++ b/hcl2template/plugin.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/packer-plugin-sdk/didyoumean"
@@ -77,6 +78,8 @@ func (cfg *PackerConfig) detectPluginBinaries() hcl.Diagnostics {
 		return diags
 	}
 
+	uninstalledPlugins := map[string]string{}
+
 	for _, pluginRequirement := range pluginReqs {
 		sortedInstalls, err := pluginRequirement.ListInstallations(opts)
 		if err != nil {
@@ -88,11 +91,7 @@ func (cfg *PackerConfig) detectPluginBinaries() hcl.Diagnostics {
 			continue
 		}
 		if len(sortedInstalls) == 0 {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("no plugin installed for %s %v", pluginRequirement.Identifier, pluginRequirement.VersionConstraints.String()),
-				Detail:   "Did you run packer init for this project ?",
-			})
+			uninstalledPlugins[pluginRequirement.Identifier.String()] = pluginRequirement.VersionConstraints.String()
 			continue
 		}
 		log.Printf("[TRACE] Found the following %q installations: %v", pluginRequirement.Identifier, sortedInstalls)
@@ -106,6 +105,20 @@ func (cfg *PackerConfig) detectPluginBinaries() hcl.Diagnostics {
 			})
 			continue
 		}
+	}
+
+	if len(uninstalledPlugins) > 0 {
+		detailMessage := &strings.Builder{}
+		detailMessage.WriteString("The following plugins are required, but not installed:\n\n")
+		for pluginName, pluginVersion := range uninstalledPlugins {
+			fmt.Fprintf(detailMessage, "* %s %s\n", pluginName, pluginVersion)
+		}
+		detailMessage.WriteString("\nDid you run packer init for this project ?")
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing plugins",
+			Detail:   detailMessage.String(),
+		})
 	}
 
 	return diags


### PR DESCRIPTION
In HCL2, if a template contains a `required_plugins' block, but the required plugins are not installed, we print a warning.

Prior to this commit, this was reported as an error once per missing plugin, which was redundant.
This commit changes that by gathering all the missing plugins once, and printing them as a bullet list, so the message isn't redundant anymore.