### PR TITLE
docs: fix typo in HCP Packer artifact/version docs

### DIFF
--- a/website/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -67,7 +67,7 @@ data "hcp-packer-version" "hardened-source" {
 # region to disambiguate.
 data "hcp-packer-artifact" "example" {
   bucket_name         = "hardened-ubuntu-16-04"
-  version_fingerprint = data.hcp_packer_version.hardened-source.fingerprint
+  version_fingerprint = data.hcp-packer-version.hardened-source.fingerprint
   platform            = "aws"
   region              = "us-east-1"
 }

--- a/website/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -64,7 +64,7 @@ data "hcp-packer-version" "hardened-source" {
 # region to disambiguate.
 data "hcp-packer-artifact" "example" {
   bucket_name         = "hardened-ubuntu-16-04"
-  version_fingerprint = data.hcp_packer_version.hardened-source.fingerprint
+  version_fingerprint = data.hcp-packer-version.hardened-source.fingerprint
   platform            = "aws"
   region              = "us-east-1"
 }


### PR DESCRIPTION
In the full example for both the hcp-packer-artifact and hcp-packer-version the hcp-packer-version reference in the example template was mistakenly spelled as "hcp_packer_version", which won't work, so we fix that typo here.