### PR TITLE
allow a script to be a part of inline commands in shell provisioner

### DIFF
--- a/packer_test/provisioner_tests/shell/provisioner_test.go
+++ b/packer_test/provisioner_tests/shell/provisioner_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package plugin_tests
 
 import (

--- a/packer_test/provisioner_tests/shell/provisioner_test.go
+++ b/packer_test/provisioner_tests/shell/provisioner_test.go
@@ -80,3 +80,18 @@ func (ts *PackerShellProvisionerTestSuite) TestInvalidShebangAsOption() {
 		SetArgs("build", "templates/shebang_as_option_invalid.pkr.hcl").
 		Assert(check.MustFail())
 }
+
+func (ts *PackerShellProvisionerTestSuite) TestEmptyInlineCommands() {
+	dir := ts.MakePluginDir()
+	defer dir.Cleanup()
+
+	ts.PackerCommand().UsePluginDir(dir).
+		SetArgs("plugins", "install", "github.com/hashicorp/docker").
+		Assert(check.MustSucceed())
+
+	ts.PackerCommand().UsePluginDir(dir).
+		AddEnv("HOME", os.Getenv("HOME")).
+		AddEnv("PATH", os.Getenv("PATH")).
+		SetArgs("build", "templates/empty_inline_list.pkr.hcl").
+		Assert(check.MustFail())
+}

--- a/packer_test/provisioner_tests/shell/provisioner_test.go
+++ b/packer_test/provisioner_tests/shell/provisioner_test.go
@@ -1,0 +1,67 @@
+package plugin_tests
+
+import (
+	"os"
+
+	"github.com/hashicorp/packer/packer_test/common/check"
+)
+
+func (ts *PackerShellProvisionerTestSuite) TestNoShebangInScript() {
+	dir := ts.MakePluginDir()
+	defer dir.Cleanup()
+
+	ts.PackerCommand().UsePluginDir(dir).
+		SetArgs("plugins", "install", "github.com/hashicorp/docker").
+		Assert(check.MustSucceed())
+
+	ts.PackerCommand().UsePluginDir(dir).
+		AddEnv("HOME", os.Getenv("HOME")).
+		AddEnv("PATH", os.Getenv("PATH")).
+		SetArgs("build", "templates/no_shebang_in_script.pkr.hcl").
+		Assert(check.MustSucceed())
+}
+
+func (ts *PackerShellProvisionerTestSuite) TestShebangInInlineScript() {
+	dir := ts.MakePluginDir()
+	defer dir.Cleanup()
+
+	ts.PackerCommand().UsePluginDir(dir).
+		SetArgs("plugins", "install", "github.com/hashicorp/docker").
+		Assert(check.MustSucceed())
+
+	ts.PackerCommand().UsePluginDir(dir).
+		AddEnv("HOME", os.Getenv("HOME")).
+		AddEnv("PATH", os.Getenv("PATH")).
+		SetArgs("build", "templates/shebang_in_inline.pkr.hcl").
+		Assert(check.MustSucceed())
+}
+
+func (ts *PackerShellProvisionerTestSuite) TestShebangAsOption() {
+	dir := ts.MakePluginDir()
+	defer dir.Cleanup()
+
+	ts.PackerCommand().UsePluginDir(dir).
+		SetArgs("plugins", "install", "github.com/hashicorp/docker").
+		Assert(check.MustSucceed())
+
+	ts.PackerCommand().UsePluginDir(dir).
+		AddEnv("HOME", os.Getenv("HOME")).
+		AddEnv("PATH", os.Getenv("PATH")).
+		SetArgs("build", "templates/shebang_as_option.pkr.hcl").
+		Assert(check.MustSucceed())
+}
+
+func (ts *PackerShellProvisionerTestSuite) TestShebangAsOptionNotInline() {
+	dir := ts.MakePluginDir()
+	defer dir.Cleanup()
+
+	ts.PackerCommand().UsePluginDir(dir).
+		SetArgs("plugins", "install", "github.com/hashicorp/docker").
+		Assert(check.MustSucceed())
+
+	ts.PackerCommand().UsePluginDir(dir).
+		AddEnv("HOME", os.Getenv("HOME")).
+		AddEnv("PATH", os.Getenv("PATH")).
+		SetArgs("build", "templates/no_shebang_inline_but_as_option.pkr.hcl").
+		Assert(check.MustSucceed())
+}

--- a/packer_test/provisioner_tests/shell/provisioner_test.go
+++ b/packer_test/provisioner_tests/shell/provisioner_test.go
@@ -65,3 +65,18 @@ func (ts *PackerShellProvisionerTestSuite) TestShebangAsOptionNotInline() {
 		SetArgs("build", "templates/no_shebang_inline_but_as_option.pkr.hcl").
 		Assert(check.MustSucceed())
 }
+
+func (ts *PackerShellProvisionerTestSuite) TestInvalidShebangAsOption() {
+	dir := ts.MakePluginDir()
+	defer dir.Cleanup()
+
+	ts.PackerCommand().UsePluginDir(dir).
+		SetArgs("plugins", "install", "github.com/hashicorp/docker").
+		Assert(check.MustSucceed())
+
+	ts.PackerCommand().UsePluginDir(dir).
+		AddEnv("HOME", os.Getenv("HOME")).
+		AddEnv("PATH", os.Getenv("PATH")).
+		SetArgs("build", "templates/shebang_as_option_invalid.pkr.hcl").
+		Assert(check.MustFail())
+}

--- a/packer_test/provisioner_tests/shell/suite_test.go
+++ b/packer_test/provisioner_tests/shell/suite_test.go
@@ -1,0 +1,23 @@
+package plugin_tests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/packer/packer_test/common"
+	"github.com/stretchr/testify/suite"
+)
+
+type PackerShellProvisionerTestSuite struct {
+	*common.PackerTestSuite
+}
+
+func Test_PackerPluginSuite(t *testing.T) {
+	baseSuite, cleanup := common.InitBaseSuite(t)
+	defer cleanup()
+
+	ts := &PackerShellProvisionerTestSuite{
+		baseSuite,
+	}
+
+	suite.Run(t, ts)
+}

