### PR TITLE
Fix documentation url for 'can()' and 'try()'

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
@@ -12,7 +12,7 @@ whether the expression produced a result without any errors.
 
 This is a special function that is able to catch errors produced when evaluating
 its argument. For most situations where you could use `can` it's better to use
-[`try`](/packer/docs/templates/hcl_templates/functions/conversion/try) instead, because it allows for more concise definition of
+[`try`](try.mdx) instead, because it allows for more concise definition of
 fallback values for failing expressions.
 
 The `can` function can only catch and handle _dynamic_ errors resulting from
@@ -24,7 +24,7 @@ as a malformed resource reference.
 variable validation rules. Although it can technically accept any sort of
 expression and be used elsewhere in the configuration, we recommend against
 using it in other contexts. For error handling elsewhere in the configuration,
-prefer to use [`try`](/packer/docs/templates/hcl_templates/functions/conversion/try).
+prefer to use [`try`](try.mdx).
 
 ## Examples
 
@@ -53,5 +53,5 @@ A local value with the name "nonexist" has not been declared.
 
 ## Related Functions
 
-- [`try`](/packer/docs/templates/hcl_templates/functions/conversion/try), which tries evaluating a sequence of expressions and
+- [`try`](try.mdx), which tries evaluating a sequence of expressions and
   returns the result of the first one that succeeds.

--- a/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
@@ -12,7 +12,7 @@ whether the expression produced a result without any errors.
 
 This is a special function that is able to catch errors produced when evaluating
 its argument. For most situations where you could use `can` it's better to use
-[`try`](try.mdx) instead, because it allows for more concise definition of
+[`try`](website/content/docs/templates/hcl_templates/functions/conversion/try.mdx) instead, because it allows for more concise definition of
 fallback values for failing expressions.
 
 The `can` function can only catch and handle _dynamic_ errors resulting from
@@ -24,7 +24,7 @@ as a malformed resource reference.
 variable validation rules. Although it can technically accept any sort of
 expression and be used elsewhere in the configuration, we recommend against
 using it in other contexts. For error handling elsewhere in the configuration,
-prefer to use [`try`](try.mdx).
+prefer to use [`try`](website/content/docs/templates/hcl_templates/functions/conversion/try.mdx).
 
 ## Examples
 
@@ -53,5 +53,5 @@ A local value with the name "nonexist" has not been declared.
 
 ## Related Functions
 
-- [`try`](try.mdx), which tries evaluating a sequence of expressions and
+- [`try`](website/content/docs/templates/hcl_templates/functions/conversion/try.mdx), which tries evaluating a sequence of expressions and
   returns the result of the first one that succeeds.

--- a/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
@@ -12,7 +12,7 @@ whether the expression produced a result without any errors.
 
 This is a special function that is able to catch errors produced when evaluating
 its argument. For most situations where you could use `can` it's better to use
-[`try`](website/content/docs/templates/hcl_templates/functions/conversion/try.mdx) instead, because it allows for more concise definition of
+[`try`](/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx) instead, because it allows for more concise definition of
 fallback values for failing expressions.
 
 The `can` function can only catch and handle _dynamic_ errors resulting from
@@ -24,7 +24,7 @@ as a malformed resource reference.
 variable validation rules. Although it can technically accept any sort of
 expression and be used elsewhere in the configuration, we recommend against
 using it in other contexts. For error handling elsewhere in the configuration,
-prefer to use [`try`](website/content/docs/templates/hcl_templates/functions/conversion/try.mdx).
+prefer to use [`try`](/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx).
 
 ## Examples
 
@@ -53,5 +53,5 @@ A local value with the name "nonexist" has not been declared.
 
 ## Related Functions
 
-- [`try`](/content/docs/templates/hcl_templates/functions/conversion/try.mdx), which tries evaluating a sequence of expressions and
+- [`try`](/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx), which tries evaluating a sequence of expressions and
   returns the result of the first one that succeeds.

--- a/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx
@@ -53,5 +53,5 @@ A local value with the name "nonexist" has not been declared.
 
 ## Related Functions
 
-- [`try`](website/content/docs/templates/hcl_templates/functions/conversion/try.mdx), which tries evaluating a sequence of expressions and
+- [`try`](/content/docs/templates/hcl_templates/functions/conversion/try.mdx), which tries evaluating a sequence of expressions and
   returns the result of the first one that succeeds.

--- a/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx
@@ -107,5 +107,5 @@ A local value with the name "nonexist" has not been declared.
 
 ## Related Functions
 
-- [`can`](can.mdx), which tries evaluating an expression and returns a
+- [`can`](website/content/docs/templates/hcl_templates/functions/conversion/can.mdx), which tries evaluating an expression and returns a
   boolean value indicating whether it succeeded.

--- a/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx
@@ -107,5 +107,5 @@ A local value with the name "nonexist" has not been declared.
 
 ## Related Functions
 
-- [`can`](/packer/docs/templates/hcl_templates/functions/conversion/can), which tries evaluating an expression and returns a
+- [`can`](can.mdx), which tries evaluating an expression and returns a
   boolean value indicating whether it succeeded.

--- a/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/conversion/try.mdx
@@ -107,5 +107,5 @@ A local value with the name "nonexist" has not been declared.
 
 ## Related Functions
 
-- [`can`](website/content/docs/templates/hcl_templates/functions/conversion/can.mdx), which tries evaluating an expression and returns a
+- [`can`](/website/content/docs/templates/hcl_templates/functions/conversion/can.mdx), which tries evaluating an expression and returns a
   boolean value indicating whether it succeeded.


### PR DESCRIPTION
the urls to can and try files referencing each other are messed up. This PR will fix the URLs