### PR TITLE
Fix panic in acceptance test due to nil BuilderSet

### DIFF
--- a/acctest/testing.go
+++ b/acctest/testing.go
@@ -136,6 +136,9 @@ func Test(t TestT, c TestCase) {
 		Components: packer.ComponentFinder{
 			PluginConfig: &packer.PluginConfig{
 				Builders: TestBuilderSet{
+					BuilderSet: packersdk.MapOfBuilder{
+						"test": func() (packersdk.Builder, error) { return c.Builder, nil },
+					},
 					StartFn: func(n string) (packersdk.Builder, error) {
 						if n == "test" {
 							return c.Builder, nil

--- a/packer/core.go
+++ b/packer/core.go
@@ -229,7 +229,7 @@ func (c *Core) generateCoreBuildProvisioner(rawP *template.Provisioner, rawName 
 			strings.Split(rawP.Type, "-")[0],
 		)
 
-		if sugg := didyoumean.NameSuggestion(rawP.Type, c.components.PluginConfig.Builders.List()); sugg != "" {
+		if sugg := didyoumean.NameSuggestion(rawP.Type, c.components.PluginConfig.Provisioners.List()); sugg != "" {
 			err = fmt.Errorf("Did you mean to use %q?", sugg)
 		}
 


### PR DESCRIPTION
- Update Acceptance Test to include BuilderSet
- Update didyoumean to call provisioners.List()


Acceptance Test Results
```
....
--- PASS: TestProvisionerPrepare_Config (0.00s)
=== RUN   TestProvisionerPrepare_InvalidKey
--- PASS: TestProvisionerPrepare_InvalidKey (0.00s)
=== RUN   TestProvisionerPrepare_Script
--- PASS: TestProvisionerPrepare_Script (0.00s)
=== RUN   TestProvisionerPrepare_ScriptAndInline
--- PASS: TestProvisionerPrepare_ScriptAndInline (0.00s)
=== RUN   TestProvisionerPrepare_ScriptAndScripts
--- PASS: TestProvisionerPrepare_ScriptAndScripts (0.00s)
=== RUN   TestProvisionerPrepare_Scripts
--- PASS: TestProvisionerPrepare_Scripts (0.00s)
=== RUN   TestProvisionerPrepare_EnvironmentVars
--- PASS: TestProvisionerPrepare_EnvironmentVars (0.00s)
=== RUN   TestProvisionerQuote_EnvironmentVars
--- PASS: TestProvisionerQuote_EnvironmentVars (0.00s)
=== RUN   TestProvisionerProvision_Inline
2023/11/22 21:15:58 ui: Provisioning with windows-shell...
2023/11/22 21:15:58 Found command: whoami
2023/11/22 21:15:58 ui: Provisioning with shell script: /var/folders/jd/zhl6kpsn1156cmqdyttt22xm0000gp/T/windows-shell-provisioner1869498396
2023/11/22 21:15:58 Opening /var/folders/jd/zhl6kpsn1156cmqdyttt22xm0000gp/T/windows-shell-provisioner1869498396 for reading
2023/11/22 21:15:58 ui: Provisioning with windows-shell...
2023/11/22 21:15:58 Found command: whoami
2023/11/22 21:15:58 ui: Provisioning with shell script: /var/folders/jd/zhl6kpsn1156cmqdyttt22xm0000gp/T/windows-shell-provisioner1055042501
2023/11/22 21:15:58 Opening /var/folders/jd/zhl6kpsn1156cmqdyttt22xm0000gp/T/windows-shell-provisioner1055042501 for reading
--- PASS: TestProvisionerProvision_Inline (0.00s)
=== RUN   TestProvisionerProvision_Scripts
2023/11/22 21:15:58 ui: Provisioning with windows-shell...
2023/11/22 21:15:58 ui: Provisioning with shell script: /var/folders/jd/zhl6kpsn1156cmqdyttt22xm0000gp/T/packer794804095
2023/11/22 21:15:58 Opening /var/folders/jd/zhl6kpsn1156cmqdyttt22xm0000gp/T/packer794804095 for reading
--- PASS: TestProvisionerProvision_Scripts (0.00s)
=== RUN   TestProvisionerProvision_ScriptsWithEnvVars
2023/11/22 21:15:58 ui: Provisioning with windows-shell...
2023/11/22 21:15:58 ui: Provisioning with shell script: /var/folders/jd/zhl6kpsn1156cmqdyttt22xm0000gp/T/packer1537855323
2023/11/22 21:15:58 Opening /var/folders/jd/zhl6kpsn1156cmqdyttt22xm0000gp/T/packer1537855323 for reading
--- PASS: TestProvisionerProvision_ScriptsWithEnvVars (0.00s)
=== RUN   TestProvisioner_createFlattenedEnvVars_windows
--- PASS: TestProvisioner_createFlattenedEnvVars_windows (0.00s)
=== RUN   TestCancel
--- PASS: TestCancel (0.00s)
PASS
```