### PR TITLE
Docs: Move hcp_packer_registry block out of the build block

### DIFF
--- a/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/website/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -18,8 +18,8 @@ To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/doc
 
 This block is available from version 1.7.7 of Packer.
 
-The presence of a `hcp_packer_registry` block in a build block will enable HCP
-Packer mode. Packer will push all builds within that build block to the remote
+The presence of a `hcp_packer_registry` block in a template file will enable HCP
+Packer mode. Packer will push all builds within that template to the remote
 registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 `HCP_CLIENT_SECRET`). If no HCP credentials are set, Packer will fail the build
 and exit immediately to avoid any potential artifact drift between the defined
@@ -34,25 +34,24 @@ source "happycloud" "macos" {
 }
 
 build {
-   hcp_packer_registry {
-    bucket_name = "ios-dev"
+  sources = ["source.happycloud.macos"]
+}
+hcp_packer_registry {
+  bucket_name = "ios-dev"
 
-    description = <<EOT
+  description = <<EOT
 Some nice description about the image which artifact is being published to HCP Packer Registry. =D
-    EOT
+  EOT
 
-    bucket_labels = {
-      "team" = "ios-development",
-      "os"   = "macos"
-    }
-
-    build_labels = {
-      "xcode"   = "11.3.0"
-      "version" = "Big Sur"
-    }
+  bucket_labels = {
+    "team" = "ios-development",
+    "os"   = "macos"
   }
 
-  sources = ["source.happycloud.macos"]
+  build_labels = {
+    "xcode"   = "11.3.0"
+    "version" = "Big Sur"
+  }
 }
 ```
 


### PR DESCRIPTION
### Description
With packer version 1.13.1 I received this warning message:
```
Warning: Build block level hcp_packer_registry are deprecated

  on  line 0:
  (source code not available)

Starting with Packer 1.12.1, it is recommended to move it to the top-level
configuration instead of within a build block.
```
 
This PR corrects the example docs to move the registry block to the top level of the template file.