### PR TITLE
Fix golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - goimports
     - gosimple
@@ -39,7 +38,6 @@ linters:
     - staticcheck
     - unconvert
     - unused
-    - varcheck
   fast: true
 
 # options for analysis running

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ install-gen-deps: ## Install dependencies for code generation
 
 install-lint-deps: ## Install linter dependencies
 	@echo "==> Updating linter dependencies..."
-	@curl -sSfL -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.52.0
+	@curl -sSfL -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.0
 
 dev: ## Build and install a development build
 	@grep 'const VersionPrerelease = ""' version/version.go > /dev/null ; if [ $$? -eq 0 ]; then \


### PR DESCRIPTION
Two things to fix here:

1. Bump the golangci-lint version to 1.54.0
2. Remove older, unsupported, linters: deadcode and varcheck.