### PR TITLE
packer_test: make PluginTestDir a structure

### DIFF
--- a/packer_test/common/commands.go
+++ b/packer_test/common/commands.go
@@ -66,8 +66,14 @@ func (pc *packerCommand) SetWD(dir string) *packerCommand {
 }
 
 // UsePluginDir sets the plugin directory in the environment to `dir`
-func (pc *packerCommand) UsePluginDir(dir string) *packerCommand {
-	return pc.AddEnv("PACKER_PLUGIN_PATH", dir)
+func (pc *packerCommand) UsePluginDir(dir *PluginDirSpec) *packerCommand {
+	return pc.UseRawPluginDir(dir.dirPath)
+}
+
+// UseRawPluginDir is meant to be used for setting the plugin directory with a
+// raw directory path instead of a PluginDirSpec.
+func (pc *packerCommand) UseRawPluginDir(dirPath string) *packerCommand {
+	return pc.AddEnv("PACKER_PLUGIN_PATH", dirPath)
 }
 
 func (pc *packerCommand) SetArgs(args ...string) *packerCommand {

--- a/packer_test/common/plugin.go
+++ b/packer_test/common/plugin.go
@@ -125,6 +125,11 @@ func (ts *PackerTestSuite) CompilePlugin(t *testing.T, versionString string) {
 	ts.compiledPlugins.Store(v.String(), outBin)
 }
 
+type PluginDirSpec struct {
+	dirPath string
+	suite   *PackerTestSuite
+}
+
 // MakePluginDir installs a list of plugins into a temporary directory and returns its path
 //
 // This can be set in the environment for a test through a function like t.SetEnv(), so
@@ -134,45 +139,68 @@ func (ts *PackerTestSuite) CompilePlugin(t *testing.T, versionString string) {
 //
 // Note: all of the plugin versions specified to be installed in this plugin directory
 // must have been compiled beforehand.
-func (ts *PackerTestSuite) MakePluginDir(pluginVersions ...string) (pluginTempDir string, cleanup func()) {
-	t := ts.T()
+func (ts *PackerTestSuite) MakePluginDir() *PluginDirSpec {
+	var err error
 
-	for _, version := range pluginVersions {
-		_ = ts.GetPluginPath(t, version)
+	pluginTempDir, err := os.MkdirTemp("", "packer-plugin-dir-temp-")
+	if err != nil {
+		return nil
 	}
+
+	return &PluginDirSpec{
+		dirPath: pluginTempDir,
+		suite:   ts,
+	}
+}
+
+// InstallPluginVersions installs several versions of the tester plugin under
+// github.com/hashicorp/tester.
+//
+// Each version of the plugin needs to have been pre-compiled.
+//
+// If a plugin is missing, the temporary directory will be removed.
+func (ps *PluginDirSpec) InstallPluginVersions(pluginVersions ...string) *PluginDirSpec {
+	t := ps.suite.T()
 
 	var err error
 
 	defer func() {
-		if err != nil {
-			if pluginTempDir != "" {
-				os.RemoveAll(pluginTempDir)
+		if err != nil || t.Failed() {
+			rmErr := os.RemoveAll(ps.Dir())
+			if rmErr != nil {
+				t.Logf("failed to remove temporary plugin directory %q: %s. This may need manual intervention.", ps.Dir(), err)
 			}
-			t.Fatalf("failed to prepare temporary plugin directory %q: %s", pluginTempDir, err)
+			t.Fatalf("failed to install plugins to temporary plugin directory %q: %s", ps.Dir(), err)
 		}
 	}()
 
-	pluginTempDir, err = os.MkdirTemp("", "packer-plugin-dir-temp-")
-	if err != nil {
-		return
-	}
-
 	for _, pluginVersion := range pluginVersions {
-		path := ts.GetPluginPath(t, pluginVersion)
-		cmd := ts.PackerCommand().SetArgs("plugins", "install", "--path", path, "github.com/hashicorp/tester").AddEnv("PACKER_PLUGIN_PATH", pluginTempDir)
+		path := ps.suite.GetPluginPath(t, pluginVersion)
+		cmd := ps.suite.PackerCommand().SetArgs("plugins", "install", "--path", path, "github.com/hashicorp/tester").AddEnv("PACKER_PLUGIN_PATH", ps.Dir())
 		cmd.Assert(check.MustSucceed())
 		out, stderr, cmdErr := cmd.run()
 		if cmdErr != nil {
 			err = fmt.Errorf("failed to install tester plugin version %q: %s\nCommand stdout: %s\nCommand stderr: %s", pluginVersion, err, out, stderr)
-			return
 		}
 	}
 
-	return pluginTempDir, func() {
-		err := os.RemoveAll(pluginTempDir)
-		if err != nil {
-			t.Logf("failed to remove temporary plugin directory %q: %s. This may need manual intervention.", pluginTempDir, err)
-		}
+	return ps
+}
+
+// Dir returns the temporary plugin dir for use in other functions
+func (ps PluginDirSpec) Dir() string {
+	return ps.dirPath
+}
+
+func (ps *PluginDirSpec) Cleanup() {
+	pluginDir := ps.Dir()
+	if pluginDir == "" {
+		return
+	}
+
+	err := os.RemoveAll(pluginDir)
+	if err != nil {
+		ps.suite.T().Logf("failed to remove temporary plugin directory %q: %s. This may need manual intervention.", pluginDir, err)
 	}
 }
 

--- a/packer_test/core_tests/local_eval_test.go
+++ b/packer_test/core_tests/local_eval_test.go
@@ -9,8 +9,8 @@ import (
 func (ts *PackerCoreTestSuite) TestEvalLocalsOrder() {
 	ts.SkipNoAcc()
 
-	pluginDir, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginDir := ts.MakePluginDir()
+	defer pluginDir.Cleanup()
 
 	ts.PackerCommand().UsePluginDir(pluginDir).
 		Runs(10).
@@ -21,8 +21,8 @@ func (ts *PackerCoreTestSuite) TestEvalLocalsOrder() {
 }
 
 func (ts *PackerCoreTestSuite) TestLocalDuplicates() {
-	pluginDir, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginDir := ts.MakePluginDir()
+	defer pluginDir.Cleanup()
 
 	for _, cmd := range []string{"console", "validate", "build"} {
 		ts.Run(fmt.Sprintf("duplicate local detection with %s command - expect error", cmd), func() {

--- a/packer_test/plugin_tests/init_test.go
+++ b/packer_test/plugin_tests/init_test.go
@@ -7,8 +7,8 @@ import (
 func (ts *PackerPluginTestSuite) TestPackerInitForce() {
 	ts.SkipNoAcc()
 
-	pluginPath, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginPath := ts.MakePluginDir()
+	defer pluginPath.Cleanup()
 
 	ts.Run("installs any missing plugins", func() {
 		ts.PackerCommand().UsePluginDir(pluginPath).
@@ -26,8 +26,8 @@ func (ts *PackerPluginTestSuite) TestPackerInitForce() {
 func (ts *PackerPluginTestSuite) TestPackerInitUpgrade() {
 	ts.SkipNoAcc()
 
-	pluginPath, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginPath := ts.MakePluginDir()
+	defer pluginPath.Cleanup()
 
 	cmd := ts.PackerCommand().UsePluginDir(pluginPath)
 	cmd.SetArgs("plugins", "install", "github.com/hashicorp/hashicups", "1.0.1")
@@ -42,8 +42,8 @@ func (ts *PackerPluginTestSuite) TestPackerInitUpgrade() {
 }
 
 func (ts *PackerPluginTestSuite) TestPackerInitWithNonGithubSource() {
-	pluginPath, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginPath := ts.MakePluginDir()
+	defer pluginPath.Cleanup()
 
 	ts.Run("try installing from a non-github source, should fail", func() {
 		ts.PackerCommand().UsePluginDir(pluginPath).
@@ -68,8 +68,8 @@ func (ts *PackerPluginTestSuite) TestPackerInitWithNonGithubSource() {
 func (ts *PackerPluginTestSuite) TestPackerInitWithMixedVersions() {
 	ts.SkipNoAcc()
 
-	pluginPath, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginPath := ts.MakePluginDir()
+	defer pluginPath.Cleanup()
 
 	ts.Run("skips the plugin installation with mixed versions before exiting with an error", func() {
 		ts.PackerCommand().UsePluginDir(pluginPath).

--- a/packer_test/plugin_tests/install_test.go
+++ b/packer_test/plugin_tests/install_test.go
@@ -3,8 +3,8 @@ package plugin_tests
 import "github.com/hashicorp/packer/packer_test/common/check"
 
 func (ts *PackerPluginTestSuite) TestInstallPluginWithMetadata() {
-	tempPluginDir, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	tempPluginDir := ts.MakePluginDir()
+	defer tempPluginDir.Cleanup()
 
 	ts.Run("install plugin with metadata in version", func() {
 		ts.PackerCommand().UsePluginDir(tempPluginDir).
@@ -32,8 +32,8 @@ func (ts *PackerPluginTestSuite) TestInstallPluginWithMetadata() {
 }
 
 func (ts *PackerPluginTestSuite) TestInstallPluginWithPath() {
-	tempPluginDir, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	tempPluginDir := ts.MakePluginDir()
+	defer tempPluginDir.Cleanup()
 
 	ts.Run("install plugin with pre-release only", func() {
 		ts.PackerCommand().UsePluginDir(tempPluginDir).
@@ -60,8 +60,8 @@ func (ts *PackerPluginTestSuite) TestInstallPluginWithPath() {
 func (ts *PackerPluginTestSuite) TestInstallPluginPrerelease() {
 	pluginPath := ts.GetPluginPath(ts.T(), "1.0.1-alpha1")
 
-	pluginDir, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginDir := ts.MakePluginDir()
+	defer pluginDir.Cleanup()
 
 	ts.Run("try install plugin with alpha1 prerelease - should fail", func() {
 		ts.PackerCommand().UsePluginDir(pluginDir).
@@ -73,8 +73,8 @@ func (ts *PackerPluginTestSuite) TestInstallPluginPrerelease() {
 func (ts *PackerPluginTestSuite) TestRemoteInstallWithPluginsInstall() {
 	ts.SkipNoAcc()
 
-	pluginPath, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginPath := ts.MakePluginDir()
+	defer pluginPath.Cleanup()
 
 	ts.Run("install latest version of a remote plugin with packer plugins install", func() {
 		ts.PackerCommand().UsePluginDir(pluginPath).
@@ -86,8 +86,8 @@ func (ts *PackerPluginTestSuite) TestRemoteInstallWithPluginsInstall() {
 func (ts *PackerPluginTestSuite) TestRemoteInstallOfPreReleasePlugin() {
 	ts.SkipNoAcc()
 
-	pluginPath, cleanup := ts.MakePluginDir()
-	defer cleanup()
+	pluginPath := ts.MakePluginDir()
+	defer pluginPath.Cleanup()
 
 	ts.Run("try to init with a pre-release constraint - should fail", func() {
 		ts.PackerCommand().UsePluginDir(pluginPath).

--- a/packer_test/plugin_tests/plugins_remove_test.go
+++ b/packer_test/plugin_tests/plugins_remove_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func (ts *PackerPluginTestSuite) TestPluginsRemoveWithSourceAddress() {
-	pluginPath, cleanup := ts.MakePluginDir("1.0.9", "1.0.10", "2.0.0")
-	defer cleanup()
+	pluginPath := ts.MakePluginDir().InstallPluginVersions("1.0.9", "1.0.10", "2.0.0")
+	defer pluginPath.Cleanup()
 
 	// Get installed plugins
-	if n := InstalledPlugins(ts, pluginPath); len(n) != 3 {
+	if n := InstalledPlugins(ts, pluginPath.Dir()); len(n) != 3 {
 		ts.T().Fatalf("Expected there to be 3 installed plugins but we got  %v", n)
 	}
 
@@ -27,7 +27,7 @@ func (ts *PackerPluginTestSuite) TestPluginsRemoveWithSourceAddress() {
 	})
 
 	// Get installed plugins after removal
-	if n := InstalledPlugins(ts, pluginPath); len(n) != 0 {
+	if n := InstalledPlugins(ts, pluginPath.Dir()); len(n) != 0 {
 		ts.T().Fatalf("Expected there to be 0 installed plugins but we got  %v", n)
 	}
 
@@ -51,11 +51,11 @@ func (ts *PackerPluginTestSuite) TestPluginsRemoveWithSourceAddress() {
 }
 
 func (ts *PackerPluginTestSuite) TestPluginsRemoveWithSourceAddressAndVersion() {
-	pluginPath, cleanup := ts.MakePluginDir("1.0.9", "1.0.10", "2.0.0")
-	defer cleanup()
+	pluginPath := ts.MakePluginDir().InstallPluginVersions("1.0.9", "1.0.10", "2.0.0")
+	defer pluginPath.Cleanup()
 
 	// Get installed plugins
-	if n := InstalledPlugins(ts, pluginPath); len(n) != 3 {
+	if n := InstalledPlugins(ts, pluginPath.Dir()); len(n) != 3 {
 		ts.T().Fatalf("Expected there to be 3 installed plugins but we got  %v", n)
 	}
 
@@ -77,17 +77,17 @@ func (ts *PackerPluginTestSuite) TestPluginsRemoveWithSourceAddressAndVersion() 
 	})
 
 	// Get installed plugins after removal
-	if n := InstalledPlugins(ts, pluginPath); len(n) != 2 {
+	if n := InstalledPlugins(ts, pluginPath.Dir()); len(n) != 2 {
 		ts.T().Fatalf("Expected there to be 2 installed plugins but we got  %v", n)
 	}
 }
 
 func (ts *PackerPluginTestSuite) TestPluginsRemoveWithLocalPath() {
-	pluginPath, cleanup := ts.MakePluginDir("1.0.9", "1.0.10")
-	defer cleanup()
+	pluginPath := ts.MakePluginDir().InstallPluginVersions("1.0.9", "1.0.10")
+	defer pluginPath.Cleanup()
 
 	// Get installed plugins
-	plugins := InstalledPlugins(ts, pluginPath)
+	plugins := InstalledPlugins(ts, pluginPath.Dir())
 	if len(plugins) != 2 {
 		ts.T().Fatalf("Expected there to be 2 installed plugins but we got  %v", len(plugins))
 	}
@@ -112,7 +112,7 @@ func (ts *PackerPluginTestSuite) TestPluginsRemoveWithLocalPath() {
 	})
 
 	// Get installed plugins after removal
-	if n := InstalledPlugins(ts, pluginPath); len(n) != 1 {
+	if n := InstalledPlugins(ts, pluginPath.Dir()); len(n) != 1 {
 		ts.T().Fatalf("Expected there to be 1 installed plugins but we got  %v", n)
 	}
 
@@ -136,11 +136,11 @@ func (ts *PackerPluginTestSuite) TestPluginsRemoveWithLocalPath() {
 }
 
 func (ts *PackerPluginTestSuite) TestPluginsRemoveWithNoArguments() {
-	pluginPath, cleanup := ts.MakePluginDir("1.0.9")
-	defer cleanup()
+	pluginPath := ts.MakePluginDir().InstallPluginVersions("1.0.9")
+	defer pluginPath.Cleanup()
 
 	// Get installed plugins
-	if n := InstalledPlugins(ts, pluginPath); len(n) != 1 {
+	if n := InstalledPlugins(ts, pluginPath.Dir()); len(n) != 1 {
 		ts.T().Fatalf("Expected there to be 1 installed plugins but we got  %v", n)
 	}
 
@@ -154,7 +154,7 @@ func (ts *PackerPluginTestSuite) TestPluginsRemoveWithNoArguments() {
 	})
 
 	// Get installed should remain the same
-	if n := InstalledPlugins(ts, pluginPath); len(n) != 1 {
+	if n := InstalledPlugins(ts, pluginPath.Dir()); len(n) != 1 {
 		ts.T().Fatalf("Expected there to be 1 installed plugins but we got  %v", n)
 	}
 
@@ -163,7 +163,7 @@ func (ts *PackerPluginTestSuite) TestPluginsRemoveWithNoArguments() {
 func InstalledPlugins(ts *PackerPluginTestSuite, dir string) []string {
 	ts.T().Helper()
 
-	cmd := ts.PackerCommand().UsePluginDir(dir).
+	cmd := ts.PackerCommand().UseRawPluginDir(dir).
 		SetArgs("plugins", "installed").
 		SetAssertFatal()
 	cmd.Assert(check.MustSucceed())


### PR DESCRIPTION
In order for the creation of a temporary directory to install plugins into to be simpler to understand and use, we change how the directory is created, cleaned-up, and installs plugins into.

Now, instead of a tuple of a string (path) and a cleanup function, we return a structure that comprises the test suite, and the temporary directory, along with methods to handle those steps independently.