### PR TITLE
acctest: Gadgets for testing files

### DIFF
--- a/packer_test/common/check/file_gadgets.go
+++ b/packer_test/common/check/file_gadgets.go
@@ -1,0 +1,35 @@
+package check
+
+import (
+	"fmt"
+	"os"
+)
+
+type fileExists struct {
+	filepath string
+	isDir    bool
+}
+
+func (fe fileExists) Check(_, _ string, _ error) error {
+	st, err := os.Stat(fe.filepath)
+	if err != nil {
+		return fmt.Errorf("failed to stat %q: %s", fe.filepath, err)
+	}
+
+	if st.IsDir() && !fe.isDir {
+		return fmt.Errorf("file %q is a directory, wasn't supposed to be", fe.filepath)
+	}
+
+	if !st.IsDir() && fe.isDir {
+		return fmt.Errorf("file %q is not a directory, was supposed to be", fe.filepath)
+	}
+
+	return nil
+}
+
+func FileExists(filePath string, isDir bool) Checker {
+	return fileExists{
+		filepath: filePath,
+		isDir:    isDir,
+	}
+}

--- a/packer_test/common/check/file_gadgets.go
+++ b/packer_test/common/check/file_gadgets.go
@@ -3,6 +3,7 @@ package check
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type fileExists struct {
@@ -31,5 +32,28 @@ func FileExists(filePath string, isDir bool) Checker {
 	return fileExists{
 		filepath: filePath,
 		isDir:    isDir,
+	}
+}
+
+type fileGlob struct {
+	filepath string
+}
+
+func (fe fileGlob) Check(_, _ string, _ error) error {
+	matches, err := filepath.Glob(fe.filepath)
+	if err != nil {
+		return fmt.Errorf("error evaluating file glob pattern %q: %v", fe.filepath, err)
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("no matches found for file glob pattern %q", fe.filepath)
+	}
+
+	return nil
+}
+
+func FileGlob(filename string) Checker {
+	return fileGlob{
+		filepath: filename,
 	}
 }


### PR DESCRIPTION
This PR adds two new checkers to the acceptance testing library, related to files; those gadgets have been extracted from two open PRs:

1. #12397 : the original implementation of the FileExists checker, which ensures a file exists after a run, and optionally if it is a directory that we expect.
2. #13171 : the FileGlob checker, which essentially does the same thing as FileExists, but with a glob expression instead, so that if the output filename isn't known with certainty beforehand, we can still check that a file exists that matches the expression we're looking for.