### PR TITLE
.release/cy.yml: Enable CI for feature branches

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -13,7 +13,8 @@ project "packer" {
     repository = "packer"
     release_branches = [
         "main",
-        "release/**"
+        "release/**",
+        "feature/**"
     ]
   }
 }


### PR DESCRIPTION
This change enables CI for feature branches, with this changes any PRs opened against
feature branches will get built by the CRT system and published to the internal registry 
for testing. CI will build full Go binaries and Docker containers. 