--- a/packer_test/provisioner_tests/shell/templates/empty_inline_list.pkr.hcl
+++ b/packer_test/provisioner_tests/shell/templates/empty_inline_list.pkr.hcl
@@ -1,0 +1,12 @@
+source "docker" "test" {
+	image = "debian:bookworm"
+	discard = true
+}
+
+build {
+	sources = ["docker.test"]
+
+	provisioner "shell" {
+		inline = []
+	}
+}

--- a/packer_test/provisioner_tests/shell/templates/no_shebang_in_script.pkr.hcl
+++ b/packer_test/provisioner_tests/shell/templates/no_shebang_in_script.pkr.hcl
@@ -1,0 +1,14 @@
+source "docker" "test" {
+	image = "debian:bookworm"
+	discard = true
+}
+
+build {
+	sources = ["docker.test"]
+
+	provisioner "shell" {
+		inline = [
+			"cat $0 | head -1 | grep -E '^#!/bin/sh -e'",
+		]
+	}
+}

--- a/packer_test/provisioner_tests/shell/templates/no_shebang_inline_but_as_option.pkr.hcl
+++ b/packer_test/provisioner_tests/shell/templates/no_shebang_inline_but_as_option.pkr.hcl
@@ -1,0 +1,17 @@
+source "docker" "test" {
+	image = "debian:bookworm"
+	discard = true
+}
+
+build {
+	sources = ["docker.test"]
+
+	provisioner "shell" {
+		inline_shebang = "/bin/bash -ex"
+		inline = [
+			"head -1 <\"$0\" | grep -qE '^#!/bin/bash'",
+			"if grep -qE \"^#!/bin/sh\" <\"$0\"; then exit 1; fi",
+			"cat \"$0\""
+		]
+	}
+}

--- a/packer_test/provisioner_tests/shell/templates/shebang_as_option.pkr.hcl
+++ b/packer_test/provisioner_tests/shell/templates/shebang_as_option.pkr.hcl
@@ -1,0 +1,17 @@
+source "docker" "test" {
+	image = "debian:bookworm"
+	discard = true
+}
+
+build {
+	sources = ["docker.test"]
+
+	provisioner "shell" {
+		inline_shebang = "/bin/bash -ex"
+		inline = [
+			"#!/bin/sh",
+			"cat \"$0\" | head -1 | grep -qE '^#!/bin/bash'",
+			"cat \"$0\""
+		]
+	}
+}

