### PR TITLE
hcl2template: err on malformed local/data dep

### DIFF
--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -441,7 +441,7 @@ func (cfg *PackerConfig) buildPrereqsDAG() (*dag.AcyclicGraph, error) {
 		for _, dep := range ds.Dependencies {
 			target := verticesMap[dep.String()]
 			if target == nil {
-				err = multierror.Append(err, fmt.Errorf("unknown dependency %q for %q", dep.String(), dsName))
+				err = multierror.Append(err, fmt.Errorf("could not get dependency %q for %q, %q missing in template", dep.String(), dsName, dep.String()))
 				continue
 			}
 
@@ -461,7 +461,7 @@ func (cfg *PackerConfig) buildPrereqsDAG() (*dag.AcyclicGraph, error) {
 			target := verticesMap[dep.String()]
 
 			if target == nil {
-				err = multierror.Append(err, fmt.Errorf("unknown dependency %q for %q", dep.String(), locName))
+				err = multierror.Append(err, fmt.Errorf("could not get dependency %q for %q, %q missing in template", dep.String(), locName, dep.String()))
 				continue
 			}
 

--- a/packer_test/dag_tests/malformed_dep_test.go
+++ b/packer_test/dag_tests/malformed_dep_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/packer_test/common/check"
+)
+
+type malformedDepTestCase struct {
+	name          string
+	command       string
+	templatePath  string
+	useSequential bool
+}
+
+func genMalformedDepTestCases() []malformedDepTestCase {
+	retVals := []malformedDepTestCase{}
+
+	for _, cmd := range []string{"build", "validate"} {
+		for _, template := range []string{"./templates/malformed_data_dep.pkr.hcl", "./templates/malformed_local_dep.pkr.hcl"} {
+			for _, seq := range []bool{true, false} {
+				retVals = append(retVals, malformedDepTestCase{
+					name: fmt.Sprintf("Malformed dep packer %s --use-sequential-evaluation=%t %s",
+						cmd, seq, template),
+					command:       cmd,
+					templatePath:  template,
+					useSequential: seq,
+				})
+			}
+		}
+	}
+
+	return retVals
+}
+
+func (ts *PackerDAGTestSuite) TestMalformedDependency() {
+	pluginDir := ts.MakePluginDir()
+	defer pluginDir.Cleanup()
+
+	for _, tc := range genMalformedDepTestCases() {
+		ts.Run(tc.name, func() {
+			ts.PackerCommand().UsePluginDir(pluginDir).
+				SetArgs(tc.command,
+					fmt.Sprintf("--use-sequential-evaluation=%t", tc.useSequential),
+					tc.templatePath).
+				Assert(check.MustFail())
+		})
+	}
+}

--- a/packer_test/dag_tests/templates/malformed_data_dep.pkr.hcl
+++ b/packer_test/dag_tests/templates/malformed_data_dep.pkr.hcl
@@ -1,0 +1,8 @@
+data "http" "trusted_ca_certificates" {
+  method = "GET"
+  url    = "http://example.com/ca-bundle.crt"
+}
+
+locals {
+  test = data.trusted_ca_certificates.url
+}

--- a/packer_test/dag_tests/templates/malformed_local_dep.pkr.hcl
+++ b/packer_test/dag_tests/templates/malformed_local_dep.pkr.hcl
@@ -1,0 +1,4 @@
+data "http" "trusted_ca_certificates" {
+  method = "GET"
+  url    = local.no_dep
+}


### PR DESCRIPTION
When introducing the DAG for locals and datasources, we forgot to handle one limit case: if a dependency for a local or data is malformed, we didn't check that a vertex was associated to it, leading to the final DAG being malformed, and the DAG library would crash in this case.

This commit fixes this problem by checking that the dependency does exist before attempting to add it to the graph as an edge for a vertex, so that it is reported accurately, and do that Packer doesn't crash.

Closes #13295 
Closes #13304 