### PR TITLE
docs: add usage clarification to File builder

### DIFF
--- a/website/content/docs/builders/file.mdx
+++ b/website/content/docs/builders/file.mdx
@@ -74,3 +74,11 @@ the artifact will be empty.
   artifact.
 
 - `content` (string) - The content that will be put into the artifact.
+## Note on Usage
+
+When using the File builder, ensure that the source path you provide
+exists on the local machine running Packer. If the path is incorrect,
+Packer will return a "file not found" error during the build stage.
+
+This small clarification helps avoid common mistakes when working with
+local-file-based artifact generation.


### PR DESCRIPTION
This PR adds a small clarification to the File builder documentation.

The File builder requires that the source path provided by the user
exists on the local machine running Packer. When the path is incorrect,
Packer will raise a "file not found" error during the build stage.

This brief note helps users avoid a common misconfiguration and improves
the overall clarity of the File builder usage instructions.

Docs-only change. No functional impact.
