### PR TITLE
Plugin discovery fixes

### DIFF
--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -300,10 +300,16 @@ func (c *PluginsInstallCommand) InstallFromBinary(opts plugingetter.ListInstalla
 		}})
 	}
 
+	// Remove metadata from plugin path
+	noMetaVersion := semver.Core().String()
+	if semver.Prerelease() != "" {
+		noMetaVersion = fmt.Sprintf("%s-%s", noMetaVersion, semver.Prerelease())
+	}
+
 	outputPrefix := fmt.Sprintf(
 		"packer-plugin-%s_v%s_%s",
 		pluginIdentifier.Type,
-		semver.String(),
+		noMetaVersion,
 		desc.APIVersion,
 	)
 	binaryPath := filepath.Join(

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -303,7 +303,7 @@ func (c *PluginsInstallCommand) InstallFromBinary(opts plugingetter.ListInstalla
 	outputPrefix := fmt.Sprintf(
 		"packer-plugin-%s_v%s_%s",
 		pluginIdentifier.Type,
-		desc.Version,
+		semver.String(),
 		desc.APIVersion,
 	)
 	binaryPath := filepath.Join(

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -211,6 +211,12 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 			log.Printf("invalid plugin pre-release version %q, only development or release binaries are accepted", pluginVersionStr)
 		}
 
+		// Check the API version matches between path and describe
+		if describeInfo.APIVersion != protocolVerionStr {
+			log.Printf("plugin %q reported API version %q while its name implies version %q, ignoring", path, describeInfo.APIVersion, protocolVerionStr)
+			continue
+		}
+
 		// no constraint means always pass, this will happen for implicit
 		// plugin requirements and when we list all plugins.
 		//

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -187,6 +187,11 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 			continue
 		}
 
+		if fmt.Sprintf("v%s", ver.String()) != pluginVersionStr {
+			log.Printf("version %q in path is non canonical, this could introduce ambiguity and is not supported, ignoring it.", pluginVersionStr)
+			continue
+		}
+
 		if ver.Prerelease() != "" && opts.ReleasesOnly {
 			log.Printf("ignoring pre-release plugin %q", path)
 			continue

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -179,7 +179,7 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 
 		// versionsStr now looks like v1.2.3_x5.1 or amazon_v1.2.3_x5.1
 		parts := strings.SplitN(versionsStr, "_", 2)
-		pluginVersionStr, protocolVerionStr := parts[0], parts[1]
+		pluginVersionStr, protocolVersionStr := parts[0], parts[1]
 		ver, err := version.NewVersion(pluginVersionStr)
 		if err != nil {
 			// could not be parsed, ignoring the file
@@ -220,8 +220,8 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 		}
 
 		// Check the API version matches between path and describe
-		if describeInfo.APIVersion != protocolVerionStr {
-			log.Printf("plugin %q reported API version %q while its name implies version %q, ignoring", path, describeInfo.APIVersion, protocolVerionStr)
+		if describeInfo.APIVersion != protocolVersionStr {
+			log.Printf("plugin %q reported API version %q while its name implies version %q, ignoring", path, describeInfo.APIVersion, protocolVersionStr)
 			continue
 		}
 
@@ -236,9 +236,9 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 			continue
 		}
 
-		if err := opts.CheckProtocolVersion(protocolVerionStr); err != nil {
+		if err := opts.CheckProtocolVersion(protocolVersionStr); err != nil {
 			log.Printf("[NOTICE] binary %s requires protocol version %s that is incompatible "+
-				"with this version of Packer. %s", path, protocolVerionStr, err)
+				"with this version of Packer. %s", path, protocolVersionStr, err)
 			continue
 		}
 

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -520,10 +520,12 @@ func Test_LessInstallList(t *testing.T) {
 				&Installation{
 					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.1",
+					APIVersion: "x5.0",
 				},
 				&Installation{
-					BinaryPath: "github.com",
+					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.2",
+					APIVersion: "x5.0",
 				},
 			},
 			true,
@@ -535,10 +537,12 @@ func Test_LessInstallList(t *testing.T) {
 				&Installation{
 					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.1",
+					APIVersion: "x5.0",
 				},
 				&Installation{
-					BinaryPath: "github.com",
+					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.1",
+					APIVersion: "x5.0",
 				},
 			},
 			false,
@@ -549,10 +553,12 @@ func Test_LessInstallList(t *testing.T) {
 				&Installation{
 					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.2",
+					APIVersion: "x5.0",
 				},
 				&Installation{
-					BinaryPath: "github.com",
+					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.1",
+					APIVersion: "x5.0",
 				},
 			},
 			false,
@@ -563,10 +569,12 @@ func Test_LessInstallList(t *testing.T) {
 				&Installation{
 					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.2-dev",
+					APIVersion: "x5.0",
 				},
 				&Installation{
-					BinaryPath: "github.com",
+					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.2",
+					APIVersion: "x5.0",
 				},
 			},
 			true,
@@ -577,10 +585,12 @@ func Test_LessInstallList(t *testing.T) {
 				&Installation{
 					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.2",
+					APIVersion: "x5.0",
 				},
 				&Installation{
-					BinaryPath: "github.com",
+					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.2-dev",
+					APIVersion: "x5.0",
 				},
 			},
 			false,
@@ -591,10 +601,12 @@ func Test_LessInstallList(t *testing.T) {
 				&Installation{
 					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.1",
+					APIVersion: "x5.0",
 				},
 				&Installation{
-					BinaryPath: "github.com",
+					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.2-dev",
+					APIVersion: "x5.0",
 				},
 			},
 			true,
@@ -605,10 +617,108 @@ func Test_LessInstallList(t *testing.T) {
 				&Installation{
 					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.3",
+					APIVersion: "x5.0",
 				},
 				&Installation{
-					BinaryPath: "github.com",
+					BinaryPath: "host/org/plugin",
 					Version:    "v1.2.2-dev",
+					APIVersion: "x5.0",
+				},
+			},
+			false,
+		},
+		{
+			"v1.2.3_x5.0 < v1.2.3_x5.1 => true",
+			InstallList{
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x5.0",
+				},
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x5.1",
+				},
+			},
+			true,
+		},
+		{
+			"v1.2.3_x5.0 < v1.2.3_x5.0 => false",
+			InstallList{
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x5.0",
+				},
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x5.0",
+				},
+			},
+			false,
+		},
+		{
+			"v1.2.3_x4.15 < v1.2.3_x5.0 => true",
+			InstallList{
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x4.15",
+				},
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x5.0",
+				},
+			},
+			true,
+		},
+		{
+			"v1.2.3_x9.0 < v1.2.3_x10.0 => true",
+			InstallList{
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x9.0",
+				},
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x10.0",
+				},
+			},
+			true,
+		},
+		{
+			"v1.2.3_x5.9 < v1.2.3_x5.10 => true",
+			InstallList{
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x5.9",
+				},
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x5.10",
+				},
+			},
+			true,
+		},
+		{
+			"v1.2.3_x5.0 < v1.2.3_x4.15 => false",
+			InstallList{
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x5.0",
+				},
+				&Installation{
+					BinaryPath: "host/org/plugin",
+					Version:    "v1.2.3",
+					APIVersion: "x4.15",
 				},
 			},
 			false,
