### PR TITLE
Datasource logic cleanup

### DIFF
--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -381,7 +381,7 @@ func (cfg *PackerConfig) recursivelyEvaluateDatasources(ref DatasourceRef, depen
 	// If we've gotten here, then it means ref doesn't seem to have any further
 	// dependencies we need to evaluate first. Evaluate it, with the cfg's full
 	// data source context.
-	datasource, startDiags := cfg.startDatasource(cfg.parser.PluginConfig.DataSources, ref, true)
+	datasource, startDiags := cfg.startDatasource(ds)
 	if startDiags.HasErrors() {
 		diags = append(diags, startDiags...)
 		return dependencies, diags

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -368,6 +368,7 @@ func (cfg *PackerConfig) recursivelyEvaluateDatasources(ref DatasourceRef, depen
 				"sources. Either your data source depends on more than ten " +
 				"other data sources, or your data sources have a cyclic " +
 				"dependency. Please simplify your config to continue. ",
+			Subject: &(cfg.Datasources[ref]).block.DefRange,
 		})
 		return dependencies, diags
 	}

--- a/hcl2template/utils.go
+++ b/hcl2template/utils.go
@@ -186,3 +186,23 @@ func ConvertPluginConfigValueToHCLValue(v interface{}) (cty.Value, error) {
 	}
 	return buildValue, nil
 }
+
+func GetVarsByType(block *hcl.Block, topLevelLabels ...string) []hcl.Traversal {
+	attributes, _ := block.Body.JustAttributes()
+
+	var vars []hcl.Traversal
+
+	for _, attr := range attributes {
+		for _, variable := range attr.Expr.Variables() {
+			rootLabel := variable.RootName()
+			for _, label := range topLevelLabels {
+				if label == rootLabel {
+					vars = append(vars, variable)
+					break
+				}
+			}
+		}
+	}
+
+	return vars
+}


### PR DESCRIPTION
This PR is linked to #12607 as it is part of the ongoing refactoring efforts regarding the HCL parsing/execution logic.

This focuses on datasources, and simplifies the code a bit by not invoking the datasources that have no dependency prior to invoking the recursive execution function.

The code to extract the variables from the expressions in the block is moved away from the datasource evaluation as it will be reusable for other block types, but needs to be improved as it only works on the top-level block here, which makes dependency evaluation for datasources dependent on their presence as an attribute in a non-nested block.

Cycle detection now also returns the location of the conflict, this way it is easier for users to troubleshoot their configs if such a situation occurs.