### PR TITLE
Enable FIPS-140 builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -138,6 +138,15 @@ ${GOX:?command not found} \
     -output "pkg/{{.OS}}_{{.Arch}}/packer" \
     .
 
+CGO_ENABLED=1 GOEXPERIMENT=boringcrypto ${GOX:?command not found} \
+    -os="${XC_OS:-$ALL_XC_OS}" \
+    -arch="${XC_ARCH:-$ALL_XC_ARCH}" \
+    -osarch="${SKIPPED_OSARCH}" \
+    -ldflags "${GOLDFLAGS}" \
+    -tags="fips" \
+    -output "pkg/{{.OS}}_{{.Arch}}_fips/packer" \
+    .
+
 # trim GOPATH to first element
 IFS="${PATHSEP}"
 # FIXME: How do you know that the first path of GOPATH is the main GOPATH? Or is the main GOPATH meant to be the first path in GOPATH?

--- a/version/fips_bulld.go
+++ b/version/fips_bulld.go
@@ -1,0 +1,27 @@
+//go:build fips
+
+package version
+
+// This validates during compilation that we are being built with a FIPS enabled go toolchain
+import (
+	_ "crypto/tls/fipsonly"
+	"runtime"
+	"strings"
+)
+
+// IsFIPS returns true if consul-k8s is operating in FIPS-140-2 mode.
+func IsFIPS() bool {
+	return true
+}
+
+func GetFIPSInfo() string {
+	str := "Enabled"
+	// Try to get the crypto module name
+	gover := strings.Split(runtime.Version(), "X:")
+	if len(gover) >= 2 {
+		gover_last := gover[len(gover)-1]
+		// Able to find crypto module name; add that to status string.
+		str = "FIPS 140-2 Enabled, crypto module " + gover_last
+	}
+	return str
+}

--- a/version/non_fips_build.go
+++ b/version/non_fips_build.go
@@ -1,0 +1,12 @@
+//go:build !fips
+
+package version
+
+// IsFIPS returns true if consul-k8s is operating in FIPS-140-2 mode.
+func IsFIPS() bool {
+	return false
+}
+
+func GetFIPSInfo() string {
+	return ""
+}

--- a/version/version.go
+++ b/version/version.go
@@ -45,6 +45,10 @@ func FormattedVersion() string {
 var SemVer *version.Version
 
 func init() {
+	if IsFIPS() {
+		Version += "+fips1402"
+	}
+
 	PackerVersion = pluginVersion.InitializePluginVersion(Version, VersionPrerelease)
 	SemVer = PackerVersion.SemVer()
 }


### PR DESCRIPTION
It would be useful if packer is FIPS-140 compliant so that it can be used in US GOV environments.

This pull request is inspired from similar work done in: [hashicorp/consul-k8s](https://github.com/hashicorp/consul-k8s/pull/2165)

I only tested locally on darwn arm64 m1: `make release` which successful compiled.