### PR TITLE
.github: use squashed commit for backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,6 +24,7 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+          BACKPORT_MERGE_COMMIT: false
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to latest release branch
         run: |
@@ -42,6 +43,7 @@ jobs:
           backport-assistant backport -automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          BACKPORT_MERGE_COMMIT: false
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to targeted release branch
         run: |
@@ -50,3 +52,4 @@ jobs:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+\\.\\w+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          BACKPORT_MERGE_COMMIT: false


### PR DESCRIPTION
The current setting for applying backports from the main branch to a release branch attempts to pick commits one by one and merge them with a merge commit to the release branch.

This seldom causes an issue where the backport assistant picks-up every commit from the beginning of the release branch, and applies them through one big merge commit, on top of everything else that was already merged into the release branch.

To limit the times it happens, we change how the backport assistant behaves to only apply one squashed commit that contains the changes from the MR into the release branch.