### PR TITLE
github: only publish latest release images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       product-version: ${{ steps.set-product-version.outputs.product-version }}
       base-product-version: ${{ steps.set-product-version.outputs.base-product-version }}
-      product-date: ${{ steps.get-product-version.outputs.product-date }}
+      product-date: ${{ steps.set-product-version.outputs.product-date }}
       product-prerelease-version: ${{ steps.set-product-version.outputs.prerelease-product-version }}
       set-ld-flags: ${{ steps.set-ld-flags.outputs.set-ld-flags }}
     steps:
@@ -242,10 +242,10 @@ jobs:
           target: release-light
           arch: ${{ matrix.arch }}
           tags: |
-            docker.io/hashicorp/${{ env.REPO_NAME }}:light
+            ${{ steps.set-product-version.output.prerelease-product-version == '' && format('docker.io/hashicorp/{0}:light', env.REPO_NAME) }}
             docker.io/hashicorp/${{ env.REPO_NAME }}:light-${{ env.version }}
             docker.io/hashicorp/${{ env.REPO_NAME }}:${{ env.version }}
-            public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:light
+            ${{ steps.set-product-version.output.prerelease-product-version == '' && format('public.ecr.aws/hashicorp/{0}:light', env.REPO_NAME) }}
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:light-${{ env.version }}
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:${{ env.version }}
           dev_tags: |
@@ -272,9 +272,9 @@ jobs:
           target: release-full
           arch: ${{ matrix.arch }}
           tags: |
-            docker.io/hashicorp/${{ env.REPO_NAME }}:full
+            ${{ steps.set-product-version.output.prerelease-product-version == '' && format('docker.io/hashicorp/{0}:full', env.REPO_NAME) }}
             docker.io/hashicorp/${{ env.REPO_NAME }}:full-${{ env.version }}
-            public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:full
+            ${{ steps.set-product-version.output.prerelease-product-version == '' && format('public.ecr.aws/hashicorp/{0}:full', env.REPO_NAME) }}
             public.ecr.aws/hashicorp/${{ env.REPO_NAME }}:full-${{ env.version }}
           dev_tags: |
             docker.io/hashicorppreview/${{ env.REPO_NAME }}:full-${{ env.version }}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -139,21 +139,8 @@ event "post-publish-website" {
   }
 }
 
-event "bump-version" {
-  depends = ["post-publish-website"]
-  action "bump-version" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "bump-version"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
 event "update-ironbank" {
-  depends = ["bump-version"]
+  depends = ["post-publish-website"]
   action "update-ironbank" {
     organization = "hashicorp"
     repository = "crt-workflows-common"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -12,7 +12,7 @@ project "packer" {
     organization = "hashicorp"
     repository = "packer"
     release_branches = [
-        "main", 
+        "main",
         "release/**"
     ]
   }


### PR DESCRIPTION
When building the container images for Packer (light and full), we should only publish them in the version being built is a release, and not a pre-release.

Changing this means that both light and full latest will always be only a final release at any time.

Closes: #12899