### PR TITLE
Update product licensing to BUSL-1.1

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,6 +1,6 @@
 project {
-  license = "MPL-2.0"
-  copyright_year = 2013
+  license = "BUSL-1.1"
+  copyright_year = 2023
   header_ignore = [
     "*.hcl2spec.go", # generated code specs, since they'll be wiped out until we support adding the headers at generation-time
     "hcl2template/testdata/**",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
           version: ${{ needs.set-product-version.outputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://www.packer.io/docs"
-          license: "MPL-2.0"
+          license: "BUSL-1.1"
           binary: "dist/${{ env.REPO_NAME }}"
           deb_depends: "openssl"
           rpm_depends: "openssl"


### PR DESCRIPTION
This changes updates the product licensing used during the release pipeline to BUSL-1.1. 
It also updates the copywrite config with the correct license type for future header generation.

