### PR TITLE
docs: string templates

### DIFF
--- a/website/content/docs/templates/hcl_templates/expressions.mdx
+++ b/website/content/docs/templates/hcl_templates/expressions.mdx
@@ -429,3 +429,54 @@ beginning a template sequence, double the leading character: `$${` or `%%{`.
 Within quoted and heredoc string expressions, the sequences `${` and `%{` begin
 _template sequences_. Templates let you directly embed expressions into a string
 literal, to dynamically construct strings from other values.
+
+The following example demonstrates how a template sequence can be used to embed
+the value of a variable into a string that can be used as script content:
+
+```hcl
+locals {
+  packages = ["git", "curl", "vim"]
+
+  install_packages = <<-EOF
+    #!/bin/bash
+    if [ ${length(local.packages)} -eq 0 ]; then
+      echo "No packages to install."
+      exit 1
+    fi
+    apt-get update
+    %{ for package in local.packages ~}
+    apt-get install -y ${package}
+    %{ endfor ~}
+  EOF
+}
+
+source "amazon-ebs" "example" {
+  # ...
+}
+
+build {
+  sources = ["source.amazon-ebs.example"]
+
+  provisioner "shell" {
+    inline = [local.install_packages]
+  }
+}
+```
+
+This can be tested using the `packer console` command:
+
+```shell
+$ packer source.pkr.hcl
+
+> local.install_packages
+
+> #!/bin/bash
+if [ 3 -eq 0 ]; then
+  echo "No packages to install."
+  exit 1
+fi
+apt-get update
+    apt-get install -y git
+    apt-get install -y curl
+    apt-get install -y vim
+```


### PR DESCRIPTION
### Description

Adds an example of a string template being used.

The example demonstrates how a template sequence can be used to embed the value of a variable into a string that can be used as script content.

```hcl
locals {
  packages = ["git", "curl", "vim"]

  install_packages = <<-EOF
    #!/bin/bash
    if [ ${length(local.packages)} -eq 0 ]; then
      echo "No packages to install."
      exit 1
    fi
    apt-get update
    %{ for package in local.packages ~}
    apt-get install -y ${package}
    %{ endfor ~}
  EOF
}

source "amazon-ebs" "example" {
  # ...
}

build {
  sources = ["source.amazon-ebs.example"]

  provisioner "shell" {
    inline = [local.install_packages]
  }
}
```

This can be tested using the `packer console` command:

```shell
$ packer source.pkr.hcl

> local.install_packages

> #!/bin/bash
if [ 3 -eq 0 ]; then
  echo "No packages to install."
  exit 1
fi
apt-get update
    apt-get install -y git
    apt-get install -y curl
    apt-get install -y vim
```


#### Reference

Closes #12651