### PR TITLE
Fix incorrect Credential file default path in docs

### DIFF
--- a/internal/hcp/env/env.go
+++ b/internal/hcp/env/env.go
@@ -16,7 +16,7 @@ import (
 func HasHCPAuth() (bool, error) {
 	// Client crendential authentication requires the following environment variables be set; `HCP_CLIENT_ID` and `HCP_CLIENT_SECRET`.
 	hasClientCredentials := HasHCPClientCredentials()
-	// Client certificate authentication requires a valid HCP certificate file placed in either the default location (~/.hcp/cred_file.json) or at a location specified in the `HCP_CRED_FILE` env var
+	// Client certificate authentication requires a valid HCP certificate file placed in either the default location (~/.config/hcp/cred_file.json) or at a location specified in the `HCP_CRED_FILE` env var
 	hasCertificate, err := HasHCPCertificateFile()
 	if err != nil {
 		return false, err

--- a/website/content/docs/hcp/index.mdx
+++ b/website/content/docs/hcp/index.mdx
@@ -45,7 +45,7 @@ authenticate to an HCP Packer Registry.
 - `HCP_CLIENT_SECRET`      - The HCP client secret of the HashiCorp Cloud Platform service principle that Packer
 can use to authenticate to an HCP Packer Registry.
 
-For certificate based auth simply specify the location of the valid HCP certificate file in the `HCP_CRED_FILE` environment variable, or place it in the default location for the HCP SDK, `~/.hcp/cred_file.json`
+For certificate based auth simply specify the location of the valid HCP certificate file in the `HCP_CRED_FILE` environment variable, or place it in the default location for the HCP SDK, `~/.config/hcp/cred_file.json`
 
 See the following HCP docs for more information on [Workload Identity Federation](https://developer.hashicorp.com/hcp/docs/hcp/iam/service-principal/workload-identity-federation) and certificate authentication
 


### PR DESCRIPTION
Fixing incorrect default credential file path in docs, and comment, this commit will also need to be back ported to the docs site