### PR TITLE
Update spacing for flags within Help text

### DIFF
--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -49,12 +49,12 @@ Usage: packer plugins install [OPTIONS...] <plugin> [<version constraint>]
       packer plugins install --path ./packer-plugin-happycloud "github.com/hashicorp/happycloud"
 
 Options:
-  - path <path>: install the plugin from a locally-sourced plugin binary. This
-                 installs the plugin where a normal invocation would, but will
-                 not try to download it from a remote location, and instead
-                 install the binary in the Packer plugins path.
-	         This option cannot be specified with a version constraint.
-  - force:       forces reinstallation of plugins, even if already installed.
+  -path <path>                  Install the plugin from a locally-sourced plugin binary. 
+                                This installs the plugin where a normal invocation would, but will 
+                                not try to download it from a remote location, and instead
+                                install the binary in the Packer plugins path. This option cannot 
+                                be specified with a version constraint.
+  -force                        Forces reinstallation of plugins, even if already installed.
 `
 
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
Before Change
```

Options:
  - path <path>: install the plugin from a locally-sourced plugin binary. This
                 installs the plugin where a normal invocation would, but will
                 not try to download it from a remote location, and instead
                 install the binary in the Packer plugins path.
                 This option cannot be specified with a version constraint.
  - force:       forces reinstallation of plugins, even if already installed.

```

After Change
```
Options:
  -path <path>                  Install the plugin from a locally-sourced plugin binary.
                                This installs the plugin where a normal invocation would, but will
                                not try to download it from a remote location, and instead
                                install the binary in the Packer plugins path. This option cannot
                                be specified with a version constraint.
  -force                        Forces reinstallation of plugins, even if already installed.
```
