### PR TITLE
Harden remote plugin installs

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -85,6 +85,7 @@ for more info.`)
 			Checksummers: []plugingetter.Checksummer{
 				{Type: "sha256", Hash: sha256.New()},
 			},
+			ReleasesOnly: true,
 		},
 	}
 

--- a/command/init.go
+++ b/command/init.go
@@ -127,7 +127,20 @@ for more info.`)
 			}
 
 			if cla.Force && !cla.Upgrade {
-				pluginRequirement.VersionConstraints, _ = gversion.NewConstraint(fmt.Sprintf("=%s", installs[len(installs)-1].Version))
+				// Only place another constaint to the latest release
+				// binary, if any, otherwise this is essentially the same
+				// as an upgrade
+				var installVersion string
+				for _, install := range installs {
+					ver, _ := gversion.NewVersion(install.Version)
+					if ver.Prerelease() == "" {
+						installVersion = install.Version
+					}
+				}
+
+				if installVersion != "" {
+					pluginRequirement.VersionConstraints, _ = gversion.NewConstraint(fmt.Sprintf("=%s", installVersion))
+				}
 			}
 		}
 

--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -130,6 +130,7 @@ func (c *PluginsInstallCommand) RunContext(buildCtx context.Context, args *Plugi
 			Checksummers: []plugingetter.Checksummer{
 				{Type: "sha256", Hash: sha256.New()},
 			},
+			ReleasesOnly: true,
 		},
 	}
 	if runtime.GOOS == "windows" {

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -864,7 +864,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 							break
 						}
 						if copyFrom == nil {
-							err := fmt.Errorf("could not find a %s file in zipfile", checksum.Filename)
+							err := fmt.Errorf("could not find a %q file in zipfile", expectedBinaryFilename)
 							errs = multierror.Append(errs, err)
 							return nil, errs
 						}

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -721,7 +721,6 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 						continue
 					}
 					if err := entry.validate("v"+version.String(), opts.BinaryInstallationOptions); err != nil {
-						log.Printf("[INFO] ignoring invalid remote binary %s: %s", entry.Filename, err)
 						continue
 					}
 

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-version"
+	goversion "github.com/hashicorp/go-version"
 	pluginsdk "github.com/hashicorp/packer-plugin-sdk/plugin"
 	"github.com/hashicorp/packer-plugin-sdk/tmp"
 	"github.com/hashicorp/packer/hcl2template/addrs"
