### PR TITLE
packer: track bundled plugins usage on telemetry

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -196,6 +196,8 @@ func (m *Meta) DetectBundledPlugins(handler packer.Handler) hcl.Diagnostics {
 		return nil
 	}
 
+	packer.CheckpointReporter.SetBundledUsage()
+
 	buf := &strings.Builder{}
 	buf.WriteString("This template relies on the use of plugins bundled into the Packer binary.\n")
 	buf.WriteString("The practice of bundling external plugins into Packer will be removed in an upcoming version.\n\n")

--- a/packer/telemetry.go
+++ b/packer/telemetry.go
@@ -26,7 +26,7 @@ const (
 	JSONTemplate    PackerTemplateType = "JSON"
 )
 
-const TelemetryVersion string = "beta/packer/6"
+const TelemetryVersion string = "beta/packer/7"
 const TelemetryPanicVersion string = "beta/packer_panic/4"
 
 var CheckpointReporter *CheckpointTelemetry
@@ -37,6 +37,7 @@ type PackerReport struct {
 	Error        string             `json:"error"`
 	Command      string             `json:"command"`
 	TemplateType PackerTemplateType `json:"template_type"`
+	UseBundled   bool               `json:"use_bundled"`
 }
 
 type CheckpointTelemetry struct {
@@ -44,6 +45,7 @@ type CheckpointTelemetry struct {
 	signatureFile string
 	startTime     time.Time
 	templateType  PackerTemplateType
+	useBundled    bool
 }
 
 func NewCheckpointReporter(disableSignature bool) *CheckpointTelemetry {
@@ -128,6 +130,11 @@ func (c *CheckpointTelemetry) SetTemplateType(t PackerTemplateType) {
 	c.templateType = t
 }
 
+// SetBundledUsage marks the template as using bundled plugins
+func (c *CheckpointTelemetry) SetBundledUsage() {
+	c.useBundled = true
+}
+
 func (c *CheckpointTelemetry) Finalize(command string, errCode int, err error) error {
 	if c == nil {
 		return nil
@@ -145,6 +152,7 @@ func (c *CheckpointTelemetry) Finalize(command string, errCode int, err error) e
 		extra.Error = err.Error()
 	}
 
+	extra.UseBundled = c.useBundled
 	extra.TemplateType = c.templateType
 	params.Payload = extra
 	// b, _ := json.MarshalIndent(params, "", "    ")


### PR DESCRIPTION
Since we are phasing out bundled plugins in the near/medium term future, we start tracking usage of bundled plugins by templates, so we have an idea how prevalent this is as practice.