### PR TITLE
docs: fix aws_secretsmanager Title Name

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/contextual/aws_secretsmanager.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/contextual/aws_secretsmanager.mdx
@@ -5,7 +5,7 @@ description: >-
   stores.
 ---
 
-# `aws_secretsmanager_key` Function
+# `aws_secretsmanager` Function
 
 Secrets can be read from the [AWS Secrets
 Manager](https://aws.amazon.com/secrets-manager/) and used within your template


### PR DESCRIPTION
Just a simple doc title fix.

