### PR TITLE
Fix broken link to Consul's environment variables page

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/contextual/consul.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/consul.mdx
@@ -36,4 +36,4 @@ This will load the key stored at the path `myservice/version` from consul.
 
 The configuration for consul (address, tokens, ...) must be specified as
 environment variables, as specified in the
-[Documentation](/consul/docs/commands#environment-variables).
+[Documentation](/consul/commands#environment-variables).


### PR DESCRIPTION
Fixes broken link to Consul environment variable documentation - [Preview](https://packer-git-fix-consul-env-variable-link-hashicorp.vercel.app/packer/docs/templates/hcl_templates/functions/contextual/consul)

Closes #12659

