### PR TITLE
fix: `packer validate` unsupported type error

### DIFF
--- a/command/test-fixtures/validate/invalid_block_type.pkr.hcl
+++ b/command/test-fixtures/validate/invalid_block_type.pkr.hcl
@@ -1,0 +1,4 @@
+src "docker" "ubuntu" {
+  image  = var.docker_image
+  commit = true
+}

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -36,6 +36,9 @@ func TestValidateCommand(t *testing.T) {
 		// wrong version field
 		{path: filepath.Join(testFixture("version_req", "wrong_field_name")), exitCode: 1},
 
+		// wrong packer block type
+		{path: filepath.Join(testFixture("validate", "invalid_block_type.pkr.hcl")), exitCode: 1},
+
 		// wrong packer block
 		{path: filepath.Join(testFixture("validate", "invalid_packer_block.pkr.hcl")), exitCode: 1},
 

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -165,6 +165,14 @@ func (p *Parser) Parse(filename string, varFiles []string, argVars map[string]st
 		return cfg, diags
 	}
 
+	// Looks for invalid arguments or unsupported block types
+	{
+		for _, file := range files {
+			_, moreDiags := file.Body.Content(configSchema)
+			diags = append(diags, moreDiags...)
+		}
+	}
+
 	// Decode required_plugins blocks.
 	//
 	// Note: using `latest` ( or actually an empty string ) in a config file
@@ -585,8 +593,7 @@ func (p *Parser) decodeDatasources(file *hcl.File, cfg *PackerConfig) hcl.Diagno
 	var diags hcl.Diagnostics
 
 	body := file.Body
-	content, moreDiags := body.Content(configSchema)
-	diags = append(diags, moreDiags...)
+	content, _ := body.Content(configSchema)
 
 	for _, block := range content.Blocks {
 		switch block.Type {

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -156,8 +156,7 @@ func (cfg *PackerConfig) EvalContext(ctx BlockContext, variables map[string]cty.
 func (c *PackerConfig) decodeInputVariables(f *hcl.File) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
-	content, moreDiags := f.Body.Content(configSchema)
-	diags = append(diags, moreDiags...)
+	content, _ := f.Body.Content(configSchema)
 
 	// for input variables we allow to use env in the default value section.
 	ectx := &hcl.EvalContext{
@@ -188,8 +187,7 @@ func (c *PackerConfig) decodeInputVariables(f *hcl.File) hcl.Diagnostics {
 func parseLocalVariableBlocks(f *hcl.File) ([]*LocalBlock, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
-	content, moreDiags := f.Body.Content(configSchema)
-	diags = append(diags, moreDiags...)
+	content, _ := f.Body.Content(configSchema)
 
 	var locals []*LocalBlock
 

--- a/hcl2template/types.required_plugins.go
+++ b/hcl2template/types.required_plugins.go
@@ -15,8 +15,7 @@ import (
 func (cfg *PackerConfig) decodeRequiredPluginsBlock(f *hcl.File) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
-	content, moreDiags := f.Body.Content(configSchema)
-	diags = append(diags, moreDiags...)
+	content, _ := f.Body.Content(configSchema)
 
 	for _, block := range content.Blocks {
 		switch block.Type {


### PR DESCRIPTION
`packer validate` would output the same error message four times per unsupported root block type found in a template (e.g., 'src' instead of 'source'). This behavior was due to a function being called four times for each file on each stage of the parsing.

Closes #13241 
