### PR TITLE
Pin UpCloud plugin version

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -93,7 +93,7 @@
     "title": "UpCloud",
     "path": "upcloud",
     "repo": "UpCloudLtd/packer-plugin-upcloud",
-    "version": "latest",
+    "version": "v1.5.2",
     "pluginTier": "verified",
     "sourceBranch": "master",
     "isHcpPackerReady": true


### PR DESCRIPTION
It looks like the 1.5.3 release of [packer-plugin-upcloud](https://github.com/UpCloudLtd/packer-plugin-upcloud) does not have the `docs.zip` file, which our docs build process relies on. This PR pins it to the latest version to 1.5.2 in the mean time.