### PR TITLE
packer: always reject plugin pre-releases

### DIFF
--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -159,6 +159,11 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 			continue
 		}
 
+		if pv.Prerelease() != "" {
+			log.Printf("pre-release version of plugin %q discovered: unsupported, ignoring", path)
+			continue
+		}
+
 		if strings.Replace(pluginVersionStr, "v", "", -1) != describeInfo.Version {
 			log.Printf("plugin %q reported version %s while its name implies version %s, ignoring", path, describeInfo.Version, pluginVersionStr)
 			continue


### PR DESCRIPTION
When a pre-release version of a plugin is locally installed, it may or may not be loaded depending on the constraints expressed in the template being executed.

If the template contains constraints for loading the plugin, it would be ignored, while if that wasn't present, it would be loaded.

This is inconsistent, and deserves to be addressed, which is what this commit does.

With this change, plugin pre-releases are now always rejected with a message in the verbose logs, so only releases are considered, whether or not the template being processed contains a `required_plugins` constraint or not.

Note: based on top of #12787 for readability