### PR TITLE
docs: amend HCL templates/functions docs

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/index.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/index.mdx
@@ -18,9 +18,9 @@ arguments in parentheses:
 max(5, 12, 9)
 ```
 
-For more details on syntax, see
-[_Function Calls_](/packer/docs/templates/hcl_templates/expressions#function-calls)
-on the Expressions page.
+For information on invoking functions in string literals, refer to the
+[String Literals](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/expressions#string-literals) section
+in the HCL2 expressions documentation.
 
 The HCL language does not support user-defined functions, and so only
 the functions built in to the language are available for use. The documentation includes all of the available built-in functions.


### PR DESCRIPTION
The HCL2 docs on built-in functions contains a link to a non-existent section of the expressions page, so we update it to link to the general page, and to the string interpolation section, since it is a common use case.

Closes: #12670 