### PR TITLE
addrs: limit source component length to 16

### DIFF
--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -137,9 +137,9 @@ func (c *PluginsInstallCommand) RunContext(buildCtx context.Context, args *Plugi
 		opts.BinaryInstallationOptions.Ext = ".exe"
 	}
 
-	plugin, diags := addrs.ParsePluginSourceString(args.PluginIdentifier)
-	if diags.HasErrors() {
-		c.Ui.Error(diags.Error())
+	plugin, err := addrs.ParsePluginSourceString(args.PluginIdentifier)
+	if err != nil {
+		c.Ui.Errorf("Invalid source string %q: %s", args.PluginIdentifier, err)
 		return 1
 	}
 

--- a/command/plugins_remove.go
+++ b/command/plugins_remove.go
@@ -142,9 +142,9 @@ func (c *PluginsRemoveCommand) RunContext(buildCtx context.Context, args []strin
 		opts.BinaryInstallationOptions.Ext = ".exe"
 	}
 
-	plugin, diags := addrs.ParsePluginSourceString(args[0])
-	if diags.HasErrors() {
-		c.Ui.Error(diags.Error())
+	plugin, err := addrs.ParsePluginSourceString(args[0])
+	if err != nil {
+		c.Ui.Errorf("Invalid source string %q: %s", args[0], err)
 		return 1
 	}
 

--- a/hcl2template/addrs/plugin.go
+++ b/hcl2template/addrs/plugin.go
@@ -218,7 +218,20 @@ func ParsePluginSourceString(str string) (*Plugin, hcl.Diagnostics) {
 		})
 	}
 
-	return &Plugin{
+	plug := &Plugin{
 		Source: str,
-	}, diags
+	}
+	if len(plug.Parts()) > 16 {
+		return nil, diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Too many parts to source URL",
+			Detail: fmt.Sprintf("The source URL must have at most 16 components, and the one provided has %d.\n"+
+				"This is unsupported by Packer, please consider using a source that has less components to it.\n"+
+				"If this is a blocking issue for you, please open an issue to ask for supporting more "+
+				"components to the source URI.",
+				len(plug.Parts())),
+		})
+	}
+
+	return plug, diags
 }

--- a/hcl2template/addrs/plugin_test.go
+++ b/hcl2template/addrs/plugin_test.go
@@ -20,6 +20,7 @@ func TestPluginParseSourceString(t *testing.T) {
 		{"invalid: only one component, rejected", "potato", nil, true},
 		{"valid: two components in name", "hashicorp/azr", &Plugin{"hashicorp/azr"}, false},
 		{"valid: three components, nothing superfluous", "github.com/hashicorp/azr", &Plugin{"github.com/hashicorp/azr"}, false},
+		{"valid: 16 components, nothing superfluous", "github.com/hashicorp/azr/a/b/c/d/e/f/g/h/i/j/k/l/m", &Plugin{"github.com/hashicorp/azr/a/b/c/d/e/f/g/h/i/j/k/l/m"}, false},
 		{"invalid: trailing slash", "github.com/hashicorp/azr/", nil, true},
 		{"invalid: reject because scheme specified", "https://github.com/hashicorp/azr", nil, true},
 		{"invalid: reject because query non nil", "github.com/hashicorp/azr?arg=1", nil, true},
@@ -28,6 +29,7 @@ func TestPluginParseSourceString(t *testing.T) {
 		{"invalid: leading slashes are removed", "/github.com/hashicorp/azr", nil, true},
 		{"invalid: plugin name contains packer-", "/github.com/hashicorp/packer-azr", nil, true},
 		{"invalid: plugin name contains packer-plugin-", "/github.com/hashicorp/packer-plugin-azr", nil, true},
+		{"invalid: 17 components, too many parts to URL", "github.com/hashicorp/azr/a/b/c/d/e/f/g/h/i/j/k/l/m/n", nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/hcl2template/addrs/plugin_test.go
+++ b/hcl2template/addrs/plugin_test.go
@@ -33,15 +33,15 @@ func TestPluginParseSourceString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotDiags := ParsePluginSourceString(tt.source)
+			got, err := ParsePluginSourceString(tt.source)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParsePluginSourceString() got = %v, want %v", got, tt.want)
 			}
-			if tt.wantDiags && len(gotDiags) == 0 {
-				t.Errorf("Expected diags, but got none")
+			if tt.wantDiags && err == nil {
+				t.Errorf("Expected error, but got none")
 			}
-			if !tt.wantDiags && len(gotDiags) != 0 {
-				t.Errorf("Unexpected diags: %s", gotDiags)
+			if !tt.wantDiags && err != nil {
+				t.Errorf("Unexpected error: %s", err)
 			}
 		})
 	}

--- a/hcl2template/types.required_plugins.go
+++ b/hcl2template/types.required_plugins.go
@@ -166,15 +166,15 @@ func decodeRequiredPluginsBlock(block *hcl.Block) (*RequiredPlugins, hcl.Diagnos
 			}
 
 			rp.Source = source.AsString()
-			p, sourceDiags := addrs.ParsePluginSourceString(rp.Source)
+			p, err := addrs.ParsePluginSourceString(rp.Source)
 
-			if sourceDiags.HasErrors() {
-				for _, diag := range sourceDiags {
-					if diag.Subject == nil {
-						diag.Subject = attr.Expr.Range().Ptr()
-					}
-				}
-				diags = append(diags, sourceDiags...)
+			if err != nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Subject:  &rp.Requirement.DeclRange,
+					Summary:  "Failed to parse source",
+					Detail:   err.Error(),
+				})
 				continue
 			} else {
 				rp.Type = p

--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -182,7 +182,22 @@ func (pr Requirement) getPluginBinaries(opts ListInstallationsOptions) ([]string
 		return nil, err
 	}
 
-	return matches, err
+	retMatches := make([]string, 0, len(matches))
+	// Don't keep plugins that are nested too deep in the hierarchy
+	for _, match := range matches {
+		dir := strings.Replace(filepath.Dir(match), opts.PluginDirectory, "", 1)
+		parts := strings.FieldsFunc(dir, func(r rune) bool {
+			return r == '/'
+		})
+		if len(parts) > 16 {
+			log.Printf("[WARN] plugin %q ignored, too many levels of depth: %d (max 16)", match, len(parts))
+			continue
+		}
+
+		retMatches = append(retMatches, match)
+	}
+
+	return retMatches, err
 }
 
 // ListInstallations lists unique installed versions of plugin Requirement pr

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -430,9 +430,9 @@ echo '{"version":"v2.10.0","api_version":"x6.1"}'`,
 
 			log.Printf("starting %s test", tt.name)
 
-			identifier, diags := addrs.ParsePluginSourceString("github.com/hashicorp/" + tt.fields.Identifier)
-			if len(diags) != 0 {
-				t.Fatalf("ParsePluginSourceString(%q): %v", tt.fields.Identifier, diags)
+			identifier, err := addrs.ParsePluginSourceString("github.com/hashicorp/" + tt.fields.Identifier)
+			if err != nil {
+				t.Fatalf("ParsePluginSourceString(%q): %v", tt.fields.Identifier, err)
 			}
 			cts, err := version.NewConstraint(tt.fields.VersionConstraints)
 			if err != nil {


### PR DESCRIPTION
When specifying/installing plugins, a source URI is required for Packer to be able to locate or install a plugin to the local plugin hierarchy.

The plugin hierarchy is based on the plugin source, where each component in this hierarchy will become a directory.

In order to avoid sources with too many levels of nesting, causing a lot of mkdirs, we limit the number of sources to 16 in this commit, this should be long enough for most of our users.