### PR TITLE
packer: log plugins used and their version/path

### DIFF
--- a/bundled_plugin_versions.go
+++ b/bundled_plugin_versions.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/packer/packer"
+	"golang.org/x/mod/modfile"
+)
+
+//go:embed go.mod
+var mod string
+
+var pluginRegex = regexp.MustCompile("packer-plugin-.*$")
+
+func GetBundledPluginVersions() map[string]packer.PluginSpec {
+	pluginSpecs := map[string]packer.PluginSpec{}
+
+	mods, err := modfile.Parse("", []byte(mod), nil)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse embedded modfile: %s", err))
+	}
+
+	for _, req := range mods.Require {
+		if pluginRegex.MatchString(req.Mod.Path) {
+			pluginName := pluginRegex.FindString(req.Mod.Path)
+			pluginShortName := strings.Replace(pluginName, "packer-plugin-", "", 1)
+			pluginSpecs[pluginShortName] = packer.PluginSpec{
+				Name:    pluginShortName,
+				Version: fmt.Sprintf("bundled (%s)", req.Mod.Version),
+				Path:    os.Args[0],
+			}
+		}
+	}
+
+	return pluginSpecs
+}

--- a/command/build.go
+++ b/command/build.go
@@ -101,6 +101,8 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 		return ret
 	}
 
+	c.LogPluginUsage(packerStarter)
+
 	hcpRegistry, diags := registry.New(packerStarter, c.Ui)
 	ret = writeDiags(c.Ui, nil, diags)
 	if ret != 0 {

--- a/command/validate.go
+++ b/command/validate.go
@@ -81,6 +81,8 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 		return ret
 	}
 
+	c.LogPluginUsage(packerStarter)
+
 	_, diags = packerStarter.GetBuilds(packer.GetBuildsOptions{
 		Only:   cla.Only,
 		Except: cla.Except,

--- a/main.go
+++ b/main.go
@@ -325,7 +325,6 @@ func loadConfig() (*config, error) {
 		PluginMinPort:      10000,
 		PluginMaxPort:      25000,
 		KnownPluginFolders: packer.PluginFolders("."),
-
 		// BuilderRedirects
 		BuilderRedirects: map[string]string{
 
@@ -391,7 +390,13 @@ func loadConfig() (*config, error) {
 			//"vsphere":          "github.com/hashicorp/vsphere",
 			//"vsphere-template": "github.com/hashicorp/vsphere",
 		},
+		PluginComponents: map[string]packer.PluginSpec{},
 	}
+	bundledPlugins := GetBundledPluginVersions()
+	for pn, ps := range bundledPlugins {
+		config.Plugins.PluginComponents[pn] = ps
+	}
+
 	if err := config.Plugins.Discover(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As maintainers of Packer and plugins, we ask our users to provide us with the versions of Packer and the plugins they use when they open an issue for us to review.

This is often misunderstood, and may be hidden in the logs, making it harder for all of us to understand where to look.

This commit adds a log statement that reports the list of plugins used, their version, and the path they've been loaded from.