### PR TITLE
datasource/http: don't error on 2xx code

### DIFF
--- a/datasource/http/data.go
+++ b/datasource/http/data.go
@@ -125,7 +125,7 @@ func (d *Datasource) Execute() (cty.Value, error) {
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return cty.NullVal(cty.EmptyObject), fmt.Errorf("HTTP request error. Response code: %d", resp.StatusCode)
 	}
 


### PR DESCRIPTION
When a server returns a code that is not 200, we error in the current state.

This is not conformant to the HTTP norm, as anything in the 2xx range is considered a success, so the datasource should not error in this case.

Therefore, this commit fixes the condition in which we report an error, so that anything in the 2xx range is now considered a success by the datasource.

Closes: #12987 