### PR TITLE
Replace build interface uses

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -162,7 +162,7 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 		packer.UiColorYellow,
 		packer.UiColorBlue,
 	}
-	buildUis := make(map[packersdk.Build]packersdk.Ui)
+	buildUis := make(map[*packer.CoreBuild]packersdk.Ui)
 	for i := range builds {
 		ui := c.Ui
 		if cla.Color {

--- a/hcl2template/common_test.go
+++ b/hcl2template/common_test.go
@@ -72,7 +72,7 @@ type parseTest struct {
 	parseWantDiags         bool
 	parseWantDiagHasErrors bool
 
-	getBuildsWantBuilds []packersdk.Build
+	getBuildsWantBuilds []*packer.CoreBuild
 	getBuildsWantDiags  bool
 	// getBuildsWantDiagHasErrors bool
 }

--- a/hcl2template/types.build.hcp_packer_registry_test.go
+++ b/hcl2template/types.build.hcp_packer_registry_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/builder/null"
 	"github.com/hashicorp/packer/packer"
 	"github.com/zclconf/go-cty/cty"
@@ -48,7 +47,7 @@ func Test_ParseHCPPackerRegistryBlock(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					BuildName:      "bucket-slug",
 					Type:           "null.test",
@@ -91,7 +90,7 @@ func Test_ParseHCPPackerRegistryBlock(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "virtualbox-iso.ubuntu-1204",
 					Prepared:       true,
@@ -145,7 +144,7 @@ func Test_ParseHCPPackerRegistryBlock(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "virtualbox-iso.ubuntu-1204",
 					Prepared:       true,
@@ -276,7 +275,7 @@ func Test_ParseHCPPackerRegistryBlock(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					BuildName:      "bucket-slug",
 					Type:           "null.test",

--- a/hcl2template/types.build_test.go
+++ b/hcl2template/types.build_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	. "github.com/hashicorp/packer/hcl2template/internal"
 	"github.com/hashicorp/packer/packer"
 	"github.com/zclconf/go-cty/cty"
@@ -55,7 +54,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			true,
 		},
 		{"untyped provisioner",
@@ -104,7 +103,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{&packer.CoreBuild{
+			[]*packer.CoreBuild{&packer.CoreBuild{
 				Provisioners: []packer.CoreBuildProvisioner{},
 			}},
 			false,
@@ -120,7 +119,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{&packer.CoreBuild{
+			[]*packer.CoreBuild{&packer.CoreBuild{
 				Builder: emptyMockBuilder,
 				CleanupProvisioner: packer.CoreBuildProvisioner{
 					PType: "shell-local",
@@ -145,7 +144,7 @@ func TestParse_build(t *testing.T) {
 				Builds:                  nil,
 			},
 			true, true,
-			[]packersdk.Build{&packer.CoreBuild{}},
+			[]*packer.CoreBuild{&packer.CoreBuild{}},
 			false,
 		},
 		{"nonexistent post-processor",
@@ -184,7 +183,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{&packer.CoreBuild{
+			[]*packer.CoreBuild{&packer.CoreBuild{
 				PostProcessors: [][]packer.CoreBuildPostProcessor{},
 			}},
 			true,
@@ -198,7 +197,7 @@ func TestParse_build(t *testing.T) {
 				Builds:                  nil,
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"named build",
@@ -225,7 +224,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			true,
 		},
 		{"post-processor with only and except",
@@ -280,7 +279,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:         "virtualbox-iso.ubuntu-1204",
 					BuilderType:  "virtualbox-iso",
@@ -397,7 +396,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:        "virtualbox-iso.ubuntu-1204",
 					BuilderType: "virtualbox-iso",
@@ -488,7 +487,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:        "virtualbox-iso.ubuntu-1204",
 					BuilderType: "virtualbox-iso",
@@ -551,7 +550,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					BuildName:      "build-name",
 					Type:           "virtualbox-iso.ubuntu-1204",
@@ -574,7 +573,7 @@ func TestParse_build(t *testing.T) {
 				Builds:                  nil,
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"use build.name in post-processor block",
@@ -606,7 +605,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					BuildName:    "test-build",
 					Type:         "virtualbox-iso.ubuntu-1204",
@@ -664,7 +663,7 @@ func TestParse_build(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					BuildName:   "build-name-test",
 					Type:        "virtualbox-iso.ubuntu-1204",

--- a/hcl2template/types.datasource_test.go
+++ b/hcl2template/types.datasource_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/builder/null"
 	"github.com/hashicorp/packer/packer"
 )
@@ -54,7 +53,7 @@ func TestParse_datasource(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null.test",
 					BuilderType:    "null",
@@ -142,7 +141,7 @@ func TestParse_datasource(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null.test",
 					BuilderType:    "null",

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	pkrfunction "github.com/hashicorp/packer/hcl2template/function"
 	"github.com/hashicorp/packer/packer"
 	"github.com/zclconf/go-cty/cty"
@@ -643,8 +642,8 @@ func (cfg *PackerConfig) getCoreBuildPostProcessors(source SourceUseBlock, block
 // GetBuilds returns a list of packer Build based on the HCL2 parsed build
 // blocks. All Builders, Provisioners and Post Processors will be started and
 // configured.
-func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]packersdk.Build, hcl.Diagnostics) {
-	res := []packersdk.Build{}
+func (cfg *PackerConfig) GetBuilds(opts packer.GetBuildsOptions) ([]*packer.CoreBuild, hcl.Diagnostics) {
+	res := []*packer.CoreBuild{}
 	var diags hcl.Diagnostics
 	possibleBuildNames := []string{}
 

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer/hcl2template/addrs"
 	. "github.com/hashicorp/packer/hcl2template/internal"
@@ -205,7 +204,7 @@ func TestParser_complete(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:        "virtualbox-iso.ubuntu-1204",
 					BuilderType: "virtualbox-iso",
@@ -569,7 +568,7 @@ func TestParser_no_init(t *testing.T) {
 				Builds:  nil,
 			},
 			false, false,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 
@@ -578,7 +577,7 @@ func TestParser_no_init(t *testing.T) {
 			parseTestArgs{"testdata/init/duplicate_required_plugins", nil, nil},
 			nil,
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"invalid_inexplicit_source.pkr.hcl",
@@ -598,7 +597,7 @@ func TestParser_no_init(t *testing.T) {
 				Basedir:                 filepath.Clean("testdata/init"),
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"invalid_short_source.pkr.hcl",
@@ -618,7 +617,7 @@ func TestParser_no_init(t *testing.T) {
 				Basedir:                 filepath.Clean("testdata/init"),
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"invalid_inexplicit_source_2.pkr.hcl",
@@ -638,7 +637,7 @@ func TestParser_no_init(t *testing.T) {
 				Basedir:                 filepath.Clean("testdata/init"),
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 	}

--- a/hcl2template/types.source_test.go
+++ b/hcl2template/types.source_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/builder/null"
 	"github.com/hashicorp/packer/packer"
 )
@@ -52,7 +51,7 @@ func TestParse_source(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null.test",
 					BuilderType:    "null",
@@ -98,7 +97,7 @@ func TestParse_source(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"used source with unknown type fails",

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer/builder/null"
 	. "github.com/hashicorp/packer/hcl2template/internal"
 	"github.com/hashicorp/packer/packer"
@@ -126,7 +125,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null.test",
 					BuilderType:    "null",
@@ -156,7 +155,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"duplicate variable in variables",
@@ -177,7 +176,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"duplicate local block",
@@ -200,7 +199,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 		{"invalid default type",
@@ -221,7 +220,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 
@@ -240,7 +239,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 
@@ -258,7 +257,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			true,
 		},
 
@@ -291,7 +290,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			true, true,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null",
 					BuilderType:    "null",
@@ -378,7 +377,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null.test",
 					BuilderType:    "null",
@@ -399,7 +398,7 @@ func TestParse_variables(t *testing.T) {
 				LocalVariables:          nil,
 			},
 			true, true,
-			[]packersdk.Build{},
+			[]*packer.CoreBuild{},
 			false,
 		},
 
@@ -442,7 +441,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null.test",
 					BuilderType:    "null",
@@ -484,7 +483,7 @@ func TestParse_variables(t *testing.T) {
 				Basedir: filepath.Join("testdata", "variables"),
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null.test",
 					BuilderType:    "null",
@@ -542,47 +541,48 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{&packer.CoreBuild{
-				Type:        "null.null-builder",
-				BuilderType: "null",
-				Prepared:    true,
-				Builder:     &null.Builder{},
-				Provisioners: []packer.CoreBuildProvisioner{
-					{
-						PType: "shell",
-						Provisioner: &packer.RetriedProvisioner{
-							MaxRetries: 1,
-							Provisioner: &HCL2Provisioner{
-								Provisioner: &MockProvisioner{
-									Config: MockConfig{
-										NestedMockConfig: NestedMockConfig{
-											Tags: []MockTag{},
+			[]*packer.CoreBuild{
+				&packer.CoreBuild{
+					Type:        "null.null-builder",
+					BuilderType: "null",
+					Prepared:    true,
+					Builder:     &null.Builder{},
+					Provisioners: []packer.CoreBuildProvisioner{
+						{
+							PType: "shell",
+							Provisioner: &packer.RetriedProvisioner{
+								MaxRetries: 1,
+								Provisioner: &HCL2Provisioner{
+									Provisioner: &MockProvisioner{
+										Config: MockConfig{
+											NestedMockConfig: NestedMockConfig{
+												Tags: []MockTag{},
+											},
+											NestedSlice: []NestedMockConfig{},
 										},
-										NestedSlice: []NestedMockConfig{},
+									},
+								},
+							},
+						},
+						{
+							PType: "shell",
+							Provisioner: &packer.RetriedProvisioner{
+								MaxRetries: 1,
+								Provisioner: &HCL2Provisioner{
+									Provisioner: &MockProvisioner{
+										Config: MockConfig{
+											NestedMockConfig: NestedMockConfig{
+												Tags: []MockTag{},
+											},
+											NestedSlice: []NestedMockConfig{},
+										},
 									},
 								},
 							},
 						},
 					},
-					{
-						PType: "shell",
-						Provisioner: &packer.RetriedProvisioner{
-							MaxRetries: 1,
-							Provisioner: &HCL2Provisioner{
-								Provisioner: &MockProvisioner{
-									Config: MockConfig{
-										NestedMockConfig: NestedMockConfig{
-											Tags: []MockTag{},
-										},
-										NestedSlice: []NestedMockConfig{},
-									},
-								},
-							},
-						},
-					},
+					PostProcessors: [][]packer.CoreBuildPostProcessor{},
 				},
-				PostProcessors: [][]packer.CoreBuildPostProcessor{},
-			},
 			},
 			false,
 		},
@@ -630,7 +630,7 @@ func TestParse_variables(t *testing.T) {
 				},
 			},
 			false, false,
-			[]packersdk.Build{
+			[]*packer.CoreBuild{
 				&packer.CoreBuild{
 					Type:           "null.test",
 					BuilderType:    "null",

--- a/internal/hcp/registry/hcl.go
+++ b/internal/hcp/registry/hcl.go
@@ -65,30 +65,19 @@ func (h *HCLRegistry) PopulateVersion(ctx context.Context) error {
 }
 
 // StartBuild is invoked when one build for the configuration is starting to be processed
-func (h *HCLRegistry) StartBuild(ctx context.Context, build sdkpacker.Build) error {
-	name := build.Name()
-	cb, ok := build.(*packer.CoreBuild)
-	if ok {
-		name = cb.Type
-	}
-
-	return h.bucket.startBuild(ctx, name)
+func (h *HCLRegistry) StartBuild(ctx context.Context, build *packer.CoreBuild) error {
+	return h.bucket.startBuild(ctx, build.Type)
 }
 
 // CompleteBuild is invoked when one build for the configuration has finished
 func (h *HCLRegistry) CompleteBuild(
 	ctx context.Context,
-	build sdkpacker.Build,
+	build *packer.CoreBuild,
 	artifacts []sdkpacker.Artifact,
 	buildErr error,
 ) ([]sdkpacker.Artifact, error) {
-	buildName := build.Name()
-	cb, ok := build.(*packer.CoreBuild)
-	if ok {
-		buildName = cb.Type
-	}
-
-	buildMetadata, envMetadata := cb.GetMetadata(), h.metadata
+	buildName := build.Type
+	buildMetadata, envMetadata := build.GetMetadata(), h.metadata
 	err := h.bucket.Version.AddMetadataToBuild(ctx, buildName, buildMetadata, envMetadata)
 	if err != nil {
 		return nil, err

--- a/internal/hcp/registry/json.go
+++ b/internal/hcp/registry/json.go
@@ -84,20 +84,19 @@ func (h *JSONRegistry) PopulateVersion(ctx context.Context) error {
 }
 
 // StartBuild is invoked when one build for the configuration is starting to be processed
-func (h *JSONRegistry) StartBuild(ctx context.Context, build sdkpacker.Build) error {
-	name := build.Name()
-	return h.bucket.startBuild(ctx, name)
+func (h *JSONRegistry) StartBuild(ctx context.Context, build *packer.CoreBuild) error {
+	return h.bucket.startBuild(ctx, build.Name())
 }
 
 // CompleteBuild is invoked when one build for the configuration has finished
 func (h *JSONRegistry) CompleteBuild(
 	ctx context.Context,
-	build sdkpacker.Build,
+	build *packer.CoreBuild,
 	artifacts []sdkpacker.Artifact,
 	buildErr error,
 ) ([]sdkpacker.Artifact, error) {
 	buildName := build.Name()
-	buildMetadata, envMetadata := build.(*packer.CoreBuild).GetMetadata(), h.metadata
+	buildMetadata, envMetadata := build.GetMetadata(), h.metadata
 	err := h.bucket.Version.AddMetadataToBuild(ctx, buildName, buildMetadata, envMetadata)
 	if err != nil {
 		return nil, err

--- a/internal/hcp/registry/null_registry.go
+++ b/internal/hcp/registry/null_registry.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	sdkpacker "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer/packer"
 )
 
 // nullRegistry is a special handler that does nothing
@@ -16,13 +17,13 @@ func (r nullRegistry) PopulateVersion(context.Context) error {
 	return nil
 }
 
-func (r nullRegistry) StartBuild(context.Context, sdkpacker.Build) error {
+func (r nullRegistry) StartBuild(context.Context, *packer.CoreBuild) error {
 	return nil
 }
 
 func (r nullRegistry) CompleteBuild(
 	ctx context.Context,
-	build sdkpacker.Build,
+	build *packer.CoreBuild,
 	artifacts []sdkpacker.Artifact,
 	buildErr error,
 ) ([]sdkpacker.Artifact, error) {

--- a/internal/hcp/registry/registry.go
+++ b/internal/hcp/registry/registry.go
@@ -16,8 +16,8 @@ import (
 // Registry is an entity capable to orchestrate a Packer build and upload metadata to HCP
 type Registry interface {
 	PopulateVersion(context.Context) error
-	StartBuild(context.Context, sdkpacker.Build) error
-	CompleteBuild(ctx context.Context, build sdkpacker.Build, artifacts []sdkpacker.Artifact, buildErr error) ([]sdkpacker.Artifact, error)
+	StartBuild(context.Context, *packer.CoreBuild) error
+	CompleteBuild(ctx context.Context, build *packer.CoreBuild, artifacts []sdkpacker.Artifact, buildErr error) ([]sdkpacker.Artifact, error)
 	VersionStatusSummary()
 	Metadata() Metadata
 }

--- a/packer/core.go
+++ b/packer/core.go
@@ -314,9 +314,9 @@ func (c *Core) generateCoreBuildProvisioner(rawP *template.Provisioner, rawName 
 
 // This is used for json templates to launch the build plugins.
 // They will be prepared via b.Prepare() later.
-func (c *Core) GetBuilds(opts GetBuildsOptions) ([]packersdk.Build, hcl.Diagnostics) {
+func (c *Core) GetBuilds(opts GetBuildsOptions) ([]*CoreBuild, hcl.Diagnostics) {
 	buildNames := c.BuildNames(opts.Only, opts.Except)
-	builds := []packersdk.Build{}
+	builds := []*CoreBuild{}
 	diags := hcl.Diagnostics{}
 	for _, n := range buildNames {
 		b, err := c.Build(n)
@@ -362,7 +362,7 @@ func (c *Core) GetBuilds(opts GetBuildsOptions) ([]packersdk.Build, hcl.Diagnost
 }
 
 // Build returns the Build object for the given name.
-func (c *Core) Build(n string) (packersdk.Build, error) {
+func (c *Core) Build(n string) (*CoreBuild, error) {
 	// Setup the builder
 	configBuilder, ok := c.builds[n]
 	if !ok {

--- a/packer/run_interfaces.go
+++ b/packer/run_interfaces.go
@@ -24,7 +24,7 @@ type BuildGetter interface {
 	// GetBuilds return all possible builds for a config. It also starts all
 	// builders.
 	// TODO(azr): rename to builder starter ?
-	GetBuilds(GetBuildsOptions) ([]packersdk.Build, hcl.Diagnostics)
+	GetBuilds(GetBuildsOptions) ([]*CoreBuild, hcl.Diagnostics)
 }
 
 type Evaluator interface {


### PR DESCRIPTION
In Packer's run interfaces, the builds we construct from the configurations (HCL2 or legacy JSON) are initialised as a list of Build from the SDK (an interface itself).
This is not necessary as we are controlling the types passed around, and they're always a CoreBuild pointer.

Therefore, typing with interface in those cases, while not necessarily wrong, is a bit limiting, especially since we are already casting the builds to CoreBuild in some places of the code.

This PR changes this so we don't type with interfaces anymore, but instead use CoreBuilds in the code, so we don't need to cast those values anymore.