### PR TITLE
Packer test dump commands

### DIFF
--- a/packer_test/common/check/gadgets.go
+++ b/packer_test/common/check/gadgets.go
@@ -198,7 +198,7 @@ func (d dump) Check(stdout, stderr string, err error) error {
 type PanicCheck struct{}
 
 func (_ PanicCheck) Check(stdout, stderr string, _ error) error {
-	if strings.Contains(stdout, "= PACKER CRASH =") || strings.Contains(stderr, "= PACKER CRASH =") {
+	if strings.Contains(stdout, "! PACKER CRASH !") || strings.Contains(stderr, "! PACKER CRASH !") {
 		return fmt.Errorf("packer has crashed: this is never normal and should be investigated")
 	}
 	return nil

--- a/packer_test/common/check/gadgets.go
+++ b/packer_test/common/check/gadgets.go
@@ -195,6 +195,20 @@ func (d dump) Check(stdout, stderr string, err error) error {
 	return nil
 }
 
+func DumpCommand(t *testing.T, command string) Checker {
+	return &dumpCommand{t, command}
+}
+
+type dumpCommand struct {
+	t       *testing.T
+	command string
+}
+
+func (d dumpCommand) Check(_, _ string, _ error) error {
+	d.t.Logf("ran command %s", d.command)
+	return nil
+}
+
 type PanicCheck struct{}
 
 func (_ PanicCheck) Check(stdout, stderr string, _ error) error {

--- a/packer_test/common/commands.go
+++ b/packer_test/common/commands.go
@@ -135,6 +135,17 @@ func (pc *packerCommand) Dump() *packerCommand {
 	return pc
 }
 
+func (pc *packerCommand) commandString() string {
+	buf := &strings.Builder{}
+
+	fmt.Fprintf(buf, "%q", pc.packerPath)
+	for _, arg := range pc.args {
+		fmt.Fprintf(buf, " %q", arg)
+	}
+
+	return buf.String()
+}
+
 // Run executes the packer command with the args/env requested and returns the
 // output streams (stdout, stderr)
 //
@@ -194,6 +205,7 @@ func (pc *packerCommand) Output() (string, string, error) {
 func (pc *packerCommand) Assert(checks ...check.Checker) {
 	if pc.dump {
 		tmpChecks := []check.Checker{
+			check.DumpCommand(pc.t, pc.commandString()),
 			check.Dump(pc.t),
 		}
 

--- a/packer_test/common/commands.go
+++ b/packer_test/common/commands.go
@@ -22,6 +22,7 @@ type packerCommand struct {
 	err          error
 	t            *testing.T
 	fatalfAssert bool
+	dump         bool
 }
 
 // PackerCommand creates a skeleton of packer command with the ability to execute gadgets on the outputs of the command.
@@ -125,6 +126,15 @@ func (pc *packerCommand) SetAssertFatal() *packerCommand {
 	return pc
 }
 
+// Dump enables a verbose mode for the test, when Assert is called, the test
+// proceeds normally, and the command-line that was invoked, along with the
+// contents of stdout/stderr will also be output in addition to the test
+// results. This is mostly useful for debugging a test.
+func (pc *packerCommand) Dump() *packerCommand {
+	pc.dump = true
+	return pc
+}
+
 // Run executes the packer command with the args/env requested and returns the
 // output streams (stdout, stderr)
 //
@@ -182,6 +192,14 @@ func (pc *packerCommand) Output() (string, string, error) {
 }
 
 func (pc *packerCommand) Assert(checks ...check.Checker) {
+	if pc.dump {
+		tmpChecks := []check.Checker{
+			check.Dump(pc.t),
+		}
+
+		checks = append(tmpChecks, checks...)
+	}
+
 	attempt := 0
 	for pc.runs > 0 {
 		attempt++


### PR DESCRIPTION
Dumping a command's results for black-box tests used to involve creating a checker, adding it to the Assert list, and running the command.
This was a bit verbose, and forced us to forward the testing.T instance to the checker so it could output it.

This PR changes how dumping a test's results work, by adding a `Dump()` function to the `packerCommand` directly, so we lighten the changes needed to have information on the command when troubleshooting/writing a test for Packer using this method.