### PR TITLE
Makefile: bump golangci-lint to 1.60.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ install-gen-deps: ## Install dependencies for code generation
 
 install-lint-deps: ## Install linter dependencies
 	@echo "==> Updating linter dependencies..."
-	@curl -sSfL -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.0
+	@curl -sSfL -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.60.1
 
 dev: ## Build and install a development build
 	@grep 'const VersionPrerelease = ""' version/version.go > /dev/null ; if [ $$? -eq 0 ]; then \


### PR DESCRIPTION
Since we bumped the Go version for the project to 1.23.2, we need to also bump the golangci-lint project to 1.60.1 in order to support it.