### PR TITLE
Deprecating `Message` method in UI interface

### DIFF
--- a/packer/ui.go
+++ b/packer/ui.go
@@ -59,8 +59,9 @@ func (u *ColoredUi) Sayf(message string, vals ...any) {
 	u.Say(fmt.Sprintf(message, vals...))
 }
 
+// Deprecated: Use `Say` instead.
 func (u *ColoredUi) Message(message string) {
-	u.Ui.Message(u.colorize(message, u.Color, false))
+	u.Say(message)
 }
 
 func (u *ColoredUi) Error(message string) {
@@ -145,8 +146,9 @@ func (u *TargetedUI) Sayf(message string, args ...any) {
 	u.Say(fmt.Sprintf(message, args...))
 }
 
+// Deprecated: Use `Say` instead.
 func (u *TargetedUI) Message(message string) {
-	u.Ui.Message(u.prefixLines(false, message))
+	u.Say(message)
 }
 
 func (u *TargetedUI) Error(message string) {
@@ -206,6 +208,7 @@ func (u *MachineReadableUi) Sayf(message string, args ...any) {
 	u.Say(fmt.Sprintf(message, args...))
 }
 
+// Deprecated: Use `Say` instead.
 func (u *MachineReadableUi) Message(message string) {
 	u.Machine("ui", "message", message)
 }
@@ -280,8 +283,9 @@ func (u *TimestampedUi) Sayf(message string, args ...any) {
 	u.Say(fmt.Sprintf(message, args...))
 }
 
+// Deprecated: Use `Say` instead.
 func (u *TimestampedUi) Message(message string) {
-	u.Ui.Message(u.timestampLine(message))
+	u.Say(message)
 }
 
 func (u *TimestampedUi) Error(message string) {

--- a/packer/ui_test.go
+++ b/packer/ui_test.go
@@ -67,7 +67,7 @@ func TestColoredUi(t *testing.T) {
 
 	ui.Message("foo")
 	result = readWriter(bufferUi)
-	if result != "\033[0;33mfoo\033[0m\n" {
+	if result != "\033[1;33mfoo\033[0m\n" {
 		t.Fatalf("invalid output: %s", result)
 	}
 
@@ -126,7 +126,7 @@ func TestTargetedUI(t *testing.T) {
 
 	targetedUi.Message("foo")
 	actual = readWriter(bufferUi)
-	expected = "    foo: foo\n"
+	expected = "==> foo: foo\n"
 	if actual != expected {
 		t.Fatalf("bad: %#v", actual)
 	}


### PR DESCRIPTION
Deprecating the `Message` method from the cli UI interface to simplify the logs and replacing them with the Say method.