### PR TITLE
Update Terminology Docs With New HCP Packer Nomenclature

### DIFF
--- a/website/content/docs/terminology.mdx
+++ b/website/content/docs/terminology.mdx
@@ -28,7 +28,7 @@ for quick referencing.
   artifact is a set of AMI IDs (one per region). For the VMware builder, the
   artifact is a directory of files comprising the created virtual machine.
 
-- `Builds` are a single task that eventually produces an image for a single
+- `Builds` are a single task that eventually produces an artifact for a single
   platform. Multiple builds run in parallel. Example usage in a sentence:
   "The Packer build produced an AMI to run our web application." Or: "Packer
   is running the builds now for VMware, AWS, and VirtualBox."
@@ -36,7 +36,7 @@ for quick referencing.
 - `Builders` are components of Packer that are able to create a machine image
   for a single platform. Builders read in some configuration and use that to
   run and generate a machine image. A builder is invoked as part of a build
-  in order to create the actual resulting images. Example builders include
+  in order to create the actual resulting artifacts. Example builders include
   VirtualBox, VMware, and Amazon EC2.
 
 - `Commands` are sub-commands for the `packer` program that perform some job.
@@ -55,7 +55,7 @@ for quick referencing.
 
 - `Provisioners` are components of Packer that install and configure software
   within a running machine prior to that machine being turned into a static
-  image. They perform the major work of making the image contain useful
+  artifact. They perform the major work of making the artifact contain useful
   software. Example provisioners include shell scripts, Chef, Puppet, etc.
 
 - `Templates` are either [HCL](https://packer.io/templates/hcl_templates) or JSON files which


### PR DESCRIPTION
Image should be artifact except when referring to machine images