### PR TITLE
[DO NOT MERGE UNTIL EOY] EOY license fixes v.1.10.x

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,6 +1,6 @@
 project {
   license = "BUSL-1.1"
-  copyright_year = 2023
+  copyright_year = 2024
   header_ignore = [
     "*.hcl2spec.go", # generated code specs, since they'll be wiped out until we support adding the headers at generation-time
     "hcl2template/testdata/**",

--- a/LICENSE
+++ b/LICENSE
@@ -1,32 +1,33 @@
 License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB Corporation Ab.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
 Parameters
 
 Licensor:             HashiCorp, Inc.
-Licensed Work:        Packer 1.10.0. The Licensed Work is (c) 2023 HashiCorp, Inc.
+Licensed Work:        Packer Version 1.10.0 or later. The Licensed Work is (c) 2024
+                      HashiCorp, Inc.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third
                       parties on a hosted or embedded basis in order to compete with 
-                      HashiCorp’s paid version(s) of the Licensed Work. For purposes 
+                      HashiCorp's paid version(s) of the Licensed Work. For purposes 
                       of this license:
 
-                      A “competitive offering” is a Product that is offered to third
+                      A "competitive offering" is a Product that is offered to third
                       parties on a paid basis, including through paid support 
                       arrangements, that significantly overlaps with the capabilities 
-                      of HashiCorp’s paid version(s) of the Licensed Work. If Your 
+                      of HashiCorp's paid version(s) of the Licensed Work. If Your 
                       Product is not a competitive offering when You first make it 
                       generally available, it will not become a competitive offering
                       later due to HashiCorp releasing a new version of the Licensed 
                       Work with additional capabilities. In addition, Products that 
                       are not provided on a paid basis are not competitive.
 
-                      “Product” means software that is offered to end users to manage 
+                      "Product" means software that is offered to end users to manage 
                       in their own environments or offered as a service on a hosted 
                       basis.
 
-                      “Embedded” means including the source code or executable code 
-                      from the Licensed Work in a competitive offering. “Embedded” 
+                      "Embedded" means including the source code or executable code 
+                      from the Licensed Work in a competitive offering. "Embedded" 
                       also means packaging the competitive offering in such a way 
                       that the Licensed Work must be accessed or downloaded for the 
                       competitive offering to operate.
@@ -85,7 +86,7 @@ Licensor or its affiliates (provided that you may use a trademark or logo of
 Licensor as expressly required by this License).
 
 TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
-AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
 EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
 TITLE.


### PR DESCRIPTION

DO NOT MERGE UNTIL EOY 2023

Updates text in license and copywrite bot files for 2024.

Updates text of LICENSE file to be ASCII compliant.
