### PR TITLE
Fix Typo `make check-generate` -> `make generate-check`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -274,7 +274,7 @@ does not attempt to track the latest version for each dependency.
 Packer relies on `go generate` to generate a [peg parser for boot
 commands](https://github.com/hashicorp/packer/blob/master/packer-plugin-sdk/bootcommand/boot_command.go),
 [docs](https://github.com/hashicorp/packer/blob/master/website/pages/partials/builder/amazon/chroot/_Config-not-required.mdx)
-and HCL2's bridging code. Packer's testing suite will run `make check-generate`
+and HCL2's bridging code. Packer's testing suite will run `make generate-check`
 to check that all the generated files Packer needs are what they should be.
 `make generate` re-generates all these file and can take a while depending on
 your machine's performances. To make it faster it is recommended to run


### PR DESCRIPTION

- `make check-generate` -> `make generate-check`
  - Fixes a minor typo, words were reversed from the actual command in the Makefile