### PR TITLE
website: fix husky command 

### DIFF
--- a/website/.husky/pre-commit
+++ b/website/.husky/pre-commit
@@ -1,1 +1,3 @@
-next-hashicorp precommit
+cd website
+
+npx next-hashicorp precommit

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,6 @@
       "devDependencies": {
         "@hashicorp/platform-cli": "^2.7.3",
         "@hashicorp/platform-content-conformance": "^0.0.12",
-        "husky": "^9.0.6",
         "next": "^14.0.4",
         "prettier": "^3.2.4"
       },
@@ -6075,21 +6074,6 @@
       "peer": true,
       "engines": {
         "node": ">=8.12.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.6.tgz",
-      "integrity": "sha512-EEuw/rfTiMjOfuL7pGO/i9otg1u36TXxqjIA6D9qxVjd/UXoDOsLor/BSFf5hTK50shwzCU3aVVwdXDp/lp7RA==",
-      "dev": true,
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -18544,12 +18528,6 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true,
       "peer": true
-    },
-    "husky": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.6.tgz",
-      "integrity": "sha512-EEuw/rfTiMjOfuL7pGO/i9otg1u36TXxqjIA6D9qxVjd/UXoDOsLor/BSFf5hTK50shwzCU3aVVwdXDp/lp7RA==",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,8 @@
       "devDependencies": {
         "@hashicorp/platform-cli": "^2.7.3",
         "@hashicorp/platform-content-conformance": "^0.0.12",
+        "dart-linkcheck": "^2.0.15",
+        "husky": "^9.0.7",
         "next": "^14.0.4",
         "prettier": "^3.2.4"
       },
@@ -3653,6 +3655,17 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
+    "node_modules/dart-linkcheck": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/dart-linkcheck/-/dart-linkcheck-2.0.15.tgz",
+      "integrity": "sha512-ZMvxkAyEpBTvBFk+DPjcK0ObNy8GM4gmrGG1qIu0EXb/zj25vjRWNnhLHKZw4JlOLo02oWlwDeqo98GuBlJcIg==",
+      "dev": true,
+      "bin": {
+        "linkcheck": "bin/linkcheck",
+        "linkcheck-linux": "bin/linkcheck-linux",
+        "linkcheck-win": "bin/linkcheck-win"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -6074,6 +6087,21 @@
       "peer": true,
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.7.tgz",
+      "integrity": "sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -16656,6 +16684,12 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
+    "dart-linkcheck": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/dart-linkcheck/-/dart-linkcheck-2.0.15.tgz",
+      "integrity": "sha512-ZMvxkAyEpBTvBFk+DPjcK0ObNy8GM4gmrGG1qIu0EXb/zj25vjRWNnhLHKZw4JlOLo02oWlwDeqo98GuBlJcIg==",
+      "dev": true
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -18528,6 +18562,12 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true,
       "peer": true
+    },
+    "husky": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.7.tgz",
+      "integrity": "sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@hashicorp/platform-cli": "^2.7.3",
     "@hashicorp/platform-content-conformance": "^0.0.12",
-    "husky": "^9.0.6",
     "next": "^14.0.4",
     "prettier": "^3.2.4"
   },
@@ -14,7 +13,7 @@
   "scripts": {
     "build": "./scripts/website-build.sh",
     "format": "next-hashicorp format",
-    "prepare": "husky",
+    "prepare": "cd .. && husky website/.husky",
     "lint": "next-hashicorp lint",
     "start": "./scripts/website-start.sh",
     "linkcheck": "linkcheck https://packer.io",

--- a/website/package.json
+++ b/website/package.json
@@ -6,6 +6,8 @@
   "devDependencies": {
     "@hashicorp/platform-cli": "^2.7.3",
     "@hashicorp/platform-content-conformance": "^0.0.12",
+    "dart-linkcheck": "^2.0.15",
+    "husky": "^9.0.7",
     "next": "^14.0.4",
     "prettier": "^3.2.4"
   },
@@ -13,11 +15,11 @@
   "scripts": {
     "build": "./scripts/website-build.sh",
     "format": "next-hashicorp format",
-    "prepare": "cd .. && husky website/.husky",
     "lint": "next-hashicorp lint",
     "start": "./scripts/website-start.sh",
     "linkcheck": "linkcheck https://packer.io",
-    "content-check": "hc-content --config base-docs"
+    "content-check": "hc-content --config base-docs",
+    "prepare": "cd .. && husky website/.husky"
   },
   "engines": {
     "npm": ">=9.6.7"


### PR DESCRIPTION
### Description

In [another PR](https://github.com/hashicorp/packer/pull/12809) the husky pre-commit hook was changed to match the v9 specs, but `website` being a sub-directory of the root directory containing `.git` was not accounted for. This PR changes the pre-commit hook and script to account for `website` being a sub-directory of the directory containg `.git`, and ensures the pre-commit hook runs as expected. ([Husky doc here](https://typicode.github.io/husky/how-to.html#project-not-in-git-root-directory)).

This PR also adds back in the `dart-linkcheck` package needed for the `linkcheck` script.

### Testing

1. cd into `website/`
2. Run `npm install`
3. Make changes to a file in `website/`
4. Run `git commit -m "<your commit message>"`
5. You should see something like this in your terminal:
```
➜ git commit -m "Fixed typos in website readme"          
✔ Preparing...
✔ Running tasks...
✔ Applying modifications...
✔ Cleaning up...
[<branch name> c06b34955] Fixed typos in website readme
 1 file changed, 2 insertions(+), 2 deletions(-)
 ```