### PR TITLE
docs: put hcl2 example in first tab

### DIFF
--- a/website/content/docs/builders/file.mdx
+++ b/website/content/docs/builders/file.mdx
@@ -25,17 +25,6 @@ Below is a fully functioning example. It create a file at `target` with the
 specified `content`.
 
 <Tabs>
-<Tab heading="JSON">
-
-```json
-{
-  "type": "file",
-  "content": "Lorem ipsum dolor sit amet",
-  "target": "dummy_artifact"
-}
-```
-
-</Tab>
 <Tab heading="HCL2">
 
 ```hcl
@@ -46,6 +35,17 @@ source "file" "basic-example" {
 
 build {
   sources = ["sources.file.basic-example"]
+}
+```
+
+</Tab>
+<Tab heading="JSON">
+
+```json
+{
+  "type": "file",
+  "content": "Lorem ipsum dolor sit amet",
+  "target": "dummy_artifact"
 }
 ```
 

--- a/website/content/docs/builders/null.mdx
+++ b/website/content/docs/builders/null.mdx
@@ -26,18 +26,6 @@ Below is a fully functioning example. It doesn't do anything useful, since no
 provisioners are defined, but it will connect to the specified host via ssh.
 
 <Tabs>
-<Tab heading="JSON">
-
-```json
-{
-  "type": "null",
-  "ssh_host": "127.0.0.1",
-  "ssh_username": "foo",
-  "ssh_password": "bar"
-}
-```
-
-</Tab>
 <Tab heading="HCL2">
 
 ```hcl
@@ -49,6 +37,18 @@ source "null" "basic-example" {
 
 build {
   sources = ["sources.null.basic-example"]
+}
+```
+
+</Tab>
+<Tab heading="JSON">
+
+```json
+{
+  "type": "null",
+  "ssh_host": "127.0.0.1",
+  "ssh_username": "foo",
+  "ssh_password": "bar"
 }
 ```
 

--- a/website/content/docs/post-processors/checksum.mdx
+++ b/website/content/docs/post-processors/checksum.mdx
@@ -33,6 +33,16 @@ a third-party post-processor.
 ## Basic example
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+post-processor "checksum" {
+  checksum_types = ["sha1", "sha256"]
+  output = "packer_{{.BuildName}}_{{.ChecksumType}}.checksum"
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -40,16 +50,6 @@ a third-party post-processor.
   "type": "checksum",
   "checksum_types": ["sha1", "sha256"],
   "output": "packer_{{.BuildName}}_{{.ChecksumType}}.checksum"
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-post-processor "checksum" {
-  checksum_types = ["sha1", "sha256"]
-  output = "packer_{{.BuildName}}_{{.ChecksumType}}.checksum"
 }
 ```
 

--- a/website/content/docs/post-processors/manifest.mdx
+++ b/website/content/docs/post-processors/manifest.mdx
@@ -48,6 +48,13 @@ is not a behavior anyone should ever expect.
 The minimal way to use the manifest post-processor is by just writing its definition, like:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+post-processor "manifest" {}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -61,18 +68,24 @@ The minimal way to use the manifest post-processor is by just writing its defini
 ```
 
 </Tab>
-<Tab heading="HCL2">
-
-```hcl
-post-processor "manifest" {}
-```
-
-</Tab>
 </Tabs>
 
 A more complete example:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+post-processor "manifest" {
+    output = "manifest.json"
+    strip_path = true
+    custom_data = {
+      my_custom_data = "example"
+    }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -87,19 +100,6 @@ A more complete example:
       }
     }
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-post-processor "manifest" {
-    output = "manifest.json"
-    strip_path = true
-    custom_data = {
-      my_custom_data = "example"
-    }
 }
 ```
 
@@ -139,6 +139,29 @@ artifacts from the manifest by using `packer_run_uuid`.
 The above manifest was generated with the following template:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "docker" "docker"{
+    image = "ubuntu:latest"
+    export_path = "packer_example"
+    run_command = ["-d", "-i", "-t", "--entrypoint=/bin/bash", "{{.Image}}"]
+}
+
+build {
+    sources = ["docker.docker"]
+
+    post-processor "manifest" {
+        output = "manifest.json"
+        strip_path = true
+        custom_data = {
+          my_custom_data = "example"
+        }
+    }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -161,29 +184,6 @@ The above manifest was generated with the following template:
       }
     }
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-source "docker" "docker"{
-    image = "ubuntu:latest"
-    export_path = "packer_example"
-    run_command = ["-d", "-i", "-t", "--entrypoint=/bin/bash", "{{.Image}}"]
-}
-
-build {
-    sources = ["docker.docker"]
-
-    post-processor "manifest" {
-        output = "manifest.json"
-        strip_path = true
-        custom_data = {
-          my_custom_data = "example"
-        }
-    }
 }
 ```
 

