### PR TITLE
FEAT: Add continue_on_error option to HCL2 provisioner blocks

### DIFF
--- a/hcl2template/enforced_provisioner.go
+++ b/hcl2template/enforced_provisioner.go
@@ -68,9 +68,10 @@ func (cfg *PackerConfig) GetCoreBuildProvisionerFromBlock(pb *ProvisionerBlock, 
 
 	// Wrap provisioner with any special behavior (pause, timeout, retry)
 	wrappedProvisioner := packer.WrapProvisionerWithOptions(hclProvisioner, packer.ProvisionerWrapOptions{
-		PauseBefore: pb.PauseBefore,
-		Timeout:     pb.Timeout,
-		MaxRetries:  pb.MaxRetries,
+		PauseBefore:     pb.PauseBefore,
+		Timeout:         pb.Timeout,
+		MaxRetries:      pb.MaxRetries,
+		ContinueOnError: pb.ContinueOnError,
 	})
 
 	return packer.CoreBuildProvisioner{

--- a/hcl2template/enforced_provisioner_test.go
+++ b/hcl2template/enforced_provisioner_test.go
@@ -193,6 +193,18 @@ provisioner "shell" {
 			wantErr:   false,
 		},
 		{
+			name: "provisioner with continue_on_error",
+			blockContent: `
+provisioner "shell" {
+  continue_on_error = true
+  inline            = ["echo 'Continue on error test'"]
+}
+`,
+			wantCount: 1,
+			wantTypes: []string{"shell"},
+			wantErr:   false,
+		},
+		{
 			name: "provisioner with only filter",
 			blockContent: `
 provisioner "shell" {

--- a/hcl2template/types.build.provisioners.go
+++ b/hcl2template/types.build.provisioners.go
@@ -63,13 +63,14 @@ func (o *OnlyExcept) Validate() hcl.Diagnostics {
 
 // ProvisionerBlock references a detected but unparsed provisioner
 type ProvisionerBlock struct {
-	PType       string
-	PName       string
-	PauseBefore time.Duration
-	MaxRetries  int
-	Timeout     time.Duration
-	Override    map[string]interface{}
-	OnlyExcept  OnlyExcept
+	PType           string
+	PName           string
+	PauseBefore     time.Duration
+	MaxRetries      int
+	Timeout         time.Duration
+	ContinueOnError bool
+	Override        map[string]interface{}
+	OnlyExcept      OnlyExcept
 	HCL2Ref
 }
 
@@ -79,14 +80,15 @@ func (p *ProvisionerBlock) String() string {
 
 func (p *Parser) decodeProvisioner(block *hcl.Block, ectx *hcl.EvalContext) (*ProvisionerBlock, hcl.Diagnostics) {
 	var b struct {
-		Name        string    `hcl:"name,optional"`
-		PauseBefore string    `hcl:"pause_before,optional"`
-		MaxRetries  int       `hcl:"max_retries,optional"`
-		Timeout     string    `hcl:"timeout,optional"`
-		Only        []string  `hcl:"only,optional"`
-		Except      []string  `hcl:"except,optional"`
-		Override    cty.Value `hcl:"override,optional"`
-		Rest        hcl.Body  `hcl:",remain"`
+		Name            string    `hcl:"name,optional"`
+		PauseBefore     string    `hcl:"pause_before,optional"`
+		MaxRetries      int       `hcl:"max_retries,optional"`
+		Timeout         string    `hcl:"timeout,optional"`
+		ContinueOnError bool      `hcl:"continue_on_error,optional"`
+		Only            []string  `hcl:"only,optional"`
+		Except          []string  `hcl:"except,optional"`
+		Override        cty.Value `hcl:"override,optional"`
+		Rest            hcl.Body  `hcl:",remain"`
 	}
 	diags := gohcl.DecodeBody(block.Body, ectx, &b)
 	if diags.HasErrors() {
@@ -94,11 +96,12 @@ func (p *Parser) decodeProvisioner(block *hcl.Block, ectx *hcl.EvalContext) (*Pr
 	}
 
 	provisioner := &ProvisionerBlock{
-		PType:      block.Labels[0],
-		PName:      b.Name,
-		MaxRetries: b.MaxRetries,
-		OnlyExcept: OnlyExcept{Only: b.Only, Except: b.Except},
-		HCL2Ref:    newHCL2Ref(block, b.Rest),
+		PType:           block.Labels[0],
+		PName:           b.Name,
+		MaxRetries:      b.MaxRetries,
+		ContinueOnError: b.ContinueOnError,
+		OnlyExcept:      OnlyExcept{Only: b.Only, Except: b.Except},
+		HCL2Ref:         newHCL2Ref(block, b.Rest),
 	}
 
 	diags = diags.Extend(provisioner.OnlyExcept.Validate())

--- a/hcl2template/types.packer_config.go
+++ b/hcl2template/types.packer_config.go
@@ -582,6 +582,14 @@ func (cfg *PackerConfig) getCoreBuildProvisioner(source SourceUseBlock, pb *Prov
 		}
 	}
 
+	// Wrap last (outside retries) so retries are exhausted before the error
+	// is ignored and the build is allowed to continue.
+	if pb.ContinueOnError {
+		provisioner = &packer.ContinueOnErrorProvisioner{
+			Provisioner: provisioner,
+		}
+	}
+
 	return packer.CoreBuildProvisioner{
 		PType:       pb.PType,
 		PName:       pb.PName,

--- a/packer/provisioner.go
+++ b/packer/provisioner.go
@@ -6,6 +6,7 @@ package packer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -142,9 +143,10 @@ func (h *ProvisionHook) Run(ctx context.Context, name string, ui packersdk.Ui, c
 // ProvisionerWrapOptions contains options for wrapping a provisioner with
 // additional behavior like pausing, timeouts, and retries.
 type ProvisionerWrapOptions struct {
-	PauseBefore time.Duration
-	Timeout     time.Duration
-	MaxRetries  int
+	PauseBefore     time.Duration
+	Timeout         time.Duration
+	MaxRetries      int
+	ContinueOnError bool
 }
 
 // WrapProvisionerWithOptions wraps a provisioner with additional behavior
@@ -169,6 +171,12 @@ func WrapProvisionerWithOptions(provisioner packersdk.Provisioner, opts Provisio
 	if opts.MaxRetries != 0 {
 		wrapped = &RetriedProvisioner{
 			MaxRetries:  opts.MaxRetries,
+			Provisioner: wrapped,
+		}
+	}
+
+	if opts.ContinueOnError {
+		wrapped = &ContinueOnErrorProvisioner{
 			Provisioner: wrapped,
 		}
 	}
@@ -242,6 +250,43 @@ func (r *RetriedProvisioner) Provision(ctx context.Context, ui packersdk.Ui, com
 	ui.Say("retry limit reached.")
 
 	return err
+}
+
+// ContinueOnErrorProvisioner is a Provisioner implementation that allows the
+// build to continue even when the wrapped provisioner returns an error.
+type ContinueOnErrorProvisioner struct {
+	Provisioner packersdk.Provisioner
+}
+
+func (p *ContinueOnErrorProvisioner) ConfigSpec() hcldec.ObjectSpec {
+	return p.Provisioner.ConfigSpec()
+}
+func (p *ContinueOnErrorProvisioner) FlatConfig() interface{} {
+	if fc, ok := p.Provisioner.(interface{ FlatConfig() interface{} }); ok {
+		return fc.FlatConfig()
+	}
+	return nil
+}
+func (p *ContinueOnErrorProvisioner) Prepare(raws ...interface{}) error {
+	return p.Provisioner.Prepare(raws...)
+}
+
+func (p *ContinueOnErrorProvisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packersdk.Communicator, generatedData map[string]interface{}) error {
+	err := p.Provisioner.Provision(ctx, ui, comm, generatedData)
+	if err == nil {
+		return nil
+	}
+
+	// Do not swallow cancellations; those should still stop the build. Return
+	// both the original provisioner failure and the context error so callers
+	// keep the failure detail while still being able to detect the
+	// cancellation via errors.Is(err, context.Canceled).
+	if ctx.Err() != nil {
+		return errors.Join(err, ctx.Err())
+	}
+
+	ui.Say(fmt.Sprintf("Warning: Provisioner failed with %q, but continue_on_error is set; continuing the build.", err))
+	return nil
 }
 
 // DebuggedProvisioner is a Provisioner implementation that waits until a key

--- a/packer/provisioner_test.go
+++ b/packer/provisioner_test.go
@@ -346,3 +346,155 @@ func TestRetriedProvisionerCancel(t *testing.T) {
 		t.Fatal("should have err")
 	}
 }
+
+func TestContinueOnErrorProvisioner_impl(t *testing.T) {
+	var _ packersdk.Provisioner = new(ContinueOnErrorProvisioner)
+}
+
+func TestContinueOnErrorProvisionerConfigSpecAndFlatConfig_doNotRecurse(t *testing.T) {
+	mock := new(packersdk.MockProvisioner)
+	prov := &ContinueOnErrorProvisioner{Provisioner: mock}
+	_ = prov.ConfigSpec()
+	_ = prov.FlatConfig()
+}
+
+func TestContinueOnErrorProvisionerPrepare(t *testing.T) {
+	mock := new(packersdk.MockProvisioner)
+	prov := &ContinueOnErrorProvisioner{
+		Provisioner: mock,
+	}
+
+	err := prov.Prepare(42)
+	if err != nil {
+		t.Fatal("should not have errored")
+	}
+	if !mock.PrepCalled {
+		t.Fatal("prepare should be called")
+	}
+	if mock.PrepConfigs[0] != 42 {
+		t.Fatal("should have proper configs")
+	}
+}
+
+func TestContinueOnErrorProvisionerProvision(t *testing.T) {
+	// A failing provisioner must not propagate its error.
+	mock := &packersdk.MockProvisioner{
+		ProvFunc: func(ctx context.Context) error {
+			return errors.New("failed")
+		},
+	}
+
+	prov := &ContinueOnErrorProvisioner{
+		Provisioner: mock,
+	}
+
+	ui := testUi()
+	comm := new(packersdk.MockCommunicator)
+	err := prov.Provision(context.Background(), ui, comm, make(map[string]interface{}))
+	if err != nil {
+		t.Fatalf("should have swallowed the error, got: %s", err)
+	}
+	if !mock.ProvCalled {
+		t.Fatal("prov should be called")
+	}
+}
+
+func TestContinueOnErrorProvisionerProvision_success(t *testing.T) {
+	// A successful provisioner returns nil as usual.
+	mock := new(packersdk.MockProvisioner)
+
+	prov := &ContinueOnErrorProvisioner{
+		Provisioner: mock,
+	}
+
+	err := prov.Provision(context.Background(), testUi(), new(packersdk.MockCommunicator), make(map[string]interface{}))
+	if err != nil {
+		t.Fatalf("should not have errored, got: %s", err)
+	}
+	if !mock.ProvCalled {
+		t.Fatal("prov should be called")
+	}
+}
+
+func TestContinueOnErrorProvisionerCancelledProvision(t *testing.T) {
+	// A cancelled context must still propagate, even with continue_on_error.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mock := &packersdk.MockProvisioner{
+		ProvFunc: func(ctx context.Context) error {
+			cancel()
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	prov := &ContinueOnErrorProvisioner{
+		Provisioner: mock,
+	}
+
+	err := prov.Provision(ctx, testUi(), new(packersdk.MockCommunicator), make(map[string]interface{}))
+	if err == nil {
+		t.Fatal("should have propagated the cancellation error")
+	}
+}
+
+// TestProvisionHook_failsWithoutContinueOnError is the negative case: when a
+// provisioner fails and is NOT wrapped with continue_on_error (i.e. the option
+// is false or unset), the hook must return the error and must NOT run any
+// subsequent provisioners.
+func TestProvisionHook_failsWithoutContinueOnError(t *testing.T) {
+	pA := &packersdk.MockProvisioner{
+		ProvFunc: func(ctx context.Context) error {
+			return errors.New("failed")
+		},
+	}
+	pB := &packersdk.MockProvisioner{}
+
+	hook := &ProvisionHook{
+		Provisioners: []*HookedProvisioner{
+			{pA, nil, ""},
+			{pB, nil, ""},
+		},
+	}
+
+	err := hook.Run(context.Background(), "foo", testUi(), new(packersdk.MockCommunicator), nil)
+	if err == nil {
+		t.Fatal("hook should have errored when a provisioner fails")
+	}
+	if !pA.ProvCalled {
+		t.Fatal("failing provisioner should have been called")
+	}
+	if pB.ProvCalled {
+		t.Fatal("subsequent provisioner should NOT run after a failure")
+	}
+}
+
+// TestProvisionHook_continueOnErrorRunsRemaining is the positive case: when the
+// failing provisioner is wrapped with continue_on_error, the hook swallows the
+// error and continues running the remaining provisioners.
+func TestProvisionHook_continueOnErrorRunsRemaining(t *testing.T) {
+	failing := &packersdk.MockProvisioner{
+		ProvFunc: func(ctx context.Context) error {
+			return errors.New("failed")
+		},
+	}
+	pB := &packersdk.MockProvisioner{}
+
+	hook := &ProvisionHook{
+		Provisioners: []*HookedProvisioner{
+			{&ContinueOnErrorProvisioner{Provisioner: failing}, nil, ""},
+			{pB, nil, ""},
+		},
+	}
+
+	err := hook.Run(context.Background(), "foo", testUi(), new(packersdk.MockCommunicator), nil)
+	if err != nil {
+		t.Fatalf("hook should not have errored, got: %s", err)
+	}
+	if !failing.ProvCalled {
+		t.Fatal("failing provisioner should have been called")
+	}
+	if !pB.ProvCalled {
+		t.Fatal("subsequent provisioner should run after a swallowed failure")
+	}
+}


### PR DESCRIPTION
### Description

Currently a build fails as soon as a single provisioner returns a non-zero exit code. Sometimes a provisioner failure is non-fatal and shouldn't abort the whole build.

This PR adds an optional `continue_on_error` boolean to HCL2 provisioner blocks. When `true`, a provisioner that returns an error logs a warning and the build continues to the next provisioner instead of failing.

```hcl
provisioner "shell" {
  continue_on_error = true
  inline            = ["exit 1"]  # build continues despite this failure
}
```

### Notes

Scoped to HCL2 templates. Legacy JSON templates use the `template.Provisioner` struct in `packer-plugin-sdk`, so JSON support would require a separate SDK change.

Closes #11889 