### PR TITLE
.github: bump backport assistant to 0.5.3

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,7 +16,7 @@ jobs:
       contents: none
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.4
+    container: hashicorpdev/backport-assistant:0.5.3
     steps:
       - name: Backport changes to stable-website
         run: |


### PR DESCRIPTION
The backport assistant bot fails all the time on the current version. While it's not clear what's the reason of the failure, this commit bumps the version of the assistant from 0.3.4 to 0.5.3 in an attempt to fix that problem.