### PR TITLE
seo improvements data sources references

### DIFF
--- a/website/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -1,9 +1,8 @@
 ---
 description: |
-  The HCP Packer Artifact Data Source retrieves information about an
-  artifact from the HCP Packer Registry. This information can be used to
-  provide a source artifact to various Packer builders.
-page_title: HCP Packer Artifact - Data Sources
+  The `hcp-packer-artifact` data source retrieves information about an
+  artifact from the HCP Packer Registry. Use the information to provide a source artifact to Packer builders.
+page_title: hcp-packer-artifact data source reference
 ---
 
 <BadgesHeader>
@@ -11,12 +10,10 @@ page_title: HCP Packer Artifact - Data Sources
   <PluginBadge type="hcp_packer_ready" />
 </BadgesHeader>
 
-# HCP Packer Artifact Data Source
+# `hcp-packer-artifact`
 
-Type: `hcp-packer-artifact`
-
-The `HCP Packer Artifact` Data Source retrieves information about an
-artifact from the HCP Packer Registry. This information can be used to
+The `hcp-packer-artifact` data source retrieves information about an
+artifact from the HCP Packer Registry. Use this retrieved information to
 provide a source artifact to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try

--- a/website/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -1,6 +1,6 @@
 ---
 description: |
-  The `hcp-packer-image` data source retrieves information about an image from the HCP Packer registry. This data source has been deprecated, use the `hcp-packer-artifact` data source instead.
+  The `hcp-packer-image` data source retrieves information about an image from the HCP Packer registry. This data source is deprecated, use the `hcp-packer-artifact` data source instead.
 page_title: hcp-packer-image data source reference
 ---
 
@@ -10,7 +10,7 @@ page_title: hcp-packer-image data source reference
 
 # `hcp-packer-image`
 
-~> **This data source id deprecated**. Use the [`hcp-packer-artifact`](/packer/docs/datasources/hcp/hcp-packer-artifact) data source instead.
+~> **This data source is deprecated**. Use the [`hcp-packer-artifact`](/packer/docs/datasources/hcp/hcp-packer-artifact) data source instead.
 
 The `hcp-packer-image` data source retrieves information about an
 image from the HCP Packer registry. This information can be used to

--- a/website/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -1,23 +1,18 @@
 ---
 description: |
-  This data source has been deprecated, please use HCP Packer Artifact data source instead.
-  The HCP Packer Image Data Source retrieves information about an
-  image from the HCP Packer registry. This information can be used to
-  provide a source image to various Packer builders.
-page_title: HCP Packer Image - Data Sources
+  The `hcp-packer-image` data source retrieves information about an image from the HCP Packer registry. This data source has been deprecated, use the `hcp-packer-artifact` data source instead.
+page_title: hcp-packer-image data source reference
 ---
 
 <BadgesHeader>
   <PluginBadge type="official" />
 </BadgesHeader>
 
-# HCP Packer Image Data Source
+# `hcp-packer-image`
 
-~> **Note:** This data source has been deprecated, please use [HCP Packer Artifact](/packer/docs/datasources/hcp/hcp-packer-artifact) data source instead.
+~> **This data source id deprecated**. Use the [`hcp-packer-artifact`](/packer/docs/datasources/hcp/hcp-packer-artifact) data source instead.
 
-Type: `hcp-packer-image`
-
-The `HCP Packer Image` Data Source retrieves information about an
+The `hcp-packer-image` data source retrieves information about an
 image from the HCP Packer registry. This information can be used to
 provide a source image to various Packer builders.
 

--- a/website/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -1,21 +1,17 @@
 ---
 description: |
-  This data source has been deprecated, please use HCP Packer Version data source instead.
-  The HCP Packer Iteration Data Source retrieves information about an
-  iteration from the HCP Packer registry. This information can be used to
-  query HCP for a source image for various Packer builders.
-page_title: HCP Packer Iteration - Data Sources
+  The `hcp-packer-iteration` data source retrieves information about an
+iteration from the HCP Packer registry. This data source is deprecated. Use the `hcpe-packer-verion` data source instead.
+page_title: hcp-packer-iteration data source reference
 ---
 
 <BadgesHeader>
   <PluginBadge type="official" />
 </BadgesHeader>
 
-# HCP Packer Iteration Data Source
+# `hcp-packer-iteration`
 
-~> **Note:** This data source has been deprecated, please use [HCP Packer Version](/packer/docs/datasources/hcp/hcp-packer-version) data source instead.
-
-Type: `hcp-packer-iteration`
+~> **This data source is deprecated**. Use the [`hcp-packer-version`](/packer/docs/datasources/hcp/hcp-packer-version) data source instead.
 
 The `HCP Packer Iteration` Data Source retrieves information about an
 iteration from the HCP Packer registry. This information can be used to query

