### PR TITLE
Suppress false positive for GO-2026-5932

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -20,6 +20,7 @@ binary {
 		suppress {
 			vulnerabilities = [
 				"GO-2022-0635", // github.com/aws/aws-sdk-go@v1.55.5 TODO(dduzgun-security): remove when deps is resolved
+				"GO-2026-5932", // golang.org/x/crypto - only affects the unmaintained openpgp subpackage (no fixed version); not imported by Packer, confirmed absent from the binary via govulncheck/symbol scan.
 			]
 		}
 	}


### PR DESCRIPTION
## Description

Resolves the release-blocking `GO-2026-5932` finding for `golang.org/x/crypto`.

The advisory only affects the unmaintained `x/crypto/openpgp` subpackage (no fixed version exists). Packer never uses it, it was only pulled into the binary transitively via `go-github/v33`'s commit-signing code.