### PR TITLE
Remove migrated integrations from plugin manifest

### DIFF
--- a/website/data/plugins-manifest.json
+++ b/website/data/plugins-manifest.json
@@ -53,13 +53,6 @@
     "version": "latest"
   },
   {
-    "title": "Mondoo",
-    "path": "mondoo",
-    "repo": "mondoohq/packer-plugin-mondoo",
-    "pluginTier": "verified",
-    "version": "latest"
-  },
-  {
     "title": "Nutanix",
     "path": "nutanix",
     "repo": "nutanix-cloud-native/packer-plugin-nutanix",
@@ -74,13 +67,6 @@
     "version": "latest",
     "pluginTier": "verified",
     "isHcpPackerReady": true
-  },
-  {
-    "title": "Scaleway",
-    "path": "scaleway",
-    "repo": "scaleway/packer-plugin-scaleway",
-    "pluginTier": "verified",
-    "version": "latest"
   },
   {
     "title": "UCloud",


### PR DESCRIPTION
This change removes Scaleway and Mondoo from the external plugins manifest in favor
of the integration framework, which they have migrated to.
