### PR TITLE
packer: relax constraints on local sources

### DIFF
--- a/acctest/plugin/component_acc_test.go
+++ b/acctest/plugin/component_acc_test.go
@@ -22,9 +22,7 @@ var basicAmazonAmiDatasourceHCL2Template string
 
 func TestAccInitAndBuildBasicAmazonAmiDatasource(t *testing.T) {
 	plugin := addrs.Plugin{
-		Hostname:  "github.com",
-		Namespace: "hashicorp",
-		Type:      "amazon",
+		Source: "github.com/hashicorp/amazon",
 	}
 	testCase := &acctest.PluginTestCase{
 		Name: "amazon-ami_basic_datasource_test",

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -308,7 +308,7 @@ func (c *PluginsInstallCommand) InstallFromBinary(opts plugingetter.ListInstalla
 
 	outputPrefix := fmt.Sprintf(
 		"packer-plugin-%s_v%s_%s",
-		pluginIdentifier.Type,
+		pluginIdentifier.Name(),
 		noMetaVersion,
 		desc.APIVersion,
 	)

--- a/hcl2template/addrs/plugin_test.go
+++ b/hcl2template/addrs/plugin_test.go
@@ -6,29 +6,109 @@ package addrs
 import (
 	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestParsePluginSourceString(t *testing.T) {
-	type args struct {
-		str string
-	}
+func TestPluginParseSourceString(t *testing.T) {
 	tests := []struct {
-		args      args
+		name      string
+		source    string
 		want      *Plugin
 		wantDiags bool
 	}{
-		{args{"potato"}, nil, true},
-		{args{"hashicorp/azr"}, nil, true},
-		{args{"github.com/hashicorp/azr"}, &Plugin{"github.com", "hashicorp", "azr"}, false},
+		{"invalid: only one component, rejected", "potato", nil, true},
+		{"valid: two components in name", "hashicorp/azr", &Plugin{"hashicorp/azr"}, false},
+		{"valid: three components, nothing superfluous", "github.com/hashicorp/azr", &Plugin{"github.com/hashicorp/azr"}, false},
+		{"invalid: trailing slash", "github.com/hashicorp/azr/", nil, true},
+		{"invalid: reject because scheme specified", "https://github.com/hashicorp/azr", nil, true},
+		{"invalid: reject because query non nil", "github.com/hashicorp/azr?arg=1", nil, true},
+		{"invalid: reject because fragment present", "github.com/hashicorp/azr#anchor", nil, true},
+		{"invalid: leading and trailing slashes are removed", "/github.com/hashicorp/azr/", nil, true},
+		{"invalid: leading slashes are removed", "/github.com/hashicorp/azr", nil, true},
+		{"invalid: plugin name contains packer-", "/github.com/hashicorp/packer-azr", nil, true},
+		{"invalid: plugin name contains packer-plugin-", "/github.com/hashicorp/packer-plugin-azr", nil, true},
 	}
 	for _, tt := range tests {
-		t.Run(tt.args.str, func(t *testing.T) {
-			got, gotDiags := ParsePluginSourceString(tt.args.str)
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotDiags := ParsePluginSourceString(tt.source)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParsePluginSourceString() got = %v, want %v", got, tt.want)
 			}
-			if tt.wantDiags == (len(gotDiags) == 0) {
-				t.Errorf("Unexpected diags %s", gotDiags)
+			if tt.wantDiags && len(gotDiags) == 0 {
+				t.Errorf("Expected diags, but got none")
+			}
+			if !tt.wantDiags && len(gotDiags) != 0 {
+				t.Errorf("Unexpected diags: %s", gotDiags)
+			}
+		})
+	}
+}
+
+func TestPluginName(t *testing.T) {
+	tests := []struct {
+		name         string
+		pluginString string
+		expectName   string
+	}{
+		{
+			"valid minimal name",
+			"github.com/hashicorp/amazon",
+			"amazon",
+		},
+		{
+			// Technically we can call `Name` on a plugin created manually
+			// but this is invalid as the Source's Name should not contain
+			// `packer-plugin-`.
+			"invalid name with prefix",
+			"github.com/hashicorp/packer-plugin-amazon",
+			"packer-plugin-amazon",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plug := &Plugin{
+				Source: tt.pluginString,
+			}
+
+			name := plug.Name()
+			if name != tt.expectName {
+				t.Errorf("Expected plugin %q to have %q as name, got %q", tt.pluginString, tt.expectName, name)
+			}
+		})
+	}
+}
+
+func TestPluginParts(t *testing.T) {
+	tests := []struct {
+		name          string
+		pluginSource  string
+		expectedParts []string
+	}{
+		{
+			"valid with two parts",
+			"factiartory.com/packer",
+			[]string{"factiartory.com", "packer"},
+		},
+		{
+			"valid with four parts",
+			"factiartory.com/hashicrop/fields/packer",
+			[]string{"factiartory.com", "hashicrop", "fields", "packer"},
+		},
+		{
+			"valid, with double-slashes in the name",
+			"factiartory.com/hashicrop//fields/packer//",
+			[]string{"factiartory.com", "hashicrop", "fields", "packer"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{tt.pluginSource}
+			diff := cmp.Diff(plugin.Parts(), tt.expectedParts)
+			if diff != "" {
+				t.Errorf("Difference found between expected and computed parts: %s", diff)
 			}
 		})
 	}

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -474,9 +474,7 @@ func TestParser_no_init(t *testing.T) {
 									Name:   "amazon",
 									Source: "github.com/hashicorp/amazon",
 									Type: &addrs.Plugin{
-										Type:      "amazon",
-										Namespace: "hashicorp",
-										Hostname:  "github.com",
+										Source: "github.com/hashicorp/amazon",
 									},
 									Requirement: VersionConstraint{
 										Required: mustVersionConstraints(version.NewConstraint(">= v0")),
@@ -486,9 +484,7 @@ func TestParser_no_init(t *testing.T) {
 									Name:   "amazon-v1",
 									Source: "github.com/hashicorp/amazon",
 									Type: &addrs.Plugin{
-										Type:      "amazon",
-										Namespace: "hashicorp",
-										Hostname:  "github.com",
+										Source: "github.com/hashicorp/amazon",
 									},
 									Requirement: VersionConstraint{
 										Required: mustVersionConstraints(version.NewConstraint(">= v1")),
@@ -498,9 +494,7 @@ func TestParser_no_init(t *testing.T) {
 									Name:   "amazon-v2",
 									Source: "github.com/hashicorp/amazon",
 									Type: &addrs.Plugin{
-										Type:      "amazon",
-										Namespace: "hashicorp",
-										Hostname:  "github.com",
+										Source: "github.com/hashicorp/amazon",
 									},
 									Requirement: VersionConstraint{
 										Required: mustVersionConstraints(version.NewConstraint(">= v2")),
@@ -510,9 +504,7 @@ func TestParser_no_init(t *testing.T) {
 									Name:   "amazon-v3",
 									Source: "github.com/hashicorp/amazon",
 									Type: &addrs.Plugin{
-										Type:      "amazon",
-										Namespace: "hashicorp",
-										Hostname:  "github.com",
+										Source: "github.com/hashicorp/amazon",
 									},
 									Requirement: VersionConstraint{
 										Required: mustVersionConstraints(version.NewConstraint(">= v3")),
@@ -522,9 +514,7 @@ func TestParser_no_init(t *testing.T) {
 									Name:   "amazon-v3-azr",
 									Source: "github.com/azr/amazon",
 									Type: &addrs.Plugin{
-										Type:      "amazon",
-										Namespace: "azr",
-										Hostname:  "github.com",
+										Source: "github.com/azr/amazon",
 									},
 									Requirement: VersionConstraint{
 										Required: mustVersionConstraints(version.NewConstraint(">= v3")),
@@ -534,9 +524,7 @@ func TestParser_no_init(t *testing.T) {
 									Name:   "amazon-v4",
 									Source: "github.com/hashicorp/amazon",
 									Type: &addrs.Plugin{
-										Type:      "amazon",
-										Namespace: "hashicorp",
-										Hostname:  "github.com",
+										Source: "github.com/hashicorp/amazon",
 									},
 									Requirement: VersionConstraint{
 										Required: mustVersionConstraints(version.NewConstraint(">= v4")),

--- a/hcl2template/types.packer_config_test.go
+++ b/hcl2template/types.packer_config_test.go
@@ -644,13 +644,26 @@ func TestParser_no_init(t *testing.T) {
 				}{
 					VersionConstraints: nil,
 					RequiredPlugins: []*RequiredPlugins{
-						{},
+						{
+							RequiredPlugins: map[string]*RequiredPlugin{
+								"amazon": {
+									Name:   "amazon",
+									Source: "hashicorp/amazon",
+									Type: &addrs.Plugin{
+										Source: "hashicorp/amazon",
+									},
+									Requirement: VersionConstraint{
+										Required: mustVersionConstraints(version.NewConstraint(">= v0")),
+									},
+								},
+							},
+						},
 					},
 				},
 				CorePackerVersionString: lockedVersion,
 				Basedir:                 filepath.Clean("testdata/init"),
 			},
-			true, true,
+			false, false,
 			[]packersdk.Build{},
 			false,
 		},

--- a/hcl2template/types.required_plugins_test.go
+++ b/hcl2template/types.required_plugins_test.go
@@ -42,7 +42,7 @@ func TestPackerConfig_required_plugin_parse(t *testing.T) {
 						"amazon": {
 							Name:   "amazon",
 							Source: "github.com/hashicorp/amazon",
-							Type:   &addrs.Plugin{Hostname: "github.com", Namespace: "hashicorp", Type: "amazon"},
+							Type:   &addrs.Plugin{Source: "github.com/hashicorp/amazon"},
 							Requirement: VersionConstraint{
 								Required: mustVersionConstraints(version.NewConstraint("~> v1.2.3")),
 							},
@@ -72,7 +72,7 @@ func TestPackerConfig_required_plugin_parse(t *testing.T) {
 						"amazon": {
 							Name:   "amazon",
 							Source: "github.com/azr/amazon",
-							Type:   &addrs.Plugin{Hostname: "github.com", Namespace: "azr", Type: "amazon"},
+							Type:   &addrs.Plugin{Source: "github.com/azr/amazon"},
 							Requirement: VersionConstraint{
 								Required: mustVersionConstraints(version.NewConstraint("~> v1.2.3")),
 							},
@@ -103,7 +103,7 @@ func TestPackerConfig_required_plugin_parse(t *testing.T) {
 						"amazon": {
 							Name:   "amazon",
 							Source: "github.com/azr/amazon",
-							Type:   &addrs.Plugin{Hostname: "github.com", Namespace: "azr", Type: "amazon"},
+							Type:   &addrs.Plugin{Source: "github.com/azr/amazon"},
 							Requirement: VersionConstraint{
 								Required: mustVersionConstraints(version.NewConstraint("~> v1.2.3")),
 							},

--- a/packer/plugin-getter/github/getter.go
+++ b/packer/plugin-getter/github/getter.go
@@ -14,10 +14,12 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/google/go-github/v33/github"
+	"github.com/hashicorp/packer/hcl2template/addrs"
 	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
 	"golang.org/x/oauth2"
 )
@@ -156,10 +158,40 @@ func (t *HostSpecificTokenAuthTransport) base() http.RoundTripper {
 	return http.DefaultTransport
 }
 
+type GithubPlugin struct {
+	Hostname  string
+	Namespace string
+	Type      string
+}
+
+func NewGithubPlugin(source *addrs.Plugin) (*GithubPlugin, error) {
+	parts := source.Parts()
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("Invalid github.com URI %q: a Github-compatible source must be in the github.com/<namespace>/<name> format.", source.String())
+	}
+
+	if parts[0] != defaultHostname {
+		return nil, fmt.Errorf("%q doesn't appear to be a valid %q source address; check source and try again.", source.String(), defaultHostname)
+	}
+
+	return &GithubPlugin{
+		Hostname:  parts[0],
+		Namespace: parts[1],
+		Type:      strings.Replace(parts[2], "packer-plugin-", "", 1),
+	}, nil
+}
+
+func (gp GithubPlugin) RealRelativePath() string {
+	return path.Join(
+		gp.Namespace,
+		fmt.Sprintf("packer-plugin-%s", gp.Type),
+	)
+}
+
 func (g *Getter) Get(what string, opts plugingetter.GetOptions) (io.ReadCloser, error) {
-	if opts.PluginRequirement.Identifier.Hostname != defaultHostname {
-		s := opts.PluginRequirement.Identifier.String() + " doesn't appear to be a valid " + defaultHostname + " source address; check source and try again."
-		return nil, errors.New(s)
+	ghURI, err := NewGithubPlugin(opts.PluginRequirement.Identifier)
+	if err != nil {
+		return nil, err
 	}
 
 	ctx := context.TODO()
@@ -188,19 +220,18 @@ func (g *Getter) Get(what string, opts plugingetter.GetOptions) (io.ReadCloser, 
 	}
 
 	var req *http.Request
-	var err error
 	transform := func(in io.ReadCloser) (io.ReadCloser, error) {
 		return in, nil
 	}
 
 	switch what {
 	case "releases":
-		u := filepath.ToSlash("/repos/" + opts.PluginRequirement.Identifier.RealRelativePath() + "/git/matching-refs/tags")
+		u := filepath.ToSlash("/repos/" + ghURI.RealRelativePath() + "/git/matching-refs/tags")
 		req, err = g.Client.NewRequest("GET", u, nil)
 		transform = transformVersionStream
 	case "sha256":
 		// something like https://github.com/sylviamoss/packer-plugin-comment/releases/download/v0.2.11/packer-plugin-comment_v0.2.11_x5_SHA256SUMS
-		u := filepath.ToSlash("https://github.com/" + opts.PluginRequirement.Identifier.RealRelativePath() + "/releases/download/" + opts.Version() + "/" + opts.PluginRequirement.FilenamePrefix() + opts.Version() + "_SHA256SUMS")
+		u := filepath.ToSlash("https://github.com/" + ghURI.RealRelativePath() + "/releases/download/" + opts.Version() + "/" + opts.PluginRequirement.FilenamePrefix() + opts.Version() + "_SHA256SUMS")
 		req, err = g.Client.NewRequest(
 			"GET",
 			u,
@@ -208,7 +239,7 @@ func (g *Getter) Get(what string, opts plugingetter.GetOptions) (io.ReadCloser, 
 		)
 		transform = transformChecksumStream()
 	case "zip":
-		u := filepath.ToSlash("https://github.com/" + opts.PluginRequirement.Identifier.RealRelativePath() + "/releases/download/" + opts.Version() + "/" + opts.ExpectedZipFilename())
+		u := filepath.ToSlash("https://github.com/" + ghURI.RealRelativePath() + "/releases/download/" + opts.Version() + "/" + opts.ExpectedZipFilename())
 		req, err = g.Client.NewRequest(
 			"GET",
 			u,

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -35,9 +35,7 @@ func TestChecksumFileEntry_init(t *testing.T) {
 	expectedVersion := "v0.3.0"
 	req := &Requirement{
 		Identifier: &addrs.Plugin{
-			Hostname:  "github.com",
-			Namespace: "ddelnano",
-			Type:      "xenserver",
+			Source: "github.com/ddelnano/xenserver",
 		},
 	}
 
@@ -460,9 +458,10 @@ func (g *mockPluginGetter) Get(what string, options GetOptions) (io.ReadCloser, 
 		}
 		toEncode = enc
 	case "zip":
-		acc := options.PluginRequirement.Identifier.Hostname + "/" +
-			options.PluginRequirement.Identifier.RealRelativePath() + "/" +
-			options.ExpectedZipFilename()
+		// Note: we'll act as if the plugin sources would always be github sources for now.
+		// This test will need to be updated if/when we move on to support other sources.
+		parts := options.PluginRequirement.Identifier.Parts()
+		acc := fmt.Sprintf("%s/%s/packer-plugin-%s/%s", parts[0], parts[1], parts[2], options.ExpectedZipFilename())
 
 		zip, found := g.Zips[acc]
 		if found == false {


### PR DESCRIPTION
The source parsing logic was heavily directed towards Github compatible source URIs, however if we want to support more cases, we need to make sure we are able to specify those URIs, and to load plugins installed from those sources.

Right now, since the getters available are only github.com, we will not support remotely instlling plugins from sources other than github.com, with the same set of constraints as before. However, we do support now installing from a local plugin binary to any kind of source, and we support loading them, including if a template wants this plugin installed locally with version constraints.

Related to: #12863 