### PR TITLE
Dev version show build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ dev: ## Build and install a development build
 	fi
 	@mkdir -p pkg/$(GOOS)_$(GOARCH)
 	@mkdir -p bin
-	@go install -ldflags '$(GOLDFLAGS)'
+	@go install -ldflags '-X "$(GIT_IMPORT).VersionMetadata=$(shell date)" $(GOLDFLAGS)'
 	@cp $(GOPATH)/bin/packer bin/packer
 	@cp $(GOPATH)/bin/packer pkg/$(GOOS)_$(GOARCH)
 

--- a/command/version.go
+++ b/command/version.go
@@ -38,7 +38,12 @@ func (c *VersionCommand) Run(args []string) int {
 	c.Ui.Machine("version-prelease", version.VersionPrerelease)
 	c.Ui.Machine("version-commit", version.GitCommit)
 
-	c.Ui.Say(fmt.Sprintf("Packer v%s", version.FormattedVersion()))
+	versionString := fmt.Sprintf("Packer v%s", version.FormattedVersion())
+	if version.VersionMetadata != "" {
+		versionString = fmt.Sprintf("%s - %s", versionString, version.VersionMetadata)
+	}
+
+	c.Ui.Say(versionString)
 
 	// If we have a version check function, then let's check for
 	// the latest version as well.


### PR DESCRIPTION
In order to help differentiate between dev builds of Packer, this change adds a date/time when built as extra version metadata (we reuse this field since it was not referenced anywhere), and change a bit the logic of the `version` command so it is reported.