### PR TITLE
plugins: install SHA256SUM file with 0644 perms

### DIFF
--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -713,7 +713,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 							log.Printf("[WARNING] %v, ignoring", err)
 						}
 
-						if err := os.WriteFile(outputFileName+checksum.Checksummer.FileExt(), []byte(hex.EncodeToString(cs)), 0555); err != nil {
+						if err := os.WriteFile(outputFileName+checksum.Checksummer.FileExt(), []byte(hex.EncodeToString(cs)), 0644); err != nil {
 							err := fmt.Errorf("failed to write local binary checksum file: %s", err)
 							errs = multierror.Append(errs, err)
 							log.Printf("[WARNING] %v, ignoring", err)


### PR DESCRIPTION
When invoking `packer plugins install` to install a plugin, or `packer init`, the checksum file would be installed with 0555 permissions.

This led in turn to further attempts at installing the plugin will succeed, but the checksum file would not be updated, as it was marked non-writable by the owner of the file, leading potentially to a situation where the plugin binary and the checksum would be out-of-sync, but could not be updated unless the user changed it.

To avoid such a problem, we write the checksum file with 0644 permissions, so the owner can read/write, while the other users can only read it.