### PR TITLE
packer: error multiple paths in PACKER_PLUGIN_PATH

### DIFF
--- a/packer/plugin_folders.go
+++ b/packer/plugin_folders.go
@@ -4,9 +4,11 @@
 package packer
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/pathing"
 )
@@ -14,6 +16,12 @@ import (
 // PluginFolder returns the known plugin folder based on system.
 func PluginFolder() (string, error) {
 	if packerPluginPath := os.Getenv("PACKER_PLUGIN_PATH"); packerPluginPath != "" {
+		if strings.ContainsRune(packerPluginPath, os.PathListSeparator) {
+			return "", fmt.Errorf("Multiple paths are no longer supported for PACKER_PLUGIN_PATH.\n"+
+				"This should be defined as one of the following options for your environment:"+
+				"\n* PACKER_PLUGIN_PATH=%v", strings.Join(strings.Split(packerPluginPath, ":"), "\n* PACKER_PLUGIN_PATH="))
+		}
+
 		return packerPluginPath, nil
 	}
 


### PR DESCRIPTION
When a user defines PACKER_PLUGIN_PATH in their environment, we need to error if their path defines multiple directories separated by `:`.

This used to be supported, but this is removed with 1.11 as we're simplifying the loading process for plugins, so we opted to fall-back to only one plugin directory supported.