### PR TITLE
Remove web team from CODEOWNERS for content directories

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,16 @@
 
 # release configuration
 
-# web presence and education
 
-/website/       @hashicorp/team-docs-packer-and-terraform @hashicorp/web-presence @hashicorp/packer
+# engineering and web presence get notified of, and can approve changes to web tooling, but not content.
+
+/website/               @hashicorp/web-presence @hashicorp/packer
+/website/data/
+/website/public/
+/website/content/
+
+# education and engineering get notified of, and can approve changes to web content.
+
+/website/data/          @hashicorp/team-docs-packer-and-terraform @hashicorp/packer
+/website/public/        @hashicorp/team-docs-packer-and-terraform @hashicorp/packer
+/website/content/       @hashicorp/team-docs-packer-and-terraform @hashicorp/packer


### PR DESCRIPTION
The web team was getting a lot of noise from my recent code owner changes, so we decided together to remove them from the CODEOWNERS for docs content directories. Please let me know if you have questions. Apologies for the back and forth! 