### PR TITLE
scripts/prepare_changelog: Replace python for with gh and jq commands

### DIFF
--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -4,78 +4,52 @@
 
 
 LAST_RELEASE=$1
-DO_PR_CHECK=1
 
 set -o pipefail
-
-is_doc_or_tech_debt_pr(){
-    if ! (($+commands[jq])); then
-        DO_PR_CHECK=0
-        echo "jq not found"
-        return 1
-    fi
-    out=$(python3 -m json.tool < pull.json  \
-    | jq '[.labels[].name == "docs" or .labels[].name == "tech-debt" or .labels[].name == "website"] | any')
-    grep -q true <<< $out
-    return $?
-}
 
 if [ -z $LAST_RELEASE ]; then
     echo "you need to give the previous release version. prepare_changelog.sh v<version>"
     exit 1
 fi
 
+if [ -z "$(which jq)" ]; then
+    echo "jq command not found"
+    return 1
+fi
+
+if [ -z "$(which jq)" ]; then
+    echo "gh command not found"
+    return 1
+fi
+
 get_prs(){
-    # git log v0.10.2...c3861d167533fb797b0fae0c380806625712e5f7 |
-    git log HEAD...${LAST_RELEASE} --first-parent --oneline --grep="Merge pull request #[0-9]\+" --grep="(#[0-9]\+)$" |
-    grep -o "#\([0-9]\+\)" | awk -F\# '{print $2}' | while read line
+   release_time="$(gh release view --json "createdAt" --jq '.createdAt' ${LAST_RELEASE})"
+   gh pr list -s merged -S "merged:>=$release_time -label:documentation -label:automated -label:tech-debt -label:website -label:legal -label:docs -author:hc-github-team-packer" --json "number" --jq '.[]|.number' \
+   | while read line
     do
-        grep -q "GH-${line}" CHANGELOG.md
-        if [ $? -ne 0 ]; then
+        if grep -q "GH-${line}" CHANGELOG.md; then
             echo $line
         fi
     done | while read PR_NUM
     do
-        if [[ -z "${GITHUB_TOKEN}" ]] || [[ -z "${GITHUB_USERNAME}" ]] ; then
-          out=$(curl -fsS "https://api.github.com/repos/hashicorp/packer/issues/${PR_NUM}" -o pull.json)
-        else
-          # authenticated call
-          out=$(curl -u ${GITHUB_USERNAME}:${GITHUB_TOKEN} -fsS "https://api.github.com/repos/hashicorp/packer/issues/${PR_NUM}" -o pull.json)
-        fi
-        exy="$?"
-        if [ $exy -ne 0 ]; then
+        out=$(gh pr view ${PR_NUM} --json "title,labels,url" > pull.json)
+        if [ "$?" -ne 0 ]; then
             echo "bad response from github: manually check PR ${PR_NUM}"
             continue
         fi
 
-        if (($DO_PR_CHECK)) && is_doc_or_tech_debt_pr; then
-            echo "Skipping PR ${PR_NUM}: labeled as tech debt, docs or website. (waiting a second so we don't get rate-limited...)"
-            continue
-        fi
-        echo "$(python3 -m json.tool < pull.json | jq -r '.title') - [GH-${PR_NUM}](https://github.com/hashicorp/packer/pull/${PR_NUM})"
+        echo "$(jq -r '.title' < pull.json) - [GH-${PR_NUM}](https://github.com/hashicorp/packer/pull/${PR_NUM})"
+        rm -f pull.json
     done
 }
-
-#is_doc_or_tech_debt_pr 52061111
-# is_doc_or_tech_debt_pr 5206 # non-doc pr
-#is_doc_or_tech_debt_pr 5434 # doc pr
-#echo $?
-#exit
-
-# prpid=$!
-# trap 'kill -9 ${prpid}; exit' INT TERM
 
 get_prs | while read line; do
     echo $line
     if [[ "$line" =~ "bad" ]]; then
         exit 1
-    elif [[ "$line" =~ "Skipping" ]]; then
-        sleep 1 # GH will rate limit us if we have several in a row
-        continue
     fi
-    rm -f pull.json
+    echo "Press enter to continue with next entry.."
     vared -ch ok
 done
-
 
 #TODO: just generate it automatically using PR titles and tags


### PR DESCRIPTION
This change uses the GitHub CLI to obtain all pull-requests merged after the latest release to help with updating the Packer CHANGELOG.

```
~>  ./scripts/prepare_changelog.sh v1.9.4
Update LICENSE text - [GH-12686](https://github.com/hashicorp/packer/pull/12686)

docs: amend HCL templates/functions docs - [GH-12672](https://github.com/hashicorp/packer/pull/12672)

build(deps-dev): bump @babel/traverse from 7.17.9 to 7.23.2 in /website - [GH-12658](https://github.com/hashicorp/packer/pull/12658)

init: warn if no requirements specified - [GH-12638](https://github.com/hashicorp/packer/pull/12638)

hcl2template: remove value validation for locals - [GH-12620](https://github.com/hashicorp/packer/pull/12620)

Updating Community Tools webpage - [GH-12612](https://github.com/hashicorp/packer/pull/12612)

Datasource logic cleanup - [GH-12608](https://github.com/hashicorp/packer/pull/12608)

version: prepare v1.9.5-dev - [GH-12602](https://github.com/hashicorp/packer/pull/12602)

Changelog setup 1.9.5 - [GH-12601](https://github.com/hashicorp/packer/pull/12601)

Update version output for `-v` and `--version` flags - [GH-12569](https://github.com/hashicorp/packer/pull/12569)
```
