### PR TITLE
Updates Go version to 1.24.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -200,6 +200,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.0
+go 1.24.12
 
 replace github.com/zclconf/go-cty => github.com/nywilken/go-cty v1.13.3 // added by packer-sdc fix as noted in github.com/hashicorp/packer-plugin-sdk/issues/187


### PR DESCRIPTION
Updating the go version to `v1.24.12` to resolve the following vulnerabilities.
```
GO-2025-4175
GO-2025-4155
GO-2025-4013
GO-2025-4012
GO-2025-4011
GO-2025-4010
GO-2025-4009
GO-2025-4008
GO-2025-4007
GO-2025-3956
GO-2025-3751
GO-2025-3750
GO-2025-3749
```