### PR TITLE
[DO NOT MERGE UNTIL EOY] EOY license updates

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,6 +1,6 @@
 project {
   license = "BUSL-1.1"
-  copyright_year = 2023
+  copyright_year = 2024
   header_ignore = [
     "*.hcl2spec.go", # generated code specs, since they'll be wiped out until we support adding the headers at generation-time
     "hcl2template/testdata/**",

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             HashiCorp, Inc.
-Licensed Work:        Packer Version 1.10.0 or later. The Licensed Work is (c) 2023
+Licensed Work:        Packer Version 1.10.0 or later. The Licensed Work is (c) 2024
                       HashiCorp, Inc.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third


### PR DESCRIPTION
DO NOT MERGE UNTIL EOY 2023

Updates text in license and copywrite bot files for 2024.

Do not backport; release branches will be addressed individually. 