### PR TITLE
packer: register plugin components only once

### DIFF
--- a/hcl2template/plugin.go
+++ b/hcl2template/plugin.go
@@ -55,16 +55,6 @@ func (cfg *PackerConfig) PluginRequirements() (plugingetter.Requirements, hcl.Di
 }
 
 func (cfg *PackerConfig) DetectPluginBinaries() hcl.Diagnostics {
-	// Do first pass to discover all the installed plugins
-	err := cfg.parser.PluginConfig.Discover()
-	if err != nil {
-		return (hcl.Diagnostics{}).Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Failed to discover installed plugins",
-			Detail:   err.Error(),
-		})
-	}
-
 	// Then we can apply any constraint from the template, if any
 	opts := plugingetter.ListInstallationsOptions{
 		PluginDirectory: cfg.parser.PluginConfig.PluginDirectory,
@@ -129,6 +119,16 @@ func (cfg *PackerConfig) DetectPluginBinaries() hcl.Diagnostics {
 			Severity: hcl.DiagError,
 			Summary:  "Missing plugins",
 			Detail:   detailMessage.String(),
+		})
+	}
+
+	// Do a second pass to discover the remaining installed plugins
+	err := cfg.parser.PluginConfig.Discover()
+	if err != nil {
+		return (hcl.Diagnostics{}).Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to discover installed plugins",
+			Detail:   err.Error(),
 		})
 	}
 

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -144,6 +144,9 @@ func (c *PluginConfig) DiscoverMultiPlugin(pluginName, pluginPath string) error 
 		if builderName == pluginsdk.DEFAULT_NAME {
 			key = pluginName
 		}
+		if c.Builders.Has(key) {
+			continue
+		}
 		c.Builders.Set(key, func() (packersdk.Builder, error) {
 			return c.Client(pluginPath, "start", "builder", builderName).Builder()
 		})
@@ -159,6 +162,9 @@ func (c *PluginConfig) DiscoverMultiPlugin(pluginName, pluginPath string) error 
 		key := pluginPrefix + postProcessorName
 		if postProcessorName == pluginsdk.DEFAULT_NAME {
 			key = pluginName
+		}
+		if c.PostProcessors.Has(key) {
+			continue
 		}
 		c.PostProcessors.Set(key, func() (packersdk.PostProcessor, error) {
 			return c.Client(pluginPath, "start", "post-processor", postProcessorName).PostProcessor()
@@ -176,6 +182,9 @@ func (c *PluginConfig) DiscoverMultiPlugin(pluginName, pluginPath string) error 
 		if provisionerName == pluginsdk.DEFAULT_NAME {
 			key = pluginName
 		}
+		if c.Provisioners.Has(key) {
+			continue
+		}
 		c.Provisioners.Set(key, func() (packersdk.Provisioner, error) {
 			return c.Client(pluginPath, "start", "provisioner", provisionerName).Provisioner()
 		})
@@ -191,6 +200,9 @@ func (c *PluginConfig) DiscoverMultiPlugin(pluginName, pluginPath string) error 
 		key := pluginPrefix + datasourceName
 		if datasourceName == pluginsdk.DEFAULT_NAME {
 			key = pluginName
+		}
+		if c.DataSources.Has(key) {
+			continue
 		}
 		c.DataSources.Set(key, func() (packersdk.Datasource, error) {
 			return c.Client(pluginPath, "start", "datasource", datasourceName).Datasource()


### PR DESCRIPTION
When running a packer command on an HCL2 template, depending on whether or not there are required_plugin blocks defined, Packer may need to discover and register a plugin's components multiple times.

This is the behaviour ever since those blocks were introduced to Packer, but given we are doing the operation multiple times, this is suboptimal.

This commit changes the way things works by first doing the restricted discovery of plugins (as dictated by required_plugins), then proceeding to the global discovery, with the change that subsequent component discoveries will not have precedence over those pre-discovered anymore.

This allows us to invert the call order of both discovery phases safely, and maintains the constraints described in the templates.