### PR TITLE
Rename plugin command

### DIFF
--- a/command/execute.go
+++ b/command/execute.go
@@ -36,7 +36,7 @@ import (
 	windowsshellprovisioner "github.com/hashicorp/packer/provisioner/windows-shell"
 )
 
-type PluginCommand struct {
+type ExecuteCommand struct {
 	Meta
 }
 
@@ -75,20 +75,20 @@ var Datasources = map[string]packersdk.Datasource{
 
 var pluginRegexp = regexp.MustCompile("packer-(builder|post-processor|provisioner|datasource)-(.+)")
 
-func (c *PluginCommand) Run(args []string) int {
+func (c *ExecuteCommand) Run(args []string) int {
 	// This is an internal call (users should not call this directly) so we're
 	// not going to do much input validation. If there's a problem we'll often
 	// just crash. Error handling should be added to facilitate debugging.
 	log.Printf("args: %#v", args)
 	if len(args) != 1 {
-		c.Ui.Error("Wrong number of args")
+		c.Ui.Error(c.Help())
 		return 1
 	}
 
 	// Plugin will match something like "packer-builder-amazon-ebs"
 	parts := pluginRegexp.FindStringSubmatch(args[0])
 	if len(parts) != 3 {
-		c.Ui.Error(fmt.Sprintf("Error parsing plugin argument [DEBUG]: %#v", parts))
+		c.Ui.Error(c.Help())
 		return 1
 	}
 	pluginType := parts[1] // capture group 1 (builder|post-processor|provisioner)
@@ -136,9 +136,9 @@ func (c *PluginCommand) Run(args []string) int {
 	return 0
 }
 
-func (*PluginCommand) Help() string {
+func (*ExecuteCommand) Help() string {
 	helpText := `
-Usage: packer plugin PLUGIN
+Usage: packer execute PLUGIN
 
   Runs an internally-compiled version of a plugin from the packer binary.
 
@@ -148,6 +148,6 @@ Usage: packer plugin PLUGIN
 	return strings.TrimSpace(helpText)
 }
 
-func (c *PluginCommand) Synopsis() string {
+func (c *ExecuteCommand) Synopsis() string {
 	return "internal plugin command"
 }

--- a/commands.go
+++ b/commands.go
@@ -107,5 +107,36 @@ func init() {
 				CheckFunc: commandVersionCheck,
 			}, nil
 		},
+
+		// plugin is essentially an alias to the plugins command
+		//
+		// It is not meant to be documented or used outside of simple
+		// typos, as it's easy to write plugin instead of plugins, so
+		// we opted not to error, but silently alias the two writings.
+		"plugin": func() (cli.Command, error) {
+			return &command.PluginsCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+		"plugin installed": func() (cli.Command, error) {
+			return &command.PluginsInstalledCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+		"plugin install": func() (cli.Command, error) {
+			return &command.PluginsInstallCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+		"plugin remove": func() (cli.Command, error) {
+			return &command.PluginsRemoveCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+		"plugin required": func() (cli.Command, error) {
+			return &command.PluginsRequiredCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -29,6 +29,12 @@ func init() {
 			}, nil
 		},
 
+		"execute": func() (cli.Command, error) {
+			return &command.ExecuteCommand{
+				Meta: *CommandMeta,
+			}, nil
+		},
+
 		"fix": func() (cli.Command, error) {
 			return &command.FixCommand{
 				Meta: *CommandMeta,
@@ -55,12 +61,6 @@ func init() {
 
 		"inspect": func() (cli.Command, error) {
 			return &command.InspectCommand{
-				Meta: *CommandMeta,
-			}, nil
-		},
-
-		"plugin": func() (cli.Command, error) {
-			return &command.PluginCommand{
 				Meta: *CommandMeta,
 			}, nil
 		},

--- a/config.go
+++ b/config.go
@@ -153,7 +153,7 @@ func (c *config) discoverInternalComponents() error {
 	for builder := range command.Builders {
 		builder := builder
 		if !c.Plugins.Builders.Has(builder) {
-			bin := fmt.Sprintf("%s%splugin%spacker-builder-%s",
+			bin := fmt.Sprintf("%s%sexecute%spacker-builder-%s",
 				packerPath, PACKERSPACE, PACKERSPACE, builder)
 			c.Plugins.Builders.Set(builder, func() (packersdk.Builder, error) {
 				return c.Plugins.Client(bin).Builder()
@@ -164,7 +164,7 @@ func (c *config) discoverInternalComponents() error {
 	for provisioner := range command.Provisioners {
 		provisioner := provisioner
 		if !c.Plugins.Provisioners.Has(provisioner) {
-			bin := fmt.Sprintf("%s%splugin%spacker-provisioner-%s",
+			bin := fmt.Sprintf("%s%sexecute%spacker-provisioner-%s",
 				packerPath, PACKERSPACE, PACKERSPACE, provisioner)
 			c.Plugins.Provisioners.Set(provisioner, func() (packersdk.Provisioner, error) {
 				return c.Plugins.Client(bin).Provisioner()
@@ -175,7 +175,7 @@ func (c *config) discoverInternalComponents() error {
 	for postProcessor := range command.PostProcessors {
 		postProcessor := postProcessor
 		if !c.Plugins.PostProcessors.Has(postProcessor) {
-			bin := fmt.Sprintf("%s%splugin%spacker-post-processor-%s",
+			bin := fmt.Sprintf("%s%sexecute%spacker-post-processor-%s",
 				packerPath, PACKERSPACE, PACKERSPACE, postProcessor)
 			c.Plugins.PostProcessors.Set(postProcessor, func() (packersdk.PostProcessor, error) {
 				return c.Plugins.Client(bin).PostProcessor()
@@ -186,7 +186,7 @@ func (c *config) discoverInternalComponents() error {
 	for dataSource := range command.Datasources {
 		dataSource := dataSource
 		if !c.Plugins.DataSources.Has(dataSource) {
-			bin := fmt.Sprintf("%s%splugin%spacker-datasource-%s",
+			bin := fmt.Sprintf("%s%sexecute%spacker-datasource-%s",
 				packerPath, PACKERSPACE, PACKERSPACE, dataSource)
 			c.Plugins.DataSources.Set(dataSource, func() (packersdk.Datasource, error) {
 				return c.Plugins.Client(bin).Datasource()

--- a/main.go
+++ b/main.go
@@ -265,7 +265,7 @@ func wrappedMain() int {
 		Args:         args,
 		Autocomplete: true,
 		Commands:     Commands,
-		HelpFunc:     excludeHelpFunc(Commands, []string{"plugin"}),
+		HelpFunc:     excludeHelpFunc(Commands, []string{"execute"}),
 		HelpWriter:   os.Stdout,
 		Name:         "packer",
 		Version:      version.Version,

--- a/main.go
+++ b/main.go
@@ -265,7 +265,7 @@ func wrappedMain() int {
 		Args:         args,
 		Autocomplete: true,
 		Commands:     Commands,
-		HelpFunc:     excludeHelpFunc(Commands, []string{"execute"}),
+		HelpFunc:     excludeHelpFunc(Commands, []string{"execute", "plugin"}),
 		HelpWriter:   os.Stdout,
 		Name:         "packer",
 		Version:      version.Version,

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/tools/imports"
 )
 
-const target = "command/plugin.go"
+const target = "command/execute.go"
 
 func main() {
 	wd, _ := os.Getwd()
@@ -278,7 +278,7 @@ packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 IMPORTS
 )
 
-type PluginCommand struct {
+type ExecuteCommand struct {
 	Meta
 }
 
@@ -292,20 +292,20 @@ DATASOURCES
 
 var pluginRegexp = regexp.MustCompile("packer-(builder|post-processor|provisioner|datasource)-(.+)")
 
-func (c *PluginCommand) Run(args []string) int {
+func (c *ExecuteCommand) Run(args []string) int {
 	// This is an internal call (users should not call this directly) so we're
 	// not going to do much input validation. If there's a problem we'll often
 	// just crash. Error handling should be added to facilitate debugging.
 	log.Printf("args: %#v", args)
 	if len(args) != 1 {
-		c.Ui.Error("Wrong number of args")
+		c.Ui.Error(c.Help())
 		return 1
 	}
 
 	// Plugin will match something like "packer-builder-amazon-ebs"
 	parts := pluginRegexp.FindStringSubmatch(args[0])
 	if len(parts) != 3 {
-		c.Ui.Error(fmt.Sprintf("Error parsing plugin argument [DEBUG]: %#v", parts))
+		c.Ui.Error(c.Help())
 		return 1
 	}
 	pluginType := parts[1] // capture group 1 (builder|post-processor|provisioner)
@@ -353,9 +353,9 @@ func (c *PluginCommand) Run(args []string) int {
 	return 0
 }
 
-func (*PluginCommand) Help() string {
+func (*ExecuteCommand) Help() string {
 	helpText := ` + "`" + `
-Usage: packer plugin PLUGIN
+Usage: packer execute PLUGIN
 
   Runs an internally-compiled version of a plugin from the packer binary.
 
@@ -365,7 +365,7 @@ Usage: packer plugin PLUGIN
 	return strings.TrimSpace(helpText)
 }
 
-func (c *PluginCommand) Synopsis() string {
+func (c *ExecuteCommand) Synopsis() string {
 	return "internal plugin command"
 }
 `


### PR DESCRIPTION
The plugin command existed so that Packer was able to invoke its embedded components for a build.
The name however is a bit close to `plugins`, and the help messages aren't clear if invoked by mistake, which can be quite confusing when trying to use Packer to manage installed plugins.

Since we're doubling down on using Packer to manage those, the problem may become exacerbated in the future, so we are renaming the command to invoke a component to `execute`. No other command is close in name to this, so it's less likely to be mistakenly invoked by a user.

In addition to `execute`, we are also using `plugin` as an alias for `plugins`, so that `packer plugins installed` and `packer plugin installed` are in effect the same command (this is true for all the other subcommands).