### PR TITLE
HCP Packer Buckets: Change UpsertBucket to call GetBucket

### DIFF
--- a/internal/hcp/api/mock_service.go
+++ b/internal/hcp/api/mock_service.go
@@ -19,7 +19,7 @@ import (
 // Upon calling a service method a boolean is set to true to indicate that a method has been called.
 // To skip the setting of these booleans set TrackCalledServiceMethods to false; defaults to true in NewMockPackerClientService().
 type MockPackerClientService struct {
-	CreateBucketCalled, UpdateBucketCalled, BucketAlreadyExist                   bool
+	CreateBucketCalled, UpdateBucketCalled, GetBucketCalled, BucketNotFound      bool
 	CreateVersionCalled, GetVersionCalled, VersionAlreadyExist, VersionCompleted bool
 	CreateBuildCalled, UpdateBuildCalled, ListBuildsCalled, BuildAlreadyDone     bool
 	TrackCalledServiceMethods                                                    bool
@@ -55,14 +55,6 @@ func (svc *MockPackerClientService) PackerServiceCreateBucket(
 	params *hcpPackerService.PackerServiceCreateBucketParams, _ runtime.ClientAuthInfoWriter,
 	opts ...hcpPackerService.ClientOption,
 ) (*hcpPackerService.PackerServiceCreateBucketOK, error) {
-
-	if svc.BucketAlreadyExist {
-		return nil, status.Error(
-			codes.AlreadyExists,
-			fmt.Sprintf("Code:%d %s", codes.AlreadyExists, codes.AlreadyExists.String()),
-		)
-	}
-
 	if params.Body.Name == "" {
 		return nil, errors.New("no bucket name was passed in")
 	}
@@ -82,6 +74,19 @@ func (svc *MockPackerClientService) PackerServiceCreateBucket(
 	}
 
 	return ok, nil
+}
+
+func (svc *MockPackerClientService) PackerServiceGetBucket(
+	params *hcpPackerService.PackerServiceGetBucketParams, _ runtime.ClientAuthInfoWriter,
+	opts ...hcpPackerService.ClientOption,
+) (*hcpPackerService.PackerServiceGetBucketOK, error) {
+	if svc.TrackCalledServiceMethods {
+		svc.GetBucketCalled = true
+	}
+	if svc.BucketNotFound {
+		return nil, status.Error(codes.NotFound, fmt.Sprintf("Code:%d %s", codes.NotFound, codes.NotFound.String()))
+	}
+	return hcpPackerService.NewPackerServiceGetBucketOK(), nil
 }
 
 func (svc *MockPackerClientService) PackerServiceUpdateBucket(

--- a/internal/hcp/registry/types.bucket.go
+++ b/internal/hcp/registry/types.bucket.go
@@ -122,7 +122,6 @@ func (bucket *Bucket) Initialize(
 	}
 
 	bucket.Destination = fmt.Sprintf("%s/%s", bucket.client.OrganizationID, bucket.client.ProjectID)
-
 	err := bucket.client.UpsertBucket(ctx, bucket.Name, bucket.Description, bucket.BucketLabels)
 	if err != nil {
 		return fmt.Errorf("failed to initialize bucket %q: %w", bucket.Name, err)

--- a/internal/hcp/registry/types.bucket_service_test.go
+++ b/internal/hcp/registry/types.bucket_service_test.go
@@ -117,7 +117,7 @@ func TestInitialize_ExistingBucketNewVersion(t *testing.T) {
 		t.Errorf("expected call to GetBucket but it didn't happen")
 	}
 	if mockService.CreateBucketCalled {
-		t.Errorf("expected call to CreateBucket but it didn't happen")
+		t.Errorf("unexpected call to CreateBucket")
 	}
 
 	if !mockService.UpdateBucketCalled {

--- a/internal/hcp/registry/types.bucket_service_test.go
+++ b/internal/hcp/registry/types.bucket_service_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestInitialize_NewBucketNewVersion(t *testing.T) {
 	mockService := hcpPackerAPI.NewMockPackerClientService()
+	mockService.BucketNotFound = true
 
 	b := &Bucket{
 		Name: "TestBucket",
@@ -34,10 +35,15 @@ func TestInitialize_NewBucketNewVersion(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
+	if !mockService.GetBucketCalled {
+		t.Errorf("expected a call to GetBucket but it didn't happen")
+	}
 	if !mockService.CreateBucketCalled {
 		t.Errorf("expected a call to CreateBucket but it didn't happen")
 	}
-
+	if mockService.UpdateBucketCalled {
+		t.Errorf("unexpected call to UpdateBucket")
+	}
 	if !mockService.CreateVersionCalled {
 		t.Errorf("expected a call to CreateVersion but it didn't happen")
 	}
@@ -65,8 +71,6 @@ func TestInitialize_NewBucketNewVersion(t *testing.T) {
 
 func TestInitialize_UnsetTemplateTypeError(t *testing.T) {
 	mockService := hcpPackerAPI.NewMockPackerClientService()
-	mockService.BucketAlreadyExist = true
-
 	b := &Bucket{
 		Name: "TestBucket",
 		client: &hcpPackerAPI.Client{
@@ -90,7 +94,6 @@ func TestInitialize_UnsetTemplateTypeError(t *testing.T) {
 
 func TestInitialize_ExistingBucketNewVersion(t *testing.T) {
 	mockService := hcpPackerAPI.NewMockPackerClientService()
-	mockService.BucketAlreadyExist = true
 
 	b := &Bucket{
 		Name: "TestBucket",
@@ -109,6 +112,12 @@ func TestInitialize_ExistingBucketNewVersion(t *testing.T) {
 	err = b.Initialize(context.TODO(), hcpPackerModels.HashicorpCloudPacker20230101TemplateTypeHCL2)
 	if err != nil {
 		t.Errorf("unexpected failure: %v", err)
+	}
+	if !mockService.GetBucketCalled {
+		t.Errorf("expected call to GetBucket but it didn't happen")
+	}
+	if mockService.CreateBucketCalled {
+		t.Errorf("expected call to CreateBucket but it didn't happen")
 	}
 
 	if !mockService.UpdateBucketCalled {
@@ -143,7 +152,6 @@ func TestInitialize_ExistingBucketNewVersion(t *testing.T) {
 
 func TestInitialize_ExistingBucketExistingVersion(t *testing.T) {
 	mockService := hcpPackerAPI.NewMockPackerClientService()
-	mockService.BucketAlreadyExist = true
 	mockService.VersionAlreadyExist = true
 
 	b := &Bucket{
@@ -175,12 +183,18 @@ func TestInitialize_ExistingBucketExistingVersion(t *testing.T) {
 		t.Errorf("unexpected call to CreateBucket")
 	}
 
+	if !mockService.GetBucketCalled {
+		t.Errorf("expected call to GetBucket but it didn't happen")
+	}
+	if mockService.CreateBucketCalled {
+		t.Errorf("unexpected call to CreateBucket")
+	}
 	if !mockService.UpdateBucketCalled {
 		t.Errorf("expected call to UpdateBucket but it didn't happen")
 	}
 
 	if mockService.CreateVersionCalled {
-		t.Errorf("unexpected a call to CreateVersion")
+		t.Errorf("unexpected call to CreateVersion")
 	}
 
 	if !mockService.GetVersionCalled {
@@ -188,7 +202,7 @@ func TestInitialize_ExistingBucketExistingVersion(t *testing.T) {
 	}
 
 	if mockService.CreateBuildCalled {
-		t.Errorf("unexpected a call to CreateBuild")
+		t.Errorf("unexpected call to CreateBuild")
 	}
 
 	if b.Version.ID != "version-id" {
@@ -212,7 +226,6 @@ func TestInitialize_ExistingBucketExistingVersion(t *testing.T) {
 
 func TestInitialize_ExistingBucketCompleteVersion(t *testing.T) {
 	mockService := hcpPackerAPI.NewMockPackerClientService()
-	mockService.BucketAlreadyExist = true
 	mockService.VersionAlreadyExist = true
 	mockService.VersionCompleted = true
 	mockService.BuildAlreadyDone = true
@@ -238,6 +251,15 @@ func TestInitialize_ExistingBucketCompleteVersion(t *testing.T) {
 		t.Errorf("unexpected failure: %v", err)
 	}
 
+	if !mockService.GetBucketCalled {
+		t.Errorf("expected call to GetBucket, but it didn't happen")
+	}
+	if !mockService.UpdateBucketCalled {
+		t.Errorf("expected call to UpdateBucket, but it didn't happen")
+	}
+	if mockService.CreateBucketCalled {
+		t.Errorf("unexpected call to CreateBucket")
+	}
 	if mockService.CreateVersionCalled {
 		t.Errorf("unexpected call to CreateVersion")
 	}
@@ -257,7 +279,6 @@ func TestInitialize_ExistingBucketCompleteVersion(t *testing.T) {
 
 func TestUpdateBuildStatus(t *testing.T) {
 	mockService := hcpPackerAPI.NewMockPackerClientService()
-	mockService.BucketAlreadyExist = true
 	mockService.VersionAlreadyExist = true
 
 	b := &Bucket{
@@ -310,9 +331,7 @@ func TestUpdateBuildStatus(t *testing.T) {
 
 func TestUpdateBuildStatus_DONENoImages(t *testing.T) {
 	mockService := hcpPackerAPI.NewMockPackerClientService()
-	mockService.BucketAlreadyExist = true
 	mockService.VersionAlreadyExist = true
-
 	b := &Bucket{
 		Name: "TestBucket",
 		client: &hcpPackerAPI.Client{

--- a/internal/hcp/registry/types.bucket_test.go
+++ b/internal/hcp/registry/types.bucket_test.go
@@ -291,7 +291,6 @@ func TestBucket_PopulateVersion(t *testing.T) {
 			t.Setenv("HCP_PACKER_BUILD_FINGERPRINT", "test-run-"+strconv.Itoa(i))
 
 			mockService := hcpPackerAPI.NewMockPackerClientService()
-			mockService.BucketAlreadyExist = true
 			mockService.VersionAlreadyExist = true
 			mockService.BuildAlreadyDone = tt.buildCompleted
 


### PR DESCRIPTION
This PR changes the API calls made by the internal function `UpsertBucket`, previously this function would call CreateBucket and then if that returned a AlreadyExists/Conflict status code it would call UpdateBucket to set the bucket  labels and description on the bucket.  This lead to failures with bucket level service principals because the principal would be scoped to only access the existing bucket, and so Packer would error out because of making an unauthorized request.

To handle this I have changed UpsertBucket to call GetBucket first, if GetBucket 404s the method then calls Create, if GetBucket succeeds it calls UpdateBucket, and if GetBucket fails with a non 404 status code Packer exits with the error from GetBucket.