### PR TITLE
hcl2template: remove value validation for locals

### DIFF
--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -295,7 +295,6 @@ func filterVarsFromLogs(inputOrLocal Variables) {
 
 func (cfg *PackerConfig) Initialize(opts packer.InitializeOptions) hcl.Diagnostics {
 	diags := cfg.InputVariables.ValidateValues()
-	diags = append(diags, cfg.LocalVariables.ValidateValues()...)
 	diags = append(diags, cfg.evaluateDatasources(opts.SkipDatasourcesExecution)...)
 	diags = append(diags, checkForDuplicateLocalDefinition(cfg.LocalBlocks)...)
 	diags = append(diags, cfg.evaluateLocalVariables(cfg.LocalBlocks)...)


### PR DESCRIPTION
Local variables can't have a validation block in their definition, so this step in not useful and should be removed.

Besides, since the validation was done on the local variables before evaluation, it did nothing at all, as the PackerConfig.LocalVariables collection gets populated during evaluation, so this is essentially a no-op, and can be safely removed.