@@ -619,9 +729,11 @@ func Test_LessInstallList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			isLess := tt.installs.Less(0, 1)
 			if isLess != tt.expectLess {
-				t.Errorf("Less mismatch for %s < %s, expected %t, got %t",
+				t.Errorf("Less mismatch for %s_%s < %s_%s, expected %t, got %t",
 					tt.installs[0].Version,
+					tt.installs[0].APIVersion,
 					tt.installs[1].Version,
+					tt.installs[1].APIVersion,
 					tt.expectLess, isLess)
 			}
 		})

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -490,91 +490,90 @@ func getFormattedInstalledPluginSuffix() string {
 }
 
 var (
-	mockPlugins = map[string]pluginsdk.Set{
-		"bird": {
-			Builders: map[string]packersdk.Builder{
-				"feather":   nil,
-				"guacamole": nil,
-			},
-		},
-		"chimney": {
-			PostProcessors: map[string]packersdk.PostProcessor{
-				"smoke": nil,
-			},
-		},
-		"data": {
-			Datasources: map[string]packersdk.Datasource{
-				"source": nil,
-			},
-		},
-	}
-	mockInstalledPlugins = map[string]pluginsdk.Set{
-		fmt.Sprintf("bird_%s", getFormattedInstalledPluginSuffix()): {
-			Builders: map[string]packersdk.Builder{
-				"feather":   nil,
-				"guacamole": nil,
-			},
-		},
-		fmt.Sprintf("chimney_%s", getFormattedInstalledPluginSuffix()): {
-			PostProcessors: map[string]packersdk.PostProcessor{
-				"smoke": nil,
-			},
-		},
-		fmt.Sprintf("data_%s", getFormattedInstalledPluginSuffix()): {
-			Datasources: map[string]packersdk.Datasource{
-				"source": nil,
-			},
-		},
-	}
-
-	invalidInstalledPluginsMock = map[string]pluginsdk.Set{
-		"bird_v0.1.1_x5.0_wrong_architecture": {
-			Builders: map[string]packersdk.Builder{
-				"feather":   nil,
-				"guacamole": nil,
-			},
-		},
-		"chimney_cool_ranch": {
-			PostProcessors: map[string]packersdk.PostProcessor{
-				"smoke": nil,
-			},
-		},
-		"data": {
-			Datasources: map[string]packersdk.Datasource{
-				"source": nil,
-			},
-		},
-	}
-	defaultNameMock = map[string]pluginsdk.Set{
-		"foo": {
-			Builders: map[string]packersdk.Builder{
-				"bar":                  nil,
-				"baz":                  nil,
-				pluginsdk.DEFAULT_NAME: nil,
-			},
-		},
-	}
-
-	doubleDefaultMock = map[string]pluginsdk.Set{
-		"yolo": {
-			Builders: map[string]packersdk.Builder{
-				"bar":                  nil,
-				"baz":                  nil,
-				pluginsdk.DEFAULT_NAME: nil,
-			},
-			PostProcessors: map[string]packersdk.PostProcessor{
-				pluginsdk.DEFAULT_NAME: nil,
-			},
-		},
-	}
-
-	badDefaultNameMock = map[string]pluginsdk.Set{
-		"foo": {
-			Builders: map[string]packersdk.Builder{
-				"bar":                  nil,
-				"baz":                  nil,
-				pluginsdk.DEFAULT_NAME: nil,
-			},
-		},
-	}
+	mockPlugins                 = map[string]pluginsdk.Set{}
+	mockInstalledPlugins        = map[string]pluginsdk.Set{}
+	invalidInstalledPluginsMock = map[string]pluginsdk.Set{}
+	defaultNameMock             = map[string]pluginsdk.Set{}
+	doubleDefaultMock           = map[string]pluginsdk.Set{}
+	badDefaultNameMock          = map[string]pluginsdk.Set{}
 )
