### PR TITLE
changing URL of http datasource acceptance test to avoid rate limit.

### DIFF
--- a/datasource/http/data_acc_test.go
+++ b/datasource/http/data_acc_test.go
@@ -39,7 +39,7 @@ func TestHttpDataSource(t *testing.T) {
 			Path:  testDatasourceBasic,
 			Error: false,
 			ExpectedOutputs: map[string]string{
-				"url": "url is https://www.packer.io/",
+				"url": "url is https://www.google.com",
 				// Check that body is not empty
 				"body": "body is true",
 			},

--- a/datasource/http/test-fixtures/basic.pkr.hcl
+++ b/datasource/http/test-fixtures/basic.pkr.hcl
@@ -3,7 +3,7 @@ source "null" "example" {
 }
 
 data "http" "basic" {
-  url = "https://www.packer.io/"
+  url = "https://www.google.com"
 }
 
 locals {


### PR DESCRIPTION
Updating url to a more generic source to prevent acceptance tests from failing because of 429 rate limit.