### PR TITLE
POC support for multiple build block with hcl2

### DIFF
--- a/internal/hcp/registry/types.bucket.go
+++ b/internal/hcp/registry/types.bucket.go
@@ -132,16 +132,15 @@ func (bucket *Bucket) Initialize(
 	return bucket.initializeVersion(ctx, templateType)
 }
 
-func (bucket *Bucket) RegisterBuildForComponent(sourceName string) {
+func (bucket *Bucket) RegisterBuildForComponent(buildName string) {
 	if bucket == nil {
 		return
 	}
 
-	if ok := bucket.Version.HasBuild(sourceName); ok {
+	if ok := bucket.Version.HasBuild(buildName); ok {
 		return
 	}
-
-	bucket.Version.expectedBuilds = append(bucket.Version.expectedBuilds, sourceName)
+	bucket.Version.expectedBuilds = append(bucket.Version.expectedBuilds, buildName)
 }
 
 // CreateInitialBuildForVersion will create a build entry on the HCP Packer Registry for the named componentType.
@@ -658,7 +657,7 @@ func (bucket *Bucket) doCompleteBuild(
 	ctx context.Context,
 	buildName string,
 	packerSDKArtifacts []packerSDK.Artifact,
-	buildErr error,
+	_ error,
 ) ([]packerSDK.Artifact, error) {
 	for _, art := range packerSDKArtifacts {
 		var sdkImages []packerSDKRegistry.Image


### PR DESCRIPTION
prepend the build block name to the component name before making any request to HCP server

![image](https://github.com/user-attachments/assets/a254a9da-81ba-478e-b5ee-d9d231befd5c)

This seems like a working solution although we probably will need to adapt it to `json` as well.

~Also the fact that the `hcp_packer_registry` block is declared within the `build` make this solution a bit weird since it gives the impression that we can use multiple `bucket` which is not the case at all.~ 

Edit: I added support for multiple buckets as well