### PR TITLE
scripts: re-add wait for changelog listing

### DIFF
--- a/scripts/prepare_changelog.sh
+++ b/scripts/prepare_changelog.sh
@@ -49,6 +49,8 @@ get_prs | while read line; do
     if [[ "$line" =~ "bad" ]]; then
         exit 1
     fi
+    echo "Press enter to continue with next entry."
+    vared -ch ok
 done
 
 #TODO: just generate it automatically using PR titles and tags


### PR DESCRIPTION
This got committed by accident into another PR, and since the change was not approved to begin with, its inclusion was a mistake, so we revert it now.