--- a/website/content/docs/provisioners/breakpoint.mdx
+++ b/website/content/docs/provisioners/breakpoint.mdx
@@ -27,6 +27,30 @@ and between every provisioner.
 ## Basic Example
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "null" "example" {
+  communicator = "none"
+}
+
+build {
+  sources = ["source.null.example"]
+
+  provisioner "shell-local" {
+    inline = ["echo hi"]
+  }
+  provisioner "breakpoint" {
+    disable = false
+    note    = "this is a breakpoint"
+  }
+  provisioner "shell-local" {
+    inline = ["echo hi 2"]
+  }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -52,30 +76,6 @@ and between every provisioner.
       "inline": "echo hi 2"
     }
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-source "null" "example" {
-  communicator = "none"
-}
-
-build {
-  sources = ["source.null.example"]
-
-  provisioner "shell-local" {
-    inline = ["echo hi"]
-  }
-  provisioner "breakpoint" {
-    disable = false
-    note    = "this is a breakpoint"
-  }
-  provisioner "shell-local" {
-    inline = ["echo hi 2"]
-  }
 }
 ```
 

--- a/website/content/docs/provisioners/file.mdx
+++ b/website/content/docs/provisioners/file.mdx
@@ -30,6 +30,16 @@ The file provisioner can upload both single files and complete directories.
 ## Basic Example
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+provisioner "file" {
+  source = "app.tar.gz"
+  destination = "/tmp/app.tar.gz"
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -37,16 +47,6 @@ The file provisioner can upload both single files and complete directories.
   "type": "file",
   "source": "app.tar.gz",
   "destination": "/tmp/app.tar.gz"
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-provisioner "file" {
-  source = "app.tar.gz"
-  destination = "/tmp/app.tar.gz"
 }
 ```
 

