### PR TITLE
Add S3 community provisioner to docs

### DIFF
--- a/website/content/partials/provisioners/community_provisioners.mdx
+++ b/website/content/partials/provisioners/community_provisioners.mdx
@@ -7,3 +7,6 @@
 - [Windows Update provisioner](https://github.com/rgl/packer-plugin-windows-update) -
   A provisioner for gracefully handling Windows updates and the reboots they
   cause.
+
+- [S3 Provisioner](https://github.com/spacechunks/packer-plugin-s3) - 
+  A provisioner that retrieves objects from S3 and stores them at a given destination.


### PR DESCRIPTION
Hey everyone, I created a provisioner supporting file retrival from S3 a while ago, and I thought it would be a good idea to add it to the docs :)