### PR TITLE
[HPR-1248] .github/workflows: Replace untrusted GHA in repo workflows

### DIFF
--- a/.github/workflows/issues-opened.yml
+++ b/.github/workflows/issues-opened.yml
@@ -23,24 +23,33 @@ jobs:
     name: Redirect to discuss
     permissions:
       contents: read
-      issues: write  # for actions-ecosystem/action-create-comment to create comments
+      issues: write  # for actions/github-script to create comments and add labels
     if: contains(github.event.issue.labels.*.name, 'question')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-create-comment@v1.0.2  # TSCCR: no entry for repository "actions-ecosystem/action-create-comment"
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            Hi 👋 thanks for reaching out.
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: |
+                Hi 👋 thanks for reaching out.
 
-            For general questions we recommend reaching out to the [community forum](https://discuss.hashicorp.com/c/packer) for greater visibility.
-            As the GitHub issue tracker is only watched by a small subset of maintainers and is really reserved for bugs and enhancements, you'll have a better chance of finding someone who can help you in the forum.
-            We'll mark this issue as needs-reply to help inform maintainers that this question is awaiting a response.
-            If no activity is taken on this question within 30 days it will be automatically closed.
+                For general questions we recommend reaching out to the [community forum](https://discuss.hashicorp.com/c/packer) for greater visibility.
+                As the GitHub issue tracker is only watched by a small subset of maintainers and is really reserved for bugs and enhancements, you'll have a better chance of finding someone who can help you in the forum.
+                We'll mark this issue as needs-reply to help inform maintainers that this question is awaiting a response.
+                If no activity is taken on this question within 30 days it will be automatically closed.
 
-            If you find the forum to be more helpful or if you've found the answer to your question elsewhere please feel free to post a response and close the issue.
-      - uses: actions-ecosystem/action-add-labels@v1.1.3  # TSCCR: no entry for repository "actions-ecosystem/action-add-labels"
+                If you find the forum to be more helpful or if you've found the answer to your question elsewhere please feel free to post a response and close the issue.
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: needs-reply
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['needs-reply']
+        })
 

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -11,7 +11,7 @@ jobs:
   sync:
     name: Sync to JIRA
     permissions:
-      issues: write # for actions-ecosytem/action-create-comment
+      issues: write # for actions/github-script to create comments
     runs-on: ubuntu-latest
     steps:    
       - name: Login
@@ -74,13 +74,17 @@ jobs:
 
       - name: Add tracking comment
         if: steps.create-ticket.outputs.issue != '' && steps.set-ticket-type.outputs.type != 'Invalid'
-        uses: actions-ecosystem/action-create-comment@v1.0.0  # TSCCR: no entry for repository "actions-ecosystem/action-create-comment"
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            This issue has been synced to JIRA for planning.
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: |
+                This issue has been synced to JIRA for planning.
 
-            JIRA ID: [${{ steps.create-ticket.outputs.issue }}](https://hashicorp.atlassian.net/browse/${{steps.create-ticket.outputs.issue}})
+                JIRA ID: [${{ steps.create-ticket.outputs.issue }}](https://hashicorp.atlassian.net/browse/${{steps.create-ticket.outputs.issue}})
 
 
 


### PR DESCRIPTION
The GHA action used for adding comments or labels to issues untrusted by TSCCR
have been replaced with an approved set of actions. The updated workflows use
actions/github-script for adding comments or labels to an issue.

Related to: https://github.com/hashicorp/security-tsccr/pull/608

>**Note:**
> https://github.com/bflad/action-migrate-issue is more recently updated, and looks reasonable to trust / use.
>
