### PR TITLE
docs: make UUIDv4 example RFC compliant

### DIFF
--- a/website/content/docs/templates/hcl_templates/functions/uuid/uuidv4.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/uuid/uuidv4.mdx
@@ -19,7 +19,7 @@ recommend using the `uuidv4` function in resource configurations.
 
 ```shell-session
 > uuidv4()
-b5ee72a3-54dd-c4b8-551c-4bdc0204cedb
+9fc99a70-7cd5-482d-bb2b-03af016e4e94
 ```
 
 ## Related Functions


### PR DESCRIPTION
# Description

The output of the example on [uuidv4 Function](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/functions/uuid/uuidv4) is not a valid RFC compliant UUIDv4. It indicates the usage of the `uuidv4()` function and outputs `b5ee72a3-54dd-c4b8-551c-4bdc0204cedb` which is not a valid UUIDv4.

I've corrected the example to output a UUIDv4 conforming to the RFC as such `xxxxxxxx-xxxx-4xxx-Nxxx-xxxxxxxxxxxx`, where:

- The 13th character is always `4` (indicating version 4).
- The 17th character must be either `8`, `9`, `a`, or `b` (indicating the first character of the variant).

# Changes

```diff
 > uuidv4()
-  b5ee72a3-54dd-c4b8-551c-4bdc0204cedb
+  9fc99a70-7cd5-482d-bb2b-03af016e4e94
```

Replaces the old UUID output with a valid RFC compliant UUIDv4.

# References

- [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122)
- [RFC 9562](https://datatracker.ietf.org/doc/html/rfc9562)

# Misc.

To make sure this wasn't an issue with the `uuidv4()` function within Hashicorp's [packer](https://github.com/hashicorp/packer) I tested the function in the following way:

### Command executed:

```ps
> .\packer.exe inspect .\uuid.pkr.hcl
```

### Contents of the _uuid.pkr.hcl_ file:

```hcl
locals {
  uuid_0 = uuidv4()
  uuid_1 = uuidv4()
  uuid_2 = uuidv4()
  uuid_3 = uuidv4()
  uuid_4 = uuidv4()
  uuid_5 = uuidv4()
  uuid_6 = uuidv4()
  uuid_7 = uuidv4()
  uuid_8 = uuidv4()
  uuid_9 = uuidv4()
}
```

### Output:

```ps
Packer Inspect: HCL2 mode

> input-variables:


> local-variables:

local.uuid_0: "90877db8-5519-46ea-ae15-7dfb92594064"
local.uuid_1: "fe6a4649-97d9-4686-b981-3295175f941a"
local.uuid_2: "9944d83d-dab2-4cfb-a1db-572d19271e7a"
local.uuid_3: "547cddb7-c979-4b87-90d0-2bd9b68858b5"
local.uuid_4: "c13dc47a-552c-4dfb-a75d-2f63bb248b41"
local.uuid_5: "3db1ce29-bdde-4642-b010-1a41d47c22a3"
local.uuid_6: "4a020460-edd1-471d-b8a2-5956c0c68257"
local.uuid_7: "1845bf87-6908-4fc0-8f11-b5b4f36c60a7"
local.uuid_8: "f5c7e552-b799-45f3-8172-46162eadfd89"
local.uuid_9: "057c2eaf-6769-4a8d-90c8-775aec80496a"

> builds:
```
