### PR TITLE
Packer init doc fixes

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -180,7 +180,7 @@ packer {
 
 func (*InitCommand) Help() string {
 	helpText := `
-Usage: packer init [options] [config.pkr.hcl|folder/]
+Usage: packer init [options] TEMPLATE
 
   Install all the missing plugins required in a Packer config. Note that Packer
   does not have a state.

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -19,6 +19,26 @@ the first command that should be executed when working with a new or existing
 template. This command is always safe to run multiple times. Though subsequent
 runs may give errors, this command will never delete anything.
 
+You should invoke `packer init` on either an HCL2 template, or a directory that contains
+at least a valid HCL2 template, and eventually other related dependencies like varfiles
+for example.
+
+Example:
+
+```sh
+$ ls .
+template.pkr.hcl varfile.pkrvars.pkr.hcl
+
+$ packer init template.pkr.hcl # You can invoke packer init on a single template in this case
+                               # This works if the template is self-contained, but may fail if
+                               # the template is meant to be built as a bundle of partials.
+
+$ packer init .                # Alternatively, you can invoke packer init on a directory instead,
+                               # which behaves the same in a configuration like this one, but if
+                               # the target is a collection ofHCL2 templates, this is the
+                               # preferred way to invoke it.
+```
+
 Packer does not currently have the notion of a state like Terraform has. In other words,
 currently `packer init` is only in charge of installing Packer plugins.
 


### PR DESCRIPTION
Following up on #11541, this changes the wording of the positional argument for `packer init`, to make it more in line with `validate` and `build`, as they work similarly regarding the target.

This also adds a bit of information regarding the template/directory accepted as target for the command in the web docs.