### PR TITLE
add missing return value when creating new XZ reader and writer

### DIFF
--- a/post-processor/compress/benchmark.go
+++ b/post-processor/compress/benchmark.go
@@ -211,7 +211,7 @@ func (c *Compressor) BenchmarkLZ4Reader(b *testing.B) {
 }
 
 func (c *Compressor) BenchmarkXZWriter(b *testing.B) {
-	cw := xz.NewWriter(c.w)
+	cw, _ := xz.NewWriter(c.w)
 	b.ResetTimer()
 
 	_, err := io.Copy(cw, c.r)
@@ -223,7 +223,7 @@ func (c *Compressor) BenchmarkXZWriter(b *testing.B) {
 }
 
 func (c *Compressor) BenchmarkXZReader(b *testing.B) {
-	cr := xz.NewReader(c.w)
+	cr, _ := xz.NewReader(c.w)
 	b.ResetTimer()
 
 	_, err := io.Copy(io.Discard, cr)


### PR DESCRIPTION
Small fix, need to add missing value when creating XZ NewWriter and NewReader