### PR TITLE
hcl2template: add alltrue & anytrue function

### DIFF
--- a/hcl2template/function/alltrue.go
+++ b/hcl2template/function/alltrue.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package function
+
+import (
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// AllTrue constructs a function that returns true if all elements of the
+// list are true. If the list is empty, return true.
+var AllTrue = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "list",
+			Type: cty.List(cty.Bool),
+		},
+	},
+	Type:         function.StaticReturnType(cty.Bool),
+	RefineResult: refineNotNull,
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		result := cty.True
+		for it := args[0].ElementIterator(); it.Next(); {
+			_, v := it.Element()
+			if !v.IsKnown() {
+				return cty.UnknownVal(cty.Bool), nil
+			}
+			if v.IsNull() {
+				return cty.False, nil
+			}
+			result = result.And(v)
+			if result.False() {
+				return cty.False, nil
+			}
+		}
+		return result, nil
+	},
+})

--- a/hcl2template/function/alltrue_test.go
+++ b/hcl2template/function/alltrue_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package function
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestAllTrue(t *testing.T) {
+	tests := []struct {
+		Collection cty.Value
+		Want       cty.Value
+		Err        bool
+	}{
+		{
+			cty.ListValEmpty(cty.Bool),
+			cty.True,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.True}),
+			cty.True,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.False}),
+			cty.False,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.True, cty.False}),
+			cty.False,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.False, cty.True}),
+			cty.False,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.True, cty.NullVal(cty.Bool)}),
+			cty.False,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.UnknownVal(cty.Bool)}),
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.UnknownVal(cty.Bool),
+				cty.UnknownVal(cty.Bool),
+			}),
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
+			false,
+		},
+		{
+			cty.UnknownVal(cty.List(cty.Bool)),
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
+			false,
+		},
+		{
+			cty.NullVal(cty.List(cty.Bool)),
+			cty.NilVal,
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("alltrue(%#v)", tc.Collection), func(t *testing.T) {
+			got, err := AllTrue.Call([]cty.Value{tc.Collection})
+
+			if tc.Err && err == nil {
+				t.Fatal("succeeded; want error")
+			}
+			if !tc.Err && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if !got.RawEquals(tc.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, tc.Want)
+			}
+		})
+	}
+}

--- a/hcl2template/function/anytrue.go
+++ b/hcl2template/function/anytrue.go
@@ -1,0 +1,44 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package function
+
+import (
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// AnyTrue constructs a function that returns true if a single element of
+// the list is true. If the list is empty, return false.
+var AnyTrue = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "list",
+			Type: cty.List(cty.Bool),
+		},
+	},
+	Type:         function.StaticReturnType(cty.Bool),
+	RefineResult: refineNotNull,
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		result := cty.False
+		var hasUnknown bool
+		for it := args[0].ElementIterator(); it.Next(); {
+			_, v := it.Element()
+			if !v.IsKnown() {
+				hasUnknown = true
+				continue
+			}
+			if v.IsNull() {
+				continue
+			}
+			result = result.Or(v)
+			if result.True() {
+				return cty.True, nil
+			}
+		}
+		if hasUnknown {
+			return cty.UnknownVal(cty.Bool), nil
+		}
+		return result, nil
+	},
+})

--- a/hcl2template/function/anytrue_test.go
+++ b/hcl2template/function/anytrue_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package function
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestAnyTrue(t *testing.T) {
+	tests := []struct {
+		Collection cty.Value
+		Want       cty.Value
+		Err        bool
+	}{
+		{
+			cty.ListValEmpty(cty.Bool),
+			cty.False,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.True}),
+			cty.True,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.False}),
+			cty.False,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.True, cty.False}),
+			cty.True,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.False, cty.True}),
+			cty.True,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.True, cty.NullVal(cty.Bool)}),
+			cty.True,
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{cty.UnknownVal(cty.Bool)}),
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
+			false,
+		},
+		{
+			cty.ListVal([]cty.Value{
+				cty.UnknownVal(cty.Bool),
+				cty.UnknownVal(cty.Bool),
+			}),
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
+			false,
+		},
+		{
+			cty.UnknownVal(cty.List(cty.Bool)),
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
+			false,
+		},
+		{
+			cty.NullVal(cty.List(cty.Bool)),
+			cty.NilVal,
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("anytrue(%#v)", tc.Collection), func(t *testing.T) {
+			got, err := AnyTrue.Call([]cty.Value{tc.Collection})
+
+			if tc.Err && err == nil {
+				t.Fatal("succeeded; want error")
+			}
+			if !tc.Err && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if !got.RawEquals(tc.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, tc.Want)
+			}
+		})
+	}
+}

