### PR TITLE
hcl2: don't show an empty source on var errors

### DIFF
--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -741,7 +741,6 @@ func (cfg *PackerConfig) collectInputVariableValues(env []string, files []*hcl.F
 					Severity: hcl.DiagError,
 					Summary:  "Invalid argument value for -var variable",
 					Detail:   fmt.Sprintf("The received arg value for %s is not compatible with the variable's type constraint: %s.", name, err),
-					Subject:  expr.Range().Ptr(),
 				})
 				val = cty.DynamicVal
 			}


### PR DESCRIPTION
If a variable is defined and overriden in the packer command-line, but there's a problem during the evaluation of this override (type error typically), we show an error message which details the problem.

This message points to a temporary in-memory HCL2 "file" that we use for parsing and evaluating the expression for the variable, but since it's virtual, there's no point in using this as the source for the error, as it will always yield "line 0" and no contents.

So, in order to limit confusion here, we remove the source for this error message.