### PR TITLE
Chore: improve plugin source parsing

### DIFF
--- a/hcl2template/addrs/plugin.go
+++ b/hcl2template/addrs/plugin.go
@@ -110,7 +110,7 @@ func ParsePluginSourceString(str string) (*Plugin, hcl.Diagnostics) {
 
 	// split the source string into individual components
 	parts := strings.Split(str, "/")
-	if len(parts) != 3 {
+	if len(parts) < 3 {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid plugin source string",
@@ -157,8 +157,8 @@ func ParsePluginSourceString(str string) (*Plugin, hcl.Diagnostics) {
 	}
 	ret.Namespace = namespace
 
-	// the hostname is always the first part in a three-part source string
-	ret.Hostname = parts[0]
+	// the hostname is always the first-to-last-second part
+	ret.Hostname = strings.Join(parts[0:len(parts)-2], "/")
 
 	// Due to how plugin executables are named and plugin git repositories
 	// are conventionally named, it's a reasonable and


### PR DESCRIPTION
## Related Issues
- #12657
- #11164

## Motivation
Hi team, when trying to implement a custom domain plugin getter to fix this API rate limitting issue, I realized that it would require a huge PR.

Knowing it would not possible for new contributor to make such a big change. I create this one as a first step to point packer plugin install to another domain instead of github.

Please be aware that this PR does not resolve above issues.

## Changes
- Allow plugin source string to have more than 3 components for more flexible hostname
Eg: `source = "artifactory.mycompany.com/my-remote-repo/hashicorp/amazon"`
Will result in `hostname = "artifactory.mycompany.com/my-remote-repo"`

## Test Evidences
- Log showing that hostname is parsed correctly
- Packer still reject hostname which is not github
<img width="690" alt="Screenshot 2024-03-03 141454" src="https://github.com/hashicorp/packer/assets/40334379/39d094f6-9f37-41f2-be52-836a0d147881">