+
+func init() {
+	mockPluginsBird := pluginsdk.NewSet()
+	mockPluginsBird.Builders = map[string]packersdk.Builder{
+		"feather":   nil,
+		"guacamole": nil,
+	}
+	mockPluginsChim := pluginsdk.NewSet()
+	mockPluginsChim.PostProcessors = map[string]packersdk.PostProcessor{
+		"smoke": nil,
+	}
+	mockPluginsData := pluginsdk.NewSet()
+	mockPluginsData.Datasources = map[string]packersdk.Datasource{
+		"source": nil,
+	}
+	mockPlugins["bird"] = *mockPluginsBird
+	mockPlugins["chimney"] = *mockPluginsChim
+	mockPlugins["data"] = *mockPluginsData
+
+	mockInstalledPluginsBird := pluginsdk.NewSet()
+	mockInstalledPluginsBird.Builders = map[string]packersdk.Builder{
+		"feather":   nil,
+		"guacamole": nil,
+	}
+	mockInstalledPluginsChim := pluginsdk.NewSet()
+	mockInstalledPluginsChim.PostProcessors = map[string]packersdk.PostProcessor{
+		"smoke": nil,
+	}
+	mockInstalledPluginsData := pluginsdk.NewSet()
+	mockInstalledPluginsData.Datasources = map[string]packersdk.Datasource{
+		"source": nil,
+	}
+	mockInstalledPlugins[fmt.Sprintf("bird_%s", getFormattedInstalledPluginSuffix())] = *mockInstalledPluginsBird
+	mockInstalledPlugins[fmt.Sprintf("chimney_%s", getFormattedInstalledPluginSuffix())] = *mockInstalledPluginsChim
+	mockInstalledPlugins[fmt.Sprintf("data_%s", getFormattedInstalledPluginSuffix())] = *mockInstalledPluginsData
+
+	invalidInstalledPluginsMockBird := pluginsdk.NewSet()
+	invalidInstalledPluginsMockBird.Builders = map[string]packersdk.Builder{
+		"feather":   nil,
+		"guacamole": nil,
+	}
+	invalidInstalledPluginsMockChimney := pluginsdk.NewSet()
+	invalidInstalledPluginsMockChimney.PostProcessors = map[string]packersdk.PostProcessor{
+		"smoke": nil,
+	}
+	invalidInstalledPluginsMockData := pluginsdk.NewSet()
+	invalidInstalledPluginsMockData.Datasources = map[string]packersdk.Datasource{
+		"source": nil,
+	}
+	invalidInstalledPluginsMock["bird_v0.1.1_x5.0_wrong_architecture"] = *invalidInstalledPluginsMockBird
+	invalidInstalledPluginsMock["chimney_cool_ranch"] = *invalidInstalledPluginsMockChimney
+	invalidInstalledPluginsMock["data"] = *invalidInstalledPluginsMockData
+
+	defaultNameFooSet := pluginsdk.NewSet()
+	defaultNameFooSet.Builders = map[string]packersdk.Builder{
+		"bar":                  nil,
+		"baz":                  nil,
+		pluginsdk.DEFAULT_NAME: nil,
+	}
+	defaultNameMock["foo"] = *defaultNameFooSet
+
+	doubleDefaultYoloSet := pluginsdk.NewSet()
+	doubleDefaultYoloSet.Builders = map[string]packersdk.Builder{
+		"bar":                  nil,
+		"baz":                  nil,
+		pluginsdk.DEFAULT_NAME: nil,
+	}
+	doubleDefaultYoloSet.PostProcessors = map[string]packersdk.PostProcessor{
+		pluginsdk.DEFAULT_NAME: nil,
+	}
+	doubleDefaultMock["yolo"] = *doubleDefaultYoloSet
+
+	badDefaultSet := pluginsdk.NewSet()
+	badDefaultSet.Builders = map[string]packersdk.Builder{
+		"bar":                  nil,
+		"baz":                  nil,
+		pluginsdk.DEFAULT_NAME: nil,
+	}
+	badDefaultNameMock["foo"] = *badDefaultSet
+}


### PR DESCRIPTION
Multiple changes here:

* Push checksum match checker on top of the discovery function, and rely more on version lib for validity/match checks.
* Scrub metadata from installed binary to avoid ambiguity
* Ensure API versions match between binary name and describe output
* Reject loading non-canonical versions of a plugin (ambiguity protection)