### PR TITLE
fix: prevent path traversal in GitHub plugin getter filename

### DIFF
--- a/packer/plugin-getter/github/getter.go
+++ b/packer/plugin-getter/github/getter.go
@@ -330,6 +330,13 @@ func (g *Getter) Validate(opt plugingetter.GetOptions, expectedVersion string, i
 	return installOpts.CheckProtocolVersion(entry.ProtVersion)
 }
 
-func (g *Getter) ExpectedFileName(pr *plugingetter.Requirement, version string, entry *plugingetter.ChecksumFileEntry, zipFileName string) string {
-	return zipFileName
+func (g *Getter) ExpectedFileName(pr *plugingetter.Requirement, version string, entry *plugingetter.ChecksumFileEntry, _ string) string {
+	pluginSourceParts := strings.Split(pr.Identifier.Source, "/")
+	return strings.Join([]string{
+		"packer-plugin-" + pluginSourceParts[2],
+		entry.BinVersion,
+		entry.ProtVersion,
+		entry.Os,
+		entry.Arch + entry.Ext,
+	}, "_")
 }

--- a/packer/plugin-getter/github/getter_test.go
+++ b/packer/plugin-getter/github/getter_test.go
@@ -6,6 +6,7 @@ package github
 import (
 	"testing"
 
+	"github.com/hashicorp/packer/hcl2template/addrs"
 	plugingetter "github.com/hashicorp/packer/packer/plugin-getter"
 	"github.com/stretchr/testify/assert"
 )
@@ -189,7 +190,25 @@ func TestValidate(t *testing.T) {
 
 func TestExpectedFileName(t *testing.T) {
 	getter := &Getter{}
-	pr := plugingetter.Requirement{}
-	fileName := getter.ExpectedFileName(&pr, "1.2.3", &plugingetter.ChecksumFileEntry{}, "packer-plugin-docker_v1.2.3_x5.0_linux_amd64.zip")
+	pr := plugingetter.Requirement{
+		Identifier: &addrs.Plugin{
+			Source: "github.com/hashicorp/docker",
+		},
+	}
+	entry := &plugingetter.ChecksumFileEntry{
+		BinVersion:  "v1.2.3",
+		ProtVersion: "x5.0",
+		Os:          "linux",
+		Arch:        "amd64",
+		Ext:         ".zip",
+	}
+	// The raw zipFileName argument must be ignored; the result is built from
+	// the validated entry fields, preventing path traversal via a crafted filename.
+	fileName := getter.ExpectedFileName(&pr, "1.2.3", entry, "packer-plugin-docker_v1.2.3_x5.0_linux_amd64.zip")
 	assert.Equal(t, "packer-plugin-docker_v1.2.3_x5.0_linux_amd64.zip", fileName)
+
+	// A malicious zipFileName with path traversal must not affect the output.
+	maliciousFileName := getter.ExpectedFileName(&pr, "1.2.3", entry,
+		`packer-plugin-docker_v1.2.3_x5.0_linux_amd64_/../../tmp/PWNED.zip`)
+	assert.Equal(t, "packer-plugin-docker_v1.2.3_x5.0_linux_amd64.zip", maliciousFileName)
 }

--- a/packer/plugin-getter/plugins_test.go
+++ b/packer/plugin-getter/plugins_test.go
@@ -875,20 +875,27 @@ func (g *mockPluginGetter) Validate(opt GetOptions, expectedVersion string, inst
 	}
 }
 
-func (g *mockPluginGetter) ExpectedFileName(pr *Requirement, version string, entry *ChecksumFileEntry, zipFileName string) string {
-	if g.Name == "github.com" {
-		return zipFileName
-	} else {
-		pluginSourceParts := strings.Split(pr.Identifier.Source, "/")
+func (g *mockPluginGetter) ExpectedFileName(pr *Requirement, version string, entry *ChecksumFileEntry, _ string) string {
+	pluginSourceParts := strings.Split(pr.Identifier.Source, "/")
 
-		// We need to verify that the plugin source is in the expected format
-		return strings.Join([]string{fmt.Sprintf("packer-plugin-%s", pluginSourceParts[2]),
-			"v" + version,
-			"x" + g.APIMajor + "." + g.APIMinor,
+	if g.Name == "github.com" {
+		// Mirror the real github getter: reconstruct from validated entry fields,
+		// never return the raw remote filename.
+		return strings.Join([]string{
+			"packer-plugin-" + pluginSourceParts[2],
+			entry.BinVersion,
+			entry.ProtVersion,
 			entry.Os,
-			entry.Arch + ".zip",
+			entry.Arch + entry.Ext,
 		}, "_")
 	}
+
+	return strings.Join([]string{fmt.Sprintf("packer-plugin-%s", pluginSourceParts[2]),
+		"v" + version,
+		"x" + g.APIMajor + "." + g.APIMinor,
+		entry.Os,
+		entry.Arch + ".zip",
+	}, "_")
 }
 
 func (g *mockPluginGetter) Get(what string, options GetOptions) (io.ReadCloser, error) {


### PR DESCRIPTION
## What

`ExpectedFileName` in the GitHub plugin getter returned the raw filename from the remote `SHA256SUMS` release asset unchanged. That string was used directly in `filepath.Join` to build both the temp execution path and the final install path, allowing a crafted filename containing `../` sequences to escape the plugin directory.

## Why it matters

An attacker who controls a GitHub plugin release (malicious plugin, or a compromised legitimate one) could write the plugin binary to an arbitrary path writable by the victim user, and have it executed immediately via `exec.Command(path, "describe")` at `packer init` time — before the plugin is ever used in a build.

The release getter (`packer/plugin-getter/release/getter.go`) was never affected because it already reconstructed the filename from validated fields instead of trusting the remote string.

## How

Mirror the release getter's approach: reconstruct the expected filename entirely from the fields `Init()` already parsed and validated (`BinVersion`, `ProtVersion`, `Os`, `Arch`, `Ext`). The raw remote `zipFileName` argument is ignored.

For a well-formed filename the output is identical to before, so there is no impact on any existing legitimate plugin.

## Changes

- `packer/plugin-getter/github/getter.go` — fix `ExpectedFileName`
- `packer/plugin-getter/github/getter_test.go` — update test to use a populated entry; add explicit traversal-filename assertion
- `packer/plugin-getter/plugins_test.go` — update `mockPluginGetter` to mirror the real implementation so integration tests exercise the fixed code path

## Backward compatibility

No breaking change. A legitimate plugin filename round-trips through `Init()` → `ExpectedFileName()` to the identical string as before.