--- a/website/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -1,7 +1,7 @@
 ---
 description: |
   The `hcp-packer-version` data source retrieves information about
-  the HCP Packer version from the HCP Packer registry. Use this information to
+  an HCP Packer version from the HCP Packer registry. Use this information to
   get a source's external identifier.
 page_title: hcp-packer-version data source reference
 ---
@@ -14,7 +14,7 @@ page_title: hcp-packer-version data source reference
 # `hcp-packer-version`
 
 The `hcp-packer-version` dsata source retrieves information about
-the HCP Packer version from the HCP Packer registry. You can use the version information to
+an HCP Packer version from the HCP Packer registry. You can use the version information to
 query HCP for a source's external identifier so that you can use it in various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the

--- a/website/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/website/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -1,9 +1,9 @@
 ---
 description: |
-  The HCP Packer Version Data Source retrieves information about
-  HCP Packer Version from the HCP Packer Registry. This information can be used to
-  query HCP for a source external identifier for various Packer builders.
-page_title: HCP Packer Version - Data Sources
+  The `hcp-packer-version` data source retrieves information about
+  the HCP Packer version from the HCP Packer registry. Use this information to
+  get a source's external identifier.
+page_title: hcp-packer-version data source reference
 ---
 
 <BadgesHeader>
@@ -11,20 +11,17 @@ page_title: HCP Packer Version - Data Sources
   <PluginBadge type="hcp_packer_ready" />
 </BadgesHeader>
 
-# HCP Packer Version Data Source
+# `hcp-packer-version`
 