--- a/website/content/guides/packer-on-cicd/pipelineing-builds.mdx
+++ b/website/content/guides/packer-on-cicd/pipelineing-builds.mdx
@@ -28,6 +28,40 @@ this example can be applied to other builders as well.
 Here is an extremely basic virtualbox-iso template:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "virtualbox-iso" "step_1" {
+  boot_command     = ["<esc><wait>", "<esc><wait>", "<enter><wait>",
+                      "/install/vmlinuz<wait>", " initrd=/install/initrd.gz",
+                      " auto-install/enable=true", " debconf/priority=critical",
+                      " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu_preseed.cfg<wait>",
+                      " -- <wait>", "<enter><wait>"]
+  disk_size        = "40960"
+  guest_os_type    = "Ubuntu_64"
+  http_directory   = "./http"
+  iso_checksum     = "sha256:946a6077af6f5f95a51f82fdc44051c7aa19f9cfc5f737954845a6050543d7c2"
+  iso_url          = "http://old-releases.ubuntu.com/releases/14.04.1/ubuntu-14.04-server-amd64.iso"
+  shutdown_command = "echo 'vagrant' | sudo -S shutdown -P now"
+  ssh_password     = "vagrant"
+  ssh_port         = 22
+  ssh_username     = "vagrant"
+  vm_name          = "vbox-example"
+}
+build {
+  sources = ["source.virtualbox-iso.step_1"]
+
+
+  provisioner "shell" {
+    inline = ["echo initial provisioning"]
+  }
+  post-processor "manifest" {
+    output = "stage-1-manifest.json"
+  }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -78,40 +112,6 @@ Here is an extremely basic virtualbox-iso template:
 ```
 
 </Tab>
-<Tab heading="HCL2">
-
-```hcl
-source "virtualbox-iso" "step_1" {
-  boot_command     = ["<esc><wait>", "<esc><wait>", "<enter><wait>",
-                      "/install/vmlinuz<wait>", " initrd=/install/initrd.gz",
-                      " auto-install/enable=true", " debconf/priority=critical",
-                      " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu_preseed.cfg<wait>",
-                      " -- <wait>", "<enter><wait>"]
-  disk_size        = "40960"
-  guest_os_type    = "Ubuntu_64"
-  http_directory   = "./http"
-  iso_checksum     = "sha256:946a6077af6f5f95a51f82fdc44051c7aa19f9cfc5f737954845a6050543d7c2"
-  iso_url          = "http://old-releases.ubuntu.com/releases/14.04.1/ubuntu-14.04-server-amd64.iso"
-  shutdown_command = "echo 'vagrant' | sudo -S shutdown -P now"
-  ssh_password     = "vagrant"
-  ssh_port         = 22
-  ssh_username     = "vagrant"
-  vm_name          = "vbox-example"
-}
-build {
-  sources = ["source.virtualbox-iso.step_1"]
-
-
-  provisioner "shell" {
-    inline = ["echo initial provisioning"]
-  }
-  post-processor "manifest" {
-    output = "stage-1-manifest.json"
-  }
-}
-```
-
-</Tab>
 </Tabs>
 
 In order to build using this template, create a directory named "http" in your
@@ -138,6 +138,29 @@ That output filename generated in the first stage can be used as the
 for the virtualbox-ovf builder.
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "virtualbox-ovf" "step_2" {
+  shutdown_command = "echo 'vagrant' | sudo -S shutdown -P now"
+  source_path      = "output-virtualbox-iso/vbox-example.ovf"
+  ssh_password     = "vagrant"
+  ssh_port         = 22
+  ssh_username     = "vagrant"
+  vm_name          = "virtualbox-example-ovf"
+}
+
+build {
+  sources = ["source.virtualbox-ovf.step_2"]
+
+  provisioner "shell" {
+    inline = ["echo secondary provisioning"]
+  }
+}
+
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -165,29 +188,6 @@ for the virtualbox-ovf builder.
 ```
 
 </Tab>
-<Tab heading="HCL2">
-
-```hcl
-source "virtualbox-ovf" "step_2" {
-  shutdown_command = "echo 'vagrant' | sudo -S shutdown -P now"
-  source_path      = "output-virtualbox-iso/vbox-example.ovf"
-  ssh_password     = "vagrant"
-  ssh_port         = 22
-  ssh_username     = "vagrant"
-  vm_name          = "virtualbox-example-ovf"
-}
-
-build {
-  sources = ["source.virtualbox-ovf.step_2"]
-
-  provisioner "shell" {
-    inline = ["echo secondary provisioning"]
-  }
-}
-
-```
-
-</Tab>
 </Tabs>
 
 ## More efficiencies
@@ -203,6 +203,28 @@ being used with a null builder, and manually sets the artifact from our
 stage-2 ovf build:
 
 <Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "null" "step_3" {
+  communicator = "none"
+}
+
+build {
+  sources = ["source.null.step_3"]
+
+  post-processors {
+    post-processor "artifice" {
+      files = ["output-virtualbox-ovf/virtualbox-example-ovf.ovf", "output-virtualbox-ovf/virtualbox-example-ovf-disk001.vmdk"]
+    }
+    post-processor "vagrant" {
+      provider_override = "virtualbox"
+    }
+  }
+}
+```
+
+</Tab>
 <Tab heading="JSON">
 
 ```json
@@ -228,28 +250,6 @@ stage-2 ovf build:
       }
     ]
   ]
-}
-```
-
-</Tab>
-<Tab heading="HCL2">
-
-```hcl
-source "null" "step_3" {
-  communicator = "none"
-}
-
-build {
-  sources = ["source.null.step_3"]
-
-  post-processors {
-    post-processor "artifice" {
-      files = ["output-virtualbox-ovf/virtualbox-example-ovf.ovf", "output-virtualbox-ovf/virtualbox-example-ovf-disk001.vmdk"]
-    }
-    post-processor "vagrant" {
-      provider_override = "virtualbox"
-    }
-  }
 }
 ```
 


### PR DESCRIPTION
This should put every example tab in HCL2 as first tab.

This would in fact make `hcl2` the default example tab.

![image](https://github.com/user-attachments/assets/0bb83b35-986a-49b3-a54d-f9213c9303ef)

command used to discover the different tabs:

```bash
$ ag '<Tab heading="JSON">' -l
website/content/docs/builders/file.mdx
website/content/docs/builders/null.mdx
website/content/docs/provisioners/shell.mdx
website/content/docs/provisioners/shell-local.mdx
website/content/docs/provisioners/powershell.mdx
website/content/docs/provisioners/windows-restart.mdx
website/content/docs/provisioners/file.mdx
website/content/docs/provisioners/breakpoint.mdx
website/content/docs/provisioners/windows-shell.mdx
website/content/docs/post-processors/manifest.mdx
website/content/docs/post-processors/checksum.mdx
website/content/docs/post-processors/shell-local.mdx
website/content/guides/packer-on-cicd/pipelineing-builds.mdx
```


Closes #13078
