### PR TITLE
command: remove unused FlagSetFlags enum

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -43,7 +43,7 @@ func (c *BuildCommand) Run(args []string) int {
 
 func (c *BuildCommand) ParseArgs(args []string) (*BuildArgs, int) {
 	var cfg BuildArgs
-	flags := c.Meta.FlagSet("build", FlagSetBuildFilter|FlagSetVars)
+	flags := c.Meta.FlagSet("build")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {

--- a/command/console.go
+++ b/command/console.go
@@ -43,7 +43,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 
 func (c *ConsoleCommand) ParseArgs(args []string) (*ConsoleArgs, int) {
 	var cfg ConsoleArgs
-	flags := c.Meta.FlagSet("console", FlagSetVars)
+	flags := c.Meta.FlagSet("console")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {

--- a/command/fix.go
+++ b/command/fix.go
@@ -36,7 +36,7 @@ func (c *FixCommand) Run(args []string) int {
 
 func (c *FixCommand) ParseArgs(args []string) (*FixArgs, int) {
 	var cfg FixArgs
-	flags := c.Meta.FlagSet("fix", FlagSetNone)
+	flags := c.Meta.FlagSet("fix")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {

--- a/command/fmt.go
+++ b/command/fmt.go
@@ -28,7 +28,7 @@ func (c *FormatCommand) Run(args []string) int {
 
 func (c *FormatCommand) ParseArgs(args []string) (*FormatArgs, int) {
 	var cfg FormatArgs
-	flags := c.Meta.FlagSet("format", FlagSetNone)
+	flags := c.Meta.FlagSet("format")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {

--- a/command/hcl2_upgrade.go
+++ b/command/hcl2_upgrade.go
@@ -47,7 +47,7 @@ func (c *HCL2UpgradeCommand) Run(args []string) int {
 
 func (c *HCL2UpgradeCommand) ParseArgs(args []string) (*HCL2UpgradeArgs, int) {
 	var cfg HCL2UpgradeArgs
-	flags := c.Meta.FlagSet("hcl2_upgrade", FlagSetNone)
+	flags := c.Meta.FlagSet("hcl2_upgrade")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {

--- a/command/init.go
+++ b/command/init.go
@@ -37,7 +37,7 @@ func (c *InitCommand) Run(args []string) int {
 
 func (c *InitCommand) ParseArgs(args []string) (*InitArgs, int) {
 	var cfg InitArgs
-	flags := c.Meta.FlagSet("init", 0)
+	flags := c.Meta.FlagSet("init")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {

--- a/command/inspect.go
+++ b/command/inspect.go
@@ -28,7 +28,7 @@ func (c *InspectCommand) Run(args []string) int {
 
 func (c *InspectCommand) ParseArgs(args []string) (*InspectArgs, int) {
 	var cfg InspectArgs
-	flags := c.Meta.FlagSet("inspect", FlagSetVars)
+	flags := c.Meta.FlagSet("inspect")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {

--- a/command/meta.go
+++ b/command/meta.go
@@ -22,16 +22,6 @@ import (
 	"github.com/hashicorp/packer/version"
 )
 
-// FlagSetFlags is an enum to define what flags are present in the
-// default FlagSet returned by Meta.FlagSet
-type FlagSetFlags uint
-
-const (
-	FlagSetNone        FlagSetFlags = 0
-	FlagSetBuildFilter FlagSetFlags = 1 << iota
-	FlagSetVars
-)
-
 // Meta contains the meta-options and functionality that nearly every
 // Packer command inherits.
 type Meta struct {
@@ -72,11 +62,8 @@ func (m *Meta) Core(tpl *template.Template, cla *MetaArgs) (*packer.Core, error)
 	return core, nil
 }
 
-// FlagSet returns a FlagSet with the common flags that every
-// command implements. The exact behavior of FlagSet can be configured
-// using the flags as the second parameter, for example to disable
-// build settings on the commands that don't handle builds.
-func (m *Meta) FlagSet(n string, _ FlagSetFlags) *flag.FlagSet {
+// FlagSet returns a FlagSet with Packer SDK Ui support built-in
+func (m *Meta) FlagSet(n string) *flag.FlagSet {
 	f := flag.NewFlagSet(n, flag.ContinueOnError)
 
 	// Create an io.Writer that writes to our Ui properly for errors.

--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -54,7 +54,7 @@ func (c *PluginsRequiredCommand) Run(args []string) int {
 
 func (c *PluginsRequiredCommand) ParseArgs(args []string) (*PluginsRequiredArgs, int) {
 	var cfg PluginsRequiredArgs
-	flags := c.Meta.FlagSet("plugins required", 0)
+	flags := c.Meta.FlagSet("plugins required")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {

--- a/command/validate.go
+++ b/command/validate.go
@@ -31,7 +31,7 @@ func (c *ValidateCommand) Run(args []string) int {
 func (c *ValidateCommand) ParseArgs(args []string) (*ValidateArgs, int) {
 	var cfg ValidateArgs
 
-	flags := c.Meta.FlagSet("validate", FlagSetBuildFilter|FlagSetVars)
+	flags := c.Meta.FlagSet("validate")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {


### PR DESCRIPTION
The enumeration for FlagSetFlags, which presumably was added when the Meta structure was introduced, aims to pre-populate the flagset for a subcommand with a series of arguments.

However, despite it being documented, it is actually not used, and therefore can safely be removed from the codebase.