### PR TITLE
docs: make TMPDIR clickable

### DIFF
--- a/website/content/docs/configure.mdx
+++ b/website/content/docs/configure.mdx
@@ -119,8 +119,8 @@ each can be found below:
   new versions of Packer. If you want to disable this for security or privacy
   reasons, you can set this environment variable to `1`.
 
-- TMPDIR (Unix) / TMP, TEMP, USERPROFILE (Windows) - This specifies the
-     directory for temporary files (defaulting to /tmp on Linux/Unix and
-     %USERPROFILE%\AppData\Local\Temp on Windows Vista and later). Customizing
+- `TMPDIR` (Unix) / `TMP`, `TEMP`, `USERPROFILE` (Windows) - This specifies the
+     directory for temporary files (defaulting to `/tmp` on Linux/Unix and
+     `%USERPROFILE%\AppData\Local\Temp` on Windows Vista and later). Customizing
      this setting might be necessary for systems where the default temporary
      directory is either non-writable or non-executable.


### PR DESCRIPTION
The option is less visible than the other one and by adding the quote,
it creates an anchor that will make it easier to link.

![image](https://github.com/user-attachments/assets/d3d68290-0cbd-44e0-aa11-90c83e219ae9)


Post comment edit:

![image](https://github.com/user-attachments/assets/5512cec7-92a4-45a5-ada6-7ed61028d93a)

