### PR TITLE
Add missing dash on `recursive` `fmt` command

### DIFF
--- a/website/content/docs/commands/fmt.mdx
+++ b/website/content/docs/commands/fmt.mdx
@@ -54,5 +54,5 @@ $ cat my-template.pkr.hcl | packer fmt -
 
 - `-` - read formatting changes from stdin and write them to stdout.
 
-- `recursive` Also process files in subdirectories. By default, only the
+- `-recursive` Also process files in subdirectories. By default, only the
   given directory (or current directory) is processed.


### PR DESCRIPTION
As per title, very minor fix but I might as well fix it.
