### PR TITLE
refactor: remove deprecated InitializePluginVersion, replace with NewPluginVersion

### DIFF
--- a/builder/file/version/version.go
+++ b/builder/file/version/version.go
@@ -11,6 +11,6 @@ import (
 var FilePluginVersion *version.PluginVersion
 
 func init() {
-	FilePluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	FilePluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/builder/null/version/version.go
+++ b/builder/null/version/version.go
@@ -11,6 +11,6 @@ import (
 var NullPluginVersion *version.PluginVersion
 
 func init() {
-	NullPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	NullPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/packer/plugin_discover_test.go
+++ b/packer/plugin_discover_test.go
@@ -306,7 +306,7 @@ func TestHelperPlugins(t *testing.T) {
 	for _, mock := range allMocks {
 		plugin, found := mock[pluginName]
 		if found {
-			plugin.SetVersion(version.InitializePluginVersion("1.0.0", ""))
+			plugin.SetVersion(version.NewPluginVersion("1.0.0", "", ""))
 			err := plugin.RunCommand(args...)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/post-processor/artifice/version/version.go
+++ b/post-processor/artifice/version/version.go
@@ -11,6 +11,6 @@ import (
 var ArtificePluginVersion *version.PluginVersion
 
 func init() {
-	ArtificePluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	ArtificePluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/post-processor/checksum/version/version.go
+++ b/post-processor/checksum/version/version.go
@@ -11,6 +11,6 @@ import (
 var ChecksumPluginVersion *version.PluginVersion
 
 func init() {
-	ChecksumPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	ChecksumPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/post-processor/compress/version/version.go
+++ b/post-processor/compress/version/version.go
@@ -11,6 +11,6 @@ import (
 var CompressPluginVersion *version.PluginVersion
 
 func init() {
-	CompressPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	CompressPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/post-processor/manifest/version/version.go
+++ b/post-processor/manifest/version/version.go
@@ -11,6 +11,6 @@ import (
 var ManifestPluginVersion *version.PluginVersion
 
 func init() {
-	ManifestPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	ManifestPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/post-processor/shell-local/version/version.go
+++ b/post-processor/shell-local/version/version.go
@@ -11,6 +11,6 @@ import (
 var ShellLocalPluginVersion *version.PluginVersion
 
 func init() {
-	ShellLocalPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	ShellLocalPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/provisioner/breakpoint/version/version.go
+++ b/provisioner/breakpoint/version/version.go
@@ -11,6 +11,6 @@ import (
 var BreakpointPluginVersion *version.PluginVersion
 
 func init() {
-	BreakpointPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	BreakpointPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/provisioner/file/version/version.go
+++ b/provisioner/file/version/version.go
@@ -11,6 +11,6 @@ import (
 var FileProvisionerVersion *version.PluginVersion
 
 func init() {
-	FileProvisionerVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	FileProvisionerVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/provisioner/powershell/version/version.go
+++ b/provisioner/powershell/version/version.go
@@ -11,6 +11,6 @@ import (
 var PowershellPluginVersion *version.PluginVersion
 
 func init() {
-	PowershellPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	PowershellPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/provisioner/shell-local/version/version.go
+++ b/provisioner/shell-local/version/version.go
@@ -11,6 +11,6 @@ import (
 var ShellLocalProvisionerVersion *version.PluginVersion
 
 func init() {
-	ShellLocalProvisionerVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	ShellLocalProvisionerVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/provisioner/shell/version/version.go
+++ b/provisioner/shell/version/version.go
@@ -11,6 +11,6 @@ import (
 var ShellPluginVersion *version.PluginVersion
 
 func init() {
-	ShellPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	ShellPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/provisioner/sleep/version/version.go
+++ b/provisioner/sleep/version/version.go
@@ -11,6 +11,6 @@ import (
 var SleepProvisionerVersion *version.PluginVersion
 
 func init() {
-	SleepProvisionerVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	SleepProvisionerVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/provisioner/windows-restart/version/version.go
+++ b/provisioner/windows-restart/version/version.go
@@ -11,6 +11,6 @@ import (
 var WindowsRestartPluginVersion *version.PluginVersion
 
 func init() {
-	WindowsRestartPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	WindowsRestartPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }

--- a/provisioner/windows-shell/version/version.go
+++ b/provisioner/windows-shell/version/version.go
@@ -11,6 +11,6 @@ import (
 var WindowsShellPluginVersion *version.PluginVersion
 
 func init() {
-	WindowsShellPluginVersion = version.InitializePluginVersion(
-		packerVersion.Version, packerVersion.VersionPrerelease)
+	WindowsShellPluginVersion = version.NewPluginVersion(
+		packerVersion.Version, packerVersion.VersionPrerelease, packerVersion.VersionMetadata)
 }


### PR DESCRIPTION
### Description:
This is just a minor refactor based on the awesome work here: https://github.com/hashicorp/packer-plugin-sdk/pull/228
Replace all the `InitializePluginVersion` with `NewPluginVersion` in the packer code base.
### Reason:
We've decided to deprecate `InitializePluginVersion`, so it is time for us to switch to `NewPluginVersion` which now supports `VersionMetadata` for plugin developers, and this can also be a seamless transition once we fully drop `InitializePluginVersion` in the future.