### PR TITLE
doc: Remove invalid commas for hcl examples

### DIFF
--- a/website/content/docs/provisioners/shell-local.mdx
+++ b/website/content/docs/provisioners/shell-local.mdx
@@ -348,8 +348,8 @@ tempfile_extension
 
 ```hcl
 provisioner "shell-local" {
-  environment_vars   = ["SHELLLOCALTEST=ShellTest2"],
-  tempfile_extension = ".cmd",
+  environment_vars   = ["SHELLLOCALTEST=ShellTest2"]
+  tempfile_extension = ".cmd"
   inline             = [echo "%SHELLLOCALTEST%"]
 }
 ```
@@ -377,7 +377,7 @@ customizations: use_linux_pathing and execute_command
 
 ```hcl
 provisioner "shell-local" {
-  environment_vars  = ["SHELLLOCALTEST=ShellTest3"],
+  environment_vars  = ["SHELLLOCALTEST=ShellTest3"]
   execute_command   = ["bash", "-c", "{{.Vars}} {{.Script}}"]
   use_linux_pathing = true
   script            = "./scripts/example_bash.sh"


### PR DESCRIPTION

### Description
Documentation change, invalid commas in HCL examples for shell-local provisioner

### Resolved Issues
N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan
N/A

### Changes to Security Controls
N/A
