### PR TITLE
Datasource eval breakdown

### DIFF
--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer/builder/null"
@@ -348,6 +349,7 @@ var cmpOpts = []cmp.Option{
 	cmpopts.IgnoreUnexported(
 		PackerConfig{},
 		Variable{},
+		BuildBlock{},
 		SourceBlock{},
 		DatasourceBlock{},
 		ProvisionerBlock{},
@@ -376,6 +378,7 @@ var cmpOpts = []cmp.Option{
 	cmpopts.IgnoreFields(packer.CoreBuildPostProcessor{},
 		"HCLConfig",
 	),
+	cmpopts.IgnoreTypes(hclsyntax.Body{}),
 	cmpopts.IgnoreTypes(hcl2template.MockBuilder{}),
 	cmpopts.IgnoreTypes(HCL2Ref{}),
 	cmpopts.IgnoreTypes([]*LocalBlock{}),

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -368,7 +368,7 @@ func (cfg *PackerConfig) decodeDatasource(block *hcl.Block) hcl.Diagnostics {
 	if cfg.Datasources == nil {
 		cfg.Datasources = Datasources{}
 	}
-	cfg.Datasources[ref] = *datasource
+	cfg.Datasources[ref] = datasource
 
 	return diags
 }

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -370,6 +370,8 @@ func (cfg *PackerConfig) decodeDatasource(block *hcl.Block) hcl.Diagnostics {
 	}
 	cfg.Datasources[ref] = datasource
 
+	datasource.getDependencies()
+
 	return diags
 }
 

--- a/hcl2template/types.build.hcp_packer_registry.go
+++ b/hcl2template/types.build.hcp_packer_registry.go
@@ -23,7 +23,7 @@ type HCPPackerRegistryBlock struct {
 	HCL2Ref
 }
 
-func (p *Parser) decodeHCPRegistry(block *hcl.Block, cfg *PackerConfig) (*HCPPackerRegistryBlock, hcl.Diagnostics) {
+func (cfg *PackerConfig) decodeHCPRegistry(block *hcl.Block) (*HCPPackerRegistryBlock, hcl.Diagnostics) {
 	par := &HCPPackerRegistryBlock{}
 	body := block.Body
 

--- a/hcl2template/types.build.hcp_packer_registry_test.go
+++ b/hcl2template/types.build.hcp_packer_registry_test.go
@@ -118,6 +118,11 @@ func Test_ParseHCPPackerRegistryBlock(t *testing.T) {
 			&PackerConfig{
 				CorePackerVersionString: lockedVersion,
 				Basedir:                 filepath.Join("testdata", "hcp_par"),
+				Builds: Builds{
+					&BuildBlock{
+						Name: "bucket-slug",
+					},
+				},
 			},
 			true, true,
 			nil,
@@ -129,6 +134,11 @@ func Test_ParseHCPPackerRegistryBlock(t *testing.T) {
 			&PackerConfig{
 				CorePackerVersionString: lockedVersion,
 				Basedir:                 filepath.Join("testdata", "hcp_par"),
+				Builds: Builds{
+					&BuildBlock{
+						Name: "bucket-slug",
+					},
+				},
 			},
 			true, true,
 			nil,

--- a/hcl2template/types.build.post-processor.go
+++ b/hcl2template/types.build.post-processor.go
@@ -26,7 +26,7 @@ func (p *PostProcessorBlock) String() string {
 	return fmt.Sprintf(buildPostProcessorLabel+"-block %q %q", p.PType, p.PName)
 }
 
-func (p *Parser) decodePostProcessor(block *hcl.Block, ectx *hcl.EvalContext) (*PostProcessorBlock, hcl.Diagnostics) {
+func (cfg *PackerConfig) decodePostProcessor(block *hcl.Block, ectx *hcl.EvalContext) (*PostProcessorBlock, hcl.Diagnostics) {
 	var b struct {
 		Name              string   `hcl:"name,optional"`
 		Only              []string `hcl:"only,optional"`

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -77,7 +77,7 @@ func (p *ProvisionerBlock) String() string {
 	return fmt.Sprintf(buildProvisionerLabel+"-block %q %q", p.PType, p.PName)
 }
 
-func (p *Parser) decodeProvisioner(block *hcl.Block, ectx *hcl.EvalContext) (*ProvisionerBlock, hcl.Diagnostics) {
+func (cfg *PackerConfig) decodeProvisioner(block *hcl.Block, ectx *hcl.EvalContext) (*ProvisionerBlock, hcl.Diagnostics) {
 	var b struct {
 		Name        string    `hcl:"name,optional"`
 		PauseBefore string    `hcl:"pause_before,optional"`

--- a/hcl2template/types.build.provisioners_test.go
+++ b/hcl2template/types.build.provisioners_test.go
@@ -52,7 +52,7 @@ func TestPackerConfig_ParseProvisionerBlock(t *testing.T) {
 				Column: 1,
 				Byte:   0,
 			})
-			_, diags = cfg.parser.decodeProvisioner(provBlock, nil)
+			_, diags = cfg.decodeProvisioner(provBlock, nil)
 
 			if !diags.HasErrors() {
 				if !test.expectError {

--- a/hcl2template/types.build_test.go
+++ b/hcl2template/types.build_test.go
@@ -64,7 +64,9 @@ func TestParse_build(t *testing.T) {
 			&PackerConfig{
 				CorePackerVersionString: lockedVersion,
 				Basedir:                 filepath.Join("testdata", "build"),
-				Builds:                  nil,
+				Builds: Builds{
+					&BuildBlock{},
+				},
 			},
 			true, true,
 			nil,
@@ -118,6 +120,18 @@ func TestParse_build(t *testing.T) {
 				Sources: map[SourceRef]SourceBlock{
 					refVBIsoUbuntu1204: {Type: "virtualbox-iso", Name: "ubuntu-1204"},
 				},
+				Builds: Builds{
+					&BuildBlock{
+						Sources: []SourceUseBlock{
+							{
+								SourceRef: refVBIsoUbuntu1204,
+							},
+						},
+						ErrorCleanupProvisionerBlock: &ProvisionerBlock{
+							PType: "shell-local",
+						},
+					},
+				},
 			},
 			true, true,
 			[]packersdk.Build{&packer.CoreBuild{
@@ -142,7 +156,9 @@ func TestParse_build(t *testing.T) {
 			&PackerConfig{
 				CorePackerVersionString: lockedVersion,
 				Basedir:                 filepath.Join("testdata", "build"),
-				Builds:                  nil,
+				Builds: Builds{
+					&BuildBlock{},
+				},
 			},
 			true, true,
 			[]packersdk.Build{&packer.CoreBuild{}},
@@ -195,7 +211,9 @@ func TestParse_build(t *testing.T) {
 			&PackerConfig{
 				CorePackerVersionString: lockedVersion,
 				Basedir:                 filepath.Join("testdata", "build"),
-				Builds:                  nil,
+				Builds: Builds{
+					&BuildBlock{},
+				},
 			},
 			true, true,
 			[]packersdk.Build{},
@@ -565,7 +583,9 @@ func TestParse_build(t *testing.T) {
 				CorePackerVersionString: lockedVersion,
 				Basedir:                 filepath.Join("testdata", "build"),
 				InputVariables:          Variables{},
-				Builds:                  nil,
+				Builds: Builds{
+					&BuildBlock{},
+				},
 			},
 			true, true,
 			[]packersdk.Build{},

--- a/hcl2template/types.datasource.go
+++ b/hcl2template/types.datasource.go
@@ -26,7 +26,7 @@ type DatasourceRef struct {
 	Name string
 }
 
-type Datasources map[DatasourceRef]DatasourceBlock
+type Datasources map[DatasourceRef]*DatasourceBlock
 
 func (data *DatasourceBlock) Ref() DatasourceRef {
 	return DatasourceRef{

--- a/hcl2template/types.datasource.go
+++ b/hcl2template/types.datasource.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcldec"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	hcl2shim "github.com/hashicorp/packer/hcl2template/shim"
+	"github.com/hashicorp/packer/packer"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -19,6 +21,9 @@ type DatasourceBlock struct {
 
 	value cty.Value
 	block *hcl.Block
+
+	// dependencies is the list of datasources to execute before this one
+	dependencies []DatasourceRef
 }
 
 type DatasourceRef struct {
@@ -33,6 +38,101 @@ func (data *DatasourceBlock) Ref() DatasourceRef {
 		Type: data.Type,
 		Name: data.Name,
 	}
+}
+
+func (ds *DatasourceBlock) getDependencies() {
+	var dependencies []DatasourceRef
+
+	// Note: when looking at the expressions, we only need to care about
+	// attributes, as HCL2 expressions are not allowed in a block's labels.
+	vars := GetVarsByType(ds.block, "data")
+	for _, v := range vars {
+		// construct, backwards, the data source type and name we
+		// need to evaluate before this one can be evaluated.
+		dependencies = append(dependencies, DatasourceRef{
+			Type: v[1].(hcl.TraverseAttr).Name,
+			Name: v[2].(hcl.TraverseAttr).Name,
+		})
+	}
+
+	ds.dependencies = dependencies
+}
+
+const notReadyDataSourceError = "Dependencies not ready"
+
+// executed returns whether or not the datasource was executed
+//
+// Having a non-empty cty.Value object means this was filled-up after the
+// datasource has been executed, so this is what we use for this test.
+func (ds DatasourceBlock) executed() bool {
+	return ds.value != cty.Value{}
+}
+
+// Execute starts the datasource and executes it immediately.
+//
+// If its dependencies are not ready for execution, this will return an error
+// and will only execute when all its dependencies have executed.
+func (ds *DatasourceBlock) Execute(cfg *PackerConfig, skipExecution bool) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	ok := true
+	for _, depRef := range ds.dependencies {
+		dep := cfg.Datasources[depRef]
+		if dep == nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Nonexistent dependency referenced",
+				Detail:   fmt.Sprintf("The referenced datasource %s.%s is not defined in the configuration, so this datasource won't be able to execute.", dep.Type, dep.Name),
+				Subject:  &ds.block.DefRange,
+			})
+			ok = false
+			continue
+		}
+
+		if !dep.executed() {
+			ok = false
+		}
+	}
+
+	if !ok {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  notReadyDataSourceError,
+			Detail:   "At least one dependency for the datasource is not executed already",
+			Subject:  &ds.block.DefRange,
+		})
+		return diags
+	}
+
+	// If we've gotten here, then it means ref doesn't seem to have any further
+	// dependencies we need to evaluate first. Evaluate it, with the cfg's full
+	// data source context.
+	datasource, diags := cfg.startDatasource(*ds)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	if skipExecution {
+		placeholderValue := cty.UnknownVal(hcldec.ImpliedType(datasource.OutputSpec()))
+		ds.value = placeholderValue
+		return diags
+	}
+
+	opts, _ := decodeHCL2Spec(ds.block.Body, cfg.EvalContext(DatasourceContext, nil), datasource)
+	sp := packer.CheckpointReporter.AddSpan(ds.Type, "datasource", opts)
+	realValue, err := datasource.Execute()
+	sp.End(err)
+	if err != nil {
+		diags = append(diags, &hcl.Diagnostic{
+			Summary:  err.Error(),
+			Subject:  &ds.block.DefRange,
+			Severity: hcl.DiagError,
+		})
+		return diags
+	}
+
+	ds.value = realValue
+	return diags
 }
 
 func (ds *Datasources) Values() (map[string]cty.Value, hcl.Diagnostics) {
@@ -129,4 +229,65 @@ func (cfg *PackerConfig) startDatasource(ds DatasourceBlock) (packersdk.Datasour
 		})
 	}
 	return datasource, diags
+}
+
+// datasourcesDone checks whether all the datasources have been executed or not
+func (cfg *PackerConfig) datasourcesDone() bool {
+	for _, ds := range cfg.Datasources {
+		if !ds.executed() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (cfg *PackerConfig) executeDatasources(skipExecution bool) hcl.Diagnostics {
+	// If we are done with datasources execution, we leave immediately
+	if cfg.datasourcesDone() {
+		return nil
+	}
+
+	var outDiags hcl.Diagnostics
+
+	foundSomething := false
+outerDSEval:
+	for _, ds := range cfg.Datasources {
+		if ds.executed() {
+			continue
+		}
+
+		diags := ds.Execute(cfg, skipExecution)
+		for _, diag := range diags {
+			if diag.Summary == notReadyDataSourceError {
+				// If we have a not ready error in the
+				// datasource list, we should attempt to run the
+				// rest, and eventually settle if we cannot move
+				// any further
+				continue outerDSEval
+			}
+		}
+
+		foundSomething = true
+
+		outDiags = append(outDiags, diags...)
+	}
+
+	if !foundSomething {
+		return append(outDiags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "No datasource could be executed",
+			Detail: `While trying to recurisvely evaluating datasources, we could not find a next datasource to execute.
+This is likely due to a cyclic dependency in your datasources`,
+		})
+	}
+
+	// If we couldn't execute a datasource for whatever reason, we leave
+	if outDiags.HasErrors() {
+		return outDiags
+	}
+
+	// If we still found something to execute, we recursively execute the
+	// remainder of the datasources
+	return outDiags.Extend(cfg.executeDatasources(skipExecution))
 }

--- a/hcl2template/types.datasource.go
+++ b/hcl2template/types.datasource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	hcl2shim "github.com/hashicorp/packer/hcl2template/shim"
-	"github.com/hashicorp/packer/packer"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -65,13 +64,15 @@ func (ds *Datasources) Values() (map[string]cty.Value, hcl.Diagnostics) {
 	return res, diags
 }
 
-func (cfg *PackerConfig) startDatasource(dataSourceStore packer.DatasourceStore, ref DatasourceRef, secondaryEvaluation bool) (packersdk.Datasource, hcl.Diagnostics) {
+func (cfg *PackerConfig) startDatasource(ds DatasourceBlock) (packersdk.Datasource, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
-	block := cfg.Datasources[ref].block
+	block := ds.block
+
+	dataSourceStore := cfg.parser.PluginConfig.DataSources
 
 	if dataSourceStore == nil {
 		diags = append(diags, &hcl.Diagnostic{
-			Summary:  "Unknown " + dataSourceLabel + " type " + ref.Type,
+			Summary:  "Unknown " + dataSourceLabel + " type " + ds.Type,
 			Subject:  block.LabelRanges[0].Ptr(),
 			Detail:   fmt.Sprintf("packer does not currently know any data source."),
 			Severity: hcl.DiagError,
@@ -79,9 +80,9 @@ func (cfg *PackerConfig) startDatasource(dataSourceStore packer.DatasourceStore,
 		return nil, diags
 	}
 
-	if !dataSourceStore.Has(ref.Type) {
+	if !dataSourceStore.Has(ds.Type) {
 		diags = append(diags, &hcl.Diagnostic{
-			Summary:  "Unknown " + dataSourceLabel + " type " + ref.Type,
+			Summary:  "Unknown " + dataSourceLabel + " type " + ds.Type,
 			Subject:  block.LabelRanges[0].Ptr(),
 			Detail:   fmt.Sprintf("known data sources: %v", dataSourceStore.List()),
 			Severity: hcl.DiagError,
@@ -89,7 +90,7 @@ func (cfg *PackerConfig) startDatasource(dataSourceStore packer.DatasourceStore,
 		return nil, diags
 	}
 
-	datasource, err := dataSourceStore.Start(ref.Type)
+	datasource, err := dataSourceStore.Start(ds.Type)
 	if err != nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Summary:  err.Error(),
@@ -99,7 +100,7 @@ func (cfg *PackerConfig) startDatasource(dataSourceStore packer.DatasourceStore,
 	}
 	if datasource == nil {
 		diags = append(diags, &hcl.Diagnostic{
-			Summary:  fmt.Sprintf("failed to start datasource plugin %q.%q", ref.Type, ref.Name),
+			Summary:  fmt.Sprintf("failed to start datasource plugin %q.%q", ds.Type, ds.Name),
 			Subject:  &block.DefRange,
 			Severity: hcl.DiagError,
 		})

--- a/hcl2template/types.datasource.go
+++ b/hcl2template/types.datasource.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	hcl2shim "github.com/hashicorp/packer/hcl2template/shim"
 	"github.com/zclconf/go-cty/cty"
@@ -130,32 +129,4 @@ func (cfg *PackerConfig) startDatasource(ds DatasourceBlock) (packersdk.Datasour
 		})
 	}
 	return datasource, diags
-}
-
-func (p *Parser) decodeDataBlock(block *hcl.Block) (*DatasourceBlock, hcl.Diagnostics) {
-	var diags hcl.Diagnostics
-	r := &DatasourceBlock{
-		Type:  block.Labels[0],
-		Name:  block.Labels[1],
-		block: block,
-	}
-
-	if !hclsyntax.ValidIdentifier(r.Type) {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid data source name",
-			Detail:   badIdentifierDetail,
-			Subject:  &block.LabelRanges[0],
-		})
-	}
-	if !hclsyntax.ValidIdentifier(r.Name) {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid data resource name",
-			Detail:   badIdentifierDetail,
-			Subject:  &block.LabelRanges[1],
-		})
-	}
-
-	return r, diags
 }

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -384,7 +384,7 @@ func (cfg *PackerConfig) recursivelyEvaluateDatasources(ref DatasourceRef, depen
 	// If we've gotten here, then it means ref doesn't seem to have any further
 	// dependencies we need to evaluate first. Evaluate it, with the cfg's full
 	// data source context.
-	datasource, startDiags := cfg.startDatasource(cfg.parser.PluginConfig.DataSources, ref, true)
+	datasource, startDiags := cfg.startDatasource(ds)
 	if startDiags.HasErrors() {
 		diags = append(diags, startDiags...)
 		return dependencies, diags

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -5,7 +5,6 @@ package hcl2template
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 
@@ -315,27 +314,17 @@ func (cfg *PackerConfig) evaluateDatasources(skipExecution bool) hcl.Diagnostics
 		// source interdependencies.
 		dependencies[ref] = []DatasourceRef{}
 
-		block := ds.block
-		body := block.Body
-		attrs, _ := body.JustAttributes()
-
-		skipFirstEval := false
-		for _, attr := range attrs {
-			vars := attr.Expr.Variables()
-			for _, v := range vars {
-				// check whether the variable is a data source
-				if v.RootName() == "data" {
-					// construct, backwards, the data source type and name we
-					// need to evaluate before this one can be evaluated.
-					dependsOn := DatasourceRef{
-						Type: v[1].(hcl.TraverseAttr).Name,
-						Name: v[2].(hcl.TraverseAttr).Name,
-					}
-					log.Printf("The data source %#v depends on datasource %#v", ref, dependsOn)
-					dependencies[ref] = append(dependencies[ref], dependsOn)
-					skipFirstEval = true
-				}
+		// Note: when looking at the expressions, we only need to care about
+		// attributes, as HCL2 expressions are not allowed in a block's labels.
+		vars := GetVarsByType(ds.block, "data")
+		for _, v := range vars {
+			// construct, backwards, the data source type and name we
+			// need to evaluate before this one can be evaluated.
+			dependsOn := DatasourceRef{
+				Type: v[1].(hcl.TraverseAttr).Name,
+				Name: v[2].(hcl.TraverseAttr).Name,
 			}
+			dependencies[ref] = append(dependencies[ref], dependsOn)
 		}
 	}
 

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gobwas/glob"
 	hcl "github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	pkrfunction "github.com/hashicorp/packer/hcl2template/function"
@@ -262,125 +261,6 @@ func (c *PackerConfig) evaluateLocalVariable(local *LocalBlock) hcl.Diagnostics 
 	}
 
 	return diags
-}
-
-func (cfg *PackerConfig) evaluateDatasources(skipExecution bool) hcl.Diagnostics {
-	var diags hcl.Diagnostics
-
-	dependencies := map[DatasourceRef][]DatasourceRef{}
-	for ref, ds := range cfg.Datasources {
-		if ds.value != (cty.Value{}) {
-			continue
-		}
-		// Pre-examine body of this data source to see if it uses another data
-		// source in any of its input expressions. If so, skip evaluating it for
-		// now, and add it to a list of datasources to evaluate again, later,
-		// with the datasources in its context.
-		// This is essentially creating a very primitive DAG just for data
-		// source interdependencies.
-		dependencies[ref] = []DatasourceRef{}
-
-		// Note: when looking at the expressions, we only need to care about
-		// attributes, as HCL2 expressions are not allowed in a block's labels.
-		vars := GetVarsByType(ds.block, "data")
-		for _, v := range vars {
-			// construct, backwards, the data source type and name we
-			// need to evaluate before this one can be evaluated.
-			dependsOn := DatasourceRef{
-				Type: v[1].(hcl.TraverseAttr).Name,
-				Name: v[2].(hcl.TraverseAttr).Name,
-			}
-			dependencies[ref] = append(dependencies[ref], dependsOn)
-		}
-	}
-
-	// Now that most of our data sources have been started and executed, we can
-	// try to execute the ones that depend on other data sources.
-	for ref := range dependencies {
-		_, moreDiags := cfg.recursivelyEvaluateDatasources(ref, dependencies, skipExecution, 0)
-		// Deduplicate diagnostics to prevent recursion messes.
-		cleanedDiags := map[string]*hcl.Diagnostic{}
-		for _, diag := range moreDiags {
-			cleanedDiags[diag.Summary] = diag
-		}
-
-		for _, diag := range cleanedDiags {
-			diags = append(diags, diag)
-		}
-	}
-
-	return diags
-}
-
-func (cfg *PackerConfig) recursivelyEvaluateDatasources(ref DatasourceRef, dependencies map[DatasourceRef][]DatasourceRef, skipExecution bool, depth int) (map[DatasourceRef][]DatasourceRef, hcl.Diagnostics) {
-	var diags hcl.Diagnostics
-	var moreDiags hcl.Diagnostics
-
-	ds := cfg.Datasources[ref]
-
-	if depth > 10 {
-		// Add a comment about recursion.
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Max datasource recursion depth exceeded.",
-			Detail: "An error occured while recursively evaluating data " +
-				"sources. Either your data source depends on more than ten " +
-				"other data sources, or your data sources have a cyclic " +
-				"dependency. Please simplify your config to continue. ",
-			Subject: &ds.block.DefRange,
-		})
-		return dependencies, diags
-	}
-
-	// Make sure everything ref depends on has already been evaluated.
-	for _, dep := range dependencies[ref] {
-		if _, ok := dependencies[dep]; ok {
-			depth += 1
-			// If this dependency is not in the map, it means we've already
-			// launched and executed this datasource. Otherwise, it means
-			// we still need to run it. RECURSION TIME!!
-			dependencies, moreDiags = cfg.recursivelyEvaluateDatasources(dep, dependencies, skipExecution, depth)
-			diags = append(diags, moreDiags...)
-			if moreDiags.HasErrors() {
-				diags = append(diags, moreDiags...)
-				return dependencies, diags
-			}
-		}
-	}
-	// If we've gotten here, then it means ref doesn't seem to have any further
-	// dependencies we need to evaluate first. Evaluate it, with the cfg's full
-	// data source context.
-	datasource, startDiags := cfg.startDatasource(ds)
-	if startDiags.HasErrors() {
-		diags = append(diags, startDiags...)
-		return dependencies, diags
-	}
-
-	if skipExecution {
-		placeholderValue := cty.UnknownVal(hcldec.ImpliedType(datasource.OutputSpec()))
-		ds.value = placeholderValue
-		cfg.Datasources[ref] = ds
-		return dependencies, diags
-	}
-
-	opts, _ := decodeHCL2Spec(ds.block.Body, cfg.EvalContext(DatasourceContext, nil), datasource)
-	sp := packer.CheckpointReporter.AddSpan(ref.Type, "datasource", opts)
-	realValue, err := datasource.Execute()
-	sp.End(err)
-	if err != nil {
-		diags = append(diags, &hcl.Diagnostic{
-			Summary:  err.Error(),
-			Subject:  &cfg.Datasources[ref].block.DefRange,
-			Severity: hcl.DiagError,
-		})
-		return dependencies, diags
-	}
-
-	ds.value = realValue
-	cfg.Datasources[ref] = ds
-	// remove ref from the dependencies map.
-	delete(dependencies, ref)
-	return dependencies, diags
 }
 
 // getCoreBuildProvisioners takes a list of provisioner block, starts according
@@ -802,7 +682,7 @@ func (p *PackerConfig) InspectConfig(opts packer.InspectConfigOptions) int {
 func (cfg *PackerConfig) Initialize(opts packer.InitializeOptions) hcl.Diagnostics {
 	diags := cfg.InputVariables.ValidateValues()
 	diags = append(diags, cfg.LocalVariables.ValidateValues()...)
-	diags = append(diags, cfg.evaluateDatasources(opts.SkipDatasourcesExecution)...)
+	diags = append(diags, cfg.executeDatasources(opts.SkipDatasourcesExecution)...)
 	diags = append(diags, checkForDuplicateLocalDefinition(cfg.LocalBlocks)...)
 	diags = append(diags, cfg.evaluateLocalVariables(cfg.LocalBlocks)...)
 

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -313,6 +313,8 @@ func (cfg *PackerConfig) evaluateDatasources(skipExecution bool) hcl.Diagnostics
 		// with the datasources in its context.
 		// This is essentially creating a very primitive DAG just for data
 		// source interdependencies.
+		dependencies[ref] = []DatasourceRef{}
+
 		block := ds.block
 		body := block.Body
 		attrs, _ := body.JustAttributes()
@@ -330,51 +332,11 @@ func (cfg *PackerConfig) evaluateDatasources(skipExecution bool) hcl.Diagnostics
 						Name: v[2].(hcl.TraverseAttr).Name,
 					}
 					log.Printf("The data source %#v depends on datasource %#v", ref, dependsOn)
-					if dependencies[ref] != nil {
-						dependencies[ref] = append(dependencies[ref], dependsOn)
-					} else {
-						dependencies[ref] = []DatasourceRef{dependsOn}
-					}
+					dependencies[ref] = append(dependencies[ref], dependsOn)
 					skipFirstEval = true
 				}
 			}
 		}
-
-		// Now we have a list of data sources that depend on other data sources.
-		// Don't evaluate these; only evaluate data sources that we didn't
-		// mark  as having dependencies.
-		if skipFirstEval {
-			continue
-		}
-
-		datasource, startDiags := cfg.startDatasource(cfg.parser.PluginConfig.DataSources, ref, false)
-		diags = append(diags, startDiags...)
-		if diags.HasErrors() {
-			continue
-		}
-
-		if skipExecution {
-			placeholderValue := cty.UnknownVal(hcldec.ImpliedType(datasource.OutputSpec()))
-			ds.value = placeholderValue
-			cfg.Datasources[ref] = ds
-			continue
-		}
-
-		dsOpts, _ := decodeHCL2Spec(body, cfg.EvalContext(DatasourceContext, nil), datasource)
-		sp := packer.CheckpointReporter.AddSpan(ref.Type, "datasource", dsOpts)
-		realValue, err := datasource.Execute()
-		sp.End(err)
-		if err != nil {
-			diags = append(diags, &hcl.Diagnostic{
-				Summary:  err.Error(),
-				Subject:  &cfg.Datasources[ref].block.DefRange,
-				Severity: hcl.DiagError,
-			})
-			continue
-		}
-
-		ds.value = realValue
-		cfg.Datasources[ref] = ds
 	}
 
 	// Now that most of our data sources have been started and executed, we can

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -361,6 +361,8 @@ func (cfg *PackerConfig) recursivelyEvaluateDatasources(ref DatasourceRef, depen
 	var diags hcl.Diagnostics
 	var moreDiags hcl.Diagnostics
 
+	ds := cfg.Datasources[ref]
+
 	if depth > 10 {
 		// Add a comment about recursion.
 		diags = append(diags, &hcl.Diagnostic{
@@ -370,11 +372,11 @@ func (cfg *PackerConfig) recursivelyEvaluateDatasources(ref DatasourceRef, depen
 				"sources. Either your data source depends on more than ten " +
 				"other data sources, or your data sources have a cyclic " +
 				"dependency. Please simplify your config to continue. ",
+			Subject: &ds.block.DefRange,
 		})
 		return dependencies, diags
 	}
 
-	ds := cfg.Datasources[ref]
 	// Make sure everything ref depends on has already been evaluated.
 	for _, dep := range dependencies[ref] {
 		if _, ok := dependencies[dep]; ok {

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -136,7 +136,7 @@ func TestParser_complete(t *testing.T) {
 					},
 				},
 				Datasources: Datasources{
-					DatasourceRef{Type: "amazon-ami", Name: "test"}: DatasourceBlock{
+					DatasourceRef{Type: "amazon-ami", Name: "test"}: &DatasourceBlock{
 						Type:  "amazon-ami",
 						Name:  "test",
 						value: cty.StringVal("foo"),

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -575,8 +575,19 @@ func TestParser_no_init(t *testing.T) {
 						Type: cty.List(cty.String),
 					},
 				},
-				Sources: nil,
-				Builds:  nil,
+				Sources: map[SourceRef]SourceBlock{
+					refAWSV3MyImage: {
+						Type: "amazon-v3-ebs",
+						Name: "my-image",
+					},
+					refVBIsoUbuntu1204: {
+						Type: "virtualbox-iso",
+						Name: "ubuntu-1204",
+					},
+				},
+				Builds: Builds{
+					&BuildBlock{},
+				},
 			},
 			false, false,
 			[]packersdk.Build{},

--- a/hcl2template/types.required_plugins.go
+++ b/hcl2template/types.required_plugins.go
@@ -12,37 +12,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func (cfg *PackerConfig) decodeRequiredPluginsBlock(f *hcl.File) hcl.Diagnostics {
-	var diags hcl.Diagnostics
-
-	content, moreDiags := f.Body.Content(configSchema)
-	diags = append(diags, moreDiags...)
-
-	for _, block := range content.Blocks {
-		switch block.Type {
-		case packerLabel:
-			content, contentDiags := block.Body.Content(packerBlockSchema)
-			diags = append(diags, contentDiags...)
-
-			// We ignore "packer_version"" here because
-			// sniffCoreVersionRequirements already dealt with that
-
-			for _, innerBlock := range content.Blocks {
-				switch innerBlock.Type {
-				case "required_plugins":
-					reqs, reqsDiags := decodeRequiredPluginsBlock(innerBlock)
-					diags = append(diags, reqsDiags...)
-					cfg.Packer.RequiredPlugins = append(cfg.Packer.RequiredPlugins, reqs)
-				default:
-					continue
-				}
-
-			}
-		}
-	}
-	return diags
-}
-
 // RequiredPlugin represents a declaration of a dependency on a particular
 // Plugin version or source.
 type RequiredPlugin struct {

--- a/hcl2template/types.required_plugins_test.go
+++ b/hcl2template/types.required_plugins_test.go
@@ -138,7 +138,7 @@ func TestPackerConfig_required_plugin_parse(t *testing.T) {
 			if len(diags) > 0 {
 				t.Fatal(diags)
 			}
-			if diags := cfg.decodeRequiredPluginsBlock(file); len(diags) > 0 {
+			if diags := cfg.decodeFile(file); len(diags) > 0 {
 				t.Fatal(diags)
 			}
 

--- a/hcl2template/types.source_test.go
+++ b/hcl2template/types.source_test.go
@@ -90,8 +90,10 @@ func TestParse_source(t *testing.T) {
 			parseTestArgs{"testdata/sources/nonexistent.pkr.hcl", nil, nil},
 			&PackerConfig{
 				CorePackerVersionString: lockedVersion,
-				Builds:                  nil,
-				Basedir:                 filepath.Join("testdata", "sources"),
+				Builds: Builds{
+					&BuildBlock{},
+				},
+				Basedir: filepath.Join("testdata", "sources"),
 				Sources: map[SourceRef]SourceBlock{
 					{Type: "nonexistent", Name: "ubuntu-1204"}: {Type: "nonexistent", Name: "ubuntu-1204"},
 				},

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -278,35 +278,6 @@ var localBlockSchema = &hcl.BodySchema{
 	},
 }
 
-func decodeLocalBlock(block *hcl.Block) (*LocalBlock, hcl.Diagnostics) {
-	name := block.Labels[0]
-
-	content, diags := block.Body.Content(localBlockSchema)
-	if !hclsyntax.ValidIdentifier(name) {
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Invalid local name",
-			Detail:   badIdentifierDetail,
-			Subject:  &block.LabelRanges[0],
-		})
-	}
-
-	l := &LocalBlock{
-		Name: name,
-	}
-
-	if attr, exists := content.Attributes["sensitive"]; exists {
-		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &l.Sensitive)
-		diags = append(diags, valDiags...)
-	}
-
-	if def, ok := content.Attributes["expression"]; ok {
-		l.Expr = def.Expr
-	}
-
-	return l, diags
-}
-
 // decodeVariableBlock decodes a "variable" block
 // ectx is passed only in the evaluation of the default value.
 func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.EvalContext) hcl.Diagnostics {

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -248,7 +248,10 @@ func TestParse_variables(t *testing.T) {
 			parseTestArgs{"testdata/variables/unset_used_string_variable.pkr.hcl", nil, nil},
 			&PackerConfig{
 				CorePackerVersionString: lockedVersion,
-				Basedir:                 filepath.Join("testdata", "variables"),
+				Builds: Builds{
+					&BuildBlock{},
+				},
+				Basedir: filepath.Join("testdata", "variables"),
 				InputVariables: Variables{
 					"foo": &Variable{
 						Name: "foo",

--- a/hcl2template/utils.go
+++ b/hcl2template/utils.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/packer/hcl2template/repl"
 	hcl2shim "github.com/hashicorp/packer/hcl2template/shim"
 	"github.com/zclconf/go-cty/cty"
@@ -188,22 +189,49 @@ func ConvertPluginConfigValueToHCLValue(v interface{}) (cty.Value, error) {
 	return buildValue, nil
 }
 
+// GetVarsByType walks through a hcl body, and gathers all the Traversals that
+// have a root type matching one of the specified top-level labels.
+//
+// This will only work on finite, expanded, HCL bodies.
+//
+// TODO: make it work on JSON serialised HCL2 templates.
 func GetVarsByType(block *hcl.Block, topLevelLabels ...string) []hcl.Traversal {
-	attributes, _ := block.Body.JustAttributes()
+	var travs []hcl.Traversal
 
-	var vars []hcl.Traversal
+	switch body := block.Body.(type) {
+	case *hclsyntax.Body:
+		travs = getVarsByTypeForHCLSyntaxBody(body)
+	default:
+		attrs, _ := body.JustAttributes()
+		for _, attr := range attrs {
+			travs = append(travs, attr.Expr.Variables()...)
+		}
+	}
 
-	for _, attr := range attributes {
-		for _, variable := range attr.Expr.Variables() {
-			rootLabel := variable.RootName()
-			for _, label := range topLevelLabels {
-				if label == rootLabel {
-					vars = append(vars, variable)
-					break
-				}
+	var rets []hcl.Traversal
+	for _, t := range travs {
+		varRootname := t.RootName()
+		for _, lbl := range topLevelLabels {
+			if varRootname == lbl {
+				rets = append(rets, t)
+				break
 			}
 		}
 	}
 
-	return vars
+	return rets
+}
+
+func getVarsByTypeForHCLSyntaxBody(body *hclsyntax.Body) []hcl.Traversal {
+	var rets []hcl.Traversal
+
+	for _, attr := range body.Attributes {
+		rets = append(rets, attr.Expr.Variables()...)
+	}
+
+	for _, block := range body.Blocks {
+		rets = append(rets, getVarsByTypeForHCLSyntaxBody(block.Body)...)
+	}
+
+	return rets
 }

--- a/hcl2template/utils.go
+++ b/hcl2template/utils.go
@@ -187,3 +187,23 @@ func ConvertPluginConfigValueToHCLValue(v interface{}) (cty.Value, error) {
 	}
 	return buildValue, nil
 }
+
+func GetVarsByType(block *hcl.Block, topLevelLabels ...string) []hcl.Traversal {
+	attributes, _ := block.Body.JustAttributes()
+
+	var vars []hcl.Traversal
+
+	for _, attr := range attributes {
+		for _, variable := range attr.Expr.Variables() {
+			rootLabel := variable.RootName()
+			for _, label := range topLevelLabels {
+				if label == rootLabel {
+					vars = append(vars, variable)
+					break
+				}
+			}
+		}
+	}
+
+	return vars
+}


### PR DESCRIPTION
This PR aims to rework the logic around datasource evaluation, so we can execute each datasource separately, and not necessarily through the `evaluateDatasources` function.

This is made as a building block for the introduction later of the DAG.

Essentially, this PR adds some dependency list to the datasources. This list is for now limited to other datasources, but will likely change when we move to a more DAG-y workflow, where locals for example can become dependencies of the datasource.

With the change in execution behaviour, we also rework the `evaluateDatasources` (renamed to `executeDatasources` for consistency), and adopt a flow similar to the local variables evaluation.


:warning: : bit messy since based on both the code from #12607 and #12608. Only the last two commits are relevant for this PR.