### PR TITLE
hcl2template: recursively evaluate local variables

### DIFF
--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -190,6 +190,8 @@ func (p *Parser) Parse(filename string, varFiles []string, argVars map[string]st
 			diags = append(diags, morediags...)
 			cfg.LocalBlocks = append(cfg.LocalBlocks, moreLocals...)
 		}
+
+		diags = diags.Extend(cfg.checkForDuplicateLocalDefinition())
 	}
 
 	// parse var files
@@ -296,7 +298,6 @@ func filterVarsFromLogs(inputOrLocal Variables) {
 func (cfg *PackerConfig) Initialize(opts packer.InitializeOptions) hcl.Diagnostics {
 	diags := cfg.InputVariables.ValidateValues()
 	diags = append(diags, cfg.evaluateDatasources(opts.SkipDatasourcesExecution)...)
-	diags = append(diags, checkForDuplicateLocalDefinition(cfg.LocalBlocks)...)
 	diags = append(diags, cfg.evaluateLocalVariables(cfg.LocalBlocks)...)
 
 	filterVarsFromLogs(cfg.InputVariables)

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -217,14 +217,16 @@ func parseLocalVariableBlocks(f *hcl.File) ([]*LocalBlock, hcl.Diagnostics) {
 	return locals, diags
 }
 
-func (c *PackerConfig) evaluateAllLocalVariables(locals []*LocalBlock) hcl.Diagnostics {
-	var diags hcl.Diagnostics
+func (c *PackerConfig) localByName(local string) (*LocalBlock, error) {
+	for _, loc := range c.LocalBlocks {
+		if loc.Name != local {
+			continue
+		}
 
-	for _, local := range locals {
-		diags = append(diags, c.evaluateLocalVariable(local)...)
+		return loc, nil
 	}
 
-	return diags
+	return nil, fmt.Errorf("local %s not found", local)
 }
 
 func (c *PackerConfig) evaluateLocalVariables(locals []*LocalBlock) hcl.Diagnostics {
@@ -238,23 +240,41 @@ func (c *PackerConfig) evaluateLocalVariables(locals []*LocalBlock) hcl.Diagnost
 		c.LocalVariables = Variables{}
 	}
 
-	for foundSomething := true; foundSomething; {
-		foundSomething = false
-		for i := 0; i < len(locals); {
-			local := locals[i]
-			moreDiags := c.evaluateLocalVariable(local)
-			if moreDiags.HasErrors() {
-				i++
+	for _, local := range c.LocalBlocks {
+		// Note: when looking at the expressions, we only need to care about
+		// attributes, as HCL2 expressions are not allowed in a block's labels.
+		vars := FilterTraversalsByType(local.Expr.Variables(), "local")
+
+		var localDeps []*LocalBlock
+		for _, v := range vars {
+			// Some local variables may be locally aliased as
+			// `local`, which
+			if len(v) < 2 {
 				continue
 			}
-			foundSomething = true
-			locals = append(locals[:i], locals[i+1:]...)
+			varName := v[1].(hcl.TraverseAttr).Name
+			block, err := c.localByName(varName)
+			if err != nil {
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing variable dependency",
+					Detail: fmt.Sprintf("The expression for variable %q depends on local.%s, which is not defined.",
+						local.Name, varName),
+				})
+				continue
+			}
+			localDeps = append(localDeps, block)
 		}
+		local.dependencies = localDeps
 	}
 
-	if len(locals) != 0 {
-		// get errors from remaining variables
-		return c.evaluateAllLocalVariables(locals)
+	// Immediately return in case the dependencies couldn't be figured out.
+	if diags.HasErrors() {
+		return diags
+	}
+
+	for _, local := range c.LocalBlocks {
+		diags = diags.Extend(c.evaluateLocalVariable(local, 0))
 	}
 
 	return diags
@@ -281,10 +301,33 @@ func checkForDuplicateLocalDefinition(locals []*LocalBlock) hcl.Diagnostics {
 	return diags
 }
 
-func (c *PackerConfig) evaluateLocalVariable(local *LocalBlock) hcl.Diagnostics {
+func (c *PackerConfig) evaluateLocalVariable(local *LocalBlock, depth int) hcl.Diagnostics {
+	// If the variable already was evaluated, we can return immediately
+	if local.evaluated {
+		return nil
+	}
+
+	if depth >= 10 {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Max local recursion depth exceeded.",
+			Detail: "An error occured while recursively evaluating locals." +
+				"Your local variables likely have a cyclic dependency. " +
+				"Please simplify your config to continue. ",
+		}}
+	}
+
 	var diags hcl.Diagnostics
 
+	for _, dep := range local.dependencies {
+		localDiags := c.evaluateLocalVariable(dep, depth+1)
+		diags = diags.Extend(localDiags)
+	}
+
 	value, moreDiags := local.Expr.Value(c.EvalContext(LocalContext, nil))
+
+	local.evaluated = true
+
 	diags = append(diags, moreDiags...)
 	if moreDiags.HasErrors() {
 		return diags

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -30,6 +30,17 @@ type LocalBlock struct {
 	// When Sensitive is set to true Packer will try its best to hide/obfuscate
 	// the variable from the output stream. By replacing the text.
 	Sensitive bool
+
+	// dependsOn lists the dependencies for being able to evaluate this local
+	//
+	// Only `local`/`locals` will be referenced here as we execute all the
+	// same component types at once.
+	dependencies []*LocalBlock
+	// evaluated toggles to true if it has been evaluated.
+	//
+	// We use this to determine if we're ready to get the value of the
+	// expression.
+	evaluated bool
 }
 
 // VariableAssignment represents a way a variable was set: the expression

--- a/hcl2template/utils.go
+++ b/hcl2template/utils.go
@@ -205,6 +205,13 @@ func GetVarsByType(block *hcl.Block, topLevelLabels ...string) []hcl.Traversal {
 		}
 	}
 
+	return FilterTraversalsByType(travs, topLevelLabels...)
+}
+
+// FilterTraversalsByType lets the caller filter the traversals per top-level type.
+//
+// This can then be used to detect dependencies between block types.
+func FilterTraversalsByType(travs []hcl.Traversal, topLevelLabels ...string) []hcl.Traversal {
 	var rets []hcl.Traversal
 	for _, t := range travs {
 		varRootname := t.RootName()

--- a/packer_test/commands_test.go
+++ b/packer_test/commands_test.go
@@ -138,6 +138,12 @@ func (pc *packerCommand) Run() (string, string, error) {
 
 	pc.err = cmd.Run()
 
+	// Check that the command didn't panic, and if it did, we can immediately error
+	panicErr := PanicCheck{}.Check(pc.stdout.String(), pc.stderr.String(), pc.err)
+	if panicErr != nil {
+		pc.t.Fatalf("Packer panicked during execution: %s", panicErr)
+	}
+
 	return pc.stdout.String(), pc.stderr.String(), pc.err
 }
 
@@ -146,8 +152,6 @@ func (pc *packerCommand) Assert(checks ...Checker) {
 	for pc.runs > 0 {
 		attempt++
 		stdout, stderr, err := pc.Run()
-
-		checks = append(checks, PanicCheck{})
 
 		for _, check := range checks {
 			checkErr := check.Check(stdout, stderr, err)

--- a/packer_test/commands_test.go
+++ b/packer_test/commands_test.go
@@ -155,6 +155,10 @@ func (pc *packerCommand) Assert(checks ...Checker) {
 
 		if pc.t.Failed() {
 			pc.t.Errorf("attempt %d failed validation", attempt)
+
+			pc.t.Logf("dumping stdout: %s", stdout)
+			pc.t.Logf("dumping stdout: %s", stderr)
+
 			break
 		}
 	}

--- a/packer_test/commands_test.go
+++ b/packer_test/commands_test.go
@@ -38,6 +38,10 @@ func (ts *PackerTestSuite) PackerCommand() *packerCommand {
 			// case of Panic will fail to be created (unless tests
 			// are running as Administrator, but please don't).
 			"TMP": os.TempDir(),
+			// Since those commands are used to run tests, we want to
+			// make them as self-contained and quick as possible.
+			// Removing telemetry here is probably for the best.
+			"CHECKPOINT_DISABLE": "1",
 		},
 		t: ts.T(),
 	}

--- a/packer_test/init_test.go
+++ b/packer_test/init_test.go
@@ -1,6 +1,8 @@
 package packer_test
 
 func (ts *PackerTestSuite) TestPackerInitForce() {
+	ts.SkipNoAcc()
+
 	pluginPath, cleanup := ts.MakePluginDir()
 	defer cleanup()
 
@@ -18,6 +20,8 @@ func (ts *PackerTestSuite) TestPackerInitForce() {
 }
 
 func (ts *PackerTestSuite) TestPackerInitUpgrade() {
+	ts.SkipNoAcc()
+
 	pluginPath, cleanup := ts.MakePluginDir()
 	defer cleanup()
 
@@ -62,6 +66,8 @@ func (ts *PackerTestSuite) TestPackerInitWithNonGithubSource() {
 }
 
 func (ts *PackerTestSuite) TestPackerInitWithMixedVersions() {
+	ts.SkipNoAcc()
+
 	pluginPath, cleanup := ts.MakePluginDir()
 	defer cleanup()
 

--- a/packer_test/install_test.go
+++ b/packer_test/install_test.go
@@ -69,6 +69,8 @@ func (ts *PackerTestSuite) TestInstallPluginPrerelease() {
 }
 
 func (ts *PackerTestSuite) TestRemoteInstallWithPluginsInstall() {
+	ts.SkipNoAcc()
+
 	pluginPath, cleanup := ts.MakePluginDir()
 	defer cleanup()
 
@@ -80,6 +82,8 @@ func (ts *PackerTestSuite) TestRemoteInstallWithPluginsInstall() {
 }
 
 func (ts *PackerTestSuite) TestRemoteInstallOfPreReleasePlugin() {
+	ts.SkipNoAcc()
+
 	pluginPath, cleanup := ts.MakePluginDir()
 	defer cleanup()
 

--- a/packer_test/local_eval_test.go
+++ b/packer_test/local_eval_test.go
@@ -1,0 +1,14 @@
+package packer_test
+
+func (ts *PackerTestSuite) TestEvalLocalsOrder() {
+	ts.SkipNoAcc()
+
+	pluginDir, cleanup := ts.MakePluginDir()
+	defer cleanup()
+
+	ts.PackerCommand().UsePluginDir(pluginDir).
+		Runs(10).
+		Stdin("local.test_local\n").
+		SetArgs("console", "./templates/locals_no_order.pkr.hcl").
+		Assert(MustSucceed(), Grep("\\[\\]", grepStdout, grepInvert))
+}

--- a/packer_test/suite_test.go
+++ b/packer_test/suite_test.go
@@ -42,6 +42,20 @@ func (ts *PackerTestSuite) buildPluginBinaries(t *testing.T) {
 	wg.Wait()
 }
 
+// SkipNoAcc is a pre-condition that skips the test if the PACKER_ACC environment
+// variable is unset, or set to "0".
+//
+// This allows us to build tests with a potential for long runs (or errors like
+// rate-limiting), so we can still test them, but only in a longer timeouted
+// context.
+func (ts *PackerTestSuite) SkipNoAcc() {
+	acc := os.Getenv("PACKER_ACC")
+	if acc == "" || acc == "0" {
+		ts.T().Logf("Skipping test as `PACKER_ACC` is unset.")
+		ts.T().Skip()
+	}
+}
+
 func Test_PackerCoreSuite(t *testing.T) {
 	ts := &PackerTestSuite{}
 

--- a/packer_test/templates/locals_duplicate.pkr.hcl
+++ b/packer_test/templates/locals_duplicate.pkr.hcl
@@ -1,0 +1,18 @@
+local "test" {
+    expression = "two"
+    sensitive = true
+}
+
+locals {
+    test = local.test
+}
+
+variable "test" {
+    type = string
+    default = "home"
+}
+source "null" "example" {}
+
+build {
+    sources = ["source.null.example"]
+}

--- a/packer_test/templates/locals_no_order.pkr.hcl
+++ b/packer_test/templates/locals_no_order.pkr.hcl
@@ -1,0 +1,7 @@
+locals {
+  test_local = can(local.test_data) ? local.test_data : []
+
+  test_data = [
+    { key = "value" }
+  ]
+}


### PR DESCRIPTION
The logic for evaluating local variables used to rely on their definition order, with some edge cases.
Typically `locals` blocks define multiple local variables, which don't necessarily appear in the same order at evaluation as within the template, leading to inconsistent behaviour, as the order in which those are added to the list of local variables is non-deterministic.

To avoid this problem, we change how local variables are evaluated, and we're adopting a workflow similar to datasources, where the local variables first build a list of direct dependencies.
Then when evaluation happens, we evaluate all the dependencies recursively for each local variable, which takes care of this issue.

As with Datasources, we add a cap to the recursion: 10. I.e. if the evaluation of a single variable provokes an infinite recursion, we stop at that point and return an error to the user, telling them to fix their template.

Closes: #13018 