### PR TITLE
UPDATE: Added a note for adding forward slash while copying files

### DIFF
--- a/website/content/docs/provisioners/file.mdx
+++ b/website/content/docs/provisioners/file.mdx
@@ -91,6 +91,11 @@ directly.
 This behavior was adopted from the standard behavior of rsync. Note that under
 the covers, rsync may or may not be used.
 
+**Note:** Packer does not infer behaviors based on the guest operating system,
+as this would add unnecessary complexity and reduce maintainability. To ensure
+consistent behavior across all platforms, use a trailing forward slash when
+specifying directories, even when working with Windows guests.
+
 ## Uploading files that don't exist before Packer starts
 
 In general, local files used as the source **must** exist before Packer is run.


### PR DESCRIPTION
Updated documentation to explicitly state that a trailing slash is required for directory uploads, regardless of the guest OS. This ensures consistency and prevents confusion, especially for Windows users.

Closes #9060 