### PR TITLE
Ensure the loop stops if the windows-restart provisioner finishes

### DIFF
--- a/provisioner/windows-restart/provisioner.go
+++ b/provisioner/windows-restart/provisioner.go
@@ -226,6 +226,9 @@ var waitForCommunicator = func(ctx context.Context, p *Provisioner) error {
 		case <-ctx.Done():
 			log.Println("Communicator wait canceled, exiting loop")
 			return fmt.Errorf("Communicator wait canceled")
+		case <-p.cancel:
+			log.Println("Communicator wait canceled via provisioner, exiting loop")
+			return nil
 		case <-time.After(retryableSleep):
 		}
 		if runCustomRestartCheck {


### PR DESCRIPTION
Obvious fix:  Seems connection retry loops go forever in the case the windows-restart provisioner finishes.