@@ -47,7 +47,7 @@ type Requirement struct {
 
 	// VersionConstraints as defined by user. Empty ( to be avoided ) means
 	// highest found version.
-	VersionConstraints version.Constraints
+	VersionConstraints goversion.Constraints
 }
 
 type BinaryInstallationOptions struct {
@@ -220,7 +220,7 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 		// versionsStr now looks like v1.2.3_x5.1 or amazon_v1.2.3_x5.1
 		parts := strings.SplitN(versionsStr, "_", 2)
 		pluginVersionStr, protocolVersionStr := parts[0], parts[1]
-		ver, err := version.NewVersion(pluginVersionStr)
+		ver, err := goversion.NewVersion(pluginVersionStr)
 		if err != nil {
 			// could not be parsed, ignoring the file
 			log.Printf("found %q with an incorrect %q version, ignoring it. %v", path, pluginVersionStr, err)
@@ -237,13 +237,13 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 			continue
 		}
 
-		rawVersion, err := version.NewVersion(pluginVersionStr)
+		rawVersion, err := goversion.NewVersion(pluginVersionStr)
 		if err != nil {
 			log.Printf("malformed version string in filename %q: %s, ignoring", pluginVersionStr, err)
 			continue
 		}
 
-		descVersion, err := version.NewVersion(describeInfo.Version)
+		descVersion, err := goversion.NewVersion(describeInfo.Version)
 		if err != nil {
 			log.Printf("malformed reported version string %q: %s, ignoring", describeInfo.Version, err)
 			continue
@@ -411,7 +411,7 @@ type GetOptions struct {
 
 	BinaryInstallationOptions
 
-	version *version.Version
+	version *goversion.Version
 
 	expectedZipFilename string
 }
@@ -614,7 +614,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 	getters := opts.Getters
 
 	log.Printf("[TRACE] getting available versions for the %s plugin", pr.Identifier)
-	versions := version.Collection{}
+	versions := goversion.Collection{}
 	var errs *multierror.Error
 	for _, getter := range getters {
 
@@ -642,7 +642,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 			continue
 		}
 		for _, release := range releases {
-			v, err := version.NewVersion(release.Version)
+			v, err := goversion.NewVersion(release.Version)
 			if err != nil {
 				err := fmt.Errorf("could not parse release version %s. %w", release.Version, err)
 				errs = multierror.Append(errs, err)

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -917,7 +917,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 		}
 	}
 
-	if errs.Len() == 0 {
+	if errs == nil || errs.Len() == 0 {
 		err := fmt.Errorf("could not find a local nor a remote checksum for plugin %q %q", pr.Identifier, pr.VersionConstraints)
 		errs = multierror.Append(errs, err)
 	}

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -726,9 +726,7 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 						continue
 					}
 					if err := entry.validate("v"+version.String(), opts.BinaryInstallationOptions); err != nil {
-						err := fmt.Errorf("ignoring invalid remote binary %s: %s", entry.Filename, err)
-						errs = multierror.Append(errs, err)
-						log.Printf("[TRACE] %s", err)
+						log.Printf("[INFO] ignoring invalid remote binary %s: %s", entry.Filename, err)
 						continue
 					}
 

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -800,7 +800,11 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 							errs = multierror.Append(errs, err)
 							return nil, errs
 						}
-						defer tmpFile.Close()
+						defer func() {
+							tmpFilePath := tmpFile.Name()
+							tmpFile.Close()
+							os.Remove(tmpFilePath)
+						}()
 
 						// start fetching binary
 						remoteZipFile, err := getter.Get("zip", GetOptions{
@@ -837,10 +841,6 @@ func (pr *Requirement) InstallLatest(opts InstallOptions) (*Installation, error)
 						if err := checksum.Checksummer.Checksum(checksum.Expected, tmpFile); err != nil {
 							err := fmt.Errorf("%w. Is the checksum file correct ? Is the binary file correct ?", err)
 							errs = multierror.Append(errs, err)
-							log.Printf("%s, truncating the zipfile", err)
-							if err := tmpFile.Truncate(0); err != nil {
-								log.Printf("[TRACE] %v", err)
-							}
 							continue
 						}
 

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -237,19 +237,13 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 			continue
 		}
 
-		rawVersion, err := goversion.NewVersion(pluginVersionStr)
-		if err != nil {
-			log.Printf("malformed version string in filename %q: %s, ignoring", pluginVersionStr, err)
-			continue
-		}
-
 		descVersion, err := goversion.NewVersion(describeInfo.Version)
 		if err != nil {
 			log.Printf("malformed reported version string %q: %s, ignoring", describeInfo.Version, err)
 			continue
 		}
 
-		if rawVersion.Compare(descVersion) != 0 {
+		if ver.Compare(descVersion) != 0 {
 			log.Printf("plugin %q reported version %q while its name implies version %q, ignoring", path, describeInfo.Version, pluginVersionStr)
 			continue
 		}
@@ -271,7 +265,7 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 		// Note: we use the raw version name here, without the pre-release
 		// suffix, as otherwise constraints reject them, which is not
 		// what we want by default.
-		if !pr.VersionConstraints.Check(rawVersion.Core()) {
+		if !pr.VersionConstraints.Check(ver.Core()) {
 			log.Printf("[TRACE] version %q of file %q does not match constraint %q", pluginVersionStr, path, pr.VersionConstraints.String())
 			continue
 		}

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -5,7 +5,6 @@ package packer
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -127,13 +126,9 @@ func (c *PluginConfig) Discover() error {
 // if the "packer-plugin-amazon" binary had an "ebs" builder one could use
 // the "amazon-ebs" builder.
 func (c *PluginConfig) DiscoverMultiPlugin(pluginName, pluginPath string) error {
-	out, err := exec.Command(pluginPath, "describe").Output()
+	desc, err := plugingetter.GetPluginDescription(pluginPath)
 	if err != nil {
-		return err
-	}
-	var desc pluginsdk.SetDescription
-	if err := json.Unmarshal(out, &desc); err != nil {
-		return err
+		return fmt.Errorf("failed to get plugin description from executable %q: %s", pluginPath, err)
 	}
 
 	pluginPrefix := pluginName + "-"


### PR DESCRIPTION
Since we're hardening what Packer is able to load locally when it comes to plugins, we need also to harden the installation process a bit.

While testing we noticed some remotes had published their plugins with version mismatches between the tag and the binary.
This was not a problem in the past, as Packer did not care for this, only the binary name was important, and the plugin could be installed without problem.

Nowadays however, since Packer enforces the plugin version reported in the name to be the same as the plugin self-reported version, this makes it impossible for the installed plugin to load anymore in such an instance.

Therefore in order to limit confusion, and so users are able to understand the problem and report it to the plugins with that mismatch, we reject the installations that expose this mismatch, and report it to the user if they cannot install anything else.

