### PR TITLE
packer: fix listing on windows with .exe ext

### DIFF
--- a/command/plugins_required.go
+++ b/command/plugins_required.go
@@ -83,11 +83,16 @@ func (c *PluginsRequiredCommand) RunContext(buildCtx context.Context, cla *Plugi
 		return ret
 	}
 
+	ext := ""
+	if runtime.GOOS == "windows" {
+		ext = ".exe"
+	}
 	opts := plugingetter.ListInstallationsOptions{
 		PluginDirectory: c.Meta.CoreConfig.Components.PluginConfig.PluginDirectory,
 		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{
 			OS:              runtime.GOOS,
 			ARCH:            runtime.GOARCH,
+			Ext:             ext,
 			APIVersionMajor: pluginsdk.APIVersionMajor,
 			APIVersionMinor: pluginsdk.APIVersionMinor,
 			Checksummers: []plugingetter.Checksummer{

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -103,7 +102,7 @@ func (c *PluginConfig) Discover() error {
 	// We'll use that later to register the components for each plugin
 	pluginMap := map[string]string{}
 	for _, install := range installations {
-		pluginBasename := path.Base(install.BinaryPath)
+		pluginBasename := filepath.Base(install.BinaryPath)
 		matches := extractPluginBasename.FindStringSubmatch(pluginBasename)
 		if len(matches) != 2 {
 			log.Printf("[INFO] - plugin %q could not have its name matched, ignoring", pluginBasename)

--- a/packer/plugin.go
+++ b/packer/plugin.go
@@ -75,11 +75,17 @@ func (c *PluginConfig) Discover() error {
 		c.PluginDirectory, _ = PluginFolder()
 	}
 
+	ext := ""
+	if runtime.GOOS == "windows" {
+		ext = ".exe"
+	}
+
 	installations, err := plugingetter.Requirement{}.ListInstallations(plugingetter.ListInstallationsOptions{
 		PluginDirectory: c.PluginDirectory,
 		BinaryInstallationOptions: plugingetter.BinaryInstallationOptions{
 			OS:              runtime.GOOS,
 			ARCH:            runtime.GOARCH,
+			Ext:             ext,
 			APIVersionMajor: pluginsdk.APIVersionMajor,
 			APIVersionMinor: pluginsdk.APIVersionMinor,
 			Checksummers: []plugingetter.Checksummer{

--- a/packer/plugin_folders.go
+++ b/packer/plugin_folders.go
@@ -13,13 +13,15 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/pathing"
 )
 
+var pathSep = fmt.Sprintf("%c", os.PathListSeparator)
+
 // PluginFolder returns the known plugin folder based on system.
 func PluginFolder() (string, error) {
 	if packerPluginPath := os.Getenv("PACKER_PLUGIN_PATH"); packerPluginPath != "" {
-		if strings.ContainsRune(packerPluginPath, os.PathListSeparator) {
+		if strings.Contains(packerPluginPath, pathSep) {
 			return "", fmt.Errorf("Multiple paths are no longer supported for PACKER_PLUGIN_PATH.\n"+
 				"This should be defined as one of the following options for your environment:"+
-				"\n* PACKER_PLUGIN_PATH=%v", strings.Join(strings.Split(packerPluginPath, ":"), "\n* PACKER_PLUGIN_PATH="))
+				"\n* PACKER_PLUGIN_PATH=%v", strings.Join(strings.Split(packerPluginPath, pathSep), "\n* PACKER_PLUGIN_PATH="))
 		}
 
 		return packerPluginPath, nil


### PR DESCRIPTION
Listing installed plugins on Windows requires the extension to be set in the ListOptions, otherwise they are not discovered.

While working on the discovery code, and consolidating it in a single location, we've forgotten to pass the argument to ListInstallations, so that makes it impossible to automatically discover installed components on Windows.

This commit fixes this issue for the plugins required, and the general discovery process during build/validate.