-Type: `hcp-packer-version`
-
-The `HCP Packer Version` Data Source retrieves information about
-HCP Packer Version from the HCP Packer Registry. This information can be used to
-query HCP for a source external identifier for various Packer builders.
+The `hcp-packer-version` dsata source retrieves information about
+the HCP Packer version from the HCP Packer registry. You can use the version information to
+query HCP for a source's external identifier so that you can use it in various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the
 [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
-An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+Packer prints an error if you try to reference metadata from a deactivated or deleted registry.
+An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
 
 ## Revoked Versions
 

--- a/website/content/docs/datasources/hcp/index.mdx
+++ b/website/content/docs/datasources/hcp/index.mdx
@@ -1,7 +1,7 @@
 ---
 description: |
-  Data sources used to data from the HCP Packer registry.
-page_title: HCP - Data sources
+  HCP Packer data sources query data stored to the HCP Packer registry. Use the data sources when your artifact metadata is centralized in HCP.
+page_title: HCP Packer Registry Data sources overview
 sidebar_title: Overview
 ---
 
@@ -9,39 +9,31 @@ sidebar_title: Overview
   <PluginBadge type="official" />
 </BadgesHeader>
 
-# HCP Packer Registry Data sources
+# HCP Packer Registry data sources overview
 
-The HCP Packer Registry bridges the gap between artifact factories and artifact
-deployments, allowing development and security teams to work together to create,
+The HCP Packer Registry connects artifact factories and artifact
+deployments so that development and security teams can work together to create,
 manage, and consume artifacts in a centralized way.
 
+## Introduction
+
 The HCP Packer Registry stores metadata about your artifacts, including when they
-were created, where the artifacts exists in the cloud, and what (if any) git commit
-is associated with your build. You can use the registry to track
+were created, where the artifacts exists in the cloud, and git commit
+information associated with your build. You can use the registry to track
 information about the artifacts your Packer builds produce, clearly
 designate which artifacts are appropriate for test and production environments,
 and query for the right artifacts to use in both Packer and Terraform
 configurations.
 
-Packer has two data sources that work together to retrieve information from the
+The following Packer data sources work together to determine and retrieve information from the
 HCP Packer registry:
 
-- [hcp-packer-version](/packer/docs/datasources/hcp/hcp-packer-version) -
-retrieves information about an HCP Packer Version in HCP Packer Registry
-- [hcp-packer-artifact](/packer/docs/datasources/hcp/hcp-packer-artifact) - retrieves
-information about a specific artifact created in the HCP Packer registry
+- [hcp-packer-version](/packer/docs/datasources/hcp/hcp-packer-version): Retrieves information about an HCP Packer version in the HCP Packer registry.
+- [hcp-packer-artifact](/packer/docs/datasources/hcp/hcp-packer-artifact): Retrieves
+information about a specific artifact created in the HCP Packer registry.
 
-Deprecated data sources: (Please use above given data sources instead)
-- [hcp-packer-iteration](/packer/docs/datasources/hcp/hcp-packer-iteration) -
-  retrieves information about an iteration in HCP Packer registry
-- [hcp-packer-image](/packer/docs/datasources/hcp/hcp-packer-image) - retrieves
-  information about a specific image created in the HCP Packer registry
+The following data source types are deprecated since v1.10.1:
 
-These data sources are intended to be used together to determine source artifact
-for pipelined Packer builds.
-
-## How to use this plugin
-
-This plugin comes bundled with the Packer core, so you do not need to install
-it separately. Please install Packer v1.7.7 or above to use the latest version
-of the HCP Packer Registry data sources.
+- [hcp-packer-iteration](/packer/docs/datasources/hcp/hcp-packer-iteration): Retrieves information about an iteration in HCP Packer registry. This data source type is deprecated. Use `hcp-packer-version` instead.
+- [hcp-packer-image](/packer/docs/datasources/hcp/hcp-packer-image): Retrieves
+  information about a specific image created in the HCP Packer registry. This data source type is deprecated. Use `hcp-packer-artifact` instead.

--- a/website/content/docs/datasources/http.mdx
+++ b/website/content/docs/datasources/http.mdx
@@ -1,8 +1,7 @@
 ---
 description: |
-  The HTTP Data Source retrieves information from an HTTP endpoint to be used
-  during Packer builds
-page_title: HTTP - Data Sources
+  The `http` data source makes an HTTP `GET` request to the specified URL and exports information about the response.
+page_title: http data source reference
 ---
 
 <BadgesHeader>
@@ -10,11 +9,9 @@ page_title: HTTP - Data Sources
   <PluginBadge type="hcp_packer_ready" />
 </BadgesHeader>
 
-# HTTP Data Source
+# `http`
 
-Type: `http`
-
-The `http` data source makes an HTTP GET request to the given URL and exports information about the response.
+The `http` data source makes an HTTP `GET` request to the specified URL and exports information about the response.
 
 
 ## Basic Example

--- a/website/content/docs/datasources/index.mdx
+++ b/website/content/docs/datasources/index.mdx
@@ -1,15 +1,14 @@
 ---
+page_title: Data sources overview
 description: |
-  Data sources allow data to be fetched for use in Packer configuration. Use of data sources
-  allows a build to use information defined outside of Packer.
-page_title: Data Sources
+  A data source holds data you want to use in the Packer configuration. Define a data source in your configuration so that Packer can use external data during builds.
 ---
 
-# Data Sources
+# Data sources
 
 Data sources let Packer fetch data to use in a template, including information defined outside of Packer.
 
 Refer to the [`data`](/packer/docs/templates/hcl_templates/datasources) block documentation to learn more about working with data sources. The documentation also contains details about each type of data source.
 
--> **Note:** Data sources is a feature exclusively available to HCL2 templates included in Packer `v1.7.0` (and newer).
+Data sources are only available in HCL2 templates and require Packer `v1.7.0` and newer.
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -740,7 +740,7 @@
     ]
   },
   {
-    "title": "Data Sources",
+    "title": "Data sources reference",
     "routes": [
       {
         "title": "Overview",
@@ -754,25 +754,35 @@
             "path": "datasources/hcp"
           },
           {
-            "title": "Version",
+            "title": "hcp-packer-version",
             "path": "datasources/hcp/hcp-packer-version"
           },
           {
-            "title": "Artifact",
+            "title": "hcp-packer-artifact",
             "path": "datasources/hcp/hcp-packer-artifact"
           },
           {
-            "title": "Iteration",
-            "path": "datasources/hcp/hcp-packer-iteration"
+            "title": "hcp-packer-iteration",
+            "path": "datasources/hcp/hcp-packer-iteration",
+            "badge" : {
+              "text": "DEPRECATED",
+              "type": "outlined",
+              "color": "neutral"
+            }
           },
           {
-            "title": "Image",
-            "path": "datasources/hcp/hcp-packer-image"
+            "title": "hcp-packer-image",
+            "path": "datasources/hcp/hcp-packer-image",
+            "badge" : {
+              "text": "DEPRECATED",
+              "type": "outlined",
+              "color": "neutral"
+            }
           }
         ]
       },
       {
-        "title": "HTTP",
+        "title": "http",
         "path": "datasources/http"
       }
     ]


### PR DESCRIPTION
This PR refreshes meta descriptions and titles of the content in /packer/docs/datasources to improve SEO. It also includes minor updates to address writing style and comprehensibility. 