### PR TITLE
Website: pin UpCloud plugin version to 1.5.2

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -93,9 +93,9 @@
     "title": "UpCloud",
     "path": "upcloud",
     "repo": "UpCloudLtd/packer-plugin-upcloud",
-    "version": "latest",
+    "version": "v1.5.2",
     "pluginTier": "verified",
-    "sourceBranch": "master",
+    "sourceBranch": "main",
     "isHcpPackerReady": true
   },
   {


### PR DESCRIPTION
This PR is to deploy the changes from [this PR](https://github.com/hashicorp/packer/pull/12767) to dev portal.

Comment from original PR: It looks like the 1.5.3 release of [packer-plugin-upcloud](https://github.com/UpCloudLtd/packer-plugin-upcloud) does not have the docs.zip file, which our docs build process relies on. This PR pins it to the latest version to 1.5.2 in the mean time.