### PR TITLE
Update Example of Parsing a Manifest to Use Only `jq`

### DIFF
--- a/website/content/docs/post-processors/manifest.mdx
+++ b/website/content/docs/post-processors/manifest.mdx
@@ -201,7 +201,7 @@ build.
 
 #!/bin/bash
 
-AMI_ID=$(jq -r '.builds[-1].artifact_id' manifest.json | cut -d ":" -f2)
+AMI_ID=$(jq -r '.builds[-1].artifact_id | split(": ") | .[1]' manifest.json)
 echo $AMI_ID
 
 ```

--- a/website/content/docs/post-processors/manifest.mdx
+++ b/website/content/docs/post-processors/manifest.mdx
@@ -201,7 +201,7 @@ build.
 
 #!/bin/bash
 
-AMI_ID=$(jq -r '.builds[-1].artifact_id | split(": ") | .[1]' manifest.json)
+AMI_ID=$(jq -r '.builds[-1].artifact_id | split(":") | .[1]' manifest.json)
 echo $AMI_ID
 
 ```


### PR DESCRIPTION
Documentation change, the example provided uses a command like `jq ... | cut -f: -d2` where jq can perform the splitting itself, no need to pipe.

Little one-line change, noticed it today while looking to parse the manifest format.