### PR TITLE
docs: fix shell-local execute_command example for -c flag

### DIFF
--- a/website/content/docs/provisioners/shell-local.mdx
+++ b/website/content/docs/provisioners/shell-local.mdx
@@ -125,7 +125,7 @@ Optional parameters:
   it is necessary below.
 
 - `execute_command` (array of strings) - The command used to execute the
-  script. By default this is `["/bin/sh", "-c", "{{.Vars}}", "{{.Script}}"]`
+  script. By default this is `["/bin/sh", "-c", "{{.Vars}} {{.Script}}"]`
   on Unix and `["cmd", "/c", "{{.Vars}}", "{{.Script}}"]` on Windows. This is
   treated as a [template engine](/packer/docs/templates/legacy_json_templates/engine). There are two
   available variables: `Script`, which is the path to the script to run, and


### PR DESCRIPTION
## Summary
- Fix incorrect `execute_command` example in shell-local provisioner documentation
- The `-c` flag requires Vars and Script as a single combined string argument

## Root Cause
The documentation shows `["/bin/sh", "-c", "{{.Vars}}", "{{.Script}}"]` which passes Vars and Script as separate arguments. With `-c`, the shell only uses the first argument after `-c` as the command string.

## Testing
- Documentation-only change

Fixes #13500

Made with [Cursor](https://cursor.com)