### PR TITLE
packer: don't load plugins with metadata in name

### DIFF
--- a/packer/plugin-getter/plugins.go
+++ b/packer/plugin-getter/plugins.go
@@ -280,6 +280,11 @@ func (pr Requirement) ListInstallations(opts ListInstallationsOptions) (InstallL
 			continue
 		}
 
+		if ver.Metadata() != "" {
+			log.Printf("found version %q with metadata in the name, this could introduce ambiguity and is not supported, ignoring it.", pluginVersionStr)
+			continue
+		}
+
 		descVersion, err := goversion.NewVersion(describeInfo.Version)
 		if err != nil {
 			log.Printf("malformed reported version string %q: %s, ignoring", describeInfo.Version, err)


### PR DESCRIPTION
If a plugin is installed in the PACKER_PLUGIN_PATH, and its version contains metadata, we reject it. This is because metadata is free-form data, which could then make it possible to have multiple conflicting versions of a plugin installed, so we don't support it and explicitely reject plugins like those.

A valid plugin with metadata in its version information should be installed without its metadata part, so there can only be one variant of the plugin installed at a specific version.