### PR TITLE
Remove plugins on the integration framework

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -1,19 +1,5 @@
 [
   {
-    "title": "1&1",
-    "path": "oneandone",
-    "repo": "hashicorp/packer-plugin-oneandone",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
-    "title": "Alibaba Cloud",
-    "path": "alicloud",
-    "repo": "hashicorp/packer-plugin-alicloud",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
     "title": "Anka",
     "path": "anka",
     "repo": "veertuinc/packer-plugin-veertu-anka",
@@ -22,60 +8,10 @@
     "version": "latest"
   },
   {
-    "title": "Ansible",
-    "path": "ansible",
-    "repo": "hashicorp/packer-plugin-ansible",
-    "version": "latest"
-  },
-  {
-    "title": "Amazon EC2",
-    "path": "amazon",
-    "repo": "hashicorp/packer-plugin-amazon",
-    "version": "latest",
-    "isHcpPackerReady": true
-  },
-  {
-    "title": "Azure",
-    "path": "azure",
-    "repo": "hashicorp/packer-plugin-azure",
-    "version": "latest",
-    "isHcpPackerReady": true
-  },
-  {
-    "title": "Chef",
-    "path": "chef",
-    "repo": "hashicorp/packer-plugin-chef",
-    "pluginTier": "community",
-    "version": "latest",
-    "archived": true
-  },
-  {
-    "title": "CloudStack",
-    "path": "cloudstack",
-    "repo": "hashicorp/packer-plugin-cloudstack",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
-    "title": "Converge",
-    "path": "converge",
-    "repo": "hashicorp/packer-plugin-converge",
-    "pluginTier": "community",
-    "version": "latest",
-    "archived": true
-  },
-  {
     "title": "DigitalOcean",
     "path": "digitalocean",
     "repo": "digitalocean/packer-plugin-digitalocean",
     "pluginTier": "verified",
-    "version": "latest",
-    "isHcpPackerReady": true
-  },
-  {
-    "title": "Docker",
-    "path": "docker",
-    "repo": "hashicorp/packer-plugin-docker",
     "version": "latest",
     "isHcpPackerReady": true
   },
@@ -94,62 +30,12 @@
     "sourceBranch": "main"
   },
   {
-    "title": "Google Cloud Platform",
-    "path": "googlecompute",
-    "repo": "hashicorp/packer-plugin-googlecompute",
-    "version": "latest",
-    "isHcpPackerReady": true
-  },
-  {
     "title": "Gridscale",
     "path": "gridscale",
     "repo": "gridscale/packer-plugin-gridscale",
     "version": "latest",
     "pluginTier": "verified",
     "isHcpPackerReady": false
-  },
-  {
-    "title": "HashiCups",
-    "path": "hashicups",
-    "repo": "hashicorp/packer-plugin-hashicups",
-    "version": "latest",
-    "isHcpPackerReady": false
-  },
-  {
-    "title": "Hetzner Cloud",
-    "path": "hetzner-cloud",
-    "repo": "hashicorp/packer-plugin-hcloud",
-    "version": "latest",
-    "pluginTier": "community"
-  },
-  {
-    "title": "HyperOne",
-    "path": "hyperone",
-    "repo": "hashicorp/packer-plugin-hyperone",
-    "version": "latest",
-    "pluginTier": "community"
-  },
-  {
-    "title": "Hyper-V",
-    "path": "hyperv",
-    "repo": "hashicorp/packer-plugin-hyperv",
-    "version": "latest",
-    "pluginTier": "community"
-  },
-  {
-    "title": "InSpec",
-    "path": "inspec",
-    "repo": "hashicorp/packer-plugin-inspec",
-    "pluginTier": "community",
-    "version": "latest",
-    "archived": true
-  },
-  {
-    "title": "JD Cloud",
-    "path": "jdcloud",
-    "repo": "hashicorp/packer-plugin-jdcloud",
-    "pluginTier": "community",
-    "version": "latest"
   },
   {
     "title": "Kamatera",
@@ -174,31 +60,10 @@
     "version": "latest"
   },
   {
-    "title": "LXC",
-    "path": "lxc",
-    "repo": "hashicorp/packer-plugin-lxc",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
-    "title": "LXD",
-    "path": "lxd",
-    "repo": "hashicorp/packer-plugin-lxd",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
     "title": "Mondoo",
     "path": "mondoo",
     "repo": "mondoohq/packer-plugin-mondoo",
     "pluginTier": "verified",
-    "version": "latest"
-  },
-  {
-    "title": "Naver Cloud",
-    "path": "ncloud",
-    "repo": "hashicorp/packer-plugin-ncloud",
-    "pluginTier": "community",
     "version": "latest"
   },
   {
@@ -208,21 +73,6 @@
     "version": "latest",
     "pluginTier": "verified",
     "sourceBranch": "main"
-  },
-  {
-    "title": "OpenStack",
-    "path": "openstack",
-    "repo": "hashicorp/packer-plugin-openstack",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
-    "title": "Oracle",
-    "path": "oracle",
-    "repo": "hashicorp/packer-plugin-oracle",
-    "pluginTier": "community",
-    "version": "latest",
-    "isHcpPackerReady": true
   },
   {
     "title": "Outscale",
@@ -238,42 +88,6 @@
     "repo": "parallels/packer-plugin-parallels",
     "version": "latest",
     "pluginTier": "verified"
-  },
-  {
-    "title": "Profitbricks",
-    "path": "profitbricks",
-    "repo": "hashicorp/packer-plugin-profitbricks",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
-    "title": "Proxmox",
-    "path": "proxmox",
-    "repo": "hashicorp/packer-plugin-proxmox",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
-    "title": "Puppet",
-    "path": "puppet",
-    "repo": "hashicorp/packer-plugin-puppet",
-    "version": "latest",
-    "pluginTier": "community",
-    "archived": true
-  },
-  {
-    "title": "QEMU",
-    "path": "qemu",
-    "repo": "hashicorp/packer-plugin-qemu",
-    "version": "latest"
-  },
-  {
-    "title": "Salt",
-    "path": "salt",
-    "repo": "hashicorp/packer-plugin-salt",
-    "pluginTier": "community",
-    "version": "latest",
-    "archived": true
   },
   {
     "title": "Scaleway",
@@ -297,20 +111,6 @@
     "version": "latest"
   },
   {
-    "title": "Tencent Cloud",
-    "path": "tencentcloud",
-    "repo": "hashicorp/packer-plugin-tencentcloud",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
-    "title": "Triton",
-    "path": "triton",
-    "repo": "hashicorp/packer-plugin-triton",
-    "pluginTier": "community",
-    "version": "latest"
-  },
-  {
     "title": "UCloud",
     "path": "ucloud",
     "repo": "ucloud/packer-plugin-ucloud",
@@ -327,37 +127,10 @@
     "isHcpPackerReady": true
   },
   {
-    "title": "Vagrant",
-    "path": "vagrant",
-    "repo": "hashicorp/packer-plugin-vagrant",
-    "pluginTier": "official",
-    "version": "latest"
-  },
-  {
-    "title": "VirtualBox",
-    "path": "virtualbox",
-    "repo": "hashicorp/packer-plugin-virtualbox",
-    "pluginTier": "official",
-    "version": "latest"
-  },
-  {
     "title": "Volcengine",
     "path": "volcengine",
     "repo": "volcengine/packer-plugin-volcengine",
     "pluginTier": "community",
-    "version": "latest"
-  },
-  {
-    "title": "VMware vSphere",
-    "path": "vsphere",
-    "repo": "hashicorp/packer-plugin-vsphere",
-    "version": "latest",
-    "isHcpPackerReady": true
-  },
-  {
-    "title": "VMware",
-    "path": "vmware",
-    "repo": "hashicorp/packer-plugin-vmware",
     "version": "latest"
   },
   {
@@ -366,13 +139,6 @@
     "repo": "vultr/packer-plugin-vultr",
     "pluginTier": "community",
     "version": "latest"
-  },
-  {
-    "title": "Yandex",
-    "path": "yandex",
-    "repo": "hashicorp/packer-plugin-yandex",
-    "version": "latest",
-    "pluginTier": "community"
   },
   {
     "title": "Ksyun",


### PR DESCRIPTION
The active plugins that resided in a HashiCorp repository have been migrated to
the integrations framework and no longer need to be listed within the plugins-manifest file.
