### PR TITLE
register ksyun plugin document

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -373,5 +373,12 @@
     "repo": "hashicorp/packer-plugin-yandex",
     "version": "latest",
     "pluginTier": "community"
+  },
+  {
+    "title": "Ksyun",
+    "path": "ksyun",
+    "repo": "kingsoftcloud/packer-plugin-ksyun",
+    "pluginTier": "community",
+    "version": "latest"
   }
 ]


### PR DESCRIPTION
Registered ksyun packer plugin documentation to packer website. Ksyun is a `PaaS` platform from China. Additionally, the plugin is able to ceate Ksyun Images. For the documentation, we've done a simple local test. 