--- a/packer_test/provisioner_tests/shell/templates/shebang_as_option_invalid.pkr.hcl
+++ b/packer_test/provisioner_tests/shell/templates/shebang_as_option_invalid.pkr.hcl
@@ -1,0 +1,17 @@
+source "docker" "test" {
+	image = "debian:bookworm"
+	discard = true
+}
+
+build {
+	sources = ["docker.test"]
+
+	provisioner "shell" {
+		inline_shebang = "#!/bin/bash -ex"
+		inline = [
+			"head -1 <\"$0\" | grep -qE '^#!/bin/bash'",
+			"if grep -qE \"^#!/bin/sh\" <\"$0\"; then exit 1; fi",
+			"cat \"$0\""
+		]
+	}
+}

--- a/packer_test/provisioner_tests/shell/templates/shebang_in_inline.pkr.hcl
+++ b/packer_test/provisioner_tests/shell/templates/shebang_in_inline.pkr.hcl
@@ -1,0 +1,15 @@
+source "docker" "test" {
+	image = "debian:bookworm"
+	discard = true
+}
+
+build {
+	sources = ["docker.test"]
+
+	provisioner "shell" {
+		inline = [
+			"#!/bin/bash -e",
+			"cat $0 | head -1 | grep -E '#!/bin/bash -e'"
+		]
+	}
+}

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -9,7 +9,6 @@ package shell
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -209,39 +208,30 @@ func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 		// Set the path to the temporary file
 		scripts = append(scripts, tf.Name())
 
