### PR TITLE
core: Fix custom plugin loading in current working directory

### DIFF
--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -239,7 +239,11 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 		pluginName = strings.SplitN(pluginName, "_", 2)[0]
 
 		log.Printf("[INFO] Discovered potential plugin: %s = %s", pluginName, match)
-		res[pluginName] = match
+		pluginPath, err := filepath.Abs(match)
+		if err != nil {
+			pluginPath = match
+		}
+		res[pluginName] = pluginPath
 	}
 
 	return res, nil

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -20,6 +20,11 @@ import (
 	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
 )
 
+var defaultChecksummer = plugingetter.Checksummer{
+	Type: "sha256",
+	Hash: sha256.New(),
+}
+
 // PluginConfig helps load and use packer plugins
 type PluginConfig struct {
 	KnownPluginFolders []string
@@ -227,6 +232,14 @@ func (c *PluginConfig) discoverSingle(glob string) (map[string]string, error) {
 			continue
 		}
 
+		if strings.Contains(strings.ToUpper(file), defaultChecksummer.FileExt()) {
+			log.Printf(
+				"[TRACE] Ignoring plugin match %s, which looks to be a checksum file",
+				match)
+			continue
+
+		}
+
 		// If the filename has a ".", trim up to there
 		if idx := strings.Index(file, ".exe"); idx >= 0 {
 			file = file[:idx]
@@ -383,7 +396,7 @@ func (c *PluginConfig) discoverInstalledComponents(path string) error {
 		APIVersionMajor: pluginsdk.APIVersionMajor,
 		APIVersionMinor: pluginsdk.APIVersionMinor,
 		Checksummers: []plugingetter.Checksummer{
-			{Type: "sha256", Hash: sha256.New()},
+			defaultChecksummer,
 		},
 	}
 

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -85,7 +85,8 @@ func (c *PluginConfig) Discover() error {
 	}
 
 	if len(c.KnownPluginFolders) == 0 {
-		c.KnownPluginFolders = PluginFolders()
+		//PluginFolders should match the call in github.com/hahicorp/packer/main.go#loadConfig
+		c.KnownPluginFolders = PluginFolders(".")
 	}
 
 	// TODO after JSON is deprecated remove support for legacy component plugins.


### PR DESCRIPTION
- Update plugin loading for current directory

Starting with Go 1.19 the loading of binaries from the current working directory was
deemed as a possible security problem. Thus the use of exec.Command or exec.LookPath no longer resolves an executable within the current working directory. This change updates the discover logic to return absolute paths for any discovered plugin, which is called directly when passed to exec.Command or exec.LookPath. By doing this Packer is able to load a custom plugin sitting in the current working directory as it did in version prior to v1.9.2.

- Update plugin discover logic

When copying a plugin's checksum file (packer-plugin-*_SHA256SUM) installed by `packer plugins install` or `packer init` into a separate directory the file may be copied with the executable bit turned out. If unchanged after the copy Packer would discover the checksum file as a possible plugin match and error when trying to execute describe on the plugin look a like. This change adds a checksum file test to the plugin matching logic. If the discovered plugin name is a checksum it is excluded from the discovered plugin list.


Closes #12543 
