### PR TITLE
Fix typos in error messages and WinRM docs

### DIFF
--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -319,7 +319,7 @@ func (c *PackerConfig) recursivelyEvaluateLocalVariable(local *LocalBlock, depth
 		return hcl.Diagnostics{&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Max local recursion depth exceeded.",
-			Detail: "An error occured while recursively evaluating locals." +
+			Detail: "An error occurred while recursively evaluating locals." +
 				"Your local variables likely have a cyclic dependency. " +
 				"Please simplify your config to continue. ",
 		}}
@@ -428,7 +428,7 @@ func (cfg *PackerConfig) recursivelyEvaluateDatasources(ref DatasourceRef, depen
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Max datasource recursion depth exceeded.",
-			Detail: "An error occured while recursively evaluating data " +
+			Detail: "An error occurred while recursively evaluating data " +
 				"sources. Either your data source depends on more than ten " +
 				"other data sources, or your data sources have a cyclic " +
 				"dependency. Please simplify your config to continue. ",

--- a/website/content/docs/communicators/winrm.mdx
+++ b/website/content/docs/communicators/winrm.mdx
@@ -182,8 +182,8 @@ cmd.exe /c net start winrm
 ```
 
 Please note that having WinRM auto-launch on all start ups may not be the right
-choice for you, if you don't need the server to recieve WinRM connections in the
-future. Clean up after yourself and close unnecesary firewall ports at a final
+choice for you, if you don't need the server to receive WinRM connections in the
+future. Clean up after yourself and close unnecessary firewall ports at a final
 provisioning step to make sure your image is secure.
 
 #### Configuring WinRM in the Cloud


### PR DESCRIPTION

**Repo:** hashicorp/packer (⭐ 15000)
**Type:** docs
**Files changed:** 2
**Lines:** +4/-4

## What
Fixes user-visible spelling mistakes: "occured" → "occurred" in two HCL2 evaluation error diagnostics (`hcl2template/types.packer_config.go`), and "recieve" → "receive" plus "unnecesary" → "unnecessary" in the WinRM communicator docs (`website/content/docs/communicators/winrm.mdx`).

## Why
These typos appear in messages users actually see — the HCL2 ones surface in CLI diagnostics when a Packer template hits a recursion depth limit on locals or data sources, and the WinRM ones are in published docs. Trivial polish, but improves perceived quality and search-ability of the error strings.

## Testing
Pure string-literal changes with no behavioral effect. Verified via `git diff --stat` (2 files, +4/-4). No tests exercise these specific strings, so existing test suite remains valid; running `go vet ./hcl2template/...` would suffice locally.

## Risk
Low — string-only edits in error `Detail` fields and Markdown prose; no logic or API surface affected.
