### PR TITLE
commands: reject constraints with pre-releases

### DIFF
--- a/command/plugins_install.go
+++ b/command/plugins_install.go
@@ -160,6 +160,18 @@ func (c *PluginsInstallCommand) RunContext(buildCtx context.Context, args *Plugi
 			c.Ui.Error(err.Error())
 			return 1
 		}
+
+		hasPrerelease := false
+		for _, con := range constraints {
+			if con.Prerelease() {
+				hasPrerelease = true
+			}
+		}
+		if hasPrerelease {
+			c.Ui.Errorf("Unsupported prerelease for constraint %q", args.Version)
+			return 1
+		}
+
 		pluginRequirement.VersionConstraints = constraints
 	}
 

--- a/hcl2template/types.required_plugins.go
+++ b/hcl2template/types.required_plugins.go
@@ -141,6 +141,22 @@ func decodeRequiredPluginsBlock(block *hcl.Block) (*RequiredPlugins, hcl.Diagnos
 				})
 				continue
 			}
+
+			hadPrerelease := false
+			for _, constraint := range constraints {
+				if constraint.Prerelease() {
+					hadPrerelease = true
+				}
+			}
+			if hadPrerelease {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid version constraint",
+					Detail:   fmt.Sprintf("Unsupported prerelease for constraint %q", constraintStr),
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+			}
+
 			vc.Required = constraints
 			rp.Requirement = vc
 


### PR DESCRIPTION
When remotely installing a plugin, constraints are used by Packer to determine which version of a plugin to install.

These constraints can be arbitrarily complex, including operators and ranges in which to look for valid versions.

However, the versions specified in those constraints should always be final releases, and not a pre-release since we don't explicitly support remotely installing pre-releases.

This commit therefore addds checks to make sure these are reported ASAP, even before the source is contacted to list releases and picking one to install.