### PR TITLE
Add callouts for the move of HashiCorp-maintained plugins to releases.hashicorp.com

### DIFF
--- a/website/content/docs/commands/build.mdx
+++ b/website/content/docs/commands/build.mdx
@@ -8,7 +8,7 @@ page_title: packer build - Commands
 
 <Note>
 
-Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
+Starting August 1st, 2025, the source for many official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
 
 </Note>
 

--- a/website/content/docs/commands/build.mdx
+++ b/website/content/docs/commands/build.mdx
@@ -6,6 +6,12 @@ page_title: packer build - Commands
 
 # `packer build` command reference
 
+<Note>
+
+Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
+
+</Note>
+
 The `packer build` command takes a template and runs all the builds within it
 in order to generate a set of artifacts. The various builds specified within a
 template are executed in parallel, unless otherwise specified. And the

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -6,6 +6,13 @@ page_title: packer init command reference
 
 # `packer init` command reference
 
+<Note>
+
+Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
+
+</Note>
+
+
 The `packer init` command initializes Packer according to an HCL template configuration. Refer to [Installing Plugins](/packer/docs/plugins/install) for additional information about installing plugins.
 
 ## Description

--- a/website/content/docs/commands/init.mdx
+++ b/website/content/docs/commands/init.mdx
@@ -8,7 +8,7 @@ page_title: packer init command reference
 
 <Note>
 
-Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
+Starting August 1st, 2025, the source for many official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
 
 </Note>
 

--- a/website/content/docs/commands/plugins/install.mdx
+++ b/website/content/docs/commands/plugins/install.mdx
@@ -8,7 +8,7 @@ page_title: packer plugins install command reference
 
 <Note>
 
-Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
+Starting August 1st, 2025, the source for many official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
 
 </Note>
 

--- a/website/content/docs/commands/plugins/install.mdx
+++ b/website/content/docs/commands/plugins/install.mdx
@@ -6,6 +6,12 @@ page_title: packer plugins install command reference
 
 # `packer plugins install` command reference
 
+<Note>
+
+Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
+
+</Note>
+
 The `packer plugins install` command downloads and installs the most recent version of a plugin binary. Refer to [Installing Plugins](/packer/docs/plugins/install) for additional information about installing plugins.
 
 ## Description

--- a/website/content/docs/plugins/index.mdx
+++ b/website/content/docs/plugins/index.mdx
@@ -6,6 +6,12 @@ page_title: Plugins
 
 # Plugin installation overview
 
+<Note>
+
+Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
+
+</Note>
+
 This topic provides overview information about installing and loading Packer plugins. Plugins are standalone applications that perform additional tasks during each build.
 
 ## Introduction

--- a/website/content/docs/plugins/index.mdx
+++ b/website/content/docs/plugins/index.mdx
@@ -8,7 +8,7 @@ page_title: Plugins
 
 <Note>
 
-Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
+Starting August 1st, 2025, the source for many official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](/packer/docs/plugins/install#install-hashicorp-maintained-plugins) for more information.
 
 </Note>
 

--- a/website/content/docs/plugins/install.mdx
+++ b/website/content/docs/plugins/install.mdx
@@ -94,7 +94,7 @@ These plugins include:
 - [Vagrant](https://developer.hashicorp.com/packer/integrations/hashicorp/vagrant)
 - [VirtualBox](https://developer.hashicorp.com/packer/integrations/hashicorp/virtualbox)
 
-Starting in Packer 1.14.0, Packer automatically installs these plugins from the new release source, and you do not need to make any changes to your Packer templates. To continue to receive updates to these plugins, we recommend that you upgrade to Packer 1.14.0 or newer. If you cannot upgrade your version of Packer, you can still install new versions of these plugins manually. Refer to [Manually install plugins using the CLI](#manually-install-plugins-using-the-cli) for more information.
+Starting in Packer 1.14.0, Packer automatically installs these plugins from the new release source, and you do not need to make any changes to your Packer templates. To continue to automatically receive updates to these plugins, you must upgrade to Packer 1.14.0 or newer. If you cannot upgrade your version of Packer, you can still install new versions of these plugins manually. Refer to [Manually install plugins using the CLI](#manually-install-plugins-using-the-cli) for more information.
 
 ## Manually install plugins using the CLI
 

--- a/website/content/docs/plugins/install.mdx
+++ b/website/content/docs/plugins/install.mdx
@@ -6,6 +6,12 @@ page_title: Install Plugins
 
 # Install Plugins
 
+<Note>
+
+Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](#install-hashicorp-maintained-plugins) for more information.
+
+</Note>
+
 This topic describes how to install external plugins for Packer. Refer to [Packer Plugins Overview](/packer/docs/plugins) for additional information about plugins.
 
 ## Overview
@@ -29,8 +35,12 @@ Note that Packer checks the plugin installation directory against the `required_
 
 By default, Packer installs plugins into the plugins directory at `$HOME/.config/packer/plugins` on Unix and  `%APPDATA%\packer.d\plugins` on Windows, but you can specify a different directory using the `PACKER_PLUGIN_PATH` environment variable.
 
-~> Note: Plugin installation requires access to temporary files under `TMPDIR`. If the system's temp directory is non-writable or non-executable, use TMPDIR to override the location of the temporary file store used by Packer.
+<Note>
+
+Plugin installation requires access to temporary files under `TMPDIR`. If the system's temp directory is non-writable or non-executable, use TMPDIR to override the location of the temporary file store used by Packer.
 Refer to the [Packer configuration reference](/packer/docs/configure) for additional information.
+
+</Note>
 
 ## Requirements
 
@@ -69,11 +79,22 @@ pinning plugin versions for build reproducibility. Refer to the [`packer` block 
 
 1. Run the `packer init` command. Packer lists all installed plugins then installs the latest plugin version matching the version constraints specified in the `required_plugins` block. Refer to the [`init` command reference](/packer/docs/commands/init) for additional information.
 
-~> Note: With the new Packer release starting from version 1.14.0, the packer init command will automatically install official (Amazon, Ansible, Azure, Docker, GoogleCloudPlatform, Qemu, Vagrant, VirtualBox) plugins from the [HashiCorp release site](https://releases.hashicorp.com/).
-These official plugins will now be released through the official release site only.
+## Install HashiCorp-maintained plugins
 
-Going forward, to use newer versions of official Packer plugins, you'll need to upgrade to Packer version 1.14.0 or later. If you're using an older version, you can still install plugins, but as a workaround, you'll need to [manually install them using the CLI](https://developer.hashicorp.com/packer/docs/plugins/install#manually-install-plugins-using-the-cli).
-There is no change to the syntax or commands for installing plugins.
+HashiCorp now makes official HashiCorp-maintained plugins available through the [HashiCorp release site](https://releases.hashicorp.com/). 
+
+These plugins include:
+
+- [Amazon](https://developer.hashicorp.com/packer/integrations/hashicorp/amazon)
+- [Ansible](https://developer.hashicorp.com/packer/integrations/hashicorp/ansible)
+- [Azure](https://developer.hashicorp.com/packer/integrations/hashicorp/azure)
+- [Docker](https://developer.hashicorp.com/packer/integrations/hashicorp/docker)
+- [Google Cloud Platform](https://developer.hashicorp.com/packer/integrations/hashicorp/googlecompute)
+- [QEMU](https://developer.hashicorp.com/packer/integrations/hashicorp/qemu)
+- [Vagrant](https://developer.hashicorp.com/packer/integrations/hashicorp/vagrant)
+- [VirtualBox](https://developer.hashicorp.com/packer/integrations/hashicorp/virtualbox)
+
+Starting in Packer 1.14.0, Packer automatically installs these plugins from the new release source, and you do not need to make any changes to your Packer templates. To continue to receive updates to these plugins, we recommend that you upgrade to Packer 1.14.0 or newer. If you cannot upgrade your version of Packer, you can still install new versions of these plugins manually. Refer to [Manually install plugins using the CLI](#manually-install-plugins-using-the-cli) for more information.
 
 ## Manually install plugins using the CLI
 
@@ -95,7 +116,6 @@ $ packer plugins install --path happycloud github.com/hashicorp/happycloud
 
 Refer to the [`packer plugins install`](/packer/docs/commands/plugins/install) reference for additional information.
 
-
 ## Upgrade plugins
 
 To upgrade plugins that are already installed, run the `packer init` with the `--upgrade` flag. Packer retrieves the latest versions of installed plugins specified in the template configuration.
@@ -109,7 +129,6 @@ $ packer init --upgrade .
 Refer to [`packer init` command](/packer/docs/commands/init) for additional information.
 
 ## Use a plugin under development
-
 
 If a development binary, such as a manually-built binary, is available at the specified source, Packer uses it in the build if it is the highest compatible version installed and if no final plugin version with the same version number is installed alongside it.
 
@@ -154,7 +173,6 @@ When a non-development version of 1.1.1 becomes available, the binary takes prec
           ├── packer-plugin-amazon_v1.1.1_x5.0_darwin_arm64
           └── packer-plugin-amazon_v1.1.1_x5.0_darwin_arm64_SHA256SUM
 ```
-
 
 ### Example Docker plugin
 

--- a/website/content/docs/plugins/install.mdx
+++ b/website/content/docs/plugins/install.mdx
@@ -8,7 +8,7 @@ page_title: Install Plugins
 
 <Note>
 
-Starting August 1st, 2025, the source for official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](#install-hashicorp-maintained-plugins) for more information.
+Starting August 1st, 2025, the source for many official HashiCorp-maintained Packer plugins is moving from GitHub releases to the official HashiCorp release site, [releases.hashicorp.com](https://releases.hashicorp.com). Refer to [Install HashiCorp-maintained plugins](#install-hashicorp-maintained-plugins) for more information.
 
 </Note>
 
@@ -81,7 +81,7 @@ pinning plugin versions for build reproducibility. Refer to the [`packer` block 
 
 ## Install HashiCorp-maintained plugins
 
-HashiCorp now makes official HashiCorp-maintained plugins available through the [HashiCorp release site](https://releases.hashicorp.com/). 
+HashiCorp now makes the following official HashiCorp-maintained plugins available through the [HashiCorp release site](https://releases.hashicorp.com/). 
 
 These plugins include:
 


### PR DESCRIPTION
### Description

Update callouts for the move of HashiCorp-maintained plugins. This adds an H2 anchor describing the change to make it easier to link user to, and adds warning boxes to the relevant pages.
