### PR TITLE
Fixed wrong parameter in doc

### DIFF
--- a/website/content/partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
+++ b/website/content/partials/packer-plugin-sdk/communicator/SSH-not-required.mdx
@@ -78,7 +78,7 @@
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
   (the default protocol for copying data) returns a non-zero error code since the MOTW
   cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+  with SFTP instead `ssh_file_transfer_method = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 


### PR DESCRIPTION
Replace `ssh_file_transfer_protocol` with `ssh_file_transfer_method` in documentation since the former does not exist as a parameter.
