### PR TITLE
Fix freebsd/arm build failure by gating Syft SBOM path on unsupported FreeBSD 32-bit targets

### DIFF
--- a/internal/sbom/generator_syft.go
+++ b/internal/sbom/generator_syft.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2013, 2025
 // SPDX-License-Identifier: BUSL-1.1
 
-//go:build !netbsd && !openbsd && !solaris && !mips && !mipsle && !mips64 && !(freebsd && 386)
+//go:build !netbsd && !openbsd && !solaris && !mips && !mipsle && !mips64 && !(freebsd && (386 || arm))
 
 package sbom
 

--- a/internal/sbom/generator_unsupported.go
+++ b/internal/sbom/generator_unsupported.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2013, 2025
 // SPDX-License-Identifier: BUSL-1.1
 
-//go:build netbsd || openbsd || solaris || mips || mipsle || mips64 || (freebsd && 386)
+//go:build netbsd || openbsd || solaris || mips || mipsle || mips64 || (freebsd && (386 || arm))
 
 package sbom
 


### PR DESCRIPTION
This PR fixes the release build failure for **FreeBSD arm (32-bit)** by routing that platform away from the **Syft-backed SBOM generator** path, which currently fails to compile due to upstream `modernc` `sqlite`/`libc` incompatibilities with the current Go toolchain.

The main **Packer** binary build remains functional for **FreeBSD arm (32-bit)**.

## What changed

- Updated Syft-enabled build tags to exclude **FreeBSD 32-bit** targets in `generator_syft.go:4`.
- Updated unsupported-platform build tags to include those targets in `generator_unsupported.go:4`.

## Why this is needed

- CI/build failures were reproducible for `GOOS=freebsd` and `GOARCH=arm` with **Go 1.25.11**.
- Failures occur in upstream dependency compilation (`modernc` `sqlite`/`libc`), not in Packer business logic.
- This is a targeted compatibility guard to keep builds green while preserving behavior on supported targets.

## Impact

- **FreeBSD amd64** remains on the normal Syft SBOM generation path.
- **FreeBSD 32-bit** targets (`386` and `arm`) now use the unsupported fallback for SBOM generation.
- Core binary build and packaging for **FreeBSD arm (32-bit)** succeeds.