### PR TITLE
hcl2template: add strcontains function

### DIFF
--- a/hcl2template/function/strcontains.go
+++ b/hcl2template/function/strcontains.go
@@ -1,0 +1,32 @@
+package function
+
+import (
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+var StrContains = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "str",
+			Type: cty.String,
+		},
+		{
+			Name: "substr",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.Bool),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		str := args[0].AsString()
+		substr := args[1].AsString()
+
+		if strings.Contains(str, substr) {
+			return cty.True, nil
+		}
+
+		return cty.False, nil
+	},
+})

--- a/hcl2template/function/strcontains_test.go
+++ b/hcl2template/function/strcontains_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package function
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestStrContains(t *testing.T) {
+	tests := []struct {
+		String    cty.Value
+		Substr    cty.Value
+		Want      cty.Value
+		ExpectErr bool
+	}{
+		{
+			cty.StringVal("hello"),
+			cty.StringVal("hel"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello"),
+			cty.StringVal("lo"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.StringVal("1"),
+			cty.BoolVal(true),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.StringVal("heo"),
+			cty.BoolVal(false),
+			false,
+		},
+		{
+			cty.StringVal("hello1"),
+			cty.NumberIntVal(1),
+			cty.UnknownVal(cty.Bool),
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("includes(%#v, %#v)", test.String, test.Substr), func(t *testing.T) {
+			got, err := StrContains.Call([]cty.Value{
+				test.String,
+				test.Substr,
+			})
+
+			if test.ExpectErr && err == nil {
+				t.Fatal("succeeded; want error")
+			}
+
+			if test.ExpectErr && err != nil {
+				return
+			}
+
+			if !test.ExpectErr && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/hcl2template/functions.go
+++ b/hcl2template/functions.go
@@ -103,6 +103,7 @@ func Functions(basedir string) map[string]function.Function {
 		"slice":              stdlib.SliceFunc,
 		"sort":               stdlib.SortFunc,
 		"split":              stdlib.SplitFunc,
+		"strcontains":        pkrfunction.StrContains,
 		"strrev":             stdlib.ReverseFunc,
 		"substr":             stdlib.SubstrFunc,
 		"textdecodebase64":   TextDecodeBase64Func,


### PR DESCRIPTION
The strcontains function check if a sub string is a indeed a subset of a given string.

closes https://github.com/hashicorp/packer/issues/13191

This function was tested inside the `packer console` command:

```
$ ./bin/packer console -config-type=hcl2
> strcontains("abcd", "ab")
> true
> strcontains("abcd", "jk")
false
```