### PR TITLE
Removed repetitive statement from HCP debug logs 

### DIFF
--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -123,7 +123,7 @@ func (cfg *PackerConfig) EvalContext(ctx BlockContext, variables map[string]cty.
 
 	iterID, ok := cfg.HCPVars["iterationID"]
 	if ok {
-		log.Printf("iterationID set: %q", iterID)
+		log.Printf("iterationID set: %q", iterID.AsString())
 
 		ectx.Variables[packerAccessor] = cty.ObjectVal(map[string]cty.Value{
 			"version":     cty.StringVal(cfg.CorePackerVersionString),

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -123,8 +123,6 @@ func (cfg *PackerConfig) EvalContext(ctx BlockContext, variables map[string]cty.
 
 	iterID, ok := cfg.HCPVars["iterationID"]
 	if ok {
-		log.Printf("iterationID set: %q", iterID.AsString())
-
 		ectx.Variables[packerAccessor] = cty.ObjectVal(map[string]cty.Value{
 			"version":     cty.StringVal(cfg.CorePackerVersionString),
 			"iterationID": iterID,


### PR DESCRIPTION
Update log to include string version of iterationID

Before
```
2023/08/05 00:42:13 iterationID set: {{{{} 'S'}} "01H71JA47BZPT0HV3VW06CPEG4"}
2023/08/05 00:42:13 iterationID set: {{{{} 'S'}} "01H71JA47BZPT0HV3VW06CPEG4"}
2023/08/05 00:42:13 iterationID set: {{{{} 'S'}} "01H71JA47BZPT0HV3VW06CPEG4"}

```

After
```
2023/08/05 00:36:14 iterationID set: "01H71HZ5NPH8RZ1DC1AEYGSZJ7"
2023/08/05 00:36:14 iterationID set: "01H71HZ5NPH8RZ1DC1AEYGSZJ7"
2023/08/05 00:36:14 iterationID set: "01H71HZ5NPH8RZ1DC1AEYGSZJ7"
```



