### PR TITLE
Adding darwin/386 as part of unsupported GOOS/GOARCH pair in builds.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@
 # Determine the arch/os combos we're building for
 ALL_XC_ARCH="386 amd64 arm arm64 ppc64le mips mips64 mipsle mipsle64 s390x"
 ALL_XC_OS="linux darwin windows freebsd openbsd solaris"
-SKIPPED_OSARCH="!darwin/arm !freebsd/arm !freebsd/arm64"
+SKIPPED_OSARCH="!darwin/arm !freebsd/arm !freebsd/arm64 !darwin/386"
 
 # Exit immediately if a command fails
 set -e


### PR DESCRIPTION
Currently running `make bin` fails with Unsupported GOOS/GOARCH pair. 

```
1 errors occurred:
--> darwin/386 error: exit status 2
Stderr: go: unsupported GOOS/GOARCH pair darwin/386

make: *** [bin] Error 1

```