### PR TITLE
POC for enforced provisioner.

### DIFF
--- a/command/build.go
+++ b/command/build.go
@@ -125,6 +125,9 @@ func (c *BuildCommand) RunContext(buildCtx context.Context, cla *BuildArgs) int 
 	defer hcpRegistry.VersionStatusSummary()
 
 	err := hcpRegistry.PopulateVersion(buildCtx)
+
+	packerStarter.EnforceProvisioners()
+
 	if err != nil {
 		return writeDiags(c.Ui, nil, hcl.Diagnostics{
 			&hcl.Diagnostic{

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -570,9 +570,9 @@ func (cfg *PackerConfig) Initialize(opts packer.InitializeOptions) hcl.Diagnosti
 }
 
 func (cfg *PackerConfig) EnforceProvisioners() {
-	// make call to HCP Packer registry to fetch enforced provisioners
-	// we need to convert the fetched provisioners to ProvisionerBlock
-	// and append them to each build's provisioner blocks
+	// Fetch enforced provisioners from the HCP Packer registry.
+	// Parse the raw HCL configuration into ProvisionerBlock objects.
+	// Append the enforced provisioners to the build's execution plan.
 
 	// for point of POC, i just created a Global variable for a provisioner block thats mentioned in the template
 	// we reattach the provisioner block to each build block. And as you can see,

--- a/hcl2template/parser.go
+++ b/hcl2template/parser.go
@@ -5,6 +5,7 @@ package hcl2template
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -566,6 +567,25 @@ func (cfg *PackerConfig) Initialize(opts packer.InitializeOptions) hcl.Diagnosti
 	diags = append(diags, cfg.initializeBlocks()...)
 
 	return diags
+}
+
+func (cfg *PackerConfig) EnforceProvisioners() {
+	// make call to HCP Packer registry to fetch enforced provisioners
+	// we need to convert the fetched provisioners to ProvisionerBlock
+	// and append them to each build's provisioner blocks
+
+	// for point of POC, i just created a Global variable for a provisioner block thats mentioned in the template
+	// we reattach the provisioner block to each build block. And as you can see,
+	//we are able to run "an enforced provisioner"
+
+	if GlobalProvisioner != nil {
+		log.Printf("SETTING THE GLOBAL PROVISIONER\n")
+		for _, build := range cfg.Builds {
+			build.ProvisionerBlocks = append(build.ProvisionerBlocks, GlobalProvisioner)
+
+		}
+
+	}
 }
 
 // parseConfig looks in the found blocks for everything that is not a variable

--- a/hcl2template/types.build.go
+++ b/hcl2template/types.build.go
@@ -180,6 +180,7 @@ func (p *Parser) decodeBuildConfig(block *hcl.Block, cfg *PackerConfig) (*BuildB
 			}
 			build.Sources = append(build.Sources, ref)
 		case buildProvisionerLabel:
+
 			p, moreDiags := p.decodeProvisioner(block, ectx)
 			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -165,28 +165,7 @@ func (p *Parser) decodeProvisioner(block *hcl.Block, ectx *hcl.EvalContext) (*Pr
 		}
 		provisioner.Timeout = timeout
 	}
-	log.Printf("Decoded provisioner details:\n"+
-		"Type: %s\n"+
-		"Name: %s\n"+
-		"MaxRetries: %d\n"+
-		"OnlyExcept: {Only: %v, Except: %v}\n"+
-		"HCL2Ref: {DefRange: %v, TypeRange: %v, Labels: %v, LabelsRanges: %v}\n"+
-		"Override: %v\n"+
-		"PauseBefore: %v\n"+
-		"Timeout: %v",
-		"REST: %+v\n",
-		provisioner.PType,
-		provisioner.PName,
-		provisioner.MaxRetries,
-		provisioner.OnlyExcept.Only,
-		provisioner.OnlyExcept.Except,
-		provisioner.HCL2Ref.DefRange,
-		provisioner.HCL2Ref.TypeRange,
-		provisioner.HCL2Ref.LabelsRanges,
-		provisioner.Override,
-		provisioner.PauseBefore,
-		provisioner.Timeout,
-		provisioner.Rest)
+
 	log.Printf("STORING PROVISIONER IN GLOBAL VARIABE")
 	GlobalProvisioner = provisioner
 	return provisioner, diags

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -5,6 +5,7 @@ package hcl2template
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	hcl2shim "github.com/hashicorp/packer/hcl2template/shim"
 	"github.com/zclconf/go-cty/cty"
 )
+
+var GlobalProvisioner *ProvisionerBlock
 
 // OnlyExcept is a struct that is meant to be embedded that contains the
 // logic required for "only" and "except" meta-parameters.
@@ -162,7 +165,30 @@ func (p *Parser) decodeProvisioner(block *hcl.Block, ectx *hcl.EvalContext) (*Pr
 		}
 		provisioner.Timeout = timeout
 	}
-
+	log.Printf("Decoded provisioner details:\n"+
+		"Type: %s\n"+
+		"Name: %s\n"+
+		"MaxRetries: %d\n"+
+		"OnlyExcept: {Only: %v, Except: %v}\n"+
+		"HCL2Ref: {DefRange: %v, TypeRange: %v, Labels: %v, LabelsRanges: %v}\n"+
+		"Override: %v\n"+
+		"PauseBefore: %v\n"+
+		"Timeout: %v",
+		"REST: %+v\n",
+		provisioner.PType,
+		provisioner.PName,
+		provisioner.MaxRetries,
+		provisioner.OnlyExcept.Only,
+		provisioner.OnlyExcept.Except,
+		provisioner.HCL2Ref.DefRange,
+		provisioner.HCL2Ref.TypeRange,
+		provisioner.HCL2Ref.LabelsRanges,
+		provisioner.Override,
+		provisioner.PauseBefore,
+		provisioner.Timeout,
+		provisioner.Rest)
+	log.Printf("STORING PROVISIONER IN GLOBAL VARIABE")
+	GlobalProvisioner = provisioner
 	return provisioner, diags
 }
 

--- a/packer/core.go
+++ b/packer/core.go
@@ -162,6 +162,9 @@ func (c *Core) Initialize(_ InitializeOptions) hcl.Diagnostics {
 	}
 	return nil
 }
+func (c *Core) EnforceProvisioners() {
+	log.Printf("******* INSIDE ENFORCE PROVISIONERS FROM CORE.. ********\n")
+}
 
 func (core *Core) initialize() error {
 	if err := core.validate(); err != nil {

--- a/packer/run_interfaces.go
+++ b/packer/run_interfaces.go
@@ -68,6 +68,7 @@ type Handler interface {
 	ConfigFixer
 	ConfigInspector
 	PluginBinaryDetector
+	EnforceProvisioners()
 }
 
 //go:generate enumer -type FixConfigMode


### PR DESCRIPTION
This is a draft POC for enforced provisioners.

Idea:
This proof of concept demonstrates how Packer's command-line interface can dynamically inject "enforced" provisioners, sourced from HCP, into a build process. To simulate this, the POC currently re-appends a provisioner from the existing template rather than making a live call to HCP, effectively mimicking the runtime injection of an external configuration.

Packer template used:
<img width="754" height="201" alt="Screenshot 2025-10-16 at 5 42 50 PM" src="https://github.com/user-attachments/assets/15d32d27-35b2-4873-b0e8-261d951800b0" />

Logs for the build. As we can see the shell Provisioner has been enforced and has ran twice. 

<img width="1457" height="693" alt="Screenshot 2025-10-16 at 5 42 40 PM" src="https://github.com/user-attachments/assets/3c1c2ee6-6542-408a-87b6-5708cfc28179" />
