### PR TITLE
fix: exclude syft dependency import on NetBSD, OpenBSD, and Solaris

### DIFF
--- a/provisioner/hcp-sbom/syft_dependency.go
+++ b/provisioner/hcp-sbom/syft_dependency.go
@@ -1,6 +1,12 @@
 // Copyright IBM Corp. 2013, 2025
 // SPDX-License-Identifier: BUSL-1.1
 
+// Exclude platforms where containerd (a transitive dependency of syft) doesn't compile.
+// Containerd has platform-specific code that lacks support for NetBSD, OpenBSD, and Solaris.
+// This exclusion only affects dependency tracking; the hcp-sbom provisioner downloads
+// pre-built syft binaries at runtime and works on all platforms where those binaries exist.
+//go:build !netbsd && !openbsd && !solaris
+
 package hcp_sbom
 
 import (


### PR DESCRIPTION
### Description
The syft library has a transitive dependency on containerd, which includes platform-specific code that doesn't compile on NetBSD, OpenBSD, and Solaris.

This change adds build constraints to exclude the syft import on these platforms. The hcp-sbom provisioner functionality is unaffected since it downloads and executes pre-built syft binaries at runtime rather than using the Go library directly. The import exists solely for dependency tracking in license and security scanning tools.
