### PR TITLE
ci(create-release-branch): pin contents: read

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,5 +1,12 @@
 name: Create a release branch
 on: [workflow_dispatch]
+
+# The actions-create-release-branch step uses secrets.ELEVATED_GITHUB_TOKEN
+# to push the release branch; the default GITHUB_TOKEN only needs read
+# access for the checkout.
+permissions:
+  contents: read
+
 jobs:
   create-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The release-branch creation workflow inherits the default `GITHUB_TOKEN` scope. `hashicorp/actions-create-release-branch@v1` already uses `secrets.ELEVATED_GITHUB_TOKEN` to push, so the default token only needs `contents: read` for the checkout. Added an inline comment explaining the chosen scope.

Matches the top-level `permissions:` style already used in `acceptance-test.yml`, `backport.yml`, `issue-comment-created.yml`, etc. YAML validated locally.