### PR TITLE
website: remove UpCloud from manifest

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -90,15 +90,6 @@
     "pluginTier": "community"
   },
   {
-    "title": "UpCloud",
-    "path": "upcloud",
-    "repo": "UpCloudLtd/packer-plugin-upcloud",
-    "version": "v1.5.2",
-    "pluginTier": "verified",
-    "sourceBranch": "master",
-    "isHcpPackerReady": true
-  },
-  {
     "title": "Volcengine",
     "path": "volcengine",
     "repo": "volcengine/packer-plugin-volcengine",


### PR DESCRIPTION
Since the UpCloud plugin has moved to the integrations model, we don't want to continue looking for a docs.zip in their repo, as it doesn't exist anymore with this migration.