### PR TITLE
docs: update link to vsphere examples

### DIFF
--- a/website/content/docs/community-tools.mdx
+++ b/website/content/docs/community-tools.mdx
@@ -57,9 +57,9 @@ vendors. We do not test or maintain community plugins.
 - [packer-baseboxes](https://github.com/taliesins/packer-baseboxes) - Templates
   for Packer to build base boxes
 
-- [vmware-samples/packer-examples-for-vsphere](https://github.com/vmware-samples/packer-examples-for-vsphere) - Examples
+- [vmware/packer-examples-for-vsphere](https://github.com/vmware/packer-examples-for-vsphere) - Examples
   to automate the creation of virtual machine images and their guest operating systems on VMware vSphere using HashiCorp Packer
-  and the Packer Plugin for VMware vSphere (vsphere-iso).
+  and the Packer Plugin for VMware vSphere.
 
 - [Parallels/packer-examples](https://github.com/parallels/packer-examples) - Examples in how to use Packer with Parallels Desktop
   to automate the creation of virtual machine images and their guest operating systems on macOS, windows and linux.


### PR DESCRIPTION
Updated the link for the Packer Examples for VMware vSphere after a repository transfer.

cc @JenGoldstrich 😄 