### PR TITLE
Add missing option doc for 'packer fmt'

### DIFF
--- a/website/content/docs/commands/fmt.mdx
+++ b/website/content/docs/commands/fmt.mdx
@@ -53,3 +53,6 @@ $ cat my-template.pkr.hcl | packer fmt -
   (always disabled if using -check)
 
 - `-` - read formatting changes from stdin and write them to stdout.
+
+- `recursive` Also process files in subdirectories. By default, only the
+  given directory (or current directory) is processed.


### PR DESCRIPTION
Hi HashiCorp team, I was looking at `man` page of `packer fmt` and saw a working option that is missing on the [packer online docs](https://developer.hashicorp.com/packer/docs/commands/fmt). Please kindly review this proposal. Thanks

> [!NOTE]
>
> The missing option is `-recursive`. Being able to see this option online in the first place would certainly have saved my 10+ minutes of work as well as others' who might experience the same.

This is what I see on my machine:

```console
$ packer -v
1.8.6

$ packer fmt -h
Usage: packer fmt [options] [TEMPLATE]

  Rewrites all Packer configuration files to a canonical format. Both
  configuration files (.pkr.hcl) and variable files (.pkrvars.hcl) are updated.
  JSON files (.json) are not modified.

  If TEMPLATE is "." the current directory will be used.
  If TEMPLATE is "-" then content will be read from STDIN.

  The given content must be in Packer's HCL2 configuration language; JSON is
  not supported.

Options:
  -check        Check if the input is formatted. Exit status will be 0 if all
                 input is properly formatted and non-zero otherwise.

  -diff         Display diffs of formatting change

  -write=false  Don't write to source files
                (always disabled if using -check)

  -recursive     Also process files in subdirectories. By default, only the
                 given directory (or current directory) is processed.
```