### PR TITLE
command: add plugin-override opt to build/validate

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -87,7 +87,13 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 		return ret
 	}
 
-	diags := packerStarter.DetectPluginBinaries()
+	diags := packerStarter.DetectPluginBinaries(cla.getIgnoredPluginAccessors())
+	ret = writeDiags(c.Ui, nil, diags)
+	if ret != 0 {
+		return ret
+	}
+
+	diags = c.Meta.ProcessOverrides(&cla.MetaArgs)
 	ret = writeDiags(c.Ui, nil, diags)
 	if ret != 0 {
 		return ret
@@ -411,6 +417,7 @@ Options:
   -machine-readable             Produce machine-readable output.
   -on-error=[cleanup|abort|ask|run-cleanup-provisioner] If the build fails do: clean up (default), abort, ask, or run-cleanup-provisioner.
   -parallel-builds=1            Number of builds to run in parallel. 1 disables parallelization. 0 means no limit (Default: 0)
+  -plugin-override              Force loading a plugin from a binary. Format must be accessor=path (ex: -plugin-override "amazon=./path/to/plugin")
   -timestamp-ui                 Enable prefixing of each ui output with an RFC3339 timestamp.
   -var 'key=value'              Variable for templates, can be used multiple times.
   -var-file=path                JSON or HCL2 file containing user variables, can be used multiple times.

--- a/command/validate.go
+++ b/command/validate.go
@@ -65,7 +65,13 @@ func (c *ValidateCommand) RunContext(ctx context.Context, cla *ValidateArgs) int
 		return 0
 	}
 
-	diags := packerStarter.DetectPluginBinaries()
+	diags := packerStarter.DetectPluginBinaries(cla.getIgnoredPluginAccessors())
+	ret = writeDiags(c.Ui, nil, diags)
+	if ret != 0 {
+		return ret
+	}
+
+	diags = c.Meta.ProcessOverrides(&cla.MetaArgs)
 	ret = writeDiags(c.Ui, nil, diags)
 	if ret != 0 {
 		return ret
@@ -120,6 +126,7 @@ Options:
   -var-file=path                JSON or HCL2 file containing user variables, can be used multiple times.
   -no-warn-undeclared-var       Disable warnings for user variable files containing undeclared variables.
   -evaluate-datasources         Evaluate data sources during validation (HCL2 only, may incur costs); Defaults to false. 
+  -plugin-override              Force loading a plugin from a binary. Format must be accessor=path (ex: -plugin-override "amazon=./path/to/plugin")
 `
 
 	return strings.TrimSpace(helpText)

--- a/packer/core.go
+++ b/packer/core.go
@@ -134,7 +134,7 @@ func NewCore(c *CoreConfig) *Core {
 
 // DetectPluginBinaries is used to load required plugins from the template,
 // since it is unsupported in JSON, this is essentially a no-op.
-func (c *Core) DetectPluginBinaries() hcl.Diagnostics {
+func (c *Core) DetectPluginBinaries([]string) hcl.Diagnostics {
 	return nil
 }
 

--- a/packer/run_interfaces.go
+++ b/packer/run_interfaces.go
@@ -43,7 +43,7 @@ type InitializeOptions struct {
 type PluginBinaryDetector interface {
 	// DetectPluginBinaries is used only for HCL2 templates, and loads required
 	// plugins if specified.
-	DetectPluginBinaries() hcl.Diagnostics
+	DetectPluginBinaries(ignore []string) hcl.Diagnostics
 }
 
 // The Handler handles all Packer things. This interface reflects the Packer


### PR DESCRIPTION
The plugin-override flag aims to forcefully load a plugin by passing in its path, ignoring completely the plugins discovered before, or those in the required_plugins block.

NOTE: this is experimental and may never be merged into the main branch of Packer.