### PR TITLE
Add concurrency to cancel duplicate workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ on:
       - release/**
       - feature/**
 
+concurrency:
+  group: ${{ github.ref  }}
+  cancel-in-progress: true
+
 env:
   REPO_NAME: "packer"
 


### PR DESCRIPTION
We shouldn't continue with building the full suite of assets if there has been changes to the feature branch.
