### PR TITLE
[HPR-1702] build: Add LICENSE file to release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,12 @@ jobs:
             cp LICENSE.txt "$TARGET_DIR/"
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -trimpath -buildvcs=false
 
+      - name: Copy license file to config_dir
+        if: ${{ matrix.goos == 'linux' }}
+        env:
+          LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ env.REPO_NAME }}"
+        run: |
+          mkdir -p "$LICENSE_DIR" && cp LICENSE "$LICENSE_DIR/LICENSE.txt"
       - name: Linux Packaging
         uses: hashicorp/actions-packaging-linux@v1
         with:
@@ -175,6 +181,7 @@ jobs:
           binary: "dist/${{ env.REPO_NAME }}"
           deb_depends: "openssl"
           rpm_depends: "openssl"
+          config_dir: ".release/linux/package/"
       - name: Add Linux Package names to env
         run: |
           echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
+            cp LICENSE.txt "$TARGET_DIR/"
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -trimpath -buildvcs=false    
 
   build-linux:
@@ -158,6 +159,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
+            cp LICENSE.txt "$TARGET_DIR/"
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -trimpath -buildvcs=false
 
       - name: Linux Packaging
@@ -220,6 +222,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
+            cp LICENSE.txt "$TARGET_DIR/"
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -tags netcgo -trimpath -buildvcs=false
 
   build-docker-light:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
-            cp LICENSE.txt "$TARGET_DIR/"
+            cp LICENSE "$TARGET_DIR/LICENSE.txt"
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -trimpath -buildvcs=false    
 
   build-linux:
@@ -159,7 +159,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
-            cp LICENSE.txt "$TARGET_DIR/"
+            cp LICENSE "$TARGET_DIR/LICENSE.txt"
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -trimpath -buildvcs=false
 
       - name: Copy license file to config_dir
@@ -229,7 +229,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |-
-            cp LICENSE.txt "$TARGET_DIR/"
+            cp LICENSE "$TARGET_DIR/LICENSE.txt"
             go build -o "$BIN_PATH" -ldflags="$LD_FLAGS" -tags netcgo -trimpath -buildvcs=false
 
   build-docker-light:

--- a/.release/docker/README.md
+++ b/.release/docker/README.md
@@ -2,6 +2,10 @@
 
 The root of this repository contains the officially supported HashiCorp Dockerfile to build the hashicorp/packer docker image. The `dev` docker image should be built for local dev and testing, while the production docker image, `release`, is built in CI and makes use of CI-built binaries. The `light` and `full` docker images are built using the official binaries from releases.hashicorp.com.
 
+## License
+
+This image is licensed under (BUSL-1.1)[https://github.com/hashicorp/packer/blob/main/LICENSE].
+
 ## Build
 
 Refer to the Makefile of this repository, especially the `docker` and `docker-dev` targets to build a local version of the dev image based on the sources available.

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,13 @@ LABEL name="Packer" \
       version=$PRODUCT_VERSION \
       release=$PRODUCT_VERSION \
       summary="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration." \
-      description="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration. Please submit issues to https://github.com/hashicorp/packer/issues"
+      description="Packer is a tool for creating identical machine images for multiple platforms from a single source configuration. Please submit issues to https://github.com/hashicorp/packer/issues" \
+      org.opencontainers.image.licenses="BUSL-1.1"
 
 RUN apk add --no-cache git bash wget openssl gnupg xorriso
 
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt
 
 ENTRYPOINT ["/bin/packer"]
 


### PR DESCRIPTION
- Add LICENSE to zipped Go binaries
- Add LICENSE details to Docker release binaries
- Add LICENSE to Linux packages


Changes based on examples https://github.com/hashicorp/crt-core-helloworld/pull/172 and [internal-guidance](https://hermes.hashicorp.services/document/1axPAhaN2xk70-GwyqRznWx6Voxetc_FLVa-zM8Kza1w)