### PR TITLE
core/hcl2: support optional() attributes in variable object types

### DIFF
--- a/hcl2template/testdata/variables/optional_attributes.pkr.hcl
+++ b/hcl2template/testdata/variables/optional_attributes.pkr.hcl
@@ -1,0 +1,13 @@
+# Copyright IBM Corp. 2024, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+variable "context" {
+  type = object({
+    with_default    = optional(string, "default_value")
+    without_default = optional(number)
+    required        = string
+  })
+  default = {
+    required = "set"
+  }
+}

--- a/hcl2template/types.variables.go
+++ b/hcl2template/types.variables.go
@@ -77,6 +77,12 @@ type Variable struct {
 	// declaration, the type of the default variable will be used. This will
 	// allow to ensure that users set this variable correctly.
 	Type cty.Type
+	// TypeDefaults holds the default values declared through optional()
+	// attribute modifiers within the variable's type constraint, if any. It is
+	// nil when the type constraint declares no such defaults. These defaults
+	// must be applied to a value before it is converted to Type so that any
+	// omitted optional attributes are populated with their declared defaults.
+	TypeDefaults *typeexpr.Defaults
 	// Common name of the variable
 	Name string
 	// Description of the variable
@@ -176,6 +182,18 @@ func (v *Variable) Value() cty.Value {
 	}
 	val := v.Values[len(v.Values)-1]
 	return val.Value
+}
+
+// applyTypeDefaults applies the default values declared through optional()
+// attribute modifiers in the variable's type constraint. It is a no-op when the
+// type declares no such defaults or when the value is null. Defaults must be
+// applied before converting a value to the variable's type so that omitted
+// optional attributes are populated with their declared defaults.
+func (v *Variable) applyTypeDefaults(val cty.Value) cty.Value {
+	if v.TypeDefaults == nil || val.IsNull() {
+		return val
+	}
+	return v.TypeDefaults.Apply(val)
 }
 
 // ValidateValue tells if the selected value for the Variable is valid according
@@ -362,13 +380,14 @@ func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.Eval
 	}
 
 	if t, ok := content.Attributes["type"]; ok {
-		tp, moreDiags := typeexpr.Type(t.Expr)
+		tp, typeDefaults, moreDiags := typeexpr.TypeConstraintWithDefaults(t.Expr)
 		diags = append(diags, moreDiags...)
 		if moreDiags.HasErrors() {
 			return diags
 		}
 
 		v.Type = tp
+		v.TypeDefaults = typeDefaults
 	}
 
 	if attr, exists := content.Attributes["sensitive"]; exists {
@@ -385,6 +404,7 @@ func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.Eval
 
 		if v.Type != cty.NilType {
 			var err error
+			defaultValue = v.applyTypeDefaults(defaultValue)
 			defaultValue, err = convert.Convert(defaultValue, v.Type)
 			if err != nil {
 				diags = append(diags, &hcl.Diagnostic{
@@ -612,6 +632,7 @@ func (cfg *PackerConfig) collectInputVariableValues(env []string, files []*hcl.F
 		diags = append(diags, valDiags...)
 		if variable.Type != cty.NilType {
 			var err error
+			val = variable.applyTypeDefaults(val)
 			val, err = convert.Convert(val, variable.Type)
 			if err != nil {
 				diags = append(diags, &hcl.Diagnostic{
@@ -702,6 +723,7 @@ func (cfg *PackerConfig) collectInputVariableValues(env []string, files []*hcl.F
 
 			if variable.Type != cty.NilType {
 				var err error
+				val = variable.applyTypeDefaults(val)
 				val, err = convert.Convert(val, variable.Type)
 				if err != nil {
 					diags = append(diags, &hcl.Diagnostic{
@@ -750,6 +772,7 @@ func (cfg *PackerConfig) collectInputVariableValues(env []string, files []*hcl.F
 
 		if variable.Type != cty.NilType {
 			var err error
+			val = variable.applyTypeDefaults(val)
 			val, err = convert.Convert(val, variable.Type)
 			if err != nil {
 				diags = append(diags, &hcl.Diagnostic{

--- a/hcl2template/types.variables_test.go
+++ b/hcl2template/types.variables_test.go
@@ -692,6 +692,40 @@ func TestParse_variables(t *testing.T) {
 	testParse(t, tests)
 }
 
+// TestParse_variables_optional_attributes ensures that the optional() attribute
+// modifier is accepted within an object type constraint and that declared
+// defaults are applied to attributes omitted from the value.
+func TestParse_variables_optional_attributes(t *testing.T) {
+	parser := getBasicParser()
+
+	cfg, diags := parser.Parse(
+		filepath.Join("testdata", "variables", "optional_attributes.pkr.hcl"),
+		nil, nil,
+	)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error diagnostics parsing optional attributes: %s", diags)
+	}
+
+	v, ok := cfg.InputVariables["context"]
+	if !ok {
+		t.Fatal("expected 'context' input variable to be present")
+	}
+
+	if v.TypeDefaults == nil {
+		t.Fatal("expected TypeDefaults to be populated for a type using optional()")
+	}
+
+	got := v.Value()
+	want := cty.ObjectVal(map[string]cty.Value{
+		"with_default":    cty.StringVal("default_value"),
+		"without_default": cty.NullVal(cty.Number),
+		"required":        cty.StringVal("set"),
+	})
+	if !got.RawEquals(want) {
+		t.Fatalf("unexpected value for context variable.\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
 func TestVariables_collectVariableValues(t *testing.T) {
 	type args struct {
 		env      []string


### PR DESCRIPTION
## Description

Packer rejected the `optional()` attribute modifier in `object` type constraints for input variables, while Terraform accepts it:

```hcl
variable "context" {
  type = object({
    bar_pro = optional(string, "bar")
  })
}
```

```
Error: Invalid type specification
Optional attribute modifier is only for type constraints, not for exact types.
```

The variable parser used HCL's `typeexpr.Type()`, which by design forbids `optional()`. This swaps it for `typeexpr.TypeConstraintWithDefaults()`, stores the returned `*typeexpr.Defaults` on the `Variable`, and applies those defaults to any omitted optional attributes before conversion — for values coming from `default`, environment (`PKR_VAR_*`), var-files, and `-var` CLI args.

This was previously blocked on upstream `hcl/v2` and `go-cty` upgrades, which have since landed, so the required API is now available.

## Behavior

- `optional(type, default)` populates omitted attributes with the declared default.
- `optional(type)` populates omitted attributes with `null`.
- Existing (non-optional) type constraints are unchanged.

## Testing

- Added `TestParse_variables_optional_attributes` covering defaulted, null, and required attributes.
- Verified end-to-end: `packer validate`/`build` now succeed and produce `bar_pro=bar` (declared default) and `baz=null` (optional, no default).
- Full hcl2template suite passes; `gofmt` clean.

Closes #12182
Closes #13098 