### PR TITLE
datasource: fix test for invalid method

### DIFF
--- a/datasource/http/data_acc_test.go
+++ b/datasource/http/data_acc_test.go
@@ -57,7 +57,7 @@ func TestHttpDataSource(t *testing.T) {
 			Path:  testDatasourceInvalidMethod,
 			Error: true,
 			Outputs: map[string]string{
-				"error": "the `method` must be one of [HEAD GET POST PUT DELETE OPTIONS PATCH]",
+				"error": "the `method` must be one of \\[HEAD GET POST PUT DELETE OPTIONS PATCH\\]",
 			},
 		},
 		{

--- a/datasource/http/data_acc_test.go
+++ b/datasource/http/data_acc_test.go
@@ -29,16 +29,16 @@ var testDatasourceInvalidMethod string
 
 func TestHttpDataSource(t *testing.T) {
 	tests := []struct {
-		Name    string
-		Path    string
-		Error   bool
-		Outputs map[string]string
+		Name            string
+		Path            string
+		Error           bool
+		ExpectedOutputs map[string]string
 	}{
 		{
 			Name:  "basic_test",
 			Path:  testDatasourceBasic,
 			Error: false,
-			Outputs: map[string]string{
+			ExpectedOutputs: map[string]string{
 				"url": "url is https://www.packer.io/",
 				// Check that body is not empty
 				"body": "body is true",
@@ -48,7 +48,7 @@ func TestHttpDataSource(t *testing.T) {
 			Name:  "url_is_empty",
 			Path:  testDatasourceEmptyUrl,
 			Error: true,
-			Outputs: map[string]string{
+			ExpectedOutputs: map[string]string{
 				"error": "the `url` must be specified",
 			},
 		},
@@ -56,7 +56,7 @@ func TestHttpDataSource(t *testing.T) {
 			Name:  "method_is_invalid",
 			Path:  testDatasourceInvalidMethod,
 			Error: true,
-			Outputs: map[string]string{
+			ExpectedOutputs: map[string]string{
 				"error": "the `method` must be one of \\[HEAD GET POST PUT DELETE OPTIONS PATCH\\]",
 			},
 		},
@@ -88,7 +88,7 @@ func TestHttpDataSource(t *testing.T) {
 						}
 					}
 
-					if tt.Outputs != nil {
+					if tt.ExpectedOutputs != nil {
 						logs, err := os.Open(logfile)
 						if err != nil {
 							return fmt.Errorf("Unable find %s", logfile)
@@ -101,7 +101,7 @@ func TestHttpDataSource(t *testing.T) {
 						}
 						logsString := string(logsBytes)
 
-						for key, val := range tt.Outputs {
+						for key, val := range tt.ExpectedOutputs {
 							if matched, _ := regexp.MatchString(val+".*", logsString); !matched {
 								t.Fatalf(
 									"logs doesn't contain expected log %v with value %v in %q",


### PR DESCRIPTION
Since the expected error to look for in the output is compiled to a regexp, the `[]` from the error message were interpreted as a set of characters, which made the regexp not match the expected output from the command.
So to avoid this problem, we escape them so they are expected verbatim in the command output.