### PR TITLE
[HPR-1261] Add docker full image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,7 +222,7 @@ jobs:
           instructions: |-
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -tags netcgo -trimpath -buildvcs=false
 
-  build-docker:
+  build-docker-light:
     name: Docker light ${{ matrix.arch }} build
     needs:
       - set-product-version
@@ -251,3 +251,31 @@ jobs:
           dev_tags: |
             docker.io/hashicorppreview/${{ env.REPO_NAME }}:${{ env.version }}
             docker.io/hashicorppreview/${{ env.REPO_NAME }}:${{ env.version }}-${{ github.sha }}
+
+  build-docker-full:
+    name: Docker full ${{ matrix.arch }} build
+    needs:
+      - set-product-version
+      - build-linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ "arm", "arm64", "386", "amd64" ]
+    env:
+      version: ${{ needs.set-product-version.outputs.product-version }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Docker Build (Action)
+        uses: hashicorp/actions-docker-build@v1
+        with:
+          version: ${{ env.version }}
+          target: release-full
+          arch: ${{ matrix.arch }}
+          tags: |
+            docker.io/hashicorp/${{ env.REPO_NAME }}:full
+            docker.io/hashicorp/${{ env.REPO_NAME }}:full-${{ env.version }}
+            public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:full
+            public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:full-${{ env.version }}
+          dev_tags: |
+            docker.io/hashicorppreview/${{ env.REPO_NAME }}:full-${{ env.version }}
+            docker.io/hashicorppreview/${{ env.REPO_NAME }}:full-${{ env.version }}-${{ github.sha }}

--- a/.release/docker/README.md
+++ b/.release/docker/README.md
@@ -1,6 +1,6 @@
 # Packer Docker Container
 
-The root of this repository contains the officially supported HashiCorp Dockerfile to build the hashicorp/packer docker image. The `dev` docker image should be built for local dev and testing, while the production docker image, `release`, is built in CI and makes use of CI-built binaries. The `official` docker image is built using the official binaries from releases.hashicorp.com. 
+The root of this repository contains the officially supported HashiCorp Dockerfile to build the hashicorp/packer docker image. The `dev` docker image should be built for local dev and testing, while the production docker image, `release`, is built in CI and makes use of CI-built binaries. The `official` docker image is built using the official binaries from releases.hashicorp.com.
 
 ## Build
 
@@ -17,14 +17,14 @@ development or release modes:
 This repository automatically builds containers for using the
 [`packer`](https://packer.io) command line program. It contains two distinct
 varieties of build, an `official` version, aka `light`, which just contains the binary.
-It also contains a `dev` version, aka `full`, which compiles the binary from source 
+It also contains a `dev` version, aka `full`, which compiles the binary from source
 inside the container before exposing it for use.
 
 ##### `official`
 
 The `official` version of this container will copy the current stable version of
 the binary, taken from releases.hashicorp.com, into the container. It will also
-set it for use as the default entrypoint. This will be the best option for most uses, 
+set it for use as the default entrypoint. This will be the best option for most uses,
 especially if you are just looking to run the binary from a container. This image
 is tagged as both `official` and `light`.
 The `latest` tag on DockerHub also points to this version.
@@ -64,8 +64,8 @@ docker run \
 
 ~> **Note**: packer init is available from Packer v1.7.0 and later
 
-The command will mount the working directory (`pwd`) to `workspace`, which is the working directory (`-w`) inside the container. 
-Any plugin installed with `packer init` will be installed under the directory specified under the `PACKER_PLUGIN_PATH` environment variable. `PACKER_PLUGIN_PATH` must be set to a path inside the volume mount so that plugins can become available at `packer build`. 
+The command will mount the working directory (`pwd`) to `workspace`, which is the working directory (`-w`) inside the container.
+Any plugin installed with `packer init` will be installed under the directory specified under the `PACKER_PLUGIN_PATH` environment variable. `PACKER_PLUGIN_PATH` must be set to a path inside the volume mount so that plugins can become available at `packer build`.
 
 Running `packer build`
 ```shell

--- a/.release/docker/README.md
+++ b/.release/docker/README.md
@@ -1,37 +1,46 @@
 # Packer Docker Container
 
-The root of this repository contains the officially supported HashiCorp Dockerfile to build the hashicorp/packer docker image. The `dev` docker image should be built for local dev and testing, while the production docker image, `release`, is built in CI and makes use of CI-built binaries. The `official` docker image is built using the official binaries from releases.hashicorp.com.
+The root of this repository contains the officially supported HashiCorp Dockerfile to build the hashicorp/packer docker image. The `dev` docker image should be built for local dev and testing, while the production docker image, `release`, is built in CI and makes use of CI-built binaries. The `light` and `full` docker images are built using the official binaries from releases.hashicorp.com.
 
 ## Build
 
-See the Makefile targets in the root of this repository for building Packer images in either
-development or release modes:
-
-  - `make docker-dev`
-  - `make docker-official`
-  - `make docker-multiarch-official`
-  - `make docker`
+Refer to the Makefile of this repository, especially the `docker` and `docker-dev` targets to build a local version of the dev image based on the sources available.
 
 ### Usage
 
 This repository automatically builds containers for using the
-[`packer`](https://packer.io) command line program. It contains two distinct
-varieties of build, an `official` version, aka `light`, which just contains the binary.
-It also contains a `dev` version, aka `full`, which compiles the binary from source
+[`packer`](https://developer.hashicorp.com/packer) command line program. It contains three distinct
+varieties of build: a `light` version, which just contains the binary,
+a `full` build, which contains the Packer binary with pre-installed plugins,
+and a `dev` version, which compiles the binary from source
 inside the container before exposing it for use.
 
-##### `official`
+##### `light`
 
-The `official` version of this container will copy the current stable version of
+The `light` version of this container will copy the current stable version of
 the binary, taken from releases.hashicorp.com, into the container. It will also
 set it for use as the default entrypoint. This will be the best option for most uses,
-especially if you are just looking to run the binary from a container. This image
-is tagged as both `official` and `light`.
+especially if you are just looking to run the binary from a container.
 The `latest` tag on DockerHub also points to this version.
 
 You can use this version with the following:
 ```shell
-docker run <args> hashicorp/packer:official <command>
+docker run <args> hashicorp/packer:light <command>
+```
+
+##### `full`
+
+The `full` version of the container builds upon `light` and pre-installs
+the plugins officially maintained by HashiCorp.
+
+You can use this version with the following:
+```shell
+docker run <args> hashicorp/packer:full <command>
+```
+
+You can view the list of pre-installed plugins with the following:
+```shell
+docker run <args> hashicorp/packer:full plugins installed
 ```
 
 ##### `dev`
@@ -41,7 +50,7 @@ the current ref of this [repository](https://github.com/hashicorp/packer). Using
 official `golang` image](https://hub.docker.com/_/golang/) as a base, this
 container will copy the source from the current branch, build the binary, and
 expose it for running. Because all build artifacts are included, it should be quite a bit larger than
-the `official` image. This version of the container is most useful for development or
+the `light` image. This version of the container is most useful for development or
 debugging.
 
 You can use this version with the following:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # ========================================================================
-# 
+#
 # This Dockerfile contains multiple targets.
 # Use 'docker build --target=<name> .' to build one.
 # e.g. `docker build --target=release-light .`
 #
-# All non-dev targets have a PRODUCT_VERSION argument that must be provided 
-# via --build-arg=PRODUCT_VERSION=<version> when building. 
+# All non-dev targets have a PRODUCT_VERSION argument that must be provided
+# via --build-arg=PRODUCT_VERSION=<version> when building.
 # e.g. --build-arg PRODUCT_VERSION=1.11.2
 #
 # For local dev and testing purposes, please build and use the `dev` docker image.
@@ -28,7 +28,7 @@ COPY bin/packer /bin/packer
 ENTRYPOINT ["/bin/packer"]
 
 
-# Official docker image that includes binaries from releases.hashicorp.com. 
+# Official docker image that includes binaries from releases.hashicorp.com.
 # This downloads the release from releases.hashicorp.com and therefore requires that
 # the release is published before building the Docker image.
 FROM docker.mirror.hashicorp.services/alpine:latest as official
@@ -79,7 +79,7 @@ ENTRYPOINT ["/bin/packer"]
 
 
 # Light docker image which can be used to run the binary from a container.
-# This image builds from the locally generated binary in ./bin/, and from CI-built binaries within CI. 
+# This image builds from the locally generated binary in ./bin/, and from CI-built binaries within CI.
 # To generate the local binary, run `make dev`.
 # This image is published to DockerHub under the `light`, `light-$VERSION`, and `latest` tags.
 FROM docker.mirror.hashicorp.services/alpine:latest as release-light

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,24 @@ COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
 
 ENTRYPOINT ["/bin/packer"]
 
+# Full docker image which can be used to run the binary from a container.
+# This image is essentially the same as the `release-light` one, but embeds
+# the official plugins in it.
+FROM release-light as release-full
+
+# Install the latest version of the official plugins
+RUN /bin/packer plugins install "github.com/hashicorp/amazon" && \
+    /bin/packer plugins install "github.com/hashicorp/ansible" && \
+    /bin/packer plugins install "github.com/hashicorp/azure" && \
+    /bin/packer plugins install "github.com/hashicorp/docker" && \
+    /bin/packer plugins install "github.com/hashicorp/googlecompute" && \
+    /bin/packer plugins install "github.com/hashicorp/qemu" && \
+    /bin/packer plugins install "github.com/hashicorp/vagrant" && \
+    /bin/packer plugins install "github.com/hashicorp/virtualbox" && \
+    /bin/packer plugins install "github.com/hashicorp/vmware" && \
+    /bin/packer plugins install "github.com/hashicorp/vsphere"
+
+ENTRYPOINT ["/bin/packer"]
 
 # Set default target to 'dev'.
 FROM dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,57 +27,6 @@ COPY bin/packer /bin/packer
 
 ENTRYPOINT ["/bin/packer"]
 
-
-# Official docker image that includes binaries from releases.hashicorp.com.
-# This downloads the release from releases.hashicorp.com and therefore requires that
-# the release is published before building the Docker image.
-FROM docker.mirror.hashicorp.services/alpine:latest as official
-
-# This is the release of Packer to pull in.
-ARG PRODUCT_VERSION
-
-LABEL name="Packer" \
-      maintainer="HashiCorp Packer Team <packer@hashicorp.com>" \
-      vendor="HashiCorp" \
-      version=$PRODUCT_VERSION \
-      release=$PRODUCT_VERSION \
-      summary="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration." \
-      description="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration. Please submit issues to https://github.com/hashicorp/packer/issues"
-
-# This is the location of the releases.
-ENV HASHICORP_RELEASES=https://releases.hashicorp.com
-
-RUN set -eux && \
-    apk add --no-cache git bash wget openssl gnupg xorriso && \
-    gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
-    mkdir -p /tmp/build && \
-    cd /tmp/build && \
-    apkArch="$(apk --print-arch)" && \
-    case "${apkArch}" in \
-        aarch64) packerArch='arm64' ;; \
-        armhf) packerArch='arm' ;; \
-        x86) packerArch='386' ;; \
-        x86_64) packerArch='amd64' ;; \
-        *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/packer/${PRODUCT_VERSION}/)" && exit 1 ;; \
-    esac && \
-    wget ${HASHICORP_RELEASES}/packer/${PRODUCT_VERSION}/packer_${PRODUCT_VERSION}_linux_${packerArch}.zip && \
-    wget ${HASHICORP_RELEASES}/packer/${PRODUCT_VERSION}/packer_${PRODUCT_VERSION}_SHA256SUMS && \
-    wget ${HASHICORP_RELEASES}/packer/${PRODUCT_VERSION}/packer_${PRODUCT_VERSION}_SHA256SUMS.sig && \
-    gpg --batch --verify packer_${PRODUCT_VERSION}_SHA256SUMS.sig packer_${PRODUCT_VERSION}_SHA256SUMS && \
-    grep packer_${PRODUCT_VERSION}_linux_${packerArch}.zip packer_${PRODUCT_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip -d /tmp/build packer_${PRODUCT_VERSION}_linux_${packerArch}.zip && \
-    cp /tmp/build/packer /bin/packer && \
-    cd /tmp && \
-    rm -rf /tmp/build && \
-    gpgconf --kill all && \
-    apk del gnupg openssl && \
-    rm -rf /root/.gnupg && \
-    # Tiny smoke test to ensure the binary we downloaded runs
-    packer version
-
-ENTRYPOINT ["/bin/packer"]
-
-
 # Light docker image which can be used to run the binary from a container.
 # This image builds from the locally generated binary in ./bin/, and from CI-built binaries within CI.
 # To generate the local binary, run `make dev`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ key points.
 First, [download a pre-built Packer
 binary](https://www.packer.io/downloads.html) for your operating system or
 [compile Packer
-yourself](https://github.com/hashicorp/packer/blob/master/.github/CONTRIBUTING.md#setting-up-go-to-work-on-packer).
+yourself](https://github.com/hashicorp/packer/blob/main/.github/CONTRIBUTING.md#setting-up-go).
 
 After Packer is installed, create your first template, which tells Packer
 what platforms to build images for and how you want to build them. In our


### PR DESCRIPTION
Part of the bundled plugin removal effort, this PR adds a new Docker target: release-full.
This image includes Packer, and all the official plugins pre-installed in its environment.