### PR TITLE
website: fix repeated word in link to hcl2_upgrade command doc

### DIFF
--- a/website/content/partials/from-1.5/legacy-json-warning.mdx
+++ b/website/content/partials/from-1.5/legacy-json-warning.mdx
@@ -3,4 +3,4 @@ templates are still supported by the Packer core, but new features added to the
 Packer core may not be implemented for JSON templates. We recommend you
 transition to HCL templates as soon as is convenient for you, in order to have
 the best possible experience with Packer. To help you upgrade your templates,
-we have written an [hcl2_upgrade command](/packer/docs/commands/hcl2_upgrade) command.
+we have written an [hcl2_upgrade command](/packer/docs/commands/hcl2_upgrade).


### PR DESCRIPTION
Hi,
This was fixed to match what was done in https://github.com/hashicorp/packer/blob/10fa4140306d667ef58bd94cf8b70e69cf0e4db1/website/content/partials/from-1.5/beta-hcl2-note.mdx#L7