### PR TITLE
Fix firewall command for WinRM HTTPS setup

### DIFF
--- a/website/content/docs/communicators/winrm.mdx
+++ b/website/content/docs/communicators/winrm.mdx
@@ -168,7 +168,7 @@ cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTPS" "@{Port=`
 
 # Make sure appropriate firewall port openings exist
 cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
-cmd.exe /c netsh firewall add portopening TCP 5986 "Port 5986"
+cmd.exe /c netsh advfirewall firewall add rule name="Port 5986" dir=in action=allow protocol=TCP localport=5986 profile=any
 
 # Restart WinRM, and set it so that it auto-launches on startup.
 cmd.exe /c net stop winrm


### PR DESCRIPTION
This PR updates the firewall rule creation command to ensure it applies to all network profiles (Public, Private, and Domain) instead of being limited to the Public profile.

**Issue**: The old command implicitly applied the firewall rule only to the Public network profile. This could cause issues if a user changes their network profile to Private or Domain, as the rule would no longer be effective, potentially blocking traffic on port 5986.

This change ensures that port 5986 remains open regardless of the active network profile. It addresses potential issues where the rule would not be applied if the user's network profile switched from public to private, thereby preventing unintended connectivity problems. (i/o timeout issues)