### PR TITLE
refactor: remove deprecated  ioutil function

### DIFF
--- a/post-processor/compress/benchmark.go
+++ b/post-processor/compress/benchmark.go
@@ -11,7 +11,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -138,7 +137,7 @@ func (c *Compressor) BenchmarkGZIPReader(b *testing.B) {
 	cr, _ := gzip.NewReader(c.w)
 	b.ResetTimer()
 
-	_, err := io.Copy(ioutil.Discard, cr)
+	_, err := io.Copy(io.Discard, cr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -159,7 +158,7 @@ func (c *Compressor) BenchmarkBGZFReader(b *testing.B) {
 	cr, _ := bgzf.NewReader(c.w, 0)
 	b.ResetTimer()
 
-	_, err := io.Copy(ioutil.Discard, cr)
+	_, err := io.Copy(io.Discard, cr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -181,7 +180,7 @@ func (c *Compressor) BenchmarkPGZIPReader(b *testing.B) {
 	cr, _ := pgzip.NewReader(c.w)
 	b.ResetTimer()
 
-	_, err := io.Copy(ioutil.Discard, cr)
+	_, err := io.Copy(io.Discard, cr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -205,7 +204,7 @@ func (c *Compressor) BenchmarkLZ4Reader(b *testing.B) {
 	cr := lz4.NewReader(c.w)
 	b.ResetTimer()
 
-	_, err := io.Copy(ioutil.Discard, cr)
+	_, err := io.Copy(io.Discard, cr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -227,7 +226,7 @@ func (c *Compressor) BenchmarkXZReader(b *testing.B) {
 	cr := xz.NewReader(c.w)
 	b.ResetTimer()
 
-	_, err := io.Copy(ioutil.Discard, cr)
+	_, err := io.Copy(io.Discard, cr)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Removed because deprecated functions are used