-		// Write our contents to it
-		fileWriter := bufio.NewWriter(tf)
-		commandBuffer := &bytes.Buffer{}
+		// Write all inline commands to this buffer
+		commandBuffer := strings.Builder{}
 		for _, command := range p.config.Inline {
 			p.config.ctx.Data = generatedData
 			command, err := interpolate.Render(command, &p.config.ctx)
 			if err != nil {
 				return fmt.Errorf("Error interpolating Inline: %s", err)
 			}
-			if _, err := commandBuffer.WriteString(command + "\n"); err != nil {
+			if _, err := fmt.Fprintf(&commandBuffer, "%s\n", command); err != nil {
 				return fmt.Errorf("Error preparing shell script: %s", err)
 			}
 		}
 
-		firstLine, err := commandBuffer.ReadString('\n')
-		if err != nil && err != io.EOF {
-			return fmt.Errorf("Error preparing shell script: %s", err)
-		}
 		// If the user has defined an inline shebang, use that.
 		// Or If command does not start with a shebang, use the default shebang.
 		// else command already has a shebang, so do not write it.
-		if p.config.inlineShebangDefined || !strings.HasPrefix(firstLine, "#!") {
-			if _, err := fileWriter.WriteString(fmt.Sprintf("#!%s\n", p.config.InlineShebang)); err != nil {
+		if p.config.inlineShebangDefined || !strings.HasPrefix(commandBuffer.String(), "#!") {
+			if _, err := fmt.Fprintf(tf, "#!%s\n", p.config.InlineShebang); err != nil {
 				return fmt.Errorf("Error preparing shell script: %s", err)
 			}
 		}
 
-		// Write the collected commands to the file buffer
-		if _, err := fileWriter.Write(commandBuffer.Bytes()); err != nil {
-			return fmt.Errorf("Error preparing shell script: %s", err)
-		}
-
-		if err := fileWriter.Flush(); err != nil {
+		// Write the collected commands to the file
+		if _, err := tf.WriteString(commandBuffer.String()); err != nil {
 			return fmt.Errorf("Error preparing shell script: %s", err)
 		}
 

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -113,7 +113,12 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 
 	if p.config.InlineShebang == "" {
 		if p.config.Inline != nil && len(p.config.Inline) > 0 && strings.HasPrefix(p.config.Inline[0], "#!") {
-			p.config.InlineShebang = strings.TrimPrefix(p.config.Inline[0], "#!")
+			newLineIndex := strings.Index(p.config.Inline[0], "\n")
+			if newLineIndex == -1 {
+				newLineIndex = len(p.config.Inline[0])
+			}
+			firstLine := strings.TrimRight(p.config.Inline[0][:newLineIndex], "\r")
+			p.config.InlineShebang = strings.TrimPrefix(firstLine, "#!")
 		} else {
 			p.config.InlineShebang = "/bin/sh -e"
 		}

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -112,7 +112,11 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 	}
 
 	if p.config.InlineShebang == "" {
-		p.config.InlineShebang = "/bin/sh -e"
+		if p.config.Inline != nil && len(p.config.Inline) > 0 && strings.HasPrefix(p.config.Inline[0], "#!") {
+			p.config.InlineShebang = strings.TrimPrefix(p.config.Inline[0], "#!")
+		} else {
+			p.config.InlineShebang = "/bin/sh -e"
+		}
 	}
 
 	if p.config.StartRetryTimeout == 0 {

--- a/provisioner/shell/provisioner.go
+++ b/provisioner/shell/provisioner.go
@@ -67,7 +67,9 @@ type Config struct {
 	// name of the tmp environment variable file, if UseEnvVarFile is true
 	envVarFile string
 
-	// If user provided a shebang for inline scripts
+	// Set true if user provided a shebang for inline scripts.
+	// This is used to determine if the default shebang must be used
+	// or should be taken from inline commands
 	inlineShebangDefined bool
 
 	ctx interpolate.Context

--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -98,50 +98,6 @@ func TestProvisionerPrepare_InlineShebang(t *testing.T) {
 	}
 }
 
-func TestProvisionerPrepare_ShebangWithinInline(t *testing.T) {
-	config := testConfig()
-	script := `#!/bin/bash
-		echo "Hello, World!"
-	`
-	config["inline"] = []interface{}{script, "foo", "bar"}
-
-	p := new(Provisioner)
-	err := p.Prepare(config)
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-
-	if p.config.InlineShebang != "/bin/bash" {
-		t.Fatalf("bad value: %s", p.config.InlineShebang)
-	}
-
-	// Test with InlineShebang, it should override the shebang in the script
-	config["inline_shebang"] = "foo"
-	p = new(Provisioner)
-	err = p.Prepare(config)
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-
-	if p.config.InlineShebang != "foo" {
-		t.Fatalf("bad value: %s", p.config.InlineShebang)
-	}
-
-	// Test with a inline that does not have a shebang
-	config["inline"] = []interface{}{"foo", "bar"}
-	delete(config, "inline_shebang")
-	p = new(Provisioner)
-	err = p.Prepare(config)
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
-
-	if p.config.InlineShebang != "/bin/sh -e" {
-		t.Fatalf("bad value: %s", p.config.InlineShebang)
-	}
-
-}
-
 func TestProvisionerPrepare_InvalidKey(t *testing.T) {
 	var p Provisioner
 	config := testConfig()

--- a/provisioner/shell/provisioner_test.go
+++ b/provisioner/shell/provisioner_test.go
@@ -98,6 +98,50 @@ func TestProvisionerPrepare_InlineShebang(t *testing.T) {
 	}
 }
 
+func TestProvisionerPrepare_ShebangWithinInline(t *testing.T) {
+	config := testConfig()
+	script := `#!/bin/bash
+		echo "Hello, World!"
+	`
+	config["inline"] = []interface{}{script, "foo", "bar"}
+
+	p := new(Provisioner)
+	err := p.Prepare(config)
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if p.config.InlineShebang != "/bin/bash" {
+		t.Fatalf("bad value: %s", p.config.InlineShebang)
+	}
+
+	// Test with InlineShebang, it should override the shebang in the script
+	config["inline_shebang"] = "foo"
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if p.config.InlineShebang != "foo" {
+		t.Fatalf("bad value: %s", p.config.InlineShebang)
+	}
+
+	// Test with a inline that does not have a shebang
+	config["inline"] = []interface{}{"foo", "bar"}
+	delete(config, "inline_shebang")
+	p = new(Provisioner)
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if p.config.InlineShebang != "/bin/sh -e" {
+		t.Fatalf("bad value: %s", p.config.InlineShebang)
+	}
+
+}
+
 func TestProvisionerPrepare_InvalidKey(t *testing.T) {
 	var p Provisioner
 	config := testConfig()


### PR DESCRIPTION
UPDATE: Instead of adding a new `content` field, the existing `inline` field is enhanced to support any script with its own  shebang.
The behavior of inline is mentioned here - https://github.com/hashicorp/packer/pull/13313#issuecomment-2699982741

Closes #11437 

~Added the `content` field to the **shell provisioner** to accept any string(supports output of `templatefile`) as a script and execute it. This is in line with the `content` field of the file provisioner.~

~With this change, the shell provisioner now supports 4 different ways in which the cmd/script can be executed in target system. Exactly one of these are accepted: `inline`, `script`, `scripts` or `content`.~

~I have modified the conditonal checks to ensure only one of the above 4 values are accepted.
Added the same unit tests that were raised in the previous PR.~

~Test configuration files:
`test.pkr.hcl`~
```
packer {
  required_plugins {
    docker = {
      version = ">= 1.0.8"
      source  = "github.com/hashicorp/docker"
    }
  }
}

variable "foo" {
    type    = string
    default = "bar"
}

source "docker" "ubuntu" {
  image  = "ubuntu:jammy"
  commit = true
}


build {
  name = "ubuntu-packer"
  sources = [
    "source.docker.ubuntu",
  ]
  provisioner "shell" {
    content = templatefile("${path.root}/script.sh.tmpl", { FOO = var.foo })
  }
}

```

~`script.sh.tmpl`~

```
#! /bin/sh

echo "This script is being executed using 'content' field Foo=${FOO}"

exit 0
```

~`> packer build test.pkr.hcl`~                                                                                                                                                  
```
ubuntu-packer.docker.ubuntu: output will be in this color.

==> ubuntu-packer.docker.ubuntu: Creating a temporary directory for sharing data...
==> ubuntu-packer.docker.ubuntu: Pulling Docker image: ubuntu:jammy
    ubuntu-packer.docker.ubuntu: jammy: Pulling from library/ubuntu
    ubuntu-packer.docker.ubuntu: Digest: sha256:ed1544e454989078f5dec1bfdabd8c5cc9c48e0705d07b678ab6ae3fb61952d2
    ubuntu-packer.docker.ubuntu: Status: Image is up to date for ubuntu:jammy
    ubuntu-packer.docker.ubuntu: docker.io/library/ubuntu:jammy
==> ubuntu-packer.docker.ubuntu: Starting docker container...
    ubuntu-packer.docker.ubuntu: Run command: docker run -v /Users/anurag.sharma/.config/packer/tmp1816147244:/packer-files -d -i -t --entrypoint=/bin/sh -- ubuntu:jammy
    ubuntu-packer.docker.ubuntu: Container ID: f8ef599e13b552d95ebb4f29eb2305db1b6f00a88bbc229b3cb1df3df698bb3b
==> ubuntu-packer.docker.ubuntu: Using docker communicator to connect: 172.17.0.2
==> ubuntu-packer.docker.ubuntu: Provisioning with shell script: /var/folders/w3/xy9kpmwx3v1f_3tvzy4lv0sr0000gn/T/packer-shell821493507
    ubuntu-packer.docker.ubuntu: This script is being executed using 'content' field Foo=bar
==> ubuntu-packer.docker.ubuntu: Committing the container
    ubuntu-packer.docker.ubuntu: Image ID: sha256:af422c5fab86c0f0d5d39f54cd531300b14f729e960821dea4a8b52c2e3e32d7
==> ubuntu-packer.docker.ubuntu: Killing the container: f8ef599e13b552d95ebb4f29eb2305db1b6f00a88bbc229b3cb1df3df698bb3b
Build 'ubuntu-packer.docker.ubuntu' finished after 4 seconds 996 milliseconds.

==> Wait completed after 4 seconds 996 milliseconds

==> Builds finished. The artifacts of successful builds are:
--> ubuntu-packer.docker.ubuntu: Imported Docker image: sha256:af422c5fab86c0f0d5d39f54cd531300b14f729e960821dea4a8b52c2e3e32d7
```