### PR TITLE
release: ignore AWS SDK vulnerability for release

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -13,4 +13,14 @@ binary {
 	osv          = true
 	oss_index    = true
 	nvd          = false
+
+	# Triage items that are _safe_ to ignore here. Note that this list should be
+	# periodically cleaned up to remove items that are no longer found by the scanner.
+	triage {
+		suppress {
+			vulnerabilities = [
+				"GO-2022-0635", // github.com/aws/aws-sdk-go@v1.55.5 TODO(dduzgun-security): remove when deps is resolved
+			]
+		}
+	}
 }


### PR DESCRIPTION
The reported AWS S3 vulnerability was inherited from the go-getter module that Packer uses for downloading files from external sources.

This vulnerability only impacts S3 uploads, therefore Packer is not vulnerable itself as go-getter only downloads such blobs.

Since the change required to fix this advisory would be to bump the AWS SDK to v2, this being a major change, is not something to do lightly, so we opted to ignore this advisory for now so it doesn't block upcoming releases.