### PR TITLE
init: warn if no requirements specified

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -66,6 +66,14 @@ func (c *InitCommand) RunContext(buildCtx context.Context, cla *InitArgs) int {
 		return ret
 	}
 
+	if len(reqs) == 0 {
+		c.Ui.Message(`
+No plugins requirement found, make sure you reference a Packer config
+containing a packer.required_plugins block. See
+https://www.packer.io/docs/templates/hcl_templates/blocks/packer
+for more info.`)
+	}
+
 	opts := plugingetter.ListInstallationsOptions{
 		FromFolders: c.Meta.CoreConfig.Components.PluginConfig.KnownPluginFolders,
 		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{


### PR DESCRIPTION
When users call `packer init` on a template that does not specify a `required_plugin` block, the command succeeds but does nothing, which is not helpful for users that may expect their plugins to install.

To remedy that problem, we now output a message like what `packer plugins required` does on templates without such a block, so that users have an idea of what to change in order to get the command to work.