### PR TITLE
nywilken/1.9.3 cleanup

### DIFF
--- a/acctest/plugin/bundled_plugin_test.go
+++ b/acctest/plugin/bundled_plugin_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package plugin
 
 import (

--- a/acctest/plugin/test-fixtures/basic_amazon_with_required_plugins.pkr.hcl
+++ b/acctest/plugin/test-fixtures/basic_amazon_with_required_plugins.pkr.hcl
@@ -12,7 +12,7 @@ source "amazon-ebs" "basic-test" {
   instance_type = "m3.medium"
   source_ami = "ami-76b2a71e"
   ssh_username = "ubuntu"
-  ami_name = "packer-plugin-bundled-amazon-ebs-test"
+  ami_name = "packer-plugin-external-amazon-ebs-test"
 }
 
 build {

--- a/internal/hcp/api/client_test.go
+++ b/internal/hcp/api/client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (


### PR DESCRIPTION
- Rename duplicate ami name to fix failing test
- Add missing copyright headers
