### PR TITLE
fix: fix slice init length

### DIFF
--- a/packer/core.go
+++ b/packer/core.go
@@ -873,7 +873,7 @@ func (c *Core) renderVarsRecursively() (*interpolate.Context, error) {
 		Key   string
 		Value string
 	}
-	sortedMap := make([]keyValue, len(repeatMap))
+	sortedMap := make([]keyValue, 0, len(repeatMap))
 	for _, k := range allKeys {
 		sortedMap = append(sortedMap, keyValue{k, repeatMap[k]})
 	}


### PR DESCRIPTION

The intention here should be to initialize a slice with a capacity of  len(repeatMap)  rather than initializing the length of this slice.




