### PR TITLE
Let IPL education and web presence approve and merge PRs to website files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,11 @@
 
 # release configuration
 
+# web presence
+
+/website/                                @hashicorp/web-presence @hashicorp/packer
+
+# education
+
+/website/content/                        @hashicorp/team-docs-packer-and-terraform @hashicorp/web-presence @hashicorp/packer
+/website/public/                         @hashicorp/team-docs-packer-and-terraform @hashicorp/web-presence @hashicorp/packer


### PR DESCRIPTION
I'm trying to standardize my team's permissions across all of our code repos that contain documentation. This PR should let the IPL education team and web presence merge PRs to the files that build Packer docs. The Packer team should still have global permissions. Feedback welcome 😊 