### PR TITLE
BUG: Fixed Packer Console's UseSequentialEval flag

### DIFF
--- a/command/cli.go
+++ b/command/cli.go
@@ -156,6 +156,10 @@ type PluginsRequiredArgs struct {
 	MetaArgs
 }
 
+func (ca *ConsoleArgs) AddFlagSets(flags *flag.FlagSet) {
+	flags.BoolVar(&ca.MetaArgs.UseSequential, "use-sequential-evaluation", false, "Fallback to using a sequential approach for local/datasource evaluation.")
+}
+
 // ConsoleArgs represents a parsed cli line for a `packer console`
 type ConsoleArgs struct {
 	MetaArgs

--- a/command/cli.go
+++ b/command/cli.go
@@ -167,7 +167,6 @@ type ConsoleArgs struct {
 
 func (fa *FixArgs) AddFlagSets(flags *flag.FlagSet) {
 	flags.BoolVar(&fa.Validate, "validate", true, "")
-	flags.BoolVar(&fa.MetaArgs.UseSequential, "use-sequential-evaluation", false, "Fallback to using a sequential approach for local/datasource evaluation.")
 
 	fa.MetaArgs.AddFlagSets(flags)
 }

--- a/command/console.go
+++ b/command/console.go
@@ -46,6 +46,7 @@ func (c *ConsoleCommand) ParseArgs(args []string) (*ConsoleArgs, int) {
 	flags := c.Meta.FlagSet("console")
 	flags.Usage = func() { c.Ui.Say(c.Help()) }
 	cfg.AddFlagSets(flags)
+	cfg.MetaArgs.AddFlagSets(flags)
 	if err := flags.Parse(args); err != nil {
 		return &cfg, 1
 	}

--- a/command/console_test.go
+++ b/command/console_test.go
@@ -29,6 +29,7 @@ func Test_console(t *testing.T) {
 	}{
 		{"help", []string{"console"}, nil, packer.ConsoleHelp + "\n"},
 		{"help", []string{"console", "--config-type=hcl2"}, nil, hcl2template.PackerConsoleHelp + "\n"},
+		{"help", []string{"console", "--config-type=hcl2", "--use-sequential-evaluation"}, nil, hcl2template.PackerConsoleHelp + "\n"},
 		{"var.fruit", []string{"console", filepath.Join(testFixture("var-arg"), "fruit_builder.pkr.hcl")}, []string{"PKR_VAR_fruit=potato"}, "potato\n"},
 		{"upper(var.fruit)", []string{"console", filepath.Join(testFixture("var-arg"), "fruit_builder.pkr.hcl")}, []string{"PKR_VAR_fruit=potato"}, "POTATO\n"},
 		{"1 + 5", []string{"console", "--config-type=hcl2"}, nil, "6\n"},


### PR DESCRIPTION
On using the `--use-sequential-evaluation` flag with packer console, we got the following error.
<img width="942" alt="image" src="https://github.com/user-attachments/assets/eb99c26a-7467-46f1-8032-0bef9595ab6f" />

Updated the FlagSets to include this flag. Working now.

<img width="663" alt="image" src="https://github.com/user-attachments/assets/f3004459-bd06-46bb-8d67-e7f6f6fe2285" />

Also removed the flag from the `fix` subcommand since it was not being used and not required.

Closes #13315 