### PR TITLE
Skips bucket update when metadata matches current state

### DIFF
--- a/internal/hcp/api/mock_service.go
+++ b/internal/hcp/api/mock_service.go
@@ -34,6 +34,7 @@ type MockPackerClientService struct {
 	CreateBuildResp   *hcpPackerModels.HashicorpCloudPacker20230101CreateBuildResponse
 
 	// Mock Gets
+	GetBucketResp  *hcpPackerModels.HashicorpCloudPacker20230101GetBucketResponse
 	GetVersionResp *hcpPackerModels.HashicorpCloudPacker20230101GetVersionResponse
 
 	// Mock enforced blocks
@@ -94,7 +95,11 @@ func (svc *MockPackerClientService) PackerServiceGetBucket(
 	if svc.BucketNotFound {
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("Code:%d %s", codes.NotFound, codes.NotFound.String()))
 	}
-	return hcpPackerService.NewPackerServiceGetBucketOK(), nil
+	resp := hcpPackerService.NewPackerServiceGetBucketOK()
+	if svc.GetBucketResp != nil {
+		resp.Payload = svc.GetBucketResp
+	}
+	return resp, nil
 }
 
 func (svc *MockPackerClientService) PackerServiceUpdateBucket(

--- a/internal/hcp/api/service_bucket.go
+++ b/internal/hcp/api/service_bucket.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"reflect"
 
 	hcpPackerService "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2023-01-01/client/packer_service"
 	hcpPackerModels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2023-01-01/models"
@@ -48,12 +49,16 @@ func (c *Client) UpsertBucket(
 	getParams.LocationProjectID = c.ProjectID
 	getParams.BucketName = bucketName
 
-	_, err := c.Packer.PackerServiceGetBucket(getParams, nil)
+	resp, err := c.Packer.PackerServiceGetBucket(getParams, nil)
 	if err != nil {
 		if CheckErrorCode(err, codes.NotFound) {
 			_, err = c.CreateBucket(ctx, bucketName, bucketDescription, bucketLabels)
 		}
 		return err
+	}
+
+	if resp != nil && resp.Payload != nil && bucketMetadataMatches(resp.Payload.Bucket, bucketDescription, bucketLabels) {
+		return nil
 	}
 
 	params := hcpPackerService.NewPackerServiceUpdateBucketParamsWithContext(ctx)
@@ -67,4 +72,24 @@ func (c *Client) UpsertBucket(
 	_, err = c.Packer.PackerServiceUpdateBucket(params, nil)
 
 	return err
+}
+
+func bucketMetadataMatches(
+	bucket *hcpPackerModels.HashicorpCloudPacker20230101Bucket,
+	description string,
+	labels map[string]string,
+) bool {
+	if bucket == nil {
+		return false
+	}
+
+	if bucket.Description != description {
+		return false
+	}
+
+	if len(bucket.Labels) == 0 && len(labels) == 0 {
+		return true
+	}
+
+	return reflect.DeepEqual(bucket.Labels, labels)
 }


### PR DESCRIPTION
Prevents unnecessary update operations by checking if the bucket's description and labels already match the requested values before issuing an update.

Improves efficiency and avoids redundant API calls.