### PR TITLE
telemetry: Add nil check in SetBundledUsage

### DIFF
--- a/packer/telemetry.go
+++ b/packer/telemetry.go
@@ -132,6 +132,9 @@ func (c *CheckpointTelemetry) SetTemplateType(t PackerTemplateType) {
 
 // SetBundledUsage marks the template as using bundled plugins
 func (c *CheckpointTelemetry) SetBundledUsage() {
+	if c == nil {
+		return
+	}
 	c.useBundled = true
 }
 

--- a/packer/telemetry_test.go
+++ b/packer/telemetry_test.go
@@ -4,6 +4,7 @@
 package packer
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,25 @@ func TestFlattenConfigKeys_nested(t *testing.T) {
 		flattenConfigKeys(inp),
 		"Input didn't flatten correctly.",
 	)
+}
+
+func TestCheckpointTelemetry(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Error("a noop CheckpointTelemetry should not to panic but it did\n", r)
+		}
+	}()
+
+	// A null CheckpointTelemetry obtained in Packer when the CHECKPOINT_DISABLE env var is set results in a NOOP reporter
+	// The null reporter can be executable as a configured reporter but does not report any telemetry data.
+	var c *CheckpointTelemetry
+	c.SetTemplateType(HCL2Template)
+	c.SetBundledUsage()
+	c.AddSpan("mockprovisioner", "provisioner", nil)
+	if err := c.ReportPanic("Bogus Panic"); err != nil {
+		t.Errorf("calling ReportPanic on a nil checkpoint reporter should not error")
+	}
+	if err := c.Finalize("test", 1, errors.New("Bogus Error")); err != nil {
+		t.Errorf("calling Finalize on a nil checkpoint reporter should not error")
+	}
 }


### PR DESCRIPTION
Invoking Packer with the  CHECKPOINT_DISABLE env. variable the telemetry reporter is left uninitialized in order to disable telemetry reporting. Any method calls on the nil reporter is expected to check if the reporter is active or in NOOP mode. This change fixes a crash when calling SetBundledUsage() on a nil CheckpointTelemetry type that occurs when using a bundled plugin with CHECKPOINT_DISABLE=1.

Closes #12591

Tests Before Change
```
--- FAIL: TestCheckpointTelemetry (0.00s)
    telemetry_test.go:41: a noop CheckpointTelemetry should not to panic but it did
         runtime error: invalid memory address or nil pointer dereference
```

Tests After Change
```
~>  go test ./packer/... -run=TestCheckpointTelemetry -v
?   	github.com/hashicorp/packer/packer/plugin-getter/github	[no test files]
=== RUN   TestCheckpointTelemetry
--- PASS: TestCheckpointTelemetry (0.00s)
PASS
ok  	github.com/hashicorp/packer/packer	0.235s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/packer/packer/plugin-getter	0.247s [no tests to run]
```
