### PR TITLE
Update CHANGELOG for Packer 1.11.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## 1.11.0 (Upcoming)
 
 ### NOTES:
+* A LICENSE.txt file has been added to the Packer release artifacts.
+     [GH-12931](https://github.com/hashicorp/packer/pull/12931)
+     [GH-12940](https://github.com/hashicorp/packer/pull/12940)
+
 * **Breaking Change**: Support for loading single-component plugins has been removed from Packer. [GH-12785](https://github.com/hashicorp/packer/pull/12785)
 
 * **Breaking Change**: Support for loading plugin binaries following
      the naming convention of packer-plugin-name has been dropped. Packer will now only load
-     plugins stored under PACKER_PLUGIN_PATH using the expected namespaced
+     plugins stored under the [Packer plugin directory](https://developer.hashicorp.com/packer/docs/configure#packer-s-plugin-directory) using the expected namespaced
      directory and CHECKSUM files. This change drops support for loading plugin
      binaries in Packer's executable directory or a template's current working
      directory. [GH-12828](https://github.com/hashicorp/packer/pull/12828)
@@ -23,18 +27,26 @@
 * core: Add `-ignore-prerelease-plugins` flag to disable the use of development
      plugin binaries for the `build` and `validate` commands development plugin
      binaries. [GH-12828](https://github.com/hashicorp/packer/pull/12828)
+     [GH-12882](https://github.com/hashicorp/packer/pull/12882)
+* Packer users can now track Packer version and plugin versions used for each
+     build artifact in HCP Packer.
+     [GH-12866](https://github.com/hashicorp/packer/pull/12866)
 
-### BUG FIXES:
-* core: fix plugin version ordering to not be lexicographic. This fixes an issue
-     with how plugins are discovered by Packer, and ensures proper version ordering.
-     This means that with this change, versions that are semantically greater,
-     but lexicographically inferior will be loaded.
-     Ex: 1.0.9 vs. 1.0.10; `1.0.9 > 1.0.10` lexicographically, but semantically
-     `1.0.10 > 1.0.9`
+
+### SECURITY:
+* Bump github.com/go-jose/go-jose/v3 to address GHSA-c5q2-7r4c-mv6g.
+     [GH-12880](https://github.com/hashicorp/packer/pull/12880)
+* Bump golang.org/x/net to v0.24.0 to address GO-2024-2687.
+     [GH-12924](https://github.com/hashicorp/packer/pull/12924)
+
 
 ### IMPROVEMENTS:
+* core: Bump github.com/hashicorp/hcp-sdk-go from 0.90.0 to 0.92.0.
+     [GH-12935](https://github.com/hashicorp/packer/pull/12935)
+* core: Bump github.com/hashicorp/packer-plugin-sdk from 0.5.2 to 0.5.3
+     [GH-12932](https://github.com/hashicorp/packer/pull/12932)
 * core: Move to predictable plugin loading schema -  Packer will now only load
-     plugins stored under PACKER_PLUGIN_PATH using the expected namespaced
+     plugins stored under the [Packer plugin directory](https://developer.hashicorp.com/packer/docs/configure#packer-s-plugin-directory) using the expected namespaced
      directory and CHECKSUM files.
      [GH-12828](https://github.com/hashicorp/packer/pull/12828)
 * core: Remove support loading single-component plugins.
@@ -50,6 +62,22 @@
      command. This addition makes it possible to pipe commands like
      `packer plugins installed` with it for speedy cleanup of installed plugins.
      [GH-12886](https://github.com/hashicorp/packer/pull/12886)
+* core: Relax Packer source address URIs within the `required_plugins` block to
+     support the installation of local plugin binary using a custom or internal
+     source address (e.g. mycompany.com/plugins/happyorg/happycloud). Remote
+     installation using `packer init` or `packer plugins install`  does not
+     support non-GitHub source URIs. Users using alternative hosts must
+     install plugins manually using `packer plugins install --path`.
+     [GH-12911](https://github.com/hashicorp/packer/pull/12911), [GH-12962] (https://github.com/hashicorp/packer/pull/12962)
+* core: Remote plugins installed containing an internal version number that
+     differs from the version number within the binary name can lead to
+     confusion when tracking Packer plugin version information. To help track
+     such discrepancies in the plugin version, `packer init` and `packer plugin
+     install` have been updated to reject installation of such plugins.
+     1.0.0-dev). Users are encouraged to notify plugin maintainers of any
+     version mismatches.
+     [GH-12915](https://github.com/hashicorp/packer/pull/12915), [GH-12953](https://github.com/hashicorp/packer/pull/12953), [GH-12972](https://github.com/hashicorp/packer/pull/12972)
+
 * core: Version metadata support for plugins. Plugins may now formally have metadata
      in their versions, Packer supports it, and applies the semver recommendations on
      them, i.e. they are ignored for comparison/sorting purposes, but allowed for
@@ -95,11 +123,23 @@ If, however, a 1.1.1 release version of the plugin is available, it will have pr
           └── packer-plugin-amazon_v1.1.1_x5.0_darwin_arm64_SHA256SUM
 ```
 
+### BUG FIXES:
+* core: fix plugin version ordering to not be lexicographic. This fixes an issue
+     with how plugins are discovered by Packer, and ensures proper version ordering.
+     This means that with this change, versions that are semantically greater,
+     but lexicographically inferior will be loaded.
+     Ex: 1.0.9 vs. 1.0.10; `1.0.9 > 1.0.10` lexicographically, but semantically
+     `1.0.10 > 1.0.9`
+* core/hcp: fix potential race condition when storing plugin details to the HCP
+     Packer metadata storage map.
+     [GH-12936](https://github.com/hashicorp/packer/pull/12936)
+
+
 ## 1.10.3 (April 22, 2024)
 
 ### NOTES
 * A LICENSE.txt file has been added to the Packer release artifacts.
-     [GH-12981](https://github.com/hashicorp/packer/pull/12931)
+     [GH-12931](https://github.com/hashicorp/packer/pull/12931)
 
 ### FEATURES
 * Packer users can now track Packer version and plugin versions used for each


### PR DESCRIPTION
This change simply updates the CHANGELOG with updates to 1.11.0, since the last alpha2 release. 

Depends on: #12911
Depends on: #12915
Depends on: #12936
