### PR TITLE
Makefile: replace enumer upstream with dmarkham's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install-build-deps: ## Install dependencies for bin build
 	@go install github.com/mitchellh/gox@v1.0.1
 
 install-gen-deps: ## Install dependencies for code generation
-	@GO111MODULE=on go install github.com/alvaroloes/enumer@master
+	@GO111MODULE=on go install github.com/dmarkham/enumer@master
 	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@latest
 
 install-lint-deps: ## Install linter dependencies

--- a/command/configtype_enumer.go
+++ b/command/configtype_enumer.go
@@ -4,11 +4,14 @@ package command
 
 import (
 	"fmt"
+	"strings"
 )
 
 const _configTypeName = "jsonhcl2"
 
 var _configTypeIndex = [...]uint8{0, 4, 8}
+
+const _configTypeLowerName = "jsonhcl2"
 
 func (i configType) String() string {
 	if i < 0 || i >= configType(len(_configTypeIndex)-1) {
@@ -17,11 +20,26 @@ func (i configType) String() string {
 	return _configTypeName[_configTypeIndex[i]:_configTypeIndex[i+1]]
 }
 
-var _configTypeValues = []configType{0, 1}
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _configTypeNoOp() {
+	var x [1]struct{}
+	_ = x[ConfigTypeJSON-(0)]
+	_ = x[ConfigTypeHCL2-(1)]
+}
+
+var _configTypeValues = []configType{ConfigTypeJSON, ConfigTypeHCL2}
 
 var _configTypeNameToValueMap = map[string]configType{
-	_configTypeName[0:4]: 0,
-	_configTypeName[4:8]: 1,
+	_configTypeName[0:4]:      ConfigTypeJSON,
+	_configTypeLowerName[0:4]: ConfigTypeJSON,
+	_configTypeName[4:8]:      ConfigTypeHCL2,
+	_configTypeLowerName[4:8]: ConfigTypeHCL2,
+}
+
+var _configTypeNames = []string{
+	_configTypeName[0:4],
+	_configTypeName[4:8],
 }
 
 // configTypeString retrieves an enum value from the enum constants string name.
@@ -30,12 +48,23 @@ func configTypeString(s string) (configType, error) {
 	if val, ok := _configTypeNameToValueMap[s]; ok {
 		return val, nil
 	}
+
+	if val, ok := _configTypeNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
 	return 0, fmt.Errorf("%s does not belong to configType values", s)
 }
 
 // configTypeValues returns all values of the enum
 func configTypeValues() []configType {
 	return _configTypeValues
+}
+
+// configTypeStrings returns a slice of all String values of the enum
+func configTypeStrings() []string {
+	strs := make([]string, len(_configTypeNames))
+	copy(strs, _configTypeNames)
+	return strs
 }
 
 // IsAconfigType returns "true" if the value is listed in the enum definition. "false" otherwise

--- a/packer/fixconfigmode_enumer.go
+++ b/packer/fixconfigmode_enumer.go
@@ -4,11 +4,14 @@ package packer
 
 import (
 	"fmt"
+	"strings"
 )
 
 const _FixConfigModeName = "StdoutInplaceDiff"
 
 var _FixConfigModeIndex = [...]uint8{0, 6, 13, 17}
+
+const _FixConfigModeLowerName = "stdoutinplacediff"
 
 func (i FixConfigMode) String() string {
 	if i < 0 || i >= FixConfigMode(len(_FixConfigModeIndex)-1) {
@@ -17,12 +20,30 @@ func (i FixConfigMode) String() string {
 	return _FixConfigModeName[_FixConfigModeIndex[i]:_FixConfigModeIndex[i+1]]
 }
 
-var _FixConfigModeValues = []FixConfigMode{0, 1, 2}
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _FixConfigModeNoOp() {
+	var x [1]struct{}
+	_ = x[Stdout-(0)]
+	_ = x[Inplace-(1)]
+	_ = x[Diff-(2)]
+}
+
+var _FixConfigModeValues = []FixConfigMode{Stdout, Inplace, Diff}
 
 var _FixConfigModeNameToValueMap = map[string]FixConfigMode{
-	_FixConfigModeName[0:6]:   0,
-	_FixConfigModeName[6:13]:  1,
-	_FixConfigModeName[13:17]: 2,
+	_FixConfigModeName[0:6]:        Stdout,
+	_FixConfigModeLowerName[0:6]:   Stdout,
+	_FixConfigModeName[6:13]:       Inplace,
+	_FixConfigModeLowerName[6:13]:  Inplace,
+	_FixConfigModeName[13:17]:      Diff,
+	_FixConfigModeLowerName[13:17]: Diff,
+}
+
+var _FixConfigModeNames = []string{
+	_FixConfigModeName[0:6],
+	_FixConfigModeName[6:13],
+	_FixConfigModeName[13:17],
 }
 
 // FixConfigModeString retrieves an enum value from the enum constants string name.
@@ -31,12 +52,23 @@ func FixConfigModeString(s string) (FixConfigMode, error) {
 	if val, ok := _FixConfigModeNameToValueMap[s]; ok {
 		return val, nil
 	}
+
+	if val, ok := _FixConfigModeNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
 	return 0, fmt.Errorf("%s does not belong to FixConfigMode values", s)
 }
 
 // FixConfigModeValues returns all values of the enum
 func FixConfigModeValues() []FixConfigMode {
 	return _FixConfigModeValues
+}
+
+// FixConfigModeStrings returns a slice of all String values of the enum
+func FixConfigModeStrings() []string {
+	strs := make([]string, len(_FixConfigModeNames))
+	copy(strs, _FixConfigModeNames)
+	return strs
 }
 
 // IsAFixConfigMode returns "true" if the value is listed in the enum definition. "false" otherwise

--- a/provisioner/powershell/executionpolicy_enumer.go
+++ b/provisioner/powershell/executionpolicy_enumer.go
@@ -4,11 +4,14 @@ package powershell
 
 import (
 	"fmt"
+	"strings"
 )
 
 const _ExecutionPolicyName = "bypassallsigneddefaultremotesignedrestrictedundefinedunrestrictednone"
 
 var _ExecutionPolicyIndex = [...]uint8{0, 6, 15, 22, 34, 44, 53, 65, 69}
+
+const _ExecutionPolicyLowerName = "bypassallsigneddefaultremotesignedrestrictedundefinedunrestrictednone"
 
 func (i ExecutionPolicy) String() string {
 	if i < 0 || i >= ExecutionPolicy(len(_ExecutionPolicyIndex)-1) {
@@ -17,17 +20,50 @@ func (i ExecutionPolicy) String() string {
 	return _ExecutionPolicyName[_ExecutionPolicyIndex[i]:_ExecutionPolicyIndex[i+1]]
 }
 
-var _ExecutionPolicyValues = []ExecutionPolicy{0, 1, 2, 3, 4, 5, 6, 7}
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _ExecutionPolicyNoOp() {
+	var x [1]struct{}
+	_ = x[ExecutionPolicyBypass-(0)]
+	_ = x[ExecutionPolicyAllsigned-(1)]
+	_ = x[ExecutionPolicyDefault-(2)]
+	_ = x[ExecutionPolicyRemotesigned-(3)]
+	_ = x[ExecutionPolicyRestricted-(4)]
+	_ = x[ExecutionPolicyUndefined-(5)]
+	_ = x[ExecutionPolicyUnrestricted-(6)]
+	_ = x[ExecutionPolicyNone-(7)]
+}
+
+var _ExecutionPolicyValues = []ExecutionPolicy{ExecutionPolicyBypass, ExecutionPolicyAllsigned, ExecutionPolicyDefault, ExecutionPolicyRemotesigned, ExecutionPolicyRestricted, ExecutionPolicyUndefined, ExecutionPolicyUnrestricted, ExecutionPolicyNone}
 
 var _ExecutionPolicyNameToValueMap = map[string]ExecutionPolicy{
-	_ExecutionPolicyName[0:6]:   0,
-	_ExecutionPolicyName[6:15]:  1,
-	_ExecutionPolicyName[15:22]: 2,
-	_ExecutionPolicyName[22:34]: 3,
-	_ExecutionPolicyName[34:44]: 4,
-	_ExecutionPolicyName[44:53]: 5,
-	_ExecutionPolicyName[53:65]: 6,
-	_ExecutionPolicyName[65:69]: 7,
+	_ExecutionPolicyName[0:6]:        ExecutionPolicyBypass,
+	_ExecutionPolicyLowerName[0:6]:   ExecutionPolicyBypass,
+	_ExecutionPolicyName[6:15]:       ExecutionPolicyAllsigned,
+	_ExecutionPolicyLowerName[6:15]:  ExecutionPolicyAllsigned,
+	_ExecutionPolicyName[15:22]:      ExecutionPolicyDefault,
+	_ExecutionPolicyLowerName[15:22]: ExecutionPolicyDefault,
+	_ExecutionPolicyName[22:34]:      ExecutionPolicyRemotesigned,
+	_ExecutionPolicyLowerName[22:34]: ExecutionPolicyRemotesigned,
+	_ExecutionPolicyName[34:44]:      ExecutionPolicyRestricted,
+	_ExecutionPolicyLowerName[34:44]: ExecutionPolicyRestricted,
+	_ExecutionPolicyName[44:53]:      ExecutionPolicyUndefined,
+	_ExecutionPolicyLowerName[44:53]: ExecutionPolicyUndefined,
+	_ExecutionPolicyName[53:65]:      ExecutionPolicyUnrestricted,
+	_ExecutionPolicyLowerName[53:65]: ExecutionPolicyUnrestricted,
+	_ExecutionPolicyName[65:69]:      ExecutionPolicyNone,
+	_ExecutionPolicyLowerName[65:69]: ExecutionPolicyNone,
+}
+
+var _ExecutionPolicyNames = []string{
+	_ExecutionPolicyName[0:6],
+	_ExecutionPolicyName[6:15],
+	_ExecutionPolicyName[15:22],
+	_ExecutionPolicyName[22:34],
+	_ExecutionPolicyName[34:44],
+	_ExecutionPolicyName[44:53],
+	_ExecutionPolicyName[53:65],
+	_ExecutionPolicyName[65:69],
 }
 
 // ExecutionPolicyString retrieves an enum value from the enum constants string name.
@@ -36,12 +72,23 @@ func ExecutionPolicyString(s string) (ExecutionPolicy, error) {
 	if val, ok := _ExecutionPolicyNameToValueMap[s]; ok {
 		return val, nil
 	}
+
+	if val, ok := _ExecutionPolicyNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
 	return 0, fmt.Errorf("%s does not belong to ExecutionPolicy values", s)
 }
 
 // ExecutionPolicyValues returns all values of the enum
 func ExecutionPolicyValues() []ExecutionPolicy {
 	return _ExecutionPolicyValues
+}
+
+// ExecutionPolicyStrings returns a slice of all String values of the enum
+func ExecutionPolicyStrings() []string {
+	strs := make([]string, len(_ExecutionPolicyNames))
+	copy(strs, _ExecutionPolicyNames)
+	return strs
 }
 
 // IsAExecutionPolicy returns "true" if the value is listed in the enum definition. "false" otherwise


### PR DESCRIPTION
Since the enumer implementation we used hadn't been updated for 5+ years, this didn't work with recent linux/go versions, and enumer crashed while attempting to parse/analyse the source files.

There's another alternative on Github, forked from the one we used, which seems more maintained now, and does produce the expected files in Packer.

Closes: #13082