### PR TITLE
Set ivoronin/packer-plugin-sshkey version to 'latest'

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -287,7 +287,7 @@
     "path": "sshkey",
     "repo": "ivoronin/packer-plugin-sshkey",
     "pluginTier": "community",
-    "version": "v1.0.1"
+    "version": "latest"
   },
   {
     "title": "Tart",


### PR DESCRIPTION
According to `plugin-manifest.json` change history my plugin's version was set to `v1.0.1` as a workaround to fix some issue with deleted releases. Is this workaround still needed? If not, lets set it to `latest` again.