--- a/hcl2template/functions.go
+++ b/hcl2template/functions.go
@@ -35,6 +35,7 @@ func Functions(basedir string) map[string]function.Function {
 		"abs":                stdlib.AbsoluteFunc,
 		"abspath":            filesystem.AbsPathFunc,
 		"alltrue":            pkrfunction.AllTrue,
+		"anytrue":            pkrfunction.AnyTrue,
 		"aws_secretsmanager": pkrfunction.AWSSecret,
 		"basename":           filesystem.BasenameFunc,
 		"base64decode":       encoding.Base64DecodeFunc,

--- a/hcl2template/functions.go
+++ b/hcl2template/functions.go
@@ -34,6 +34,7 @@ func Functions(basedir string) map[string]function.Function {
 	funcs := map[string]function.Function{
 		"abs":                stdlib.AbsoluteFunc,
 		"abspath":            filesystem.AbsPathFunc,
+		"alltrue":            pkrfunction.AllTrue,
 		"aws_secretsmanager": pkrfunction.AWSSecret,
 		"basename":           filesystem.BasenameFunc,
 		"base64decode":       encoding.Base64DecodeFunc,

--- a/website/content/docs/templates/hcl_templates/functions/collection/alltrue.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/alltrue.mdx
@@ -1,0 +1,25 @@
+---
+page_title: alltrue - Functions - Configuration Language
+description: |-
+  The alltrue function determines whether all elements of a collection
+  are true or "true". If the collection is empty, it returns true.
+---
+
+# `alltrue` Function
+
+`alltrue` returns `true` if all elements in a given collection are `true`
+or `"true"`. It also returns `true` if the collection is empty.
+
+```hcl
+alltrue(list)
+```
+
+## Examples
+
+```command
+> alltrue(["true", true])
+true
+> alltrue([true, false])
+false
+```
+

--- a/website/content/docs/templates/hcl_templates/functions/collection/anytrue.mdx
+++ b/website/content/docs/templates/hcl_templates/functions/collection/anytrue.mdx
@@ -1,0 +1,28 @@
+---
+page_title: anytrue - Functions - Configuration Language
+description: |-
+  The anytrue function determines whether any element of a collection
+  is true or "true". If the collection is empty, it returns false.
+---
+
+# `anytrue` Function
+
+`anytrue` returns `true` if any element in a given collection is `true`
+or `"true"`. It also returns `false` if the collection is empty.
+
+```hcl
+anytrue(list)
+```
+
+## Examples
+
+```command
+> anytrue(["true"])
+true
+> anytrue([true])
+true
+> anytrue([true, false])
+true
+> anytrue([])
+false
+```

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -331,6 +331,10 @@
                     "path": "templates/hcl_templates/functions/collection/alltrue"
                   },
                   {
+                    "title": "anytrue",
+                    "path": "templates/hcl_templates/functions/collection/anytrue"
+                  },
+                  {
                     "title": "chunklist",
                     "path": "templates/hcl_templates/functions/collection/chunklist"
                   },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -327,6 +327,10 @@
                 "title": "Collection Functions",
                 "routes": [
                   {
+                    "title": "alltrue",
+                    "path": "templates/hcl_templates/functions/collection/alltrue"
+                  },
+                  {
                     "title": "chunklist",
                     "path": "templates/hcl_templates/functions/collection/chunklist"
                   },


### PR DESCRIPTION
## alltrue

Function that return `true` if all elements of the collection are `true`

![image](https://github.com/user-attachments/assets/12e1e383-b973-4a56-aee6-f9f69bab9033)

### manual tests
tested with `packer console --config-type=hcl2`

```
> alltrue([true, false])
false
> alltrue(["true", true])
true
> alltrue(["true", 123])
> Error: Invalid function argument

  on <console-input> line 1:
  (source code not available)

Invalid value for "list" parameter: element 1: bool required.
```

## anytrue

Function that return `true` if at least 1 element is `true`

![image](https://github.com/user-attachments/assets/114d666b-ff3e-4fa8-bf48-be1033076cba)

### manual tests

tested with `packer console --config-type=hcl2`
```
> anytrue([true, false])
> true
>

> anytrue([true, true])
> true
>
>
> anytrue([false, false])
> false
>

> anytrue(["true"])
> true
> anytrue(["true", 123])
> Error: Invalid function argument

  on <console-input> line 1:
  (source code not available)

Invalid value for "list" parameter: element 1: bool required.
```

Closes #13073

