### PR TITLE
website: fix myawesomecloud reference

### DIFF
--- a/website/content/docs/plugins/install-plugins.mdx
+++ b/website/content/docs/plugins/install-plugins.mdx
@@ -178,9 +178,9 @@ Here is an example `required_plugins` block:
 ```hcl
 packer {
   required_plugins {
-    coolcloud = {
+    myawesomecloud = {
       version = ">= 2.7.0"
-      source = "github.com/hashicorp/coolcloud"
+      source = "github.com/hashicorp/myawesomecloud"
     }
     happycloud = {
       version = ">= 1.1.3"


### PR DESCRIPTION
When updating the docs in prevision for Packer 1.11.0, we changed the templates that show how plugins are installed/discovered with commands like packer init.

While doing so, a template had its component renamed to coolcloud, but the following prose did not change, making the text inconsistent.

Since there are other mentions of myawesomecloud in the codebase, we choose to settle on this one for that example too.