### PR TITLE
fmt: print parse errors on error

### DIFF
--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -177,3 +177,18 @@ func Test_fmt_pipe(t *testing.T) {
 		})
 	}
 }
+
+const malformedTemplate = "test-fixtures/fmt_errs/malformed.pkr.hcl"
+
+func TestFmtParseError(t *testing.T) {
+	p := helperCommand(t, "fmt", malformedTemplate)
+	outs, err := p.CombinedOutput()
+	if err == nil {
+		t.Errorf("Expected failure to format file, but command did not fail")
+	}
+	strLogs := string(outs)
+
+	if !strings.Contains(strLogs, "An argument or block definition is required here.") {
+		t.Errorf("Expected some diags about parse error, found none")
+	}
+}

--- a/command/test-fixtures/fmt_errs/malformed.pkr.hcl
+++ b/command/test-fixtures/fmt_errs/malformed.pkr.hcl
@@ -1,0 +1,14 @@
+variable "region" {
+  type =string
+}
+
+invalid
+
+source "amazon-ebs" "example" {
+  region = var.region
+}
+
+build {
+  sources = ["source.amazon-ebs.example"]
+}
+

--- a/hcl2template/formatter.go
+++ b/hcl2template/formatter.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -135,7 +136,7 @@ func (f *HCL2Formatter) processFile(filename string) ([]byte, error) {
 
 	_, diags := f.parser.ParseHCL(inSrc, filename)
 	if diags.HasErrors() {
-		return nil, fmt.Errorf("failed to parse HCL %s", filename)
+		return nil, multierror.Append(nil, diags.Errs()...)
 	}
 
 	outSrc := hclwrite.Format(inSrc)


### PR DESCRIPTION
The fmt command reformats HCL2 templates, provided it can parse the file and reformat its contents according to the standards set by the HCL library's formatters.

However, if the file is malformed for some reason, the command will fail with a parse error, but while the parse error message is shown, the actual errors in the template(s) are not forwarded, making it hard for users to understand what went wrong with the contents of the file they're trying to format.

In order to be more helpful with those errors, we now forward those parsing errors to the UI.