### PR TITLE
hcp: don't continue if HEAD doesn't exist

### DIFF
--- a/internal/hcp/registry/metadata/vcs.go
+++ b/internal/hcp/registry/metadata/vcs.go
@@ -53,13 +53,14 @@ func (g *Git) Type() string {
 }
 
 func (g *Git) Details() map[string]interface{} {
-	resp := map[string]interface{}{}
-
 	headRef, err := g.repo.Head()
 	if err != nil {
-		log.Printf("[ERROR] failed to get the git branch name: %s", err)
-	} else {
-		resp["ref"] = headRef.Name().Short()
+		log.Printf("[ERROR] failed to get reference to git HEAD: %s", err)
+		return nil
+	}
+
+	resp := map[string]interface{}{
+		"ref": headRef.Name().Short(),
 	}
 
 	commit, err := g.repo.CommitObject(headRef.Hash())


### PR DESCRIPTION
In HCP's metadata package, especially the VCS/git parts, we keep the current HEAD for a repository, along with the state it is in, in order to report it to HCP Packer when the build completes.

However, when a build is run on a template from an empty Git repository, and HCP Packer is enabled, the code would crash when trying to get the information on the current HEAD, as it doesn't exist.

The git library we use returns an error in such a case, but this was ignored, leading to a crash when attempting to get the hash to this reference later on.

This commit fixes the problem by NOT ignoring the error to get the head, and immediately stop processing the git data as it doesn't yet exist.