### PR TITLE
Add VirtualBox as known plugin prefix

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -268,6 +268,7 @@ var knownPluginPrefixes = map[string]string{
 	"googlecompute": "github.com/hashicorp/googlecompute",
 	"qemu":          "github.com/hashicorp/qemu",
 	"vagrant":       "github.com/hashicorp/vagrant",
+	"virtualbox":    "github.com/hashicorp/virtualbox",
 	"vmware":        "github.com/hashicorp/vmware",
 	"vsphere":       "github.com/hashicorp/vsphere",
 }


### PR DESCRIPTION
It was found in https://github.com/hashicorp/packer/issues/12715 that the bundled version of the
Virtualbox plugin was not included in the bundled plugin warning. This miss lead to a user consistently
receiving warning even when addressing the reported warning.
